### PR TITLE
Keep vendored Gridbook fused FP4 prefill opt-in

### DIFF
--- a/docs/lanes/nvfp4-cb/STANDARDS.md
+++ b/docs/lanes/nvfp4-cb/STANDARDS.md
@@ -4,6 +4,10 @@ Dated 2026-07-21 (Robert: "make a definitive determination about final kernel
 and format standards"). This page is the contract production runs build
 against. Changes to it require a served A/B, not a preference.
 
+The vendored Gridbook runtime follows this contract: dense and MoE fused-FP4
+prefill are disabled unless their respective opt-in environment variables are
+set. Kernel-only speedups do not promote a path across activation buckets.
+
 ## Format standard (what an artifact may contain)
 
 **Production formats** — the complete set:

--- a/plugins/gridbook/gridbook/linear.py
+++ b/plugins/gridbook/gridbook/linear.py
@@ -55,10 +55,8 @@ _FP4_FUSED_MODE: list = []
 
 
 def _fp4_fused_mode() -> str:
-    # DEFAULT-ON since 2026-07-31 (Robert's call). Set
-    # PRISMAQUANT_CB_FUSED_FP4=0 to restore the Triton decode path.
-    #
-    # What this changes for a served artifact: the fp4 activation bucket moves
+    # Explicit opt-in: what this changes for a served artifact is the fp4
+    # activation bucket moving
     # from the Triton path's fp32 emulation scales to the format's native
     # ue4m3 scale factors — measured ~7.5e-2 relative against Triton. The fused
     # kernel is bit-exact against the stock NVF4 collective, so this is
@@ -68,7 +66,7 @@ def _fp4_fused_mode() -> str:
     # docs/lanes/nvfp4-cb/fp4-fused-prefill.md.
     if not _FP4_FUSED_MODE:
         _FP4_FUSED_MODE.append(
-            os.environ.get("PRISMAQUANT_CB_FUSED_FP4", "1").strip())
+            os.environ.get("PRISMAQUANT_CB_FUSED_FP4", "").strip())
     return _FP4_FUSED_MODE[0]
 
 

--- a/plugins/gridbook/gridbook/moe.py
+++ b/plugins/gridbook/gridbook/moe.py
@@ -492,13 +492,14 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         # not codec.fp4_group16_act_qdq). An explicit PRISMAQUANT_CB_PREFILL
         # is authoritative and bypasses this default, so stock/loop remain
         # real bisection controls rather than being silently preempted.
-        # DEFAULT-ON since 2026-07-31 (Robert's call); tile 128 is the measured
-        # best (5.2-5.6x the per-expert loop). PRISMAQUANT_CB_FUSED_FP4_MOE=0
-        # restores the per-expert loop. Same unvalidated-on-serving-metric
-        # caveat as the dense gate in linear.py applies.
+        # Explicit opt-in until a served quality gate and routing-shape ladder
+        # pass. Tile 128 is 5.2-5.6x faster than the per-expert loop on the
+        # measured shapes, but its padding cost has a sharp token-count cliff.
+        # The same unvalidated-on-serving-metric caveat as the dense gate in
+        # linear.py applies.
         requested_mode = os.environ.get("PRISMAQUANT_CB_PREFILL")
         if requested_mode is None and self.is_fp4 and num_tokens > 16:
-            gf4 = os.environ.get("PRISMAQUANT_CB_FUSED_FP4_MOE", "1").strip()
+            gf4 = os.environ.get("PRISMAQUANT_CB_FUSED_FP4_MOE", "").strip()
             if gf4 in ("1", "128", "256"):
                 out = self._apply_prefill_grouped_fused_fp4(
                     layer, x, topk_weights, topk_ids, act,
@@ -506,10 +507,10 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
                 if out is not None:
                     return out
 
-        # Preserve current policy: fp8 uses measured auto; fp4 first tries its
-        # default fused path above and falls back to the conservative loop on a
-        # constraint miss. Stock remains explicitly selectable, now with safe
-        # byte budgeting and a zero-copy packed view.
+        # Preserve current policy: fp8 uses measured auto; fp4 uses the
+        # conservative loop unless the explicit fused gate above succeeds.
+        # Stock remains explicitly selectable, with safe byte budgeting and a
+        # zero-copy packed view.
         mode = requested_mode or ("auto" if not self.is_fp4 else "loop")
         if mode == "auto":
             return self._apply_prefill_auto(

--- a/plugins/gridbook/tests/test_moe_fp4_stock_prefill.py
+++ b/plugins/gridbook/tests/test_moe_fp4_stock_prefill.py
@@ -2,8 +2,9 @@
 
 Three things are decidable on CPU from shapes and config ints alone:
 
-  1. ``_apply_inline``'s mode precedence — an explicit stock/loop request must
-     bypass the default fused-FP4 path; an unset request keeps current policy.
+  1. ``_apply_inline``'s mode precedence — fused FP4 is explicitly opted in;
+     an unset request takes the conservative loop, and an explicit stock/loop
+     request remains authoritative.
   2. ``_stock_chunk_default`` — the fp4 bf16 chunk transient is 2 B/elt, so the
      fp8 lane's flat 256 holds every expert of a large MoE live at once. The
      fp4 chunk is byte-budgeted instead; fp8 keeps its 256 verbatim.
@@ -63,19 +64,28 @@ def moe(request):
     """``gridbook.moe``, importable with or without a real vLLM install."""
     import importlib
 
-    before = set(sys.modules)
+    # Preserve complete module objects, not only names. Another CPU test may
+    # have installed a deliberately smaller vLLM stub first; ``import vllm``
+    # alone would then succeed even though the MoE submodules are absent.
+    before = {
+        name: module for name, module in sys.modules.items()
+        if name.startswith("vllm") or name.startswith("gridbook")
+    }
     stubbed = False
     try:
-        import vllm  # noqa: F401
+        from vllm.model_executor.layers.fused_moe.config import (  # noqa: F401
+            FusedMoEConfig,
+        )
     except Exception:
         _install_vllm_stubs()
         stubbed = True
     mod = importlib.import_module("gridbook.moe")
     yield mod
     if stubbed:
-        for name in set(sys.modules) - before:
+        for name in list(sys.modules):
             if name.startswith("vllm") or name.startswith("gridbook"):
                 sys.modules.pop(name, None)
+        sys.modules.update(before)
 
 
 def _method(moe, *, grid, k, n_sub, type_size, is_v2=True):
@@ -144,13 +154,22 @@ def _dispatch_mode(moe, monkeypatch, m, fused_fp4="fused_fp4"):
     return m._apply_inline(lay, x, w, ids)
 
 
-def test_unset_fp4_keeps_current_fused_default(moe, monkeypatch):
+def test_unset_fp4_uses_conservative_loop(moe, monkeypatch):
     monkeypatch.delenv("PRISMAQUANT_CB_PREFILL", raising=False)
+    monkeypatch.delenv("PRISMAQUANT_CB_FUSED_FP4_MOE", raising=False)
+    assert _dispatch_mode(moe, monkeypatch, _fp4(moe)) == "loop"
+
+
+@pytest.mark.parametrize("value", ["1", "128", "256"])
+def test_fp4_fused_prefill_is_explicitly_opted_in(moe, monkeypatch, value):
+    monkeypatch.delenv("PRISMAQUANT_CB_PREFILL", raising=False)
+    monkeypatch.setenv("PRISMAQUANT_CB_FUSED_FP4_MOE", value)
     assert _dispatch_mode(moe, monkeypatch, _fp4(moe)) == "fused_fp4"
 
 
-def test_unset_fp4_fused_miss_falls_back_to_loop(moe, monkeypatch):
+def test_opted_in_fp4_fused_miss_falls_back_to_loop(moe, monkeypatch):
     monkeypatch.delenv("PRISMAQUANT_CB_PREFILL", raising=False)
+    monkeypatch.setenv("PRISMAQUANT_CB_FUSED_FP4_MOE", "1")
     assert _dispatch_mode(
         moe, monkeypatch, _fp4(moe), fused_fp4=None) == "loop"
 

--- a/plugins/gridbook/tests/test_weight_residency.py
+++ b/plugins/gridbook/tests/test_weight_residency.py
@@ -74,7 +74,27 @@ if "vllm" not in sys.modules:
 
 from gridbook import codec                                        # noqa: E402
 from gridbook.config import PrismaQuantConfig                      # noqa: E402
+from gridbook import linear as cb_linear                           # noqa: E402
 from gridbook.linear import PrismaQuantCBLinearMethod              # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_fp4_fused_mode_cache():
+    """Keep process-global dispatch policy independent between tests."""
+    cb_linear._FP4_FUSED_MODE.clear()
+    yield
+    cb_linear._FP4_FUSED_MODE.clear()
+
+
+def test_dense_fp4_fused_prefill_is_opt_in(monkeypatch):
+    monkeypatch.delenv("PRISMAQUANT_CB_FUSED_FP4", raising=False)
+    assert cb_linear._fp4_fused_mode() == ""
+
+
+@pytest.mark.parametrize("value", ["1", "midm"])
+def test_dense_fp4_fused_prefill_explicit_modes(monkeypatch, value):
+    monkeypatch.setenv("PRISMAQUANT_CB_FUSED_FP4", value)
+    assert cb_linear._fp4_fused_mode() == value
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Why

The vendored Gridbook runtime contradicted PrismaQuant's own production standard: dense and grouped-MoE fused FP4 prefill were default-on even though they change the activation bucket (fp32-emulated group scales to native ue4m3 factors), measured about 7.5e-2 relative output movement, and have no served KL/PPL A/B. Grouped MoE also has a sharp token-padding cliff.

## What changed

- Make dense `PRISMAQUANT_CB_FUSED_FP4` an explicit opt-in.
- Make MoE `PRISMAQUANT_CB_FUSED_FP4_MOE` an explicit opt-in.
- Preserve the optimized kernels and explicit `1`/`128`/`256` and `midm` controls.
- Correct stale dispatch comments and pin the producer/runtime contract in the standards page.
- Add default-off, explicit-mode, fallback, and test-stub isolation coverage.

This mirrors Gridbook PR #13. The broader contribution line originated with @jsconsultancy; this safety follow-up is attributed to RobTand.

## Validation

- `python3 -m pytest -q tests/test_moe_fp4_stock_prefill.py tests/test_weight_residency.py`: 62 passed.
- `git diff --check`: passed.
- A full no-vLLM aggregate run is currently blocked by a pre-existing cross-file vLLM-stub leak reproducible on the unchanged base; it is not introduced by this diff and will be tracked separately.

## Integration note

This targets `claude/docs-consolidation`, PrismaQuant's current clean integration line. That line is 272 commits ahead of public `main`; targeting `main` directly would bury this five-file safety change in an unrelated 272-commit diff.
