### PR TITLE
release: bump Gridbook source to 0.4.0

### DIFF
--- a/plugins/gridbook/gridbook/__init__.py
+++ b/plugins/gridbook/gridbook/__init__.py
@@ -13,7 +13,7 @@ falls back to a correct-but-slow Triton path.
 # Single source of truth for package and release metadata. This file is synced
 # from PrismaQuant's development tree into the standalone Gridbook release repo;
 # release tags are cut only from the latter and must match this value exactly.
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 
 def register() -> None:


### PR DESCRIPTION
## Summary

- bump the authoritative vendored Gridbook version source from 0.3.0 to 0.4.0
- unblock the standalone Gridbook release PR after ten post-0.3.0 runtime, correctness, performance, and validation-protocol merges

The standalone release tree was synchronized from this exact committed producer source; the drift check reports `0 added, 0 updated, 0 deleted`. Held HIP paths remain excluded by policy, and no Strix/gfx1151/HIP/ROCm work is changed or validated.

## Validation

- standalone PR #23 packaging/install/CPU matrix is green on Python 3.10-3.13
- local 0.4.0 sdist/wheel build, strict Twine, and distribution inventory checks pass
- installed-wheel CUDA extension compile gate passes from site-packages with `TORCH_CUDA_ARCH_LIST=12.1` (compile-only, no GPU)

Final Jason artifact serving validation remains a standalone release/tag gate, not part of this one-line producer version change.
