### PR TITLE
gridbook: sync dotted MoE target boundary

### DIFF
--- a/plugins/gridbook/gridbook/config.py
+++ b/plugins/gridbook/gridbook/config.py
@@ -439,7 +439,12 @@ class PrismaQuantConfig(QuantizationConfig):
             if name.split(".")[-1] not in _MOE_LEAVES:
                 continue
             variants = _candidate_bases(name)
-            if any(v.startswith(b) for v in variants for b in bases):
+            # A target must be a dotted child of this exact expert prefix.
+            # Raw ``startswith`` also accepts neighbouring module names such
+            # as ``experts2`` and ``experts_backup``, silently assigning their
+            # scheme to the live ``experts`` stack.
+            if any(v.startswith(b.rstrip(".") + ".")
+                   for v in variants for b in bases):
                 return sch
         return None
 

--- a/plugins/gridbook/tests/test_target_namespace_compat.py
+++ b/plugins/gridbook/tests/test_target_namespace_compat.py
@@ -271,6 +271,19 @@ def test_moe_scheme_does_not_overmatch():
         "language_model.model.layers.1.mlp.shared_expert") is None
 
 
+@pytest.mark.parametrize("neighbour", ["experts2", "experts_backup"])
+@pytest.mark.parametrize("prefix", _MOE_EXPERT_PREFIXES)
+def test_moe_scheme_requires_a_dotted_prefix_boundary(neighbour, prefix):
+    """A sibling whose name merely starts with ``experts`` is not that stack."""
+    cfg = PrismaQuantConfig.from_config(_moe_config([
+        f"model.layers.1.mlp.{neighbour}.gate_up_proj",
+        f"model.layers.1.mlp.{neighbour}.down_proj",
+    ]))
+    cfg._ensure_resolved()
+
+    assert cfg._moe_scheme_for_prefix(prefix) is None
+
+
 # ---------------------------------------------------------------------------
 # The FOURTH namespace vintage: post-``apply_vllm_mapper`` (issue #1,
 # RobTand/gridbook, 2026-07-25).


### PR DESCRIPTION
## Value

Mirrors Gridbook PR #19 into the PrismaQuant producer tree. The MoE scheme resolver now requires a true dotted child of the expert prefix, so sibling modules such as `experts2` and `experts_backup` cannot silently donate their codebook scheme to `experts`.

This is the isolated, fail-closed correctness portion extracted from Gridbook draft #12. No graded-rung runtime machinery is included.

## Validation

- namespace compatibility: 87 passed
- provenance configuration: 9 passed
- top-level loader: 22 passed
- compileall and diff hygiene passed
- standalone sync comparison: 0 added, 0 updated, 0 deleted outside the three intentionally held HIP paths

Original finding and patch design by Jason Wong (@jsconsultancy); extraction and review by @RobTand. Strix/HIP work remains cancelled and unchanged.