### PR TITLE
Footprint: per-tensor source-byte manifest; reject negative floors

### DIFF
--- a/prismaquant/allocator.py
+++ b/prismaquant/allocator.py
@@ -2042,7 +2042,18 @@ def main():
                 "floor (lm_head/embed/norms).")
         budget_bytes = float(args.target_disk_gb) * _fp.GB
         src_total, src_by_dtype = _fp.source_checkpoint_bytes(probe_model_path)
-        regime = _fp.source_regime(src_by_dtype)  # robust bf16/fp8 (not by mass)
+        regime = _fp.source_regime(src_by_dtype)  # recorded for reporting only
+        # Per-tensor source-byte manifest: each re-encoded Linear is charged
+        # its ACTUAL header byte span (weight + scale siblings), never a
+        # regime-wide per-param rate. On mixed sources (an MXFP4-packed
+        # DSv4-Flash checkpoint: I8 nibble experts + E8M0 scales, F8
+        # attention, BF16 floor) the old regime accounting removed more
+        # bytes than the checkpoint holds, driving the floor negative.
+        src_manifest = _fp.source_tensor_bytes_manifest(
+            probe_model_path,
+            name_map=getattr(model_profile, "checkpoint_to_live_name", None),
+        )
+        manifest_missing: set[str] = set()
 
         def _artifact_for_target(t: float):
             assign_t, ach_t, tot_t, _mut = _solve_for_target(t)
@@ -2050,13 +2061,23 @@ def main():
                 return None
             expanded_t = _expand_assignment_for_seed_json(assign_t)
             body_aux = _assignment_bits_total(expanded_t) / 8.0
-            reenc_src = 0
+            reenc_by_name: dict[str, int] = {}
             for n in expanded_t:
-                e = _stats_entry_for_assignment_name(n)
-                if isinstance(e, dict):
-                    reenc_src += _fp.reencoded_source_bytes_for_shape(
-                        _shape_from_stats(e), regime)
-            floor = float(src_total) - reenc_src
+                nb = src_manifest.get(n)
+                if nb is None and n.endswith(".weight"):
+                    nb = src_manifest.get(n[: -len(".weight")])
+                if nb is None:
+                    # Not resolvable in the checkpoint headers: leave the
+                    # tensor priced in the floor (conservative — the artifact
+                    # estimate can only over-count, never under-count) and
+                    # report it loudly after the grid pass.
+                    manifest_missing.add(n)
+                    continue
+                reenc_by_name[n] = int(nb)
+            floor = float(src_total) - sum(reenc_by_name.values())
+            _fp.check_floor_non_negative(
+                floor, float(src_total), reenc_by_name,
+                context=f"byte-budget selector (target_bits={t:.3f})")
             return {
                 "target_bits": float(t), "achieved_bits": float(ach_t),
                 "bpp": float(ach_t), "dloss": float(tot_t),
@@ -2070,6 +2091,15 @@ def main():
             r = _artifact_for_target(float(row["target_bits"]))
             if r is not None:
                 grid.append(r)
+        if manifest_missing:
+            print(
+                "[alloc] WARNING: "
+                f"{len(manifest_missing)} re-encoded Linears not found in the "
+                "source checkpoint manifest; their source bytes stay in the "
+                "floor (artifact size over-counted, never under-counted). "
+                f"Sample: {sorted(manifest_missing)[:8]}",
+                flush=True,
+            )
         sel = select_under_byte_budget(grid, budget_bytes)
 
         rd = knee_summary.get("rd_curve") if isinstance(knee_summary, dict) else None
@@ -2080,6 +2110,8 @@ def main():
             "budget_bytes": budget_bytes,
             "source_total_bytes": float(src_total),
             "source_regime": regime,
+            "source_accounting": "per_tensor_manifest_v2",
+            "manifest_missing_linears": len(manifest_missing),
             "source_bytes_per_param": int(
                 _fp.dominant_source_bytes_per_param(src_by_dtype)),
             "feasible": bool(sel["feasible"]),

--- a/prismaquant/allocator.py
+++ b/prismaquant/allocator.py
@@ -2049,11 +2049,16 @@ def main():
         # DSv4-Flash checkpoint: I8 nibble experts + E8M0 scales, F8
         # attention, BF16 floor) the old regime accounting removed more
         # bytes than the checkpoint holds, driving the floor negative.
+        # `expert_parent_for_projection` bridges the per-expert-on-disk /
+        # packed-live MoE layouts (…experts.{i}.gate_proj -> the packed
+        # …experts.gate_up_proj the allocator names), same mapping the
+        # layer-streaming pack bridge uses.
         src_manifest = _fp.source_tensor_bytes_manifest(
             probe_model_path,
             name_map=getattr(model_profile, "checkpoint_to_live_name", None),
+            expert_parent_for_projection=getattr(
+                model_profile, "packed_expert_parent_for_projection", None),
         )
-        manifest_missing: set[str] = set()
 
         def _artifact_for_target(t: float):
             assign_t, ach_t, tot_t, _mut = _solve_for_target(t)
@@ -2061,19 +2066,14 @@ def main():
                 return None
             expanded_t = _expand_assignment_for_seed_json(assign_t)
             body_aux = _assignment_bits_total(expanded_t) / 8.0
-            reenc_by_name: dict[str, int] = {}
-            for n in expanded_t:
-                nb = src_manifest.get(n)
-                if nb is None and n.endswith(".weight"):
-                    nb = src_manifest.get(n[: -len(".weight")])
-                if nb is None:
-                    # Not resolvable in the checkpoint headers: leave the
-                    # tensor priced in the floor (conservative — the artifact
-                    # estimate can only over-count, never under-count) and
-                    # report it loudly after the grid pass.
-                    manifest_missing.add(n)
-                    continue
-                reenc_by_name[n] = int(nb)
+            # A re-encoded name the manifest cannot resolve is a hard error
+            # (raised BEFORE any selection numbers are consumed): it would
+            # stay priced in the floor while its quantized body bytes are
+            # still added, and on a packed-MoE model that double-counts the
+            # entire expert mass — every rung then reads "below the floor".
+            reenc_by_name = _fp.resolve_reencoded_source_bytes(
+                src_manifest, expanded_t,
+                context=f"byte-budget selector (target_bits={t:.3f})")
             floor = float(src_total) - sum(reenc_by_name.values())
             _fp.check_floor_non_negative(
                 floor, float(src_total), reenc_by_name,
@@ -2091,15 +2091,6 @@ def main():
             r = _artifact_for_target(float(row["target_bits"]))
             if r is not None:
                 grid.append(r)
-        if manifest_missing:
-            print(
-                "[alloc] WARNING: "
-                f"{len(manifest_missing)} re-encoded Linears not found in the "
-                "source checkpoint manifest; their source bytes stay in the "
-                "floor (artifact size over-counted, never under-counted). "
-                f"Sample: {sorted(manifest_missing)[:8]}",
-                flush=True,
-            )
         sel = select_under_byte_budget(grid, budget_bytes)
 
         rd = knee_summary.get("rd_curve") if isinstance(knee_summary, dict) else None
@@ -2111,7 +2102,6 @@ def main():
             "source_total_bytes": float(src_total),
             "source_regime": regime,
             "source_accounting": "per_tensor_manifest_v2",
-            "manifest_missing_linears": len(manifest_missing),
             "source_bytes_per_param": int(
                 _fp.dominant_source_bytes_per_param(src_by_dtype)),
             "feasible": bool(sel["feasible"]),

--- a/prismaquant/allocator.py
+++ b/prismaquant/allocator.py
@@ -1268,6 +1268,50 @@ def main():
     costs = cost_data["costs"]
     print(f"[alloc] stats: {len(stats)} Linears, costs: {len(costs)} Linears")
 
+    # ---- Fisher renormalization ----
+    # Older incremental probes finalized `h_trace = h_trace_raw /
+    # n_tokens_seen` PER ROW, where per-expert Linears only count their
+    # ROUTED tokens — inflating a rarely-routed expert's Fisher by
+    # (global/routed), up to ~33,000x, i.e. inverted importance weighting.
+    # The raw accumulators are stored, so recompute every derived field here
+    # with the one correct shared denominator: the global calib token count
+    # (probe meta nsamples x seqlen). Dense rows saw exactly that many
+    # tokens, so their values are unchanged; probes written by the fixed
+    # finalize (meta.fisher_norm_tokens) renormalize to identical values —
+    # the recompute is idempotent.
+    _meta = probe.get("meta", {}) or {}
+    _norm_tokens = int(_meta.get("fisher_norm_tokens", 0) or 0)
+    if _norm_tokens <= 0:
+        _norm_tokens = (int(_meta.get("nsamples", 0) or 0)
+                        * int(_meta.get("seqlen", 0) or 0))
+    if _norm_tokens > 0:
+        _renormed = 0
+        for _entry in stats.values():
+            if not isinstance(_entry, dict) or "h_trace_raw" not in _entry:
+                continue
+            _entry["h_trace"] = float(_entry["h_trace_raw"]) / _norm_tokens
+            if "h_w2_sum_raw" in _entry:
+                _entry["h_w2_sum"] = (
+                    float(_entry["h_w2_sum_raw"]) / _norm_tokens)
+            _per_raw = _entry.get("h_trace_per_expert_raw")
+            if _per_raw is not None:
+                _entry["h_trace_per_expert"] = [
+                    float(v) / _norm_tokens for v in _per_raw]
+            _renormed += 1
+        print(f"[alloc] Fisher renormalized: {_renormed}/{len(stats)} rows "
+              f"→ h_trace_raw / {_norm_tokens} global calib tokens "
+              "(per-expert routed-count normalization corrected)", flush=True)
+    else:
+        _needs_fix = sum(
+            1 for _e in stats.values()
+            if isinstance(_e, dict) and "h_trace_raw" in _e
+            and int(_e.get("n_tokens_seen", 0) or 0) > 0)
+        if _needs_fix:
+            print("[alloc] WARNING: probe meta lacks nsamples/seqlen; cannot "
+                  "renormalize h_trace by the global calib token count. "
+                  "Per-expert Fisher may be inflated by routed-token "
+                  "normalization.", flush=True)
+
     allow_pinned = [s.strip() for s in (args.allow_pinned or "").split(",") if s.strip()]
     allocation_excluded = []
     for name in sorted(set(stats) | set(costs)):

--- a/prismaquant/footprint.py
+++ b/prismaquant/footprint.py
@@ -131,6 +131,63 @@ def source_regime(by_dtype: Mapping[str, int]) -> str:
     return "bf16"
 
 
+def source_tensor_bytes_manifest(
+    model_path: str,
+    name_map=None,
+) -> dict[str, int]:
+    """Exact on-disk source bytes per weight tensor, keyed by live qname base.
+
+    Walks the safetensors headers and, for every ``<base>.weight`` tensor,
+    sums its byte span with its quantization sidecars (``<base>.scale``,
+    ``<base>.weight_scale_inv``) — exactly the bytes the export removes from
+    the checkpoint when it re-encodes that Linear. ``name_map`` maps a
+    checkpoint key to the live transformers parameter name
+    (``ModelProfile.checkpoint_to_live_name``); identity when None. Keys are
+    stored without the ``.weight`` suffix to match allocator qnames.
+
+    This is the per-tensor replacement for the regime-wide
+    ``reencoded_source_bytes_for_shape`` accounting, which charges EVERY
+    re-encoded Linear at the FP8_SOURCE layout (1 B/param + fp32 block
+    scales) as soon as any F8 dtype is present in the checkpoint. On a
+    mixed-precision source that is wrong per tensor class — e.g. the
+    MXFP4-packed routed experts of a DSv4-Flash checkpoint (I8 nibble
+    weights + E8M0 group scales, ~0.53 B/param) were charged 1 B/param,
+    "removing" 279.9 GB from a 166.9 GB checkpoint and driving the
+    non-quantizable floor to −113 GB. Summing actual header byte spans can
+    never exceed the checkpoint total, so a floor computed from this
+    manifest is >= 0 by construction (a negative floor is always an
+    accounting bug — rejected at the consumers).
+    """
+    spans: dict[str, int] = {}
+    shards = sorted(glob.glob(os.path.join(model_path, "*.safetensors")))
+    if not shards:
+        raise FileNotFoundError(
+            f"no *.safetensors shards under {model_path!r}; cannot build the "
+            "per-tensor source-byte manifest")
+    for shard in shards:
+        header = _read_safetensors_header(shard)
+        for name, meta in header.items():
+            if name == "__metadata__":
+                continue
+            a, b = meta["data_offsets"]
+            spans[name] = spans.get(name, 0) + (int(b) - int(a))
+    out: dict[str, int] = {}
+    for name, nb in spans.items():
+        if not name.endswith(".weight"):
+            continue
+        base = name[: -len(".weight")]
+        total = (nb
+                 + spans.get(base + ".scale", 0)
+                 + spans.get(base + ".weight_scale_inv", 0))
+        live = name_map(name) if name_map is not None else name
+        if not live:
+            continue  # dropped by the profile (never re-encoded; stays in floor)
+        if live.endswith(".weight"):
+            live = live[: -len(".weight")]
+        out[live] = out.get(live, 0) + total
+    return out
+
+
 def reencoded_source_bytes_for_shape(shape: tuple[int, ...], regime: str) -> int:
     """On-disk source bytes of ONE re-encoded Linear, by source regime.
 
@@ -141,6 +198,12 @@ def reencoded_source_bytes_for_shape(shape: tuple[int, ...], regime: str) -> int
     scale). This is what makes the floor exact for fp8-native sources: every
     re-encoded Linear's *full* source footprint (weight + scale_inv) is removed
     from the floor, not just the weight bytes.
+
+    WARNING: regime-wide accounting is only correct when the body is
+    uniformly bf16 or uniformly fp8. For mixed-precision sources (e.g.
+    MXFP4-packed experts, I8 + E8M0 scales) use
+    :func:`source_tensor_bytes_manifest`, which charges each tensor its
+    actual header byte span. Consumers must reject a negative floor.
     """
     if regime == "fp8":
         return int(fr.get_format("FP8_SOURCE").memory_bytes_for_shape(shape))
@@ -148,6 +211,55 @@ def reencoded_source_bytes_for_shape(shape: tuple[int, ...], regime: str) -> int
     for d in shape:
         n *= int(d)
     return n * 2  # bf16/fp16 source weight, no scale sibling
+
+
+def _tensor_class(qname: str) -> str:
+    """Coarse tensor-class label for floor-accounting diagnostics."""
+    if ".shared_experts." in qname:
+        return "shared_experts"
+    if ".experts." in qname:
+        return "routed_experts"
+    if ".self_attn." in qname or ".attn." in qname:
+        return "attention"
+    if ".mlp." in qname or ".ffn." in qname:
+        return "mlp"
+    return "other"
+
+
+def check_floor_non_negative(
+    floor_bytes: float,
+    source_total_bytes: float,
+    reencoded_by_name: Mapping[str, int],
+    *,
+    context: str,
+) -> None:
+    """A negative non-quantizable floor is ALWAYS an accounting bug.
+
+    It means the source bytes 'removed' for re-encoding exceed the bytes the
+    checkpoint actually holds — e.g. MXFP4-packed experts (~0.53 B/param on
+    disk) charged at the FP8_SOURCE 1 B/param layout can drive the floor
+    negative and let an artifact more than twice the budget 'fit' it. Raises
+    with the per-tensor-class byte breakdown so the offending class is
+    named, never rationalized.
+    """
+    if floor_bytes >= 0:
+        return
+    by_class: dict[str, int] = {}
+    for qname, nb in reencoded_by_name.items():
+        cls = _tensor_class(qname)
+        by_class[cls] = by_class.get(cls, 0) + int(nb)
+    detail = ", ".join(
+        f"{cls}={nb / GB:.2f}GB"
+        for cls, nb in sorted(by_class.items(), key=lambda kv: -kv[1]))
+    raise ValueError(
+        f"[footprint] negative non-quantizable floor in {context}: "
+        f"floor={floor_bytes / GB:.3f}GB (source_total="
+        f"{source_total_bytes / GB:.3f}GB, reencoded_source="
+        f"{(source_total_bytes - floor_bytes) / GB:.3f}GB). Removed source "
+        f"bytes by tensor class: {detail}. The per-class source-byte rate is "
+        "wrong (mixed-precision source charged at a uniform regime?). Use "
+        "source_tensor_bytes_manifest() for per-tensor accounting; do not "
+        "ship a selection computed from this floor.")
 
 
 # fp32 weight_global_scale + fp32 input_global_scale per emitted NVFP4
@@ -213,7 +325,7 @@ def assignment_artifact_bytes(
     ``reencoded_source_bytes``, ``n_reencoded``, ``n_missing_stats``, ``regime``.
     """
     body_quant = 0
-    reenc_src = 0
+    reenc_by_name: dict[str, int] = {}
     n_reencoded = 0
     n_missing = 0
     for qname, fmt in assignment.items():
@@ -228,9 +340,13 @@ def assignment_artifact_bytes(
         body_quant += fr.get_format(name).memory_bytes_for_shape(shape)
         if name == "NVFP4":
             body_quant += nvfp4_global_sidecar_bytes(qname, shape)
-        reenc_src += reencoded_source_bytes_for_shape(shape, regime)
+        reenc_by_name[qname] = reencoded_source_bytes_for_shape(shape, regime)
         n_reencoded += 1
+    reenc_src = sum(reenc_by_name.values())
     floor = int(source_total_bytes) - reenc_src
+    check_floor_non_negative(
+        floor, int(source_total_bytes), reenc_by_name,
+        context="assignment_artifact_bytes")
     return {
         "artifact_bytes": floor + body_quant,
         "floor_bytes": floor,
@@ -272,20 +388,30 @@ def floor_bytes_for_model(
     formats (only the re-encoded *format* varies, not which tensors are
     re-encoded), so callers sweeping many allocations compute this once and pass
     ``source_total_bytes`` + ``regime`` to ``assignment_artifact_bytes`` per
-    candidate. ``regime`` defaults to :func:`source_regime` (robust fp8/bf16
-    detection); each re-encoded Linear's source bytes follow the regime
-    (fp8 removes the weight_scale_inv sibling too).
+    candidate. Each re-encoded Linear is charged its actual header byte
+    span from :func:`source_tensor_bytes_manifest` (this function has the
+    model path, so it never needs the regime-wide per-param rate); names
+    missing from the manifest stay priced in the floor — over-count only.
+    ``regime`` defaults to :func:`source_regime` (robust fp8/bf16
+    detection) and is returned for the per-candidate
+    ``assignment_artifact_bytes`` calls, which have no model path.
+    ``stats`` is retained for call compatibility (shapes are no longer
+    needed to price source bytes).
     """
     total, by_dtype = source_checkpoint_bytes(model_path)
     reg = regime if regime is not None else source_regime(by_dtype)
-    reenc_src = 0
+    manifest = source_tensor_bytes_manifest(model_path)
+    reenc_by_name: dict[str, int] = {}
     for qname in reencoded_names:
-        entry = stats.get(qname)
-        if entry is None and qname.endswith(".weight"):
-            entry = stats.get(qname[: -len(".weight")])
-        if isinstance(entry, dict):
-            reenc_src += reencoded_source_bytes_for_shape(
-                _shape_from_stats(entry), reg)
+        nb = manifest.get(qname)
+        if nb is None and qname.endswith(".weight"):
+            nb = manifest.get(qname[: -len(".weight")])
+        if nb is not None:
+            reenc_by_name[qname] = int(nb)
+    reenc_src = sum(reenc_by_name.values())
+    check_floor_non_negative(
+        int(total) - reenc_src, total, reenc_by_name,
+        context="floor_bytes_for_model")
     return {
         "source_total_bytes": total,
         "regime": reg,

--- a/prismaquant/footprint.py
+++ b/prismaquant/footprint.py
@@ -131,19 +131,87 @@ def source_regime(by_dtype: Mapping[str, int]) -> str:
     return "bf16"
 
 
+# Quantization sidecar suffixes summed into their base tensor's manifest
+# entry: the export removes these together with the weight when it
+# re-encodes a Linear (DSv4 ``.scale`` MXFP4/E8M0 group scales, DeepSeek /
+# MiniMax fp8 ``.weight_scale_inv`` 128x128 block scales, compressed-tensors
+# ``.weight_scale``). A standalone sidecar with no base tensor is never
+# re-encoded and stays priced in the floor.
+_SIDECAR_SUFFIXES = (".scale", ".weight_scale_inv", ".weight_scale")
+
+
+def _default_expert_parent_for_projection(projection_name: str) -> str | None:
+    """No-profile fallback for the per-expert -> packed projection mapping.
+
+    Mirrors ``ModelProfile.packed_expert_parent_for_projection``'s legacy
+    fallback: per-expert ``gate_proj``/``up_proj`` fuse into the packed
+    ``gate_up_proj`` (output-axis cat, the transformers packed-FusedMoE
+    convention); ``down_proj`` packs 1:1. Anything else (e.g. MiniMax's
+    per-expert ``w1``/``w2``/``w3`` modules, which stay per-expert live)
+    has no packed parent here — callers with a profile should pass its
+    ``packed_expert_parent_for_projection`` instead.
+    """
+    if projection_name in ("gate_proj", "up_proj"):
+        return "gate_up_proj"
+    if projection_name == "down_proj":
+        return "down_proj"
+    return None
+
+
+def packed_expert_alias(qname: str, parent_for_projection=None) -> str | None:
+    """Packed live qname a per-expert Linear aggregates into, or None.
+
+    ``...experts.{i}.{proj}`` -> ``...experts.{parent}`` when
+    ``parent_for_projection(proj)`` names a packed parent
+    (``ModelProfile.packed_expert_parent_for_projection``; the legacy
+    gate/up/down fallback when None). Non-expert names and unrecognized
+    projections return None. This is the same structural
+    ``experts.{idx}.{leaf}`` detection the profile layer uses for
+    packed-format grouping (``packed_expert_format_group``).
+    """
+    parts = str(qname).split(".")
+    if len(parts) < 3 or parts[-3] != "experts" or not parts[-2].isdigit():
+        return None
+    fn = (parent_for_projection if parent_for_projection is not None
+          else _default_expert_parent_for_projection)
+    parent = fn(parts[-1])
+    if not parent:
+        return None
+    return ".".join(parts[:-2] + [str(parent)])
+
+
 def source_tensor_bytes_manifest(
     model_path: str,
     name_map=None,
+    expert_parent_for_projection=None,
 ) -> dict[str, int]:
     """Exact on-disk source bytes per weight tensor, keyed by live qname base.
 
-    Walks the safetensors headers and, for every ``<base>.weight`` tensor,
-    sums its byte span with its quantization sidecars (``<base>.scale``,
-    ``<base>.weight_scale_inv``) — exactly the bytes the export removes from
-    the checkpoint when it re-encodes that Linear. ``name_map`` maps a
-    checkpoint key to the live transformers parameter name
-    (``ModelProfile.checkpoint_to_live_name``); identity when None. Keys are
-    stored without the ``.weight`` suffix to match allocator qnames.
+    Walks the safetensors headers and, for every weight tensor, sums its
+    byte span with its quantization sidecars (``<base>.scale``,
+    ``<base>.weight_scale_inv``, ``<base>.weight_scale``) — exactly the
+    bytes the export removes from the checkpoint when it re-encodes that
+    Linear. ``name_map`` maps a checkpoint key to the live transformers
+    parameter name (``ModelProfile.checkpoint_to_live_name``); identity
+    when None. Keys are stored without the ``.weight`` suffix to match
+    allocator qnames.
+
+    Both packed-MoE on-disk layouts resolve to the packed allocator names
+    (``...experts.gate_up_proj`` / ``...experts.down_proj``):
+
+    - **Packed 3-D on disk** (LFM2.5, Qwen3.6-35B): the expert param is a
+      checkpoint key with NO ``.weight`` suffix. Suffix-less keys are kept
+      (only sidecar keys are folded into their base), so the packed tensor
+      lands in the manifest under its own name.
+    - **Per-expert 2-D on disk** (``...experts.{i}.{proj}.weight``): each
+      per-expert span is ALSO accumulated into the packed parent name via
+      :func:`packed_expert_alias` (gate+up fuse into gate_up), driven by
+      ``expert_parent_for_projection``
+      (``ModelProfile.packed_expert_parent_for_projection``; legacy
+      gate/up/down fallback when None). The per-expert entries are kept
+      alongside the packed aggregate so per-expert-named allocations
+      resolve too — a ``reencoded_names`` list must use ONE naming scheme
+      per tensor (any consistent probe does), never both.
 
     This is the per-tensor replacement for the regime-wide
     ``reencoded_source_bytes_for_shape`` accounting, which charges EVERY
@@ -172,19 +240,70 @@ def source_tensor_bytes_manifest(
             a, b = meta["data_offsets"]
             spans[name] = spans.get(name, 0) + (int(b) - int(a))
     out: dict[str, int] = {}
+
+    def _add(live: str, nb: int) -> None:
+        out[live] = out.get(live, 0) + nb
+
     for name, nb in spans.items():
-        if not name.endswith(".weight"):
-            continue
-        base = name[: -len(".weight")]
-        total = (nb
-                 + spans.get(base + ".scale", 0)
-                 + spans.get(base + ".weight_scale_inv", 0))
+        if any(name.endswith(s) for s in _SIDECAR_SUFFIXES):
+            continue  # folded into its base tensor's entry below
+        # Packed 3-D expert params have no ".weight" suffix; the key IS the
+        # base (and its sidecars still hang off `<base>.scale` etc.).
+        base = name[: -len(".weight")] if name.endswith(".weight") else name
+        total = nb + sum(spans.get(base + s, 0) for s in _SIDECAR_SUFFIXES)
         live = name_map(name) if name_map is not None else name
         if not live:
             continue  # dropped by the profile (never re-encoded; stays in floor)
         if live.endswith(".weight"):
             live = live[: -len(".weight")]
-        out[live] = out.get(live, 0) + total
+        _add(live, total)
+        packed = packed_expert_alias(live, expert_parent_for_projection)
+        if packed is not None:
+            _add(packed, total)
+    return out
+
+
+def resolve_reencoded_source_bytes(
+    manifest: Mapping[str, int],
+    reencoded_names: Iterable[str],
+    *,
+    context: str,
+) -> dict[str, int]:
+    """Look up each re-encoded Linear's actual source bytes in the manifest.
+
+    A name the manifest cannot resolve is a HARD ERROR, not a warning: an
+    unresolved Linear's source bytes stay in the floor while its quantized
+    body bytes are still added, silently inflating the artifact estimate —
+    on a packed-MoE model by the full expert mass, at which point every
+    rung reads "below the floor". Raising here, before any selection
+    numbers are computed, puts the offending tensor names in front of the
+    operator instead of a fatal below-the-floor exit with a trailing
+    warning.
+    """
+    out: dict[str, int] = {}
+    missing: list[str] = []
+    for qname in reencoded_names:
+        nb = manifest.get(qname)
+        if nb is None and qname.endswith(".weight"):
+            nb = manifest.get(qname[: -len(".weight")])
+        if nb is None:
+            missing.append(qname)
+        else:
+            out[qname] = int(nb)
+    if missing:
+        shown = sorted(missing)[:10]
+        raise ValueError(
+            f"[footprint] {len(missing)} re-encoded Linear(s) not resolvable "
+            f"in the source checkpoint manifest ({context}): "
+            + ", ".join(shown)
+            + (", …" if len(missing) > len(shown) else "")
+            + ". Their source bytes would stay in the floor while their "
+            "quantized bytes are still added (artifact over-count; on a "
+            "packed-MoE model the entire expert mass is double-counted and "
+            "every rung reads 'below the floor'). Fix the profile's name "
+            "resolution (checkpoint_to_live_name / "
+            "packed_expert_parent_for_projection) so every re-encoded "
+            "tensor resolves; do not consume these numbers.")
     return out
 
 
@@ -303,6 +422,7 @@ def assignment_artifact_bytes(
     source_total_bytes: int,
     regime: str = "bf16",
     canonicalize: bool = True,
+    source_manifest: Mapping[str, int] | None = None,
 ) -> dict:
     """Exact on-disk bytes of the exported artifact for ``assignment``.
 
@@ -315,18 +435,31 @@ def assignment_artifact_bytes(
     is correct for any tensor that ships verbatim (and explains why a handful of
     fused super-names / pins can be missing yet the total stays exact).
 
-    ``regime`` ('bf16' | 'fp8', from source_regime) sets each re-encoded Linear's
-    *source* byte size removed from the floor: bf16 -> 2 bytes/param; fp8 -> the
-    full FP8_SOURCE layout (fp8 weight + fp32 128x128 weight_scale_inv), so the
-    source scale sibling is removed too (else it is double-counted: left in the
-    floor and re-added by the export).
+    ``source_manifest`` (from :func:`source_tensor_bytes_manifest`) is the
+    preferred source-byte accounting and the one
+    :func:`floor_bytes_for_model` and the allocator's byte-budget selector
+    use: each re-encoded Linear is charged its ACTUAL header byte span
+    (weight + scale siblings), so the two paths agree exactly. A priced
+    Linear the manifest cannot resolve is a hard error
+    (:func:`resolve_reencoded_source_bytes`).
+
+    Without a manifest, ``regime`` ('bf16' | 'fp8', from source_regime) sets
+    each re-encoded Linear's *source* byte size removed from the floor:
+    bf16 -> 2 bytes/param; fp8 -> the full FP8_SOURCE layout (fp8 weight +
+    fp32 128x128 weight_scale_inv), so the source scale sibling is removed
+    too (else it is double-counted: left in the floor and re-added by the
+    export). This is exact ONLY for a uniformly-bf16 or uniformly-fp8
+    (128x128-block-scaled) body; on any other source pass a manifest — a
+    mixed source drives the floor negative and is rejected
+    (``check_floor_non_negative``), never silently shipped.
 
     Returns a dict: ``artifact_bytes``, ``floor_bytes``, ``body_quant_bytes``,
-    ``reencoded_source_bytes``, ``n_reencoded``, ``n_missing_stats``, ``regime``.
+    ``reencoded_source_bytes``, ``n_reencoded``, ``n_missing_stats``,
+    ``regime``, ``source_accounting``.
     """
     body_quant = 0
     reenc_by_name: dict[str, int] = {}
-    n_reencoded = 0
+    priced: list[str] = []
     n_missing = 0
     for qname, fmt in assignment.items():
         entry = stats.get(qname)
@@ -340,8 +473,13 @@ def assignment_artifact_bytes(
         body_quant += fr.get_format(name).memory_bytes_for_shape(shape)
         if name == "NVFP4":
             body_quant += nvfp4_global_sidecar_bytes(qname, shape)
-        reenc_by_name[qname] = reencoded_source_bytes_for_shape(shape, regime)
-        n_reencoded += 1
+        if source_manifest is None:
+            reenc_by_name[qname] = reencoded_source_bytes_for_shape(
+                shape, regime)
+        priced.append(qname)
+    if source_manifest is not None:
+        reenc_by_name = resolve_reencoded_source_bytes(
+            source_manifest, priced, context="assignment_artifact_bytes")
     reenc_src = sum(reenc_by_name.values())
     floor = int(source_total_bytes) - reenc_src
     check_floor_non_negative(
@@ -352,9 +490,11 @@ def assignment_artifact_bytes(
         "floor_bytes": floor,
         "body_quant_bytes": body_quant,
         "reencoded_source_bytes": reenc_src,
-        "n_reencoded": n_reencoded,
+        "n_reencoded": len(priced),
         "n_missing_stats": n_missing,
         "regime": regime,
+        "source_accounting": (
+            "per_tensor_manifest" if source_manifest is not None else "regime"),
     }
 
 
@@ -364,12 +504,14 @@ def assignment_artifact_gb(
     *,
     source_total_bytes: int,
     regime: str = "bf16",
+    source_manifest: Mapping[str, int] | None = None,
 ) -> float:
     """Convenience: just the artifact size in GB (decimal, matches index.json)."""
     return assignment_artifact_bytes(
         assignment, stats,
         source_total_bytes=source_total_bytes,
         regime=regime,
+        source_manifest=source_manifest,
     )["artifact_bytes"] / GB
 
 
@@ -379,35 +521,38 @@ def floor_bytes_for_model(
     stats: Mapping[str, dict],
     *,
     regime: str | None = None,
+    name_map=None,
+    expert_parent_for_projection=None,
 ) -> dict:
     """Compute the non-quantizable floor (and the scalars to reuse) from a model.
 
     Convenience wrapper that reads the checkpoint headers once and returns
     ``{source_total_bytes, regime, source_bytes_per_param, floor_bytes,
-    reencoded_source_bytes, source_dtype_bytes}``. The floor is constant across
-    formats (only the re-encoded *format* varies, not which tensors are
-    re-encoded), so callers sweeping many allocations compute this once and pass
-    ``source_total_bytes`` + ``regime`` to ``assignment_artifact_bytes`` per
-    candidate. Each re-encoded Linear is charged its actual header byte
-    span from :func:`source_tensor_bytes_manifest` (this function has the
-    model path, so it never needs the regime-wide per-param rate); names
-    missing from the manifest stay priced in the floor — over-count only.
-    ``regime`` defaults to :func:`source_regime` (robust fp8/bf16
-    detection) and is returned for the per-candidate
-    ``assignment_artifact_bytes`` calls, which have no model path.
-    ``stats`` is retained for call compatibility (shapes are no longer
-    needed to price source bytes).
+    reencoded_source_bytes, source_manifest, source_dtype_bytes}``. The floor
+    is constant across formats (only the re-encoded *format* varies, not which
+    tensors are re-encoded), so callers sweeping many allocations compute this
+    once and pass ``source_total_bytes`` + ``source_manifest`` to
+    ``assignment_artifact_bytes`` per candidate. Each re-encoded Linear is
+    charged its actual header byte span from
+    :func:`source_tensor_bytes_manifest` (this function has the model path,
+    so it never needs the regime-wide per-param rate); a name the manifest
+    cannot resolve is a hard error (:func:`resolve_reencoded_source_bytes`) —
+    an unresolved name would silently over-count the artifact.
+    ``name_map`` / ``expert_parent_for_projection`` are the profile's
+    ``checkpoint_to_live_name`` / ``packed_expert_parent_for_projection``
+    (pass them for any packed-MoE architecture; defaults handle the
+    identity naming and the legacy gate/up/down packing). ``regime``
+    defaults to :func:`source_regime` (robust fp8/bf16 detection) and is
+    returned for reporting. ``stats`` is retained for call compatibility
+    (shapes are no longer needed to price source bytes).
     """
     total, by_dtype = source_checkpoint_bytes(model_path)
     reg = regime if regime is not None else source_regime(by_dtype)
-    manifest = source_tensor_bytes_manifest(model_path)
-    reenc_by_name: dict[str, int] = {}
-    for qname in reencoded_names:
-        nb = manifest.get(qname)
-        if nb is None and qname.endswith(".weight"):
-            nb = manifest.get(qname[: -len(".weight")])
-        if nb is not None:
-            reenc_by_name[qname] = int(nb)
+    manifest = source_tensor_bytes_manifest(
+        model_path, name_map=name_map,
+        expert_parent_for_projection=expert_parent_for_projection)
+    reenc_by_name = resolve_reencoded_source_bytes(
+        manifest, reencoded_names, context="floor_bytes_for_model")
     reenc_src = sum(reenc_by_name.values())
     check_floor_non_negative(
         int(total) - reenc_src, total, reenc_by_name,
@@ -418,5 +563,6 @@ def floor_bytes_for_model(
         "source_bytes_per_param": dominant_source_bytes_per_param(by_dtype),
         "floor_bytes": int(total) - reenc_src,
         "reencoded_source_bytes": reenc_src,
+        "source_manifest": manifest,
         "source_dtype_bytes": by_dtype,
     }

--- a/prismaquant/incremental_measure_quant_cost.py
+++ b/prismaquant/incremental_measure_quant_cost.py
@@ -61,10 +61,10 @@ from .measure_quant_cost import (
     _finalize_results,
     _measure_packed_experts,
     _normalize_fisher_output_mse_row_weights,
-    canonical_linear_name,
     measure_batched_gpu,
     measure_unbatched,
     prepare_cost_context,
+    resolve_cost_target_name,
     start_mem_watchdog,
 )
 from .streaming_model import (
@@ -291,7 +291,7 @@ def _measure_production_render_dense(
     }
 
     for name, mod in module.named_modules():
-        canonical_name = canonical_linear_name(name, profile)
+        canonical_name = resolve_cost_target_name(name, target_names, profile)
         if not isinstance(mod, nn.Linear) or canonical_name not in target_names:
             continue
         if canonical_name not in act_cache:

--- a/prismaquant/incremental_probe.py
+++ b/prismaquant/incremental_probe.py
@@ -1208,12 +1208,10 @@ def _compute_global_precompute(
 
     for d in range(prefetch_depth):
         ctx.schedule_prefetch(d)
-    # v22 Fix E1: keep activations on device through phase-1 to avoid
-    # the per-layer .cpu() sync that stalls the forward pipeline. We
-    # batch the device→host transfer at the END of phase-1 in a single
-    # call. The pickled precompute cache (and downstream phase-3) want
-    # CPU tensors, which we produce after the loop.
-    device_acts: list[torch.Tensor] = [hidden.detach()]
+    # Phase-1 activations are captured to host per layer (see the note at
+    # the append below). The pickled precompute cache (and downstream
+    # phase-3) want CPU tensors, which this produces directly.
+    host_acts: list[torch.Tensor] = [hidden.detach().to("cpu")]
     for L in range(num_layers):
         load_t0 = time.time()
         src = ctx.install(L)
@@ -1234,7 +1232,13 @@ def _compute_global_precompute(
             )
         fwd_s = time.time() - fwd_t0
         hidden = out
-        device_acts.append(hidden.detach())
+        # Capture each activation to host inside the loop: stacking all
+        # L+1 activations device-resident before one .cpu() doubles the
+        # peak device memory of the activation working set, at the exact
+        # phase-1/2 transition where the probe's high-water mark already
+        # sits. The copy is per-layer and off the hot path (the layer
+        # forward dominates), so there is nothing worth batching.
+        host_acts.append(hidden.detach().to("cpu"))
         ctx.unload(L)
         if L % 8 == 0 or L == num_layers - 1:
             print(f"[incremental/global] fwd L{L:02d}  src={src}  "
@@ -1245,18 +1249,12 @@ def _compute_global_precompute(
     # phase-3's isolated forwards can reconstruct it.
     shared_pass_state = _profile.capture_forward_pass_state(pass_state)
 
-    # v22 Fix E1: batched device→host transfer for the activations
-    # captured during phase-1. All have the same (B, T, H) shape so we
-    # stack into one (L+1, B, T, H) tensor and do a single .cpu() —
-    # 62 individual transfers collapsed into one. After the copy lands,
-    # we split back into a list of CPU tensors so the rest of the code
-    # (precompute cache pickle, phase-3 reads) sees the original layout.
+    # (v22 Fix E1 — the batched stack-then-.cpu() transfer — is intentionally
+    # NOT used here: activations are captured host-side per layer in the
+    # loop above, so they are already CPU tensors in the expected layout.)
     t_h2h = time.time()
-    stacked = torch.stack(device_acts, dim=0).cpu()
-    activations_cpu: list[torch.Tensor] = [
-        stacked[i].clone() for i in range(stacked.size(0))
-    ]
-    del device_acts, stacked
+    activations_cpu: list[torch.Tensor] = host_acts
+    host_acts = []
     print(f"[incremental/global] phase-1 forward: {time.time()-t_phase:.1f}s  "
           f"(host transfer {time.time()-t_h2h:.1f}s)  "
           f"{ctx.layer_cache.summary()}", flush=True)

--- a/prismaquant/incremental_probe.py
+++ b/prismaquant/incremental_probe.py
@@ -1524,6 +1524,35 @@ def _load_precompute_cache(path: Path, expected_meta: dict[str, Any],
     )
 
 
+def finalize_fisher_stats(merged_stats: dict, global_tokens: int) -> None:
+    """Normalize raw Fisher accumulators into ``h_trace`` (etc.), in place.
+
+    Fisher normalization must share ONE denominator across every row: the
+    global calibration token count (nsamples x seqlen). Dense trunk Linears
+    accumulate exactly that many tokens in ``n_tokens_seen``, so their
+    values are unchanged by dividing by the global count. Per-expert
+    Linears, however, only see their ROUTED tokens; a per-row
+    ``h_trace_raw / n_tokens_seen`` inflates a rarely-routed expert's
+    Fisher by (global/routed) — exactly inverted importance weighting (the
+    least-used experts look the most sensitive). Tokens never routed to an
+    expert contribute zero gradient, so the empirical Fisher over the
+    calibration set divides by the GLOBAL count for every row.
+    ``n_tokens_seen`` is kept raw (routed count) — the h_detail blob writer
+    still normalizes per-Linear and stamps units="per_token" for its own
+    single-tensor consumers.
+    """
+    for s in merged_stats.values():
+        s["h_trace"] = s.get("h_trace_raw", 0.0) / global_tokens
+        s["h_w2_sum"] = s.get("h_w2_sum_raw", 0.0) / global_tokens
+        # Per-expert Fisher trace (only present on packed-3D stat entries;
+        # dense Linears have no per-expert dimension). Normalize by the
+        # same token count so it shares units with `h_trace`.
+        per = s.get("h_trace_per_expert_raw")
+        if per is not None:
+            s["h_trace_per_expert"] = [float(v) / global_tokens for v in per]
+        s["h_trace_norm_tokens"] = global_tokens
+
+
 # ---------------------------------------------------------------------------
 # Per-shard body runner — phase-3 of streaming_probe, scoped to the
 # Linears matching this shard's regex. Phase-1 + Phase-2 are now global
@@ -2473,16 +2502,11 @@ def _run_body_streaming_shard(
         del grad_at_tail, grad_out
 
     # ---- Finalize ----
-    for s in merged_stats.values():
-        tokens = max(s.get("n_tokens_seen", 1), 1)
-        s["h_trace"] = s.get("h_trace_raw", 0.0) / tokens
-        s["h_w2_sum"] = s.get("h_w2_sum_raw", 0.0) / tokens
-        # Per-expert Fisher trace (only present on packed-3D stat entries;
-        # dense Linears have no per-expert dimension). Normalize by the
-        # same token count so it shares units with `h_trace`.
-        per = s.get("h_trace_per_expert_raw")
-        if per is not None:
-            s["h_trace_per_expert"] = [float(v) / tokens for v in per]
+    # One shared denominator for every row — the global calib token count
+    # (see finalize_fisher_stats for why per-row n_tokens_seen is wrong
+    # for routed-expert Linears).
+    global_tokens = max(int(calib.size(0)) * int(seqlen), 1)
+    finalize_fisher_stats(merged_stats, global_tokens)
 
     detail_dir = Path(h_detail_dir) if h_detail_dir else None
     if detail_dir is not None:
@@ -2587,6 +2611,9 @@ def _run_body_streaming_shard(
                 "activation_rows_limit": int(activation_rows_limit),
                 "linear_include": linear_include,
                 "linear_exclude": linear_exclude,
+                # Marker: h_trace/h_w2_sum/h_trace_per_expert are divided by
+                # the GLOBAL calib token count (not per-row n_tokens_seen).
+                "fisher_norm_tokens": global_tokens,
             },
         }, f)
     print(f"[incremental] wrote {out_path}", flush=True)

--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -1519,7 +1519,13 @@ def _call_layer(layer: nn.Module, hidden: torch.Tensor, *,
         lt = _layer_attention_type(layer)
         pe = pe.get(lt)
         if pe is None:
-            if len(position_embeddings) == 1:
+            if "main" in position_embeddings:
+                # DSv4: rotary.layer_types are rope AXES ("main"/"compress"),
+                # not attention-schedule types — the vendored probe forward
+                # feeds layer_type="main" rope to every decoder layer (the
+                # compress branch is stubbed out in probe mode).
+                pe = position_embeddings["main"]
+            elif len(position_embeddings) == 1:
                 pe = next(iter(position_embeddings.values()))
             else:
                 raise RuntimeError(

--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -457,7 +457,11 @@ def _apply_fp8_dequant_inplace(
     """For each tensor in `out` whose key matches a `fp8_scale_inv_map`
     entry, read the scale_inv, apply the checkpoint-declared block
     dequant (`fp8_scale_inv_map.block`, see `_fp8_dequant_block`), and
-    replace the loaded tensor with the dequanted bf16 weight.
+    replace the loaded tensor with the dequanted bf16 weight. MXFP4
+    tensors (OCP MX FP4 E2M1 nibble pairs with per-32-element E8M0
+    scales, e.g. DSv4-Flash routed experts) are detected by signature
+    and dequanted on a dedicated path (step 3b) instead of the
+    block-FP8 broadcast.
 
     Tensors and scales are both grouped by shape and multiplied in a
     single batched 5-D broadcast op per shape-group. On MiniMax-M2.7
@@ -495,8 +499,19 @@ def _apply_fp8_dequant_inplace(
     block_r, block_c = _fp8_dequant_block(fp8_scale_inv_map)
     by_shape: dict[tuple[int, int], list[str]] = defaultdict(list)
     fallback: list[str] = []
+    mxfp4_names: list[str] = []
     for name in loaded_scales:
         w = out[name]
+        # DSv4-Flash routed experts are MXFP4, not block-FP8: E2M1 nibble
+        # pairs packed into int8 (low nibble = even element) with per-row
+        # E8M0 scales over 32 logical elements. Signature: int8 weight +
+        # scale grid (out, packed_in/16). Handled in step 3b below.
+        if (w.dim() == 2 and w.dtype == torch.int8
+                and loaded_scales[name].dim() == 2
+                and loaded_scales[name].shape[0] == w.shape[0]
+                and loaded_scales[name].shape[1] * 16 == w.shape[1]):
+            mxfp4_names.append(name)
+            continue
         if w.dim() != 2:
             fallback.append(name)
             continue
@@ -542,6 +557,32 @@ def _apply_fp8_dequant_inplace(
             out[n] = dequanted_stack[i].contiguous()
         dequanted += E
         del w_stack, s_stack, w4, s4, dequanted_stack
+
+    # Step 3b: MXFP4 tensors (DSv4-Flash routed experts). Vectorized
+    # nibble unpack + per-32-element E8M0 scale, per the OCP Microscaling
+    # Formats (MX) v1.0 spec: FP4 E2M1 element grid ({0, 0.5, 1, 1.5, 2,
+    # 3, 4, 6} with a sign bit), one shared E8M0 power-of-two scale per
+    # 32-element group.
+    if mxfp4_names:
+        lut = torch.tensor(
+            [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+             0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+            dtype=torch.bfloat16, device=device)
+        for name in mxfp4_names:
+            wp = out[name].to(device=device).view(torch.uint8)
+            rows, packed_in = wp.shape
+            logical_in = packed_in * 2
+            deq = torch.empty(rows, logical_in, dtype=torch.bfloat16,
+                              device=device)
+            deq[:, 0::2] = lut[(wp & 0x0F).to(torch.long)]
+            deq[:, 1::2] = lut[(wp >> 4).to(torch.long)]
+            sb = loaded_scales[name].to(device=device).view(torch.uint8)
+            scale = torch.exp2((sb.to(torch.float32) - 127.0))
+            deq = (deq.reshape(rows, logical_in // 32, 32).to(torch.float32)
+                   * scale.unsqueeze(-1)).to(torch.bfloat16)
+            out[name] = deq.reshape(rows, logical_in).contiguous()
+            dequanted += 1
+            del wp, deq, sb, scale
 
     # Step 4: Fallback path for any shapes we didn't batch.
     for name in fallback:

--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -1649,12 +1649,24 @@ def _compute_attention_mask(
             cfg.sliding_window
         )
 
-    return {
+    masks = {
         "full_attention": create_causal_mask(**mask_kwargs),
         "sliding_attention": create_sliding_window_causal_mask(
             **sliding_mask_kwargs
         ),
     }
+    # DSv4-Flash: the compress-ratio ladder yields layer types beyond the
+    # Gemma pair — compressed_sparse_attention (ratio 4) and
+    # heavily_compressed_attention (ratio 128). In probe mode every
+    # compressed variant degrades to sliding-window-only attention (the
+    # vendored layer stubs out the compressor and skips the long-range
+    # branch), and the vendored root feeds one sliding-window mask to all
+    # layers. Alias exactly those two types to the sliding mask; any
+    # other unknown layer type still fails loudly downstream.
+    for lt in ("compressed_sparse_attention", "heavily_compressed_attention"):
+        if lt in layer_types and lt not in masks:
+            masks[lt] = masks["sliding_attention"]
+    return masks
 
 
 def _resolve_base_prefix(root: nn.Module, base: nn.Module) -> str:

--- a/prismaquant/measure_quant_cost.py
+++ b/prismaquant/measure_quant_cost.py
@@ -72,6 +72,117 @@ def canonical_linear_name(name: str, profile=None) -> str:
     return f"{prefix}.{parent}.{expert_id}"
 
 
+def resolve_cost_target_name(name: str, target_names: set[str],
+                             profile=None) -> str:
+    """Cost-row key for a live module name, honoring raw-name probes.
+
+    ``canonical_linear_name`` remaps per-expert live names to packed-style
+    names (``experts.gate_up_proj.E`` / ``experts.down_proj.E``). Models
+    whose probe keys per-expert Linears under the RAW live names
+    (DSv4-Flash) would then miss ``target_names`` and every routed expert
+    would be silently skipped. Fall back to the raw live name when the
+    remapped name misses but the raw name is a target.
+    """
+    canonical = canonical_linear_name(name, profile)
+    if canonical not in target_names and name in target_names:
+        return name
+    return canonical
+
+
+_PER_EXPERT_NAME_RE = re.compile(r"^(.+\.experts)\.(\d+)\.([^.]+)$")
+
+
+def _expert_cost_sample_n() -> int:
+    """PRISMAQUANT_EXPERT_COST_SAMPLE: stratified experts-per-(layer,
+    projection) sample for cost measurement; 0 (default) measures every
+    expert. Shared by the packed-stack path and the per-expert dense path."""
+    return int(os.environ.get(
+        "PRISMAQUANT_EXPERT_COST_SAMPLE",
+        os.environ.get("PRISMAQUANT_GGUF_EXPERT_COST_SAMPLE", "0"),
+    ) or 0)
+
+
+def _expert_cost_sample_split(
+    target_names: set[str],
+) -> tuple[set[str], dict[str, list[str]]]:
+    """Stratified expert subsample for UNPACKED per-expert MoE Linears.
+
+    The dense analog of the packed-stack lever at `_measure_packed_experts`:
+    models whose experts live as per-expert nn.Linears (DSv4-Flash: 256
+    experts x 3 projections x 43 layers) would push every expert tensor
+    through the exhaustive-grid IQ search = days. Measure only a
+    deterministic, evenly spaced sample of expert ids per (experts-prefix,
+    projection) group — the same linspace rule the packed path applies to
+    stack rows — and extrapolate the rest (see _extrapolate_expert_costs).
+    Like the packed path, this only affects the allocator's cost estimates;
+    export always quantizes every expert exactly.
+
+    Returns (names_to_measure, extrapolate) where `extrapolate` maps each
+    skipped per-expert name to the sorted sampled names of its group.
+    """
+    sample_n = _expert_cost_sample_n()
+    measure = set(target_names)
+    if sample_n <= 0:
+        return measure, {}
+    groups: dict[tuple[str, str], list[tuple[int, str]]] = {}
+    for name in target_names:
+        m = _PER_EXPERT_NAME_RE.match(name)
+        if m:
+            groups.setdefault((m.group(1), m.group(3)), []).append(
+                (int(m.group(2)), name))
+    extrapolate: dict[str, list[str]] = {}
+    for members in groups.values():
+        if len(members) <= sample_n:
+            continue
+        members.sort()
+        idx = torch.linspace(
+            0, len(members) - 1, sample_n,
+        ).round().long().unique().tolist()
+        sampled = sorted(members[i][1] for i in idx)
+        sampled_set = set(sampled)
+        for _eid, name in members:
+            if name not in sampled_set:
+                measure.discard(name)
+                extrapolate[name] = sampled
+    return measure, extrapolate
+
+
+def _extrapolate_expert_costs(
+    results: dict, extrapolate: dict[str, list[str]],
+) -> None:
+    """Fill skipped per-expert cost rows with their group's sampled mean.
+
+    Mirrors the packed path, where one sampled measurement prices the whole
+    expert stack: every expert must keep a cost row, because the allocator
+    drops row-less names entirely (build_candidates), which would silently
+    shrink the DP's bit/disk accounting and the serving-unit membership.
+    """
+    for name, sources in extrapolate.items():
+        merged: dict[str, dict] = {}
+        fmt_names: set[str] = set()
+        for src in sources:
+            fmt_names.update(results.get(src, {}))
+        for fmt in fmt_names:
+            entries = [
+                results[src][fmt] for src in sources
+                if fmt in results.get(src, {})
+                and "error" not in results[src][fmt]
+            ]
+            if not entries:
+                continue
+            out: dict[str, object] = {"expert_cost_extrapolated": True}
+            for key in ("weight_mse", "output_mse", "rel_output_mse",
+                        "predicted_dloss", "fisher_output_mse"):
+                vals = [float(e[key]) for e in entries if key in e]
+                if vals:
+                    out[key] = sum(vals) / len(vals)
+            if any(e.get("output_mse_measured") is False for e in entries):
+                out["output_mse_measured"] = False
+            merged[fmt] = out
+        if merged:
+            results[name] = merged
+
+
 def _accumulate_result(bucket: dict, name: str, fmt: str,
                        weight_mse: float, output_mse: float,
                        rel_output_mse: float,
@@ -442,12 +553,12 @@ def measure_unbatched(model: nn.Module, act_cache: "ActivationIndex",
     accum: dict[str, dict[str, dict]] = {}
     processed = 0
     tstart = time.time()
-    target_list = list(target_names)
-    n_total = len(target_list)
+    measure_names, expert_extrapolate = _expert_cost_sample_split(target_names)
+    n_total = len(measure_names)
 
     for name, mod in model.named_modules():
-        canonical_name = canonical_linear_name(name, profile)
-        if not isinstance(mod, nn.Linear) or canonical_name not in target_names:
+        canonical_name = resolve_cost_target_name(name, target_names, profile)
+        if not isinstance(mod, nn.Linear) or canonical_name not in measure_names:
             continue
         if canonical_name not in act_cache:
             continue
@@ -524,7 +635,9 @@ def measure_unbatched(model: nn.Module, act_cache: "ActivationIndex",
             elapsed = time.time() - tstart
             eta = elapsed / processed * (n_total - processed)
             print(f"[cost] {processed}/{n_total} eta={eta:.0f}s", flush=True)
-    return _finalize_results(accum)
+    results = _finalize_results(accum)
+    _extrapolate_expert_costs(results, expert_extrapolate)
+    return results
 
 
 # ---------------------------------------------------------------------------
@@ -540,7 +653,7 @@ def _group_by_shape(model: nn.Module, target_names: set[str], profile=None
     """
     groups: dict[tuple[int, int], list[tuple[str, nn.Linear]]] = {}
     for name, mod in model.named_modules():
-        canonical_name = canonical_linear_name(name, profile)
+        canonical_name = resolve_cost_target_name(name, target_names, profile)
         if not isinstance(mod, nn.Linear) or canonical_name not in target_names:
             continue
         key = (mod.in_features, mod.out_features)
@@ -962,10 +1075,7 @@ def _measure_packed_experts(
         # less quantize work (IQ exhaustive-grid on 3.5G-elem stacks is
         # ~25 min/layer at full E — 2026-07-11). Export always quantizes
         # every expert exactly; this only affects the DP's cost estimates.
-        sample_n = int(os.environ.get(
-            "PRISMAQUANT_EXPERT_COST_SAMPLE",
-            os.environ.get("PRISMAQUANT_GGUF_EXPERT_COST_SAMPLE", "0"),
-        ) or 0)
+        sample_n = _expert_cost_sample_n()
         for spec in specs:
             try:
                 # Family-agnostic: NVFP4/FP8 registry quantize on a full
@@ -1274,10 +1384,16 @@ def measure_batched_gpu(model: nn.Module, act_cache: "ActivationIndex",
     `fisher_output_mse` from `g2_per_token` when those tensors are present.
     """
     dev = torch.device(device)
-    groups = _group_by_shape(model, target_names, profile)
+    # Stratified per-expert subsample (PRISMAQUANT_EXPERT_COST_SAMPLE) for
+    # unpacked MoE Linears; skipped experts get their group's sampled mean
+    # after finalize, so downstream coverage matches a full measurement.
+    measure_names, expert_extrapolate = _expert_cost_sample_split(target_names)
+    groups = _group_by_shape(model, measure_names, profile)
     total_linears = sum(len(v) for v in groups.values())
     print(f"[cost] batched: {len(groups)} shape groups, "
-          f"{total_linears} Linears total", flush=True)
+          f"{total_linears} Linears total"
+          + (f" (expert sample: {len(expert_extrapolate)} extrapolated)"
+             if expert_extrapolate else ""), flush=True)
 
     accum: dict[str, dict[str, dict]] = {}
     processed = 0
@@ -1501,7 +1617,9 @@ def measure_batched_gpu(model: nn.Module, act_cache: "ActivationIndex",
                       flush=True)
     if _prefetch_pool is not None:
         _prefetch_pool.shutdown(wait=False)
-    return _finalize_results(accum)
+    results = _finalize_results(accum)
+    _extrapolate_expert_costs(results, expert_extrapolate)
+    return results
 
 
 def prepare_cost_context(probe_path: str,

--- a/tests/test_expert_cost_subsample.py
+++ b/tests/test_expert_cost_subsample.py
@@ -1,0 +1,112 @@
+"""Unit tests for the dense-path stratified expert cost subsample.
+
+``_expert_cost_sample_split`` picks a deterministic, evenly spaced sample of
+expert ids per (experts-prefix, projection) group; ``_extrapolate_expert_costs``
+fills the skipped experts' cost rows with their group's sampled mean so every
+expert keeps a cost row (the allocator drops row-less names entirely, which
+would silently shrink the DP's bit/disk accounting and serving-unit
+membership).
+"""
+from __future__ import annotations
+
+import pytest
+
+from prismaquant.measure_quant_cost import (
+    _expert_cost_sample_split,
+    _extrapolate_expert_costs,
+)
+
+
+def _expert_names(layer: int, n_experts: int, proj: str) -> list[str]:
+    return [
+        f"model.layers.{layer}.mlp.experts.{e}.{proj}"
+        for e in range(n_experts)
+    ]
+
+
+def test_sample_split_disabled_measures_everything(monkeypatch):
+    monkeypatch.delenv("PRISMAQUANT_EXPERT_COST_SAMPLE", raising=False)
+    names = set(_expert_names(0, 16, "gate_proj")) | {"model.layers.0.self_attn.q_proj"}
+    measure, extrapolate = _expert_cost_sample_split(names)
+    assert measure == names
+    assert extrapolate == {}
+
+
+def test_sample_split_is_deterministic_evenly_spaced_and_keeps_non_experts(monkeypatch):
+    monkeypatch.setenv("PRISMAQUANT_EXPERT_COST_SAMPLE", "4")
+    dense = "model.layers.0.self_attn.q_proj"
+    experts = _expert_names(0, 16, "down_proj")
+    names = set(experts) | {dense}
+    measure, extrapolate = _expert_cost_sample_split(names)
+    # Deterministic: same call, same answer.
+    measure2, extrapolate2 = _expert_cost_sample_split(names)
+    assert measure == measure2 and extrapolate == extrapolate2
+    # Non-expert rows are always measured.
+    assert dense in measure
+    # linspace(0, 15, 4).round() -> expert ids 0, 5, 10, 15.
+    sampled = sorted(n for n in measure if n != dense)
+    assert sampled == sorted(
+        f"model.layers.0.mlp.experts.{e}.down_proj" for e in (0, 5, 10, 15))
+    # Every skipped expert maps to the sorted sampled names of its group.
+    assert set(extrapolate) == set(experts) - set(sampled)
+    for skipped, sources in extrapolate.items():
+        assert sources == sampled
+        assert skipped not in measure
+
+
+def test_sample_split_leaves_small_groups_alone(monkeypatch):
+    monkeypatch.setenv("PRISMAQUANT_EXPERT_COST_SAMPLE", "8")
+    names = set(_expert_names(0, 8, "up_proj"))
+    measure, extrapolate = _expert_cost_sample_split(names)
+    assert measure == names
+    assert extrapolate == {}
+
+
+def test_sample_split_groups_by_projection(monkeypatch):
+    monkeypatch.setenv("PRISMAQUANT_EXPERT_COST_SAMPLE", "2")
+    gate = _expert_names(3, 8, "gate_proj")
+    down = _expert_names(3, 8, "down_proj")
+    measure, extrapolate = _expert_cost_sample_split(set(gate) | set(down))
+    # Each (prefix, projection) group samples independently: 2 gate + 2 down.
+    assert len(measure) == 4
+    assert sum(1 for n in measure if n.endswith("gate_proj")) == 2
+    assert sum(1 for n in measure if n.endswith("down_proj")) == 2
+    # Skipped rows only extrapolate from their own projection's sample.
+    for skipped, sources in extrapolate.items():
+        proj = skipped.rsplit(".", 1)[1]
+        assert all(s.endswith(proj) for s in sources)
+
+
+def test_extrapolate_fills_skipped_rows_with_sampled_mean():
+    sources = ["e.experts.0.down_proj", "e.experts.7.down_proj"]
+    results = {
+        sources[0]: {
+            "Q4_K": {"weight_mse": 1.0, "output_mse": 2.0,
+                     "predicted_dloss": 4.0},
+            "IQ2_XXS": {"weight_mse": 3.0, "output_mse": 5.0,
+                        "predicted_dloss": 9.0, "output_mse_measured": False},
+        },
+        sources[1]: {
+            "Q4_K": {"weight_mse": 3.0, "output_mse": 4.0,
+                     "predicted_dloss": 8.0},
+            # IQ2_XXS errored on this expert: excluded from the mean.
+            "IQ2_XXS": {"error": "quantize failed"},
+        },
+    }
+    _extrapolate_expert_costs(results, {"e.experts.3.down_proj": sources})
+    row = results["e.experts.3.down_proj"]
+    assert row["Q4_K"]["weight_mse"] == pytest.approx(2.0)
+    assert row["Q4_K"]["output_mse"] == pytest.approx(3.0)
+    assert row["Q4_K"]["predicted_dloss"] == pytest.approx(6.0)
+    assert row["Q4_K"]["expert_cost_extrapolated"] is True
+    # Only the non-error entry feeds IQ2_XXS; its unmeasured-output marker
+    # propagates so downstream pricing knows the mean is weight-mse-derived.
+    assert row["IQ2_XXS"]["weight_mse"] == pytest.approx(3.0)
+    assert row["IQ2_XXS"]["output_mse_measured"] is False
+
+
+def test_extrapolate_skips_rows_with_no_usable_sources():
+    results = {"e.experts.0.down_proj": {"Q4_K": {"error": "boom"}}}
+    _extrapolate_expert_costs(
+        results, {"e.experts.1.down_proj": ["e.experts.0.down_proj"]})
+    assert "e.experts.1.down_proj" not in results

--- a/tests/test_fisher_normalization.py
+++ b/tests/test_fisher_normalization.py
@@ -1,0 +1,76 @@
+"""Fisher h_trace must be normalized by the GLOBAL calib token count.
+
+Synthetic reproducer: two identical Linears with identical gradient
+statistics over the same calibration run. The "dense" one sees every token
+(most carrying zero gradient); the "expert" one only sees the tokens routed
+to it — the very tokens that carry the gradient. Tokens never routed to an
+expert contribute zero gradient, so both rows have the SAME empirical
+Fisher. The old per-row `h_trace_raw / n_tokens_seen` divided the expert by
+its routed count only, inflating it by (global/routed).
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+from prismaquant.incremental_probe import finalize_fisher_stats
+
+
+def _h_trace_raw(x: torch.Tensor, gy: torch.Tensor) -> float:
+    """The probe's per-token trace accumulator: sum_t ||gy_t||^2 * ||x_t||^2."""
+    return float((gy.pow(2).sum(dim=1) * x.pow(2).sum(dim=1)).sum().item())
+
+
+def test_h_trace_equal_for_equal_gradient_mass_after_global_normalization():
+    torch.manual_seed(0)
+    global_tokens, routed_tokens = 32, 4  # the expert is routed 1/8 of tokens
+    dense = nn.Linear(16, 8, bias=False)
+    expert = nn.Linear(16, 8, bias=False)
+    expert.load_state_dict(dense.state_dict())
+
+    x = torch.randn(global_tokens, 16)
+    # Identical per-token gradients on the routed tokens; zero elsewhere
+    # (a token never routed to the expert contributes zero gradient).
+    gy = torch.zeros(global_tokens, 8)
+    gy[:routed_tokens] = torch.randn(routed_tokens, 8)
+
+    y_dense = dense(x)                      # dense row: all 32 tokens
+    y_dense.backward(gy)
+    y_expert = expert(x[:routed_tokens])    # expert row: its 4 routed tokens
+    y_expert.backward(gy[:routed_tokens])
+
+    stats = {
+        "dense": {"h_trace_raw": _h_trace_raw(x, gy),
+                  "h_w2_sum_raw": 0.0, "n_tokens_seen": global_tokens},
+        "expert": {"h_trace_raw": _h_trace_raw(x[:routed_tokens],
+                                               gy[:routed_tokens]),
+                   "h_w2_sum_raw": 0.0, "n_tokens_seen": routed_tokens},
+    }
+    # Same gradient mass -> same raw accumulator (and same weight grads).
+    assert stats["expert"]["h_trace_raw"] == pytest.approx(
+        stats["dense"]["h_trace_raw"])
+    assert torch.allclose(dense.weight.grad, expert.weight.grad)
+
+    # OLD normalization (per-row n_tokens_seen), computed inline for
+    # contrast: the expert looks (global/routed) = 8x more sensitive.
+    old = {n: s["h_trace_raw"] / s["n_tokens_seen"] for n, s in stats.items()}
+    assert old["expert"] == pytest.approx(
+        old["dense"] * global_tokens / routed_tokens)
+
+    finalize_fisher_stats(stats, global_tokens)
+    assert stats["expert"]["h_trace"] == pytest.approx(stats["dense"]["h_trace"])
+    assert stats["dense"]["h_trace"] == pytest.approx(
+        stats["dense"]["h_trace_raw"] / global_tokens)
+    # n_tokens_seen stays raw (routed count) for the h_detail consumers.
+    assert stats["expert"]["n_tokens_seen"] == routed_tokens
+    assert stats["expert"]["h_trace_norm_tokens"] == global_tokens
+
+
+def test_rows_without_token_counter_use_global_count_not_one():
+    """Stat rows filled by the batched MoE-block flush path never increment
+    n_tokens_seen; the old finalize divided them by max(0, 1) == 1."""
+    stats = {"expert": {"h_trace_raw": 64.0, "h_w2_sum_raw": 0.0,
+                        "n_tokens_seen": 0}}
+    finalize_fisher_stats(stats, 32)
+    assert stats["expert"]["h_trace"] == pytest.approx(2.0)

--- a/tests/test_footprint.py
+++ b/tests/test_footprint.py
@@ -200,3 +200,77 @@ def test_assignment_artifact_bytes_packed_nvfp4_counts_per_expert_globals():
         + 8 * 4 * 2  # per-expert weight_global + input_global, gate+up
     )
     assert r["body_quant_bytes"] == expected
+
+
+# ---------------------------------------------------------------------------
+# Per-tensor source-byte manifest (mixed-precision sources)
+# ---------------------------------------------------------------------------
+
+def _mixed_source_checkpoint(tmp_path):
+    """Two re-encoded tensors on a mixed source: an MXFP4-packed expert
+    (I8 nibble weights, 0.5 B/param on disk, + E8M0 group scales) and an
+    fp8 attention Linear (+ fp32 weight_scale_inv), plus a BF16 floor
+    tensor. The fp8 dtype flips the regime detector to "fp8", so the
+    regime path charges the packed expert 1 B/LOGICAL-param — about twice
+    its actual on-disk bytes."""
+    _write_safetensors(tmp_path / "m.safetensors", {
+        # logical (64, 256) packed 2-per-byte -> stored (64, 128) I8 = 8192 B
+        "layers.0.experts.0.down_proj.weight": ("I8", (64, 128)),
+        # E8M0 scale per 32-element group: (64, 8) U8 = 512 B
+        "layers.0.experts.0.down_proj.scale": ("U8", (64, 8)),
+        "layers.0.self_attn.q_proj.weight": ("F8_E4M3", (32, 32)),   # 1024 B
+        "layers.0.self_attn.q_proj.weight_scale_inv": ("F32", (1, 1)),  # 4 B
+        "embed.weight": ("BF16", (100, 8)),                         # 1600 B
+    })
+    stats = {
+        "layers.0.experts.0.down_proj": {
+            "n_params": 64 * 256, "in_features": 256, "out_features": 64},
+        "layers.0.self_attn.q_proj": {
+            "n_params": 32 * 32, "in_features": 32, "out_features": 32},
+    }
+    reencoded = list(stats)
+    return stats, reencoded
+
+
+def test_source_tensor_bytes_manifest_charges_actual_spans(tmp_path):
+    _mixed_source_checkpoint(tmp_path)
+    manifest = fp.source_tensor_bytes_manifest(str(tmp_path))
+    assert manifest["layers.0.experts.0.down_proj"] == 8192 + 512
+    assert manifest["layers.0.self_attn.q_proj"] == 1024 + 4
+    assert manifest["embed"] == 1600
+
+
+def test_manifest_floor_non_negative_where_regime_path_goes_negative(tmp_path):
+    stats, reencoded = _mixed_source_checkpoint(tmp_path)
+    total, by_dtype = fp.source_checkpoint_bytes(str(tmp_path))
+    regime = fp.source_regime(by_dtype)
+    assert regime == "fp8"
+
+    # Regime-wide accounting: the packed expert's LOGICAL params are charged
+    # 1 B each -> more bytes removed than the tensor (or checkpoint) holds.
+    regime_removed = {
+        q: fp.reencoded_source_bytes_for_shape(
+            (stats[q]["out_features"], stats[q]["in_features"]), regime)
+        for q in reencoded
+    }
+    regime_floor = total - sum(regime_removed.values())
+    assert regime_floor < 0
+    with pytest.raises(ValueError, match="negative non-quantizable floor"):
+        fp.check_floor_non_negative(
+            regime_floor, total, regime_removed, context="unit")
+
+    # Manifest accounting: actual header spans can never exceed the total.
+    manifest = fp.source_tensor_bytes_manifest(str(tmp_path))
+    manifest_floor = total - sum(manifest[q] for q in reencoded)
+    assert manifest_floor == 1600  # exactly the BF16 floor tensor
+    fp.check_floor_non_negative(
+        manifest_floor, total, {q: manifest[q] for q in reencoded},
+        context="unit")  # does not raise
+
+
+def test_floor_bytes_for_model_uses_manifest_on_mixed_source(tmp_path):
+    stats, reencoded = _mixed_source_checkpoint(tmp_path)
+    info = fp.floor_bytes_for_model(str(tmp_path), reencoded, stats)
+    assert info["regime"] == "fp8"
+    assert info["reencoded_source_bytes"] == (8192 + 512) + (1024 + 4)
+    assert info["floor_bytes"] == 1600

--- a/tests/test_footprint.py
+++ b/tests/test_footprint.py
@@ -274,3 +274,150 @@ def test_floor_bytes_for_model_uses_manifest_on_mixed_source(tmp_path):
     assert info["regime"] == "fp8"
     assert info["reencoded_source_bytes"] == (8192 + 512) + (1024 + 4)
     assert info["floor_bytes"] == 1600
+
+
+def test_assignment_artifact_bytes_manifest_agrees_with_floor_model(tmp_path):
+    # PR-15 review: assignment_artifact_bytes must use the SAME manifest
+    # accounting as floor_bytes_for_model (the regime path merely raised on
+    # this mixed source instead of pricing it).
+    stats, reencoded = _mixed_source_checkpoint(tmp_path)
+    info = fp.floor_bytes_for_model(str(tmp_path), reencoded, stats)
+    r = fp.assignment_artifact_bytes(
+        {q: "NVFP4" for q in reencoded}, stats,
+        source_total_bytes=info["source_total_bytes"],
+        regime=info["regime"],
+        source_manifest=info["source_manifest"],
+    )
+    assert r["source_accounting"] == "per_tensor_manifest"
+    assert r["floor_bytes"] == info["floor_bytes"] == 1600
+    assert r["reencoded_source_bytes"] == info["reencoded_source_bytes"]
+    # The regime path on the same mixed source cannot agree — it goes
+    # negative and is rejected, never silently shipped.
+    with pytest.raises(ValueError, match="negative non-quantizable floor"):
+        fp.assignment_artifact_bytes(
+            {q: "NVFP4" for q in reencoded}, stats,
+            source_total_bytes=info["source_total_bytes"], regime="fp8",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Packed-MoE expert name resolution (PR-15 review: the manifest must price
+# packed allocator names on BOTH on-disk layouts)
+# ---------------------------------------------------------------------------
+
+# hidden=32, intermediate=16, 2 experts. Per-expert projections on disk:
+# gate/up (16, 32) each, down (32, 16). The allocator names the PACKED live
+# params: gate_up_proj = output-axis gate+up fusion -> (2, 32, 32), and
+# down_proj -> (2, 32, 16).
+_PACKED_STATS = {
+    "layers.0.mlp.experts.gate_up_proj": {
+        "n_params": 2 * 32 * 32, "in_features": 32, "out_features": 32,
+        "num_experts": 2},
+    "layers.0.mlp.experts.down_proj": {
+        "n_params": 2 * 32 * 16, "in_features": 16, "out_features": 32,
+        "num_experts": 2},
+}
+_PACKED_NAMES = list(_PACKED_STATS)
+
+
+def _case_a_per_expert_disk(tmp_path):
+    """CASE A: per-expert 2-D tensors on disk; allocator names are packed."""
+    _write_safetensors(tmp_path / "m.safetensors", {
+        "layers.0.mlp.experts.0.gate_proj.weight": ("BF16", (16, 32)),  # 1024
+        "layers.0.mlp.experts.0.up_proj.weight": ("BF16", (16, 32)),    # 1024
+        "layers.0.mlp.experts.0.down_proj.weight": ("BF16", (32, 16)),  # 1024
+        "layers.0.mlp.experts.1.gate_proj.weight": ("BF16", (16, 32)),
+        "layers.0.mlp.experts.1.up_proj.weight": ("BF16", (16, 32)),
+        "layers.0.mlp.experts.1.down_proj.weight": ("BF16", (32, 16)),
+        "embed.weight": ("BF16", (100, 8)),                             # 1600
+    })
+
+
+def test_packed_expert_alias():
+    assert fp.packed_expert_alias("layers.0.mlp.experts.7.gate_proj") == \
+        "layers.0.mlp.experts.gate_up_proj"
+    assert fp.packed_expert_alias("layers.0.mlp.experts.7.up_proj") == \
+        "layers.0.mlp.experts.gate_up_proj"
+    assert fp.packed_expert_alias("layers.0.mlp.experts.7.down_proj") == \
+        "layers.0.mlp.experts.down_proj"
+    # not per-expert / unknown projection / non-expert container -> None
+    assert fp.packed_expert_alias("layers.0.mlp.experts.gate_up_proj") is None
+    assert fp.packed_expert_alias("layers.0.mlp.experts.7.w1") is None
+    assert fp.packed_expert_alias("layers.0.self_attn.q_proj") is None
+    # profile callable wins over the fallback
+    assert fp.packed_expert_alias(
+        "layers.0.mlp.experts.3.w1",
+        lambda p: "w1_w3" if p in ("w1", "w3") else None,
+    ) == "layers.0.mlp.experts.w1_w3"
+
+
+def test_manifest_case_a_per_expert_disk_aggregates_to_packed(tmp_path):
+    _case_a_per_expert_disk(tmp_path)
+    m = fp.source_tensor_bytes_manifest(str(tmp_path))
+    # gate+up fuse into gate_up across both experts; down aggregates 1:1.
+    assert m["layers.0.mlp.experts.gate_up_proj"] == 4 * 1024
+    assert m["layers.0.mlp.experts.down_proj"] == 2 * 1024
+    # per-expert entries are kept for per-expert-named allocations
+    assert m["layers.0.mlp.experts.0.gate_proj"] == 1024
+    assert m["layers.0.mlp.experts.1.down_proj"] == 1024
+
+    info = fp.floor_bytes_for_model(str(tmp_path), _PACKED_NAMES, _PACKED_STATS)
+    assert info["reencoded_source_bytes"] == 6 * 1024
+    assert info["floor_bytes"] == 1600  # exactly the embed
+
+    # end-to-end: artifact = floor + quantized expert bodies, floor exact
+    r = fp.assignment_artifact_bytes(
+        {q: "NVFP4" for q in _PACKED_NAMES}, _PACKED_STATS,
+        source_total_bytes=info["source_total_bytes"],
+        regime=info["regime"], source_manifest=info["source_manifest"],
+    )
+    body = (fr.get_format("NVFP4").memory_bytes_for_shape((2, 32, 32))
+            + 8 * 2 * 2   # gate_up: per-expert globals x 2 projections
+            + fr.get_format("NVFP4").memory_bytes_for_shape((2, 32, 16))
+            + 8 * 2)      # down: per-expert globals x 1 projection
+    assert r["floor_bytes"] == 1600
+    assert r["artifact_bytes"] == 1600 + body
+
+
+def test_manifest_case_b_packed_3d_without_weight_suffix(tmp_path):
+    """CASE B: packed 3-D checkpoint keys carry NO '.weight' suffix (the
+    transformers packed-experts convention: the param IS the key). They must
+    not be skipped, and sidecars still attach to the suffix-less base."""
+    _write_safetensors(tmp_path / "m.safetensors", {
+        "layers.0.mlp.experts.gate_up_proj": ("F8_E4M3", (2, 32, 32)),   # 2048
+        "layers.0.mlp.experts.gate_up_proj.scale": ("U8", (2, 32, 1)),   # 64
+        "layers.0.mlp.experts.down_proj": ("F8_E4M3", (2, 32, 16)),      # 1024
+        "embed.weight": ("BF16", (100, 8)),                              # 1600
+    })
+    m = fp.source_tensor_bytes_manifest(str(tmp_path))
+    assert m["layers.0.mlp.experts.gate_up_proj"] == 2048 + 64
+    assert m["layers.0.mlp.experts.down_proj"] == 1024
+    # standalone sidecar keys never become their own manifest entries
+    assert "layers.0.mlp.experts.gate_up_proj.scale" not in m
+
+    info = fp.floor_bytes_for_model(str(tmp_path), _PACKED_NAMES, _PACKED_STATS)
+    assert info["reencoded_source_bytes"] == 2048 + 64 + 1024
+    assert info["floor_bytes"] == 1600
+
+
+def test_unresolved_reencoded_name_is_a_hard_error(tmp_path):
+    # PR-15 review: a re-encoded Linear the manifest cannot resolve must be
+    # a hard error NAMING the tensor, raised before the numbers are consumed
+    # — not a post-hoc warning after a fatal "below the floor" exit.
+    with pytest.raises(ValueError, match=r"ghost\.proj"):
+        fp.resolve_reencoded_source_bytes(
+            {"layer.w": 64}, ["layer.w", "ghost.proj"], context="unit")
+
+    _case_a_per_expert_disk(tmp_path)
+    with pytest.raises(ValueError, match=r"not\.in\.checkpoint"):
+        fp.floor_bytes_for_model(
+            str(tmp_path), _PACKED_NAMES + ["not.in.checkpoint"], _PACKED_STATS)
+
+    stats = dict(_PACKED_STATS)
+    stats["not.in.checkpoint"] = {
+        "n_params": 32, "in_features": 32, "out_features": 1}
+    with pytest.raises(ValueError, match=r"not\.in\.checkpoint"):
+        fp.assignment_artifact_bytes(
+            {"not.in.checkpoint": "NVFP4"}, stats,
+            source_total_bytes=10_000, regime="bf16",
+            source_manifest={"layer.w": 64})


### PR DESCRIPTION
> Stacked on #14 — only the last commit is new here; I'll rebase as predecessors merge.


**Commit:** `footprint: per-tensor source-byte manifest; reject negative floors`

### Summary
`source_regime` / `reencoded_source_bytes_for_shape` charge EVERY re-encoded
Linear at the FP8_SOURCE layout (1 B/param + fp32 block scales) as soon as
any F8 dtype appears in the checkpoint. On a mixed-precision source (an
MXFP4-packed DSv4-Flash checkpoint: I8 nibble experts at ~0.53 B/param on
disk + F8 attention + BF16 floor) that removed more source bytes than the
checkpoint holds — a negative non-quantizable floor, which let an artifact
more than twice the byte budget "fit" it.

- `source_tensor_bytes_manifest()`: exact on-disk bytes per weight tensor
  (safetensors header `data_offsets` span + `.scale` / `.weight_scale_inv`
  siblings), keyed by live qname. Sums of actual spans can never exceed the
  checkpoint total, so a manifest floor is ≥ 0 by construction.
- The allocator's byte-budget selector and `floor_bytes_for_model` (which
  has the model path) now price from the manifest; names missing from the
  manifest stay in the floor (over-count only, loud warning).
- `check_floor_non_negative()`: a negative floor is always an accounting
  bug — raise `ValueError` with the per-tensor-class byte breakdown instead
  of shipping a selection.

Stated plainly: `assignment_artifact_bytes` prices candidates from
precomputed scalars and has no model path, so it keeps the regime rate — on
a mixed source it now **fails loudly** with `ValueError` rather than being
silently wrong; callers that hit this should price via
`floor_bytes_for_model` / the manifest.

### What changes for existing users
Uniform bf16 or fp8 sources: byte-identical accounting (the manifest spans
equal the regime rates there). Mixed sources: correct floors where the old
path under- or over-counted, and a hard error instead of a silently negative
floor.

### How to verify
`pytest tests/test_footprint.py -q` — includes a tiny mixed-source
safetensors fixture (I8-packed expert + E8M0 scales, F8 attention + fp32
scale_inv, BF16 floor) showing the regime path's floor going negative and
rejected while the manifest floor is exact and non-negative.

### Tests
New in `tests/test_footprint.py`: manifest span accounting, the
negative-vs-non-negative floor contrast, and `floor_bytes_for_model` on the
mixed fixture. Existing footprint identities unchanged and still pass.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXh7ricvRaq4pMg4RKPDf5
