### PR TITLE
gridbook: sync fail-closed runtime contracts

### DIFF
--- a/plugins/gridbook/README.md
+++ b/plugins/gridbook/README.md
@@ -75,7 +75,10 @@ The CUDA sources live **inside** the package (`gridbook/csrc`, shipped via
 `[tool.setuptools.package-data]` in `pyproject.toml`) and JIT-build on first
 model load; a repo-root-relative `csrc` broke every non-editable install before
 `bf1ada0`. Without `nvcc` the plugin still serves correctly through Triton
-fallbacks — a correctness path, not a speed path. `tp=1` only.
+fallbacks — a correctness path, not a speed path. The shipping CUDA contract
+accepts BF16 activations only. A live tensor-parallel size above one is rejected
+during model construction, as is an FP8-CB target on a device below `sm_89`;
+FP4-CB retains the broader BF16 fallback.
 
 ## Registration and dispatch
 
@@ -221,7 +224,7 @@ The serve scripts pass them through explicitly (`scripts/serve_laguna_smoke.sh:4
 
 | Variable | Default | Effect |
 |---|---|---|
-| `PRISMAQUANT_CB_PREFILL` | `auto` (fp8) / `loop` (fp4) | `stock` · `batched` · `grouped_fused[_r1]` · `l2_pipeline` · `loop` |
+| `PRISMAQUANT_CB_PREFILL` | `auto` (fp8) / `loop` (fp4) | `auto` · `stock` · `batched` · `grouped_fused[_r1]` · `l2_pipeline` · `loop`; unknown spellings fail, and changing it mid-process requires a restart |
 | `PRISMAQUANT_CB_PREFILL_AUTO_FORCE` | unset | pin an `auto` winner without timing (bisection) |
 | `PRISMAQUANT_CB_AUTOTUNE_MIN_M` | 1024 | token floor below which `auto` runs stock and caches nothing |
 | `PRISMAQUANT_CB_FUSED_MIDM` | `1` | `0` disables the mid-M fused prefill |

--- a/plugins/gridbook/gridbook/config.py
+++ b/plugins/gridbook/gridbook/config.py
@@ -49,6 +49,28 @@ _FUSED_FALLBACK = {
 }
 
 
+def _initialized_tensor_parallel_world_size() -> int | None:
+    """Return vLLM's TP size once model parallelism exists.
+
+    Config/resolver unit tests intentionally run without a distributed vLLM
+    process.  Production calls ``get_quant_method`` while constructing the
+    worker model, after vLLM initializes its model-parallel groups; that is the
+    first point where the documented TP=1 restriction can be enforced against
+    the real serving state instead of an argument string.
+    """
+
+    try:
+        from vllm.distributed import (
+            get_tensor_model_parallel_world_size,
+            model_parallel_is_initialized,
+        )
+    except (ImportError, AttributeError):  # pragma: no cover - minimal stubs
+        return None
+    if not model_parallel_is_initialized():
+        return None
+    return int(get_tensor_model_parallel_world_size())
+
+
 def _canonical_prefix(prefix: str) -> str:
     """vLLM serving prefix -> canonical target namespace. Some model classes
     wrap the LM (`language_model.model.layers.*` on Qwen3.5-class VL) while
@@ -132,6 +154,42 @@ class PrismaQuantConfig(QuantizationConfig):
         self._cb_targets: set[str] = set()
         self.ct_config = None                        # stock CompressedTensorsConfig
         self._codebooks: dict[str, torch.Tensor] | None = None
+        self._tp_world_size: int | None = None
+
+    def _require_supported_tensor_parallel(self) -> None:
+        if self._tp_world_size == 1:
+            return
+        world_size = _initialized_tensor_parallel_world_size()
+        if world_size is None:
+            return
+        if world_size != 1:
+            raise ValueError(
+                "Gridbook currently supports tensor-parallel size 1 only; "
+                f"the live vLLM worker reports TP={world_size}"
+            )
+        self._tp_world_size = world_size
+
+    @staticmethod
+    def _require_cb_device_capability(scheme: dict, prefix: str) -> None:
+        """Reject an FP8-CB artifact before its first illegal prefill.
+
+        FP8-CB's shipping large-M path uses vLLM's native FP8 quantizer and
+        CUTLASS scaled GEMM, whose hardware floor is sm_89.  The main decode
+        extension itself can compile for sm_80, so a global capability floor
+        would otherwise let an A100 load successfully and fail only when the
+        first prompt crosses the 16-token decode boundary.  FP4-CB retains the
+        broader BF16 transient fallback and is not rejected here.
+        """
+
+        if scheme.get("grid") != "fp8" or not torch.cuda.is_available():
+            return
+        capability = tuple(torch.cuda.get_device_capability())
+        if capability < (8, 9):
+            raise ValueError(
+                f"FP8-CB target {prefix!r} requires compute capability sm_89+ "
+                "for its shipping prefill path; "
+                f"the current device reports sm_{capability[0]}{capability[1]}"
+            )
 
     # -- lazy resolution of the (possibly pointer) quant config --------------
     def _ensure_resolved(self) -> None:
@@ -222,7 +280,10 @@ class PrismaQuantConfig(QuantizationConfig):
         return "gridbook"
 
     def get_supported_act_dtypes(self) -> list[torch.dtype]:
-        return [torch.bfloat16, torch.float16]
+        # Shipping CUDA decode and grouped-MoE bindings require BF16 inputs.
+        # Advertising FP16 lets vLLM accept a model dtype that later fails at
+        # the native boundary (or changes dtype at a fallback/crossover).
+        return [torch.bfloat16]
 
     @classmethod
     def get_min_capability(cls) -> int:
@@ -363,6 +424,7 @@ class PrismaQuantConfig(QuantizationConfig):
 
     def get_quant_method(self, layer: torch.nn.Module,
                          prefix: str) -> "QuantizeMethodBase | None":
+        self._require_supported_tensor_parallel()
         self._ensure_resolved()
         from .linear import PrismaQuantCBLinearMethod
 
@@ -381,6 +443,7 @@ class PrismaQuantConfig(QuantizationConfig):
                       f"{'CB' if scheme is not None else 'no-scheme'}",
                       file=sys.stderr, flush=True)
             if scheme is not None:
+                self._require_cb_device_capability(scheme, prefix)
                 return PrismaQuantCBLinearMethod(self, scheme, prefix)
             # 2) explicitly-ignored -> BF16 passthrough.
             if self._is_ignored(prefix):
@@ -404,6 +467,7 @@ class PrismaQuantConfig(QuantizationConfig):
         if RoutedExperts is not None and isinstance(layer, RoutedExperts):
             scheme = self._moe_scheme_for_prefix(prefix)
             if scheme is not None:
+                self._require_cb_device_capability(scheme, prefix)
                 from .moe import PrismaQuantCBMoEMethod
                 return PrismaQuantCBMoEMethod(
                     self, layer.moe_config, scheme, prefix)

--- a/plugins/gridbook/gridbook/moe.py
+++ b/plugins/gridbook/gridbook/moe.py
@@ -107,6 +107,41 @@ def _window_fits_superblock(k: int, type_size: int) -> bool:
 # reject degrades to segmented once, not per forward.
 _GROUPED_MM_OK: bool | None = None
 
+# Every accepted public/diagnostic prefill selector. Historically every unknown
+# spelling fell through to ``batched`` -- the high-transient experimental path
+# that has crashed a large serve. Pin the environment once per process and fail
+# on typos or mid-serve mutation so one model cannot split its layers across
+# different execution contracts.
+_PREFILL_MODES = frozenset({
+    "auto",
+    "batched",
+    "grouped_fused",
+    "grouped_fused_r1",
+    "l2_pipeline",
+    "loop",
+    "stock",
+})
+_PREFILL_MODE_STATE: list[str | None] = []
+
+
+def _requested_prefill_mode() -> str | None:
+    raw = os.environ.get("PRISMAQUANT_CB_PREFILL")
+    current = raw.strip() if raw is not None else None
+    if current == "" or (current is not None and current not in _PREFILL_MODES):
+        allowed = ", ".join(sorted(_PREFILL_MODES))
+        raise ValueError(
+            "invalid PRISMAQUANT_CB_PREFILL="
+            f"{raw!r}; expected one of: {allowed}, or leave it unset"
+        )
+    if not _PREFILL_MODE_STATE:
+        _PREFILL_MODE_STATE.append(current)
+    elif current != _PREFILL_MODE_STATE[0]:
+        raise RuntimeError(
+            "PRISMAQUANT_CB_PREFILL changed after Gridbook dispatch was fixed; "
+            "restart the process instead of mixing prefill contracts"
+        )
+    return _PREFILL_MODE_STATE[0]
+
 
 def _grouped_mm_available() -> bool:
     global _GROUPED_MM_OK
@@ -501,7 +536,7 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         # measured shapes, but its padding cost has a sharp token-count cliff.
         # The same unvalidated-on-serving-metric caveat as the dense gate in
         # linear.py applies.
-        requested_mode = os.environ.get("PRISMAQUANT_CB_PREFILL")
+        requested_mode = _requested_prefill_mode()
         if requested_mode is None and self.is_fp4 and num_tokens > 16:
             gf4 = os.environ.get("PRISMAQUANT_CB_FUSED_FP4_MOE", "").strip()
             if gf4 in ("1", "128", "256"):
@@ -544,8 +579,10 @@ class PrismaQuantCBMoEMethod(FusedMoEMethodBase):
         if mode == "stock":
             return self._apply_prefill_stock(
                 layer, x, topk_weights, topk_ids, act)
-        return self._apply_prefill_batched(
-            layer, x, topk_weights, topk_ids, act)
+        if mode == "batched":
+            return self._apply_prefill_batched(
+                layer, x, topk_weights, topk_ids, act)
+        raise AssertionError(f"unhandled validated CB prefill mode: {mode}")
 
     # -- prefill: fp4 grouped FUSED (block-scaled decode-in-prologue) --------
     def _gf4_ok(self, layer) -> bool:

--- a/plugins/gridbook/tests/test_moe_fp4_stock_prefill.py
+++ b/plugins/gridbook/tests/test_moe_fp4_stock_prefill.py
@@ -88,6 +88,13 @@ def moe(request):
         sys.modules.update(before)
 
 
+@pytest.fixture(autouse=True)
+def _reset_prefill_mode_state(moe):
+    moe._PREFILL_MODE_STATE.clear()
+    yield
+    moe._PREFILL_MODE_STATE.clear()
+
+
 def _method(moe, *, grid, k, n_sub, type_size, is_v2=True):
     """A ``PrismaQuantCBMoEMethod`` with ``__init__`` bypassed (the fixture
     pattern the other MoE test files use) carrying just the format fields the
@@ -193,6 +200,22 @@ def test_explicit_fp4_mode_bypasses_fused_default(moe, monkeypatch, mode):
 def test_fp8_explicit_mode_still_overrides_auto(moe, monkeypatch):
     monkeypatch.setenv("PRISMAQUANT_CB_PREFILL", "loop")
     assert _dispatch_mode(moe, monkeypatch, _fp8(moe)) == "loop"
+
+
+@pytest.mark.parametrize("value", ["", "stok", "AUTO", "unknown"])
+def test_invalid_prefill_mode_fails_instead_of_selecting_batched(
+        moe, monkeypatch, value):
+    monkeypatch.setenv("PRISMAQUANT_CB_PREFILL", value)
+    with pytest.raises(ValueError, match="invalid PRISMAQUANT_CB_PREFILL"):
+        _dispatch_mode(moe, monkeypatch, _fp8(moe))
+
+
+def test_prefill_mode_cannot_change_mid_process(moe, monkeypatch):
+    monkeypatch.setenv("PRISMAQUANT_CB_PREFILL", "loop")
+    assert _dispatch_mode(moe, monkeypatch, _fp8(moe)) == "loop"
+    monkeypatch.setenv("PRISMAQUANT_CB_PREFILL", "stock")
+    with pytest.raises(RuntimeError, match="changed after Gridbook dispatch"):
+        _dispatch_mode(moe, monkeypatch, _fp8(moe))
 
 
 # --------------------------------------------------------------------------- #

--- a/plugins/gridbook/tests/test_target_namespace_compat.py
+++ b/plugins/gridbook/tests/test_target_namespace_compat.py
@@ -581,6 +581,50 @@ def test_get_quant_method_delegates_gate_projection_not_router(monkeypatch):
         _Linear(), "model.layers.1.mlp.gate_proj") is delegated
 
 
+def test_config_advertises_only_the_bf16_runtime_contract():
+    import torch
+
+    cfg = PrismaQuantConfig(_config())
+    assert cfg.get_supported_act_dtypes() == [torch.bfloat16]
+    assert torch.float16 not in cfg.get_supported_act_dtypes()
+
+
+def test_live_tensor_parallel_size_above_one_fails_before_dispatch(monkeypatch):
+    import gridbook.config as config_mod
+
+    cfg = PrismaQuantConfig(_config())
+    monkeypatch.setattr(config_mod, "_initialized_tensor_parallel_world_size",
+                        lambda: 2)
+    with pytest.raises(ValueError, match=r"TP=2"):
+        # The gate precedes config resolution and method/weight construction.
+        cfg.get_quant_method(object(), "model.layers.0.mlp.down_proj")
+
+    monkeypatch.setattr(config_mod, "_initialized_tensor_parallel_world_size",
+                        lambda: 1)
+    cfg._require_supported_tensor_parallel()
+    assert cfg._tp_world_size == 1
+
+
+def test_fp8_cb_rejects_sm80_before_the_first_prefill(monkeypatch):
+    import gridbook.config as config_mod
+
+    cfg = PrismaQuantConfig(_config())
+    monkeypatch.setattr(config_mod.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(config_mod.torch.cuda, "get_device_capability",
+                        lambda: (8, 0))
+    with pytest.raises(ValueError, match=r"sm_89\+.*sm_80"):
+        cfg._require_cb_device_capability(_SCHEME, "model.layers.0.mlp.down_proj")
+
+    monkeypatch.setattr(config_mod.torch.cuda, "get_device_capability",
+                        lambda: (8, 9))
+    cfg._require_cb_device_capability(_SCHEME, "model.layers.0.mlp.down_proj")
+
+    fp4 = {**_SCHEME, "grid": "fp4"}
+    monkeypatch.setattr(config_mod.torch.cuda, "get_device_capability",
+                        lambda: (8, 0))
+    cfg._require_cb_device_capability(fp4, "model.layers.0.mlp.down_proj")
+
+
 _SUBSET_ENTRIES = ["model.layers.1.mlp.gate", "model.layers.1.mlp", "lm_head",
                    "mlp.down_proj", "model.layers.1"]
 _SUBSET_NAMES = ["model.layers.1.mlp.gate", "model.layers.1.mlp.gate_proj",


### PR DESCRIPTION
## Summary

Mirrors merged Gridbook PR #20 into the authoritative PrismaQuant plugin tree:

- advertises BF16 only, matching the shipping CUDA bindings
- rejects live tensor-parallel sizes above one before config resolution or weight construction
- rejects FP8-CB on pre-sm89 devices before the first unsupported large-M prefill
- validates and freezes PRISMAQUANT_CB_PREFILL so typos cannot silently choose batched fallback
- updates producer plugin documentation and focused coverage

## Validation

- focused suites: 90 passed and 34 passed
- isolated non-HIP plugin sweep: 437 passed, 169 hardware-gated skips
- clean diff and compile checks

No Strix Halo, HIP, or gfx1151 file was inspected or changed.