### PR TITLE
fix: HALO on Qwen3.5/3.6 — gamma fold + linear_attn block detection

### DIFF
--- a/docs/ultraplan-context-2026-05-09.md
+++ b/docs/ultraplan-context-2026-05-09.md
@@ -1,0 +1,366 @@
+# PrismaQuant — context for /ultraplan session 2026-05-09
+
+## TL;DR
+
+We just resolved the HALO smoke on Qwen3.5-0.8B. We found two HALO bugs (latent
+since the original module, surfaced by the 2026-05-09 d5626e2 enable-on-qwen3.5-dense
+commit), fixed them on branch `fix/halo-qwen35-rmsnorm-fold` (commits 5898583
++ 22c6c65, not pushed), verified end-to-end, and made HALO opt-in / EXPERIMENTAL
+in the CLI help. Now we want to plan the next phase of PrismaQuant additions.
+
+The strategic question is which improvements actually move the bpp/KL Pareto on
+the production stack and are worth the engineering investment, and which are
+research code paths that don't ship.
+
+## Repository state
+
+- Branch: `fix/halo-qwen35-rmsnorm-fold` (local, not pushed). 2 commits ahead of
+  `0a92c3d docs: add claude handover` on `main`.
+- Shipped 27B artifact: `dq-runs/qwen36-27b-step00-production-cache-vllmlegal-export-main-20260509T073125Z/exported`.
+  KL=0.031 / 5.16 bpp / Qwen3.6-27B / vLLM-load verified. **Does not use HALO.**
+- Allocator stack today: per-Linear knapsack/Pareto + GPTQ (OBS rounding) +
+  closed-form scale_sweep + activation_clip + sibling-globals unification +
+  block-output-match refinement (NVFP4_block_match) + mixed-format allocation.
+- Pre-existing cross-layer machinery in repo: PrismaSCOUT (L3 redesign),
+  PrismaCLADE / block-CLADO, output-Fisher refinement, polish (iterate-perturbed-
+  allocation), KL sensitivity probe, dense cone, QUBO refinements. Most
+  exists; few have demonstrated reproducible non-regressive wins on the
+  production stack at modern scale.
+
+## Today's HALO smoke result (so it's grounded)
+
+Setup: untied lm_head Qwen3.5-0.8B (HALO requires untied; cloned embed →
+lm_head shard, 485 MiB, hardlinked the rest). Layer config: 195 entries
+(150 NVFP4 body + 45 BF16 covering lm_head, linear_attn.in_proj_a/b, MTP).
+RTN-only (no production cache, no GPTQ, no scale_sweep — pure infra smoke).
+
+Outcome before fix:
+- Both no-HALO and HALO exports completed. Both vLLM-loaded in eager+graph.
+- No-HALO: coherent generation (' Paris, and the capital of the United
+  States is Washington, D. C.').
+- HALO: newline spam (`'\n\n\n…'`, max_tokens of newlines).
+
+Diagnosis (via BF16-only HALO sanity test): 0% argmax agreement, |logit
+diff| max 31.1. Math/code bug, not RTN compounding.
+
+Root cause: TWO bugs.
+
+1. **Gamma-fold bug.** `prismaquant/halo.py:fold_gamma_into_linears` assumed
+   Llama-style RMSNorm (`weight * normalize(x)`). Qwen3_5RMSNorm computes
+   `(1 + weight) * normalize(x)` (centered residual, weight init zeros).
+   The fold absorbed `weight` instead of `(1 + weight)`, then reset
+   `norm.weight = 1.0`, leaving the post-fold norm computing `(1+1) = 2x`.
+   Mismultiplied by `(2*weight) / (1 + weight)` per fold site — for typical
+   pretrained weights ≈ 5–10×. Compounded across 49 fold sites per Qwen3.5/3.6
+   dense model.
+
+2. **`default_block_specs` missing linear_attn.** The in-memory full-model
+   spec builder didn't detect the linear_attention layers' linear_attn block;
+   only `block_specs_for_layer` (the streaming-export per-layer path) did.
+   So in BF16 sanity tests, 30 specs found instead of 48 — 18 linear_attn
+   blocks missing means residual stream rotated but linear_attn weights
+   unrotated → garbage from those layers regardless of the gamma fix.
+
+Fix (commit 5898583):
+- Added `_OFFSET_RESIDUAL_NORM_CLASSES = {"Qwen3_5RMSNorm"}` whitelist plus
+  explicit `offset_residual: bool | None` override on `fold_gamma_into_linears`.
+  When offset-residual: gamma = `1 + weight`, post-fold reset = `weight = 0`.
+- Refactored `default_block_specs` to delegate to `block_specs_for_layer` per
+  layer so both paths emit identical specs (48 not 30).
+- 3 new tests: offset-residual fold preservation, class-name auto-detect,
+  Llama-style regression guard. 16/16 halo + 81/81 halo+export pass.
+
+Verification post-fix:
+- BF16 sanity: 48 specs, |diff| max 0.375 on logits magnitude ~17, **96.9%
+  argmax agreement**. (The 3.1% disagreement is BF16 cancellation noise
+  through 24 layers + Hadamard + 248k vocab — expected at BF16 precision.)
+- Quantized HALO eager: `' the capital of the United States.\nA. True\n…'`
+- Quantized HALO graph: `' the capital of France.\n- The capital of France
+  is the capital of France'`
+- Coherent English in both modes. Quality at this 0.8B / RTN-only scale is
+  similar to no-HALO; HALO's intended quality win shows up at lower bpp /
+  with the production cache + GPTQ + scale_sweep stack — not here.
+
+Documentation update (commit 22c6c65): `--halo-mode` help text now leads with
+"EXPERIMENTAL, opt-in; default OFF" + notes that the literature ~0.20-0.30
+PPL gain is from RTN baselines, not from the full PrismaQuant production
+stack. Runtime warning prints when HALO is engaged.
+
+## The strategic conversation we had
+
+User asked the meta question: cross-layer interaction machinery (PrismaSCOUT,
+CLADO, output-Fisher, polish-of-many) was a huge investment, but the per-
+Linear allocator generates great results. Is cross-layer interaction simply
+not as big a deal as one might expect?
+
+My read on the empirical evidence:
+
+- Per-Linear knapsack + GPTQ + scale_sweep + activation_clip is doing 90%+ of
+  the work on Qwen3.6-27B. KL=0.031 at 5.16 bpp is competitive.
+- Polish-of-1 reliably adds ~5% KL improvement on top (the shipped 27B step
+  00 polish move). Polish-of-many is noise-dominated at n=8 calibration:
+  between-seed variance ~40% of mean, train→val sign flip on most moves
+  (May 7 audit `AUDIT_OVERFITTING_2026-05-07.md`).
+- L3 / CLADO / output-Fisher haven't demonstrated reproducible non-
+  regressive wins on the production stack.
+- May 7 KL sensitivity probe on Qwen3-0.6B got -44% KL with **per-Linear
+  sensitivity → multi-choice knapsack**. No cross-layer modeling.
+- PrismaSCOUT v5's claimed -34% on Qwen3-4B at 4.5 bpp is unreplicated end-
+  to-end (blocked on GB10 OOM, never made it to a shipped recipe).
+
+Why per-Linear seems to work so well, plausibly:
+
+1. NVFP4 group_size=16 already does local outlier diffusion.
+2. GPTQ is implicitly cross-layer-aware: minimizes output MSE given the
+   activation distribution at this Linear, which is a function of every
+   upstream layer.
+3. Modern LLMs are massively over-parameterized; quant errors damp through
+   downstream redundancy.
+4. Cross-layer signal is small relative to calibration noise. If per-Linear
+   SNR is ~5 and cross-layer interaction SNR is ~0.5 at n=8, no clever DP
+   recovers signal from below the noise floor.
+
+Conclusion: the cross-layer infrastructure isn't wasted (it's how you proved
+the null result, which is publication-grade), but extending it as a quality
+lever is not where the next gains live. **Per-Linear improvements are
+where to invest.**
+
+## User-imposed format constraint
+
+vLLM-supported, weight/activation rate-matched. Final menu:
+
+- NVFP4 (W4A4)
+- MXFP8_E4M3 (W8A8 microscaling)
+- MXFP8_E5M2 (W8A8 microscaling, larger dynamic range)
+- FP8_E4M3 (W8A8 per-tensor or per-channel)
+- FP8_E5M2 (W8A8 alternative)
+- BF16 (W16A16 passthrough)
+
+**Excluded**: NVINT2/3 (no W4A4 path), MXFP4 (4-bit activations not viable),
+MXFP6 (no vLLM kernel), OWQ/SqueezeLLM-style mixed-precision per-weight
+(needs custom kernels). No new kernels period.
+
+The interesting per-Linear decisions in this menu:
+- **NVFP4 vs MXFP8 vs FP8 vs BF16** — bpp tradeoff (allocator-level)
+- **E4M3 vs E5M2** within MXFP8 and within FP8 — precision/range tradeoff
+  (per-Linear, currently undifferentiated by the probe)
+- **MXFP8 vs FP8** at the same nominal bpp — group structure tradeoff
+
+The current KL sensitivity probe doesn't differentiate E4M3/E5M2 within a
+format family. It should.
+
+## Calibration data discussion
+
+Today's default is presumably WikiText-2 or similar. Literature drift
+suggests:
+
+- Wikitext-2 is monoculture encyclopedic English; under-exercises code/math/
+  multilingual outlier patterns.
+- Modern good defaults: RedPajama-V2, FineWeb-Edu (curated, reproducible,
+  diverse).
+- C4/OpenWebText: diverse but noisy, license issues.
+- The Pile: gated.
+
+My suggested calibration mix (4-bucket diversity-weighted, fixed dataset
+hashes for reproducibility):
+- 40% prose (FineWeb-Edu)
+- 20% code (StarCoder data subset)
+- 20% math (proof-pile or GSM8K-train, or Lean/Coq subsets)
+- 20% multilingual (FLORES or mC4 sample)
+- n=256 sequences × 4096 tokens (vs n=128 × 2048 baseline)
+
+WikiText-2 stays as a comparability column in any results table — not as
+the working calibration set.
+
+Single most testable claim: **diversity matters more than n_samples beyond
+~64.** Worth measuring once on Qwen3.6-27B (KL probe on monoculture wikitext
+vs diverse mix at same n) and looking at how many promotions diverge.
+
+## Activation calibration discussion
+
+Today's pipeline:
+- `--activation-cache-dir` — per-Linear input cache during a probe forward
+- `compute_nvfp4_input_global_scale(acts)` — max_abs/6.0 type scaling
+- `PRISMAQUANT_ACT_CLIP_QUANTILE` — p99.9 default quantile clip
+- Sibling-globals unification across fused groups (qkv, gate_up, in_proj_qkvz)
+
+Improvements I'd consider (per-Linear, vLLM-compatible, no new kernels):
+
+1. **Per-Linear quantile sweep.** Today's clip quantile is one value
+   model-wide. Different Linears want different clips (early-layer attention
+   wants higher, late-layer down_proj wants lower). Sweep on calibration,
+   pick per-Linear, store in cache. Plausible 1-2% improvement.
+
+2. **Asymmetric quantization for SiLU-output Linears.** `gate_proj` /
+   `up_proj` outputs are post-SiLU positive-skewed. Symmetric NVFP4 wastes
+   half the codebook. vLLM's `nv_fp4_with_static_gs` supports asymmetric
+   variant — confirm it's wired and benchmarked.
+
+3. **Production-faithful activation re-cache** (Codex's Step F applied to
+   activations). Today's activation cache is built when most Linears are
+   BF16 — the activation distribution at Linear L when upstream Linears
+   are at NVFP4 is *different*. Re-cache after staging the production
+   assignment, then re-fit `input_global_scale` per Linear from that state.
+   **This is the single most underexploited correction in the pipeline.**
+   Plausible 5-10% if the May 7 audit finding ("most calibration work is
+   fishing in noise") points to upstream context shift as the dominant
+   bottleneck.
+
+4. **Length-distribution-aware calibration.** Most activation work today
+   is at one sequence length. State-space / linear_attn / RoPE-position
+   behaviors differ at long context. n=64 at 4096 + n=64 at 16384 may
+   catch outliers that n=128 at 2048 misses.
+
+5. **Per-token (dynamic) activation scaling for outlier-heavy Linears.**
+   Already supported by NVFP4 path (`act_dynamic: true`). Audit that it's
+   actually engaged at runtime for the Linears that need it.
+
+## Numerical methods landscape (ParoQuant + alternatives)
+
+User flagged ParoQuant as a candidate replacement for HALO. After
+evaluation:
+
+**ParoQuant** (Liang et al., ICLR 2026, arXiv:2511.10645):
+- Pairwise rotations (Givens-style) instead of full Hadamard
+- Trained per layer (not random) — adds calibration-time optimization step
+- Group-aligned with NVFP4's group_size=16 — the big differentiator over
+  HALO/QuaRot which scramble all channels uniformly
+- Same vLLM compatibility model: absorb rotation into adjacent Linear weights
+- Same prerequisites as HALO: untied lm_head, norm-style awareness (inherits
+  our gamma-fold fix), profile-specific topology
+
+**Worth considering alongside ParoQuant**:
+- **SmoothQuant** — per-channel activation→weight migration (s such that
+  Y = (X/s) @ (sW)). vLLM-compatible (absorb into upstream norm gamma).
+  Untested on NVFP4+group=16, but simpler than rotation.
+- **FlatQuant** (2024) — learned per-Linear affine optimized for "flatness"
+  rather than incoherence. Beats QuaRot on Llama at W4A4.
+- **OmniQuant** — jointly learnable clip + weight transform via SGD.
+  Replaces scale_sweep, doesn't compose.
+- **Per-Linear GPTQ damping sweep** — tune λ per Linear instead of global
+  scalar. Simple, low-risk, ~1% improvement.
+- **Fisher-weighted GPTQ loss** — weight by Fisher info instead of uniform
+  output MSE. PrismaQuant has Fisher infrastructure already.
+
+**Skip**:
+- AWQ (codebase comment: +230% PPL on NVFP4 group=16, designed for W4A16
+  per-channel only)
+- OWQ / SqueezeLLM (per-weight mixed precision needs custom kernels)
+- QuIP# / LDLQ (target sub-2-bit; not differentiated at 4-bit)
+- AffineQuant (subset of FlatQuant)
+- AdaRound true-SGD (closed-form approximation = our scale_sweep; diminishing
+  returns)
+
+## Per-Linear damping vs ParoQuant interaction (user asked)
+
+Damping doesn't compete with ParoQuant directly:
+- Damping = regularization on weight-update size to prevent overfitting
+  calibration noise. Operates on GPTQ inner loop.
+- ParoQuant = reshapes input distribution so groups absorb outliers.
+- Different mechanisms, different problems. Optimal λ shifts post-rotation
+  but is just per-Linear scalar config — re-sweep is cheap.
+
+Quantile sweep DOES compete with ParoQuant:
+- Both handle outliers. Aggressive activation clipping reduces what
+  rotation has to redistribute.
+- The two methods compete for the same outlier-handling budget.
+
+Compose-friendly with rotation (always run regardless):
+- Production-faithful re-cache
+- Format menu E4M3/E5M2 differentiation
+- Calibration diversity
+- scale_sweep (already in)
+
+Methodology rule: anytime you compare A vs A+rotation, both arms must use
+the same per-Linear sweeps re-run on their respective configurations.
+Otherwise comparing well-tuned-no-rot vs default-tuned-rot understates
+rotation's value (or vice versa).
+
+## My recommended priority ordering (the actual plan question)
+
+1. **HALO measurement on 27B production stack.** One overnight run. Re-
+   export Qwen3.6-27B with `--halo-mode random` on top of the existing seed
+   candidate + production cache + GPTQ + scale_sweep, validate vs the
+   shipped artifact's KL=0.031. **Decides whether rotation pays at all on
+   this stack** — gates everything downstream.
+2. **Production-faithful activation re-cache** (Step F applied to
+   activations). Composes with everything, including ParoQuant. Plausibly
+   the largest non-rotation single win.
+3. **Format menu E4M3/E5M2 differentiation.** Cheap, local, no new methods.
+   Pure allocator change. Plausibly 1-2% KL.
+4. **Per-Linear GPTQ damping sweep.** Cheap, local, low-risk, ~1%.
+5. **Calibration diversity** (4-bucket mix, fixed dataset hashes).
+6. **THEN if HALO measurement is positive**: ParoQuant evaluation. Pick
+   ParoQuant over FlatQuant if the HALO-on-27B result shows clustered gains
+   (some Linears benefit a lot, most don't) — that's the ParoQuant signal.
+   Pick FlatQuant if uniform-ish gains.
+7. **Per-Linear activation quantile sweep.** Defer until rotation question
+   is decided to avoid attribution issues.
+8. **Fisher-weighted GPTQ loss.** Heavier; save for after simpler wins
+   validate.
+
+What we DO NOT pursue:
+- Sub-NVFP4 formats (no W4A4 path on weight, no kernels)
+- AWQ
+- Custom-kernel methods (OWQ, SqueezeLLM, etc.)
+- Polish-of-many extensions (noise-dominated)
+- Cross-layer DP refinement (CLADO/output-Fisher) as a quality lever — keep
+  as research code path
+
+## Files to know
+
+- Branch state: `/home/rob/prismaquant/` on `fix/halo-qwen35-rmsnorm-fold`,
+  2 commits ahead of main, not pushed.
+- Smoke artifacts: `/home/rob/dq-runs/qwen35-0p8b-halo-smoke-20260509T132625Z/`
+  - `SUMMARY.md` — full smoke writeup including fix verification
+  - `exports/{nohalo,halo-random,halo-random-fixed}/` — the three artifact variants
+  - `halo_bf16_sanity.py` — BF16-only HALO test
+  - logs in `logs/`
+- Shipped 27B: `/home/rob/dq-runs/qwen36-27b-step00-production-cache-vllmlegal-export-main-20260509T073125Z/`
+- Current handover: `/home/rob/prismaquant/docs/claude_handover_2026-05-09.md`
+- Memory notes referenced:
+  - `paroquant_candidate.md` — user flagged 2026-05-09
+  - `halo_qwen35_norm_bug.md` — bug + fix record
+  - `polish_overfit_2026_05_07.md` — n=8 polish overfitting audit
+  - `prismaclade_l3_non_additivity.md` — L3 DP regression
+  - `prismaquant_traction_context.md` — 60k HF downloads, paper-grade work,
+    bias toward provably-non-regressive methods
+  - `feedback_cuda_graphs_everywhere.md` — fixed-shape paths capture into
+    CUDA graphs by default with env-gated fallback
+
+## What I want from the plan
+
+Given the priority ordering above, generate a concrete plan for:
+
+1. **The HALO-on-27B measurement run** (#1). Specify: seed candidate to use,
+   export invocation, validation methodology (KL on what calibration set,
+   how many samples), pass/fail thresholds, and what the decision tree is
+   based on the outcome (HALO ships behind a flag / HALO drops / pursue
+   ParoQuant directly).
+
+2. **The production-faithful activation re-cache** (#2). Specify: where in
+   the pipeline this slots, what existing code paths it modifies (probably
+   `production_weight_cache.py` + `build_rtn_cache.py` + the activation
+   indexing path), how to validate it (smoke on Qwen3-0.6B → 4B → 27B), and
+   whether it's a default-on or opt-in change.
+
+3. **The format menu E4M3/E5M2 differentiation** (#3). Specify: probe
+   changes to `kl_sensitivity_probe.py`, allocator changes to consume the
+   richer table, exporter changes to handle E4M3/E5M2 selection (most likely
+   already supported via `data_type` field — just needs the probe to emit
+   the right entries).
+
+4. **Damping sweep + calibration diversity** (#4-5). Specify: what gets
+   parametrized, where the sweep lives, what the diverse calibration mix
+   is concretely (HF dataset names, hashes, mixing logic).
+
+5. **Sequencing**: what runs first, what blocks what, what can run in
+   parallel, what's the critical path to a Qwen3.6-27B re-export with all
+   wins composed.
+
+The output should be implementable — concrete file paths, commit boundaries,
+test plan, validation gates. Not a research roadmap; a delivery plan with
+optional research forks.
+
+If the plan thinks the priority ordering above is wrong, push back with
+reasoning and an alternative.

--- a/prismaquant/export_native_compressed.py
+++ b/prismaquant/export_native_compressed.py
@@ -5105,23 +5105,35 @@ def main():
                          "against the same cache.")
     ap.add_argument("--halo-mode", default="off",
                     choices=("off", "random"),
-                    help="HALO rotation preprocessor (#4). When 'random', "
-                         "applies a random Hadamard rotation R to the "
-                         "residual stream and absorbs R into adjacent "
-                         "Linear weights. Diffuses outliers across "
-                         "channels — downstream NVFP4/MXFP8 quantization "
-                         "has lower reconstruction error. No new vLLM "
-                         "kernel required (R is absorbed into weights "
-                         "and norms). Expected gain: ~0.20-0.30 PPL on "
-                         "Llama-class models. Critical: assumes standard "
+                    help="HALO rotation preprocessor (EXPERIMENTAL, opt-in; "
+                         "default OFF). When 'random', applies a random "
+                         "Hadamard rotation R to the residual stream and "
+                         "absorbs R into adjacent Linear weights. Diffuses "
+                         "outliers across channels — downstream NVFP4/MXFP8 "
+                         "RTN reconstruction error is lower in theory. No "
+                         "new vLLM kernel required (R is absorbed into "
+                         "weights and norms). Literature gain on Llama-class "
+                         "W4A4 is ~0.20-0.30 PPL against an RTN baseline; "
+                         "the gain on top of PrismaQuant's full GPTQ + "
+                         "scale_sweep + activation_clip + sibling-globals "
+                         "stack is UNMEASURED on every architecture as of "
+                         "2026-05-09 — the published Qwen3.6-27B artifact "
+                         "does not use HALO. Use only for research / Pareto "
+                         "exploration, not ship-grade artifacts, until "
+                         "per-arch quality wins have been measured against "
+                         "the no-HALO baseline. Correctness verified on "
+                         "Qwen3.5/3.6 dense (untied-lm_head + offset-residual "
+                         "RMSNorm fold). Critical: assumes standard "
                          "transformer block topology (input_layernorm + "
                          "q/k/v/o_proj, post_attention_layernorm + "
-                         "gate/up/down_proj), untied embeddings, and "
-                         "a standard dense residual stream. Non-power-of-2 "
+                         "gate/up/down_proj), untied embeddings, and a "
+                         "standard dense residual stream. Non-power-of-2 "
                          "hidden sizes use a structured block-Hadamard "
                          "rotation. Profile-specific overrides are still "
                          "needed for packed MoE or non-standard residual "
-                         "topologies.")
+                         "topologies. MTP spec-decode acceptance under HALO "
+                         "is unvalidated — manifest flags "
+                         "`mtp_policy: passthrough_requires_spec_decode_validation`.")
     ap.add_argument("--halo-seed", type=int, default=0,
                     help="RNG seed for HALO sign-diagonal in random "
                          "Hadamard. Saved alongside the artifact at "
@@ -5374,6 +5386,12 @@ def main():
     halo_R = None
     halo_meta = {"mode": "off"}
     if args.halo_mode == "random":
+        print("[halo] EXPERIMENTAL: HALO is enabled. Pareto win on top of "
+              "PrismaQuant's GPTQ + scale_sweep + activation_clip stack is "
+              "UNMEASURED as of 2026-05-09. Treat the resulting artifact as a "
+              "research output, not ship-grade, until KL/PPL has been "
+              "compared against the same recipe with --halo-mode off.",
+              flush=True)
         from .halo import _hadamard_block_sizes, random_hadamard
         from transformers import AutoConfig as _AC
 

--- a/prismaquant/halo.py
+++ b/prismaquant/halo.py
@@ -200,21 +200,62 @@ def _get_module_by_qname(model: nn.Module, qname: str) -> nn.Module:
     return cur
 
 
+# RMSNorm classes whose forward computes `(1 + weight) * normalize(x)` rather
+# than the Llama-style `weight * normalize(x)`. The Qwen3.5/3.6 family adopts
+# the offset-residual form (weight init to zeros, learned residual centered on
+# 1). For these, the *effective* gamma absorbed into the downstream Linear is
+# `1 + weight`, and after fold the norm should compute identity scaling —
+# which means setting `weight = 0` (so `1 + 0 = 1`) rather than `weight = 1`.
+_OFFSET_RESIDUAL_NORM_CLASSES: frozenset[str] = frozenset({
+    "Qwen3_5RMSNorm",
+})
+
+
+def _is_offset_residual_norm(norm: nn.Module) -> bool:
+    """Auto-detect offset-residual RMSNorm by class name.
+
+    Used as the default when callers don't pass an explicit override. The
+    class-name lookup keeps detection localized to HALO and avoids importing
+    transformers (which would couple PrismaQuant to specific model classes).
+    """
+    return type(norm).__name__ in _OFFSET_RESIDUAL_NORM_CLASSES
+
+
 def fold_gamma_into_linears(model: nn.Module, norm_qname: str,
-                            downstream_linears: list[str]) -> None:
+                            downstream_linears: list[str], *,
+                            offset_residual: bool | None = None) -> None:
     """Fold an RMSNorm's gamma into one or more downstream Linear weights
     by per-input-channel scaling. After this:
-      - The Linear's effective behavior on `gamma * normalize(x)` is
-        unchanged from its prior behavior on the same input.
-      - The norm's gamma is reset to 1.0 so subsequent rotation is valid.
+      - The Linear's effective behavior on `effective_gamma * normalize(x)`
+        is unchanged from its prior behavior on the same input.
+      - The norm's residual weight is reset so the post-fold norm computes
+        identity scaling, leaving `R · LN(x) = LN(R · x)` valid for the
+        subsequent rotation step.
 
     For shared norms feeding multiple Linears (the standard q/k/v fan-out
     after input_layernorm), each Linear absorbs the full gamma.
+
+    Two RMSNorm conventions are handled:
+
+      Llama-style (default): `forward(x) = weight * normalize(x)`.
+        `effective_gamma = weight`. Reset `weight = 1` post-fold so the
+        norm computes `1 * normalize(x) = normalize(x)`.
+
+      Offset-residual (Qwen3.5/3.6 `Qwen3_5RMSNorm`):
+        `forward(x) = (1 + weight) * normalize(x)`.
+        `effective_gamma = 1 + weight`. Reset `weight = 0` post-fold so the
+        norm computes `(1 + 0) * normalize(x) = normalize(x)`.
+
+    If `offset_residual=None`, the convention is auto-detected by inspecting
+    the norm's Python class against `_OFFSET_RESIDUAL_NORM_CLASSES`.
     """
     norm = _get_module_by_qname(model, norm_qname)
     if not hasattr(norm, "weight"):
         return
-    gamma = norm.weight.detach().to(torch.float32)
+    if offset_residual is None:
+        offset_residual = _is_offset_residual_norm(norm)
+    weight_raw = norm.weight.detach().to(torch.float32)
+    gamma = weight_raw + 1.0 if offset_residual else weight_raw
     for linear_qname in downstream_linears:
         lin = _get_module_by_qname(model, linear_qname)
         if not hasattr(lin, "weight"):
@@ -227,9 +268,12 @@ def fold_gamma_into_linears(model: nn.Module, norm_qname: str,
                 f"{W.shape[1]} for {linear_qname}")
         W = W * gamma[None, :]
         lin.weight.data = W.to(lin.weight.dtype)
-    # Reset gamma to 1 so future operations don't double-apply.
+    # Post-fold the residual weight must yield identity scaling: weight=1 for
+    # Llama-style norms (so `1 * normalize(x)`), weight=0 for offset-residual
+    # norms (so `(1 + 0) * normalize(x)`).
+    reset_value = 0.0 if offset_residual else 1.0
     with torch.no_grad():
-        norm.weight.fill_(1.0)
+        norm.weight.fill_(reset_value)
 
 
 # ---------------------------------------------------------------------------
@@ -592,54 +636,17 @@ def default_block_specs(model: nn.Module, *,
     for i in range(n_layers):
         layer_qname = f"{body_layer_prefix}.{i}"
 
-        # Attention block.
-        attn_in = []
-        for proj in ("self_attn.q_proj", "self_attn.k_proj",
-                     "self_attn.v_proj"):
-            try:
-                _get_module_by_qname(model, f"{layer_qname}.{proj}")
-                attn_in.append(f"{layer_qname}.{proj}")
-            except AttributeError:
-                pass
-        attn_out = []
-        for proj in ("self_attn.o_proj", "self_attn.out_proj"):
-            try:
-                _get_module_by_qname(model, f"{layer_qname}.{proj}")
-                attn_out.append(f"{layer_qname}.{proj}")
-                break
-            except AttributeError:
-                continue
-        if attn_in and attn_out:
-            blocks.append(HaloBlockSpec(
-                name=f"layer{i}.attn",
-                dim=hidden,
-                norm_qname=f"{layer_qname}.input_layernorm",
-                input_linears=attn_in,
-                output_linears=attn_out,
-            ))
-
-        # MLP / MoE block.
-        mlp_in = []
-        for proj in ("mlp.gate_proj", "mlp.up_proj"):
-            try:
-                _get_module_by_qname(model, f"{layer_qname}.{proj}")
-                mlp_in.append(f"{layer_qname}.{proj}")
-            except AttributeError:
-                pass
-        mlp_out = []
+        # Resolve the layer module from the qname so we can defer all
+        # attention/linear_attn/MLP block detection to `block_specs_for_layer`.
+        # Sharing one source of truth keeps the streaming export path and the
+        # in-memory full-model path emitting identical specs — otherwise (as
+        # the 2026-05-09 qwen3_5 smoke proved) the in-memory path silently
+        # skips linear_attn blocks while the streaming path includes them.
         try:
-            _get_module_by_qname(model, f"{layer_qname}.mlp.down_proj")
-            mlp_out.append(f"{layer_qname}.mlp.down_proj")
+            layer_mod = _get_module_by_qname(model, layer_qname)
         except AttributeError:
-            pass
-        if mlp_in and mlp_out:
-            blocks.append(HaloBlockSpec(
-                name=f"layer{i}.mlp",
-                dim=hidden,
-                norm_qname=f"{layer_qname}.post_attention_layernorm",
-                input_linears=mlp_in,
-                output_linears=mlp_out,
-            ))
+            continue
+        blocks.extend(block_specs_for_layer(layer_mod, layer_qname, hidden))
 
     return HaloModelSpec(
         dim=hidden,

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -91,6 +91,27 @@ class _RMSNorm(nn.Module):
         return self.weight * x
 
 
+class _Qwen35RMSNorm(nn.Module):
+    """Offset-residual RMSNorm matching transformers Qwen3_5RMSNorm.
+
+    Forward computes `(1 + weight) * normalize(x)`; weight is initialized to
+    zeros and learned as a centered residual around 1. HALO's gamma fold must
+    treat the effective gamma as `1 + weight` rather than `weight`, otherwise
+    the post-fold residual stream is mismultiplied by `(2 * weight) / (1 +
+    weight)` per fold site (catastrophic for small pretrained weights).
+    """
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        # Match transformers' init: zeros, not ones.
+        self.weight = nn.Parameter(torch.zeros(dim))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        var = x.pow(2).mean(-1, keepdim=True)
+        x = x * torch.rsqrt(var + self.eps)
+        return (1.0 + self.weight) * x
+
+
 class _NormThenLinear(nn.Module):
     def __init__(self, d: int):
         super().__init__()
@@ -100,6 +121,23 @@ class _NormThenLinear(nn.Module):
         with torch.no_grad():
             self.norm.weight.copy_(
                 torch.linspace(0.5, 1.5, d, dtype=torch.float32))
+
+    def forward(self, x):
+        return self.lin(self.norm(x))
+
+
+class _OffsetResidualNormThenLinear(nn.Module):
+    """`_NormThenLinear` variant using `_Qwen35RMSNorm` with non-trivial
+    learned residual."""
+    def __init__(self, d: int):
+        super().__init__()
+        self.norm = _Qwen35RMSNorm(d)
+        self.lin = nn.Linear(d, d, bias=False)
+        with torch.no_grad():
+            # Centered residual ~0.0 with light spread, mimicking pretrained
+            # qwen3_5 magnitudes (effective gamma = 1 + weight ≈ [0.7, 1.3]).
+            self.norm.weight.copy_(
+                torch.linspace(-0.3, 0.3, d, dtype=torch.float32))
 
     def forward(self, x):
         return self.lin(self.norm(x))
@@ -118,6 +156,92 @@ def test_fold_gamma_preserves_output():
     assert torch.allclose(model.norm.weight, torch.ones(d), atol=1e-7)
     assert torch.allclose(y_before, y_after, atol=1e-5), \
         f"max diff = {(y_before - y_after).abs().max().item()}"
+
+
+def test_fold_gamma_offset_residual_preserves_output():
+    """Offset-residual (Qwen3_5-style) RMSNorm fold must absorb effective
+    gamma `(1 + weight)` and reset `weight = 0` post-fold so the norm computes
+    identity scaling. Verifies the patch that fixes the qwen3_5_dense HALO
+    smoke regression on 2026-05-09."""
+    torch.manual_seed(0)
+    d = 32
+    model = _OffsetResidualNormThenLinear(d).eval()
+    x = torch.randn(4, d, dtype=torch.float32)
+    with torch.no_grad():
+        y_before = model(x)
+        fold_gamma_into_linears(model, "norm", ["lin"], offset_residual=True)
+        y_after = model(x)
+    # For offset-residual norms, post-fold weight must be 0 (so `(1 + 0) = 1`
+    # — identity scaling), NOT 1 (which would scale by 2).
+    assert torch.allclose(model.norm.weight, torch.zeros(d), atol=1e-7), (
+        f"offset-residual norm.weight should reset to 0; got "
+        f"{model.norm.weight}")
+    assert torch.allclose(y_before, y_after, atol=1e-5), \
+        f"max diff = {(y_before - y_after).abs().max().item()}"
+
+
+class Qwen3_5RMSNorm(nn.Module):
+    """Test-local class whose name matches the production transformers
+    `Qwen3_5RMSNorm`, so HALO's class-name-based auto-detect of the
+    offset-residual convention fires without importing transformers."""
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.zeros(dim))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        var = x.pow(2).mean(-1, keepdim=True)
+        x = x * torch.rsqrt(var + self.eps)
+        return (1.0 + self.weight) * x
+
+
+def test_fold_gamma_offset_residual_autodetects_qwen35_class():
+    """`fold_gamma_into_linears` should auto-detect the offset-residual
+    convention when the norm class name matches the production
+    `Qwen3_5RMSNorm`. No explicit override should be required."""
+    torch.manual_seed(0)
+    d = 32
+
+    class _Wrapper(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm = Qwen3_5RMSNorm(d)
+            self.lin = nn.Linear(d, d, bias=False)
+            with torch.no_grad():
+                self.norm.weight.copy_(
+                    torch.linspace(-0.3, 0.3, d, dtype=torch.float32))
+
+        def forward(self, x):
+            return self.lin(self.norm(x))
+
+    model = _Wrapper().eval()
+    x = torch.randn(4, d, dtype=torch.float32)
+    with torch.no_grad():
+        y_before = model(x)
+        # No explicit override — auto-detect via class name must fire.
+        fold_gamma_into_linears(model, "norm", ["lin"])
+        y_after = model(x)
+    assert torch.allclose(model.norm.weight, torch.zeros(d), atol=1e-7), (
+        f"offset-residual auto-detect failed; norm.weight={model.norm.weight}")
+    assert torch.allclose(y_before, y_after, atol=1e-5), \
+        f"max diff = {(y_before - y_after).abs().max().item()}"
+
+
+def test_fold_gamma_llama_style_unaffected_by_patch():
+    """Regression guard: the Llama-style fold must still work the same
+    (weight=1 post-fold, output preserved) when offset_residual is left at
+    default and the norm class isn't in the offset-residual whitelist."""
+    torch.manual_seed(0)
+    d = 32
+    model = _NormThenLinear(d).eval()
+    x = torch.randn(4, d, dtype=torch.float32)
+    with torch.no_grad():
+        y_before = model(x)
+        fold_gamma_into_linears(model, "norm", ["lin"])  # auto-detect: False
+        y_after = model(x)
+    # Standard Llama-style fold: weight should land at 1.0.
+    assert torch.allclose(model.norm.weight, torch.ones(d), atol=1e-7)
+    assert torch.allclose(y_before, y_after, atol=1e-5)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **`fold_gamma_into_linears` now handles offset-residual RMSNorm.** Class-name auto-detect of `Qwen3_5RMSNorm` (init weight zeros, forward `(1 + weight) * normalize(x)`) plus an explicit `offset_residual: bool | None` override. When offset-residual: gamma = `1 + weight`, post-fold reset = `weight = 0`. The old fold absorbed `weight` and reset to 1.0, leaving the post-fold norm at `(1+1) = 2x` — mismultiplied by `(2*weight) / (1 + weight)` per fold site (~5–10× off for typical pretrained weights), compounded across 49 fold sites per Qwen3.5/3.6 dense model.
- **`default_block_specs` delegates to `block_specs_for_layer`.** The in-memory full-model spec builder was missing `linear_attn` block detection while the streaming-export per-layer builder had it (added in `d5626e2`). Refactor so both paths emit identical specs (48 not 30 on Qwen3.5/3.6 with 24 layers × 2 blocks).
- **HALO marked EXPERIMENTAL in CLI help + runtime warn.** `--halo-mode` is already CLI-opt-in (default `off`); help text now leads with that, notes the literature ~0.20–0.30 PPL gain is from RTN baselines (not from PrismaQuant's full GPTQ + scale_sweep + activation_clip stack which is unmeasured), and prints a one-line `[halo] EXPERIMENTAL` warning at materialization time.

## Background

HALO export for `qwen3_5_dense` was unblocked in `d5626e2` (the same commit that added `linear_attn` specs and `block_hadamard_matrix`). That landed without an end-to-end smoke. Today's smoke on Qwen3.5-0.8B (untied lm_head) proved both bugs were latent in the original HALO module since `d48575c` — they just had no Qwen3.5/3.6 path to run on until `d5626e2`. Neither bug affects the shipped 27B artifact (which doesn't use HALO).

## Test plan

- [x] `pytest tests/test_halo.py` — 16 passed (13 original + 3 new)
- [x] `pytest tests/test_halo.py tests/test_prismaquant_export_native_compressed.py` — 81 passed
- [x] BF16-only sanity on Qwen3.5-0.8B (untied lm_head): 48 specs (was 30), `\|diff\|` max 0.375 on logits magnitude ~17, **96.9% argmax agreement** (was 0.0%)
- [x] Quantized HALO eager + cudagraph on Qwen3.5-0.8B: coherent English in both modes (was newline-spam in both)
- [ ] HALO measurement on Qwen3.6-27B production stack (separate work — gates whether HALO ever ships behind a flag; tracked in the parallel /ultraplan session)
- [ ] MTP spec-decode acceptance under HALO (manifest already flags `mtp_policy: passthrough_requires_spec_decode_validation`; not addressed here)

## Notes for reviewer

The third commit (`1ef8dcd docs: ultraplan context …`) is an unrelated context document staged for a parallel /ultraplan planning session. Happy to drop it from this PR and land it separately if you prefer a clean HALO-only history.

Full smoke writeup: `/home/rob/dq-runs/qwen35-0p8b-halo-smoke-20260509T132625Z/SUMMARY.md` (local, not in repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)