### PR TITLE
Sync post-0.3 Gridbook runtime safety fixes

### DIFF
--- a/plugins/gridbook/gridbook/linear.py
+++ b/plugins/gridbook/gridbook/linear.py
@@ -63,7 +63,7 @@ def _fp4_fused_mode() -> str:
     # arguably the *more* faithful rendering of what NVFP4 hardware serving
     # does; but it is a change in served numerics that has NOT been validated
     # on the serving metric (no KL/PPL A/B). See
-    # docs/lanes/nvfp4-cb/fp4-fused-prefill.md.
+    # docs/KERNELS.md ("Fused decode-in-prologue").
     if not _FP4_FUSED_MODE:
         _FP4_FUSED_MODE.append(
             os.environ.get("PRISMAQUANT_CB_FUSED_FP4", "").strip())
@@ -257,21 +257,29 @@ class PrismaQuantCBLinearMethod(LinearMethodBase):
                 f"{self.prefix}: checkpoint role rows {shard_widths} "
                 f"(sum {sum(shard_widths)}) != logical width sum {sum(widths)}")
         blocks, row_offsets = [], []
+        # Fused projections commonly reuse the exact same shared codebook for
+        # every role.  Keep one physical block per exact reference tuple and
+        # point all matching roles at it.  Comparing references (rather than
+        # tensor values) is deliberate: differently named codebooks remain
+        # distinct even when their current contents happen to match.
+        block_offsets: dict[tuple[str, ...], int] = {}
         cb_cumoffset = 0
         for i, sp in enumerate(shard_prefixes):
             ref = self.quant_config.target_scheme[sp]["codebook_ref"]
-            names = ref if isinstance(ref, list) else [ref]
-            subs = [codebooks[n].to(dev) for n in names]
-            flat = codec.build_flat_codebook(
-                subs, self.prefix, "fp4" if self.is_fp4 else "fp8")
-            blocks.append(flat)
+            names = tuple(ref) if isinstance(ref, (list, tuple)) else (ref,)
+            if names not in block_offsets:
+                subs = [codebooks[n].to(dev) for n in names]
+                flat = codec.build_flat_codebook(
+                    subs, self.prefix, "fp4" if self.is_fp4 else "fp8")
+                block_offsets[names] = cb_cumoffset
+                blocks.append(flat)
+                cb_cumoffset += flat.numel()
             w = shard_widths[i]
-            # cumulative base (not i*cb_total): correct even if per-shard
-            # codebooks differ in size. All rows of shard i point at that
-            # shard's block within the concatenated cb_flat.
-            row_offsets.append(torch.full((w,), cb_cumoffset,
+            # Exact-reference duplicates reuse their first block; distinct
+            # references retain a cumulative base (rather than i*cb_total),
+            # which remains correct when blocks differ in size.
+            row_offsets.append(torch.full((w,), block_offsets[names],
                                           dtype=torch.int32, device=dev))
-            cb_cumoffset += flat.numel()
         cb_flat = torch.cat(blocks).contiguous()
         cb_row_offset = torch.cat(row_offsets).contiguous()
 
@@ -283,6 +291,12 @@ class PrismaQuantCBLinearMethod(LinearMethodBase):
             "every output row (kernels index it by row).")
         layer._cb_flat = cb_flat
         layer._cb_row_offset = cb_row_offset
+        # The fp8 mid-M fused kernel has no row-offset input: every row uses
+        # LUT base zero.  Derive and cache its safety fact without a CUDA->host
+        # sync.  One interned block means every role necessarily points at the
+        # first (zero-based) block; two or more blocks must use the offset-aware
+        # fallback paths.
+        layer._cb_fp8_fused_lut_ok = len(blocks) == 1
         dummy = torch.zeros(1, dtype=torch.float32, device=dev)
         if self.is_fp4 and self.is_v2:
             # v2: NO resident fp32 plane (spec §4/G4). The kernel composes the
@@ -384,6 +398,30 @@ class PrismaQuantCBLinearMethod(LinearMethodBase):
                   f"(K={K} k={self.k} ts={self.type_size} n_sub={self.n_sub})")
         layer._cb_ptc_ok = ok
         return ok
+
+    def _fused_fp8_lut_ok(self, layer) -> bool:
+        """Whether the offset-free fp8 fused kernel can decode every row.
+
+        ``cb_fused_prefill_mm_scaled`` receives the flat LUT but no per-row
+        offsets, so it always addresses LUT base zero.  A uniform non-zero
+        base is therefore not sufficient unless the caller also slices the
+        LUT (which this path intentionally does not do).  Production layers
+        cache this fact while interning blocks at load time; the tensor check
+        is a defensive/testing fallback for manually constructed layers.  The
+        format checks pin the four-subtable fp8 layout hard-coded by the CUDA
+        prologue rather than relying on the shipped scheme menu implicitly.
+        """
+        ok = getattr(layer, "_cb_fp8_fused_lut_ok", None)
+        if ok is None:
+            ro = getattr(layer, "_cb_row_offset", None)
+            ok = (ro is not None and ro.numel() == layer._cb_N
+                  and ro.numel() > 0
+                  and bool((ro == 0).all().item()))
+            layer._cb_fp8_fused_lut_ok = ok
+        return (not self.is_fp4
+                and self.n_sub == 4
+                and self.type_size == 4 * self.k
+                and bool(ok))
 
     # -- fp4-MMA fused prefill (opt-in; see the dispatch site below) ---------
     def _fused_fp4_ok(self, layer, K: int) -> bool:
@@ -488,7 +526,7 @@ class PrismaQuantCBLinearMethod(LinearMethodBase):
         # global x per-group-16 ue4m3 SF) instead of the Triton/transient
         # paths' fp32-group-scale QDQ — the hardware SF operand is ue4m3, an
         # fp32 group scale is unrepresentable. Promotion therefore requires a
-        # served KL A/B (docs/lanes/nvfp4-cb/fp4-fused-prefill.md), which is
+        # served KL A/B (docs/KERNELS.md), which is
         # why this lands opt-in. "1" = all prefill M; "midm" = only the fp8
         # kernel's proven 16<M<=128 niche.
         if (self.is_fp4 and bias is None and M > PREFILL_M_THRESHOLD
@@ -583,7 +621,8 @@ class PrismaQuantCBLinearMethod(LinearMethodBase):
         # Step-4 rungs only (the kernel's KBits template dispatch).
         if (bias is None and 16 < x2.shape[0] <= 128
                 and self.k in (28, 32, 36, 40, 44, 48)
-                and os.environ.get("PRISMAQUANT_CB_FUSED_MIDM", "1") != "0"):
+                and os.environ.get("PRISMAQUANT_CB_FUSED_MIDM", "1") != "0"
+                and self._fused_fp8_lut_ok(layer)):
             from .cuda_ext import get_fused_ext
             fext = get_fused_ext()
             if fext is not None and hasattr(fext, "cb_fused_prefill_mm_scaled"):

--- a/plugins/gridbook/gridbook/moe.py
+++ b/plugins/gridbook/gridbook/moe.py
@@ -490,8 +490,8 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         # producer/prologue. Values: "1"/"128" tile_m=128, "256" tile_m=256.
         # NOTE the activation bucket changes on this path (native NVFP4 quant,
         # not codec.fp4_group16_act_qdq). An explicit PRISMAQUANT_CB_PREFILL
-        # is authoritative and bypasses this default, so stock/loop remain
-        # real bisection controls rather than being silently preempted.
+        # is authoritative and bypasses this opt-in attempt, so stock/loop
+        # remain real bisection controls rather than being silently preempted.
         # Explicit opt-in until a served quality gate and routing-shape ladder
         # pass. Tile 128 is 5.2-5.6x faster than the per-expert loop on the
         # measured shapes, but its padding cost has a sharp token-count cliff.
@@ -507,10 +507,10 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
                 if out is not None:
                     return out
 
-        # Preserve current policy: fp8 uses measured auto; fp4 uses the
-        # conservative loop unless the explicit fused gate above succeeds.
-        # Stock remains explicitly selectable, with safe byte budgeting and a
-        # zero-copy packed view.
+        # Preserve current policy: fp8 uses measured auto; fp4 defaults to the
+        # conservative loop. Only the explicit FUSED_FP4_MOE gate above tries
+        # the fused path, falling back here on a constraint miss. Stock remains
+        # explicitly selectable, with safe byte budgeting and a zero-copy view.
         mode = requested_mode or ("auto" if not self.is_fp4 else "loop")
         if mode == "auto":
             return self._apply_prefill_auto(

--- a/plugins/gridbook/gridbook/ops.py
+++ b/plugins/gridbook/gridbook/ops.py
@@ -7,10 +7,12 @@ vLLM import here, so the op is usable from the standalone correctness tests too.
 """
 from __future__ import annotations
 
-import torch
-
+import itertools
 import os
 import sys
+import weakref
+
+import torch
 
 from .kernels import cb_decode_linear
 
@@ -378,7 +380,9 @@ def _cb_moe_combine_fake(y, pair_w, tok_start, T):
 # carries only (tensors..., layer_id) and the impl/fake consult the registry.
 # The id is a python int baked per call site — each layer module passes its
 # own — so the traced graph binds each site to its layer statically.
-_LAYER_REGISTRY: dict = {}
+_LAYER_REGISTRY: dict[int, tuple[weakref.ReferenceType,
+                                 weakref.ReferenceType]] = {}
+_LAYER_IDS = itertools.count()
 _DISPATCH_VIA_OP: list = []
 
 
@@ -390,20 +394,55 @@ def dispatch_via_op() -> bool:
 
 
 def register_cb_layer(method, layer) -> int:
-    layer_id = len(_LAYER_REGISTRY)
-    _LAYER_REGISTRY[layer_id] = (method, layer)
+    """Register one compiled-dispatch target without owning its model.
+
+    vLLM can load and unload several engines in one Python process.  Strong
+    references here used to pin every method, layer, parameter, and associated
+    GPU allocation until process exit.  The module/quant-method ownership graph
+    is authoritative; this registry is only an integer indirection for custom
+    ops, so both references must be weak.
+
+    IDs are monotonic rather than derived from ``len(_LAYER_REGISTRY)``.  A
+    captured graph containing an expired ID can therefore never alias a newly
+    loaded layer after the weakref callback removes its old entry.
+    """
+    layer_id = next(_LAYER_IDS)
+
+    def expire(_ref, *, expected_id=layer_id):
+        _LAYER_REGISTRY.pop(expected_id, None)
+
+    method_ref = weakref.ref(method, expire)
+    layer_ref = weakref.ref(layer, expire)
+    _LAYER_REGISTRY[layer_id] = (method_ref, layer_ref)
     return layer_id
+
+
+def _lookup_cb_layer(layer_id: int):
+    entry = _LAYER_REGISTRY.get(layer_id)
+    if entry is None:
+        raise RuntimeError(
+            f"CB dispatch layer id {layer_id} is stale or unknown; the model "
+            "may have been unloaded")
+    method = entry[0]()
+    layer = entry[1]()
+    if method is None or layer is None:
+        # A callback normally removes the entry first.  Keep this explicit for
+        # finalizer ordering and interpreter-shutdown edge cases.
+        _LAYER_REGISTRY.pop(layer_id, None)
+        raise RuntimeError(
+            f"CB dispatch layer id {layer_id} expired after model unload")
+    return method, layer
 
 
 @torch.library.custom_op("prismaquant::cb_linear_forward", mutates_args=())
 def cb_linear_forward(x: torch.Tensor, layer_id: int) -> torch.Tensor:
-    method, layer = _LAYER_REGISTRY[layer_id]
+    method, layer = _lookup_cb_layer(layer_id)
     return method._apply_inline(layer, x)
 
 
 @cb_linear_forward.register_fake
 def _cb_linear_forward_fake(x, layer_id):
-    _method, layer = _LAYER_REGISTRY[layer_id]
+    _method, layer = _lookup_cb_layer(layer_id)
     return torch.empty((*x.shape[:-1], layer._cb_N), dtype=x.dtype,
                        device=x.device)
 
@@ -411,7 +450,7 @@ def _cb_linear_forward_fake(x, layer_id):
 @torch.library.custom_op("prismaquant::cb_moe_forward", mutates_args=())
 def cb_moe_forward(x: torch.Tensor, topk_weights: torch.Tensor,
                    topk_ids: torch.Tensor, layer_id: int) -> torch.Tensor:
-    method, layer = _LAYER_REGISTRY[layer_id]
+    method, layer = _lookup_cb_layer(layer_id)
     return method._apply_inline(layer, x, topk_weights, topk_ids)
 
 

--- a/plugins/gridbook/tests/test_layer_registry.py
+++ b/plugins/gridbook/tests/test_layer_registry.py
@@ -1,0 +1,139 @@
+"""Lifecycle guarantees for the custom-op layer indirection registry."""
+from __future__ import annotations
+
+import gc
+import weakref
+
+import pytest
+import torch
+
+from gridbook import ops
+
+
+class _Layer:
+    _cb_N = 5
+
+
+class _Method:
+    def _apply_inline(self, layer, x, *args):
+        del args
+        return torch.zeros((*x.shape[:-1], layer._cb_N), dtype=x.dtype)
+
+
+class _MoEMethod:
+    def _apply_inline(self, layer, x, topk_weights, topk_ids):
+        del layer, topk_weights, topk_ids
+        return torch.full_like(x, 2)
+
+
+def test_registry_does_not_retain_unloaded_model():
+    method = _Method()
+    layer = _Layer()
+    method_ref = weakref.ref(method)
+    layer_ref = weakref.ref(layer)
+    layer_id = ops.register_cb_layer(method, layer)
+
+    del method, layer
+    gc.collect()
+
+    assert method_ref() is None
+    assert layer_ref() is None
+    assert layer_id not in ops._LAYER_REGISTRY
+    with pytest.raises(RuntimeError, match="stale or unknown"):
+        ops._lookup_cb_layer(layer_id)
+
+
+def test_layer_ownership_keeps_method_live_until_model_unload():
+    method = _Method()
+    layer = _Layer()
+    # This mirrors vLLM's LinearBase.quant_method ownership.
+    layer.quant_method = method
+    method_ref = weakref.ref(method)
+    layer_ref = weakref.ref(layer)
+    layer_id = ops.register_cb_layer(method, layer)
+
+    del method
+    gc.collect()
+    assert method_ref() is not None
+    assert layer_id in ops._LAYER_REGISTRY
+
+    del layer
+    gc.collect()
+    assert method_ref() is None
+    assert layer_ref() is None
+    assert layer_id not in ops._LAYER_REGISTRY
+
+
+def test_expired_id_is_never_reused_for_new_layer():
+    first_method = _Method()
+    first_layer = _Layer()
+    first_id = ops.register_cb_layer(first_method, first_layer)
+    del first_method, first_layer
+    gc.collect()
+
+    second_method = _Method()
+    second_layer = _Layer()
+    second_id = ops.register_cb_layer(second_method, second_layer)
+
+    assert second_id > first_id
+    with pytest.raises(RuntimeError, match="stale or unknown"):
+        ops._lookup_cb_layer(first_id)
+    assert ops._lookup_cb_layer(second_id) == (second_method, second_layer)
+
+
+def test_live_linear_dispatch_keeps_output_contract():
+    method = _Method()
+    layer = _Layer()
+    layer_id = ops.register_cb_layer(method, layer)
+
+    out = ops.cb_linear_forward(torch.ones((2, 3)), layer_id)
+
+    assert out.shape == (2, layer._cb_N)
+    assert torch.equal(out, torch.zeros_like(out))
+
+
+def test_live_moe_dispatch_keeps_output_contract():
+    method = _MoEMethod()
+    layer = _Layer()
+    layer_id = ops.register_cb_layer(method, layer)
+    x = torch.ones((3, 7))
+
+    out = ops.cb_moe_forward(
+        x,
+        torch.ones((3, 2)),
+        torch.zeros((3, 2), dtype=torch.int64),
+        layer_id,
+    )
+
+    assert out.shape == x.shape
+    assert torch.equal(out, torch.full_like(x, 2))
+
+
+def test_linear_custom_op_fake_and_schema_contract():
+    method = _Method()
+    layer = _Layer()
+    layer_id = ops.register_cb_layer(method, layer)
+    x = torch.ones((2, 3))
+
+    torch.library.opcheck(ops.cb_linear_forward, (x, layer_id))
+
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode() as mode:
+        fake_out = ops.cb_linear_forward(mode.from_tensor(x), layer_id)
+    assert fake_out.shape == (2, layer._cb_N)
+
+
+def test_linear_custom_op_compiles_with_static_layer_id():
+    method = _Method()
+    layer = _Layer()
+    layer_id = ops.register_cb_layer(method, layer)
+
+    def forward(x):
+        return ops.cb_linear_forward(x, layer_id)
+
+    compiled = torch.compile(forward, backend="eager", fullgraph=True)
+    out = compiled(torch.ones((2, 3)))
+
+    assert out.shape == (2, layer._cb_N)
+    assert torch.equal(out, torch.zeros_like(out))

--- a/plugins/gridbook/tests/test_weight_residency.py
+++ b/plugins/gridbook/tests/test_weight_residency.py
@@ -250,3 +250,225 @@ def test_weight_scale_is_not_duplicated():
     layer, _ = _loaded_layer()
     assert (layer._cb_scale.untyped_storage().data_ptr()
             == layer.weight_scale.data.untyped_storage().data_ptr())
+
+
+# ---------------------------------------------------------------------------
+# 3. fused roles: exact codebook references share one LUT block safely
+# ---------------------------------------------------------------------------
+
+_FUSED_K = 28
+_FUSED_TYPE_SIZE = 4 * _FUSED_K
+_FUSED_SCHEME = {
+    "grid": "fp8", "mode": "product", "k": _FUSED_K, "n_sub": 4,
+    "type_size": _FUSED_TYPE_SIZE, "group_size": 0, "vec_dim": 8,
+    "codebook_group": "attn", "codebook_source": "learned",
+}
+_FUSED_PREFIX = "model.layers.0.self_attn.qkv_proj"
+_FUSED_ROLES = [
+    "model.layers.0.self_attn.q_proj",
+    "model.layers.0.self_attn.k_proj",
+    "model.layers.0.self_attn.v_proj",
+]
+_REF_A = tuple(f"cb.a.sub{i}" for i in range(4))
+_REF_B = tuple(f"cb.b.sub{i}" for i in range(4))
+_FUSED_WIDTHS = (3, 5, 4)
+_FUSED_BLOCK_VALUES = 4 * (2 ** (_FUSED_K // 4)) * 2
+
+
+def _fused_loaded_layer(role_refs):
+    """Load a three-role fused dense layer without touching CUDA or vLLM TP."""
+    target_scheme = {
+        role: {**_FUSED_SCHEME, "codebook_ref": list(ref)}
+        for role, ref in zip(_FUSED_ROLES, role_refs)
+    }
+    all_names = {name for ref in role_refs for name in ref}
+    codebooks = {
+        name: torch.full(
+            (2 ** (_FUSED_K // 4), 2),
+            # Deliberately identical contents across differently named refs:
+            # deduplication is by provenance identity, never by current value.
+            1.0,
+            dtype=torch.bfloat16,
+        )
+        for name in all_names
+    }
+
+    class _FusedConfig:
+        def __init__(self):
+            self.target_scheme = target_scheme
+
+        def shard_target_keys(self, prefix, *, unfused_fallback=False):
+            assert prefix == _FUSED_PREFIX
+            assert unfused_fallback
+            return list(_FUSED_ROLES)
+
+        def get_codebooks(self):
+            return codebooks
+
+    method = PrismaQuantCBLinearMethod(
+        _FusedConfig(),
+        {**_FUSED_SCHEME, "codebook_ref": list(role_refs[0])},
+        _FUSED_PREFIX,
+    )
+    layer = _Layer()
+    rows = sum(_FUSED_WIDTHS)
+    row_bytes = (_K // codec.SUPERBLOCK) * _FUSED_TYPE_SIZE
+    layer.cb_qweight = torch.nn.Parameter(
+        torch.randint(0, 256, (rows, row_bytes), dtype=torch.uint8),
+        requires_grad=False,
+    )
+    layer.weight_scale = torch.nn.Parameter(
+        torch.linspace(0.5, 1.5, rows), requires_grad=False)
+    layer.logical_widths = list(_FUSED_WIDTHS)
+    layer._cb_input_size = _K
+    method.process_weights_after_loading(layer)
+    return method, layer, codebooks
+
+
+def _flat_for_ref(ref, codebooks):
+    return codec.build_flat_codebook(
+        [codebooks[name] for name in ref], _FUSED_PREFIX, "fp8")
+
+
+def test_identical_fused_refs_deduplicate_block_and_offsets():
+    method, layer, _ = _fused_loaded_layer([_REF_A, _REF_A, _REF_A])
+    assert layer._cb_flat.numel() == _FUSED_BLOCK_VALUES
+    assert torch.equal(
+        layer._cb_row_offset,
+        torch.zeros(sum(_FUSED_WIDTHS), dtype=torch.int32),
+    )
+    assert layer._cb_fp8_fused_lut_ok is True
+    assert method._fused_fp8_lut_ok(layer) is True
+
+
+def test_distinct_fused_refs_keep_distinct_blocks_and_offsets():
+    method, layer, _ = _fused_loaded_layer([_REF_A, _REF_B, _REF_A])
+    expected_offsets = torch.tensor(
+        [0] * _FUSED_WIDTHS[0]
+        + [_FUSED_BLOCK_VALUES] * _FUSED_WIDTHS[1]
+        + [0] * _FUSED_WIDTHS[2],
+        dtype=torch.int32,
+    )
+    assert layer._cb_flat.numel() == 2 * _FUSED_BLOCK_VALUES
+    assert torch.equal(layer._cb_row_offset, expected_offsets)
+    assert layer._cb_fp8_fused_lut_ok is False
+    assert method._fused_fp8_lut_ok(layer) is False
+
+
+def test_codebook_ref_order_is_part_of_dedup_identity():
+    reversed_ref = tuple(reversed(_REF_A))
+    method, layer, _ = _fused_loaded_layer([_REF_A, reversed_ref, _REF_A])
+    assert layer._cb_flat.numel() == 2 * _FUSED_BLOCK_VALUES
+    assert torch.equal(
+        layer._cb_row_offset,
+        torch.tensor(
+            [0] * _FUSED_WIDTHS[0]
+            + [_FUSED_BLOCK_VALUES] * _FUSED_WIDTHS[1]
+            + [0] * _FUSED_WIDTHS[2],
+            dtype=torch.int32,
+        ),
+    )
+    assert method._fused_fp8_lut_ok(layer) is False
+
+
+@pytest.mark.parametrize("role_refs", [
+    (_REF_A, _REF_A, _REF_A),
+    (_REF_A, _REF_B, _REF_A),
+])
+def test_dedup_preserves_every_rows_addressed_lut(role_refs):
+    """The compact layout addresses the same LUT as the old concatenation."""
+    _method, layer, codebooks = _fused_loaded_layer(role_refs)
+    legacy_blocks = [_flat_for_ref(ref, codebooks) for ref in role_refs]
+    legacy_flat = torch.cat(legacy_blocks)
+    legacy_base = 0
+    row = 0
+    for width, block in zip(_FUSED_WIDTHS, legacy_blocks):
+        new_bases = layer._cb_row_offset[row:row + width]
+        assert bool((new_bases == new_bases[0]).all())
+        new_base = int(new_bases[0])
+        assert torch.equal(
+            layer._cb_flat[new_base:new_base + block.numel()],
+            legacy_flat[legacy_base:legacy_base + block.numel()],
+        )
+        legacy_base += block.numel()
+        row += width
+
+
+def _mock_fp8_ops(monkeypatch, N):
+    vops = types.ModuleType("vllm._custom_ops")
+    vops.scaled_fp8_quant = lambda x, **kw: (
+        x, torch.ones(x.shape[0], 1, dtype=torch.float32))
+    vops.cutlass_scaled_mm = lambda xq, wt, sa, ws, dtype, bias: torch.full(
+        (xq.shape[0], N), 7.0, dtype=torch.bfloat16)
+    monkeypatch.setitem(sys.modules, "vllm._custom_ops", vops)
+    monkeypatch.setattr(sys.modules["vllm"], "_custom_ops", vops,
+                        raising=False)
+    return vops
+
+
+def test_same_ref_fused_roles_enter_midm_kernel(monkeypatch):
+    from gridbook import cuda_ext
+
+    method, layer, _ = _fused_loaded_layer([_REF_A, _REF_A, _REF_A])
+    N, K, M = layer._cb_N, layer._cb_K, 32
+    _mock_fp8_ops(monkeypatch, N)
+    calls = []
+
+    class _FusedExt:
+        @staticmethod
+        def cb_fused_prefill_mm_scaled(xq, qw, cb, sa, ws, n, k, k_bits):
+            calls.append((qw, cb, n, k, k_bits))
+            return torch.full((M, N), 11.0, dtype=torch.bfloat16)
+
+    monkeypatch.setattr(cuda_ext, "get_fused_ext", lambda: _FusedExt())
+    monkeypatch.setattr(
+        sys.modules["gridbook.linear"], "expand_cb_to_fp8",
+        lambda *a, **kw: pytest.fail("eligible shared LUT fell back"),
+    )
+    monkeypatch.setenv("PRISMAQUANT_CB_FUSED_MIDM", "1")
+    out = method._apply_inline(layer, torch.zeros(M, K, dtype=torch.bfloat16))
+    assert len(calls) == 1
+    assert calls[0][1] is layer._cb_flat_fp8
+    assert torch.equal(out, torch.full_like(out, 11.0))
+
+
+def test_distinct_ref_fused_roles_fall_back_before_extension(monkeypatch):
+    from gridbook import cuda_ext
+
+    method, layer, _ = _fused_loaded_layer([_REF_A, _REF_B, _REF_A])
+    N, K, M = layer._cb_N, layer._cb_K, 32
+    _mock_fp8_ops(monkeypatch, N)
+    monkeypatch.setattr(
+        cuda_ext, "get_fused_ext",
+        lambda: pytest.fail("offset-unsafe fused extension was queried"),
+    )
+    fallback_calls = []
+
+    def _expand(*args, **kwargs):
+        fallback_calls.append((args, kwargs))
+        return torch.zeros(N, K, dtype=torch.float32)
+
+    monkeypatch.setattr(
+        sys.modules["gridbook.linear"], "expand_cb_to_fp8", _expand)
+    monkeypatch.setenv("PRISMAQUANT_CB_FUSED_MIDM", "1")
+    out = method._apply_inline(layer, torch.zeros(M, K, dtype=torch.bfloat16))
+    assert len(fallback_calls) == 1
+    assert torch.equal(out, torch.full_like(out, 7.0))
+
+
+def test_fused_lut_guard_rejects_uniform_nonzero_base():
+    """The kernel starts at cb[0]; merely uniform offsets are insufficient."""
+    method, layer, _ = _fused_loaded_layer([_REF_A, _REF_A, _REF_A])
+    del layer._cb_fp8_fused_lut_ok
+    layer._cb_row_offset.fill_(_FUSED_BLOCK_VALUES)
+    assert method._fused_fp8_lut_ok(layer) is False
+
+
+@pytest.mark.parametrize("attr,value", [
+    ("n_sub", 2),
+    ("type_size", _FUSED_TYPE_SIZE + 16),
+])
+def test_fused_lut_guard_rejects_incompatible_fp8_layout(attr, value):
+    method, layer, _ = _fused_loaded_layer([_REF_A, _REF_A, _REF_A])
+    setattr(method, attr, value)
+    assert method._fused_fp8_lut_ok(layer) is False


### PR DESCRIPTION
## Why

The PrismaQuant development copy is the source consumed by scripts/sync_gridbook.py. It had drifted behind reviewed Gridbook changes after v0.3.0, so the next one-way sync would have overwritten runtime safety fixes and deleted their lifecycle test.

## What changed

- Sync exact-reference codebook interning and the offset-free fused-FP8 eligibility guard.
- Sync weak, monotonic compiled-dispatch layer registration so unloaded models release their layers and GPU allocations without stale-ID aliasing.
- Sync the full residency, fused-LUT, opcheck, compile, and unload lifecycle coverage.
- Preserve the producer-only HIP hooks and the existing HIP publication hold; this PR changes only paths already intended to mirror.

## Validation

- Gridbook sync check: 0 added, 0 updated, 0 deleted.
- Sync meta-suite: 4 passed.
- Focused runtime suites: 79 passed.
- Per-file vendored-plugin sweep: 21 files passed and 9 hardware-only files cleanly skipped; no failing file.
- Python compileall and git diff check passed.

The original JW2026 contribution line remains attributed to Jason Wong @jsconsultancy. This synchronization and safety review is attributed to Robert Tand.