### PR TITLE
Fisher: normalize h_trace by the global calib token count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,8 +104,15 @@ Under Tradeoff; an earlier internal name for the L3-polish piece was
 ### The cost cascade (cheap→faithful, each level gates the next)
 - **L1 — additive Fisher.** `predicted_dloss = ½·H_trace·MSE` per `(Linear,
   format)`, from the diagonal-Fisher 2nd-order loss expansion. `H_trace` is the
-  empirical Fisher diagonal trace (one calibration backward pass; MoE experts
-  divided by routing probability). Solve the multi-choice knapsack DP. Seconds.
+  empirical Fisher diagonal trace (one calibration backward pass; **every row —
+  dense or MoE expert — is normalized by the same global calib token count**,
+  since tokens never routed to an expert contribute zero gradient to the
+  mean-Δloss objective). Superseded conventions, both reversed on purpose: an
+  explicit ÷route_prob (removed in audit M4) and the per-routed-token division
+  that M4 kept as "the implicit ÷token-fraction" (removed in PR #14 — it
+  inflated rarely-routed unpacked-expert rows by global/routed, i.e. inverted
+  importance weighting; see `finalize_fisher_stats`). Solve the multi-choice
+  knapsack DP. Seconds.
 - **L2 — perturbed-X fixed point.** Re-measure each Linear's *output* MSE under
   the activation distribution induced by the current assignment (upstream quant
   noise shifts downstream inputs), re-solve, iterate to weighted-Hamming

--- a/docs/prismaquant_design.md
+++ b/docs/prismaquant_design.md
@@ -142,15 +142,19 @@ and (optionally) a per-row/per-output-channel diagonal `h_full`.
 
 For MoE packed experts, the same principle applies — squared
 gradient per weight — but the storage layout is `[E, M, N]` instead
-of `[out, in]`. The implementation in
-`sensitivity_probe._GradNormCapture` (line 413) chunks along the
-expert dimension to bound peak memory and uses the
-`RouterTracker` (line 920+) to **divide each expert's Fisher by its
-observed routing probability**. Without that scaling, sparse experts
-look artificially less sensitive than densely routed ones. With it,
-expert Fisher values are calibrated as "loss change *per actually
-used token*" and become comparable across the expert bank and across
-dense Linears.
+of `[out, in]`. Every accumulator — dense trunk, packed expert, or
+per-expert `nn.Linear` — is normalized by the **same global
+calibration token count** (`finalize_fisher_stats`): tokens never
+routed to an expert contribute zero gradient, so under the mean-Δloss
+objective the empirical Fisher divides by the global count for every
+row, and expert values are directly comparable across the expert bank
+and against dense Linears. Two earlier conventions were deliberately
+reversed: an explicit ÷route_prob via the `RouterTracker` (removed in
+audit M4; `route_prob` is metadata only now), and the per-routed-token
+division M4 retained as the "implicit ÷token-fraction" (removed in
+PR #14 — it is the same 1/p_e scaling, and it *inflated* rarely-routed
+unpacked-expert rows by (global/routed), inverting importance
+weighting in the knapsack).
 
 ### 2.3 Why empirical Fisher and not true Hessian
 

--- a/prismaquant/allocator.py
+++ b/prismaquant/allocator.py
@@ -1268,6 +1268,50 @@ def main():
     costs = cost_data["costs"]
     print(f"[alloc] stats: {len(stats)} Linears, costs: {len(costs)} Linears")
 
+    # ---- Fisher renormalization ----
+    # Older incremental probes finalized `h_trace = h_trace_raw /
+    # n_tokens_seen` PER ROW, where per-expert Linears only count their
+    # ROUTED tokens — inflating a rarely-routed expert's Fisher by
+    # (global/routed), up to ~33,000x, i.e. inverted importance weighting.
+    # The raw accumulators are stored, so recompute every derived field here
+    # with the one correct shared denominator: the global calib token count
+    # (probe meta nsamples x seqlen). Dense rows saw exactly that many
+    # tokens, so their values are unchanged; probes written by the fixed
+    # finalize (meta.fisher_norm_tokens) renormalize to identical values —
+    # the recompute is idempotent.
+    _meta = probe.get("meta", {}) or {}
+    _norm_tokens = int(_meta.get("fisher_norm_tokens", 0) or 0)
+    if _norm_tokens <= 0:
+        _norm_tokens = (int(_meta.get("nsamples", 0) or 0)
+                        * int(_meta.get("seqlen", 0) or 0))
+    if _norm_tokens > 0:
+        _renormed = 0
+        for _entry in stats.values():
+            if not isinstance(_entry, dict) or "h_trace_raw" not in _entry:
+                continue
+            _entry["h_trace"] = float(_entry["h_trace_raw"]) / _norm_tokens
+            if "h_w2_sum_raw" in _entry:
+                _entry["h_w2_sum"] = (
+                    float(_entry["h_w2_sum_raw"]) / _norm_tokens)
+            _per_raw = _entry.get("h_trace_per_expert_raw")
+            if _per_raw is not None:
+                _entry["h_trace_per_expert"] = [
+                    float(v) / _norm_tokens for v in _per_raw]
+            _renormed += 1
+        print(f"[alloc] Fisher renormalized: {_renormed}/{len(stats)} rows "
+              f"→ h_trace_raw / {_norm_tokens} global calib tokens "
+              "(per-expert routed-count normalization corrected)", flush=True)
+    else:
+        _needs_fix = sum(
+            1 for _e in stats.values()
+            if isinstance(_e, dict) and "h_trace_raw" in _e
+            and int(_e.get("n_tokens_seen", 0) or 0) > 0)
+        if _needs_fix:
+            print("[alloc] WARNING: probe meta lacks nsamples/seqlen; cannot "
+                  "renormalize h_trace by the global calib token count. "
+                  "Per-expert Fisher may be inflated by routed-token "
+                  "normalization.", flush=True)
+
     allow_pinned = [s.strip() for s in (args.allow_pinned or "").split(",") if s.strip()]
     allocation_excluded = []
     for name in sorted(set(stats) | set(costs)):

--- a/prismaquant/allocator.py
+++ b/prismaquant/allocator.py
@@ -1021,6 +1021,77 @@ def validate_final_serving_promotion_noop(
     )
 
 
+def renormalize_probe_fisher(stats: dict, meta: dict, *,
+                             allow_legacy: bool = False) -> int | None:
+    """Recompute h_trace/h_w2_sum/h_trace_per_expert from the stored RAW
+    accumulators with the one correct shared denominator: the global calib
+    token count.
+
+    Older incremental probes finalized `h_trace = h_trace_raw /
+    n_tokens_seen` PER ROW, where per-expert Linears only count their
+    ROUTED tokens — inflating a rarely-routed expert's Fisher by
+    (global/routed), i.e. inverted importance weighting. The typical
+    inflation is ~n_experts/top_k (≈32x on a 256-expert top-8 model);
+    the degenerate 1-routed-token case reaches ~33,000x at a 32k-token
+    calibration. Dense rows saw exactly the global count, so their values
+    are unchanged; probes written by the fixed finalize
+    (meta.fisher_norm_tokens) renormalize to identical values — the
+    recompute is idempotent.
+
+    Returns the token count used, or None when the probe carries raw
+    accumulators but no usable token count. In that case the default is a
+    HARD ERROR (SystemExit) — silently allocating on routed-token-
+    normalized Fisher mis-spends the bit budget; `allow_legacy=True`
+    (--allow-legacy-fisher-norm) downgrades it to a warning and keeps the
+    probe's stored h_trace values.
+    """
+    meta = meta or {}
+    norm_tokens = int(meta.get("fisher_norm_tokens", 0) or 0)
+    if norm_tokens <= 0:
+        norm_tokens = (int(meta.get("nsamples", 0) or 0)
+                       * int(meta.get("seqlen", 0) or 0))
+    if norm_tokens > 0:
+        renormed = 0
+        for entry in stats.values():
+            if not isinstance(entry, dict) or "h_trace_raw" not in entry:
+                continue
+            entry["h_trace"] = float(entry["h_trace_raw"]) / norm_tokens
+            if "h_w2_sum_raw" in entry:
+                entry["h_w2_sum"] = (
+                    float(entry["h_w2_sum_raw"]) / norm_tokens)
+            per_raw = entry.get("h_trace_per_expert_raw")
+            if per_raw is not None:
+                entry["h_trace_per_expert"] = [
+                    float(v) / norm_tokens for v in per_raw]
+            # Keep the probe-side stamp truthful on legacy pickles.
+            entry["h_trace_norm_tokens"] = norm_tokens
+            renormed += 1
+        print(f"[alloc] Fisher renormalized: {renormed}/{len(stats)} rows "
+              f"→ h_trace_raw / {norm_tokens} global calib tokens "
+              "(per-expert routed-count normalization corrected)", flush=True)
+        return norm_tokens
+
+    raw_rows = sum(
+        1 for e in stats.values()
+        if isinstance(e, dict) and "h_trace_raw" in e)
+    if raw_rows:
+        msg = (
+            "probe meta lacks fisher_norm_tokens and nsamples/seqlen, so "
+            f"h_trace cannot be renormalized by the global calib token "
+            f"count ({raw_rows} rows carry raw Fisher accumulators). "
+            "Legacy per-row normalization inflates routed-expert rows by "
+            "(global/routed) — typically ~n_experts/top_k — and the "
+            "allocator would mis-spend the bit budget on rarely-routed "
+            "experts. Re-run the probe with current code (it stamps "
+            "meta.fisher_norm_tokens), or pass --allow-legacy-fisher-norm "
+            "to proceed with the stored legacy values anyway.")
+        if not allow_legacy:
+            raise SystemExit(f"[alloc] ERROR: {msg}")
+        print(f"[alloc] WARNING (--allow-legacy-fisher-norm): {msg}",
+              flush=True)
+    return None
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--probe", required=True, help="sensitivity_probe pickle")
@@ -1045,6 +1116,16 @@ def main():
                          "silently-corrupt artifact. Off by default: "
                          "the allocator hard-errors instead and asks for "
                          "--model-override.")
+    ap.add_argument("--allow-legacy-fisher-norm", action="store_true",
+                    help="Permit allocation from a probe whose meta lacks "
+                         "fisher_norm_tokens / nsamples+seqlen, i.e. whose "
+                         "h_trace cannot be renormalized by the global calib "
+                         "token count. Such probes carry the legacy per-row "
+                         "normalization that inflates routed-expert Fisher "
+                         "by (global/routed) — typically ~n_experts/top_k. "
+                         "Off by default: the allocator hard-errors and asks "
+                         "for a re-probe. Use only to reproduce historical "
+                         "allocations.")
     ap.add_argument("--target-bits", type=float, default=4.75)
     ap.add_argument("--target-disk-gb", type=float, default=None,
                     help="Fit-the-card ship selection: instead of --target-bits, "
@@ -1269,48 +1350,12 @@ def main():
     print(f"[alloc] stats: {len(stats)} Linears, costs: {len(costs)} Linears")
 
     # ---- Fisher renormalization ----
-    # Older incremental probes finalized `h_trace = h_trace_raw /
-    # n_tokens_seen` PER ROW, where per-expert Linears only count their
-    # ROUTED tokens — inflating a rarely-routed expert's Fisher by
-    # (global/routed), up to ~33,000x, i.e. inverted importance weighting.
-    # The raw accumulators are stored, so recompute every derived field here
-    # with the one correct shared denominator: the global calib token count
-    # (probe meta nsamples x seqlen). Dense rows saw exactly that many
-    # tokens, so their values are unchanged; probes written by the fixed
-    # finalize (meta.fisher_norm_tokens) renormalize to identical values —
-    # the recompute is idempotent.
-    _meta = probe.get("meta", {}) or {}
-    _norm_tokens = int(_meta.get("fisher_norm_tokens", 0) or 0)
-    if _norm_tokens <= 0:
-        _norm_tokens = (int(_meta.get("nsamples", 0) or 0)
-                        * int(_meta.get("seqlen", 0) or 0))
-    if _norm_tokens > 0:
-        _renormed = 0
-        for _entry in stats.values():
-            if not isinstance(_entry, dict) or "h_trace_raw" not in _entry:
-                continue
-            _entry["h_trace"] = float(_entry["h_trace_raw"]) / _norm_tokens
-            if "h_w2_sum_raw" in _entry:
-                _entry["h_w2_sum"] = (
-                    float(_entry["h_w2_sum_raw"]) / _norm_tokens)
-            _per_raw = _entry.get("h_trace_per_expert_raw")
-            if _per_raw is not None:
-                _entry["h_trace_per_expert"] = [
-                    float(v) / _norm_tokens for v in _per_raw]
-            _renormed += 1
-        print(f"[alloc] Fisher renormalized: {_renormed}/{len(stats)} rows "
-              f"→ h_trace_raw / {_norm_tokens} global calib tokens "
-              "(per-expert routed-count normalization corrected)", flush=True)
-    else:
-        _needs_fix = sum(
-            1 for _e in stats.values()
-            if isinstance(_e, dict) and "h_trace_raw" in _e
-            and int(_e.get("n_tokens_seen", 0) or 0) > 0)
-        if _needs_fix:
-            print("[alloc] WARNING: probe meta lacks nsamples/seqlen; cannot "
-                  "renormalize h_trace by the global calib token count. "
-                  "Per-expert Fisher may be inflated by routed-token "
-                  "normalization.", flush=True)
+    # One shared denominator (the global calib token count) recomputed
+    # from the stored raw accumulators; hard error on probes that cannot
+    # be renormalized unless --allow-legacy-fisher-norm. See
+    # renormalize_probe_fisher for the full story.
+    renormalize_probe_fisher(stats, probe.get("meta", {}),
+                             allow_legacy=args.allow_legacy_fisher_norm)
 
     allow_pinned = [s.strip() for s in (args.allow_pinned or "").split(",") if s.strip()]
     allocation_excluded = []

--- a/prismaquant/incremental_measure_quant_cost.py
+++ b/prismaquant/incremental_measure_quant_cost.py
@@ -61,10 +61,10 @@ from .measure_quant_cost import (
     _finalize_results,
     _measure_packed_experts,
     _normalize_fisher_output_mse_row_weights,
-    canonical_linear_name,
     measure_batched_gpu,
     measure_unbatched,
     prepare_cost_context,
+    resolve_cost_target_name,
     start_mem_watchdog,
 )
 from .streaming_model import (
@@ -291,7 +291,7 @@ def _measure_production_render_dense(
     }
 
     for name, mod in module.named_modules():
-        canonical_name = canonical_linear_name(name, profile)
+        canonical_name = resolve_cost_target_name(name, target_names, profile)
         if not isinstance(mod, nn.Linear) or canonical_name not in target_names:
             continue
         if canonical_name not in act_cache:

--- a/prismaquant/incremental_probe.py
+++ b/prismaquant/incremental_probe.py
@@ -1208,12 +1208,10 @@ def _compute_global_precompute(
 
     for d in range(prefetch_depth):
         ctx.schedule_prefetch(d)
-    # v22 Fix E1: keep activations on device through phase-1 to avoid
-    # the per-layer .cpu() sync that stalls the forward pipeline. We
-    # batch the device→host transfer at the END of phase-1 in a single
-    # call. The pickled precompute cache (and downstream phase-3) want
-    # CPU tensors, which we produce after the loop.
-    device_acts: list[torch.Tensor] = [hidden.detach()]
+    # Phase-1 activations are captured to host per layer (see the note at
+    # the append below). The pickled precompute cache (and downstream
+    # phase-3) want CPU tensors, which this produces directly.
+    host_acts: list[torch.Tensor] = [hidden.detach().to("cpu")]
     for L in range(num_layers):
         load_t0 = time.time()
         src = ctx.install(L)
@@ -1234,7 +1232,13 @@ def _compute_global_precompute(
             )
         fwd_s = time.time() - fwd_t0
         hidden = out
-        device_acts.append(hidden.detach())
+        # Capture each activation to host inside the loop: stacking all
+        # L+1 activations device-resident before one .cpu() doubles the
+        # peak device memory of the activation working set, at the exact
+        # phase-1/2 transition where the probe's high-water mark already
+        # sits. The copy is per-layer and off the hot path (the layer
+        # forward dominates), so there is nothing worth batching.
+        host_acts.append(hidden.detach().to("cpu"))
         ctx.unload(L)
         if L % 8 == 0 or L == num_layers - 1:
             print(f"[incremental/global] fwd L{L:02d}  src={src}  "
@@ -1245,18 +1249,12 @@ def _compute_global_precompute(
     # phase-3's isolated forwards can reconstruct it.
     shared_pass_state = _profile.capture_forward_pass_state(pass_state)
 
-    # v22 Fix E1: batched device→host transfer for the activations
-    # captured during phase-1. All have the same (B, T, H) shape so we
-    # stack into one (L+1, B, T, H) tensor and do a single .cpu() —
-    # 62 individual transfers collapsed into one. After the copy lands,
-    # we split back into a list of CPU tensors so the rest of the code
-    # (precompute cache pickle, phase-3 reads) sees the original layout.
+    # (v22 Fix E1 — the batched stack-then-.cpu() transfer — is intentionally
+    # NOT used here: activations are captured host-side per layer in the
+    # loop above, so they are already CPU tensors in the expected layout.)
     t_h2h = time.time()
-    stacked = torch.stack(device_acts, dim=0).cpu()
-    activations_cpu: list[torch.Tensor] = [
-        stacked[i].clone() for i in range(stacked.size(0))
-    ]
-    del device_acts, stacked
+    activations_cpu: list[torch.Tensor] = host_acts
+    host_acts = []
     print(f"[incremental/global] phase-1 forward: {time.time()-t_phase:.1f}s  "
           f"(host transfer {time.time()-t_h2h:.1f}s)  "
           f"{ctx.layer_cache.summary()}", flush=True)

--- a/prismaquant/incremental_probe.py
+++ b/prismaquant/incremental_probe.py
@@ -1524,6 +1524,35 @@ def _load_precompute_cache(path: Path, expected_meta: dict[str, Any],
     )
 
 
+def finalize_fisher_stats(merged_stats: dict, global_tokens: int) -> None:
+    """Normalize raw Fisher accumulators into ``h_trace`` (etc.), in place.
+
+    Fisher normalization must share ONE denominator across every row: the
+    global calibration token count (nsamples x seqlen). Dense trunk Linears
+    accumulate exactly that many tokens in ``n_tokens_seen``, so their
+    values are unchanged by dividing by the global count. Per-expert
+    Linears, however, only see their ROUTED tokens; a per-row
+    ``h_trace_raw / n_tokens_seen`` inflates a rarely-routed expert's
+    Fisher by (global/routed) — exactly inverted importance weighting (the
+    least-used experts look the most sensitive). Tokens never routed to an
+    expert contribute zero gradient, so the empirical Fisher over the
+    calibration set divides by the GLOBAL count for every row.
+    ``n_tokens_seen`` is kept raw (routed count) — the h_detail blob writer
+    still normalizes per-Linear and stamps units="per_token" for its own
+    single-tensor consumers.
+    """
+    for s in merged_stats.values():
+        s["h_trace"] = s.get("h_trace_raw", 0.0) / global_tokens
+        s["h_w2_sum"] = s.get("h_w2_sum_raw", 0.0) / global_tokens
+        # Per-expert Fisher trace (only present on packed-3D stat entries;
+        # dense Linears have no per-expert dimension). Normalize by the
+        # same token count so it shares units with `h_trace`.
+        per = s.get("h_trace_per_expert_raw")
+        if per is not None:
+            s["h_trace_per_expert"] = [float(v) / global_tokens for v in per]
+        s["h_trace_norm_tokens"] = global_tokens
+
+
 # ---------------------------------------------------------------------------
 # Per-shard body runner — phase-3 of streaming_probe, scoped to the
 # Linears matching this shard's regex. Phase-1 + Phase-2 are now global
@@ -2473,16 +2502,11 @@ def _run_body_streaming_shard(
         del grad_at_tail, grad_out
 
     # ---- Finalize ----
-    for s in merged_stats.values():
-        tokens = max(s.get("n_tokens_seen", 1), 1)
-        s["h_trace"] = s.get("h_trace_raw", 0.0) / tokens
-        s["h_w2_sum"] = s.get("h_w2_sum_raw", 0.0) / tokens
-        # Per-expert Fisher trace (only present on packed-3D stat entries;
-        # dense Linears have no per-expert dimension). Normalize by the
-        # same token count so it shares units with `h_trace`.
-        per = s.get("h_trace_per_expert_raw")
-        if per is not None:
-            s["h_trace_per_expert"] = [float(v) / tokens for v in per]
+    # One shared denominator for every row — the global calib token count
+    # (see finalize_fisher_stats for why per-row n_tokens_seen is wrong
+    # for routed-expert Linears).
+    global_tokens = max(int(calib.size(0)) * int(seqlen), 1)
+    finalize_fisher_stats(merged_stats, global_tokens)
 
     detail_dir = Path(h_detail_dir) if h_detail_dir else None
     if detail_dir is not None:
@@ -2587,6 +2611,9 @@ def _run_body_streaming_shard(
                 "activation_rows_limit": int(activation_rows_limit),
                 "linear_include": linear_include,
                 "linear_exclude": linear_exclude,
+                # Marker: h_trace/h_w2_sum/h_trace_per_expert are divided by
+                # the GLOBAL calib token count (not per-row n_tokens_seen).
+                "fisher_norm_tokens": global_tokens,
             },
         }, f)
     print(f"[incremental] wrote {out_path}", flush=True)

--- a/prismaquant/incremental_probe.py
+++ b/prismaquant/incremental_probe.py
@@ -75,6 +75,7 @@ from .sensitivity_probe import (
     FisherAccumulator,
     RouterTracker,
     discover_moe_structure,
+    finalize_fisher_stats,
     h_detail_blob,
     install_packed_expert_hooks,
     load_calibration,
@@ -1524,33 +1525,11 @@ def _load_precompute_cache(path: Path, expected_meta: dict[str, Any],
     )
 
 
-def finalize_fisher_stats(merged_stats: dict, global_tokens: int) -> None:
-    """Normalize raw Fisher accumulators into ``h_trace`` (etc.), in place.
-
-    Fisher normalization must share ONE denominator across every row: the
-    global calibration token count (nsamples x seqlen). Dense trunk Linears
-    accumulate exactly that many tokens in ``n_tokens_seen``, so their
-    values are unchanged by dividing by the global count. Per-expert
-    Linears, however, only see their ROUTED tokens; a per-row
-    ``h_trace_raw / n_tokens_seen`` inflates a rarely-routed expert's
-    Fisher by (global/routed) — exactly inverted importance weighting (the
-    least-used experts look the most sensitive). Tokens never routed to an
-    expert contribute zero gradient, so the empirical Fisher over the
-    calibration set divides by the GLOBAL count for every row.
-    ``n_tokens_seen`` is kept raw (routed count) — the h_detail blob writer
-    still normalizes per-Linear and stamps units="per_token" for its own
-    single-tensor consumers.
-    """
-    for s in merged_stats.values():
-        s["h_trace"] = s.get("h_trace_raw", 0.0) / global_tokens
-        s["h_w2_sum"] = s.get("h_w2_sum_raw", 0.0) / global_tokens
-        # Per-expert Fisher trace (only present on packed-3D stat entries;
-        # dense Linears have no per-expert dimension). Normalize by the
-        # same token count so it shares units with `h_trace`.
-        per = s.get("h_trace_per_expert_raw")
-        if per is not None:
-            s["h_trace_per_expert"] = [float(v) / global_tokens for v in per]
-        s["h_trace_norm_tokens"] = global_tokens
+# `finalize_fisher_stats` lives in sensitivity_probe (next to
+# h_detail_blob, so both probe backends and every h-detail writer share
+# the single global-token normalization convention); it is re-exported
+# here because this module is the production backend consumers import
+# it from.
 
 
 # ---------------------------------------------------------------------------
@@ -1657,6 +1636,11 @@ def _run_body_streaming_shard(
           f"across {sum(1 for x in layer_linear_names if x)} layers "
           f"+ {len(resident_linears)} resident Linears "
           f"(include={linear_include!r})", flush=True)
+
+    # One shared Fisher denominator for every row AND every h-detail blob
+    # — the global calib token count (see finalize_fisher_stats for why
+    # per-row n_tokens_seen is wrong for routed-expert Linears).
+    global_tokens = max(int(calib.size(0)) * int(seqlen), 1)
 
     top_k = read_top_k(model, default=2)
 
@@ -2444,13 +2428,15 @@ def _run_body_streaming_shard(
                     full_key = f"{layer_prefix}{local_key}"
                     fname = re.sub(r"[^A-Za-z0-9_-]", "__", full_key) + ".pt"
                     # Per-token units + explicit marker (audit M9): the
-                    # accumulator is token-summed; normalize by this
-                    # layer's token count so the blob matches the
-                    # sensitivity-probe writer's units.
-                    entry = acc_stats.get(full_key, {})
+                    # accumulator is token-summed; normalize by the
+                    # GLOBAL calib token count — the same denominator the
+                    # scalar h_trace gets in finalize_fisher_stats.
+                    # (Packed-3D rows count the full batch in
+                    # n_tokens_seen, so this is numerically identical to
+                    # the previous per-row count; global is used for
+                    # uniformity with the per-expert-Linear writers.)
                     torch.save(
-                        h_detail_blob(tensor,
-                                      int(entry.get("n_tokens_seen", 0)),
+                        h_detail_blob(tensor, global_tokens,
                                       full_key, kind="packed"),
                         detail_dir / fname)
                 packed_full_acc.clear()
@@ -2503,9 +2489,8 @@ def _run_body_streaming_shard(
 
     # ---- Finalize ----
     # One shared denominator for every row — the global calib token count
-    # (see finalize_fisher_stats for why per-row n_tokens_seen is wrong
-    # for routed-expert Linears).
-    global_tokens = max(int(calib.size(0)) * int(seqlen), 1)
+    # (hoisted above; see finalize_fisher_stats for why per-row
+    # n_tokens_seen is wrong for routed-expert Linears).
     finalize_fisher_stats(merged_stats, global_tokens)
 
     detail_dir = Path(h_detail_dir) if h_detail_dir else None
@@ -2522,12 +2507,15 @@ def _run_body_streaming_shard(
             # used to save the raw token-summed accumulator under "H",
             # leaving HDetailIndex consumers ~n_tokens× hotter than
             # blobs from sensitivity_probe. h_detail_blob normalizes by
-            # the tokens this Linear actually saw and stamps
-            # units="per_token"; g2_per_token stays raw (it is already
-            # a per-token vector).
-            tokens = int(merged_stats.get(fqn, {}).get("n_tokens_seen", 0))
+            # the GLOBAL calib token count — the same denominator the
+            # scalar h_trace gets in finalize_fisher_stats above, so
+            # predicted_dloss fallback rows built from these blobs stay
+            # on the scalar's scale (per-expert nn.Linear rows only see
+            # their ROUTED tokens; dividing by that per-row count left
+            # the detail (global/routed)× hotter than the scalar).
+            # g2_per_token stays raw (it is already a per-token vector).
             torch.save(
-                h_detail_blob(h, tokens, fqn, kind="linear",
+                h_detail_blob(h, global_tokens, fqn, kind="linear",
                               g2_per_token=g2_per_token),
                 detail_dir / fname,
             )
@@ -2821,7 +2809,11 @@ def _run_mtp_streaming_shard(
         if device.type == "cuda":
             torch.cuda.empty_cache()
 
-    acc.finalize(tracker=None)
+    # Global calib token count, matching the meta nsamples×seqlen product
+    # below (the MTP shift trims 2 tokens/sample — a uniform constant, and
+    # keeping the meta product keeps the allocator renorm idempotent).
+    fisher_norm_tokens = max(int(calib.size(0)) * int(seqlen), 1)
+    acc.finalize(tracker=None, global_tokens=fisher_norm_tokens)
     acc.remove_hooks()
 
     renamed = dict(acc.stats)
@@ -2841,6 +2833,7 @@ def _run_mtp_streaming_shard(
                 "dataset": dataset_name,
                 "nsamples": int(calib.size(0)),
                 "seqlen": seqlen,
+                "fisher_norm_tokens": fisher_norm_tokens,
                 "dtype": dtype_name,
                 "device_map": "streaming-layerwise",
                 "execution_device": str(device),

--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -1519,7 +1519,13 @@ def _call_layer(layer: nn.Module, hidden: torch.Tensor, *,
         lt = _layer_attention_type(layer)
         pe = pe.get(lt)
         if pe is None:
-            if len(position_embeddings) == 1:
+            if "main" in position_embeddings:
+                # DSv4: rotary.layer_types are rope AXES ("main"/"compress"),
+                # not attention-schedule types — the vendored probe forward
+                # feeds layer_type="main" rope to every decoder layer (the
+                # compress branch is stubbed out in probe mode).
+                pe = position_embeddings["main"]
+            elif len(position_embeddings) == 1:
                 pe = next(iter(position_embeddings.values()))
             else:
                 raise RuntimeError(

--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -457,7 +457,11 @@ def _apply_fp8_dequant_inplace(
     """For each tensor in `out` whose key matches a `fp8_scale_inv_map`
     entry, read the scale_inv, apply the checkpoint-declared block
     dequant (`fp8_scale_inv_map.block`, see `_fp8_dequant_block`), and
-    replace the loaded tensor with the dequanted bf16 weight.
+    replace the loaded tensor with the dequanted bf16 weight. MXFP4
+    tensors (OCP MX FP4 E2M1 nibble pairs with per-32-element E8M0
+    scales, e.g. DSv4-Flash routed experts) are detected by signature
+    and dequanted on a dedicated path (step 3b) instead of the
+    block-FP8 broadcast.
 
     Tensors and scales are both grouped by shape and multiplied in a
     single batched 5-D broadcast op per shape-group. On MiniMax-M2.7
@@ -495,8 +499,19 @@ def _apply_fp8_dequant_inplace(
     block_r, block_c = _fp8_dequant_block(fp8_scale_inv_map)
     by_shape: dict[tuple[int, int], list[str]] = defaultdict(list)
     fallback: list[str] = []
+    mxfp4_names: list[str] = []
     for name in loaded_scales:
         w = out[name]
+        # DSv4-Flash routed experts are MXFP4, not block-FP8: E2M1 nibble
+        # pairs packed into int8 (low nibble = even element) with per-row
+        # E8M0 scales over 32 logical elements. Signature: int8 weight +
+        # scale grid (out, packed_in/16). Handled in step 3b below.
+        if (w.dim() == 2 and w.dtype == torch.int8
+                and loaded_scales[name].dim() == 2
+                and loaded_scales[name].shape[0] == w.shape[0]
+                and loaded_scales[name].shape[1] * 16 == w.shape[1]):
+            mxfp4_names.append(name)
+            continue
         if w.dim() != 2:
             fallback.append(name)
             continue
@@ -542,6 +557,32 @@ def _apply_fp8_dequant_inplace(
             out[n] = dequanted_stack[i].contiguous()
         dequanted += E
         del w_stack, s_stack, w4, s4, dequanted_stack
+
+    # Step 3b: MXFP4 tensors (DSv4-Flash routed experts). Vectorized
+    # nibble unpack + per-32-element E8M0 scale, per the OCP Microscaling
+    # Formats (MX) v1.0 spec: FP4 E2M1 element grid ({0, 0.5, 1, 1.5, 2,
+    # 3, 4, 6} with a sign bit), one shared E8M0 power-of-two scale per
+    # 32-element group.
+    if mxfp4_names:
+        lut = torch.tensor(
+            [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+             0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+            dtype=torch.bfloat16, device=device)
+        for name in mxfp4_names:
+            wp = out[name].to(device=device).view(torch.uint8)
+            rows, packed_in = wp.shape
+            logical_in = packed_in * 2
+            deq = torch.empty(rows, logical_in, dtype=torch.bfloat16,
+                              device=device)
+            deq[:, 0::2] = lut[(wp & 0x0F).to(torch.long)]
+            deq[:, 1::2] = lut[(wp >> 4).to(torch.long)]
+            sb = loaded_scales[name].to(device=device).view(torch.uint8)
+            scale = torch.exp2((sb.to(torch.float32) - 127.0))
+            deq = (deq.reshape(rows, logical_in // 32, 32).to(torch.float32)
+                   * scale.unsqueeze(-1)).to(torch.bfloat16)
+            out[name] = deq.reshape(rows, logical_in).contiguous()
+            dequanted += 1
+            del wp, deq, sb, scale
 
     # Step 4: Fallback path for any shapes we didn't batch.
     for name in fallback:

--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -1649,12 +1649,24 @@ def _compute_attention_mask(
             cfg.sliding_window
         )
 
-    return {
+    masks = {
         "full_attention": create_causal_mask(**mask_kwargs),
         "sliding_attention": create_sliding_window_causal_mask(
             **sliding_mask_kwargs
         ),
     }
+    # DSv4-Flash: the compress-ratio ladder yields layer types beyond the
+    # Gemma pair — compressed_sparse_attention (ratio 4) and
+    # heavily_compressed_attention (ratio 128). In probe mode every
+    # compressed variant degrades to sliding-window-only attention (the
+    # vendored layer stubs out the compressor and skips the long-range
+    # branch), and the vendored root feeds one sliding-window mask to all
+    # layers. Alias exactly those two types to the sliding mask; any
+    # other unknown layer type still fails loudly downstream.
+    for lt in ("compressed_sparse_attention", "heavily_compressed_attention"):
+        if lt in layer_types and lt not in masks:
+            masks[lt] = masks["sliding_attention"]
+    return masks
 
 
 def _resolve_base_prefix(root: nn.Module, base: nn.Module) -> str:

--- a/prismaquant/measure_quant_cost.py
+++ b/prismaquant/measure_quant_cost.py
@@ -291,18 +291,21 @@ class HDetailIndex:
     @staticmethod
     def h_diag_from_blob(blob: dict) -> torch.Tensor:
         """Return the Fisher diagonal from an h-detail blob, in PER-TOKEN
-        units.
+        units (v4: per GLOBAL calibration token).
 
         Both writers (`sensitivity_probe.FisherAccumulator.finalize` and
-        `incremental_probe`) now normalize by token count and stamp
+        `incremental_probe`) normalize by the GLOBAL calib token count —
+        the same denominator as the scalar ``h_trace`` — and stamp
         ``units: "per_token"`` via `sensitivity_probe.h_detail_blob`
-        (audit M9). Legacy blobs without the marker:
+        (audits M9 + the PR #14 global-denominator fix). Legacy blobs:
 
-          - ``h_diag``: accepted as per-token — that writer always
-            divided by token count. Caveat: pre-v3 sensitivity blobs for
-            UNPACKED expert Linears additionally divided by route_prob
-            (audit M4) and are indistinguishable from the blob alone;
-            regenerate such h-detail dirs if expert rows matter.
+          - v3 ``h_diag`` (or unmarked): accepted as per-token. Caveats,
+            both undetectable from the blob alone — regenerate the
+            h-detail dir if expert rows matter: (a) v3 blobs for
+            UNPACKED per-expert Linears divided by the row's ROUTED
+            token count, (global/routed)× hotter than the v4/scalar
+            scale; (b) pre-v3 sensitivity blobs for those rows
+            additionally divided by route_prob (audit M4).
           - raw ``H``: the old incremental writer's token-SUMMED
             accumulator — ~n_tokens× hot for this consumer. Refuse
             rather than silently mis-scale predicted_dloss; regenerate

--- a/prismaquant/measure_quant_cost.py
+++ b/prismaquant/measure_quant_cost.py
@@ -72,6 +72,117 @@ def canonical_linear_name(name: str, profile=None) -> str:
     return f"{prefix}.{parent}.{expert_id}"
 
 
+def resolve_cost_target_name(name: str, target_names: set[str],
+                             profile=None) -> str:
+    """Cost-row key for a live module name, honoring raw-name probes.
+
+    ``canonical_linear_name`` remaps per-expert live names to packed-style
+    names (``experts.gate_up_proj.E`` / ``experts.down_proj.E``). Models
+    whose probe keys per-expert Linears under the RAW live names
+    (DSv4-Flash) would then miss ``target_names`` and every routed expert
+    would be silently skipped. Fall back to the raw live name when the
+    remapped name misses but the raw name is a target.
+    """
+    canonical = canonical_linear_name(name, profile)
+    if canonical not in target_names and name in target_names:
+        return name
+    return canonical
+
+
+_PER_EXPERT_NAME_RE = re.compile(r"^(.+\.experts)\.(\d+)\.([^.]+)$")
+
+
+def _expert_cost_sample_n() -> int:
+    """PRISMAQUANT_EXPERT_COST_SAMPLE: stratified experts-per-(layer,
+    projection) sample for cost measurement; 0 (default) measures every
+    expert. Shared by the packed-stack path and the per-expert dense path."""
+    return int(os.environ.get(
+        "PRISMAQUANT_EXPERT_COST_SAMPLE",
+        os.environ.get("PRISMAQUANT_GGUF_EXPERT_COST_SAMPLE", "0"),
+    ) or 0)
+
+
+def _expert_cost_sample_split(
+    target_names: set[str],
+) -> tuple[set[str], dict[str, list[str]]]:
+    """Stratified expert subsample for UNPACKED per-expert MoE Linears.
+
+    The dense analog of the packed-stack lever at `_measure_packed_experts`:
+    models whose experts live as per-expert nn.Linears (DSv4-Flash: 256
+    experts x 3 projections x 43 layers) would push every expert tensor
+    through the exhaustive-grid IQ search = days. Measure only a
+    deterministic, evenly spaced sample of expert ids per (experts-prefix,
+    projection) group — the same linspace rule the packed path applies to
+    stack rows — and extrapolate the rest (see _extrapolate_expert_costs).
+    Like the packed path, this only affects the allocator's cost estimates;
+    export always quantizes every expert exactly.
+
+    Returns (names_to_measure, extrapolate) where `extrapolate` maps each
+    skipped per-expert name to the sorted sampled names of its group.
+    """
+    sample_n = _expert_cost_sample_n()
+    measure = set(target_names)
+    if sample_n <= 0:
+        return measure, {}
+    groups: dict[tuple[str, str], list[tuple[int, str]]] = {}
+    for name in target_names:
+        m = _PER_EXPERT_NAME_RE.match(name)
+        if m:
+            groups.setdefault((m.group(1), m.group(3)), []).append(
+                (int(m.group(2)), name))
+    extrapolate: dict[str, list[str]] = {}
+    for members in groups.values():
+        if len(members) <= sample_n:
+            continue
+        members.sort()
+        idx = torch.linspace(
+            0, len(members) - 1, sample_n,
+        ).round().long().unique().tolist()
+        sampled = sorted(members[i][1] for i in idx)
+        sampled_set = set(sampled)
+        for _eid, name in members:
+            if name not in sampled_set:
+                measure.discard(name)
+                extrapolate[name] = sampled
+    return measure, extrapolate
+
+
+def _extrapolate_expert_costs(
+    results: dict, extrapolate: dict[str, list[str]],
+) -> None:
+    """Fill skipped per-expert cost rows with their group's sampled mean.
+
+    Mirrors the packed path, where one sampled measurement prices the whole
+    expert stack: every expert must keep a cost row, because the allocator
+    drops row-less names entirely (build_candidates), which would silently
+    shrink the DP's bit/disk accounting and the serving-unit membership.
+    """
+    for name, sources in extrapolate.items():
+        merged: dict[str, dict] = {}
+        fmt_names: set[str] = set()
+        for src in sources:
+            fmt_names.update(results.get(src, {}))
+        for fmt in fmt_names:
+            entries = [
+                results[src][fmt] for src in sources
+                if fmt in results.get(src, {})
+                and "error" not in results[src][fmt]
+            ]
+            if not entries:
+                continue
+            out: dict[str, object] = {"expert_cost_extrapolated": True}
+            for key in ("weight_mse", "output_mse", "rel_output_mse",
+                        "predicted_dloss", "fisher_output_mse"):
+                vals = [float(e[key]) for e in entries if key in e]
+                if vals:
+                    out[key] = sum(vals) / len(vals)
+            if any(e.get("output_mse_measured") is False for e in entries):
+                out["output_mse_measured"] = False
+            merged[fmt] = out
+        if merged:
+            results[name] = merged
+
+
 def _accumulate_result(bucket: dict, name: str, fmt: str,
                        weight_mse: float, output_mse: float,
                        rel_output_mse: float,
@@ -442,12 +553,12 @@ def measure_unbatched(model: nn.Module, act_cache: "ActivationIndex",
     accum: dict[str, dict[str, dict]] = {}
     processed = 0
     tstart = time.time()
-    target_list = list(target_names)
-    n_total = len(target_list)
+    measure_names, expert_extrapolate = _expert_cost_sample_split(target_names)
+    n_total = len(measure_names)
 
     for name, mod in model.named_modules():
-        canonical_name = canonical_linear_name(name, profile)
-        if not isinstance(mod, nn.Linear) or canonical_name not in target_names:
+        canonical_name = resolve_cost_target_name(name, target_names, profile)
+        if not isinstance(mod, nn.Linear) or canonical_name not in measure_names:
             continue
         if canonical_name not in act_cache:
             continue
@@ -524,7 +635,9 @@ def measure_unbatched(model: nn.Module, act_cache: "ActivationIndex",
             elapsed = time.time() - tstart
             eta = elapsed / processed * (n_total - processed)
             print(f"[cost] {processed}/{n_total} eta={eta:.0f}s", flush=True)
-    return _finalize_results(accum)
+    results = _finalize_results(accum)
+    _extrapolate_expert_costs(results, expert_extrapolate)
+    return results
 
 
 # ---------------------------------------------------------------------------
@@ -540,7 +653,7 @@ def _group_by_shape(model: nn.Module, target_names: set[str], profile=None
     """
     groups: dict[tuple[int, int], list[tuple[str, nn.Linear]]] = {}
     for name, mod in model.named_modules():
-        canonical_name = canonical_linear_name(name, profile)
+        canonical_name = resolve_cost_target_name(name, target_names, profile)
         if not isinstance(mod, nn.Linear) or canonical_name not in target_names:
             continue
         key = (mod.in_features, mod.out_features)
@@ -962,10 +1075,7 @@ def _measure_packed_experts(
         # less quantize work (IQ exhaustive-grid on 3.5G-elem stacks is
         # ~25 min/layer at full E — 2026-07-11). Export always quantizes
         # every expert exactly; this only affects the DP's cost estimates.
-        sample_n = int(os.environ.get(
-            "PRISMAQUANT_EXPERT_COST_SAMPLE",
-            os.environ.get("PRISMAQUANT_GGUF_EXPERT_COST_SAMPLE", "0"),
-        ) or 0)
+        sample_n = _expert_cost_sample_n()
         for spec in specs:
             try:
                 # Family-agnostic: NVFP4/FP8 registry quantize on a full
@@ -1274,10 +1384,16 @@ def measure_batched_gpu(model: nn.Module, act_cache: "ActivationIndex",
     `fisher_output_mse` from `g2_per_token` when those tensors are present.
     """
     dev = torch.device(device)
-    groups = _group_by_shape(model, target_names, profile)
+    # Stratified per-expert subsample (PRISMAQUANT_EXPERT_COST_SAMPLE) for
+    # unpacked MoE Linears; skipped experts get their group's sampled mean
+    # after finalize, so downstream coverage matches a full measurement.
+    measure_names, expert_extrapolate = _expert_cost_sample_split(target_names)
+    groups = _group_by_shape(model, measure_names, profile)
     total_linears = sum(len(v) for v in groups.values())
     print(f"[cost] batched: {len(groups)} shape groups, "
-          f"{total_linears} Linears total", flush=True)
+          f"{total_linears} Linears total"
+          + (f" (expert sample: {len(expert_extrapolate)} extrapolated)"
+             if expert_extrapolate else ""), flush=True)
 
     accum: dict[str, dict[str, dict]] = {}
     processed = 0
@@ -1501,7 +1617,9 @@ def measure_batched_gpu(model: nn.Module, act_cache: "ActivationIndex",
                       flush=True)
     if _prefetch_pool is not None:
         _prefetch_pool.shutdown(wait=False)
-    return _finalize_results(accum)
+    results = _finalize_results(accum)
+    _extrapolate_expert_costs(results, expert_extrapolate)
+    return results
 
 
 def prepare_cost_context(probe_path: str,

--- a/prismaquant/sensitivity_probe.py
+++ b/prismaquant/sensitivity_probe.py
@@ -451,11 +451,19 @@ def load_multimodal_calibration(
 _ALLOW_SUMSQ_PACKED_FISHER_ENV = "PRISMAQUANT_ALLOW_SUMSQ_PACKED_FISHER"
 
 
-def h_detail_blob(h_raw: torch.Tensor, n_tokens: int, name: str, *,
+def h_detail_blob(h_raw: torch.Tensor, global_tokens: int, name: str, *,
                   kind: str = "linear",
                   g2_per_token: torch.Tensor | None = None) -> dict:
     """Normalize a token-SUMMED Fisher diagonal accumulator to per-token
     units and wrap it in the canonical h-detail blob schema.
+
+    ``global_tokens`` must be the GLOBAL calibration token count — the
+    same denominator `finalize_fisher_stats` applies to the scalar
+    ``h_trace`` — never a per-row routed-token count. v4 pins this:
+    passing an unpacked expert Linear's own ``n_tokens_seen`` here left
+    the detail blob (global/routed)× hotter than the scalar it must
+    agree with, so `predicted_dloss` fallback rows priced expert rows on
+    a different scale than the rest of the knapsack.
 
     Every h-detail writer (this module's `FisherAccumulator.finalize` and
     `incremental_probe`'s two writer sites) goes through this helper so
@@ -466,7 +474,7 @@ def h_detail_blob(h_raw: torch.Tensor, n_tokens: int, name: str, *,
     probe produced the directory). ``g2_per_token`` is already a
     per-token vector and is stored as-is.
     """
-    tokens = max(int(n_tokens), 1)
+    tokens = max(int(global_tokens), 1)
     h = h_raw.detach().to("cpu", torch.float32) / tokens
     blob = {
         "h_diag": h,
@@ -474,11 +482,56 @@ def h_detail_blob(h_raw: torch.Tensor, n_tokens: int, name: str, *,
         "kind": kind,
         "shape": list(h.shape),
         "units": "per_token",
-        "h_detail_version": 3,   # v3: unit marker; no route_prob term (M4)
+        # v3: unit marker; no route_prob term (M4).
+        # v4: denominator is the GLOBAL calib token count for every row
+        #     (v3 unpacked-expert blobs were per-ROUTED-token).
+        "h_detail_version": 4,
+        "norm_tokens": tokens,
     }
     if g2_per_token is not None:
         blob["g2_per_token"] = g2_per_token
     return blob
+
+
+def finalize_fisher_stats(merged_stats: dict, global_tokens: int) -> None:
+    """Normalize raw Fisher accumulators into ``h_trace`` (etc.), in place.
+
+    Fisher normalization must share ONE denominator across every row: the
+    global calibration token count (nsamples x seqlen). Dense trunk Linears
+    accumulate exactly that many tokens in ``n_tokens_seen``, so their
+    values are unchanged by dividing by the global count. Per-expert
+    Linears, however, only see their ROUTED tokens; a per-row
+    ``h_trace_raw / n_tokens_seen`` inflates a rarely-routed expert's
+    Fisher by (global/routed) — exactly inverted importance weighting (the
+    least-used experts look the most sensitive). Tokens never routed to an
+    expert contribute zero gradient, so the empirical Fisher over the
+    calibration set divides by the GLOBAL count for every row.
+
+    HISTORY — this deliberately REVERSES a documented convention. Audit M4
+    removed an explicit ÷route_prob on the grounds that dividing by the
+    routed-token count was "the one implicit ÷token-fraction the MoE
+    convention prescribes", and both backends then shipped per-routed-token
+    as the single normalization (pinned by the original
+    tests/test_packed_expert_per_token_fisher.py). M4's *agreement* goal
+    stands — one division, both backends, route_prob as metadata only —
+    but per-routed-token was the wrong denominator for the mean-Δloss
+    objective the allocator optimizes: it is the same 1/p_e inflation M4
+    removed, merely implicit. CLAUDE.md §3 records the same reversal.
+
+    ``n_tokens_seen`` stays raw (routed count, metadata). Every h-detail
+    blob is normalized by the SAME global count (`h_detail_blob` v4) so
+    scalar and per-weight detail Fisher share one denominator.
+    """
+    for s in merged_stats.values():
+        s["h_trace"] = s.get("h_trace_raw", 0.0) / global_tokens
+        s["h_w2_sum"] = s.get("h_w2_sum_raw", 0.0) / global_tokens
+        # Per-expert Fisher trace (only present on packed-3D stat entries;
+        # dense Linears have no per-expert dimension). Normalize by the
+        # same token count so it shares units with `h_trace`.
+        per = s.get("h_trace_per_expert_raw")
+        if per is not None:
+            s["h_trace_per_expert"] = [float(v) / global_tokens for v in per]
+        s["h_trace_norm_tokens"] = global_tokens
 
 
 def _scalar_acc_add(acc: dict, name: str, value: torch.Tensor) -> None:
@@ -1806,7 +1859,7 @@ class FisherAccumulator:
             self.stats[name]["n_tokens_seen"] += T
         return hook
 
-    def finalize(self, tracker: RouterTracker | None):
+    def finalize(self, tracker: RouterTracker | None, global_tokens: int):
         # Flush GPU-resident scalar accumulators (h_trace, h_w2_sum) into
         # the stats dict. Single sync per Linear here costs one CUDA stall
         # per name, vs. thousands during the backward sweep without it.
@@ -1832,18 +1885,22 @@ class FisherAccumulator:
                         s["router_path"], s["expert_id"])
 
         # Single normalization convention (matches incremental_probe, the
-        # production backend): divide by the tokens this entry actually
-        # saw. For unpacked expert Linears `n_tokens_seen` counts ROUTED
-        # tokens, so this is already the per-routed-token mean — i.e. the
-        # one implicit ÷token-fraction the MoE convention prescribes.
-        # A second explicit ÷route_prob (removed here; audit M4) made
-        # this backend disagree with incremental_probe by ~1/p_e and
-        # overweighted sparse-expert rows in the same knapsack.
+        # production backend): ONE shared denominator for every row — the
+        # GLOBAL calibration token count.
+        #
+        # HISTORY: this deliberately reverses the per-`n_tokens_seen`
+        # division that audit M4 documented as "the one implicit
+        # ÷token-fraction the MoE convention prescribes" (the explicit
+        # ÷route_prob was removed then precisely because the implicit
+        # per-routed-token division already applied it). That reading was
+        # wrong for the mean-Δloss objective: tokens never routed to an
+        # expert contribute zero gradient, so dividing an unpacked expert
+        # row by its ROUTED count inflates it by (global/routed) — the
+        # very 1/p_e overweighting M4 set out to remove, merely implicit.
+        # See finalize_fisher_stats for the full derivation + history.
         # `route_prob` stays in the stats as metadata only.
-        for s in self.stats.values():
-            tokens = max(s["n_tokens_seen"], 1)
-            s["h_trace"] = s["h_trace_raw"] / tokens
-            s["h_w2_sum"] = s["h_w2_sum_raw"] / tokens
+        global_tokens = max(int(global_tokens), 1)
+        finalize_fisher_stats(self.stats, global_tokens)
 
         if self.cache_dir is not None:
             self.cache_dir.mkdir(parents=True, exist_ok=True)
@@ -1884,11 +1941,14 @@ class FisherAccumulator:
             for name, acc in self._h_full.items():
                 if name not in self.stats:
                     continue
-                tokens = max(self.stats[name]["n_tokens_seen"], 1)
-                # Same normalization as the scalar trace: per (routed)
-                # token only. (A pre-v3 revision additionally divided
-                # expert entries by route_prob — audit M4; such h-detail
-                # dirs are in different units and must be regenerated.)
+                # Same denominator as the scalar trace: the GLOBAL calib
+                # token count (v4). A v3-era revision divided by this
+                # row's own n_tokens_seen — per-ROUTED-token for unpacked
+                # expert Linears, (global/routed)× hotter than the scalar
+                # — and a pre-v3 revision additionally divided expert
+                # entries by route_prob (audit M4). h-detail dirs from
+                # either era are in different units on expert rows and
+                # must be regenerated.
                 #
                 # Per-token gradient² (g²_t) — concatenate the chunk vectors
                 # collected during the hook. This is the per-token Fisher
@@ -1899,21 +1959,22 @@ class FisherAccumulator:
                                 else torch.empty(0, dtype=torch.float32))
                 fname = sub.sub("__", name) + ".pt"
                 torch.save(
-                    h_detail_blob(acc, tokens, name, kind="linear",
+                    h_detail_blob(acc, global_tokens, name, kind="linear",
                                   g2_per_token=g2_per_token),
                     self.h_detail_dir / fname)
                 self.stats[name]["h_detail_path"] = fname
             for full_name, ch in self._h_packed_channel.items():
                 if full_name not in self.stats:
                     continue
-                tokens = max(self.stats[full_name]["n_tokens_seen"], 1)
                 # Packed experts don't carry a router_path — routing is
                 # baked into the Fisher signal via how often each expert
-                # was selected. Normalize by token count only. (The
-                # channel accumulator may be device-resident; h_detail_blob
-                # lands it on CPU for the saved blob.)
+                # was selected. Normalize by the global token count, same
+                # as the scalar. (The channel accumulator may be
+                # device-resident; h_detail_blob lands it on CPU for the
+                # saved blob.)
                 fname = sub.sub("__", full_name) + ".pt"
-                torch.save(h_detail_blob(ch, tokens, full_name, kind="packed"),
+                torch.save(h_detail_blob(ch, global_tokens, full_name,
+                                         kind="packed"),
                            self.h_detail_dir / fname)
                 self.stats[full_name]["h_detail_path"] = fname
 
@@ -2272,7 +2333,11 @@ def run_probe_pass(model: nn.Module,
         del out, loss, ids, embed, logits
         acc._saved_inputs.clear()
 
-    acc.finalize(tracker)
+    # Global calib token count — must equal the meta nsamples×seqlen
+    # product below so the allocator's load-time renormalization is
+    # idempotent on probes written by this finalize.
+    fisher_norm_tokens = int(calib.size(0)) * int(seqlen)
+    acc.finalize(tracker, fisher_norm_tokens)
     acc.remove_hooks()
     if tracker is not None:
         tracker.remove_hooks()
@@ -2293,6 +2358,7 @@ def run_probe_pass(model: nn.Module,
                 "dataset": dataset_name,
                 "nsamples": calib.size(0),
                 "seqlen": seqlen,
+                "fisher_norm_tokens": fisher_norm_tokens,
                 "dtype": dtype_name,
                 "device_map": str(load_device_map),
                 "execution_device": str(exec_device),
@@ -2486,7 +2552,13 @@ def run_multimodal_visual_probe_pass(
         del out, loss, logits
         acc._saved_inputs.clear()
 
-    acc.finalize(tracker)
+    # Global calib token budget. Multimodal samples vary in real token
+    # count, so nsamples×max_text_len is an upper bound — but it is ONE
+    # shared constant across every row (relative Fisher is what the
+    # knapsack prices) and it matches the meta nsamples×seqlen product
+    # the allocator renormalizes by, keeping that recompute idempotent.
+    fisher_norm_tokens = max(int(len(triples)) * int(max_text_len), 1)
+    acc.finalize(tracker, fisher_norm_tokens)
     acc.remove_hooks()
     if tracker is not None:
         tracker.remove_hooks()
@@ -2507,6 +2579,7 @@ def run_multimodal_visual_probe_pass(
                 "dataset": dataset_name,
                 "nsamples": len(triples),
                 "seqlen": max_text_len,
+                "fisher_norm_tokens": fisher_norm_tokens,
                 "dtype": str(dtype),
                 "device_map": requested_device,
                 "execution_device": str(exec_device),
@@ -2898,7 +2971,11 @@ def run_streaming_multimodal_visual_probe_pass(
                   f"fwd_avg={total_fwd / max(successes, 1):.2f}s "
                   f"bwd_avg={total_bwd / max(successes, 1):.2f}s", flush=True)
 
-    acc.finalize(tracker)
+    # Same convention as the non-streaming multimodal pass: an upper-bound
+    # but SHARED global token constant, equal to the meta nsamples×seqlen
+    # product so the allocator's renormalization is idempotent.
+    fisher_norm_tokens = max(int(successes) * int(max_text_len), 1)
+    acc.finalize(tracker, fisher_norm_tokens)
     acc.remove_hooks()
     if tracker is not None:
         tracker.remove_hooks()
@@ -2919,6 +2996,7 @@ def run_streaming_multimodal_visual_probe_pass(
                 "dataset": dataset_name,
                 "nsamples": successes,
                 "seqlen": max_text_len,
+                "fisher_norm_tokens": fisher_norm_tokens,
                 "dtype": str(dtype),
                 "device_map": requested_device,
                 "execution_device": str(device),

--- a/tests/test_expert_cost_subsample.py
+++ b/tests/test_expert_cost_subsample.py
@@ -1,0 +1,112 @@
+"""Unit tests for the dense-path stratified expert cost subsample.
+
+``_expert_cost_sample_split`` picks a deterministic, evenly spaced sample of
+expert ids per (experts-prefix, projection) group; ``_extrapolate_expert_costs``
+fills the skipped experts' cost rows with their group's sampled mean so every
+expert keeps a cost row (the allocator drops row-less names entirely, which
+would silently shrink the DP's bit/disk accounting and serving-unit
+membership).
+"""
+from __future__ import annotations
+
+import pytest
+
+from prismaquant.measure_quant_cost import (
+    _expert_cost_sample_split,
+    _extrapolate_expert_costs,
+)
+
+
+def _expert_names(layer: int, n_experts: int, proj: str) -> list[str]:
+    return [
+        f"model.layers.{layer}.mlp.experts.{e}.{proj}"
+        for e in range(n_experts)
+    ]
+
+
+def test_sample_split_disabled_measures_everything(monkeypatch):
+    monkeypatch.delenv("PRISMAQUANT_EXPERT_COST_SAMPLE", raising=False)
+    names = set(_expert_names(0, 16, "gate_proj")) | {"model.layers.0.self_attn.q_proj"}
+    measure, extrapolate = _expert_cost_sample_split(names)
+    assert measure == names
+    assert extrapolate == {}
+
+
+def test_sample_split_is_deterministic_evenly_spaced_and_keeps_non_experts(monkeypatch):
+    monkeypatch.setenv("PRISMAQUANT_EXPERT_COST_SAMPLE", "4")
+    dense = "model.layers.0.self_attn.q_proj"
+    experts = _expert_names(0, 16, "down_proj")
+    names = set(experts) | {dense}
+    measure, extrapolate = _expert_cost_sample_split(names)
+    # Deterministic: same call, same answer.
+    measure2, extrapolate2 = _expert_cost_sample_split(names)
+    assert measure == measure2 and extrapolate == extrapolate2
+    # Non-expert rows are always measured.
+    assert dense in measure
+    # linspace(0, 15, 4).round() -> expert ids 0, 5, 10, 15.
+    sampled = sorted(n for n in measure if n != dense)
+    assert sampled == sorted(
+        f"model.layers.0.mlp.experts.{e}.down_proj" for e in (0, 5, 10, 15))
+    # Every skipped expert maps to the sorted sampled names of its group.
+    assert set(extrapolate) == set(experts) - set(sampled)
+    for skipped, sources in extrapolate.items():
+        assert sources == sampled
+        assert skipped not in measure
+
+
+def test_sample_split_leaves_small_groups_alone(monkeypatch):
+    monkeypatch.setenv("PRISMAQUANT_EXPERT_COST_SAMPLE", "8")
+    names = set(_expert_names(0, 8, "up_proj"))
+    measure, extrapolate = _expert_cost_sample_split(names)
+    assert measure == names
+    assert extrapolate == {}
+
+
+def test_sample_split_groups_by_projection(monkeypatch):
+    monkeypatch.setenv("PRISMAQUANT_EXPERT_COST_SAMPLE", "2")
+    gate = _expert_names(3, 8, "gate_proj")
+    down = _expert_names(3, 8, "down_proj")
+    measure, extrapolate = _expert_cost_sample_split(set(gate) | set(down))
+    # Each (prefix, projection) group samples independently: 2 gate + 2 down.
+    assert len(measure) == 4
+    assert sum(1 for n in measure if n.endswith("gate_proj")) == 2
+    assert sum(1 for n in measure if n.endswith("down_proj")) == 2
+    # Skipped rows only extrapolate from their own projection's sample.
+    for skipped, sources in extrapolate.items():
+        proj = skipped.rsplit(".", 1)[1]
+        assert all(s.endswith(proj) for s in sources)
+
+
+def test_extrapolate_fills_skipped_rows_with_sampled_mean():
+    sources = ["e.experts.0.down_proj", "e.experts.7.down_proj"]
+    results = {
+        sources[0]: {
+            "Q4_K": {"weight_mse": 1.0, "output_mse": 2.0,
+                     "predicted_dloss": 4.0},
+            "IQ2_XXS": {"weight_mse": 3.0, "output_mse": 5.0,
+                        "predicted_dloss": 9.0, "output_mse_measured": False},
+        },
+        sources[1]: {
+            "Q4_K": {"weight_mse": 3.0, "output_mse": 4.0,
+                     "predicted_dloss": 8.0},
+            # IQ2_XXS errored on this expert: excluded from the mean.
+            "IQ2_XXS": {"error": "quantize failed"},
+        },
+    }
+    _extrapolate_expert_costs(results, {"e.experts.3.down_proj": sources})
+    row = results["e.experts.3.down_proj"]
+    assert row["Q4_K"]["weight_mse"] == pytest.approx(2.0)
+    assert row["Q4_K"]["output_mse"] == pytest.approx(3.0)
+    assert row["Q4_K"]["predicted_dloss"] == pytest.approx(6.0)
+    assert row["Q4_K"]["expert_cost_extrapolated"] is True
+    # Only the non-error entry feeds IQ2_XXS; its unmeasured-output marker
+    # propagates so downstream pricing knows the mean is weight-mse-derived.
+    assert row["IQ2_XXS"]["weight_mse"] == pytest.approx(3.0)
+    assert row["IQ2_XXS"]["output_mse_measured"] is False
+
+
+def test_extrapolate_skips_rows_with_no_usable_sources():
+    results = {"e.experts.0.down_proj": {"Q4_K": {"error": "boom"}}}
+    _extrapolate_expert_costs(
+        results, {"e.experts.1.down_proj": ["e.experts.0.down_proj"]})
+    assert "e.experts.1.down_proj" not in results

--- a/tests/test_fisher_normalization.py
+++ b/tests/test_fisher_normalization.py
@@ -27,6 +27,7 @@ import pytest
 import torch
 from torch import nn
 
+from prismaquant.allocator import renormalize_probe_fisher
 from prismaquant.incremental_probe import finalize_fisher_stats
 from prismaquant.measure_quant_cost import HDetailIndex
 from prismaquant.sensitivity_probe import FisherAccumulator, h_detail_blob
@@ -166,3 +167,50 @@ def test_sensitivity_backend_scalar_and_blob_agree_end_to_end():
             assert blob["norm_tokens"] == global_tokens
             assert float(blob["h_diag"].sum()) == pytest.approx(
                 s["h_trace"], rel=1e-4)
+
+def _legacy_probe_stats():
+    """A legacy-finalized probe: expert row divided by its routed count."""
+    return {
+        "dense": {"h_trace_raw": 64.0, "h_w2_sum_raw": 8.0,
+                  "h_trace": 2.0, "h_w2_sum": 0.25, "n_tokens_seen": 32},
+        "expert": {"h_trace_raw": 64.0, "h_w2_sum_raw": 8.0,
+                   "h_trace": 16.0, "h_w2_sum": 2.0, "n_tokens_seen": 4},
+    }
+
+
+def test_allocator_renormalizes_from_meta_and_is_idempotent():
+    stats = _legacy_probe_stats()
+    assert renormalize_probe_fisher(
+        stats, {"nsamples": 4, "seqlen": 8}) == 32
+    assert stats["expert"]["h_trace"] == pytest.approx(2.0)
+    assert stats["expert"]["h_w2_sum"] == pytest.approx(0.25)
+    assert stats["dense"]["h_trace"] == pytest.approx(2.0)
+    assert stats["expert"]["h_trace_norm_tokens"] == 32
+    # fisher_norm_tokens (stamped by the fixed finalize) wins over
+    # nsamples x seqlen, and re-running changes nothing.
+    assert renormalize_probe_fisher(
+        stats, {"fisher_norm_tokens": 32, "nsamples": 999, "seqlen": 999}) == 32
+    assert stats["expert"]["h_trace"] == pytest.approx(2.0)
+
+
+def test_allocator_hard_fails_on_probe_without_token_meta():
+    stats = _legacy_probe_stats()
+    with pytest.raises(SystemExit, match="allow-legacy-fisher-norm"):
+        renormalize_probe_fisher(stats, {})
+    # Values untouched by the failed attempt.
+    assert stats["expert"]["h_trace"] == pytest.approx(16.0)
+
+
+def test_allocator_legacy_escape_hatch_keeps_stored_values():
+    stats = _legacy_probe_stats()
+    assert renormalize_probe_fisher(stats, {}, allow_legacy=True) is None
+    assert stats["expert"]["h_trace"] == pytest.approx(16.0)
+    assert stats["dense"]["h_trace"] == pytest.approx(2.0)
+
+
+def test_allocator_no_raw_rows_is_silent_no_op():
+    """Probes without raw accumulators (nothing to renormalize, nothing to
+    detect) must not trip the hard fail."""
+    stats = {"dense": {"h_trace": 2.0, "n_tokens_seen": 32}}
+    assert renormalize_probe_fisher(stats, {}) is None
+    assert stats["dense"]["h_trace"] == pytest.approx(2.0)

--- a/tests/test_fisher_normalization.py
+++ b/tests/test_fisher_normalization.py
@@ -7,14 +7,29 @@ to it — the very tokens that carry the gradient. Tokens never routed to an
 expert contribute zero gradient, so both rows have the SAME empirical
 Fisher. The old per-row `h_trace_raw / n_tokens_seen` divided the expert by
 its routed count only, inflating it by (global/routed).
+
+Also pins:
+  - scalar/detail denominator agreement: the h-detail blob (which feeds
+    `predicted_dloss` via measure_quant_cost) and the scalar `h_trace`
+    must share the one global-token denominator — sum(h_diag) == h_trace;
+  - the sensitivity backend (`FisherAccumulator.finalize`) applies the
+    same convention end-to-end, scalar and blob;
+  - the allocator's load-time renormalization: recompute from raw
+    accumulators when meta carries the token count, hard-fail when it
+    does not (escape hatch: --allow-legacy-fisher-norm).
 """
 from __future__ import annotations
+
+import tempfile
+from pathlib import Path
 
 import pytest
 import torch
 from torch import nn
 
 from prismaquant.incremental_probe import finalize_fisher_stats
+from prismaquant.measure_quant_cost import HDetailIndex
+from prismaquant.sensitivity_probe import FisherAccumulator, h_detail_blob
 
 
 def _h_trace_raw(x: torch.Tensor, gy: torch.Tensor) -> float:
@@ -74,3 +89,80 @@ def test_rows_without_token_counter_use_global_count_not_one():
                         "n_tokens_seen": 0}}
     finalize_fisher_stats(stats, 32)
     assert stats["expert"]["h_trace"] == pytest.approx(2.0)
+
+
+def test_scalar_and_h_detail_share_the_global_denominator():
+    """The h-detail blob (predicted_dloss fallback input) and the scalar
+    h_trace must be divided by the SAME global token count. Identity:
+    h_diag[i,j] = sum_t gy_ti^2 x_tj^2 / N  =>  sum(h_diag) == h_trace.
+    Dividing the expert blob by its routed count instead (the pre-fix
+    writer behavior) leaves the detail (global/routed)x hotter than the
+    scalar — the mixed-units error, relocated into the knapsack."""
+    torch.manual_seed(1)
+    global_tokens, routed_tokens = 32, 4
+    x_r = torch.randn(routed_tokens, 16)
+    gy_r = torch.randn(routed_tokens, 8)
+
+    # Expert row: raw accumulators over its routed tokens only.
+    h_full_raw = gy_r.pow(2).t() @ x_r.pow(2)       # token-summed [out, in]
+    stats = {"expert": {"h_trace_raw": _h_trace_raw(x_r, gy_r),
+                        "h_w2_sum_raw": 0.0, "n_tokens_seen": routed_tokens}}
+    finalize_fisher_stats(stats, global_tokens)
+
+    blob = h_detail_blob(h_full_raw, global_tokens, "expert", kind="linear")
+    h_diag = HDetailIndex.h_diag_from_blob(blob)
+    assert blob["norm_tokens"] == global_tokens
+    assert float(h_diag.sum()) == pytest.approx(
+        stats["expert"]["h_trace"], rel=1e-5)
+
+    # Contrast: a per-routed-token blob disagrees with the scalar by
+    # exactly (global/routed).
+    stale = HDetailIndex.h_diag_from_blob(
+        h_detail_blob(h_full_raw, routed_tokens, "expert", kind="linear"))
+    assert float(stale.sum()) == pytest.approx(
+        stats["expert"]["h_trace"] * global_tokens / routed_tokens, rel=1e-5)
+
+
+def test_sensitivity_backend_scalar_and_blob_agree_end_to_end():
+    """FisherAccumulator.finalize: an unpacked expert Linear routed a
+    fraction of the calib tokens lands at the same h_trace as a dense
+    twin with identical gradient mass, and its h-detail blob sums to the
+    scalar (shared global denominator), while n_tokens_seen stays raw."""
+    torch.manual_seed(2)
+    global_tokens, routed_tokens = 24, 3
+    model = nn.Module()
+    model.dense = nn.Linear(6, 5, bias=False)
+    model.expert = nn.Linear(6, 5, bias=False)
+    model.expert.load_state_dict(model.dense.state_dict())
+    for p in model.parameters():
+        p.requires_grad_(False)
+
+    x = torch.randn(global_tokens, 6)
+    v = torch.zeros(global_tokens, 5)
+    v[:routed_tokens] = torch.randn(routed_tokens, 5)
+
+    with tempfile.TemporaryDirectory() as td:
+        h_dir = Path(td) / "h"
+        acc = FisherAccumulator(model, ["dense", "expert"], {},
+                                h_detail_dir=h_dir)
+        xg = x.detach().requires_grad_(True)
+        xr = x[:routed_tokens].detach().requires_grad_(True)
+        loss = (model.dense(xg) * v).sum() + \
+            (model.expert(xr) * v[:routed_tokens]).sum()
+        loss.backward()
+        acc.finalize(None, global_tokens=global_tokens)
+        acc.remove_hooks()
+
+        d, e = acc.stats["dense"], acc.stats["expert"]
+        assert d["n_tokens_seen"] == global_tokens
+        assert e["n_tokens_seen"] == routed_tokens
+        assert e["h_trace"] == pytest.approx(d["h_trace"], rel=1e-4)
+        assert e["h_trace_norm_tokens"] == global_tokens
+
+        index = HDetailIndex(h_dir, ["dense", "expert"])
+        for name, s in (("dense", d), ("expert", e)):
+            blob = index.load_blob(name)
+            assert blob["h_detail_version"] == 4
+            assert blob["norm_tokens"] == global_tokens
+            assert float(blob["h_diag"].sum()) == pytest.approx(
+                s["h_trace"], rel=1e-4)

--- a/tests/test_fisher_normalization.py
+++ b/tests/test_fisher_normalization.py
@@ -1,0 +1,76 @@
+"""Fisher h_trace must be normalized by the GLOBAL calib token count.
+
+Synthetic reproducer: two identical Linears with identical gradient
+statistics over the same calibration run. The "dense" one sees every token
+(most carrying zero gradient); the "expert" one only sees the tokens routed
+to it — the very tokens that carry the gradient. Tokens never routed to an
+expert contribute zero gradient, so both rows have the SAME empirical
+Fisher. The old per-row `h_trace_raw / n_tokens_seen` divided the expert by
+its routed count only, inflating it by (global/routed).
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+from prismaquant.incremental_probe import finalize_fisher_stats
+
+
+def _h_trace_raw(x: torch.Tensor, gy: torch.Tensor) -> float:
+    """The probe's per-token trace accumulator: sum_t ||gy_t||^2 * ||x_t||^2."""
+    return float((gy.pow(2).sum(dim=1) * x.pow(2).sum(dim=1)).sum().item())
+
+
+def test_h_trace_equal_for_equal_gradient_mass_after_global_normalization():
+    torch.manual_seed(0)
+    global_tokens, routed_tokens = 32, 4  # the expert is routed 1/8 of tokens
+    dense = nn.Linear(16, 8, bias=False)
+    expert = nn.Linear(16, 8, bias=False)
+    expert.load_state_dict(dense.state_dict())
+
+    x = torch.randn(global_tokens, 16)
+    # Identical per-token gradients on the routed tokens; zero elsewhere
+    # (a token never routed to the expert contributes zero gradient).
+    gy = torch.zeros(global_tokens, 8)
+    gy[:routed_tokens] = torch.randn(routed_tokens, 8)
+
+    y_dense = dense(x)                      # dense row: all 32 tokens
+    y_dense.backward(gy)
+    y_expert = expert(x[:routed_tokens])    # expert row: its 4 routed tokens
+    y_expert.backward(gy[:routed_tokens])
+
+    stats = {
+        "dense": {"h_trace_raw": _h_trace_raw(x, gy),
+                  "h_w2_sum_raw": 0.0, "n_tokens_seen": global_tokens},
+        "expert": {"h_trace_raw": _h_trace_raw(x[:routed_tokens],
+                                               gy[:routed_tokens]),
+                   "h_w2_sum_raw": 0.0, "n_tokens_seen": routed_tokens},
+    }
+    # Same gradient mass -> same raw accumulator (and same weight grads).
+    assert stats["expert"]["h_trace_raw"] == pytest.approx(
+        stats["dense"]["h_trace_raw"])
+    assert torch.allclose(dense.weight.grad, expert.weight.grad)
+
+    # OLD normalization (per-row n_tokens_seen), computed inline for
+    # contrast: the expert looks (global/routed) = 8x more sensitive.
+    old = {n: s["h_trace_raw"] / s["n_tokens_seen"] for n, s in stats.items()}
+    assert old["expert"] == pytest.approx(
+        old["dense"] * global_tokens / routed_tokens)
+
+    finalize_fisher_stats(stats, global_tokens)
+    assert stats["expert"]["h_trace"] == pytest.approx(stats["dense"]["h_trace"])
+    assert stats["dense"]["h_trace"] == pytest.approx(
+        stats["dense"]["h_trace_raw"] / global_tokens)
+    # n_tokens_seen stays raw (routed count) for the h_detail consumers.
+    assert stats["expert"]["n_tokens_seen"] == routed_tokens
+    assert stats["expert"]["h_trace_norm_tokens"] == global_tokens
+
+
+def test_rows_without_token_counter_use_global_count_not_one():
+    """Stat rows filled by the batched MoE-block flush path never increment
+    n_tokens_seen; the old finalize divided them by max(0, 1) == 1."""
+    stats = {"expert": {"h_trace_raw": 64.0, "h_w2_sum_raw": 0.0,
+                        "n_tokens_seen": 0}}
+    finalize_fisher_stats(stats, 32)
+    assert stats["expert"]["h_trace"] == pytest.approx(2.0)

--- a/tests/test_incremental_measure_quant_cost.py
+++ b/tests/test_incremental_measure_quant_cost.py
@@ -329,7 +329,7 @@ class TestIncrementalMeasureQuantCost(unittest.TestCase):
                 )
                 loss = model(x).pow(2).sum()
                 loss.backward()
-                acc.finalize(tracker=None)
+                acc.finalize(tracker=None, global_tokens=3)
             finally:
                 acc.remove_hooks()
 

--- a/tests/test_packed_expert_per_token_fisher.py
+++ b/tests/test_packed_expert_per_token_fisher.py
@@ -9,15 +9,23 @@ FIX 1 (audit M3): packed-MoE expert Fisher uses the per-token-summed
     packed compute (e.g. bmm) fail-fasts unless
     PRISMAQUANT_ALLOW_SUMSQ_PACKED_FISHER=1.
 
-FIX 2 (audit M4): `FisherAccumulator.finalize` applies the single
-    per-routed-token normalization for unpacked MoE expert Linears — no
-    second ÷route_prob — so the `run_probe_pass` backend agrees with the
-    incremental (production) backend's convention.
+FIX 2 (audit M4, denominator superseded by PR #14):
+    `FisherAccumulator.finalize` applies a SINGLE normalization — no
+    second ÷route_prob (route_prob is metadata only) — so the
+    `run_probe_pass` backend agrees with the incremental (production)
+    backend's convention. M4 originally made that single division
+    per-ROUTED-token; PR #14 deliberately reversed the denominator to
+    the GLOBAL calib token count for every row (tokens never routed to
+    an expert contribute zero gradient, so per-routed-token inflated
+    sparse-expert rows by global/routed). The no-double-division
+    property M4 pinned still holds and is still pinned here.
 
 FIX 3 (audit M9): every h-detail writer goes through
     `sensitivity_probe.h_detail_blob` (per-token units + explicit
     ``units: "per_token"`` marker); `HDetailIndex.h_diag_from_blob`
-    refuses legacy raw token-summed ``H`` blobs.
+    refuses legacy raw token-summed ``H`` blobs. Since PR #14 the blob
+    denominator is the GLOBAL calib token count (v4), matching the
+    scalar `h_trace`.
 """
 import os
 import tempfile
@@ -318,12 +326,14 @@ class _StubTracker:
 
 
 class TestBackendNormalizationAgreement(unittest.TestCase):
-    """FIX 2 (audit M4): the run_probe_pass backend's expert h_trace is
-    the per-routed-token mean — the same single-division convention the
-    incremental (production) backend implements — with route_prob kept
-    as metadata only, never applied as a second division."""
+    """FIX 2 (audit M4) + the PR #14 denominator reversal: the
+    run_probe_pass backend's expert h_trace is the routed-token gradient
+    mass divided ONCE, by the GLOBAL calib token count — the same
+    single-division convention the incremental (production) backend
+    implements — with route_prob kept as metadata only, never applied
+    as a second division."""
 
-    def test_expert_h_trace_is_per_routed_token_mean(self):
+    def test_expert_h_trace_is_global_token_mean(self):
         torch.manual_seed(0)
         E, hidden, inter, T = 3, 6, 4, 24
         model = _UnpackedMoE(E, hidden, inter).to(DEV)
@@ -332,9 +342,9 @@ class TestBackendNormalizationAgreement(unittest.TestCase):
         with torch.no_grad():
             top = model.router(x).argmax(dim=-1)
 
-        # Reference: the incremental backend's convention, computed
-        # brute-force — Σ_t ‖∇_t W_e‖² over ROUTED tokens t, divided by
-        # the routed-token count.
+        # Reference: Σ_t ‖∇_t W_e‖² over ROUTED tokens t (tokens never
+        # routed to e contribute zero gradient), divided by the GLOBAL
+        # calib token count T — finalize_fisher_stats' convention.
         ref = {}
         for e, expert in enumerate(model.experts):
             sel = (top == e).nonzero(as_tuple=True)[0]
@@ -345,8 +355,7 @@ class TestBackendNormalizationAgreement(unittest.TestCase):
                     expert.w1.weight)
                 total += float(g.pow(2).sum())
             if sel.numel():
-                ref[f"experts.{e}.w1"] = (total / int(sel.numel()),
-                                          int(sel.numel()))
+                ref[f"experts.{e}.w1"] = (total / T, int(sel.numel()))
 
         tracked = [f"experts.{e}.w1" for e in range(E)]
         expert_info = {f"experts.{e}.w1": ("router", str(e))
@@ -356,17 +365,25 @@ class TestBackendNormalizationAgreement(unittest.TestCase):
         acc = FisherAccumulator(model, tracked, expert_info)
         xg = x.detach().requires_grad_(True)
         (model(xg) * v).sum().backward()
-        # A route_prob well below 1 — the pre-fix code would divide by it
-        # and report 4× the per-routed-token mean.
-        acc.finalize(_StubTracker(0.25))
+        # A route_prob well below 1 — the pre-M4 code would divide by it
+        # as a SECOND division; still pinned as metadata-only.
+        acc.finalize(_StubTracker(0.25), global_tokens=T)
 
         for name, (ref_mean, n_routed) in ref.items():
             with self.subTest(linear=name):
                 s = acc.stats[name]
+                # n_tokens_seen stays raw (routed count, metadata) —
+                # the denominator is the global count.
                 self.assertEqual(s["n_tokens_seen"], n_routed)
+                self.assertEqual(s["h_trace_norm_tokens"], T)
                 self.assertEqual(s["route_prob"], 0.25)  # metadata only
                 self.assertLess(abs(s["h_trace"] - ref_mean),
                                 5e-3 * abs(ref_mean))
+                # Pin the reversal: for a sparsely routed expert the old
+                # per-routed-token convention was (T/n_routed)× hotter.
+                if n_routed < T:
+                    self.assertGreater(
+                        (s["h_trace_raw"] / n_routed) / s["h_trace"], 1.0)
 
 
 class TestHDetailUnits(unittest.TestCase):
@@ -377,7 +394,10 @@ class TestHDetailUnits(unittest.TestCase):
         raw = torch.full((2, 3), 12.0)
         blob = h_detail_blob(raw, 4, "toy.fc")
         self.assertEqual(blob["units"], "per_token")
-        self.assertEqual(blob["h_detail_version"], 3)
+        # v4: denominator is the GLOBAL calib token count (PR #14), and
+        # the blob records it.
+        self.assertEqual(blob["h_detail_version"], 4)
+        self.assertEqual(blob["norm_tokens"], 4)
         self.assertEqual(blob["kind"], "linear")
         self.assertTrue(torch.equal(blob["h_diag"],
                                     torch.full((2, 3), 3.0)))
@@ -428,7 +448,7 @@ class TestHDetailUnits(unittest.TestCase):
             acc = FisherAccumulator(model, ["fc"], {}, h_detail_dir=h_dir)
             xg2 = x.detach().requires_grad_(True)
             (model.fc(xg2) * v).sum().backward()
-            acc.finalize(None)
+            acc.finalize(None, global_tokens=T)
 
             index = HDetailIndex(h_dir, ["fc"])
             self.assertIn("fc", index)

--- a/uv.lock
+++ b/uv.lock
@@ -693,6 +693,109 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.15.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d0/55fe630f4cf94e3fcba868240fad8c8cdd1f764e2a932f8926347e6ec4cd/coverage-7.15.2.tar.gz", hash = "sha256:3df60dc267f0a2ca23cb7a9ab1109c62b9335ffbf519fcfe167157c28c09b81d", size = 927741, upload-time = "2026-07-15T18:56:19.558Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/060ce69008ac97bbc01b1411b3e55b61f6f015659400b46749b662107831/coverage-7.15.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b5bd92ff1ec22e535eab0de75fa6db021992791f461a2aceb7822c625a1187d", size = 221284, upload-time = "2026-07-15T18:53:29.52Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a3/d936e8b53edd9684100a6aefaf3fcabaa54728fe33324436c8d279c047aa/coverage-7.15.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:44826758cfe73fcd0e6af5deb4ba6d5417cc1d13df3acb35c93484a11160f846", size = 221799, upload-time = "2026-07-15T18:53:31.708Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/a3/ca234b06aec7ee28226f11d39a696b4481fe5eddfce8e03bf39979bb8ffb/coverage-7.15.2-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:09f5c6ec5901f667bd97dd140b5b9a2586b10efec66f46fb1e6d8135f8b95bdf", size = 248544, upload-time = "2026-07-15T18:53:33.212Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/89/dda79527bb7573ba91828b2fb91b3105d87378d6a2749ca0c0924ce0addd/coverage-7.15.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1d16e3a7104ea84f03e614611b3edbf6fb6892554b3ab0fe7fbb3f2b2ef04376", size = 250374, upload-time = "2026-07-15T18:53:34.683Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c6/c33755a34572f81f49a8c0cdf6b622f35ccb3238b136e1909daf0cdd4319/coverage-7.15.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d46e62cb35d91e6e2589fda6d28074426b0e276422b5d2ebef2c6b11dc60dbfd", size = 252239, upload-time = "2026-07-15T18:53:36.205Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/6f/dc341741b375be53a5baeee5b4bf0f0e525d38caed428f7932d23bb7bcb1/coverage-7.15.2-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dfd3db045e95960ae3683059571e597fda7cc610106a8916f77c5839048c1deb", size = 254150, upload-time = "2026-07-15T18:53:37.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/8d/966a18a5b195cb4e77b14c53f5f3dce22b5da05e6de7fafd1e08f2d2067a/coverage-7.15.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:affd532502d34c0472d0cdb181325c89f1d2c44992fef0c17e88e7b1576259a1", size = 249234, upload-time = "2026-07-15T18:53:39.394Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/8b/8b2e367496ab48484d48e79984fec76cdc1b7cb5d3a00ee799a5602e3ec9/coverage-7.15.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d17d7512151fedfcc64c1821a8977fc9be0dbf495754669afcab7b57abc98ae9", size = 250276, upload-time = "2026-07-15T18:53:41.027Z" },
+    { url = "https://files.pythonhosted.org/packages/63/92/1199318a200eb6c8c6ce0192c892c8710ac791abbe0f35099294620bbfda/coverage-7.15.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e26ff680768b8095e8874aabe0e9d3a47a2a9f176a8340d05f8604c56457c23a", size = 248283, upload-time = "2026-07-15T18:53:42.557Z" },
+    { url = "https://files.pythonhosted.org/packages/56/da/be284a55c5619bda891a89c27dfd59324a2c6a14d755cf6aac6960ceebeb/coverage-7.15.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7e8f27131dc7cd53de2c137dd207b3720919320b3c20d499dc30aa9ee6173287", size = 252093, upload-time = "2026-07-15T18:53:44.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/53/ee112da833ddd77b73c6d781a98029b45b584b136615b4900ed0569f887e/coverage-7.15.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:728a33676d4c3f0db977990a4bd421dcaa3be3e53b5b6273036fff6666008e89", size = 248552, upload-time = "2026-07-15T18:53:45.7Z" },
+    { url = "https://files.pythonhosted.org/packages/82/6a/802cfc802e9113494c80bf3f284cd4d72faeb1f24e244f61046af364f2ca/coverage-7.15.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:29c052f7c83ccfcc5c577eaae025d2e4a9bb80daf03c0ac31c996e83b000ce88", size = 249154, upload-time = "2026-07-15T18:53:47.256Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/65/529808e91d651147edae408fd9e894abc3b8cad7f3e594bbc36719a3e13a/coverage-7.15.2-cp310-cp310-win32.whl", hash = "sha256:1268ac8fb9ddcd783d3948dbabaf80a5d53bfdaa0575e873e2139a692f797443", size = 223334, upload-time = "2026-07-15T18:53:48.768Z" },
+    { url = "https://files.pythonhosted.org/packages/68/0f/0e1829d7001130876dfbc0b4e1c737ea7c155b809e3e4a98a0aa268e2369/coverage-7.15.2-cp310-cp310-win_amd64.whl", hash = "sha256:9f4432898c4bf2fba0435bbe35dd4437d7264565e5a88a21f5b49d8662a6b629", size = 223959, upload-time = "2026-07-15T18:53:50.429Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/3a/54536704f507d4573bf9161c4d0dd3dd59b6d85e48c664e901b6844d8e33/coverage-7.15.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2f1ec6f304b156669cfde653b4e9a953f5de87e247ea02ac599bce0ab2744036", size = 221414, upload-time = "2026-07-15T18:53:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d9/8ba925d29743e3577b21e4d8c11a702b76bc93c41e7fdfd1177af63d4b8d/coverage-7.15.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d3361879d736f469f45723c11ea1a5bbdaf1f6928f0e632c940378b5aa9b660", size = 221913, upload-time = "2026-07-15T18:53:53.682Z" },
+    { url = "https://files.pythonhosted.org/packages/09/54/a855f3aa0187f2b431ade4e4791b77b56282cfb5d201c83ec26a31b5b36a/coverage-7.15.2-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c6a98d698f9e2c8008d0370ec7fc452ebfcc530002ae2d0061170d768b992589", size = 252332, upload-time = "2026-07-15T18:53:55.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d3/13ac97b4370640ba3452fc8559b06cc2f479ce3ba4a0b632a73e44c38a7d/coverage-7.15.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d50dd325e18ec25bfcc10cd7f99b04df1ab9ec76b0918c260e60817ad0643dee", size = 254243, upload-time = "2026-07-15T18:53:57.055Z" },
+    { url = "https://files.pythonhosted.org/packages/88/83/5eca144942d8d0659d3f55176517f4a59cdc65eefd17146a0770935a3ebd/coverage-7.15.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:67d7602480a47bdf5b675635403625553ebaa70d5a62a657c035149fd401cea0", size = 256352, upload-time = "2026-07-15T18:53:58.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ba/d3db2e01a50fc88cdb4c0f19542bcf6f61489e34dc9aa3538413e2459a38/coverage-7.15.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cee0f89f4767a6057c8fbf168f8135f18be651300496086bd873e3189fed0487", size = 258313, upload-time = "2026-07-15T18:54:00.497Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b3/aba83416e9177df28e5186d856c19158c59fc0e7e814aaa61a4a2354ad1b/coverage-7.15.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a29ec5305a7335aacee2d799e3422e91e1c8a12474986e2b3b07e315c91be82f", size = 252449, upload-time = "2026-07-15T18:54:02.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a5/4b00ecac0194431ab451b0f6710f8e2517d04cef60f821b14dec4637d575/coverage-7.15.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:48ccc6395958eda89093ecdc35644c86f23a8b23a7f4d44958812b721aad67c1", size = 254043, upload-time = "2026-07-15T18:54:04.072Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b6/cfa209b4313ee7f1b34da47efcd789ea51c024ad35af390e00f5a3c10a2e/coverage-7.15.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:81f382c5a94b434ec1f6da607edb904c76d7212e618cd4d1bc9f97bed4120ef5", size = 252107, upload-time = "2026-07-15T18:54:06.745Z" },
+    { url = "https://files.pythonhosted.org/packages/36/67/e8cac5a6954038c98d7fe7eb9802afe7ab3ecb637bb7cc00e69b4148b56d/coverage-7.15.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:bbc808daf4f5cd567af8075ecc72d21c6dfef9a254709a621a84c217c935ebc0", size = 255873, upload-time = "2026-07-15T18:54:08.48Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/92/395cca9f330a86c3fe3471d73e2c102116c4c58fdc619dbbc125c6e93a54/coverage-7.15.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a4c46b247b5d4b78f613bd89fea926d32b25c6cc61a50bd1e99ba310348f3dad", size = 251826, upload-time = "2026-07-15T18:54:10.083Z" },
+    { url = "https://files.pythonhosted.org/packages/51/60/3e91b20295439652424f426b7086ec5bf4fbe3f604c73eda22b986c4fd6b/coverage-7.15.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:094dd37f3ef7b2da8b068b583d1f4c40f91c65197e16c52a71962d5d537fc5db", size = 252735, upload-time = "2026-07-15T18:54:11.878Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/8c07839005e5e3c6b3877d3a6e2a80ce766589f31dd2b6882b78d59a7b8c/coverage-7.15.2-cp311-cp311-win32.whl", hash = "sha256:a63b9e190711134d581c4d703df5df09851b1acf99792c7aacbbe9f41f0283c9", size = 223500, upload-time = "2026-07-15T18:54:13.525Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/98/59d83c257cd59f0fbaf9d9ddb26b744a576760dfd1ae16e516408894a02b/coverage-7.15.2-cp311-cp311-win_amd64.whl", hash = "sha256:8bb9f4b4279187560796a4cdaca3b0a93dd97e48ee667df005f4ed9a97403688", size = 223973, upload-time = "2026-07-15T18:54:15.163Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/09/2d285c8bef5c4f695d120c1c96dc11715638aa8e134069f210bb6a62a9fe/coverage-7.15.2-cp311-cp311-win_arm64.whl", hash = "sha256:8c726b232659cbd2ae57ade46509eb068c9bd7a06df9fcbff6fe484870006934", size = 223519, upload-time = "2026-07-15T18:54:16.803Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/50/eb5bf42e531611a9f8d272556b1ed4de503f84a91413584094487cf69f8f/coverage-7.15.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1adac78e5abc7c5438f7a209c9ca69d06542f0bf481d728b6989ea80b813fdf9", size = 221587, upload-time = "2026-07-15T18:54:18.439Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d1/da99af464c335d4e023a6efcd7ec30f63b88a43c93745154ab74ffb31cea/coverage-7.15.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b868acc62aa5de3be7a9d05c2333bf8359ca987e43f9cb30ff8fbda6a024ab73", size = 221943, upload-time = "2026-07-15T18:54:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/8a/13c42723d61ca447eafa18732e8141dd6a63f2732e1c7e1502c182dd88d7/coverage-7.15.2-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6f6966fc30e6f06ca8f98fb0ce51eda6b111b3ee8d066a8b1ec9e77fa06ab55d", size = 253450, upload-time = "2026-07-15T18:54:21.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/29/99021303f98fbdcb63504b4d07bea4cc025b9b2dd907c4f07c85d50a0dab/coverage-7.15.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:68af907f595ab01a78f794932ff3bdf929c316d3000810d38dbc247129e26f8b", size = 256187, upload-time = "2026-07-15T18:54:23.4Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a8/fd503715ed6ca9c5d742923aa5209257340b367a867b2ced0c7d4ba8a0b9/coverage-7.15.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:afa29e2eff3d5729267e2cb2fd4ce9d61c952932fb2694e34ccb5d9540c6a296", size = 257301, upload-time = "2026-07-15T18:54:25.183Z" },
+    { url = "https://files.pythonhosted.org/packages/da/40/3f4b8fb409810036ebc2857d36adc0498c6e957b5df0290c5036b2e143f1/coverage-7.15.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbf44513ceb1589e31948e20eafbde9deaface90e1a1afa5f5f77b4423d17ce6", size = 259562, upload-time = "2026-07-15T18:54:27.204Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/8a/9bdffbef47db77cce3d6b02a28f7e919b19f0106c4b080c2c2246040f885/coverage-7.15.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9deddf09eecb717b7f980414b43d90a5b22ff3967d2949ab29cb0aa83d9e9098", size = 253841, upload-time = "2026-07-15T18:54:29.134Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1e/9031efde019d31a06646261fce6dfc5c3c74e951e27a71e5c9a424563178/coverage-7.15.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ae901f7e55ba405c84ee1cab3d3e962e4e871e4a2bcb9c90911adbd69b42ac5a", size = 255221, upload-time = "2026-07-15T18:54:31.142Z" },
+    { url = "https://files.pythonhosted.org/packages/56/db/787acde872389fc84a9ef9d8cd1ccc658e391ab4cb5b28092a714426a394/coverage-7.15.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a0f47002c6eeb7c280228467a4cb0cc15ca2103a8421b986b2d3ec04a0f9bd8b", size = 253366, upload-time = "2026-07-15T18:54:32.886Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/9b/6f57bc4b93c842eef1695f8cdaf2318e35e7ba54f5ba80d84be213ab7858/coverage-7.15.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1cd7a5beb7af3e864a13b1f0fb26efd3695da43ef0daf71e586adfffaf34d5b2", size = 257434, upload-time = "2026-07-15T18:54:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/88/26/b3186a21b2acc83e451118978905c81c7072c3333707804db09a78c096a2/coverage-7.15.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:97a5c5457a9fb1d6c4e06cfb5dc835871fbfb6a6a51addc9e925bdeff5ef7440", size = 252935, upload-time = "2026-07-15T18:54:36.548Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c2/c9f3376b2e717ea69ed7a6e9a5fcab968fb0b290db6cf4bd9a1fc7541b75/coverage-7.15.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0901cfe6c13bcd2302da4f83e884555d2a22bda6e4c476f09ef204ba20ca536e", size = 254807, upload-time = "2026-07-15T18:54:38.296Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e1/dfc15401f4a8aaeb486e1ba3e9e3c40522a6e38bd0ecf0b3f29cb8082957/coverage-7.15.2-cp312-cp312-win32.whl", hash = "sha256:b171bdd71cb7ff792bf32e376173b0ace7e7963e7e57c58dfc42063a6a7174cd", size = 223641, upload-time = "2026-07-15T18:54:40.103Z" },
+    { url = "https://files.pythonhosted.org/packages/91/40/81b6d809d320cd366ec5bdf8176575e897dcb8efe7fb4b489ef9e93e4d13/coverage-7.15.2-cp312-cp312-win_amd64.whl", hash = "sha256:582edc45c2040543fef83341be23c43024a3ab3ae0c2d8bc498a06282905ad40", size = 224172, upload-time = "2026-07-15T18:54:41.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/28/9f14ec438149f7de557f45518f09b4a7917b795cc37083aa7db482693f8c/coverage-7.15.2-cp312-cp312-win_arm64.whl", hash = "sha256:a638db90c61cd219aeee65e83a24fdaa57269a741ae0cf773309208ac862cee3", size = 223556, upload-time = "2026-07-15T18:54:43.674Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d5/f8c838e6b7282976f7c918884b792df7a0c42c5bba5d99c60ad2d221d56d/coverage-7.15.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1121caa19159a38b5463eaae4b1e1fde81e525b15ecc5e000cd5b1a108f743a8", size = 221606, upload-time = "2026-07-15T18:54:45.448Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/37/97c926376364f66298cc44893b89cdf17b8bc406376497c4061ae4b8a8ff/coverage-7.15.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a300c6934e0989c327b9e8a1e110329da4641149f872bbe9f70168be66da76c1", size = 221982, upload-time = "2026-07-15T18:54:47.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/30/a36050a6e83c2135ee0776f452ca3948224befc6d7f26acecc082d0c106a/coverage-7.15.2-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2617f8799d268fabdeef42a7e89ac3a23e1deee9025427db2df970f99a89a578", size = 252972, upload-time = "2026-07-15T18:54:49.2Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d3/06b5f1daf95f0f15ab05bd75f26ba5f3c8b33d0bb72f3aaa3cf41d1bad3a/coverage-7.15.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7dc2950a2992cd676d35c20ae63522836deeb034f08874699d14068710af3dc1", size = 255569, upload-time = "2026-07-15T18:54:51.098Z" },
+    { url = "https://files.pythonhosted.org/packages/81/1c/9afb3f8de2b8d36960391c48559a2e3ff96594b58099f115921549ea8d0d/coverage-7.15.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9e36686f7a442185db2400b3df171aac520869faf9deb59df687d28659eda2a6", size = 256806, upload-time = "2026-07-15T18:54:53.145Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d8/b989f96061a5e32d82fddd1b1b9ff48a7c8f8ae7606f0e80fd9de54b1e33/coverage-7.15.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d29ca7bd67af6e12e74632d65f026eabc1364da5c254494cd914446a28a3ef7", size = 258936, upload-time = "2026-07-15T18:54:55.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fa/f99771f5110457c7b511c1935ca49ddf288218eaa84322e028b9334146ae/coverage-7.15.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:db9c8438057e5b0f6a22a0af99c0c1d26b57fbbdbd1be5861ddb8f897fcc3a2d", size = 253178, upload-time = "2026-07-15T18:54:57.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/96/c098a6044d119c751ceede7be91035fa8310170ec24a6523aff72f0a5793/coverage-7.15.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:63022c4c8dec1d0342f05c3ede99842fe3d007689acc45e86f123a1746e4a026", size = 254934, upload-time = "2026-07-15T18:54:59.41Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a2/1457b3a7a50c8d77500103b97a046db863e2f59a1cf6d2f814595f349885/coverage-7.15.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6c0be82b4d4aa5b2704e08518e2252f3e3d110164bcca826816801052e48a7aa", size = 252898, upload-time = "2026-07-15T18:55:01.338Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/0e/76958874c471ecfcdde0d2b2747bb2c61bdbf34a40636f4ce9db9923e643/coverage-7.15.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4510fb9cdf6bb02dfa6af0be4a534b8102d086e22e4a33f8836df663da3d660d", size = 257056, upload-time = "2026-07-15T18:55:03.243Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/7c/3d7c4e3bf58baa40327dc7edc2272b17cf02299366d52763db1b0ca1556a/coverage-7.15.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:42ec3d989421b174a2ab607c1539f24127ad362757b7f1c0c0d7a2993f7eb37b", size = 252718, upload-time = "2026-07-15T18:55:05.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b8/1cecffed9ce14fb25be9ba42d37b6bb61485c9a3ddd43cd3dde36b6087d8/coverage-7.15.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8f91bce78e32343af184c3b7fa28fcf5a9e2641f4b6623d392038f804939188", size = 254490, upload-time = "2026-07-15T18:55:06.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2c/42984561bc7f4c045dca67516a0c50ee5ef8d84352dbeb5559dc86c4823e/coverage-7.15.2-cp313-cp313-win32.whl", hash = "sha256:434e68d531858205895eb0d74b73d20b84260de426387d53c422a5acda2cf050", size = 223647, upload-time = "2026-07-15T18:55:08.941Z" },
+    { url = "https://files.pythonhosted.org/packages/41/9f/39c7c9245efc583beddf89a87683574e663ed93637f3afb6cd7b88405676/coverage-7.15.2-cp313-cp313-win_amd64.whl", hash = "sha256:26c3b04a6377fd7c09800921fa934e3a17c0020439cd59df73e73ae1d4b6a78c", size = 224190, upload-time = "2026-07-15T18:55:10.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/de/3a2883cf8a213659280ef4b403059e17a9acaeb7fc7fd4105e1226ff2e6d/coverage-7.15.2-cp313-cp313-win_arm64.whl", hash = "sha256:3ed010aa1b69cda8e827aabfca9866216c980e2dca82ab9a78c5f83689964c8b", size = 223583, upload-time = "2026-07-15T18:55:12.678Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5f/aed265fd7a3551a394f36dfe41868aee709b7f95db4052205b4ad1563ac3/coverage-7.15.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f633c5c5fc783732f6312280122e859538fa24461235597c13d803ea9a108a", size = 221650, upload-time = "2026-07-15T18:55:14.527Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/2c/222ba12a545189017120f8eddfc1a0bd4616b47d5d4a8d99421edb2fe4c6/coverage-7.15.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:075560438765b7a2ef43bf7aa7758661b53d889df47f062a31bda6c1ade553a2", size = 221988, upload-time = "2026-07-15T18:55:16.674Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/38/304b5877ab46e6c290b4292cfcf3fe28245f0e5597cad7f6acc91fc7e0a4/coverage-7.15.2-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:25fd15dd40a0a2c51a500d664ca29053c09c3259d998407bf982b6e114696138", size = 253029, upload-time = "2026-07-15T18:55:18.856Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/58/821b533b8db9e44cf1d8a97bd525149ced40dde1d0093da02cb78e715244/coverage-7.15.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9a6367e4aff723e8ee8190836836124284e8fcd4265e307c844010cfa074f3f", size = 255536, upload-time = "2026-07-15T18:55:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f2/7aa06604c389d32ea7f0a6a988359a7eafc3cd3f8e7bc2e88cd2fdf0b877/coverage-7.15.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9854ca62c152874b2060772503535be2e8f53f70b8aaa7686b094888d872f984", size = 256881, upload-time = "2026-07-15T18:55:23.125Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/4f/1ef342339c7916d0096bc5888cc0f653882cc7bc8f897d5cb89143287c9b/coverage-7.15.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:913b6c56e110da40e035bbd168353bf7aaa2544a5eaccea5d98a4629aac156c7", size = 259196, upload-time = "2026-07-15T18:55:25.099Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f4/7ed055d7a9c5ec13b161773a115a5ccc6b0081d568c31fad830806306cc7/coverage-7.15.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aaccad4129d735a8a4d526f26929894c9a4e8ef7034566f210b176749d6906e3", size = 253036, upload-time = "2026-07-15T18:55:27.018Z" },
+    { url = "https://files.pythonhosted.org/packages/14/79/ea82cca18c242a3a38b6c017da39726aa62dcb64aa635abf79b92009975c/coverage-7.15.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a164b50081fc7357331c4024ef4d17b78ba325f8380d05f5a69599a7e05257ee", size = 254887, upload-time = "2026-07-15T18:55:29.084Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ba/a136db3c0d9562b00e10b72540dbf3a33cd3bc5b95060c9308e247494623/coverage-7.15.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:bfd341ccf78128e72c094bc70cc25b3ef309c33c7c2c66ba3ed4309549e02de1", size = 252852, upload-time = "2026-07-15T18:55:31.184Z" },
+    { url = "https://files.pythonhosted.org/packages/17/17/ea334246b16b7d059953fad6fdefa11e33c68efbd3fe37b1098120a1fac2/coverage-7.15.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1473b3ba8e7ee0f076117b1a72c23f579a2b9e2bb742f48a8d86ea27ca93f91a", size = 257128, upload-time = "2026-07-15T18:55:33.163Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c3/074fb66d46d607855f710876b117cbda562c5ab08363528e78820449f937/coverage-7.15.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:17c432b5f73ad52ef46fb06019f6fa7c66ce381961cf0f7dfd1d3a4bd3a98145", size = 252668, upload-time = "2026-07-15T18:55:35.063Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c1/f620850ada9b36435921c9a3a8057013422b1d964eb4bf37fe138724d192/coverage-7.15.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:77f0ef5011df53a4bd1b35211ab122287f8d9b8d7aa1c4553e5c2deb24b1d446", size = 254325, upload-time = "2026-07-15T18:55:37.125Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/31/a729ca3689404493af82ef8e6ff70bd88bdda8da89aeef6ca9b387aeb2b4/coverage-7.15.2-cp314-cp314-win32.whl", hash = "sha256:f653e5d7248c1191ec988a85c72edeab46c3ff44f90639a4ed4874ec0be90243", size = 223844, upload-time = "2026-07-15T18:55:39.078Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/83/5d809dc808fb1698c671f3e372259bb9158e64b7ea526fc6ab7de64de9fe/coverage-7.15.2-cp314-cp314-win_amd64.whl", hash = "sha256:9911f31aad8906abe337c271343485cf20df5e70df5d2f57f9f136e7b55f26bc", size = 224331, upload-time = "2026-07-15T18:55:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/16/4e/35e488548e952795829e129995c4174df33bf432b591d1aa42c8d9e4e7ad/coverage-7.15.2-cp314-cp314-win_arm64.whl", hash = "sha256:e38def96ad59853824c97953fdcd2c320a84ba3ce99b417db78af8bb6c3db635", size = 223760, upload-time = "2026-07-15T18:55:43.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/49/dd2c86cd6374038f6e415fb5bfb86db5218553209c081384a020369dee79/coverage-7.15.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:835ec4e20b45f0a7f63ed78f94065aca00de033403df8377bfe8b9c6abc0a7be", size = 222384, upload-time = "2026-07-15T18:55:45.569Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/173ff17a1c0808e5a438f549f6f145d5ac7528f2791310b63523e3200ac7/coverage-7.15.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7466cc7ab6dc0db871d264bf99e8779f0917ee63d40730af0552f71535a6e072", size = 222647, upload-time = "2026-07-15T18:55:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f8/b8cba872162356fb44ac79c10309d987206a4461e32072fc29228dad7331/coverage-7.15.2-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e370c12133095ff18432de8c044962be85a5a96d90c6fcbce8e17e76236d2328", size = 264013, upload-time = "2026-07-15T18:55:49.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/67/a807a7586d0b8cae485308ddd55756f0806c92f8e0b411bacbf23c48edf3/coverage-7.15.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fe41909c9515c3bfdb5f02c4d1f857dba322d9a9a1178069b91eea77889df63a", size = 266135, upload-time = "2026-07-15T18:55:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/cd78771dc985f7e4ebdcc82b1a96d9a932af9e806f01f2f91a89f4c72e80/coverage-7.15.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6aa28cfb6488e5453b5b762d65f73aa586380f6693a04d58078ce228a29b06c0", size = 268555, upload-time = "2026-07-15T18:55:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3e/10134cf81275188c58568f324fc74aedff32c63ca4d5bbc513a91944a6f0/coverage-7.15.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcc0aae933921d03096f53b0b03eeb702129fd406dee59f08d2efacc68681fa5", size = 269674, upload-time = "2026-07-15T18:55:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4a/771b77de446cba985dc414bbc5844bd21604da05dbc044286df8318a48a7/coverage-7.15.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7c63387e21ab21f512c69c9756a8c7dadd322c7275edb064064433c9a09c3743", size = 263101, upload-time = "2026-07-15T18:55:58.107Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b5/70a7011da15f4071943361183aefa27847f3e3aec4fd335f1cb3d3a622b1/coverage-7.15.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e55510bc98ae943cece9e667a6c0fe94c6a92913720dea34243657a17993d0c", size = 266007, upload-time = "2026-07-15T18:56:00.468Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/f9547e804ce7ad49646ffeffac26699510efbe6c0f751b66fdc960c4e825/coverage-7.15.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:2ff08701be2d1556fc78b326c80a3e8042da09352ecb3819105f8e386c8a3071", size = 263611, upload-time = "2026-07-15T18:56:02.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/59/f576a396659c0efd351f5c1544f67c3560e89c7761cabf7f65e412beeda5/coverage-7.15.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:38c9518b7103826c403a461544e3c2e77151e8676d06eaed85911a97e962584a", size = 267344, upload-time = "2026-07-15T18:56:04.622Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/5d/c2e4fce3579c0cb635024293f1a32bbe26df101b3e3a69f22243d1352b6c/coverage-7.15.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:dee88b1ed88587abd8c0269a1fc1f4cc77f7750d1dfde2869e2a123af420e67d", size = 262456, upload-time = "2026-07-15T18:56:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/956287d69436b66094bc4b57ac2da71e43bfd2a5524e958900b9f582fcf8/coverage-7.15.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fbeeeecea279727f8ac16c8e1133ddfeee793e985c86ae343d6a5ce744eef8c", size = 264771, upload-time = "2026-07-15T18:56:08.795Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/5a/6f979530c2734c575de77cf58f5f28d51f7123a94b5030fd9156fe5f363c/coverage-7.15.2-cp314-cp314t-win32.whl", hash = "sha256:cb0fddaa6884be6aae36ced9544b5e90f7d5f03845a2853bf47a14953a4e8688", size = 224151, upload-time = "2026-07-15T18:56:10.856Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7e/27f6b2a74d484742f4017553e710b01e396b23d809df3e95ca0bb9a2824b/coverage-7.15.2-cp314-cp314t-win_amd64.whl", hash = "sha256:77f091ea3a9cc611cd29f433565476bc1936c084ac8eee00ea0e7e70c27e4199", size = 224981, upload-time = "2026-07-15T18:56:12.928Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/48/284863423aa474240f6842bd00d680da22f4e6ea2e466618ef7c9c9e69a9/coverage-7.15.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6fc448c377d6eeb00a47c673494bd9bae29280ca53987e1869e67ebedfe20658", size = 224294, upload-time = "2026-07-15T18:56:15.156Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/82/32e3bd191d498e64f6f911ad55d14006a0861e54869d2d32452326399e65/coverage-7.15.2-py3-none-any.whl", hash = "sha256:eb6bcae8d1a9d305351ecb108232441d11c5cfe9de840a04388ba5d2db8d735c", size = 213375, upload-time = "2026-07-15T18:56:17.305Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
 name = "cryptography"
 version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -832,37 +935,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -978,7 +1081,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -3226,10 +3329,10 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -3305,10 +3408,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
 wheels = [
@@ -3485,6 +3588,7 @@ dependencies = [
     { name = "accelerate" },
     { name = "compressed-tensors" },
     { name = "datasets" },
+    { name = "gguf" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
@@ -3500,6 +3604,7 @@ serve = [
 ]
 test = [
     { name = "pytest" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -3507,8 +3612,10 @@ requires-dist = [
     { name = "accelerate", specifier = ">=0.30" },
     { name = "compressed-tensors", specifier = ">=0.15" },
     { name = "datasets", specifier = ">=3.0" },
+    { name = "gguf", specifier = ">=0.17" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=5" },
     { name = "safetensors", specifier = ">=0.4" },
     { name = "torch", specifier = ">=2.6" },
     { name = "tqdm" },
@@ -4163,6 +4270,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -693,109 +693,6 @@ wheels = [
 ]
 
 [[package]]
-name = "coverage"
-version = "7.15.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/d0/55fe630f4cf94e3fcba868240fad8c8cdd1f764e2a932f8926347e6ec4cd/coverage-7.15.2.tar.gz", hash = "sha256:3df60dc267f0a2ca23cb7a9ab1109c62b9335ffbf519fcfe167157c28c09b81d", size = 927741, upload-time = "2026-07-15T18:56:19.558Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/03/060ce69008ac97bbc01b1411b3e55b61f6f015659400b46749b662107831/coverage-7.15.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b5bd92ff1ec22e535eab0de75fa6db021992791f461a2aceb7822c625a1187d", size = 221284, upload-time = "2026-07-15T18:53:29.52Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/a3/d936e8b53edd9684100a6aefaf3fcabaa54728fe33324436c8d279c047aa/coverage-7.15.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:44826758cfe73fcd0e6af5deb4ba6d5417cc1d13df3acb35c93484a11160f846", size = 221799, upload-time = "2026-07-15T18:53:31.708Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/a3/ca234b06aec7ee28226f11d39a696b4481fe5eddfce8e03bf39979bb8ffb/coverage-7.15.2-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:09f5c6ec5901f667bd97dd140b5b9a2586b10efec66f46fb1e6d8135f8b95bdf", size = 248544, upload-time = "2026-07-15T18:53:33.212Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/89/dda79527bb7573ba91828b2fb91b3105d87378d6a2749ca0c0924ce0addd/coverage-7.15.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1d16e3a7104ea84f03e614611b3edbf6fb6892554b3ab0fe7fbb3f2b2ef04376", size = 250374, upload-time = "2026-07-15T18:53:34.683Z" },
-    { url = "https://files.pythonhosted.org/packages/67/c6/c33755a34572f81f49a8c0cdf6b622f35ccb3238b136e1909daf0cdd4319/coverage-7.15.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d46e62cb35d91e6e2589fda6d28074426b0e276422b5d2ebef2c6b11dc60dbfd", size = 252239, upload-time = "2026-07-15T18:53:36.205Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/6f/dc341741b375be53a5baeee5b4bf0f0e525d38caed428f7932d23bb7bcb1/coverage-7.15.2-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dfd3db045e95960ae3683059571e597fda7cc610106a8916f77c5839048c1deb", size = 254150, upload-time = "2026-07-15T18:53:37.863Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/8d/966a18a5b195cb4e77b14c53f5f3dce22b5da05e6de7fafd1e08f2d2067a/coverage-7.15.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:affd532502d34c0472d0cdb181325c89f1d2c44992fef0c17e88e7b1576259a1", size = 249234, upload-time = "2026-07-15T18:53:39.394Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/8b/8b2e367496ab48484d48e79984fec76cdc1b7cb5d3a00ee799a5602e3ec9/coverage-7.15.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d17d7512151fedfcc64c1821a8977fc9be0dbf495754669afcab7b57abc98ae9", size = 250276, upload-time = "2026-07-15T18:53:41.027Z" },
-    { url = "https://files.pythonhosted.org/packages/63/92/1199318a200eb6c8c6ce0192c892c8710ac791abbe0f35099294620bbfda/coverage-7.15.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e26ff680768b8095e8874aabe0e9d3a47a2a9f176a8340d05f8604c56457c23a", size = 248283, upload-time = "2026-07-15T18:53:42.557Z" },
-    { url = "https://files.pythonhosted.org/packages/56/da/be284a55c5619bda891a89c27dfd59324a2c6a14d755cf6aac6960ceebeb/coverage-7.15.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7e8f27131dc7cd53de2c137dd207b3720919320b3c20d499dc30aa9ee6173287", size = 252093, upload-time = "2026-07-15T18:53:44.271Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/53/ee112da833ddd77b73c6d781a98029b45b584b136615b4900ed0569f887e/coverage-7.15.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:728a33676d4c3f0db977990a4bd421dcaa3be3e53b5b6273036fff6666008e89", size = 248552, upload-time = "2026-07-15T18:53:45.7Z" },
-    { url = "https://files.pythonhosted.org/packages/82/6a/802cfc802e9113494c80bf3f284cd4d72faeb1f24e244f61046af364f2ca/coverage-7.15.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:29c052f7c83ccfcc5c577eaae025d2e4a9bb80daf03c0ac31c996e83b000ce88", size = 249154, upload-time = "2026-07-15T18:53:47.256Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/65/529808e91d651147edae408fd9e894abc3b8cad7f3e594bbc36719a3e13a/coverage-7.15.2-cp310-cp310-win32.whl", hash = "sha256:1268ac8fb9ddcd783d3948dbabaf80a5d53bfdaa0575e873e2139a692f797443", size = 223334, upload-time = "2026-07-15T18:53:48.768Z" },
-    { url = "https://files.pythonhosted.org/packages/68/0f/0e1829d7001130876dfbc0b4e1c737ea7c155b809e3e4a98a0aa268e2369/coverage-7.15.2-cp310-cp310-win_amd64.whl", hash = "sha256:9f4432898c4bf2fba0435bbe35dd4437d7264565e5a88a21f5b49d8662a6b629", size = 223959, upload-time = "2026-07-15T18:53:50.429Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/3a/54536704f507d4573bf9161c4d0dd3dd59b6d85e48c664e901b6844d8e33/coverage-7.15.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2f1ec6f304b156669cfde653b4e9a953f5de87e247ea02ac599bce0ab2744036", size = 221414, upload-time = "2026-07-15T18:53:51.941Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/d9/8ba925d29743e3577b21e4d8c11a702b76bc93c41e7fdfd1177af63d4b8d/coverage-7.15.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d3361879d736f469f45723c11ea1a5bbdaf1f6928f0e632c940378b5aa9b660", size = 221913, upload-time = "2026-07-15T18:53:53.682Z" },
-    { url = "https://files.pythonhosted.org/packages/09/54/a855f3aa0187f2b431ade4e4791b77b56282cfb5d201c83ec26a31b5b36a/coverage-7.15.2-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c6a98d698f9e2c8008d0370ec7fc452ebfcc530002ae2d0061170d768b992589", size = 252332, upload-time = "2026-07-15T18:53:55.467Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/d3/13ac97b4370640ba3452fc8559b06cc2f479ce3ba4a0b632a73e44c38a7d/coverage-7.15.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d50dd325e18ec25bfcc10cd7f99b04df1ab9ec76b0918c260e60817ad0643dee", size = 254243, upload-time = "2026-07-15T18:53:57.055Z" },
-    { url = "https://files.pythonhosted.org/packages/88/83/5eca144942d8d0659d3f55176517f4a59cdc65eefd17146a0770935a3ebd/coverage-7.15.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:67d7602480a47bdf5b675635403625553ebaa70d5a62a657c035149fd401cea0", size = 256352, upload-time = "2026-07-15T18:53:58.83Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/ba/d3db2e01a50fc88cdb4c0f19542bcf6f61489e34dc9aa3538413e2459a38/coverage-7.15.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cee0f89f4767a6057c8fbf168f8135f18be651300496086bd873e3189fed0487", size = 258313, upload-time = "2026-07-15T18:54:00.497Z" },
-    { url = "https://files.pythonhosted.org/packages/78/b3/aba83416e9177df28e5186d856c19158c59fc0e7e814aaa61a4a2354ad1b/coverage-7.15.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a29ec5305a7335aacee2d799e3422e91e1c8a12474986e2b3b07e315c91be82f", size = 252449, upload-time = "2026-07-15T18:54:02.456Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/a5/4b00ecac0194431ab451b0f6710f8e2517d04cef60f821b14dec4637d575/coverage-7.15.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:48ccc6395958eda89093ecdc35644c86f23a8b23a7f4d44958812b721aad67c1", size = 254043, upload-time = "2026-07-15T18:54:04.072Z" },
-    { url = "https://files.pythonhosted.org/packages/75/b6/cfa209b4313ee7f1b34da47efcd789ea51c024ad35af390e00f5a3c10a2e/coverage-7.15.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:81f382c5a94b434ec1f6da607edb904c76d7212e618cd4d1bc9f97bed4120ef5", size = 252107, upload-time = "2026-07-15T18:54:06.745Z" },
-    { url = "https://files.pythonhosted.org/packages/36/67/e8cac5a6954038c98d7fe7eb9802afe7ab3ecb637bb7cc00e69b4148b56d/coverage-7.15.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:bbc808daf4f5cd567af8075ecc72d21c6dfef9a254709a621a84c217c935ebc0", size = 255873, upload-time = "2026-07-15T18:54:08.48Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/92/395cca9f330a86c3fe3471d73e2c102116c4c58fdc619dbbc125c6e93a54/coverage-7.15.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a4c46b247b5d4b78f613bd89fea926d32b25c6cc61a50bd1e99ba310348f3dad", size = 251826, upload-time = "2026-07-15T18:54:10.083Z" },
-    { url = "https://files.pythonhosted.org/packages/51/60/3e91b20295439652424f426b7086ec5bf4fbe3f604c73eda22b986c4fd6b/coverage-7.15.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:094dd37f3ef7b2da8b068b583d1f4c40f91c65197e16c52a71962d5d537fc5db", size = 252735, upload-time = "2026-07-15T18:54:11.878Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/eb/8c07839005e5e3c6b3877d3a6e2a80ce766589f31dd2b6882b78d59a7b8c/coverage-7.15.2-cp311-cp311-win32.whl", hash = "sha256:a63b9e190711134d581c4d703df5df09851b1acf99792c7aacbbe9f41f0283c9", size = 223500, upload-time = "2026-07-15T18:54:13.525Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/98/59d83c257cd59f0fbaf9d9ddb26b744a576760dfd1ae16e516408894a02b/coverage-7.15.2-cp311-cp311-win_amd64.whl", hash = "sha256:8bb9f4b4279187560796a4cdaca3b0a93dd97e48ee667df005f4ed9a97403688", size = 223973, upload-time = "2026-07-15T18:54:15.163Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/09/2d285c8bef5c4f695d120c1c96dc11715638aa8e134069f210bb6a62a9fe/coverage-7.15.2-cp311-cp311-win_arm64.whl", hash = "sha256:8c726b232659cbd2ae57ade46509eb068c9bd7a06df9fcbff6fe484870006934", size = 223519, upload-time = "2026-07-15T18:54:16.803Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/50/eb5bf42e531611a9f8d272556b1ed4de503f84a91413584094487cf69f8f/coverage-7.15.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1adac78e5abc7c5438f7a209c9ca69d06542f0bf481d728b6989ea80b813fdf9", size = 221587, upload-time = "2026-07-15T18:54:18.439Z" },
-    { url = "https://files.pythonhosted.org/packages/06/d1/da99af464c335d4e023a6efcd7ec30f63b88a43c93745154ab74ffb31cea/coverage-7.15.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b868acc62aa5de3be7a9d05c2333bf8359ca987e43f9cb30ff8fbda6a024ab73", size = 221943, upload-time = "2026-07-15T18:54:20.062Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/8a/13c42723d61ca447eafa18732e8141dd6a63f2732e1c7e1502c182dd88d7/coverage-7.15.2-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6f6966fc30e6f06ca8f98fb0ce51eda6b111b3ee8d066a8b1ec9e77fa06ab55d", size = 253450, upload-time = "2026-07-15T18:54:21.765Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/29/99021303f98fbdcb63504b4d07bea4cc025b9b2dd907c4f07c85d50a0dab/coverage-7.15.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:68af907f595ab01a78f794932ff3bdf929c316d3000810d38dbc247129e26f8b", size = 256187, upload-time = "2026-07-15T18:54:23.4Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/a8/fd503715ed6ca9c5d742923aa5209257340b367a867b2ced0c7d4ba8a0b9/coverage-7.15.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:afa29e2eff3d5729267e2cb2fd4ce9d61c952932fb2694e34ccb5d9540c6a296", size = 257301, upload-time = "2026-07-15T18:54:25.183Z" },
-    { url = "https://files.pythonhosted.org/packages/da/40/3f4b8fb409810036ebc2857d36adc0498c6e957b5df0290c5036b2e143f1/coverage-7.15.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbf44513ceb1589e31948e20eafbde9deaface90e1a1afa5f5f77b4423d17ce6", size = 259562, upload-time = "2026-07-15T18:54:27.204Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/8a/9bdffbef47db77cce3d6b02a28f7e919b19f0106c4b080c2c2246040f885/coverage-7.15.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9deddf09eecb717b7f980414b43d90a5b22ff3967d2949ab29cb0aa83d9e9098", size = 253841, upload-time = "2026-07-15T18:54:29.134Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/1e/9031efde019d31a06646261fce6dfc5c3c74e951e27a71e5c9a424563178/coverage-7.15.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ae901f7e55ba405c84ee1cab3d3e962e4e871e4a2bcb9c90911adbd69b42ac5a", size = 255221, upload-time = "2026-07-15T18:54:31.142Z" },
-    { url = "https://files.pythonhosted.org/packages/56/db/787acde872389fc84a9ef9d8cd1ccc658e391ab4cb5b28092a714426a394/coverage-7.15.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a0f47002c6eeb7c280228467a4cb0cc15ca2103a8421b986b2d3ec04a0f9bd8b", size = 253366, upload-time = "2026-07-15T18:54:32.886Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/9b/6f57bc4b93c842eef1695f8cdaf2318e35e7ba54f5ba80d84be213ab7858/coverage-7.15.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1cd7a5beb7af3e864a13b1f0fb26efd3695da43ef0daf71e586adfffaf34d5b2", size = 257434, upload-time = "2026-07-15T18:54:34.7Z" },
-    { url = "https://files.pythonhosted.org/packages/88/26/b3186a21b2acc83e451118978905c81c7072c3333707804db09a78c096a2/coverage-7.15.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:97a5c5457a9fb1d6c4e06cfb5dc835871fbfb6a6a51addc9e925bdeff5ef7440", size = 252935, upload-time = "2026-07-15T18:54:36.548Z" },
-    { url = "https://files.pythonhosted.org/packages/20/c2/c9f3376b2e717ea69ed7a6e9a5fcab968fb0b290db6cf4bd9a1fc7541b75/coverage-7.15.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0901cfe6c13bcd2302da4f83e884555d2a22bda6e4c476f09ef204ba20ca536e", size = 254807, upload-time = "2026-07-15T18:54:38.296Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/e1/dfc15401f4a8aaeb486e1ba3e9e3c40522a6e38bd0ecf0b3f29cb8082957/coverage-7.15.2-cp312-cp312-win32.whl", hash = "sha256:b171bdd71cb7ff792bf32e376173b0ace7e7963e7e57c58dfc42063a6a7174cd", size = 223641, upload-time = "2026-07-15T18:54:40.103Z" },
-    { url = "https://files.pythonhosted.org/packages/91/40/81b6d809d320cd366ec5bdf8176575e897dcb8efe7fb4b489ef9e93e4d13/coverage-7.15.2-cp312-cp312-win_amd64.whl", hash = "sha256:582edc45c2040543fef83341be23c43024a3ab3ae0c2d8bc498a06282905ad40", size = 224172, upload-time = "2026-07-15T18:54:41.882Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/28/9f14ec438149f7de557f45518f09b4a7917b795cc37083aa7db482693f8c/coverage-7.15.2-cp312-cp312-win_arm64.whl", hash = "sha256:a638db90c61cd219aeee65e83a24fdaa57269a741ae0cf773309208ac862cee3", size = 223556, upload-time = "2026-07-15T18:54:43.674Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/d5/f8c838e6b7282976f7c918884b792df7a0c42c5bba5d99c60ad2d221d56d/coverage-7.15.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1121caa19159a38b5463eaae4b1e1fde81e525b15ecc5e000cd5b1a108f743a8", size = 221606, upload-time = "2026-07-15T18:54:45.448Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/37/97c926376364f66298cc44893b89cdf17b8bc406376497c4061ae4b8a8ff/coverage-7.15.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a300c6934e0989c327b9e8a1e110329da4641149f872bbe9f70168be66da76c1", size = 221982, upload-time = "2026-07-15T18:54:47.341Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/30/a36050a6e83c2135ee0776f452ca3948224befc6d7f26acecc082d0c106a/coverage-7.15.2-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2617f8799d268fabdeef42a7e89ac3a23e1deee9025427db2df970f99a89a578", size = 252972, upload-time = "2026-07-15T18:54:49.2Z" },
-    { url = "https://files.pythonhosted.org/packages/31/d3/06b5f1daf95f0f15ab05bd75f26ba5f3c8b33d0bb72f3aaa3cf41d1bad3a/coverage-7.15.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7dc2950a2992cd676d35c20ae63522836deeb034f08874699d14068710af3dc1", size = 255569, upload-time = "2026-07-15T18:54:51.098Z" },
-    { url = "https://files.pythonhosted.org/packages/81/1c/9afb3f8de2b8d36960391c48559a2e3ff96594b58099f115921549ea8d0d/coverage-7.15.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9e36686f7a442185db2400b3df171aac520869faf9deb59df687d28659eda2a6", size = 256806, upload-time = "2026-07-15T18:54:53.145Z" },
-    { url = "https://files.pythonhosted.org/packages/64/d8/b989f96061a5e32d82fddd1b1b9ff48a7c8f8ae7606f0e80fd9de54b1e33/coverage-7.15.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d29ca7bd67af6e12e74632d65f026eabc1364da5c254494cd914446a28a3ef7", size = 258936, upload-time = "2026-07-15T18:54:55.015Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/fa/f99771f5110457c7b511c1935ca49ddf288218eaa84322e028b9334146ae/coverage-7.15.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:db9c8438057e5b0f6a22a0af99c0c1d26b57fbbdbd1be5861ddb8f897fcc3a2d", size = 253178, upload-time = "2026-07-15T18:54:57.527Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/96/c098a6044d119c751ceede7be91035fa8310170ec24a6523aff72f0a5793/coverage-7.15.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:63022c4c8dec1d0342f05c3ede99842fe3d007689acc45e86f123a1746e4a026", size = 254934, upload-time = "2026-07-15T18:54:59.41Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a2/1457b3a7a50c8d77500103b97a046db863e2f59a1cf6d2f814595f349885/coverage-7.15.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6c0be82b4d4aa5b2704e08518e2252f3e3d110164bcca826816801052e48a7aa", size = 252898, upload-time = "2026-07-15T18:55:01.338Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/0e/76958874c471ecfcdde0d2b2747bb2c61bdbf34a40636f4ce9db9923e643/coverage-7.15.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4510fb9cdf6bb02dfa6af0be4a534b8102d086e22e4a33f8836df663da3d660d", size = 257056, upload-time = "2026-07-15T18:55:03.243Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/7c/3d7c4e3bf58baa40327dc7edc2272b17cf02299366d52763db1b0ca1556a/coverage-7.15.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:42ec3d989421b174a2ab607c1539f24127ad362757b7f1c0c0d7a2993f7eb37b", size = 252718, upload-time = "2026-07-15T18:55:05.029Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/b8/1cecffed9ce14fb25be9ba42d37b6bb61485c9a3ddd43cd3dde36b6087d8/coverage-7.15.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8f91bce78e32343af184c3b7fa28fcf5a9e2641f4b6623d392038f804939188", size = 254490, upload-time = "2026-07-15T18:55:06.889Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/2c/42984561bc7f4c045dca67516a0c50ee5ef8d84352dbeb5559dc86c4823e/coverage-7.15.2-cp313-cp313-win32.whl", hash = "sha256:434e68d531858205895eb0d74b73d20b84260de426387d53c422a5acda2cf050", size = 223647, upload-time = "2026-07-15T18:55:08.941Z" },
-    { url = "https://files.pythonhosted.org/packages/41/9f/39c7c9245efc583beddf89a87683574e663ed93637f3afb6cd7b88405676/coverage-7.15.2-cp313-cp313-win_amd64.whl", hash = "sha256:26c3b04a6377fd7c09800921fa934e3a17c0020439cd59df73e73ae1d4b6a78c", size = 224190, upload-time = "2026-07-15T18:55:10.789Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/de/3a2883cf8a213659280ef4b403059e17a9acaeb7fc7fd4105e1226ff2e6d/coverage-7.15.2-cp313-cp313-win_arm64.whl", hash = "sha256:3ed010aa1b69cda8e827aabfca9866216c980e2dca82ab9a78c5f83689964c8b", size = 223583, upload-time = "2026-07-15T18:55:12.678Z" },
-    { url = "https://files.pythonhosted.org/packages/81/5f/aed265fd7a3551a394f36dfe41868aee709b7f95db4052205b4ad1563ac3/coverage-7.15.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f633c5c5fc783732f6312280122e859538fa24461235597c13d803ea9a108a", size = 221650, upload-time = "2026-07-15T18:55:14.527Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/2c/222ba12a545189017120f8eddfc1a0bd4616b47d5d4a8d99421edb2fe4c6/coverage-7.15.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:075560438765b7a2ef43bf7aa7758661b53d889df47f062a31bda6c1ade553a2", size = 221988, upload-time = "2026-07-15T18:55:16.674Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/38/304b5877ab46e6c290b4292cfcf3fe28245f0e5597cad7f6acc91fc7e0a4/coverage-7.15.2-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:25fd15dd40a0a2c51a500d664ca29053c09c3259d998407bf982b6e114696138", size = 253029, upload-time = "2026-07-15T18:55:18.856Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/58/821b533b8db9e44cf1d8a97bd525149ced40dde1d0093da02cb78e715244/coverage-7.15.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9a6367e4aff723e8ee8190836836124284e8fcd4265e307c844010cfa074f3f", size = 255536, upload-time = "2026-07-15T18:55:21.027Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/f2/7aa06604c389d32ea7f0a6a988359a7eafc3cd3f8e7bc2e88cd2fdf0b877/coverage-7.15.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9854ca62c152874b2060772503535be2e8f53f70b8aaa7686b094888d872f984", size = 256881, upload-time = "2026-07-15T18:55:23.125Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/4f/1ef342339c7916d0096bc5888cc0f653882cc7bc8f897d5cb89143287c9b/coverage-7.15.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:913b6c56e110da40e035bbd168353bf7aaa2544a5eaccea5d98a4629aac156c7", size = 259196, upload-time = "2026-07-15T18:55:25.099Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/f4/7ed055d7a9c5ec13b161773a115a5ccc6b0081d568c31fad830806306cc7/coverage-7.15.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aaccad4129d735a8a4d526f26929894c9a4e8ef7034566f210b176749d6906e3", size = 253036, upload-time = "2026-07-15T18:55:27.018Z" },
-    { url = "https://files.pythonhosted.org/packages/14/79/ea82cca18c242a3a38b6c017da39726aa62dcb64aa635abf79b92009975c/coverage-7.15.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a164b50081fc7357331c4024ef4d17b78ba325f8380d05f5a69599a7e05257ee", size = 254887, upload-time = "2026-07-15T18:55:29.084Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/ba/a136db3c0d9562b00e10b72540dbf3a33cd3bc5b95060c9308e247494623/coverage-7.15.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:bfd341ccf78128e72c094bc70cc25b3ef309c33c7c2c66ba3ed4309549e02de1", size = 252852, upload-time = "2026-07-15T18:55:31.184Z" },
-    { url = "https://files.pythonhosted.org/packages/17/17/ea334246b16b7d059953fad6fdefa11e33c68efbd3fe37b1098120a1fac2/coverage-7.15.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1473b3ba8e7ee0f076117b1a72c23f579a2b9e2bb742f48a8d86ea27ca93f91a", size = 257128, upload-time = "2026-07-15T18:55:33.163Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/c3/074fb66d46d607855f710876b117cbda562c5ab08363528e78820449f937/coverage-7.15.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:17c432b5f73ad52ef46fb06019f6fa7c66ce381961cf0f7dfd1d3a4bd3a98145", size = 252668, upload-time = "2026-07-15T18:55:35.063Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/c1/f620850ada9b36435921c9a3a8057013422b1d964eb4bf37fe138724d192/coverage-7.15.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:77f0ef5011df53a4bd1b35211ab122287f8d9b8d7aa1c4553e5c2deb24b1d446", size = 254325, upload-time = "2026-07-15T18:55:37.125Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/31/a729ca3689404493af82ef8e6ff70bd88bdda8da89aeef6ca9b387aeb2b4/coverage-7.15.2-cp314-cp314-win32.whl", hash = "sha256:f653e5d7248c1191ec988a85c72edeab46c3ff44f90639a4ed4874ec0be90243", size = 223844, upload-time = "2026-07-15T18:55:39.078Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/83/5d809dc808fb1698c671f3e372259bb9158e64b7ea526fc6ab7de64de9fe/coverage-7.15.2-cp314-cp314-win_amd64.whl", hash = "sha256:9911f31aad8906abe337c271343485cf20df5e70df5d2f57f9f136e7b55f26bc", size = 224331, upload-time = "2026-07-15T18:55:41.346Z" },
-    { url = "https://files.pythonhosted.org/packages/16/4e/35e488548e952795829e129995c4174df33bf432b591d1aa42c8d9e4e7ad/coverage-7.15.2-cp314-cp314-win_arm64.whl", hash = "sha256:e38def96ad59853824c97953fdcd2c320a84ba3ce99b417db78af8bb6c3db635", size = 223760, upload-time = "2026-07-15T18:55:43.518Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/49/dd2c86cd6374038f6e415fb5bfb86db5218553209c081384a020369dee79/coverage-7.15.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:835ec4e20b45f0a7f63ed78f94065aca00de033403df8377bfe8b9c6abc0a7be", size = 222384, upload-time = "2026-07-15T18:55:45.569Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/74/173ff17a1c0808e5a438f549f6f145d5ac7528f2791310b63523e3200ac7/coverage-7.15.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7466cc7ab6dc0db871d264bf99e8779f0917ee63d40730af0552f71535a6e072", size = 222647, upload-time = "2026-07-15T18:55:47.544Z" },
-    { url = "https://files.pythonhosted.org/packages/84/f8/b8cba872162356fb44ac79c10309d987206a4461e32072fc29228dad7331/coverage-7.15.2-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e370c12133095ff18432de8c044962be85a5a96d90c6fcbce8e17e76236d2328", size = 264013, upload-time = "2026-07-15T18:55:49.768Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/67/a807a7586d0b8cae485308ddd55756f0806c92f8e0b411bacbf23c48edf3/coverage-7.15.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fe41909c9515c3bfdb5f02c4d1f857dba322d9a9a1178069b91eea77889df63a", size = 266135, upload-time = "2026-07-15T18:55:51.941Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/67/cd78771dc985f7e4ebdcc82b1a96d9a932af9e806f01f2f91a89f4c72e80/coverage-7.15.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6aa28cfb6488e5453b5b762d65f73aa586380f6693a04d58078ce228a29b06c0", size = 268555, upload-time = "2026-07-15T18:55:54.065Z" },
-    { url = "https://files.pythonhosted.org/packages/18/3e/10134cf81275188c58568f324fc74aedff32c63ca4d5bbc513a91944a6f0/coverage-7.15.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcc0aae933921d03096f53b0b03eeb702129fd406dee59f08d2efacc68681fa5", size = 269674, upload-time = "2026-07-15T18:55:56.066Z" },
-    { url = "https://files.pythonhosted.org/packages/75/4a/771b77de446cba985dc414bbc5844bd21604da05dbc044286df8318a48a7/coverage-7.15.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7c63387e21ab21f512c69c9756a8c7dadd322c7275edb064064433c9a09c3743", size = 263101, upload-time = "2026-07-15T18:55:58.107Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/b5/70a7011da15f4071943361183aefa27847f3e3aec4fd335f1cb3d3a622b1/coverage-7.15.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e55510bc98ae943cece9e667a6c0fe94c6a92913720dea34243657a17993d0c", size = 266007, upload-time = "2026-07-15T18:56:00.468Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/0d/f9547e804ce7ad49646ffeffac26699510efbe6c0f751b66fdc960c4e825/coverage-7.15.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:2ff08701be2d1556fc78b326c80a3e8042da09352ecb3819105f8e386c8a3071", size = 263611, upload-time = "2026-07-15T18:56:02.615Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/59/f576a396659c0efd351f5c1544f67c3560e89c7761cabf7f65e412beeda5/coverage-7.15.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:38c9518b7103826c403a461544e3c2e77151e8676d06eaed85911a97e962584a", size = 267344, upload-time = "2026-07-15T18:56:04.622Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/5d/c2e4fce3579c0cb635024293f1a32bbe26df101b3e3a69f22243d1352b6c/coverage-7.15.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:dee88b1ed88587abd8c0269a1fc1f4cc77f7750d1dfde2869e2a123af420e67d", size = 262456, upload-time = "2026-07-15T18:56:06.641Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/dd/956287d69436b66094bc4b57ac2da71e43bfd2a5524e958900b9f582fcf8/coverage-7.15.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fbeeeecea279727f8ac16c8e1133ddfeee793e985c86ae343d6a5ce744eef8c", size = 264771, upload-time = "2026-07-15T18:56:08.795Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/5a/6f979530c2734c575de77cf58f5f28d51f7123a94b5030fd9156fe5f363c/coverage-7.15.2-cp314-cp314t-win32.whl", hash = "sha256:cb0fddaa6884be6aae36ced9544b5e90f7d5f03845a2853bf47a14953a4e8688", size = 224151, upload-time = "2026-07-15T18:56:10.856Z" },
-    { url = "https://files.pythonhosted.org/packages/54/7e/27f6b2a74d484742f4017553e710b01e396b23d809df3e95ca0bb9a2824b/coverage-7.15.2-cp314-cp314t-win_amd64.whl", hash = "sha256:77f091ea3a9cc611cd29f433565476bc1936c084ac8eee00ea0e7e70c27e4199", size = 224981, upload-time = "2026-07-15T18:56:12.928Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/48/284863423aa474240f6842bd00d680da22f4e6ea2e466618ef7c9c9e69a9/coverage-7.15.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6fc448c377d6eeb00a47c673494bd9bae29280ca53987e1869e67ebedfe20658", size = 224294, upload-time = "2026-07-15T18:56:15.156Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/82/32e3bd191d498e64f6f911ad55d14006a0861e54869d2d32452326399e65/coverage-7.15.2-py3-none-any.whl", hash = "sha256:eb6bcae8d1a9d305351ecb108232441d11c5cfe9de840a04388ba5d2db8d735c", size = 213375, upload-time = "2026-07-15T18:56:17.305Z" },
-]
-
-[package.optional-dependencies]
-toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11'" },
-]
-
-[[package]]
 name = "cryptography"
 version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -935,37 +832,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -1081,7 +978,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -3329,10 +3226,10 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -3408,10 +3305,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
 wheels = [
@@ -3588,7 +3485,6 @@ dependencies = [
     { name = "accelerate" },
     { name = "compressed-tensors" },
     { name = "datasets" },
-    { name = "gguf" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
@@ -3604,7 +3500,6 @@ serve = [
 ]
 test = [
     { name = "pytest" },
-    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -3612,10 +3507,8 @@ requires-dist = [
     { name = "accelerate", specifier = ">=0.30" },
     { name = "compressed-tensors", specifier = ">=0.15" },
     { name = "datasets", specifier = ">=3.0" },
-    { name = "gguf", specifier = ">=0.17" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=5" },
     { name = "safetensors", specifier = ">=0.4" },
     { name = "torch", specifier = ">=2.6" },
     { name = "tqdm" },
@@ -4270,20 +4163,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
-]
-
-[[package]]
-name = "pytest-cov"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "coverage", extra = ["toml"] },
-    { name = "pluggy" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> Stacked on #13 — only the last 3 commits are new here (1 original + review round 1); I'll rebase as predecessors merge.


**Commit:** `probe/alloc: normalize Fisher h_trace by the global calib token count`

### Summary
The incremental probe finalized `h_trace = h_trace_raw / n_tokens_seen` PER
ROW. For per-expert-`nn.Linear` layouts, `n_tokens_seen` only counts the
tokens ROUTED to that expert — inflating a rarely-routed expert's Fisher by
(global/routed), i.e. exactly inverted importance weighting: the least-used
experts look the most sensitive, and the allocator spends bits on them while
attention/shared rows starve at the floor. Typical inflation is
~n_experts/top_k (≈32x on a 256-expert top-8 model); ~33,000x only in the
degenerate case of an expert routed 1 token of a 32,768-token calibration.

Scope correction from review: DSv4-Flash itself probes packed-3D under the
current toolchain (transformers 5.6.0 instantiates packed `*Experts`
containers), so this change is near-inert on today's shipped artifact
classes. It bites where experts genuinely probe as per-expert `nn.Linear`:
older transformers pins (MiniMax pins 4.57.5), vendored modeling files, and
`--model-override` runs on older images.

Tokens never routed to an expert contribute zero gradient, so the empirical
Fisher over the calibration set divides by the GLOBAL token count
(nsamples × seqlen) for every row (`finalize_fisher_stats`). Honest scope:

- **Dense trunk rows: unchanged** (they accumulate exactly the global count).
- **Packed-3D expert entries: unchanged** (their `n_tokens_seen` already
  incremented by the full batch token count).
- **Per-expert-Linear rows: fixed** (the headline case).
- **Batched MoE-block flush rows: fixed as a bonus** — they never incremented
  `n_tokens_seen`, so the old finalize divided them by 1.

Existing probe pickles are corrected at allocator load time from the stored
raw accumulators (`h_trace_raw`, `h_w2_sum_raw`, `h_trace_per_expert_raw`,
meta nsamples/seqlen) without re-probing; the recompute is idempotent for
probes written by the fixed finalize (stamped `meta.fisher_norm_tokens`).

### Review round 1
- `95b3993` extends the same global denominator to the h-detail blobs and
  the sensitivity backend (the review's mixed-units relocation): all writers
  funnel `global_tokens`, blobs carry `h_detail_version: 4` + `norm_tokens`,
  every pickle stamps `meta.fisher_norm_tokens`. It also reverses the
  documented M4 convention ON THE RECORD — the M4 comment block,
  `finalize_fisher_stats`'s docstring, CLAUDE.md §3, and
  `docs/prismaquant_design.md` §2.2 updated in the same commit.
- `612fc38` hard-fails probes that carry raw accumulators but no token meta
  (`renormalize_probe_fisher()`); `--allow-legacy-fisher-norm` restores the
  warning path. Detection widened to the flush-path rows
  (`n_tokens_seen == 0`) the old `> 0` gate missed.

### What changes for existing users
Allocations on per-expert-Linear MoE models can change substantially (that
is the fix). Dense-model probes and packed-3D probes produce identical
h_trace values before and after. Probes lacking nsamples/seqlen meta now
hard-fail at load (`--allow-legacy-fisher-norm` opts back into the warning).

### How to verify
`pytest tests/test_fisher_normalization.py -v` — the synthetic reproducer:
two identical Linears with identical gradient mass over the same calibration
run (the "dense" one sees every token, most carrying zero gradient; the
"expert" one sees only its routed tokens). Equal h_trace after the fix; the
old per-row normalization, computed inline for contrast, inflates the expert
by exactly (global/routed).

### Tests
`tests/test_fisher_normalization.py` now 8 tests: the reproducer, the
divided-by-1 flush-path row, scalar/detail denominator agreement
(`sum(h_diag) == h_trace` at writer level and end-to-end), renorm-from-meta,
idempotence, hard fail, escape hatch, no-raw-rows no-op.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015onx7cSnJWSYdrL9bzFQXC