### PR TITLE
Fix partial LFM CB expert export layouts

### DIFF
--- a/prismaquant/export_nvfp4_cb.py
+++ b/prismaquant/export_nvfp4_cb.py
@@ -145,11 +145,17 @@ def _pack_skeleton_experts(
     skeleton: dict,
     profile,
     fp8_scale_inv_map=None,
+    target_qnames: set[str] | None = None,
 ) -> int:
     """Per-expert-on-disk MoE checkpoints (Qwen3.5-MoE / Ornith): assemble
     the packed ``<experts>.gate_up_proj/.down_proj`` skeleton tensors the CB
     targets name, via layer_streaming's tested bridge. No-op for dense or
     already-packed checkpoints.
+
+    When ``target_qnames`` is supplied, only those packed parents are
+    assembled. This is required for partial mixed assignments: an omitted or
+    BF16 expert bank must stay in its original per-expert checkpoint layout,
+    which is the layout architecture-specific vLLM loaders consume.
 
     Memory discipline: the bridge is invoked once PER packed group (the
     ``live_param_shape`` gate restricts each call), so the transient is one
@@ -181,6 +187,34 @@ def _pack_skeleton_experts(
         except Exception:
             return False
 
+    requested = None if target_qnames is None else set(target_qnames)
+
+    def is_requested(packed_full: str) -> bool:
+        if requested is None:
+            return True
+        variants = {packed_full}
+        canon = _canonical_qname(packed_full, profile)
+        if canon is not None:
+            variants.add(canon)
+        return bool(variants & requested)
+
+    def packed_source_parts(source_name: str):
+        """Return ``(packed_parent, expert_id, projection)`` for either a
+        checkpoint or profile-mapped live per-expert source name."""
+        name = (source_name[:-len(".weight")]
+                if source_name.endswith(".weight") else source_name)
+        try:
+            head, proj = name.rsplit(".", 1)
+            experts_path, idx = head.rsplit(".", 1)
+        except ValueError:
+            return None
+        if not idx.isdigit():
+            return None
+        parent = profile.packed_expert_parent_for_projection(proj)
+        if parent is None:
+            return None
+        return f"{experts_path}.{parent}", int(idx), proj
+
     # Pre-derive each packed group's expected shape from its per-expert
     # members (E, sum of fused projection out-dims, in).
     members: dict[str, dict[int, dict[str, tuple]]] = defaultdict(
@@ -194,6 +228,15 @@ def _pack_skeleton_experts(
         except Exception:
             live_weight_name = None
         live_weight_name = live_weight_name or key
+        raw_parts = packed_source_parts(key)
+        live_parts = packed_source_parts(live_weight_name)
+        candidate_parents = {
+            parts[0] for parts in (raw_parts, live_parts)
+            if parts is not None
+        }
+        if requested is not None and not any(
+                is_requested(parent) for parent in candidate_parents):
+            continue
         if key.endswith(".weight") and (
             t.dtype == torch.float8_e4m3fn
             or live_weight_name in (fp8_scale_inv_map or {})
@@ -203,14 +246,10 @@ def _pack_skeleton_experts(
                 "FP8/MXFP4 per-expert tensors before dequantization; use "
                 "export_nvfp4_cb_streaming for this source"
             )
-        head, proj = name.rsplit(".", 1)
-        experts_path, idx = head.rsplit(".", 1)
-        if not idx.isdigit():
+        if raw_parts is None:
             continue
-        parent = profile.packed_expert_parent_for_projection(proj)
-        if parent is None:
-            continue
-        members[f"{experts_path}.{parent}"][int(idx)][proj] = tuple(t.shape)
+        packed_full, idx, proj = raw_parts
+        members[packed_full][idx][proj] = tuple(t.shape)
     expected: dict[str, tuple] = {}
     for packed_full, by_e in members.items():
         parent = packed_full.rsplit(".", 1)[1]
@@ -242,9 +281,54 @@ def _pack_skeleton_experts(
     return produced
 
 
+def _try_resolve_direct_packed_expert(qname, skeleton, profile):
+    """Resolve a direct packed expert parameter key (no ``.weight`` suffix).
+
+    Packed expert containers expose 3-D ``nn.Parameter`` objects directly on
+    some HF models. A checkpoint saved from that live representation therefore
+    legitimately contains ``...experts.gate_up_proj`` rather than
+    ``...experts.gate_up_proj.weight``. Accept only profile-declared packed
+    parents under an ``experts`` container, and require rank 3 so an unrelated
+    suffix-less tensor can never be mistaken for a quantization target.
+    """
+    if profile is None:
+        return None
+    try:
+        packed_names = frozenset(profile.packed_expert_param_names())
+    except Exception:
+        return None
+    if not packed_names:
+        return None
+    candidates = [qname]
+    try:
+        mapped = profile.source_tensor_name(qname)
+        if mapped not in candidates:
+            candidates.append(mapped)
+    except Exception:
+        pass
+    for key in candidates:
+        if key not in skeleton or "." not in key:
+            continue
+        parent, leaf = key.rsplit(".", 1)
+        if not parent.endswith(".experts") or leaf not in packed_names:
+            continue
+        if hasattr(skeleton, "get_shape"):
+            shape = tuple(skeleton.get_shape(key))
+        else:
+            shape = tuple(skeleton[key].shape)
+        if len(shape) != 3:
+            raise ValueError(
+                f"{qname}: direct packed expert source {key!r} must be rank-3 "
+                f"[experts, out_features, in_features], got {shape}")
+        return key
+    return None
+
+
 def _try_resolve_skeleton(qname, skeleton, profile, suffix=".weight"):
     """Recipe qname -> actual skeleton key, or None if neither the direct name
-    nor the profile-mapped (checkpoint-convention) name is present."""
+    nor the profile-mapped (checkpoint-convention) name is present. For the
+    default weight lookup, also accepts a validated direct 3-D packed-expert
+    parameter key (the native LFM live/save representation)."""
     direct = qname + suffix
     if direct in skeleton:
         return direct
@@ -252,6 +336,9 @@ def _try_resolve_skeleton(qname, skeleton, profile, suffix=".weight"):
         mapped = profile.source_tensor_name(qname) + suffix
         if mapped in skeleton:
             return mapped
+    if suffix == ".weight":
+        return _try_resolve_direct_packed_expert(
+            qname, skeleton, profile)
     return None
 
 
@@ -263,6 +350,8 @@ def _resolve_skeleton(qname, skeleton, profile, suffix=".weight"):
     tried = [qname + suffix]
     if profile is not None:
         tried.append(profile.source_tensor_name(qname) + suffix)
+        if suffix == ".weight":
+            tried.extend([qname, profile.source_tensor_name(qname)])
     raise KeyError(
         f"{qname}: no skeleton tensor for {suffix!r} (tried {tried})")
 
@@ -474,14 +563,6 @@ def export_nvfp4_cb(
     # also carries the checkpoint-declared block shape and declared MXFP4 set;
     # missing scales fail closed in cb_source_weight_bf16_value.
     _source_fp8_scale_map = build_cb_source_fp8_scale_map(model_dir)
-    # Per-expert-on-disk MoE checkpoints: assemble the packed expert stacks
-    # the CB targets name BEFORE any skeleton resolution below.
-    _pack_skeleton_experts(
-        skeleton,
-        _profile,
-        _source_fp8_scale_map,
-    )
-
     # --- Coverage gate: classify every assigned format into CB / stock-CT /
     # BF16-passthrough (the mixed container, LAYOUT.md §4; "FP8 in every
     # recipe"). ---
@@ -510,6 +591,22 @@ def export_nvfp4_cb(
             f"{sorted({f for _, f in illegal})} — it carries the CB families "
             f"+ stock NVFP4/FP8_DYNAMIC (CT-delegated) + FP8_SOURCE "
             f"(verbatim fp8 passthrough) + BF16 passthrough only")
+
+    # Per-expert-on-disk MoE checkpoints: assemble only packed parents that
+    # are actually quantized. Packing every detected bank mutates omitted/BF16
+    # LFM layers from their loadable ``experts.E.w1/w2/w3.weight`` layout into
+    # aggregate ``gate_up_proj/down_proj.weight`` passthrough tensors that
+    # vLLM's architecture loader cannot consume.
+    _pack_skeleton_experts(
+        skeleton,
+        _profile,
+        fp8_scale_inv_map=_source_fp8_scale_map,
+        target_qnames=set(cb_targets) | set(stock_targets),
+    )
+    # FP8_SOURCE is deliberately excluded above: it is a byte-verbatim
+    # passthrough contract and must already resolve to a source weight plus its
+    # scale_inv sibling. Synthesizing a packed stack would change that payload
+    # and still would not produce the required packed scale tensor.
 
     # Sidecar stock targets (visual/audio — modules the profile's LM mapping
     # drops): ship WEIGHT-ONLY (W4A16). Text-only calibration has no visual
@@ -760,7 +857,12 @@ def export_nvfp4_cb(
         # EXPORTED tensor names — vLLM's convention, incl. the language_model
         # infix); `canon` is the canonical recipe qname that assignment /
         # col_weights / cb_targets are keyed by (nested -> canonical).
-        ckpt_qname = name[:-len(".weight")] if name.endswith(".weight") else None
+        if name.endswith(".weight"):
+            ckpt_qname = name[:-len(".weight")]
+        elif _try_resolve_direct_packed_expert(name, skeleton, _profile) == name:
+            ckpt_qname = name
+        else:
+            ckpt_qname = None
         canon = _canonical_qname(ckpt_qname, _profile) if ckpt_qname else None
         if canon is None and ckpt_qname is not None and (
                 ckpt_qname in stock_targets or ckpt_qname in cb_targets):

--- a/prismaquant/export_nvfp4_cb_streaming.py
+++ b/prismaquant/export_nvfp4_cb_streaming.py
@@ -72,6 +72,7 @@ from prismaquant.export_nvfp4_cb import (
     _parse_cb_format,
     _role_of,
     _to_device,
+    _try_resolve_direct_packed_expert,
     _try_resolve_skeleton,
 )
 from prismaquant.layer_config import load_assignment
@@ -104,8 +105,15 @@ _ST_DTYPE = {
 # Inverse (safetensors dtype string -> torch dtype), used by the DELTA-EXPORT
 # reuse path to read a prior artifact's per-tensor dtype from its header.
 _ST_DTYPE_INV = {v: k for k, v in _ST_DTYPE.items()}
-_EXPERT_RE = re.compile(
+_LEGACY_EXPERT_RE = re.compile(
     r"^(.*\.experts)\.(\d+)\.(gate_proj|up_proj|down_proj)\.weight$")
+
+_LEGACY_PACKED_PROJECTIONS = {
+    "gate_up_proj": ("gate_proj", "up_proj"),
+    "down_proj": ("down_proj",),
+    "gate_proj": ("gate_proj",),
+    "up_proj": ("up_proj",),
+}
 
 
 # ---------------------------------------------------------------------------
@@ -361,49 +369,131 @@ class _StreamWriter:
 # Per-expert -> stacked plan
 # ---------------------------------------------------------------------------
 
-def _plan_expert_stacks(skeleton: _LazySkeleton) -> dict[str, dict]:
+def _packed_expert_param_names(profile) -> frozenset[str]:
+    if profile is not None:
+        try:
+            names = frozenset(profile.packed_expert_param_names())
+            if names:
+                return names
+        except Exception:
+            pass
+    return frozenset(_LEGACY_PACKED_PROJECTIONS)
+
+
+def _packed_expert_projection_names(profile, packed_proj: str) -> tuple[str, ...]:
+    if profile is not None:
+        try:
+            names = tuple(profile.packed_expert_projection_names(packed_proj))
+            if names:
+                return names
+        except Exception:
+            pass
+    return _LEGACY_PACKED_PROJECTIONS.get(packed_proj, (packed_proj,))
+
+
+def _plan_expert_stacks(skeleton: _LazySkeleton, profile=None) -> dict[str, dict]:
     """Group per-expert on-disk tensors into stacked-output plans keyed by the
     LIVE packed qname (``…experts.gate_up_proj`` = fused gate+up, or
-    ``…experts.down_proj``). Returns {live_packed_base: {proj: {i: base}}}."""
+    ``…experts.down_proj``). Projection names and fusion order come from the
+    model profile (for example LFM uses ``w1/w3`` + ``w2`` rather than
+    ``gate_proj/up_proj`` + ``down_proj``). The legacy projection names remain
+    as a fallback for profile-less synthetic checkpoints.
+
+    Returns ``{checkpoint_experts_prefix: {projection: {expert_id: base}}}``.
+    """
     experts: dict[str, dict[str, dict[int, str]]] = {}
+    regex = None
+    if profile is not None:
+        try:
+            regex = profile.per_expert_moe_regex()
+        except Exception:
+            regex = None
+    pat = None
+    if regex:
+        pat = re.compile(regex[len("re:"):] if regex.startswith("re:")
+                         else regex)
+
+    def _profile_match(base: str) -> bool:
+        if pat is None:
+            return False
+        if pat.match(base):
+            return True
+        try:
+            return bool(pat.match(profile.to_vllm_internal_name(base)))
+        except Exception:
+            return False
+
     for name in skeleton.keys():
-        m = _EXPERT_RE.match(name)
-        if not m:
+        if not name.endswith(".weight"):
             continue
-        prefix, idx, proj = m.group(1), int(m.group(2)), m.group(3)
         base = name[:-len(".weight")]
+        if pat is not None:
+            if not _profile_match(base):
+                continue
+            try:
+                head, proj = base.rsplit(".", 1)
+                prefix, idx_s = head.rsplit(".", 1)
+            except ValueError:
+                continue
+            if not idx_s.isdigit():
+                continue
+            try:
+                parent = profile.packed_expert_parent_for_projection(proj)
+            except Exception:
+                parent = None
+            if parent is None:
+                continue
+            idx = int(idx_s)
+        else:
+            m = _LEGACY_EXPERT_RE.match(name)
+            if not m:
+                continue
+            prefix, idx, proj = m.group(1), int(m.group(2)), m.group(3)
         experts.setdefault(prefix, {}).setdefault(proj, {})[idx] = base
     return experts
 
 
-def _stacked_source_weight(skeleton, prefix, packed_proj, members) -> \
+def _stacked_source_weight(skeleton, profile, prefix, packed_proj, members) -> \
         torch.Tensor:
     """Materialise the full stacked source weight (E, out, in) for a packed
     expert group — used only where a stack must be resident (codebook
     training sampling); the packer streams per expert."""
-    return torch.stack([_expert_weight(skeleton, prefix, packed_proj,
+    projections = _packed_expert_projection_names(profile, packed_proj)
+    return torch.stack([_expert_weight(skeleton, profile, prefix, packed_proj,
                                        members, e)
-                        for e in range(_n_experts(members))])
+                        for e in range(_n_experts(members, projections))])
 
 
-def _n_experts(members: dict[str, dict[int, str]]) -> int:
-    proj = next(iter(members))
-    ids = members[proj]
-    n = len(ids)
-    if sorted(ids) != list(range(n)):
-        raise ValueError(f"non-contiguous expert ids for {proj}: {sorted(ids)}")
-    return n
+def _n_experts(members: dict[str, dict[int, str]],
+               projections: tuple[str, ...] | None = None) -> int:
+    projections = tuple(projections or members)
+    if not projections:
+        raise ValueError("expert group has no projections")
+    expected_ids = None
+    for proj in projections:
+        ids = members.get(proj)
+        if ids is None:
+            raise ValueError(f"expert group is missing projection {proj!r}")
+        got = sorted(ids)
+        if got != list(range(len(got))):
+            raise ValueError(f"non-contiguous expert ids for {proj}: {got}")
+        if expected_ids is None:
+            expected_ids = got
+        elif got != expected_ids:
+            raise ValueError(
+                f"expert ids differ across projections: {proj} has {got}, "
+                f"expected {expected_ids}")
+    return len(expected_ids)
 
 
-def _expert_weight(skeleton, prefix, packed_proj, members, e) -> torch.Tensor:
-    """One expert's fp32 weight for the packed projection: gate_up_proj fuses
-    cat([gate_e, up_e], dim=0); down_proj is the single down_e."""
-    if packed_proj == "gate_up_proj":
-        g = skeleton.dequant_weight(members["gate_proj"][e] + ".weight")
-        u = skeleton.dequant_weight(members["up_proj"][e] + ".weight")
-        return torch.cat([g, u], dim=0)
-    proj = packed_proj if packed_proj in members else "down_proj"
-    return skeleton.dequant_weight(members[proj][e] + ".weight")
+def _expert_weight(skeleton, profile, prefix, packed_proj, members,
+                   e) -> torch.Tensor:
+    """Materialize one expert's packed projection using profile-declared
+    projection names and order (for example LFM gate_up = ``w1`` then ``w3``)."""
+    projections = _packed_expert_projection_names(profile, packed_proj)
+    tensors = [skeleton.dequant_weight(members[p][e] + ".weight")
+               for p in projections]
+    return tensors[0] if len(tensors) == 1 else torch.cat(tensors, dim=0)
 
 
 # ---------------------------------------------------------------------------
@@ -731,7 +821,7 @@ def export_nvfp4_cb_streaming(
         profile = detect_profile(str(model_dir))
     except Exception:
         profile = None
-    expert_groups = _plan_expert_stacks(skeleton)
+    expert_groups = _plan_expert_stacks(skeleton, profile)
 
     # --- Stock-CT codecs (mixed container: the plugin delegates non-"scheme"
     # groups to vLLM's CompressedTensors path). REUSE the authoritative
@@ -794,23 +884,25 @@ def export_nvfp4_cb_streaming(
         key = _try_resolve_skeleton(qname, skeleton, profile, suffix)
         if key is not None:
             return "tensor", key
-        # packed-expert group keyed by the live packed name.
-        m = re.match(r"^(.*\.experts)\.(gate_up_proj|down_proj|gate_proj|"
-                     r"up_proj)$", qname)
-        if m:
-            prefix, packed_proj = m.group(1), m.group(2)
+        # Packed-expert groups are keyed by CHECKPOINT prefixes. Resolve the
+        # recipe qname directly and through the profile's source mapping, and
+        # accept only packed parents declared by that profile.
+        candidates = [qname]
+        if profile is not None:
+            try:
+                mapped = profile.source_tensor_name(qname)
+                if mapped not in candidates:
+                    candidates.append(mapped)
+            except Exception:
+                pass
+        packed_names = _packed_expert_param_names(profile)
+        for candidate in candidates:
+            if "." not in candidate:
+                continue
+            prefix, packed_proj = candidate.rsplit(".", 1)
+            if not prefix.endswith(".experts") or packed_proj not in packed_names:
+                continue
             grp = expert_groups.get(prefix)
-            if grp is None and profile is not None:
-                # Nested-prefix checkpoints (Qwen3.5-VLM: recipe
-                # `model.layers.*` vs on-disk `model.language_model.layers.*`)
-                # — the groups are keyed by CHECKPOINT prefixes; map the
-                # recipe prefix through the profile (same resolution the
-                # dense `_try_resolve_skeleton` path uses).
-                try:
-                    grp = expert_groups.get(
-                        profile.source_tensor_name(prefix))
-                except Exception:
-                    grp = None
             if grp is not None:
                 return "experts", (prefix, packed_proj, grp)
         return None, None
@@ -821,14 +913,15 @@ def export_nvfp4_cb_streaming(
             return tuple(skeleton.get_shape(h))
         if kind == "experts":
             prefix, packed_proj, grp = h
-            n = _n_experts(grp)
-            if packed_proj == "gate_up_proj":
-                g = skeleton.get_shape(grp["gate_proj"][0] + ".weight")
-                u = skeleton.get_shape(grp["up_proj"][0] + ".weight")
-                return (n, int(g[0]) + int(u[0]), int(g[1]))
-            proj = packed_proj if packed_proj in grp else "down_proj"
-            s = skeleton.get_shape(grp[proj][0] + ".weight")
-            return (n, int(s[0]), int(s[1]))
+            projections = _packed_expert_projection_names(profile, packed_proj)
+            n = _n_experts(grp, projections)
+            shapes = [skeleton.get_shape(grp[p][0] + ".weight")
+                      for p in projections]
+            in_f = int(shapes[0][1])
+            if any(len(s) != 2 or int(s[1]) != in_f for s in shapes):
+                raise ValueError(
+                    f"{qname}: incompatible expert projection shapes {shapes}")
+            return (n, sum(int(s[0]) for s in shapes), in_f)
         raise KeyError(f"{qname}: no streaming source (tensor or expert group)")
 
     # --- Coverage gate (lazy: shapes only). ---
@@ -1245,14 +1338,19 @@ def export_nvfp4_cb_streaming(
     # artifact at a 4.75 bpp target).
     consumed_expert_bases = set()
     for prefix, projs in expert_groups.items():
-        canon_prefix = _canonical_qname(prefix, profile) or prefix
-        packed_names = set()
-        for p in {prefix, canon_prefix}:
-            packed_names |= {f"{p}.gate_up_proj", f"{p}.down_proj",
-                             f"{p}.gate_proj", f"{p}.up_proj"}
-        if packed_names & cb_targets_set:
-            for proj, ids in projs.items():
-                for e, base in ids.items():
+        # Consume only the source projections belonging to an actually-CB
+        # packed parent. A partial layer (for example gate_up=CB, down=BF16)
+        # must retain the untouched per-expert tensors for its BF16 parent.
+        for packed_proj in _packed_expert_param_names(profile):
+            checkpoint_qname = f"{prefix}.{packed_proj}"
+            canon_qname = _canonical_qname(checkpoint_qname, profile)
+            variants = {checkpoint_qname}
+            if canon_qname is not None:
+                variants.add(canon_qname)
+            if not variants & cb_targets_set:
+                continue
+            for proj in _packed_expert_projection_names(profile, packed_proj):
+                for base in projs.get(proj, {}).values():
                     consumed_expert_bases.add(base + ".weight")
     resolved_source_scale_keys = {
         entry[1] for entry in skeleton._fp8_scale_inv_map.values()
@@ -1267,8 +1365,13 @@ def export_nvfp4_cb_streaming(
             ".weight_scale_inv"
         ):
             continue   # consumed with its fp8 weight, or an unused sidecar
-        ckpt_qname = (name[:-len(".weight")] if name.endswith(".weight")
-                      else None)
+        if name.endswith(".weight"):
+            ckpt_qname = name[:-len(".weight")]
+        elif _try_resolve_direct_packed_expert(
+                name, skeleton, profile) == name:
+            ckpt_qname = name
+        else:
+            ckpt_qname = None
         canon = _canonical_qname(ckpt_qname, profile) if ckpt_qname else None
         if canon in cb_targets_set or canon in source_set \
                 or canon in stock_set:
@@ -1424,8 +1527,10 @@ def _stream_pack_target(skeleton, profile, resolved, qname, grid, mode, k,
     # in-memory exporter packs a pre-stacked 3-D tensor. Peak = one MoE layer's
     # experts, not the model.
     prefix, packed_proj, grp = h
-    n = _n_experts(grp)
-    w = torch.stack([_expert_weight(skeleton, prefix, packed_proj, grp, e)
+    projections = _packed_expert_projection_names(profile, packed_proj)
+    n = _n_experts(grp, projections)
+    w = torch.stack([_expert_weight(skeleton, profile, prefix, packed_proj,
+                                    grp, e)
                      for e in range(n)]).to(device)
     if cb_render_identity is not None:
         from prismaquant.production_weight_cache import (
@@ -1465,7 +1570,7 @@ def _train_shared_codebook_streaming(skeleton, profile, expert_groups,
         else:
             prefix, packed_proj, grp = h
             weights.append(_stacked_source_weight(
-                skeleton, prefix, packed_proj, grp).to(device))
+                skeleton, profile, prefix, packed_proj, grp).to(device))
         cws.append(col_weights[q].to(device))
     return _train_shared_codebook(
         weights, cws, grid=grid, mode=mode, k=k, seed=seed, iters=iters,

--- a/tests/test_nvfp4_cb_streaming.py
+++ b/tests/test_nvfp4_cb_streaming.py
@@ -452,6 +452,180 @@ def test_streaming_per_expert_bridging(workdir):
         assert torch.equal(tm[key], ts[key]), key
 
 
+def _lfm_per_expert_model(mdl: Path, layers=(2,), E=2, inter=256, hid=256,
+                          seed=17):
+    """Tiny LFM checkpoint layout: per-expert w1/w3 fuse to gate_up and w2
+    maps to down. Dimensions stay superblock-legal for real CB packing."""
+    torch.manual_seed(seed)
+    tensors = {"model.embedding_norm.weight":
+               torch.ones(hid, dtype=torch.bfloat16)}
+    for layer in layers:
+        prefix = f"model.layers.{layer}.feed_forward.experts"
+        for e in range(E):
+            tensors[f"{prefix}.{e}.w1.weight"] = (
+                torch.randn(inter, hid) * 0.3).to(torch.bfloat16)
+            tensors[f"{prefix}.{e}.w3.weight"] = (
+                torch.randn(inter, hid) * 0.3).to(torch.bfloat16)
+            tensors[f"{prefix}.{e}.w2.weight"] = (
+                torch.randn(hid, inter) * 0.3).to(torch.bfloat16)
+    mdl.mkdir(parents=True, exist_ok=True)
+    save_file(tensors, str(mdl / "model.safetensors"))
+    (mdl / "config.json").write_text(json.dumps({
+        "model_type": "lfm2_moe",
+        "architectures": ["Lfm2MoeForCausalLM"],
+        "hidden_size": hid,
+        "intermediate_size": inter,
+        "num_local_experts": E,
+    }))
+    return tensors
+
+
+def _lfm_cb_assignment(layer: int) -> dict:
+    prefix = f"model.layers.{layer}.feed_forward.experts"
+    return {
+        f"{prefix}.gate_up_proj": {"data_type": "nvfp4_cb", "cb_k": 16},
+        f"{prefix}.down_proj": {"data_type": "nvfp4_cb", "cb_k": 16},
+    }
+
+
+def _lfm_col_weights(layer: int, E=2, inter=256, hid=256) -> dict:
+    prefix = f"model.layers.{layer}.feed_forward.experts"
+    return {
+        f"{prefix}.gate_up_proj": torch.rand(E, 1, hid) + 0.05,
+        f"{prefix}.down_proj": torch.rand(E, 1, inter) + 0.05,
+    }
+
+
+def test_streaming_lfm_profile_declared_expert_projections(workdir):
+    """Regression: streaming must discover LFM's w1/w2/w3 source tensors via
+    the profile rather than a gate_proj/up_proj/down_proj-only regex."""
+    mdl = workdir / "lfm"
+    _lfm_per_expert_model(mdl)
+    ap = workdir / "a.json"
+    _assign(ap, _lfm_cb_assignment(2))
+    cw = _lfm_col_weights(2)
+
+    cm = export_nvfp4_cb(mdl, ap, workdir / "m", cw, device="cpu")
+    cs = export_nvfp4_cb_streaming(mdl, ap, workdir / "s", cw, device="cpu")
+    assert cm == cs
+    tm = load_file(str(workdir / "m" / "model.safetensors"))
+    ts = load_file(str(workdir / "s" / "model.safetensors"))
+    assert _tensors_equal(tm, ts)
+    prefix = "model.layers.2.feed_forward.experts"
+    assert f"{prefix}.gate_up_proj.cb_qweight" in ts
+    assert f"{prefix}.down_proj.cb_qweight" in ts
+    assert not any(k.startswith(prefix + ".0.") for k in ts)
+
+
+def _lfm_direct_packed_model(mdl: Path, layers=(2,), E=2, inter=256,
+                             hid=256, seed=19):
+    """LFM's live ``nn.Parameter`` save layout has no ``.weight`` suffix."""
+    torch.manual_seed(seed)
+    tensors = {"model.embedding_norm.weight":
+               torch.ones(hid, dtype=torch.bfloat16)}
+    for layer in layers:
+        prefix = f"model.layers.{layer}.feed_forward.experts"
+        tensors[f"{prefix}.gate_up_proj"] = (
+            torch.randn(E, 2 * inter, hid) * 0.3).to(torch.bfloat16)
+        tensors[f"{prefix}.down_proj"] = (
+            torch.randn(E, hid, inter) * 0.3).to(torch.bfloat16)
+    mdl.mkdir(parents=True, exist_ok=True)
+    save_file(tensors, str(mdl / "model.safetensors"))
+    (mdl / "config.json").write_text(json.dumps({
+        "model_type": "lfm2_moe",
+        "architectures": ["Lfm2MoeForCausalLM"],
+        "hidden_size": hid,
+        "intermediate_size": inter,
+        "num_local_experts": E,
+    }))
+    return tensors
+
+
+def test_streaming_lfm_direct_packed_source_is_validated_and_exported(workdir):
+    """Regression for packed LFM saves whose expert parameter keys are the
+    direct qnames. Both exporters must quantize selected rank-3 tensors while
+    preserving direct BF16 banks and marking them ignored."""
+    mdl = workdir / "lfm-packed"
+    original = _lfm_direct_packed_model(mdl, layers=(2, 3))
+    ap = workdir / "a.json"
+    assignment = _lfm_cb_assignment(2)
+    bf16_prefix = "model.layers.3.feed_forward.experts"
+    assignment.update({
+        f"{bf16_prefix}.gate_up_proj": "BF16",
+        f"{bf16_prefix}.down_proj": "BF16",
+    })
+    _assign(ap, assignment)
+    cw = _lfm_col_weights(2)
+
+    cm = export_nvfp4_cb(mdl, ap, workdir / "m", cw, device="cpu")
+    cs = export_nvfp4_cb_streaming(mdl, ap, workdir / "s", cw, device="cpu")
+    assert cm == cs
+    tm = load_file(str(workdir / "m" / "model.safetensors"))
+    ts = load_file(str(workdir / "s" / "model.safetensors"))
+    assert _tensors_equal(tm, ts)
+    cb_prefix = "model.layers.2.feed_forward.experts"
+    assert f"{cb_prefix}.gate_up_proj.cb_qweight" in ts
+    assert f"{cb_prefix}.down_proj.cb_qweight" in ts
+    for projection in ("gate_up_proj", "down_proj"):
+        key = f"{bf16_prefix}.{projection}"
+        assert torch.equal(ts[key], original[key])
+    quant_config = json.loads((workdir / "s" / "quant_config.json").read_text())
+    assert {f"{bf16_prefix}.gate_up_proj", f"{bf16_prefix}.down_proj"} \
+        <= set(quant_config["ignore"])
+
+
+def test_streaming_lfm_direct_packed_source_rejects_non_3d(workdir):
+    mdl = workdir / "lfm-packed-bad"
+    tensors = _lfm_direct_packed_model(mdl)
+    key = "model.layers.2.feed_forward.experts.gate_up_proj"
+    tensors[key] = torch.randn(512, 256).to(torch.bfloat16)
+    save_file(tensors, str(mdl / "model.safetensors"))
+    ap = workdir / "a.json"
+    _assign(ap, _lfm_cb_assignment(2))
+    with pytest.raises(ValueError, match="direct packed expert source.*rank-3"):
+        export_nvfp4_cb_streaming(
+            mdl, ap, workdir / "s", _lfm_col_weights(2), device="cpu")
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+def test_partial_lfm_mixed_export_preserves_bf16_per_expert(
+        workdir, streaming):
+    """A CB layer may coexist with an explicitly BF16 LFM layer. Only the CB
+    parents are stacked; BF16 stays as the original per-expert checkpoint
+    tensors expected by LFM's vLLM loader."""
+    mdl = workdir / "lfm"
+    original = _lfm_per_expert_model(mdl, layers=(2, 3))
+    ap = workdir / "a.json"
+    assignment = _lfm_cb_assignment(2)
+    bf16_prefix = "model.layers.3.feed_forward.experts"
+    assignment.update({
+        f"{bf16_prefix}.gate_up_proj": {
+            "data_type": "bfloat16", "bits": 16},
+        f"{bf16_prefix}.down_proj": {
+            "data_type": "bfloat16", "bits": 16},
+    })
+    _assign(ap, assignment)
+    out = workdir / ("streaming" if streaming else "memory")
+    exporter = export_nvfp4_cb_streaming if streaming else export_nvfp4_cb
+    exporter(mdl, ap, out, _lfm_col_weights(2), device="cpu")
+
+    exported = load_file(str(out / "model.safetensors"))
+    cb_prefix = "model.layers.2.feed_forward.experts"
+    assert f"{cb_prefix}.gate_up_proj.cb_qweight" in exported
+    assert f"{cb_prefix}.down_proj.cb_qweight" in exported
+    assert not any(k.startswith(cb_prefix + ".0.") for k in exported)
+    assert f"{bf16_prefix}.gate_up_proj.weight" not in exported
+    assert f"{bf16_prefix}.down_proj.weight" not in exported
+    expected_ignore = set()
+    for e in range(2):
+        for proj in ("w1", "w2", "w3"):
+            key = f"{bf16_prefix}.{e}.{proj}.weight"
+            assert torch.equal(exported[key], original[key])
+            expected_ignore.add(key[:-len(".weight")])
+    quant_config = json.loads((out / "quant_config.json").read_text())
+    assert expected_ignore <= set(quant_config["ignore"])
+
+
 # --- bounded peak residency ------------------------------------------------
 
 def test_streaming_peak_residency(workdir, monkeypatch):


### PR DESCRIPTION
## Problem

Partial LFM2 MoE CB exports were not load-safe:

- The resident exporter assembled every per-expert bank before classifying the assignment. If only selected LFM layers were quantized, omitted or BF16 banks lost their original `experts.<id>.w1/w2/w3.weight` tensors and were emitted as aggregate `gate_up_proj/down_proj.weight` passthrough tensors. The LFM vLLM loader cannot load that BF16 representation.
- The streaming exporter discovered only `gate_proj/up_proj/down_proj` per-expert sources, so standard LFM `w1/w2/w3` checkpoints could not resolve packed CB targets.
- LFM checkpoints saved from the live packed module can legitimately use direct rank-3 keys such as `experts.gate_up_proj` without a `.weight` suffix; those inputs were accepted by validation preparation but not by the exporters.

## Fix

- Drive streaming expert discovery, projection order, shape validation, and materialization from the model profile. LFM now maps `w1,w3 -> gate_up_proj` and `w2 -> down_proj`.
- Classify the resident assignment before expert assembly and stack only CB or stock quantized targets. BF16 and omitted banks retain their original per-expert tensors.
- Consume only source projections belonging to an actual CB parent in streaming passthrough, including parent-level mixed assignments.
- Resolve direct packed expert keys only for profile-declared expert parents and fail closed unless the source is rank 3.
- Preserve the newer source-value and profile-resolved FP8/MXFP4 scale contracts from the target branch. Selective matching checks both checkpoint and live/profile aliases, so required scaled-source rejection remains fail closed.
- Keep FP8_SOURCE out of assembly because it is a byte-verbatim weight plus scale passthrough contract.

## Automated tests

- Focused LFM plus profile-scaled source tests: 7 passed.
- Broad relevant suite: 227 passed:
  - `tests/test_nvfp4_cb_formats.py`
  - `tests/test_nvfp4_cb_pipeline.py`
  - `tests/test_nvfp4_cb_streaming.py`
  - `tests/test_moe_imatrix.py`
  - `tests/test_per_expert_packing.py`
- CI is green on Python 3.11, Python 3.12, and the import-surface job.
- `compileall` and `git diff --check` pass.

## Live LFM2.5 8B-A1B validation

Validated the corrected partial export in the pinned Gridbook/vLLM CUDA image against the local unquantized BF16 model:

- Exact recursive export inventory: 8 files, 14,537,263,589 bytes; declared and measured file sizes match exactly.
- Codebook sidecar digest and both declared lattice subtable digests match.
- Safetensors is contiguous and complete: 1,926 tensors, exactly eight selected U8 CB tensors, and all 1,918 common untouched tensors retain identical dtype and shape.
- The eight selected stacked targets replace exactly 384 selected per-expert BF16 source tensors. Untouched expert banks remain in their original individual BF16 `w1/w2/w3` representation.
- vLLM loaded the complete 13.52-GiB artifact. Layers 2, 8, 14, and 23 loaded both `w13` and `w2` CB stacks.
- A chunked-prefill exact-full-vocabulary forward A/B executed all four baseline loop calls and all four TileM128 fused calls with zero errors or fallbacks. This validates export, load, fill, and execution. The fused numerical result remains a separate Gridbook enablement decision and is not a producer-quality claim.

Evidence SHA-256:

- report: `051a82082bf8b0af480dfc08a98736525c6899d6c395667f453d1f792cf9d02e`
- log: `58606f4b93f0c0bf2c98949cbdc70649c3e98ea1bae2a91aba7ef1e36772c05e`
- structure verification: `cbe3219ad6a5e978f74d8324c51048f170e9c55bf78d558f344aa9d7866de7f7`
- inventory verification: `83d4afd741a11e51e9701f72a32a8fc8678a7c59211e8453577d3665ae04e2fb`

Upstream contributor link requested by Robert: @jsconsultancy.
