### PR TITLE
Source-passthrough format family: MXFP4/FP8-block experts+body, measured route verdicts, exporter lane

### DIFF
--- a/docs/lanes/nvfp4-cb/source-passthrough.md
+++ b/docs/lanes/nvfp4-cb/source-passthrough.md
@@ -71,12 +71,43 @@ probe inventory: 33,325 Linears
 
 ## The formats
 
-| Format | Source kind | bpw | Synthesized candidate | Serve route | Backed |
+| Format | Wire id | Source kind | bpw | Synth. | Route status on sm121 |
 |---|---|---|---|---|---|
-| `MXFP4_SOURCE` | `mxfp4` | 4.25 | yes | `delegated_native_mxfp4` | **no — pending** |
-| `FP8_BLOCK_UE8M0_SOURCE` | `fp8_ue8m0` | 8.00049 | yes | `delegated_native_fp8_block_ue8m0` | yes |
-| `FP8_SOURCE` | `fp8` | 8.00195 | no | `delegated_native_fp8_block` | yes |
-| `BF16` | `bf16` | 16 | no | `delegated_native_bf16` | yes |
+| `MXFP4_SOURCE` | `mxfp4_e2m1_ue8m0_g32` | `mxfp4` | 4.25 | yes | **backed — requires `--moe-backend marlin`** |
+| `FP8_BLOCK_UE8M0_SOURCE` | `fp8_e4m3_ue8m0_block128` | `fp8_ue8m0` | 8.00049 | yes | **blocked (measured)** |
+| `FP8_SOURCE` | — | `fp8` | 8.00195 | no | backed (other checkpoints) |
+| `BF16` | — | `bf16` | 16 | no | backed |
+
+### The route verdicts came out the opposite way round
+
+Both were measured on GB10/sm121, 2026-08-03. The intuition "the released
+checkpoint already serves this way, so a route must exist" is **false**:
+
+* **`MXFP4_SOURCE` is native-confirmed** — but only via vLLM's Marlin MoE
+  backend. The auto-selected `DeepGEMM_MXFP4` asserts on the SF
+  transformation, FlashInfer is gated to capability family 100, and the OAI
+  Triton path is hard-excluded on SM12x (0/15 kernels). `--moe-backend marlin`
+  is therefore **part of the serving contract, not a tuning hint**, and it
+  travels with the artifact.
+* **`FP8_BLOCK_UE8M0_SOURCE` is blocked** — every route measured dead:
+  `deep_gemm` assert, cutlass `scaled_mm` rejects the block layout, triton
+  `KeyError: float8_e8m0fnu`, flashinfer's gate is sm90-exact, marlin-linear
+  tops out at sm89.
+
+**The architectural consequence: CB re-encoding of the body is the only way
+DSV4-Flash serves on this box at all.** The body's CB rungs are load-bearing,
+not merely economical.
+
+A blocked or pending rung still stays **on the menu** — if the DP wants it,
+that is the serving gap surfacing in the allocation rather than at deploy
+time — but the exporter refuses to ship a selection containing one without
+`--allow-route-pending-passthrough`.
+
+### Serving notes for the shipped artifact
+
+    --moe-backend marlin        (MXFP4 experts; the default backend asserts)
+    --kv-cache-dtype fp8        (the SM120 MLA backend asserts otherwise)
+    VLLM_USE_DEEP_GEMM=0        (the hyper-connections path breaks otherwise)
 
 "Synthesized candidate" means the allocator *manufactures* the cost row rather
 than requiring a column in the cost table. No cost run will ever have a column
@@ -130,82 +161,48 @@ decode prologue to fuse, so an empty backed set is the honest state rather than
 a data gap; it resolves with
 `rungs_source = lane_declares_no_fused_mid_m_lane`.
 
-### Route status
+### Route status policy
 
-`FP8_BLOCK_UE8M0_SOURCE` is **backed**: it is how the released checkpoint
-already serves, so "does a serve path exist" is answered by the model running
-at all — no new kernel is involved.
+`route_status` is a **measurement**, not design intent: `backed` (measured
+serving, possibly with a requirement), `pending` (unaudited), `blocked`
+(measured, every known route dead). Anything other than `backed` keeps the
+rung on the menu but makes the export fail closed without
+`--allow-route-pending-passthrough`; the acknowledgement is recorded in
+`quant_config["provenance"]["route_pending_passthrough_acknowledged"]`.
 
-`MXFP4_SOURCE` is **route-pending**. The loader side is being built across the
-repo boundary and has not been serve-validated here. The policy:
+## The declaration: `source_passthrough`
 
-* the rung stays **on** the allocator's menu. An allocation that wants a
-  route-pending passthrough is reporting a *serving gap*, and masking the rung
-  would hide exactly that signal while also removing the unit's only
-  zero-error option;
-* the **export** fails closed. Shipping an artifact whose selection contains a
-  format in `ROUTE_PENDING_PASSTHROUGH_FORMATS` requires the explicit
-  `--allow-route-pending-passthrough` flag, and the acknowledgement is recorded
-  in `quant_config["provenance"]["route_pending_passthrough_acknowledged"]`.
-
-## The declaration: `expert_format_routing`
-
-The serving side must be able to tell, per expert group and without inference,
-whether the bytes are a Gridbook codebook payload or the checkpoint's own. That
-declaration lives in `quant_config.json` inside the existing
-`execution_contracts` object — the same family as the K0.2 `nvfp4_w4a4` record.
+The serving side must be able to tell, per unit and without inference, whether
+the bytes are a Gridbook codebook payload or the checkpoint's own. The
+consumer-side reader is implemented and shipped, so this is its exact spelling
+— a top-level key in `quant_config.json`:
 
 ```json
-"execution_contracts": {
-  "nvfp4_w4a4": { "...": "unchanged K0.2 record" },
-  "expert_format_routing": {
-    "schema": "prismaquant.expert_format_routing.v1",
-    "unit": "layer_expert_group",
-    "routes": [
-      "gridbook_cb",
-      "delegated_native_mxfp4",
-      "delegated_native_fp8_block_ue8m0",
-      "delegated_native_fp8_block",
-      "delegated_native_bf16"
-    ],
-    "group_count": 43,
-    "groups": {
-      "model.layers.39.mlp.experts": {
-        "route": "delegated_native_mxfp4",
-        "format": "MXFP4_SOURCE",
-        "route_backed": false,
-        "cb_activation_contract": false,
-        "tensors": ["layers.39.ffn.experts.0.w1.scale", "..."]
-      },
-      "model.layers.0.mlp.experts": {
-        "route": "gridbook_cb",
-        "format": "NVFP4_CB_K14",
-        "route_backed": true,
-        "cb_activation_contract": true,
-        "tensors": ["..."]
-      }
-    },
-    "groups_sha256": "<64 lowercase hex>"
+"source_passthrough": {
+  "version": 1,
+  "units": {
+    "model.layers.39.mlp.experts": "mxfp4_e2m1_ue8m0_g32",
+    "model.layers.7.self_attn.wq_a": "fp8_e4m3_ue8m0_block128"
   }
 }
 ```
 
-Invariants the producer asserts and the loader may re-check:
+* the format-id enum is **closed**: `mxfp4_e2m1_ue8m0_g32`,
+  `fp8_e4m3_ue8m0_block128` (`PASSTHROUGH_WIRE_FORMAT_IDS` is the one mapping
+  from registry name to wire id);
+* a unit may be an expert group **or** a dense body Linear — there is no
+  expert-only framing and no exhaustiveness claim;
+* **absence of the key means a legacy all-CB artifact**, so the key is emitted
+  only when at least one unit is passthrough;
+* load-time refusal on: unknown `version`, unknown format id, malformed
+  `units`, or **a unit claimed by both the CB config groups and
+  `source_passthrough`**. The producer asserts all four before writing.
 
-1. every routed-expert group in the model appears exactly **once**;
-2. `route` is `gridbook_cb` **iff** the format is a CB rung; otherwise it
-   equals that format's `SourcePassthroughContract.serving_route`. An unknown
-   route string or unknown format is a hard refusal on **both** the write and
-   the parse side — the enum is closed and versioned;
-3. `cb_activation_contract` is true **iff** the group contributes an entry to
-   the K0.2 activation attestation. A `delegated_native_*` group must be
-   `false`, and that is what makes its **absence** from the K0.2 record
-   unambiguous rather than a missing attestation;
-4. the count of groups with `cb_activation_contract == true` equals the K0.2
-   record's routed-MoE `module_count`. This is the reconciliation that closes
-   the silent gap: without it, an artifact with source-passthrough layers
-   reports fewer attested MoE modules than the model has, and a consumer
-   cannot tell "by design" from "partially exported".
+The K0.2 reconciliation survives as a **producer-side invariant** rather than
+a wire field: CB-attested routed-expert modules and passthrough units must be
+disjoint and together cover the routed-expert set. That is what makes a
+passthrough layer's absence from the K0.2 attestation a declaration rather
+than a silent gap.
 
 ### Tensor naming
 

--- a/docs/lanes/nvfp4-cb/source-passthrough.md
+++ b/docs/lanes/nvfp4-cb/source-passthrough.md
@@ -1,0 +1,234 @@
+# Source passthrough in the nvfp4-cb container
+
+Status: producer side implemented; the `delegated_native_mxfp4` serve route is
+pending its cross-repo audit (see [Route status](#route-status)).
+
+## The rule
+
+> Any format the model natively uses belongs on the passthrough menu.
+
+For every serving unit, the allocator's cheapest honest option is to keep the
+bytes the checkpoint already has. A source-passthrough rung is that option
+made explicit:
+
+* **Δloss is exactly 0, by construction.** Every cost in this pipeline is
+  measured against the *dequantized source*. Shipping the source bytes
+  unchanged is the identity transform on that reference. There is nothing to
+  measure and no measurement branch to take — the candidate is priced `0.0`
+  with provenance `cost_source="source_passthrough"`, and no cost run can ever
+  produce a more accurate number for it.
+* **Bytes are the exact source slice** — the weight tensor plus every
+  scale/aux tensor of the unit — pinned against the checkpoint's own
+  safetensors header spans before an allocation ships.
+* **Legality is a dtype fact, not a policy.** A passthrough format is legal
+  exactly where the source already *is* that format. The same rule runs in
+  both directions: it is what masks `BF16` on an MXFP4 expert and what masks
+  `MXFP4_SOURCE` on a BF16 embedding.
+
+This is a **family**, not a set of special cases.
+`allocator_candidates.SOURCE_PASSTHROUGH_CONTRACTS` is the single table; adding
+a newly encountered native format is a table entry, not a new code path.
+
+## Census: DeepSeek-V4-Flash-0731
+
+Taken from the safetensors index + shard headers + `config.json` only (no
+tensor data read). Grouped by `(weight dtype, scale/aux pattern, rank)`.
+
+| Weight dtype | Aux/scale pattern | Rank | Tensors | GB | Unit classes |
+|---|---|---|---|---|---|
+| `I8` | `.scale`: `F8_E8M0`, 32-value groups | 2 | 35,328 | 157.437 | routed experts (43 body layers + 3 MTP) |
+| `F8_E4M3` | `.scale`: `F8_E8M0`, block 128×128 | 2 | 390 | 6.304 | attn projections, shared experts, indexer, MTP |
+| `BF16` | none | 2 | 196 | 2.966 | embed/lm_head, MoE router, compressor, indexer |
+| `F32` | none | 2 | 156 | 0.151 | compressor/indexer aux |
+| `I64` | none | 2 | 3 | 0.019 | router `tid2eid` index table |
+| `BF16` | none | 1 | 249 | 0.001 | norms, biases |
+| `F32` | none | 1 | 234 | 0.000 | scalars |
+
+Two findings changed the design:
+
+1. **The routed experts are MXFP4, and the pre-existing manifest scan called
+   them fp8.** The weights are nibble-packed E2M1 carried in `I8` (`w1`/`w3`
+   stored `[2048, 2048]` for a logical `[2048, 4096]`), with `F8_E8M0` group
+   scales. The old classifier keyed on "has a scale sibling" and stamped
+   `fp8`, which would have made `FP8_SOURCE` — an 8.002 bpw format — legal on
+   a 4.25 bpw unit.
+2. **The body is *not* `FP8_SOURCE`.** It is block-FP8 with **one-byte UE8M0
+   block exponents** (`config.json` → `quantization_config.scale_fmt ==
+   "ue8m0"`), not the FP32 `weight_scale_inv` plane `FP8_SOURCE` models. Same
+   element grid, different on-disk contract: 8.00049 bpw vs 8.00195, and
+   `FP8_SOURCE`'s exporter widens its scale plane to FP32 on write, which here
+   would quadruple the scale bytes and emit a tensor the model's own loader
+   does not expect. It gets its own format, `FP8_BLOCK_UE8M0_SOURCE`.
+
+Mapped onto the probe inventory the census is exact and complete:
+
+```
+probe inventory: 33,325 Linears
+  mxfp4       33,024   routed experts        -> MXFP4_SOURCE
+  fp8_ue8m0      301   body Linears          -> FP8_BLOCK_UE8M0_SOURCE
+  (none without a source kind)
+```
+
+## The formats
+
+| Format | Source kind | bpw | Synthesized candidate | Serve route | Backed |
+|---|---|---|---|---|---|
+| `MXFP4_SOURCE` | `mxfp4` | 4.25 | yes | `delegated_native_mxfp4` | **no — pending** |
+| `FP8_BLOCK_UE8M0_SOURCE` | `fp8_ue8m0` | 8.00049 | yes | `delegated_native_fp8_block_ue8m0` | yes |
+| `FP8_SOURCE` | `fp8` | 8.00195 | no | `delegated_native_fp8_block` | yes |
+| `BF16` | `bf16` | 16 | no | `delegated_native_bf16` | yes |
+
+"Synthesized candidate" means the allocator *manufactures* the cost row rather
+than requiring a column in the cost table. No cost run will ever have a column
+for a byte-copy contract, and asking the encoder to "measure" a copy would burn
+GPU hours reproducing a zero. `FP8_SOURCE` and `BF16` are deliberately not
+synthesized: the cost pipeline already emits real rows for them where they are
+legal, and synthesizing over an existing row would hide a disagreement.
+
+Because MXFP4 and block-FP8 are fixed-rate, the generic `FormatSpec`
+arithmetic reproduces the checkpoint byte for byte, and that identity is
+*checked* rather than trusted — `footprint.assignment_artifact_bytes` refuses
+an allocation where a passthrough unit's header span and its closed-form byte
+count disagree, because the floor subtracts the span while the body would add
+the closed form and the artifact budget would silently drift:
+
+```
+expert w1  [2048, 4096]  4,194,304 + 262,144 = 4,456,448 B   (4.25 bpw)
+attn.wo_a  [8192, 4096] 33,554,432 +   2,048 = 33,556,480 B  (8.00049 bpw)
+expert layer (256 experts × 3 projections)   = 3,422,552,064 B
+43 expert layers                             = 147,169,738,752 B
+```
+
+## Cost provenance
+
+Three values a selected rung's price can carry, and they are distinguishable in
+the shipped artifact:
+
+| `cost_source` | Meaning |
+|---|---|
+| `output_mse` / `predicted_dloss` / `weight_mse` | measured this run |
+| `band_interpolated` | fitted by the RD-ladder from measured anchors; the tensor's own law cleared a holdout gate, and a tensor whose law was rejected had its rungs measured instead |
+| `source_passthrough` | never measured, because the exporter copies the bytes |
+| `bit_exact` | a *measured* lossless re-encode (`weight_mse == 0`) |
+
+`bit_exact` and `source_passthrough` are both free but are not the same claim:
+one ran an encoder and found the output identical, the other never ran one.
+`cost_entry_is_exact_by_construction` is the union, and it is what pricing and
+the P5a branch label key off, so the two cannot drift apart.
+
+## Serving lanes and route status
+
+Source-passthrough rungs are declared as **distinct serving lanes**, so P5b
+accounting never files them under a CB contract they do not have. A unit on
+`delegated_native_mxfp4` has *no CB activation contract at all* — which is why
+the K0.2 attestation scopes itself to CB layers and the artifact declares the
+source-passthrough groups explicitly, rather than leaving them looking like a
+missing attestation.
+
+Neither lane declares a `fused_mid_m` block. A passthrough rung has no Gridbook
+decode prologue to fuse, so an empty backed set is the honest state rather than
+a data gap; it resolves with
+`rungs_source = lane_declares_no_fused_mid_m_lane`.
+
+### Route status
+
+`FP8_BLOCK_UE8M0_SOURCE` is **backed**: it is how the released checkpoint
+already serves, so "does a serve path exist" is answered by the model running
+at all — no new kernel is involved.
+
+`MXFP4_SOURCE` is **route-pending**. The loader side is being built across the
+repo boundary and has not been serve-validated here. The policy:
+
+* the rung stays **on** the allocator's menu. An allocation that wants a
+  route-pending passthrough is reporting a *serving gap*, and masking the rung
+  would hide exactly that signal while also removing the unit's only
+  zero-error option;
+* the **export** fails closed. Shipping an artifact whose selection contains a
+  format in `ROUTE_PENDING_PASSTHROUGH_FORMATS` requires the explicit
+  `--allow-route-pending-passthrough` flag, and the acknowledgement is recorded
+  in `quant_config["provenance"]["route_pending_passthrough_acknowledged"]`.
+
+## The declaration: `expert_format_routing`
+
+The serving side must be able to tell, per expert group and without inference,
+whether the bytes are a Gridbook codebook payload or the checkpoint's own. That
+declaration lives in `quant_config.json` inside the existing
+`execution_contracts` object — the same family as the K0.2 `nvfp4_w4a4` record.
+
+```json
+"execution_contracts": {
+  "nvfp4_w4a4": { "...": "unchanged K0.2 record" },
+  "expert_format_routing": {
+    "schema": "prismaquant.expert_format_routing.v1",
+    "unit": "layer_expert_group",
+    "routes": [
+      "gridbook_cb",
+      "delegated_native_mxfp4",
+      "delegated_native_fp8_block_ue8m0",
+      "delegated_native_fp8_block",
+      "delegated_native_bf16"
+    ],
+    "group_count": 43,
+    "groups": {
+      "model.layers.39.mlp.experts": {
+        "route": "delegated_native_mxfp4",
+        "format": "MXFP4_SOURCE",
+        "route_backed": false,
+        "cb_activation_contract": false,
+        "tensors": ["layers.39.ffn.experts.0.w1.scale", "..."]
+      },
+      "model.layers.0.mlp.experts": {
+        "route": "gridbook_cb",
+        "format": "NVFP4_CB_K14",
+        "route_backed": true,
+        "cb_activation_contract": true,
+        "tensors": ["..."]
+      }
+    },
+    "groups_sha256": "<64 lowercase hex>"
+  }
+}
+```
+
+Invariants the producer asserts and the loader may re-check:
+
+1. every routed-expert group in the model appears exactly **once**;
+2. `route` is `gridbook_cb` **iff** the format is a CB rung; otherwise it
+   equals that format's `SourcePassthroughContract.serving_route`. An unknown
+   route string or unknown format is a hard refusal on **both** the write and
+   the parse side — the enum is closed and versioned;
+3. `cb_activation_contract` is true **iff** the group contributes an entry to
+   the K0.2 activation attestation. A `delegated_native_*` group must be
+   `false`, and that is what makes its **absence** from the K0.2 record
+   unambiguous rather than a missing attestation;
+4. the count of groups with `cb_activation_contract == true` equals the K0.2
+   record's routed-MoE `module_count`. This is the reconciliation that closes
+   the silent gap: without it, an artifact with source-passthrough layers
+   reports fewer attested MoE modules than the model has, and a consumer
+   cannot tell "by design" from "partially exported".
+
+### Tensor naming
+
+Passthrough groups emit the **checkpoint's own spelling**, because the point is
+that the native loader consumes them unchanged:
+
+```
+layers.<L>.ffn.experts.<E>.{w1,w3,w2}.weight    I8       (nibble-packed E2M1)
+layers.<L>.ffn.experts.<E>.{w1,w3,w2}.scale     F8_E8M0  (per-32 group scales)
+```
+
+They are **not** stacked into the packed `ffn.experts.{gate_up_proj,down_proj}`
+form a CB layer uses, **not** re-encoded, and **not** added to
+`quant_config["ignore"]` (an ignore entry declares a tensor unquantized, which
+these are not).
+
+## Where the code lives
+
+| Concern | Location |
+|---|---|
+| Format specs | `prismaquant/format_registry.py` |
+| Contract table, source-kind census, candidate synthesis | `prismaquant/allocator_candidates.py` |
+| Byte pinning against the checkpoint | `prismaquant/footprint.py` |
+| Legality, lanes, route-pending | `prismaquant/serving_profile_specs/nvfp4_cb.json` |
+| Emit + declaration | `prismaquant/export_nvfp4_cb_streaming.py`, `prismaquant/cb_export_config.py` |
+| K0.2 scoping | `prismaquant/nvfp4_activation_contract.py` |

--- a/prismaquant/activation_fair_pricing.py
+++ b/prismaquant/activation_fair_pricing.py
@@ -114,6 +114,13 @@ _PROVENANCE_SAMPLE_ROWS = 12
 # that produced it (the same rule selection.json's ``ratchet_objective``
 # follows).
 BRANCH_BIT_EXACT = "bit_exact"
+# A byte-verbatim SOURCE passthrough (allocator_candidates
+# .SOURCE_PASSTHROUGH_FORMATS): the exporter copies the checkpoint's own bytes,
+# so there is no re-encode to price and no encoder ran. Distinct from
+# ``bit_exact``, which is a MEASURED zero produced by actually re-encoding and
+# finding the result identical — both are free, and the artifact should be able
+# to say which one it got.
+BRANCH_SOURCE_PASSTHROUGH = "source_passthrough"
 BRANCH_MEASURED = "measured_output_mse"
 BRANCH_ACTIVATION_IDENTITY = "activation_identity"
 BRANCH_CALIBRATED = "weight_only_activation_calibrated"

--- a/prismaquant/allocator.py
+++ b/prismaquant/allocator.py
@@ -2357,10 +2357,18 @@ def main():
                   "allowed WITHOUT source verification", flush=True)
             source_manifest = None
         if source_manifest:
-            n_fp8 = sum(1 for v in source_manifest.values() if v == "fp8")
-            n_bf16 = sum(1 for v in source_manifest.values() if v == "bf16")
-            print(f"[alloc] source-dtype manifest: {n_fp8} fp8, "
-                  f"{n_bf16} bf16 (gates FP8_SOURCE/BF16 per source)",
+            # Report EVERY kind the scan found, not a hardcoded fp8/bf16 pair.
+            # A checkpoint whose units are mxfp4 and fp8_ue8m0 printed "0 fp8,
+            # 238 bf16" under the old line — which reads as "nothing was
+            # classified" precisely when the classification is the interesting
+            # part, and hides a newly censused native format entirely.
+            kinds = Counter(source_manifest.values())
+            summary = ", ".join(
+                f"{count} {kind}" for kind, count in sorted(kinds.items())
+            )
+            gated = ", ".join(sorted(PASSTHROUGH_SOURCE_REQUIREMENTS))
+            print(f"[alloc] source-dtype manifest: {summary} "
+                  f"(gates {gated} per source)",
                   flush=True)
 
     # A requested production CB rung needs a measured row everywhere it is

--- a/prismaquant/allocator_candidates.py
+++ b/prismaquant/allocator_candidates.py
@@ -15,6 +15,7 @@ from .activation_fair_pricing import (
     BRANCH_BIT_EXACT,
     BRANCH_CALIBRATED,
     BRANCH_MEASURED,
+    BRANCH_SOURCE_PASSTHROUGH,
     BRANCH_UNCALIBRATED,
     ActivationFairPricing,
     CalibrationRow,
@@ -39,10 +40,149 @@ from .serving_profiles import (
     serving_lane_route,
 )
 
-PASSTHROUGH_SOURCE_REQUIREMENTS: dict[str, str] = {
-    "FP8_SOURCE": "fp8",
-    "BF16": "bf16",
+# The provenance string a source-passthrough candidate carries in place of a
+# measured cost. It is NOT an estimator name like ``output_mse`` or
+# ``weight_mse``: it says the row was never measured because there is nothing
+# to measure.
+SOURCE_PASSTHROUGH_COST_SOURCE = "source_passthrough"
+
+# Serving-route token for a passthrough whose bytes the model's OWN loader
+# consumes, with no Gridbook codec in the path.
+ROUTE_DELEGATED_NATIVE = "delegated_native"
+
+
+@dataclass(frozen=True)
+class SourcePassthroughContract:
+    """One native source format the producer can ship back UNCHANGED.
+
+    "Any format the model natively uses belongs on a passthrough menu": the
+    allocator's cheapest honest option for a unit is always to keep the bytes
+    the checkpoint already has. This table is that menu, one entry per
+    (source format, unit contract) the census finds, so adding a newly
+    encountered native format is a data change rather than a new code path.
+
+    Fields:
+      ``source_kind``  the token ``_scan_source_dtype_manifest`` stamps on a
+        unit whose stored bytes ARE this format. It is the whole legality
+        gate: the format is legal exactly where the source already is it, in
+        both directions — BF16 is masked on mxfp4 experts and MXFP4_SOURCE is
+        masked on the bf16 embedding by the identical rule.
+      ``zero_cost_by_construction`` whether the allocator SYNTHESIZES the
+        candidate rather than requiring a cost-table column. True for formats
+        no cost run will ever have a column for.
+      ``serving_route``  the P5b lane route id.
+      ``route_backed``  whether a serve route for these bytes is known to
+        EXIST today. False does not remove the rung from the menu — an
+        allocator that wants an unbacked passthrough is reporting a serving
+        gap, and hiding the rung would hide the signal — but it does make the
+        export fail closed without an explicit override.
+      ``detail``  why this entry exists, for the mask/provenance records.
+    """
+
+    format_name: str
+    source_kind: str
+    zero_cost_by_construction: bool
+    serving_route: str
+    route_backed: bool
+    detail: str
+
+
+SOURCE_PASSTHROUGH_CONTRACTS: dict[str, SourcePassthroughContract] = {
+    contract.format_name: contract
+    for contract in (
+        # Legacy DeepSeek-V3 / MiniMax block-FP8: FP32 ``weight_scale_inv``.
+        # Serves through stock compressed-tensors block-fp8 today.
+        SourcePassthroughContract(
+            format_name="FP8_SOURCE",
+            source_kind="fp8",
+            zero_cost_by_construction=False,
+            serving_route=f"{ROUTE_DELEGATED_NATIVE}_fp8_block",
+            route_backed=True,
+            detail=(
+                "native block-FP8 with an FP32 weight_scale_inv plane; the "
+                "cost pipeline emits real rows for it, so its candidate is "
+                "not synthesized"
+            ),
+        ),
+        # DeepSeek-V3.1/V4 block-FP8: one-byte UE8M0 block exponents. Same
+        # element grid as FP8_SOURCE, different scale plane and different
+        # byte count — see the FormatSpec comment.
+        SourcePassthroughContract(
+            format_name="FP8_BLOCK_UE8M0_SOURCE",
+            source_kind="fp8_ue8m0",
+            zero_cost_by_construction=True,
+            serving_route=f"{ROUTE_DELEGATED_NATIVE}_fp8_block_ue8m0",
+            route_backed=True,
+            detail=(
+                "native block-FP8 with UE8M0 block exponents; this IS how the "
+                "released checkpoint serves, so the route is the model's own"
+            ),
+        ),
+        # DeepSeek-V4 routed experts: nibble-packed E2M1 + E8M0 group scales.
+        SourcePassthroughContract(
+            format_name="MXFP4_SOURCE",
+            source_kind="mxfp4",
+            zero_cost_by_construction=True,
+            serving_route=f"{ROUTE_DELEGATED_NATIVE}_mxfp4",
+            route_backed=False,
+            detail=(
+                "native packed MXFP4 routed experts; the serving side loads "
+                "them on the model's own path rather than through a codebook "
+                "decoder, and that route is pending its cross-repo audit"
+            ),
+        ),
+        # Unquantized passthrough. Not a "source format" in the census sense,
+        # but it obeys the same rule and predates this table.
+        SourcePassthroughContract(
+            format_name="BF16",
+            source_kind="bf16",
+            zero_cost_by_construction=False,
+            serving_route=f"{ROUTE_DELEGATED_NATIVE}_bf16",
+            route_backed=True,
+            detail="unquantized passthrough on a bf16 source",
+        ),
+    )
 }
+
+# Kept as the flat {format: required_kind} view every existing consumer
+# (allocator promotion legality, export defensive checks, the visual
+# passthrough contract) already imports. DERIVED from the table above so a new
+# census format cannot be legal in one place and unknown in the other.
+PASSTHROUGH_SOURCE_REQUIREMENTS: dict[str, str] = {
+    name: contract.source_kind
+    for name, contract in SOURCE_PASSTHROUGH_CONTRACTS.items()
+}
+
+# Passthrough formats whose Δloss is EXACT BY CONSTRUCTION, so the allocator
+# synthesizes their candidate instead of requiring a cost-table column.
+#
+# Every cost in this pipeline is measured against the DEQUANTIZED SOURCE. A
+# format that ships the source bytes UNCHANGED is therefore the identity
+# transform on the reference: its Δloss is 0.0 as a matter of arithmetic, not
+# of measurement, and no cost run can ever produce a more accurate number for
+# it. FP8_SOURCE and BF16 are deliberately NOT members: the cost pipeline
+# already emits real rows for them on the checkpoints where they are legal,
+# and synthesizing over a table that has an entry would hide a disagreement.
+# The newer source formats are members because no cost table will ever have a
+# column for them — they are byte-copy contracts, and asking the encoder to
+# "measure" a copy would burn GPU hours to reproduce a zero.
+#
+# Membership is not self-certifying: ``cost_entry_is_source_passthrough``
+# additionally requires the format to be a registered passthrough format whose
+# activation path is the identity, so a stray ``cost_source`` string in a
+# hand-written table cannot claim exactness for an activation-quantizing rung.
+SOURCE_PASSTHROUGH_FORMATS: frozenset[str] = frozenset(
+    name for name, contract in SOURCE_PASSTHROUGH_CONTRACTS.items()
+    if contract.zero_cost_by_construction
+)
+
+# Passthrough formats with no known serve route today. On the menu (an
+# allocator that wants one is reporting a serving gap), but the exporter
+# refuses to ship a selection containing one without an explicit override.
+ROUTE_PENDING_PASSTHROUGH_FORMATS: frozenset[str] = frozenset(
+    name for name, contract in SOURCE_PASSTHROUGH_CONTRACTS.items()
+    if not contract.route_backed
+)
 
 
 def serialized_candidate_payload(
@@ -342,13 +482,168 @@ def cost_entry_is_bit_exact(
         return False
 
 
+def cost_entry_is_source_passthrough(
+    cost_entry: dict,
+    format_name: str | None = None,
+) -> bool:
+    """Whether this entry ships the SOURCE bytes and is therefore exact.
+
+    The dual of ``cost_entry_is_bit_exact``. That predicate proves exactness
+    from a MEASUREMENT (``weight_mse == 0.0`` recorded by a real cost run);
+    this one proves it from a CONTRACT — the exporter copies the source slice
+    verbatim, so the re-encode error is not small, it does not exist.
+
+    Three independent conditions, all required, so the claim cannot be forged
+    by writing a string into a cost table:
+
+      * the entry declares ``cost_source="source_passthrough"``;
+      * the format is a declared member of ``SOURCE_PASSTHROUGH_FORMATS``;
+      * the format's activation path is the identity
+        (``FormatSpec.act_quant_changes_input`` is False) — the same
+        dtype-level gate ``cost_entry_is_bit_exact`` applies, because
+        shipping the weights verbatim only silences the W side.
+
+    ``cost_entry_is_bit_exact`` deliberately refuses ANY entry carrying an
+    explicit ``cost_source``, since those normally mean "an upstream pipeline
+    priced this row and defaulted weight_mse to a placeholder 0.0". A
+    source-passthrough entry is the one case where the explicit provenance is
+    itself the proof, which is why it gets a predicate of its own rather than
+    a hole punched in that rule.
+    """
+    if cost_entry.get("cost_source") != SOURCE_PASSTHROUGH_COST_SOURCE:
+        return False
+    if format_name is None:
+        return False
+    canonical = fr.canonical_format_name(str(format_name))
+    if canonical not in SOURCE_PASSTHROUGH_FORMATS:
+        return False
+    try:
+        spec = fr.get_format(canonical)
+    except KeyError:
+        return False
+    return not spec.act_quant_changes_input
+
+
+BAND_INTERPOLATED_COST_SOURCE = "band_interpolated"
+
+
+def cost_entry_is_band_interpolated(cost_entry: dict) -> bool:
+    """Whether this row's cost was FITTED from ladder anchors, not measured.
+
+    Stamped by the cost stage's RD-ladder interpolation
+    (``measure_quant_cost``, ``PRISMAQUANT_CB_LADDER_INTERP=1``). Such a row
+    is not a guess — the tensor's own law had to clear a holdout gate before
+    the fit was accepted, and a tensor whose law was rejected had its rungs
+    measured instead — but it IS a prediction, and a shipped artifact must be
+    able to say which of its selected prices were predictions.
+    """
+    return cost_entry.get("cost_source") == BAND_INTERPOLATED_COST_SOURCE
+
+
+def drop_interpolated_candidates_dominated_by_measured(
+    candidates: dict[str, list[Candidate]],
+    costs: dict,
+    *,
+    band: float,
+) -> tuple[dict[str, list[Candidate]], int]:
+    """Remove interpolated candidates a measured one already beats.
+
+    The DP optimizes over estimates, so a Δloss gap SMALLER than the
+    interpolator's own validated error is not evidence — it is a coin flip,
+    and letting it decide means an unmeasured rung can displace a measured one
+    on noise alone. This drops an interpolated candidate only when a measured
+    candidate for the SAME unit is both
+
+      * within ``band`` relative Δloss (i.e. indistinguishable at the
+        interpolator's demonstrated resolution), and
+      * no more expensive in bytes.
+
+    Both conditions are required, so a genuine trade survives: an interpolated
+    rung that is materially cheaper in bytes, or materially better in Δloss,
+    is still on the menu. Only the strictly-dominated-within-noise case is
+    removed. ``band`` must be the MEASURED holdout error from this run's own
+    validation, not a taste constant.
+
+    Returns the filtered candidates and the number dropped.
+    """
+    if band <= 0.0:
+        return candidates, 0
+    out: dict[str, list[Candidate]] = {}
+    dropped = 0
+    for name, cands in candidates.items():
+        rows = costs.get(name, {})
+        measured = [
+            c for c in cands
+            if not cost_entry_is_band_interpolated(rows.get(c.fmt, {}))
+        ]
+        kept = []
+        for cand in cands:
+            if not cost_entry_is_band_interpolated(rows.get(cand.fmt, {})):
+                kept.append(cand)
+                continue
+            scale = max(abs(cand.predicted_dloss), 1e-30)
+            if any(
+                other.memory_bytes <= cand.memory_bytes
+                and abs(other.predicted_dloss - cand.predicted_dloss) / scale
+                <= band
+                for other in measured
+            ):
+                dropped += 1
+                continue
+            kept.append(cand)
+        out[name] = kept or cands
+    return out, dropped
+
+
+def cost_entry_is_exact_by_construction(
+    cost_entry: dict,
+    format_name: str | None = None,
+) -> bool:
+    """Whether this row's Δloss is exactly 0.0 with no measurement involved.
+
+    The union of the two ways a row can be free: a measured lossless
+    re-encode (``cost_entry_is_bit_exact``) and a byte-verbatim source
+    passthrough (``cost_entry_is_source_passthrough``). Pricing, the measured
+    branch test and the P5a branch label all key off THIS predicate so the two
+    cannot drift apart; ``cost_entry_source`` still reports which of the two
+    it was.
+    """
+    return (
+        cost_entry_is_bit_exact(cost_entry, format_name)
+        or cost_entry_is_source_passthrough(cost_entry, format_name)
+    )
+
+
+def synthesized_source_passthrough_cost_entry(format_name: str) -> dict:
+    """The cost row for a passthrough candidate the cost table cannot hold.
+
+    Not a placeholder and not an estimate: ``predicted_dloss`` is 0.0 because
+    the exporter ships the source slice unchanged, and the explicit
+    ``cost_source`` records that provenance so no downstream reader mistakes
+    the zero for an unmeasured activation cost (the failure mode
+    ``cost_entry_prices_unmeasured_activation_at_zero`` exists to catch).
+    ``output_mse_measured=False`` states plainly that no output measurement
+    was taken — because none was needed.
+    """
+    return {
+        "cost_source": SOURCE_PASSTHROUGH_COST_SOURCE,
+        "predicted_dloss": 0.0,
+        "weight_mse": 0.0,
+        "output_mse": 0.0,
+        "output_mse_measured": False,
+        "source_passthrough_format": fr.canonical_format_name(
+            str(format_name)
+        ),
+    }
+
+
 def cost_entry_uses_measured_output_mse(
     stats_entry: dict,
     cost_entry: dict,
     format_name: str | None = None,
 ) -> bool:
     """Whether ``cost_entry_predicted_dloss`` will read ``output_mse``."""
-    if cost_entry_is_bit_exact(cost_entry, format_name):
+    if cost_entry_is_exact_by_construction(cost_entry, format_name):
         return False
     return _has_measured_output_mse(stats_entry, cost_entry)
 
@@ -461,6 +756,12 @@ def cost_entry_activation_pricing_branch(
     question is answerable from the artifact rather than from the code
     version that produced it.
     """
+    if cost_entry_is_source_passthrough(cost_entry, format_name):
+        # Neither measured nor weight-only: the row was never priced from an
+        # error estimate at all. It gets its own label so the artifact can
+        # tell "shipped the source bytes" apart from "measured a lossless
+        # re-encode" — both are free, but only one of them ran an encoder.
+        return BRANCH_SOURCE_PASSTHROUGH
     if cost_entry_is_bit_exact(cost_entry, format_name):
         return BRANCH_BIT_EXACT
     if _has_measured_output_mse(stats_entry, cost_entry):
@@ -520,10 +821,13 @@ def cost_entry_predicted_dloss(
     price off zero — ``cost_entry_prices_unmeasured_activation_at_zero``
     keeps its full strength.
     """
-    if cost_entry_is_bit_exact(cost_entry, format_name):
-        # Lossless re-encode END TO END (weights verbatim AND identity
-        # activation path): zero cost by construction, regardless of any
-        # noisy output_mse measurement (see cost_entry_is_bit_exact).
+    if cost_entry_is_exact_by_construction(cost_entry, format_name):
+        # Zero cost by construction, in one of two ways: a lossless re-encode
+        # END TO END (weights verbatim AND identity activation path,
+        # ``cost_entry_is_bit_exact``), or a byte-verbatim source passthrough
+        # whose exporter never re-encodes at all
+        # (``cost_entry_is_source_passthrough``). Either way the answer does
+        # not depend on a measurement, so it outranks any noisy output_mse.
         return 0.0
     if _has_measured_output_mse(stats_entry, cost_entry):
         return cost_entry_measured_activation_dloss(
@@ -818,6 +1122,15 @@ def build_candidates(stats: dict, costs: dict, formats: list[fr.FormatSpec],
                     entry = costs[name][candidate_name]
                     entry_fmt = candidate_name
                     break
+            if entry is None and spec.name in SOURCE_PASSTHROUGH_FORMATS:
+                # No cost table will ever carry a column for a byte-copy
+                # contract. Synthesize the row rather than dropping the
+                # candidate: silently omitting it would take the unit's
+                # CHEAPEST ZERO-ERROR option off the menu and leave the DP
+                # choosing only among lossy re-encodes. The legality gate
+                # below still has to agree the source IS this format.
+                entry = synthesized_source_passthrough_cost_entry(spec.name)
+                entry_fmt = spec.name
             if entry is None or "error" in entry:
                 continue
             verdict = check_stats_format_applicability(
@@ -1811,7 +2124,12 @@ def _scan_source_dtype_manifest(
     packed_bases: set[str] = set()
     for key in weight_map:
         matched = False
-        for suffix in (".weight_scale_inv", ".weight_scale", ".weight"):
+        # ``.scale`` is the OCP-MX / DSv4 group-scale sibling spelling, and it
+        # is listed LAST so it can never shadow ``.weight_scale``: the two do
+        # not overlap as suffixes ("...weight_scale"[-6:] == "_scale", not
+        # ".scale"), but ordering makes that independent of that coincidence.
+        for suffix in (".weight_scale_inv", ".weight_scale", ".weight",
+                       ".scale"):
             if key.endswith(suffix):
                 base = key[: -len(suffix)]
                 bases.setdefault(base, set()).add(suffix[1:])
@@ -1821,9 +2139,11 @@ def _scan_source_dtype_manifest(
             bases.setdefault(key, set()).add("weight")
             packed_bases.add(key)
     weight_dtypes: dict[str, str] = {}
+    scale_dtypes: dict[str, str] = {}
     shard_keys: dict[str, list[str]] = defaultdict(list)
     for key, shard in weight_map.items():
-        if not (key.endswith(".weight") or key in packed_bases):
+        if not (key.endswith(".weight") or key.endswith(".scale")
+                or key in packed_bases):
             continue
         path = src / str(shard)
         if path.is_file():
@@ -1832,16 +2152,21 @@ def _scan_source_dtype_manifest(
         try:
             with safe_open(path, framework="pt", device="cpu") as sf:
                 for key in keys:
-                    base = (
-                        key[:-len(".weight")]
-                        if key.endswith(".weight") else key
-                    )
+                    is_scale = key.endswith(".scale")
+                    if is_scale:
+                        base = key[: -len(".scale")]
+                    elif key.endswith(".weight"):
+                        base = key[: -len(".weight")]
+                    else:
+                        base = key
                     try:
-                        weight_dtypes[base] = str(
-                            sf.get_slice(key).get_dtype()
-                        ).upper()
+                        dtype = str(sf.get_slice(key).get_dtype()).upper()
                     except Exception:
                         continue
+                    if is_scale:
+                        scale_dtypes[base] = dtype
+                    else:
+                        weight_dtypes[base] = dtype
         except Exception:
             continue
 
@@ -1909,7 +2234,23 @@ def _scan_source_dtype_manifest(
         if "weight" not in suffixes:
             continue
         dtype = weight_dtypes.get(base)
-        if "weight_scale_inv" in suffixes or "weight_scale" in suffixes:
+        scale_dtype = scale_dtypes.get(base)
+        # E8M0 group/block exponents are the discriminator for the two native
+        # formats FP8_SOURCE cannot represent. Both tests run BEFORE the
+        # generic ``F8`` test, because the SCALE plane of both is itself
+        # ``F8_E8M0`` and would otherwise be mistaken for an fp8 weight
+        # contract with an FP32 scale_inv plane — a format whose byte count
+        # and whose exported scale dtype are both wrong for this checkpoint.
+        if scale_dtype == "F8_E8M0" and dtype in {"I8", "U8"}:
+            # Nibble-packed 4-bit elements carried in an 8-bit container with
+            # a power-of-two group scale: OCP-MX MXFP4 as DeepSeek-V4 ships
+            # its routed experts.
+            source_kind = "mxfp4"
+        elif scale_dtype == "F8_E8M0" and dtype == "F8_E4M3":
+            # Block-FP8 with UE8M0 block exponents (DeepSeek-V3.1/V4), NOT
+            # the FP32 weight_scale_inv contract FP8_SOURCE models.
+            source_kind = "fp8_ue8m0"
+        elif "weight_scale_inv" in suffixes or "weight_scale" in suffixes:
             source_kind = "fp8"
         elif dtype == "BF16":
             source_kind = "bf16"
@@ -1943,5 +2284,14 @@ def _scan_source_dtype_manifest(
                     live_qname = str(recipe_mapper(live_qname))
                 except Exception:
                     pass
-            manifest[live_qname] = "fp8"
+            # A profile's ``fp8_scale_pairs`` answers "does this weight have a
+            # serialized scale sibling the dequant pass must read", which is
+            # true of EVERY block-scaled format — DSv4's MXFP4 experts and its
+            # UE8M0 body both appear there. It is not a claim about which fp8
+            # contract the bytes are, so it must not overwrite a kind the
+            # header scan derived from the actual dtypes: doing so is what
+            # made 33,024 packed-MXFP4 experts look like FP32-scaled fp8.
+            # It still fills in names the dtype scan could not classify.
+            if manifest.get(live_qname) in (None, "other"):
+                manifest[live_qname] = "fp8"
     return manifest

--- a/prismaquant/allocator_candidates.py
+++ b/prismaquant/allocator_candidates.py
@@ -50,6 +50,14 @@ SOURCE_PASSTHROUGH_COST_SOURCE = "source_passthrough"
 # consumes, with no Gridbook codec in the path.
 ROUTE_DELEGATED_NATIVE = "delegated_native"
 
+# What a MEASUREMENT says about serving a passthrough's bytes. These are
+# verdicts from a real serve attempt on real hardware, not design intent —
+# which matters, because on DSv4-Flash/GB10 the measured answers came out the
+# OPPOSITE way round from the obvious guess.
+ROUTE_STATUS_BACKED = "backed"          # measured serving, possibly with a requirement
+ROUTE_STATUS_PENDING = "pending"        # no verdict yet; unaudited
+ROUTE_STATUS_BLOCKED = "blocked"        # measured, every known route dead
+
 
 @dataclass(frozen=True)
 class SourcePassthroughContract:
@@ -71,11 +79,21 @@ class SourcePassthroughContract:
         candidate rather than requiring a cost-table column. True for formats
         no cost run will ever have a column for.
       ``serving_route``  the P5b lane route id.
-      ``route_backed``  whether a serve route for these bytes is known to
-        EXIST today. False does not remove the rung from the menu — an
-        allocator that wants an unbacked passthrough is reporting a serving
-        gap, and hiding the rung would hide the signal — but it does make the
-        export fail closed without an explicit override.
+      ``wire_format_id``  the closed-enum spelling the artifact declares and
+        the serving side reads (quant_config.json ``source_passthrough``).
+        Distinct from ``format_name``: the producer's registry name is ours to
+        rename, the wire id is a cross-repo contract.
+      ``route_status``  what a MEASUREMENT says about serving these bytes, per
+        ``ROUTE_STATUS_*``. Never remove a rung from the menu — an allocator
+        that wants an unservable passthrough is reporting a serving gap, and
+        hiding the rung would hide the signal — but anything other than
+        ``backed`` makes the export fail closed without an explicit override.
+      ``route_requirement``  the serving-side condition that makes a BACKED
+        route actually fire (e.g. a non-default vLLM MoE backend). Belongs in
+        the artifact's serving notes; a backed route with an unmet
+        requirement serves no better than a blocked one.
+      ``route_evidence``  what was measured, and on what hardware. A route
+        verdict without its evidence is a rumour.
       ``detail``  why this entry exists, for the mask/provenance records.
     """
 
@@ -83,8 +101,16 @@ class SourcePassthroughContract:
     source_kind: str
     zero_cost_by_construction: bool
     serving_route: str
-    route_backed: bool
+    route_status: str
     detail: str
+    wire_format_id: str | None = None
+    route_requirement: str | None = None
+    route_evidence: str | None = None
+
+    @property
+    def route_backed(self) -> bool:
+        """Whether a serve route for these bytes is known to exist."""
+        return self.route_status == ROUTE_STATUS_BACKED
 
 
 SOURCE_PASSTHROUGH_CONTRACTS: dict[str, SourcePassthroughContract] = {
@@ -97,11 +123,16 @@ SOURCE_PASSTHROUGH_CONTRACTS: dict[str, SourcePassthroughContract] = {
             source_kind="fp8",
             zero_cost_by_construction=False,
             serving_route=f"{ROUTE_DELEGATED_NATIVE}_fp8_block",
-            route_backed=True,
+            route_status=ROUTE_STATUS_BACKED,
             detail=(
                 "native block-FP8 with an FP32 weight_scale_inv plane; the "
                 "cost pipeline emits real rows for it, so its candidate is "
                 "not synthesized"
+            ),
+            route_evidence=(
+                "stock compressed-tensors block-fp8; served on the "
+                "checkpoints this format was written for (MiniMax M2, "
+                "DeepSeek-V3)"
             ),
         ),
         # DeepSeek-V3.1/V4 block-FP8: one-byte UE8M0 block exponents. Same
@@ -110,25 +141,48 @@ SOURCE_PASSTHROUGH_CONTRACTS: dict[str, SourcePassthroughContract] = {
         SourcePassthroughContract(
             format_name="FP8_BLOCK_UE8M0_SOURCE",
             source_kind="fp8_ue8m0",
+            wire_format_id="fp8_e4m3_ue8m0_block128",
             zero_cost_by_construction=True,
             serving_route=f"{ROUTE_DELEGATED_NATIVE}_fp8_block_ue8m0",
-            route_backed=True,
+            route_status=ROUTE_STATUS_BLOCKED,
             detail=(
-                "native block-FP8 with UE8M0 block exponents; this IS how the "
-                "released checkpoint serves, so the route is the model's own"
+                "native block-FP8 with UE8M0 block exponents. 'The checkpoint "
+                "already serves this way' turned out NOT to imply a serve "
+                "route on our target: measured on GB10/sm121, every route is "
+                "dead. Keeping the rung on the menu is deliberate — if the DP "
+                "still wants it, that is the serving gap becoming visible in "
+                "the allocation instead of at deploy time."
+            ),
+            route_evidence=(
+                "sm121 measured 2026-08-03: deep_gemm assert; cutlass "
+                "scaled_mm rejects the block layout; triton KeyError on "
+                "float8_e8m0fnu; flashinfer gated sm90-exact; marlin-linear "
+                "is <=sm89. CONSEQUENCE: CB re-encoding of the body is the "
+                "only way this checkpoint serves on this box at all."
             ),
         ),
         # DeepSeek-V4 routed experts: nibble-packed E2M1 + E8M0 group scales.
         SourcePassthroughContract(
             format_name="MXFP4_SOURCE",
             source_kind="mxfp4",
+            wire_format_id="mxfp4_e2m1_ue8m0_g32",
             zero_cost_by_construction=True,
             serving_route=f"{ROUTE_DELEGATED_NATIVE}_mxfp4",
-            route_backed=False,
+            route_status=ROUTE_STATUS_BACKED,
+            route_requirement="vllm --moe-backend marlin",
             detail=(
-                "native packed MXFP4 routed experts; the serving side loads "
-                "them on the model's own path rather than through a codebook "
-                "decoder, and that route is pending its cross-repo audit"
+                "native packed MXFP4 routed experts, served by the model's "
+                "own path rather than a codebook decoder. BACKED, but only "
+                "off the default: the auto-selected backend is broken on our "
+                "target, so the requirement below is part of the contract, "
+                "not a tuning hint."
+            ),
+            route_evidence=(
+                "sm121 measured 2026-08-03: native-confirmed via vLLM Marlin "
+                "MoE (--moe-backend marlin). The AUTO default DeepGEMM_MXFP4 "
+                "asserts on the SF transformation; FlashInfer is gated to "
+                "capability family 100; the OAI Triton path is hard-excluded "
+                "on SM12x (0/15 kernels)."
             ),
         ),
         # Unquantized passthrough. Not a "source format" in the census sense,
@@ -138,8 +192,9 @@ SOURCE_PASSTHROUGH_CONTRACTS: dict[str, SourcePassthroughContract] = {
             source_kind="bf16",
             zero_cost_by_construction=False,
             serving_route=f"{ROUTE_DELEGATED_NATIVE}_bf16",
-            route_backed=True,
+            route_status=ROUTE_STATUS_BACKED,
             detail="unquantized passthrough on a bf16 source",
+            route_evidence="plain container floats; no kernel required",
         ),
     )
 }
@@ -176,13 +231,46 @@ SOURCE_PASSTHROUGH_FORMATS: frozenset[str] = frozenset(
     if contract.zero_cost_by_construction
 )
 
-# Passthrough formats with no known serve route today. On the menu (an
-# allocator that wants one is reporting a serving gap), but the exporter
-# refuses to ship a selection containing one without an explicit override.
+# Passthrough formats with no DEMONSTRATED serve route on the target — either
+# unaudited (pending) or measured dead (blocked). On the menu (an allocator
+# that wants one is reporting a serving gap), but the exporter refuses to ship
+# a selection containing one without an explicit override.
 ROUTE_PENDING_PASSTHROUGH_FORMATS: frozenset[str] = frozenset(
     name for name, contract in SOURCE_PASSTHROUGH_CONTRACTS.items()
     if not contract.route_backed
 )
+
+# The closed wire enum the artifact declares and the serving side reads
+# (quant_config.json "source_passthrough"). Registry names are ours to rename;
+# these are a cross-repo contract, so they are declared once here and the
+# exporter maps through this table rather than spelling them again.
+PASSTHROUGH_WIRE_FORMAT_IDS: dict[str, str] = {
+    name: contract.wire_format_id
+    for name, contract in SOURCE_PASSTHROUGH_CONTRACTS.items()
+    if contract.wire_format_id is not None
+}
+
+
+def passthrough_serving_notes() -> dict[str, dict[str, str]]:
+    """Per-format serving requirements/evidence for the artifact's notes.
+
+    A BACKED route with an unmet requirement serves no better than a blocked
+    one, so the requirement travels with the artifact rather than living in a
+    run book.
+    """
+    return {
+        name: {
+            key: value
+            for key, value in (
+                ("route_status", contract.route_status),
+                ("route", contract.serving_route),
+                ("requirement", contract.route_requirement),
+                ("evidence", contract.route_evidence),
+            )
+            if value is not None
+        }
+        for name, contract in sorted(SOURCE_PASSTHROUGH_CONTRACTS.items())
+    }
 
 
 def serialized_candidate_payload(

--- a/prismaquant/cb_export_config.py
+++ b/prismaquant/cb_export_config.py
@@ -13,12 +13,19 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from copy import deepcopy
+from dataclasses import dataclass
 import hashlib
 import json
 from typing import Any
 
 import torch
 
+from prismaquant import format_registry as fr
+from prismaquant.allocator_candidates import (
+    PASSTHROUGH_WIRE_FORMAT_IDS,
+    SOURCE_PASSTHROUGH_CONTRACTS,
+    SourcePassthroughContract,
+)
 from prismaquant.cb_layout import (
     FP4_GROUP,
     SCALE_CODING_TWO_TIER,
@@ -44,6 +51,324 @@ _STOCK_CT_SCHEMES = {
     "NVFP4": NVFP4_SCHEME,
     "FP8_E4M3": FP8_E4M3_SCHEME,
 }
+
+# ---------------------------------------------------------------------------
+# Source-passthrough wire contracts + the routed-expert routing declaration
+# ---------------------------------------------------------------------------
+# A unit can leave this producer on one of several EXECUTION ROUTES, and the
+# difference is not a scheme detail — it decides which loader reads the bytes:
+#
+#   gridbook_cb              the exporter re-encoded the weight into a CB
+#                            payload; gridbook's own decoder serves it.
+#   delegated_native_*       the exporter copied the checkpoint's own bytes;
+#                            some other loader serves them, and which one is
+#                            exactly what the route id names.
+#
+# ``allocator_candidates.SOURCE_PASSTHROUGH_CONTRACTS`` is the single table of
+# native source formats and their routes. Everything below DERIVES from it plus
+# the format registry, so a newly censused native format is a table entry, not
+# a new branch here: its route, its backedness, its config group and its
+# routing-declaration vocabulary all follow.
+#
+# WHY THE DECLARATION EXISTS. Nothing else in the artifact says which route a
+# routed-expert group took. The CB config_groups only name what IS CB, the
+# ``ignore`` list only names unquantized passthrough, and the K0.2 activation
+# record only names modules that contributed a calibrated fp4 stage. A
+# delegated group is invisible in all three — so a consumer cannot tell "this
+# layer is served natively, by design" from "this layer's attestation is
+# missing". That indistinguishability is the whole reason this record exists;
+# ``cb_activation_contract`` is the field that resolves it.
+
+# The scale-plane dtype the compressed-tensors vocabulary reads. A passthrough
+# whose serialized scale plane is ALREADY that dtype can be normalized into the
+# CT namespace on write (rename + trivial cast) and delegated to vLLM's stock
+# block-FP8 path; any other plane can only be read by the loader that wrote it,
+# so it must ship byte-verbatim under the CHECKPOINT's own tensor names.
+# Widening it instead would multiply the scale bytes and emit a tensor the
+# model's own loader does not expect — the opposite of a passthrough.
+_CT_SCALE_DTYPE_NAME = "fp32"
+_NO_SCALE_PLANE_DTYPE_NAMES = frozenset({"none", ""})
+
+# ---------------------------------------------------------------------------
+# The `source_passthrough` declaration (top-level key in quant_config.json)
+# ---------------------------------------------------------------------------
+# WIRE CONTRACT. The consumer side owns this shape; the spellings below are its
+# closed enum, not ours, so they are a hand-maintained table rather than
+# something derived from FormatSpec fields. Deriving them would let a registry
+# field rename silently change what the artifact claims — a rename is a local
+# refactor, a wire-id change is a load failure at the other end.
+#
+# ABSENCE of the key means "legacy all-CB artifact". That is why the producer
+# omits it entirely when nothing is passthrough rather than emitting an empty
+# record: an empty `units` would be a positive claim that nothing is delegated,
+# which is a different statement from a file written before this key existed.
+SOURCE_PASSTHROUGH_DECLARATION_KEY = "source_passthrough"
+SOURCE_PASSTHROUGH_DECLARATION_VERSION = 1
+# The registry-name -> wire-id map, re-exported from the ONE place the
+# passthrough family is declared (``allocator_candidates
+# .SOURCE_PASSTHROUGH_CONTRACTS``). It is hand-pinned there rather than derived
+# from FormatSpec fields, for the reason that matters here: a local rename of a
+# registry format must not be able to silently change a cross-repo wire
+# contract. Keeping a SECOND literal copy in this module would defeat that
+# differently — two hand-pinned tables can disagree, and the artifact would
+# then declare one thing while the allocator believed another. One table,
+# re-exported under the name the exporter reads.
+# tests/test_source_passthrough_family.py pins the literal strings.
+SOURCE_PASSTHROUGH_WIRE_IDS: dict[str, str] = dict(
+    PASSTHROUGH_WIRE_FORMAT_IDS
+)
+SOURCE_PASSTHROUGH_WIRE_FORMATS: dict[str, str] = {
+    wire_id: name for name, wire_id in SOURCE_PASSTHROUGH_WIRE_IDS.items()
+}
+
+# Config-group ``format`` token for a source passthrough. Deliberately NOT a
+# compressed-tensors format string: nothing in that vocabulary describes "the
+# architecture's own kernel reads its own tensors". The group describes the
+# TENSOR-level layout of the targets that left on that lane; the declaration
+# above describes UNIT-level routing. Different granularity, and the group does
+# not restate the route — one source of truth for that.
+SOURCE_PASSTHROUGH_GROUP_FORMAT = "source-passthrough"
+
+
+@dataclass(frozen=True)
+class PassthroughWire:
+    """How ONE source-passthrough format's tensors reach the artifact."""
+
+    format_name: str
+    contract: SourcePassthroughContract
+    spec: Any                    # format_registry.FormatSpec
+    ct_normalized: bool
+
+
+def source_passthrough_wire(format_name: str) -> PassthroughWire:
+    """Resolve a format name to its passthrough wire contract, or refuse.
+
+    An unknown format is a hard error rather than a default: "copy the bytes"
+    is only a safe instruction when the table says which bytes those are and
+    which loader has agreed to read them.
+    """
+
+    canonical = fr.canonical_format_name(str(format_name))
+    contract = SOURCE_PASSTHROUGH_CONTRACTS.get(canonical)
+    if contract is None:
+        raise ValueError(
+            f"{format_name!r} is not a declared source-passthrough format "
+            f"(allocator_candidates.SOURCE_PASSTHROUGH_CONTRACTS: "
+            f"{sorted(SOURCE_PASSTHROUGH_CONTRACTS)})"
+        )
+    spec = fr.get_format(canonical)
+    return PassthroughWire(
+        format_name=canonical,
+        contract=contract,
+        spec=spec,
+        ct_normalized=str(spec.scale_dtype_name) == _CT_SCALE_DTYPE_NAME,
+    )
+
+
+def source_passthrough_wire_id(format_name: str) -> str:
+    """Registry format name -> the consumer's wire id. THE one mapping.
+
+    Fails closed on a format with no wire id. A newly censused passthrough that
+    reached the emitter without one must stop the export, not be dropped from
+    ``units``: a silently omitted unit reads to the consumer as "this is CB",
+    which is the one wrong answer that loads.
+    """
+
+    canonical = source_passthrough_wire(format_name).format_name
+    try:
+        return SOURCE_PASSTHROUGH_WIRE_IDS[canonical]
+    except KeyError:
+        raise ValueError(
+            f"{canonical} is a source-passthrough format with no wire id in "
+            f"SOURCE_PASSTHROUGH_WIRE_IDS {sorted(SOURCE_PASSTHROUGH_WIRE_IDS)}"
+            "; the consumer's format enum is closed, so this unit cannot be "
+            "declared and must not be shipped undeclared"
+        ) from None
+
+
+def _has_serialized_scale_plane(spec) -> bool:
+    """Whether this format ships a SECOND tensor beside its element plane."""
+
+    return (
+        int(spec.scale_bits) > 0
+        and str(spec.scale_dtype_name) not in _NO_SCALE_PLANE_DTYPE_NAMES
+    )
+
+
+# Passthrough formats the exporter emits as a WEIGHT + SCALE PAIR. BF16 is
+# excluded by construction (no serialized scale plane): it is a plain verbatim
+# tensor copy the generic passthrough loop already performs, and it needs no
+# config group of its own because ``ignore`` already describes it.
+SOURCE_PASSTHROUGH_EXPORT_FORMATS: frozenset[str] = frozenset(
+    name for name in SOURCE_PASSTHROUGH_CONTRACTS
+    if _has_serialized_scale_plane(fr.get_format(name))
+)
+# The subset that ships byte-verbatim under the CHECKPOINT's own tensor names.
+# Membership is what makes a unit UNCOLLAPSIBLE in the streaming exporter (a
+# packed parent it never writes must not be named), what selects the emit
+# branch, and what puts the unit in the declaration — so those decisions cannot
+# drift apart.
+DELEGATED_NATIVE_PASSTHROUGH_FORMATS: frozenset[str] = frozenset(
+    name for name in SOURCE_PASSTHROUGH_EXPORT_FORMATS
+    if not source_passthrough_wire(name).ct_normalized
+)
+
+
+def source_passthrough_config_group(format_name: str) -> dict[str, Any]:
+    """The scheme-less config group one delegated-native passthrough gets.
+
+    Built from the FormatSpec rather than hand-written per format, so the group
+    cannot describe a different on-disk contract than the one the accountant
+    priced and the emitter copied.  It states LAYOUT only; routing is stated
+    once, in the ``source_passthrough`` declaration.
+    """
+
+    wire = source_passthrough_wire(format_name)
+    spec = wire.spec
+    weights: dict[str, Any] = {
+        "num_bits": int(spec.weight_bits),
+        "type": "float",
+        "element_dtype": str(spec.weight_element_dtype),
+        "scale_dtype": str(spec.scale_dtype_name),
+        "symmetric": True,
+        "dynamic": False,
+        # Verbatim: these bytes were not produced here and are not re-derivable
+        # from anything this exporter wrote.
+        "source_passthrough": True,
+    }
+    if spec.scale_block_shape is not None:
+        weights["strategy"] = "block"
+        weights["block_structure"] = [int(d) for d in spec.scale_block_shape]
+    else:
+        weights["strategy"] = "group"
+        weights["group_size"] = int(spec.group_size)
+    return {
+        "format": SOURCE_PASSTHROUGH_GROUP_FORMAT,
+        "source_format": wire.format_name,
+        "source_passthrough_id": source_passthrough_wire_id(wire.format_name),
+        "weights": weights,
+        # The producer applies no activation quantization of its own on a
+        # passthrough route; the A side is the released checkpoint's contract.
+        "input_activations": None,
+    }
+
+
+def build_source_passthrough_declaration(
+    units: Mapping[str, str],
+) -> dict[str, Any]:
+    """Build + validate the declaration from ``{unit id: registry format}``.
+
+    A UNIT is whatever the allocator decided atomically — a routed-expert group
+    (``model.layers.7.mlp.experts``) or a dense Linear
+    (``model.layers.7.self_attn.wq_a``). Deliberately not expert-only: the
+    UE8M0 block-FP8 body ships on the same contract, and framing the record
+    around expert groups would have left those units undeclarable.
+
+    There is no exhaustiveness claim here — the record says which units ARE
+    passthrough, not that it has enumerated every unit in the model — so a
+    partially-allocated model needs no special case.
+    """
+
+    if not units:
+        raise ValueError(
+            "source_passthrough needs at least one unit; an artifact with no "
+            "passthrough unit must OMIT the key (its absence is what marks a "
+            "legacy all-CB artifact)"
+        )
+    declared: dict[str, str] = {}
+    for unit_id, format_name in units.items():
+        unit = str(unit_id)
+        if not unit or unit != unit.strip():
+            raise ValueError(
+                f"source_passthrough unit id {unit_id!r} is not a usable "
+                "module name"
+            )
+        declared[unit] = source_passthrough_wire_id(format_name)
+    return {
+        "version": SOURCE_PASSTHROUGH_DECLARATION_VERSION,
+        "units": dict(sorted(declared.items())),
+    }
+
+
+def _cb_config_group_targets(quant_config: Mapping[str, Any]) -> set[str]:
+    """Target names the CB config groups claim, un-anchored."""
+
+    targets: set[str] = set()
+    groups = quant_config.get("config_groups")
+    if not isinstance(groups, Mapping):
+        return targets
+    for group in groups.values():
+        if not isinstance(group, Mapping) or "scheme" not in group:
+            continue
+        for target in group.get("targets") or ():
+            name = str(target)
+            if name.startswith("re:^") and name.endswith("$"):
+                name = name[len("re:^"):-1].replace("[.]", ".")
+            targets.add(name)
+    return targets
+
+
+def parse_source_passthrough_declaration(
+    quant_config: Mapping[str, Any],
+) -> dict[str, str] | None:
+    """Read + re-validate the declaration, or ``None`` for a legacy artifact.
+
+    THE consumer-side definition, kept beside the producer's so the two cannot
+    drift, and used by the producer as its own pre-write assertion. Returns
+    ``{unit id: wire format id}``.
+
+    Refusal cases are exactly the ones a loader must reject: an unknown
+    version, a malformed ``units`` map, an unknown format id, and a unit
+    claimed by BOTH the CB config groups and this record. That last check is
+    conservative here on purpose — it can only compare the two in the SAME
+    namespace, and a checkpoint whose serialized names differ from its recipe
+    names (DSv4) hides the collision from a string test. The exporter runs the
+    strong version of it, where both namespaces are in hand.
+    """
+
+    record = quant_config.get(SOURCE_PASSTHROUGH_DECLARATION_KEY)
+    if record is None:
+        return None
+    if not isinstance(record, Mapping):
+        raise ValueError(
+            f"{SOURCE_PASSTHROUGH_DECLARATION_KEY} must be an object, got "
+            f"{type(record).__name__}"
+        )
+    version = record.get("version")
+    if version != SOURCE_PASSTHROUGH_DECLARATION_VERSION:
+        raise ValueError(
+            f"unsupported {SOURCE_PASSTHROUGH_DECLARATION_KEY} version "
+            f"{version!r}; this reader implements "
+            f"{SOURCE_PASSTHROUGH_DECLARATION_VERSION}"
+        )
+    units = record.get("units")
+    if not isinstance(units, Mapping) or not units:
+        raise ValueError(
+            f"{SOURCE_PASSTHROUGH_DECLARATION_KEY} carries no units; the key "
+            "is present, so it is a positive claim and cannot be empty"
+        )
+    parsed: dict[str, str] = {}
+    for unit_id, wire_id in units.items():
+        if not isinstance(unit_id, str) or not isinstance(wire_id, str):
+            raise ValueError(
+                f"{SOURCE_PASSTHROUGH_DECLARATION_KEY} units must map string "
+                f"unit ids to string format ids, got {unit_id!r}: {wire_id!r}"
+            )
+        if wire_id not in SOURCE_PASSTHROUGH_WIRE_FORMATS:
+            raise ValueError(
+                f"{SOURCE_PASSTHROUGH_DECLARATION_KEY} unit {unit_id!r} "
+                f"declares unknown format id {wire_id!r}; legal ids are "
+                f"{sorted(SOURCE_PASSTHROUGH_WIRE_FORMATS)}"
+            )
+        parsed[unit_id] = wire_id
+    contested = sorted(set(parsed) & _cb_config_group_targets(quant_config))
+    if contested:
+        raise ValueError(
+            f"{contested} are claimed by BOTH a CB config group and "
+            f"{SOURCE_PASSTHROUGH_DECLARATION_KEY}; a unit is decoded by "
+            "gridbook's codec or handed to the model's own loader, never both"
+        )
+    return parsed
 
 
 def _validated_codebook_sequence(
@@ -235,6 +560,7 @@ def build_quant_config(
     assignment: Mapping[str, str],
     cb_targets: Mapping[str, CBTarget],
     source_targets: Iterable[str],
+    native_source_targets: Mapping[str, str] | None = None,
     stock_targets: Mapping[str, str],
     by_group: Mapping[tuple[str, str], Sequence[str]],
     codebooks: Mapping[tuple[str, str], object],
@@ -252,13 +578,31 @@ def build_quant_config(
     cb_target_name: TargetName = _identity_target,
     delegated_target_name: TargetName = _identity_target,
     source_target_name: TargetName = _identity_target,
+    native_source_target_name: TargetName = _identity_target,
+    source_passthrough_units: Mapping[str, str] | None = None,
+    route_pending_passthrough_acknowledged: Iterable[str] = (),
     weight_only_stock_targets: Iterable[str] = (),
     streaming_provenance: bool | None = None,
     include_tensor_formats: bool = False,
 ) -> dict[str, Any]:
-    """Build the complete producer-owned ``quant_config.json`` payload."""
+    """Build the complete producer-owned ``quant_config.json`` payload.
+
+    ``source_targets`` is the CT-NORMALIZED passthrough lane (FP8_SOURCE: the
+    weight copied verbatim, its FP32 scale plane renamed into the
+    compressed-tensors namespace).  ``native_source_targets`` is the
+    BYTE-VERBATIM lane, ``{qname: format}``, one config group per format taken
+    from :func:`source_passthrough_config_group`.  The split is the wire
+    contract, not a taxonomy: see ``_CT_SCALE_DTYPE_NAME``.
+
+    ``source_passthrough_units`` is ``{unit id: registry format name}`` for the
+    units this artifact delegates, and becomes the top-level
+    ``source_passthrough`` key.  Empty or ``None`` omits the key entirely —
+    its ABSENCE is what marks a legacy all-CB artifact, so an empty record
+    would be a different (and false) claim.
+    """
 
     source_targets = list(source_targets)
+    native_source_targets = dict(native_source_targets or {})
     weight_only_stock_targets = set(weight_only_stock_targets)
     assignment_sha = hashlib.sha256(
         json.dumps(
@@ -328,6 +672,22 @@ def build_quant_config(
             for qname in source_targets
         )
         config_groups[f"group_{len(config_groups)}"] = source_group
+    native_by_format: dict[str, list[str]] = {}
+    for qname, fmt in native_source_targets.items():
+        native_by_format.setdefault(
+            source_passthrough_wire(fmt).format_name, []
+        ).append(qname)
+    for fmt, qnames in sorted(native_by_format.items()):
+        # Targets are the CHECKPOINT-spelled bases, anchored the same way the
+        # other delegated groups are. The native loader keys off those names,
+        # not off the recipe's live spelling, so naming anything else here
+        # would describe tensors this artifact does not contain.
+        native_group = source_passthrough_config_group(fmt)
+        native_group["targets"] = sorted(
+            _explicit_regex(native_source_target_name(qname))
+            for qname in qnames
+        )
+        config_groups[f"group_{len(config_groups)}"] = native_group
 
     provenance: dict[str, Any] = {
         "git_commit": git_commit,
@@ -342,11 +702,23 @@ def build_quant_config(
         "cb_targets": len(cb_targets),
         "stock_ct_targets": len(stock_targets),
         "fp8_source_targets": len(source_targets),
+        # Per-format counts rather than one key per format: a newly censused
+        # passthrough shows up here without a provenance schema change.
+        "source_passthrough_targets": {
+            fmt: len(qnames)
+            for fmt, qnames in sorted(native_by_format.items())
+        },
         "serialized_payload": dict(serialized_payload_summary),
         "render_identity_verified": cb_render_identity is not None,
     }
     if streaming_provenance is not None:
         provenance["streaming"] = bool(streaming_provenance)
+    acknowledged = sorted(set(route_pending_passthrough_acknowledged))
+    if acknowledged:
+        # The override was a CLI flag on one machine at one moment; the
+        # artifact has to carry the fact that it was used, or "was this shipped
+        # knowing no serve route existed?" is unanswerable from the artifact.
+        provenance["route_pending_passthrough_acknowledged"] = acknowledged
     if cb_render_identity is not None:
         provenance["cb_render_identity"] = cb_render_identity
     if include_tensor_formats:
@@ -354,6 +726,7 @@ def build_quant_config(
             qname: assignment[qname]
             for qname in sorted(
                 set(cb_targets) | set(stock_targets) | set(source_targets)
+                | set(native_source_targets)
             )
         }
 
@@ -365,6 +738,15 @@ def build_quant_config(
         **({"codebook_file": codebook_file} if codebook_file else {}),
         "provenance": provenance,
     }
+    if source_passthrough_units:
+        quant_config[SOURCE_PASSTHROUGH_DECLARATION_KEY] = (
+            build_source_passthrough_declaration(source_passthrough_units)
+        )
+        # Read it straight back through the CONSUMER's own parser before the
+        # file exists. Every refusal case that parser implements is a load
+        # failure at the other end, so the producer must never be the one to
+        # generate one.
+        parse_source_passthrough_declaration(quant_config)
     if activation_execution_contract is not None:
         quant_config["execution_contracts"] = {
             activation_contract_ref: dict(activation_execution_contract),
@@ -376,9 +758,22 @@ def build_quant_config(
 
 
 __all__ = [
+    "DELEGATED_NATIVE_PASSTHROUGH_FORMATS",
+    "SOURCE_PASSTHROUGH_DECLARATION_KEY",
+    "SOURCE_PASSTHROUGH_DECLARATION_VERSION",
+    "SOURCE_PASSTHROUGH_EXPORT_FORMATS",
+    "SOURCE_PASSTHROUGH_GROUP_FORMAT",
+    "SOURCE_PASSTHROUGH_WIRE_FORMATS",
+    "SOURCE_PASSTHROUGH_WIRE_IDS",
+    "PassthroughWire",
     "build_cb_scheme",
     "build_quant_config",
+    "build_source_passthrough_declaration",
     "cb_scheme_reuse_signature",
     "codebook_tensor_names",
     "codebook_tensors",
+    "parse_source_passthrough_declaration",
+    "source_passthrough_config_group",
+    "source_passthrough_wire",
+    "source_passthrough_wire_id",
 ]

--- a/prismaquant/emu_forward_kl.py
+++ b/prismaquant/emu_forward_kl.py
@@ -34,6 +34,7 @@ from typing import Mapping
 import torch
 
 from . import format_registry as fr
+from .allocator_candidates import PASSTHROUGH_SOURCE_REQUIREMENTS
 from .measure_quant_cost import canonical_linear_name
 
 # Teacher-confident threshold: teacher top-1 prob must exceed this for a
@@ -230,9 +231,15 @@ def _collect_targets(model, format_map: Mapping[str, dict]):
         spec = fr.get_format(fmt)
         cw = entry.get("col_weights") if isinstance(entry, Mapping) else None
         smooth = entry.get("smooth_scale") if isinstance(entry, Mapping) else None
-        # Only BF16 / FP8_SOURCE are passthrough-only (CLAUDE.md principle 11);
-        # every other format — including real FP8_E4M3 — is rendered.
-        skip_weight = spec.name in ("BF16", "FP8_SOURCE")
+        # Only the SOURCE-PASSTHROUGH family is passthrough-only (CLAUDE.md
+        # principle 11); every other format — including real FP8_E4M3 — is
+        # rendered. Read from the one table rather than a name tuple: this
+        # list was ("BF16", "FP8_SOURCE") when those were the only two, and a
+        # newly censused native format silently missing from it would be
+        # RE-RENDERED here — emulating quantization error for bytes the
+        # exporter copies verbatim, i.e. reporting a KL the artifact does not
+        # have.
+        skip_weight = spec.name in PASSTHROUGH_SOURCE_REQUIREMENTS
         if skip_weight and not _wants_act_emulation(spec):
             continue
         targets.append((qname, mod, spec, cw, smooth))

--- a/prismaquant/export_nvfp4_cb_streaming.py
+++ b/prismaquant/export_nvfp4_cb_streaming.py
@@ -24,8 +24,11 @@ one expert alone equals packing it inside the stack) — pinned byte-for-byte
 in tests/test_nvfp4_cb_streaming.py. Both exporters call the single
 ``cb_export_config`` builder for container/config/sidecar metadata.
 
-Scope: bf16 source + fp8-source READ + CB families + BF16 passthrough +
-FP8_SOURCE passthrough + stock-CT **DENSE** rungs (vanilla NVFP4 / FP8_DYNAMIC
+Scope: bf16 source + fp8-source READ + CB families + BF16 passthrough + the
+SOURCE-PASSTHROUGH family (``allocator_candidates.SOURCE_PASSTHROUGH_CONTRACTS``
+— FP8_SOURCE normalized into the compressed-tensors namespace, MXFP4_SOURCE and
+FP8_BLOCK_UE8M0_SOURCE copied byte-verbatim under the checkpoint's own names)
++ stock-CT **DENSE** rungs (vanilla NVFP4 / FP8_DYNAMIC
 quantised in-container). Stock rungs are packed RTN via the authoritative
 ``export_native_compressed`` codecs (byte-identical to the in-memory
 export_nvfp4_cb and to those packers called directly; no GPTQ/act-order in this
@@ -63,13 +66,21 @@ import torch
 from safetensors import safe_open
 
 from prismaquant import nvfp4_cb_formats as cb
+from prismaquant.allocator_candidates import (
+    ROUTE_PENDING_PASSTHROUGH_FORMATS,
+    SOURCE_PASSTHROUGH_CONTRACTS,
+)
 from prismaquant.cb_export_config import (
+    SOURCE_PASSTHROUGH_EXPORT_FORMATS,
+    parse_source_passthrough_declaration,
     build_cb_scheme,
     build_quant_config,
     cb_scheme_reuse_signature,
     codebook_tensor_names as _codebook_tensor_names,
     codebook_tensors as _codebook_tensors,
+    source_passthrough_wire,
 )
+from prismaquant.format_registry import get_format as _fr_get_format
 from prismaquant.export_nvfp4_cb import (
     _canonical_qname,
     _export_base_name,
@@ -101,6 +112,7 @@ from prismaquant.nvfp4_cb_footprint import (
 )
 from prismaquant.nvfp4_activation_contract import (
     NVFP4_ACTIVATION_CONTRACT_KEY,
+    routed_moe_attested_module_names,
     NVFP4_ACTIVATION_CONTRACT_SCHEMA,
     NVFP4_ACTIVATION_EXECUTION,
     build_execution_contract,
@@ -110,9 +122,19 @@ from prismaquant.nvfp4_activation_contract import (
 )
 
 # safetensors dtype string codes for the tensors we emit.
+#
+# F8_E8M0 is here because the byte-verbatim passthrough lane ships the
+# checkpoint's E8M0 scale plane UNCHANGED: DSv4-Flash carries it for both the
+# routed MXFP4 experts (`layers.N.ffn.experts.E.w{1,2,3}.scale`) and the
+# block-FP8 body (`layers.N.attn.*.scale`). Re-encoding it to F32, as the
+# FP8_SOURCE branch does with its fp32 block scales, would quadruple its size
+# and stop being a byte copy. A missing entry is not a soft failure —
+# `_StreamWriter.write` indexes this map to build the header and would die with
+# a bare KeyError.
 _ST_DTYPE = {
     torch.uint8: "U8", torch.float32: "F32", torch.float16: "F16",
     torch.bfloat16: "BF16", torch.float8_e4m3fn: "F8_E4M3",
+    torch.float8_e8m0fnu: "F8_E8M0",
     torch.int64: "I64", torch.int32: "I32", torch.int8: "I8",
     torch.bool: "BOOL",
 }
@@ -153,6 +175,7 @@ class _LazySkeleton:
             with safe_open(single, framework="pt", device="cpu") as f:
                 self.weight_map = {k: "model.safetensors" for k in f.keys()}
         self._open: dict[str, object] = {}
+        self._shard_hdr: dict[str, tuple[dict, int]] = {}
         try:
             self._profile = detect_profile(str(self.dir))
         except Exception:
@@ -220,6 +243,33 @@ class _LazySkeleton:
     def load(self, name: str) -> torch.Tensor:
         return self._handle(name).get_tensor(name)
 
+    def _hdr(self, shard: Path) -> tuple[dict, int]:
+        """Parsed safetensors header + data-start offset for one shard."""
+        key = str(shard)
+        if key not in self._shard_hdr:
+            with open(shard, "rb") as f:
+                (hlen,) = struct.unpack("<Q", f.read(8))
+                hdr = json.loads(f.read(hlen))
+            self._shard_hdr[key] = (hdr, 8 + hlen)
+        return self._shard_hdr[key]
+
+    def raw_slice(self, name: str) -> tuple[Path, int, int]:
+        """``(shard_path, absolute file offset, nbytes)`` for a raw byte copy.
+
+        The SOURCE-side twin of ``_PriorArtifact.raw_slice``, and the reason
+        the native lane is a passthrough rather than a re-serialization: paired
+        with ``_StreamWriter.add(copy_src=...)`` it moves a source tensor from
+        the checkpoint's file to the artifact's file in 16 MiB chunks without
+        ever constructing a torch.Tensor. On DSv4-Flash that is 147 GB of
+        routed-expert payload the exporter never materialises — "stream, don't
+        load" applied to the one lane where there is nothing to encode.
+        """
+        shard = self.dir / self.weight_map[name]
+        hdr, data0 = self._hdr(shard)
+        meta = hdr[name]
+        lo, hi = meta["data_offsets"]
+        return shard, data0 + int(lo), int(hi) - int(lo)
+
     def dequant_weight(self, weight_key: str) -> torch.Tensor:
         """Return the weight as fp32 for encoding. bf16/fp16 sources cast
         through the BF16 load contract; native-FP8 and declared MXFP4 sources
@@ -256,6 +306,78 @@ def _nbytes(dtype: torch.dtype, shape) -> int:
     for d in shape:
         n *= int(d)
     return n * torch.empty((), dtype=dtype).element_size()
+
+
+# On-disk dtypes each FormatSpec element/scale name can legally appear as.
+# Sourced from the decode side (`layer_streaming._E8M0_SCALE_DTYPES` accepts
+# all three E8M0 spellings) so a checkpoint the loader would decode is a
+# checkpoint this exporter will copy, and no other.
+_PASSTHROUGH_ELEMENT_DTYPES = {
+    "fp8_e4m3": (torch.float8_e4m3fn,),
+    "fp4_e2m1": (torch.int8, torch.uint8),
+}
+_PASSTHROUGH_SCALE_DTYPES = {
+    "uint8_e8m0": (torch.float8_e8m0fnu, torch.uint8, torch.int8),
+    "fp32": (torch.float32,),
+}
+# Logical elements per stored byte. >1 means a sub-byte pack, whose stored
+# shape is NOT its logical shape.
+_PASSTHROUGH_ELEMENTS_PER_BYTE = {"fp8_e4m3": 1, "fp4_e2m1": 2}
+
+
+def _passthrough_scale_shape(spec, logical_shape) -> tuple[int, ...]:
+    """The scale-plane shape one passthrough FormatSpec implies for a weight.
+
+    Derived from the registry rather than hardcoded per format: a block format
+    (``scale_block_shape``) tiles both dims, a group format divides the reduce
+    dim by ``group_size``.  A future census entry gets its expectation for free.
+    """
+    rows, cols = int(logical_shape[0]), int(logical_shape[1])
+    if spec.scale_block_shape is not None:
+        block_rows, block_cols = (int(d) for d in spec.scale_block_shape)
+        return (-(-rows // block_rows), -(-cols // block_cols))
+    group = int(spec.group_size)
+    if group <= 0 or cols % group:
+        raise ValueError(
+            f"{spec.name}: in_features={cols} is not a multiple of the "
+            f"declared group size {group}")
+    return (rows, cols // group)
+
+
+def _assert_passthrough_planes_agree(qname, fmt, spec, wkey, wsh, wdtype,
+                                     skey, ssh, sdtype) -> None:
+    """Metadata-only check that a source pair really is this format on disk.
+
+    The decode-side twins (`layer_streaming._check_mxfp4_packed_grid` /
+    `_check_fp8_scale_grid`) need the tensors; this runs during PLANNING, from
+    safetensors metadata alone, so a declaration/layout disagreement fails
+    before 147 GB has been copied rather than after.
+    """
+    element_dtypes = _PASSTHROUGH_ELEMENT_DTYPES[str(spec.weight_element_dtype)]
+    scale_dtypes = _PASSTHROUGH_SCALE_DTYPES[str(spec.scale_dtype_name)]
+    per_byte = _PASSTHROUGH_ELEMENTS_PER_BYTE[str(spec.weight_element_dtype)]
+    problems = []
+    if len(wsh) != 2 or wdtype not in element_dtypes:
+        problems.append(
+            f"weight {wkey!r} is {wdtype}{wsh}, expected a 2-D "
+            f"{'/'.join(str(d) for d in element_dtypes)} plane")
+    if len(ssh) != 2 or sdtype not in scale_dtypes:
+        problems.append(
+            f"scale {skey!r} is {sdtype}{ssh}, expected a 2-D "
+            f"{'/'.join(str(d) for d in scale_dtypes)} plane")
+    if not problems:
+        logical = (int(wsh[0]), int(wsh[1]) * per_byte)
+        expected = _passthrough_scale_shape(spec, logical)
+        if tuple(ssh) != expected:
+            problems.append(
+                f"scale {skey!r} is {tuple(ssh)}, but {spec.name} over a "
+                f"logical {logical} weight implies {expected}")
+    if problems:
+        raise ValueError(
+            f"{qname}: assigned {fmt}, but the checkpoint pair does not match "
+            f"that on-disk contract — {'; '.join(problems)}. A passthrough "
+            "copies bytes it does not interpret, so the source must already "
+            "BE the format it is being shipped as.")
 
 
 def _stock_output_specs(fmt: str, shape) -> list[tuple[str, torch.dtype, tuple]]:
@@ -311,6 +433,15 @@ class _StreamWriter:
         off = 0
         for name, dtype, shape, _, _ in self._entries:
             nb = _nbytes(dtype, shape)
+            if name in header:
+                # The header is a dict but the data stream is not: a duplicate
+                # name keeps only the LAST span while both blobs are still
+                # written, producing a file whose offsets are silently wrong
+                # from that point on. Cheap to check, and the passthrough lane
+                # adds tens of thousands of names from a second namespace.
+                raise AssertionError(
+                    f"{name}: planned twice; two emit paths claim the same "
+                    "output tensor")
             header[name] = {"dtype": _ST_DTYPE[dtype], "shape": list(shape),
                             "data_offsets": [off, off + nb]}
             off += nb
@@ -555,6 +686,17 @@ def _collapse_per_expert_assignment(assignment, expert_groups, profile):
     are a byte-width assert and a scheme-signature comparison, so a mixed stack
     that reached serving would be a load-time crash at best.
 
+    A SOURCE-PASSTHROUGH group (``cb_export_config
+    .SOURCE_PASSTHROUGH_EXPORT_FORMATS``) is deliberately NOT collapsed. The
+    collapse exists to name a packed parent that gridbook's CB loader anchors
+    on; a passthrough group has no CB loader and no packed parent, because the
+    exporter copies the per-expert checkpoint tensors and whichever loader owns
+    them reads them under their own names. Naming ``…experts.gate_up_proj`` for
+    it would promise a stack that is never written — the same reason
+    export_nvfp4_cb excludes FP8_SOURCE from ``_pack_skeleton_experts``. The
+    uniformity check still runs first, so a layer that MIXES a CB rung with a
+    passthrough is refused rather than silently split across two loaders.
+
     Returns ``(collapsed_assignment, members_by_target, report)``. Members are
     ``{packed_qname: {(projection, expert_id): member_recipe_qname}}`` so the
     imatrix, the render identity and the source-value verification all stay
@@ -615,6 +757,13 @@ def _collapse_per_expert_assignment(assignment, expert_groups, profile):
                     f"{len(present)} members — refusing to name it. "
                     f"Sample per format: {by_fmt}. Re-run the allocator with "
                     "the expert group constrained to one rung.")
+            if formats[0] in SOURCE_PASSTHROUGH_EXPORT_FORMATS:
+                # Keep the per-expert entries EXPANDED: they are the units this
+                # route actually emits. `consumed` still claims the projections
+                # so a narrower packed parent from the profile-less fallback
+                # vocabulary cannot re-collapse them behind this decision.
+                consumed.update(projections)
+                continue
             for q in present:
                 del collapsed[q]
             consumed.update(projections)
@@ -993,6 +1142,55 @@ def _reuse_verify_and_report(prior, reuse, reuse_verify, reuse_prior,
 # Streaming export
 # ---------------------------------------------------------------------------
 
+def assert_routes_reconcile(*, cb_units, passthrough_units, cb_tensors,
+                            passthrough_tensors, cb_modules,
+                            passthrough_modules, attested) -> None:
+    """Producer-side invariant; none of this is written to the artifact.
+
+    This is what ``cb_activation_contract`` used to buy on the wire, kept as an
+    internal check now that the field is gone:
+
+      * NO unit is claimed by both gridbook's codec and a passthrough. That is
+        the load-time refusal the consumer names, and the exporter is the only
+        place that can see it across BOTH namespaces — the declaration speaks
+        recipe names and the config groups speak serialized ones, so the
+        consumer's own same-string test cannot catch it on DSv4.
+      * No TENSOR is emitted by both routes either. The unit check is the
+        contract-level statement; this is the physical one that would catch a
+        namespace bug the unit ids happened to hide.
+      * The K0.2 attestation covers exactly the CB routed groups: a delegated
+        group must never be attested (it has no CB activation contract at all),
+        and an attested module must be a CB group. THAT is what makes a
+        delegated group's ABSENCE from the K0.2 record a declaration rather
+        than a dropped attestation.
+
+    A routed-expert group left entirely on BF16 passthrough is on neither route
+    by definition and is correctly absent from both module sets.
+    """
+    contested = sorted(set(cb_units) & set(passthrough_units))
+    if contested:
+        raise AssertionError(
+            f"{contested[:5]} are claimed by BOTH a CB config group and the "
+            "source_passthrough declaration; a unit is decoded by gridbook's "
+            "codec or handed to the model's own loader, never both")
+    shared = sorted(set(cb_tensors) & set(passthrough_tensors))
+    if shared:
+        raise AssertionError(
+            f"{shared[:5]} are emitted by both a CB target and a "
+            "source-passthrough target")
+    both_routed = sorted(set(attested) & set(passthrough_modules))
+    if both_routed:
+        raise AssertionError(
+            f"{both_routed[:5]} are attested by the routed-MoE activation "
+            "contract AND declared source-passthrough; a delegated group has "
+            "no CB activation contract to attest")
+    unattributed = sorted(set(attested) - set(cb_modules))
+    if unattributed:
+        raise AssertionError(
+            f"the routed-MoE activation contract attests {unattributed[:5]}, "
+            "which no CB expert unit claims")
+
+
 def _reject_disabled_reuse_before_output_transaction(function):
     """Preserve the quarantine gate ahead of any resume/output interpretation."""
     signature = inspect.signature(function)
@@ -1033,6 +1231,7 @@ def export_nvfp4_cb_streaming(
     reuse_prior: str | Path | None = None,
     reuse_verify: int = 3,
     allow_unstamped_research: bool = False,
+    allow_route_pending_passthrough: bool = False,
     activation_cache_dir: str | Path | None = None,
     activation_scale_policy: str | None = None,
 ) -> dict[str, int]:
@@ -1047,6 +1246,14 @@ def export_nvfp4_cb_streaming(
     fast). Default ``None`` = whole-model passthrough, byte-identical to before.
     Used to export just the MTP sidecar (``model.layers.80.``) without dragging
     the ~550 GB body through as bf16 passthrough.
+
+    ``allow_route_pending_passthrough`` overrides the ship gate on a
+    source-passthrough rung whose serve route has not been validated
+    (``allocator_candidates.ROUTE_PENDING_PASSTHROUGH_FORMATS``). The rung stays
+    on the allocator's menu on purpose — an allocation that wants it is
+    reporting a serving gap worth seeing — so the refusal lives here, at the
+    ship step, and the override is recorded in the artifact's provenance rather
+    than only in the operator's shell history.
 
     ``reuse_prior`` is reserved but currently fails closed. The prior gate did
     not bind exact source content, treated an imatrix mismatch as a warning,
@@ -1134,6 +1341,25 @@ def export_nvfp4_cb_streaming(
             f"into {expert_stack_report['stacks']} packed expert stack(s)",
             flush=True,
         )
+    # Every spelling of a routed-expert tensor -> the group prefix that OWNS
+    # it: the packed parents both namespaces can name, and every per-expert
+    # member under both its checkpoint and its recipe name. This is what lets a
+    # CB stack and a delegated per-expert leaf collapse to the same unit id.
+    _expert_group_of: dict[str, str] = {}
+    for _prefix, _projs in expert_groups.items():
+        for _packed_proj in _packed_expert_param_names(profile):
+            _packed = f"{_prefix}.{_packed_proj}"
+            _expert_group_of[_packed] = _prefix
+            _canon_packed = _canonical_qname(_packed, profile)
+            if _canon_packed:
+                _expert_group_of[_canon_packed] = _prefix
+        for _members in _projs.values():
+            for _member in _members.values():
+                _expert_group_of[_member] = _prefix
+                _canon_member = _canonical_qname(_member, profile)
+                if _canon_member:
+                    _expert_group_of[_canon_member] = _prefix
+
     # Every recipe qname a CB target is VERIFIED and IMATRIX-WEIGHTED under.
     # For a packed stack that is its members, not the stack: the recipe's
     # render identity, the cost rows and the col_weights pickle are all keyed
@@ -1163,9 +1389,14 @@ def export_nvfp4_cb_streaming(
     )
     _STOCK_CT_FORMATS = ("NVFP4", "FP8_E4M3")   # FP8_DYNAMIC canonicalizes here
 
-    # --- Classify every target (CB / FP8_SOURCE / stock-CT dense / BF16). ---
+    # --- Classify every target (CB / source passthrough / stock-CT dense /
+    # BF16). The passthrough lane splits by WIRE CONTRACT, not by name:
+    # `cb_export_config.source_passthrough_wire` says whether a format's scale
+    # plane can be normalized into the compressed-tensors namespace or must
+    # ship byte-verbatim under the checkpoint's own names. ---
     cb_targets: dict[str, tuple[str, str, int]] = {}
-    source_targets: list[str] = []
+    source_targets: list[str] = []              # CT-normalized (FP8_SOURCE)
+    native_source_targets: dict[str, str] = {}  # qname -> byte-verbatim format
     stock_targets: dict[str, str] = {}          # qname -> "NVFP4" | "FP8_E4M3"
     illegal = []
     for qname, fmt in assignment.items():
@@ -1176,8 +1407,11 @@ def export_nvfp4_cb_streaming(
             cb_targets[qname] = parsed
             continue
         canon = canonical_format_name(fmt)
-        if canon == "FP8_SOURCE":
-            source_targets.append(qname)
+        if canon in SOURCE_PASSTHROUGH_EXPORT_FORMATS:
+            if source_passthrough_wire(canon).ct_normalized:
+                source_targets.append(qname)
+            else:
+                native_source_targets[qname] = canon
             continue
         if canon in _STOCK_CT_FORMATS:
             stock_targets[qname] = canon
@@ -1186,9 +1420,35 @@ def export_nvfp4_cb_streaming(
     if illegal:
         raise ValueError(
             "streaming CB export carries CB families + stock NVFP4/FP8_DYNAMIC "
-            "(CT-delegated) + FP8_SOURCE + BF16 only; unsupported rung(s) "
-            f"{sorted({f for _, f in illegal})} — assign a legal format or use "
-            "the in-memory export_nvfp4_cb.")
+            "(CT-delegated) + the source-passthrough family "
+            f"{sorted(SOURCE_PASSTHROUGH_EXPORT_FORMATS)} + BF16 only; "
+            f"unsupported rung(s) {sorted({f for _, f in illegal})} — assign a "
+            "legal format or use the in-memory export_nvfp4_cb.")
+
+    # --- ROUTE-PENDING SHIP GATE. A passthrough rung whose serve route has not
+    # been validated stays ON the allocator's menu deliberately: an allocation
+    # that wants it is reporting a serving gap worth seeing, and masking the
+    # rung would hide that signal while removing the unit's only zero-error
+    # option. The fail-closed point is therefore the SHIP step, here. ---
+    route_pending = Counter(
+        fmt for fmt in list(native_source_targets.values())
+        + [canonical_format_name(assignment[q]) for q in source_targets]
+        if fmt in ROUTE_PENDING_PASSTHROUGH_FORMATS
+    )
+    if route_pending and not allow_route_pending_passthrough:
+        lanes = ", ".join(
+            f"{fmt} -> lane {SOURCE_PASSTHROUGH_CONTRACTS[fmt].serving_route} "
+            f"({count} unit(s))"
+            for fmt, count in sorted(route_pending.items())
+        )
+        raise ValueError(
+            "refusing to ship a route-pending source passthrough: "
+            f"{lanes}. No validated serve route exists for these bytes yet "
+            "(allocator_candidates.ROUTE_PENDING_PASSTHROUGH_FORMATS), so the "
+            "artifact would load into a lane nothing has been shown to "
+            "execute. Pass --allow-route-pending-passthrough "
+            "(allow_route_pending_passthrough=True) to ship it anyway; the "
+            "acknowledgement is recorded in the artifact's provenance.")
 
     # Text calibration cannot cover visual/audio sidecar modules that the
     # language-model profile deliberately drops.  Match the resident exporter:
@@ -1207,7 +1467,7 @@ def export_nvfp4_cb_streaming(
     if subset_prefixes is not None:
         outside = sorted(
             q for q in list(cb_targets) + list(source_targets)
-            + list(stock_targets)
+            + list(native_source_targets) + list(stock_targets)
             if not any(_base_name(q).startswith(p)
                        for p in subset_prefixes))
         if outside:
@@ -1554,11 +1814,16 @@ def export_nvfp4_cb_streaming(
     ignore: list[str] = []
     cb_targets_set = set(cb_targets)
     source_set = set(source_targets)
+    native_source_set = set(native_source_targets)
     stock_set = set(stock_targets)
     emitted_bases: set[str] = set()   # checkpoint tensor keys we consume
     cb_serialized_shapes: dict[str, tuple[int, ...]] = {}
     cb_output_tensor_names: set[str] = set()
     planned_cb_tensor_bytes = 0
+    # Physical tensor names each routed-expert target contributes, so the
+    # source_passthrough declaration and the route reconciliation describe what
+    # was actually planned rather than what the naming rules imply.
+    tensor_names_by_target: dict[str, list[str]] = {}
 
     # CB + FP8_SOURCE targets (keyed by canonical/recipe qname).
     for qname in list(cb_targets) + list(source_targets):
@@ -1583,7 +1848,7 @@ def export_nvfp4_cb_streaming(
                 export_base + ".weight_scale", torch.float32, ssh,
                 (lambda k=skey: skeleton.load(k).to(torch.float32)
                  .contiguous()))
-            counts["FP8_SOURCE"] += 1
+            counts[canonical_format_name(assignment[qname])] += 1
             continue
         grid, mode, k = cb_targets[qname]
         ref, fmt, codebook, _ = target_cb[qname]
@@ -1672,6 +1937,7 @@ def export_nvfp4_cb_streaming(
         elif _claimed_activation_contract is not None:
             expected.append((input_scale_name, torch.float32, (1,)))
             cb_output_tensor_names.add(input_scale_name)
+        tensor_names_by_target[qname] = [name for name, _d, _s in expected]
 
         # DELTA-EXPORT eligibility: same format + scheme signature + byte-equal
         # codebook + every planned output already present in the prior at the
@@ -1750,6 +2016,83 @@ def export_nvfp4_cb_streaming(
             if prior is not None:
                 reuse["encoded"] += 1
                 reuse["reasons"][reason] += 1
+        counts[fmt] += 1
+
+    # BYTE-VERBATIM source passthrough: the checkpoint's own element plane and
+    # its own scale plane, copied BYTE FOR BYTE under their CHECKPOINT names.
+    # Covers every format in `DELEGATED_NATIVE_PASSTHROUGH_FORMATS` — DSv4's
+    # nibble-packed MXFP4 routed experts and its UE8M0 block-FP8 body are the
+    # same wire contract at two element grids, so they are one branch.
+    #
+    # Three things this branch deliberately does NOT do, each differing from the
+    # CT-normalized FP8_SOURCE branch above for a stated reason:
+    #
+    #  * it does not widen the scale to F32. FP8_SOURCE renames
+    #    `.weight_scale_inv` -> `.weight_scale` and casts, because vLLM's stock
+    #    block-FP8 CT path reads an fp32 scale. Nothing reads an E8M0 plane
+    #    except the loader that wrote it, which wants the exponents it shipped;
+    #    casting would quadruple 12.5 GB of DSv4 scale bytes to buy a format no
+    #    consumer asked for. That is the whole reason these formats are separate
+    #    registry entries rather than FP8_SOURCE with a different scale dtype.
+    #  * it does not rename. The native DeepseekV4 loader resolves
+    #    `layers.N.ffn.experts.E.w{1,2,3}.{weight,scale}`; emitting the live
+    #    `model.layers.N.mlp.experts.…` spelling would produce an artifact whose
+    #    tensors nothing resolves.
+    #  * it does not add the target to `ignore`. `ignore` means "unquantized,
+    #    load it as-is"; these ARE quantized and are described by their own
+    #    config group — the same rule the FP8_SOURCE branch follows.
+    #
+    # The copy runs through `_LazySkeleton.raw_slice` + `_StreamWriter`'s
+    # chunked copy path, so no source tensor is ever materialised.
+    from prismaquant.cb_source_decode import checkpoint_weight_to_live_name
+
+    for qname in sorted(native_source_targets):
+        fmt = native_source_targets[qname]
+        spec = _fr_get_format(fmt)
+        wkey = _try_resolve_skeleton(qname, skeleton, profile)
+        if wkey is None:
+            raise ValueError(
+                f"{qname}: assigned {fmt} but no source tensor (tried the "
+                ".weight key + the profile-mapped checkpoint name). The "
+                "source-passthrough family is passthrough-only — never "
+                "synthesize it.")
+        live_weight = checkpoint_weight_to_live_name(wkey, profile=profile)
+        scale_entry = skeleton._fp8_scale_inv_map.get(live_weight)
+        skey = scale_entry[1] if scale_entry is not None else None
+        if skey is None or skey not in skeleton:
+            raise ValueError(
+                f"{qname}: assigned {fmt} but {wkey!r} has no resolved "
+                f"{spec.scale_dtype_name} scale sibling; an element plane "
+                "without its scale plane is not a loadable tensor.")
+        elements_per_byte = _PASSTHROUGH_ELEMENTS_PER_BYTE[
+            str(spec.weight_element_dtype)]
+        if elements_per_byte > 1:
+            # A SUB-BYTE element plane is not self-describing: its stored dtype
+            # is just "one byte". Only the checkpoint's own declaration
+            # (`autoscale.declared_fp4_expert_dtype`, surfaced as the scale
+            # map's `mxfp4_names`) says those bytes are packed nibbles, and the
+            # passthrough copies bytes it never interprets — so without the
+            # declaration it would happily ship reinterpreted garbage. A
+            # byte-per-element plane needs no such gate: its dtype IS the claim.
+            declared = getattr(
+                skeleton._fp8_scale_inv_map, "mxfp4_names", frozenset())
+            if live_weight not in declared:
+                raise ValueError(
+                    f"{qname}: assigned {fmt} but the checkpoint does not "
+                    f"DECLARE {wkey!r} as a packed sub-byte plane (config "
+                    "expert_dtype). A shape heuristic here would ship "
+                    "reinterpreted garbage.")
+        wsh = tuple(int(d) for d in skeleton.get_shape(wkey))
+        ssh = tuple(int(d) for d in skeleton.get_shape(skey))
+        wdtype = skeleton.get_dtype(wkey)
+        sdtype = skeleton.get_dtype(skey)
+        _assert_passthrough_planes_agree(
+            qname, fmt, spec, wkey, wsh, wdtype, skey, ssh, sdtype)
+        emitted_bases.add(wkey)
+        emitted_bases.add(skey)
+        writer.add(wkey, wdtype, wsh, None, copy_src=skeleton.raw_slice(wkey))
+        writer.add(skey, sdtype, ssh, None, copy_src=skeleton.raw_slice(skey))
+        tensor_names_by_target[qname] = [wkey, skey]
         counts[fmt] += 1
 
     # Stock-CT DENSE targets: analytic on-disk tensors packed RTN via the
@@ -1867,8 +2210,14 @@ def export_nvfp4_cb_streaming(
         else:
             ckpt_qname = None
         canon = _canonical_qname(ckpt_qname, profile) if ckpt_qname else None
+        # The byte-verbatim passthrough lane is in this test for the same
+        # reason FP8_SOURCE is: its tensors were already emitted (under their
+        # checkpoint names, so `emitted_bases` catches them too) and, more
+        # importantly, they must NOT land in `ignore`. A per-expert passthrough
+        # group is not collapsed, so every one of its 768 per-layer bases
+        # passes through this loop.
         if canon in cb_targets_set or canon in source_set \
-                or canon in stock_set:
+                or canon in native_source_set or canon in stock_set:
             continue
         shape = skeleton.get_shape(name)
         dtype = skeleton.get_dtype(name)
@@ -1964,10 +2313,118 @@ def export_nvfp4_cb_streaming(
             else qname
         )
 
+    def _decision_unit_id(qname: str) -> str:
+        """The unit id the declaration names this target by.
+
+        A UNIT is what the allocator decided atomically. For anything inside a
+        routed-expert group that is the experts MODULE, not the individual
+        Linear: the CB route names a packed parent (``…experts.gate_up_proj``)
+        while the delegated route names 768 per-expert leaves, and the two have
+        to collapse to the same id or "is this unit claimed twice?" cannot be
+        asked. Everything else — a dense body Linear on the UE8M0 lane — is its
+        own unit.
+        """
+        return _expert_group_of.get(qname, qname)
+
+    def _physical_expert_module(prefix: str) -> str | None:
+        """The SERIALIZED prefix K0.2 names this routed-expert group by.
+
+        The activation attestation is keyed by physical names
+        (``layers.7.ffn.experts``) while units are recipe names
+        (``model.layers.7.mlp.experts``); reconciling the two needs this bridge
+        and not a string heuristic. ``assume_resolvable`` is required because
+        the packed parent never exists on disk — the same reason
+        ``_base_name`` needs it for a collapsed CB stack.
+        """
+        for packed_proj in sorted(_packed_expert_param_names(profile)):
+            base = _export_base_name(
+                f"{prefix}.{packed_proj}", profile, skeleton,
+                assume_resolvable=True)
+            if "." in base:
+                return base.rsplit(".", 1)[0]
+        return None
+
+    def _source_passthrough_units() -> dict[str, str]:
+        """``{unit id: registry format}`` for every delegated unit, validated.
+
+        No exhaustiveness claim: this says which units ARE passthrough, not
+        that every unit in the model was enumerated. What it does enforce is
+        that a unit is passthrough WHOLE — a routed-expert group with some
+        members delegated and some not would ship half a layer to the model's
+        own loader and half to gridbook's codec, which neither can serve.
+        """
+        units: dict[str, str] = {}
+        for qname, fmt in native_source_targets.items():
+            unit = _decision_unit_id(qname)
+            previous = units.setdefault(unit, fmt)
+            if previous != fmt:
+                raise ValueError(
+                    f"{unit}: source-passthrough unit mixes {previous} and "
+                    f"{fmt}; a unit ships on ONE contract or the export cannot "
+                    "declare it")
+        for prefix, projs in expert_groups.items():
+            if prefix not in units:
+                continue
+            members = {member for proj in projs.values()
+                       for member in proj.values()}
+            delegated = {
+                member for member in members
+                if member in native_source_set
+                or (_canonical_qname(member, profile) or member)
+                in native_source_set
+            }
+            if delegated != members:
+                raise ValueError(
+                    f"{prefix}: {len(delegated)} of {len(members)} per-expert "
+                    "tensors are on a source passthrough; a delegated expert "
+                    "group is served whole by the model's own loader or not "
+                    "at all")
+        return units
+
+    def _route_reconciliation_sets(units):
+        """Collect the sets ``assert_routes_reconcile`` compares.
+
+        Kept beside the export because only here are BOTH namespaces in hand:
+        the declaration speaks recipe names and the config groups speak
+        serialized ones.
+        """
+        cb_units = {_decision_unit_id(qname) for qname in cb_targets}
+        cb_modules: set[str] = set()
+        passthrough_modules: set[str] = set()
+        for prefix in expert_groups:
+            physical = _physical_expert_module(prefix)
+            if physical is None:
+                continue
+            if prefix in units:
+                passthrough_modules.add(physical)
+            elif prefix in cb_units:
+                cb_modules.add(physical)
+        return {
+            "cb_units": cb_units,
+            "passthrough_units": set(units),
+            "cb_tensors": {
+                name for qname in cb_targets
+                for name in tensor_names_by_target.get(qname, ())
+            },
+            "passthrough_tensors": {
+                name for qname in native_source_targets
+                for name in tensor_names_by_target.get(qname, ())
+            },
+            "cb_modules": cb_modules,
+            "passthrough_modules": passthrough_modules,
+            "attested": set(routed_moe_attested_module_names(
+                activation_execution_contract)),
+        }
+
+    _declared_passthrough_units = _source_passthrough_units()
+    assert_routes_reconcile(
+        **_route_reconciliation_sets(_declared_passthrough_units))
+
     quant_config = build_quant_config(
         assignment=assignment,
         cb_targets=cb_targets,
         source_targets=source_targets,
+        native_source_targets=native_source_targets,
         stock_targets=stock_targets,
         by_group=by_group,
         codebooks=codebooks,
@@ -1985,6 +2442,11 @@ def export_nvfp4_cb_streaming(
         cb_target_name=_cb_target_name,
         delegated_target_name=_delegated_target_name,
         source_target_name=_delegated_target_name,
+        # The byte-verbatim lane keeps the CHECKPOINT spelling: those are the
+        # names its tensors were actually written under, above.
+        native_source_target_name=_base_name,
+        source_passthrough_units=_declared_passthrough_units,
+        route_pending_passthrough_acknowledged=sorted(route_pending),
         weight_only_stock_targets=sidecar_stock,
         streaming_provenance=True,
         include_tensor_formats=False,
@@ -2213,6 +2675,14 @@ def main(argv=None) -> None:
         "identity",
     )
     ap.add_argument(
+        "--allow-route-pending-passthrough",
+        action="store_true",
+        help="ship a source-passthrough rung whose serve route is not yet "
+        "validated (allocator_candidates.ROUTE_PENDING_PASSTHROUGH_FORMATS, "
+        "today MXFP4_SOURCE -> lane delegated_native_mxfp4). Refused by "
+        "default; the acknowledgement is recorded in the artifact provenance.",
+    )
+    ap.add_argument(
         "--scale-coding",
         default=cb.SCALE_CODING_TWO_TIER,
         choices=[cb.SCALE_CODING_V1, cb.SCALE_CODING_TWO_TIER],
@@ -2261,6 +2731,7 @@ def main(argv=None) -> None:
         subset_prefixes=args.subset_prefix, reuse_prior=reuse_prior,
         reuse_verify=reuse_verify,
         allow_unstamped_research=args.allow_unstamped_research,
+        allow_route_pending_passthrough=args.allow_route_pending_passthrough,
         activation_cache_dir=args.activation_cache_dir,
         activation_scale_policy=args.activation_scale_policy)
     size = sum(p.stat().st_size for p in Path(args.out).glob("*")) / 1e9

--- a/prismaquant/footprint.py
+++ b/prismaquant/footprint.py
@@ -628,12 +628,33 @@ def assignment_artifact_bytes(
     ``cb_serialization_context`` so a v1/v2 layout or sidecar sharing policy is
     never inferred silently.
     """
+    from prismaquant.allocator_candidates import SOURCE_PASSTHROUGH_FORMATS
+
     body_quant = 0
     cb_assignment: dict[str, str] = {}
     cb_shapes: dict[str, tuple[int, ...]] = {}
     reenc_by_name: dict[str, int] = {}
     priced: list[str] = []
     missing_stats: list[str] = []
+    passthrough_names: list[str] = []
+    # A source-passthrough unit ships the checkpoint's own bytes, so its
+    # contribution must be the SAME number this function subtracts from the
+    # floor for it. On the manifest path those are two different computations
+    # — ``resolve_reencoded_source_bytes`` reads real header spans while the
+    # body loop evaluates a closed form — and they only cancel if the format's
+    # arithmetic reproduces the checkpoint exactly. Resolve the spans FIRST so
+    # a passthrough is charged the measured span itself, and cross-check the
+    # closed form against it below rather than trusting either alone.
+    passthrough_spans: dict[str, int] = {}
+    if source_manifest is not None:
+        passthrough_names = [
+            qname for qname, fmt in assignment.items()
+            if (fr.canonical_format_name(fmt) if canonicalize else fmt)
+            in SOURCE_PASSTHROUGH_FORMATS
+        ]
+        if passthrough_names:
+            passthrough_spans = resolve_reencoded_source_bytes(
+                source_manifest, passthrough_names, context=context)
     for qname, fmt in assignment.items():
         entry = stats.get(qname)
         if entry is None and qname.endswith(".weight"):
@@ -643,7 +664,22 @@ def assignment_artifact_bytes(
             continue
         shape = _shape_from_stats(entry)
         name = fr.canonical_format_name(fmt) if canonicalize else fmt
-        if is_cb_format(name):
+        if name in SOURCE_PASSTHROUGH_FORMATS and qname in passthrough_spans:
+            span = int(passthrough_spans[qname])
+            closed_form = int(fr.get_format(name).memory_bytes_for_shape(shape))
+            if span != closed_form:
+                raise ValueError(
+                    f"[footprint] {context}: {qname} is assigned the "
+                    f"passthrough format {name}, whose exporter copies the "
+                    f"source slice VERBATIM, but the checkpoint's own bytes "
+                    f"for it ({span}) disagree with the format's accounting "
+                    f"({closed_form}). One of the two is wrong about this "
+                    "checkpoint, and shipping either number would make the "
+                    "artifact budget false — the floor subtracts the span "
+                    "while the body would add the closed form."
+                )
+            body_quant += span
+        elif is_cb_format(name):
             if cb_serialization_context is None:
                 raise ValueError(
                     f"[footprint] {context}: assignment contains {name} but "

--- a/prismaquant/format_registry.py
+++ b/prismaquant/format_registry.py
@@ -846,6 +846,87 @@ register_format(FormatSpec(
     activation_quantize_dequantize=lambda x: x.clone(),
 ))
 
+# Source-FP8 passthrough, UE8M0 block-scale variant — the DeepSeek-V3.1/V4
+# spelling of block-FP8. Same E4M3 element grid and same 128x128 block as
+# FP8_SOURCE, but the block scale is a ONE-BYTE unsigned E8M0 exponent
+# (config.json ``quantization_config.scale_fmt == "ue8m0"``) rather than the
+# FP32 ``weight_scale_inv`` plane FP8_SOURCE was written for.
+#
+# This is a DIFFERENT ON-DISK CONTRACT, not a cosmetic difference, which is why
+# it gets its own format instead of widening FP8_SOURCE:
+#
+#   * bytes. FP8_SOURCE charges 32 bits per 128x128 block (8.00195 bpw); this
+#     charges 8 (8.00049 bpw). Measured on DSv4-Flash: ``layers.0.attn.wo_a``
+#     is 33,554,432 weight bytes + 2,048 scale bytes, which is this formula
+#     exactly and NOT FP8_SOURCE's.
+#   * bit-exactness. The FP8_SOURCE export path widens its scale plane to FP32
+#     on write. Doing that here would quadruple the scale bytes and emit a
+#     tensor the checkpoint's own loader does not expect — the opposite of a
+#     passthrough.
+#
+# Serving: this is how the released checkpoint already serves, so the route is
+# native and BACKED today (allocator_candidates.SOURCE_PASSTHROUGH_CONTRACTS).
+register_format(FormatSpec(
+    name="FP8_BLOCK_UE8M0_SOURCE",
+    weight_bits=8, group_size=128, scale_bits=8,
+    scale_dtype_name="uint8_e8m0",
+    weight_element_dtype="fp8_e4m3",
+    scale_block_shape=(128, 128),
+    act_bits=None,
+    family="fp", min_capability_sm=89,
+    autoround_config=lambda: dict(bits=8, group_size=128,
+                                   data_type="fp8_e4m3", sym=True,
+                                   scale_fmt="ue8m0",
+                                   act_bits=16, act_data_type="float"),
+    quantize_dequantize=lambda w: w.clone(),
+    activation_quantize_dequantize=lambda x: x.clone(),
+))
+
+# Source-MXFP4 passthrough — the OCP-MX sibling of FP8_SOURCE, for models whose
+# ROUTED EXPERTS ship as nibble-packed E2M1 with per-32-block E8M0 scales
+# (DeepSeek-V4-Flash-0731: ``layers.N.ffn.experts.E.{w1,w3,w2}.{weight,scale}``,
+# I8 weight + F8_E8M0 scale, config ``expert_dtype: "fp4"``). When the allocator
+# picks this format the exporter STREAM-COPIES those source tensors verbatim —
+# no dequant, no re-encode, no CB stacking — and the serving side loads them on
+# the model's own native path rather than through a codebook decoder.
+#
+# WHY THE ACCOUNTING IS EXACT, NOT ESTIMATED. MXFP4 is a fixed-rate format, so
+# the generic FormatSpec arithmetic reproduces the checkpoint byte for byte:
+# for a [2048, 4096] expert projection, 2048*4096*4/8 = 4,194,304 weight bytes
+# plus 2048*(4096/32)*8/8 = 262,144 E8M0 scale bytes = 4,456,448 — precisely
+# the two source slices' sizes. ``memory_bytes_for_shape`` is therefore the
+# authoritative producer accountant here (unlike the CB families, whose
+# FormatSpec is deliberately only a nominal view), and
+# ``allocator_candidates.assert_source_passthrough_bytes_match_source`` pins
+# that identity against the real safetensors index before an allocation ships.
+#
+# WHY Δloss IS ZERO BY CONSTRUCTION. Every cost in this pipeline is measured
+# against the DEQUANTIZED SOURCE: the probe's BF16 view of an expert IS the
+# lossless dequant of exactly these bytes. Shipping them unchanged is the
+# identity transform on the reference, so there is nothing to measure and no
+# measurement branch to take — the candidate is priced 0.0 with provenance
+# ``cost_source="source_passthrough"`` (allocator_candidates
+# .SOURCE_PASSTHROUGH_FORMATS). This is the same claim FP8_SOURCE makes, one
+# element grid down; ``act_bits=None`` states the matching dtype-level fact
+# that this producer applies no activation quantization of its own, so the row
+# never enters P5a's activation calibration (its A side is the released
+# checkpoint's own contract, not a re-encode this pipeline chose).
+#
+# effective_bits = 4 + 8/32 = 4.25 bpw exactly.
+register_format(FormatSpec(
+    name="MXFP4_SOURCE",
+    weight_bits=4, group_size=32, scale_bits=8,
+    scale_dtype_name="uint8_e8m0",
+    weight_element_dtype="fp4_e2m1",
+    act_bits=None,
+    family="mx", min_capability_sm=100,
+    autoround_config=lambda: dict(bits=4, group_size=32,
+                                   data_type="fp4_e2m1", sym=True,
+                                   act_bits=16, act_data_type="float"),
+    quantize_dequantize=lambda w: w.clone(),
+    activation_quantize_dequantize=lambda x: x.clone(),
+))
+
 
 # GGUF k-quants (llama.cpp / vLLM-GGUF serving lane) — two-tier superblock
 # formats along the input dim: fp16 super-scale(s) per 256 + quantized

--- a/prismaquant/gridbook_runtime/gridbook_runtime_pin.json
+++ b/prismaquant/gridbook_runtime/gridbook_runtime_pin.json
@@ -1,6 +1,6 @@
 {
   "schema": "prismaquant.gridbook_runtime_pin.v1",
   "repository": "https://github.com/RobTand/gridbook.git",
-  "commit": "746473c8459acd24c71e7602d1c982da2f8fa80e",
+  "commit": "7c0b52764c9be7f813294e05c1b4c68d42ae840e",
   "version": "0.7.0"
 }

--- a/prismaquant/layer_config.py
+++ b/prismaquant/layer_config.py
@@ -58,6 +58,11 @@ _GGUF_FORMAT_NAMES = frozenset(
 # ladder is torch-free ``cb_layout.CB_FORMAT_NAMES``; do not rebuild it here.
 _NVFP4_CB_FORMAT_NAMES = CB_FORMAT_NAMES
 
+# Checkpoint ``quantization_config.scale_fmt`` spellings that mean a one-byte
+# UE8M0 block exponent. Kept as a literal so this module stays torch-free;
+# ``layer_streaming._E8M0_SCALE_FMTS`` is the decode-side twin.
+_UE8M0_SCALE_FMTS = frozenset({"ue8m0", "e8m0"})
+
 
 def canonicalize_format(entry: dict | str | int) -> str:
     """Map a layer-config entry to an export/runtime format name.
@@ -89,6 +94,22 @@ def canonicalize_format(entry: dict | str | int) -> str:
             return "NVFP4"
         if dt == "mx_fp" and bits == 4:
             return "MXFP4"
+        if dt == "fp4_e2m1" and bits == 4:
+            # MXFP4_SOURCE — the byte-verbatim OCP-MX passthrough, named by
+            # its ELEMENT dtype rather than by ``mx_fp`` precisely so it does
+            # not collide with MXFP4 (the rung this pipeline would re-encode
+            # itself). The distinction is not cosmetic: MXFP4 is a format the
+            # exporter produces, MXFP4_SOURCE is a claim that the checkpoint
+            # already ships these exact bytes and the exporter must copy them.
+            # group_size is part of the claim (OCP-MX blocks are 32), so a
+            # different one is a different contract, not a variant.
+            group_size = int(entry.get("group_size", 0))
+            if group_size != 32:
+                raise ValueError(
+                    "MXFP4_SOURCE is the OCP-MX group-of-32 passthrough; "
+                    f"got group_size={group_size} in {entry!r}"
+                )
+            return "MXFP4_SOURCE"
         if dt == "mx_fp" and bits == 8:
             elt = str(entry.get("weight_element_dtype", "fp8_e4m3")).lower()
             if elt == "fp8_e5m2":
@@ -99,6 +120,15 @@ def canonicalize_format(entry: dict | str | int) -> str:
         if dt == "fp8_e4m3" and bits == 8:
             group_size = int(entry.get("group_size", 0))
             if group_size == 128:
+                # Same E4M3 element grid and same 128x128 block, but the SCALE
+                # PLANE differs and that is the whole on-disk contract: a
+                # one-byte UE8M0 exponent (DeepSeek-V3.1/V4) is not the FP32
+                # weight_scale_inv plane FP8_SOURCE names, and the exporter
+                # widens the latter to FP32 on write. Reading them as one
+                # format would ship 4x the scale bytes in a layout the
+                # checkpoint's own loader does not expect.
+                if str(entry.get("scale_fmt", "")).lower() in _UE8M0_SCALE_FMTS:
+                    return "FP8_BLOCK_UE8M0_SOURCE"
                 return "FP8_SOURCE"
             if group_size == 32:
                 return "MXFP8_E4M3"
@@ -125,10 +155,20 @@ def canonicalize_format(entry: dict | str | int) -> str:
             return value.upper()
         if value in ("nvfp4", "fp4", "4"):
             return "NVFP4"
+        if value in ("mxfp4_source", "mx_fp4_source"):
+            # Checked BEFORE the plain MXFP4 spellings: a substring-free
+            # equality test would still pass either way, but keeping the
+            # narrower claim first documents that the two are different
+            # contracts rather than aliases.
+            return "MXFP4_SOURCE"
         if value in ("mxfp4", "mx_fp4"):
             return "MXFP4"
         if value in ("mxfp8", "mxfp8_e4m3"):
             return "MXFP8_E4M3"
+        if value in ("fp8_block_ue8m0_source", "fp8_block_ue8m0"):
+            return "FP8_BLOCK_UE8M0_SOURCE"
+        if value in ("fp8_source", "fp8_block_source"):
+            return "FP8_SOURCE"
         if value in ("fp8", "fp8_dynamic", "fp8_e4m3", "fp8_e4m3fn", "8"):
             return "FP8_E4M3"
         if value in ("mxfp8_e5m2", "mx_fp8_e5m2"):

--- a/prismaquant/measure_quant_cost.py
+++ b/prismaquant/measure_quant_cost.py
@@ -323,13 +323,24 @@ def _extrapolate_expert_costs(
             results[name] = merged
 
 
+# Provenance stamped on a cost row the RD-ladder fitted rather than measured
+# (``PRISMAQUANT_CB_LADDER_INTERP=1``). The row survived that tensor's own
+# holdout gate — a tensor whose law is rejected has its predicted rungs
+# MEASURED instead (see the ladder block in ``measure_batched_gpu``) — so this
+# marks "fitted and validated", not "guessed". The allocator reports it per
+# selected rung so a shipped artifact can say which of its chosen prices were
+# interpolated.
+BAND_INTERPOLATED_COST_SOURCE = "band_interpolated"
+
+
 def _accumulate_result(bucket: dict, name: str, fmt: str,
                        weight_mse: float, output_mse: float,
                        rel_output_mse: float,
                        predicted_dloss: float | None = None,
                        fisher_output_mse: float | None = None,
                        output_mse_measured: bool = True,
-                       n_activation_rows: int | None = None):
+                       n_activation_rows: int | None = None,
+                       cost_source: str | None = None):
     per_name = bucket.setdefault(name, {})
     acc = per_name.setdefault(fmt, {
         "_count": 0,
@@ -342,8 +353,17 @@ def _accumulate_result(bucket: dict, name: str, fmt: str,
         "_fisher_output_mse_count": 0,
         "_output_mse_measured": True,
         "_n_activation_rows": None,
+        "_cost_source": None,
     })
     acc["_count"] += 1
+    if cost_source is not None:
+        # Provenance of the NUMBER, not of the measurement quality:
+        # ``output_mse_measured=False`` already says "no output measurement",
+        # but it cannot distinguish a ladder-interpolated row from a
+        # packed-expert row whose routed forward could not be reconstructed.
+        # A rung that the DP later selects must be able to say which of the
+        # two it was.
+        acc["_cost_source"] = str(cost_source)
     if n_activation_rows is not None:
         prev = acc.get("_n_activation_rows")
         acc["_n_activation_rows"] = (
@@ -378,6 +398,7 @@ def _finalize_results(bucket: dict[str, dict]) -> dict[str, dict]:
             fisher_sum = acc.pop("_fisher_output_mse_sum", 0.0)
             output_mse_measured = bool(acc.pop("_output_mse_measured", True))
             n_act_rows = acc.pop("_n_activation_rows", None)
+            cost_source = acc.pop("_cost_source", None)
             entry = {
                 "weight_mse": acc.pop("_weight_mse_sum") / n,
                 "output_mse": acc.pop("_output_mse_sum") / n,
@@ -385,6 +406,8 @@ def _finalize_results(bucket: dict[str, dict]) -> dict[str, dict]:
             }
             if not output_mse_measured:
                 entry["output_mse_measured"] = False
+            if cost_source is not None:
+                entry["cost_source"] = cost_source
             if n_act_rows is not None:
                 # How many activation rows the output-side numbers rest on.
                 # The allocator/provenance needs this to tell a well-covered
@@ -2286,6 +2309,7 @@ def measure_batched_gpu(model: nn.Module, act_cache: "ActivationIndex",
                                 predicted_dloss=fills["predicted_dloss"],
                                 fisher_output_mse=fills["fisher_output_mse"],
                                 output_mse_measured=False,
+                                cost_source=BAND_INTERPOLATED_COST_SOURCE,
                             )
                     if fail_idx:
                         ladder_reject += len(fail_idx)

--- a/prismaquant/nvfp4_activation_contract.py
+++ b/prismaquant/nvfp4_activation_contract.py
@@ -847,6 +847,53 @@ def routed_moe_stages_sha256(
     return digest.hexdigest()
 
 
+def routed_moe_attested_module_names(
+    record: Mapping[str, Any] | None,
+) -> tuple[str, ...]:
+    """The routed-MoE modules an execution-contract record actually attests.
+
+    ONE definition of "what is in K0.2's scope", read off the record rather
+    than re-derived from the assignment, so the producer's reconciliation and
+    a consumer's audit cannot disagree about it.  ``()`` means the record
+    attests no routed-MoE module at all — either it is dense-only or it is
+    absent.
+
+    THE SCOPE PROBLEM THIS EXISTS FOR.  :func:`build_routed_moe_stage_attestation`
+    can only attest a module that CONTRIBUTED a calibrated fp4 stage scalar.  A
+    routed-expert layer that ships on a source-passthrough rung
+    (``MXFP4_SOURCE``: the checkpoint's own bytes, served by the model's native
+    kernel) has no CB activation contract to attest and is therefore simply
+    ABSENT here — which, read alone, is indistinguishable from a partial or
+    failed export that dropped a module it should have calibrated.  The
+    completeness guard below cannot close that: it only fires for a module that
+    reached the record with ONE of its two stages.
+
+    The gap is closed OUTSIDE this record, deliberately, by the top-level
+    ``source_passthrough`` declaration
+    (``cb_export_config.build_source_passthrough_declaration``): it positively
+    names every unit handed to the model's own loader, and
+    ``export_nvfp4_cb_streaming.assert_routes_reconcile`` proves that scope is
+    disjoint from this one before an artifact ships.  The K0.2 record's own
+    field set stays byte-identical, because it is a pinned cross-repository
+    contract whose consumer rejects unknown keys outright
+    (tests/test_gridbook_attestation_interop.py) — widening it "additively" is
+    exactly the failure that test exists to catch.
+    """
+
+    if not isinstance(record, Mapping):
+        return ()
+    section = record.get(NVFP4_ROUTED_MOE_STAGE_KEY)
+    if not isinstance(section, Mapping):
+        return ()
+    names = section.get("module_names")
+    if not isinstance(names, (list, tuple)):
+        raise ValueError(
+            "routed-MoE stage section has no module_names list; refusing to "
+            "guess the attested scope"
+        )
+    return tuple(str(name) for name in names)
+
+
 def build_routed_moe_stage_attestation(
     scales: Mapping[str, float],
     *,
@@ -863,6 +910,10 @@ def build_routed_moe_stage_attestation(
     reaches export with only one attested stage: that is precisely the state
     the existing partial LFM artifact is in, and no artifact may claim
     fused-MoE readiness from it.
+
+    What it CANNOT see is a routed-expert layer that contributed no stage at
+    all — see :func:`routed_moe_attested_module_names` for why that is not this
+    record's job to declare, and where it is declared instead.
     """
 
     mapper = target_name or (lambda name: name)
@@ -1169,6 +1220,7 @@ __all__ = [
     "nvfp4_activation_qdq_served",
     "resolve_input_global_scale_policy",
     "resolve_input_global_scale_value",
+    "routed_moe_attested_module_names",
     "routed_moe_stage",
     "routed_moe_stages_sha256",
     "select_mse_grid_input_global_scale",

--- a/prismaquant/serving_profile_specs/nvfp4_cb.json
+++ b/prismaquant/serving_profile_specs/nvfp4_cb.json
@@ -6,8 +6,13 @@
   "export_lane": {
     "id": "nvfp4_cb",
     "exporter": "prismaquant.export_nvfp4_cb",
-    "codec_formats_from": ["prismaquant.export_nvfp4_cb:EXPORTABLE_FORMATS"],
-    "passthrough_formats": ["MXFP4_SOURCE", "FP8_BLOCK_UE8M0_SOURCE"],
+    "codec_formats_from": [
+      "prismaquant.export_nvfp4_cb:EXPORTABLE_FORMATS"
+    ],
+    "passthrough_formats": [
+      "MXFP4_SOURCE",
+      "FP8_BLOCK_UE8M0_SOURCE"
+    ],
     "reason": "exporter_cannot_emit",
     "detail": "The exporter's codec surface remains the structural upper bound: NVFP4_CB_K12..K24, research-compatible NVFP4_CB_S13..S16, FP8_CB_K28..K48, delegated NVFP4/FP8_DYNAMIC, FP8_SOURCE, and BF16. The production format rule below deliberately narrows that emittable set by excluding signed S13..S16; their decoder/export support remains available for legacy and explicitly research-scoped artifacts. INT4_W4A16 remains a registry-only research format until the approved Gridbook-owned packing/profile/loader/delegation work is implemented and validated. Anything outside the exporter declaration hard-fails rather than silently BF16-coercing a Linear and blowing the allocated byte budget."
   },
@@ -26,7 +31,7 @@
         "BF16"
       ],
       "reason": "profile_mismatch",
-      "detail": "The production nvfp4_cb menu carries product-VQ NVFP4_CB_K12..K24 (fp4/E2M1 grid, two-tier-v2 serialized rate 1.78125..3.28125 bpw), product-VQ FP8_CB_K28..K48 (fp8/E4M3 grid, 3.5..6.0 index bpw plus the serialized per-output FP32 scale), and the native carriers. Signed S13..S16 remain codec-compatible but are research-only after losing 78.48% (609/776) of matched weight-MSE comparisons, so this production rule excludes them. Plain NVFP4 is W4A4 and FP8_DYNAMIC/FP8-CB are W8A8; comparisons therefore name the full activation/backend contract. FP8_SOURCE, FP8_BLOCK_UE8M0_SOURCE and MXFP4_SOURCE are passthrough-only and BF16 is unquantized passthrough. The three SOURCE carriers are a FAMILY, not three special cases: each ships the checkpoint's own bytes for the units whose source already IS that format, and allocator_candidates.SOURCE_PASSTHROUGH_CONTRACTS is the one table that says which source kind each requires. That source-kind gate — not this allow-list — is what keeps MXFP4_SOURCE off a bf16 embedding and BF16 off an mxfp4 expert; the entries here only state that the container can carry them at all. FP8_BLOCK_UE8M0_SOURCE is the DeepSeek-V3.1/V4 block-FP8 spelling (E4M3 elements, ONE-BYTE UE8M0 block exponents, 8.00049 bpw) and is deliberately distinct from FP8_SOURCE's FP32 weight_scale_inv plane (8.00195 bpw): same element grid, different on-disk contract, different byte count, and FP8_SOURCE's exporter widens its scale plane to FP32, which on a UE8M0 checkpoint would quadruple the scale bytes and emit a tensor the model's own loader does not expect. This allow-list proves only exporter/runtime legality; served KL/PPL and phase-specific performance remain external release gates recorded by the native-parity benchmark protocol."
+      "detail": "The production nvfp4_cb menu carries product-VQ NVFP4_CB_K12..K24 (fp4/E2M1 grid, two-tier-v2 serialized rate 1.78125..3.28125 bpw), product-VQ FP8_CB_K28..K48 (fp8/E4M3 grid, 3.5..6.0 index bpw plus the serialized per-output FP32 scale), and the native carriers. Signed S13..S16 remain codec-compatible but are research-only after losing 78.48% (609/776) of matched weight-MSE comparisons, so this production rule excludes them. Plain NVFP4 is W4A4 and FP8_DYNAMIC/FP8-CB are W8A8; comparisons therefore name the full activation/backend contract. FP8_SOURCE, FP8_BLOCK_UE8M0_SOURCE and MXFP4_SOURCE are passthrough-only and BF16 is unquantized passthrough. The three SOURCE carriers are a FAMILY, not three special cases: each ships the checkpoint's own bytes for the units whose source already IS that format, and allocator_candidates.SOURCE_PASSTHROUGH_CONTRACTS is the one table that says which source kind each requires. That source-kind gate \u2014 not this allow-list \u2014 is what keeps MXFP4_SOURCE off a bf16 embedding and BF16 off an mxfp4 expert; the entries here only state that the container can carry them at all. FP8_BLOCK_UE8M0_SOURCE is the DeepSeek-V3.1/V4 block-FP8 spelling (E4M3 elements, ONE-BYTE UE8M0 block exponents, 8.00049 bpw) and is deliberately distinct from FP8_SOURCE's FP32 weight_scale_inv plane (8.00195 bpw): same element grid, different on-disk contract, different byte count, and FP8_SOURCE's exporter widens its scale plane to FP32, which on a UE8M0 checkpoint would quadruple the scale bytes and emit a tensor the model's own loader does not expect. This allow-list proves only exporter/runtime legality; served KL/PPL and phase-specific performance remain external release gates recorded by the native-parity benchmark protocol."
     },
     {
       "id": "cb_packed_expert_stock_ct_unsupported",
@@ -69,7 +74,7 @@
       ],
       "out_features_multiple_of": 8,
       "reason": "kernel_shape",
-      "detail": "Gridbook's fp4-CB N-dimension load gate: the decode/expand kernels and the NVFP4 buffers they write tile the OUTPUT dim in groups of 8 rows, so a Linear with out_features % 8 != 0 has no fp4-CB load path at all. Modelling only the K % 256 superblock rule let the allocator legally assign a rung whose serving lane does not exist (gridbook docs/audits/ultraplan_perf_2026-08-01.md §6, cost-model asymmetry 3); this is the producer-side mirror of that load gate, so the DP can no longer spend budget on an unloadable shape."
+      "detail": "Gridbook's fp4-CB N-dimension load gate: the decode/expand kernels and the NVFP4 buffers they write tile the OUTPUT dim in groups of 8 rows, so a Linear with out_features % 8 != 0 has no fp4-CB load path at all. Modelling only the K % 256 superblock rule let the allocator legally assign a rung whose serving lane does not exist (gridbook docs/audits/ultraplan_perf_2026-08-01.md \u00a76, cost-model asymmetry 3); this is the producer-side mirror of that load gate, so the DP can no longer spend budget on an unloadable shape."
     },
     {
       "id": "cb_fp8_out_features_load_gate",
@@ -78,7 +83,7 @@
       ],
       "out_features_multiple_of": 16,
       "reason": "kernel_shape",
-      "detail": "Gridbook's fp8-CB N-dimension load gate: the fp8-CB expand/fused prologue writes E4M3 buffers in 16-row output groups (one FP32 weight_scale per output row, packed 16 rows at a time), so a Linear with out_features % 16 != 0 has no fp8-CB load path. The gate is DIFFERENT from the fp4 family's (8) and both are grid facts, not policy — declared per grid from cb_layout's family table so a new rung inherits its family's gate automatically."
+      "detail": "Gridbook's fp8-CB N-dimension load gate: the fp8-CB expand/fused prologue writes E4M3 buffers in 16-row output groups (one FP32 weight_scale per output row, packed 16 rows at a time), so a Linear with out_features % 16 != 0 has no fp8-CB load path. The gate is DIFFERENT from the fp4 family's (8) and both are grid facts, not policy \u2014 declared per grid from cb_layout's family table so a new rung inherits its family's gate automatically."
     }
   ],
   "serving_lanes": [
@@ -88,8 +93,8 @@
         "FP8_BLOCK_UE8M0_SOURCE"
       ],
       "activation_contract": "w8a8-dynamic-e4m3-block128-ue8m0",
-      "fallback_route": "delegated_native_fp8_block (the model's own block-FP8 path; no Gridbook codec in the dispatch)",
-      "detail": "SOURCE-PASSTHROUGH lane, not a CB one: the artifact ships the checkpoint's own E4M3 bytes and UE8M0 block exponents unchanged, and the serving side loads them exactly as it loads the released checkpoint. That is what makes this route BACKED without a new kernel — it is the route the source already serves on, so 'does a serve path exist' is answered by the model running at all. There is deliberately no fused_mid_m block: a passthrough rung has no Gridbook decode prologue to fuse, so an empty backed set here is the honest state rather than a data gap, and it resolves with rungs_source=lane_declares_no_fused_mid_m_lane. Byte contract: 8 bits/element plus one UE8M0 byte per 128x128 block = 8.00049 bpw, which the producer pins against the checkpoint's own header spans before an allocation ships (footprint.assignment_artifact_bytes refuses a span/closed-form disagreement)."
+      "fallback_route": "route_blocked on sm121 (deep_gemm assert / cutlass scaled_mm reject / triton float8_e8m0fnu KeyError / flashinfer sm90-exact gate / marlin-linear <=sm89)",
+      "detail": "SOURCE-PASSTHROUGH lane for the checkpoint's own block-FP8 body: E4M3 elements with ONE-BYTE UE8M0 block exponents at 128x128, copied verbatim. ROUTE STATUS: BLOCKED. The intuition that 'the released checkpoint already serves this way, so the route must exist' is measurably FALSE on our target -- on GB10/sm121, 2026-08-03, every route was tried and every route is dead: deep_gemm asserts, cutlass scaled_mm rejects the block layout, triton raises KeyError on float8_e8m0fnu, flashinfer's gate is sm90-exact, and marlin-linear tops out at sm89. THE CONSEQUENCE IS ARCHITECTURAL: CB re-encoding of the body is the only way DSV4-Flash serves on this box at all, so the body's CB rungs are load-bearing rather than merely economical. The rung stays on the menu deliberately -- if the DP still wants it, that is the serving gap surfacing in the allocation instead of at deploy time -- but the exporter refuses to ship a selection containing it without an explicit override. Byte contract: 8.00049 bpw, pinned against the checkpoint's own header spans."
     },
     {
       "id": "delegated_native_mxfp4",
@@ -97,8 +102,8 @@
         "MXFP4_SOURCE"
       ],
       "activation_contract": "delegated-native-mxfp4-e2m1-group32-ue8m0",
-      "fallback_route": "route_pending (no validated Gridbook dispatch; the model's own routed-expert MXFP4 loader is the intended path)",
-      "detail": "SOURCE-PASSTHROUGH lane for the released checkpoint's own packed routed experts: nibble-packed E2M1 with per-32 E8M0 group scales, copied verbatim, served by the model's native DeepseekV4 routed-expert path rather than by any codebook decoder. It is declared as a DISTINCT lane precisely so P5b accounting never files these units under a CB contract they do not have — a unit on this lane has no CB activation contract at all, which is also why the K0.2 attestation scopes itself to CB layers and the artifact declares the source-passthrough groups explicitly rather than leaving them looking like a missing attestation. ROUTE STATUS: pending. The loader side is being built across the repo boundary and has not been serve-validated here, so allocator_candidates.ROUTE_PENDING_PASSTHROUGH_FORMATS lists this format and the exporter refuses to ship a selection containing it without an explicit override. The rung stays ON the menu regardless: an allocator that wants a route-pending passthrough is reporting a serving gap worth seeing, and masking the rung would hide exactly that signal while also removing the unit's only zero-error option. No fused_mid_m block, for the same reason as the lane above."
+      "fallback_route": "vllm Marlin MoE (REQUIRES --moe-backend marlin; the auto default DeepGEMM_MXFP4 asserts on sm121)",
+      "detail": "SOURCE-PASSTHROUGH lane for the released checkpoint's own packed routed experts: nibble-packed E2M1 with per-32 E8M0 group scales, copied verbatim, served by the model's native DeepseekV4 routed-expert path rather than by any codebook decoder. Declared as a DISTINCT lane so P5b never files these units under a CB contract they do not have -- a unit here has no CB activation contract at all, which is why the K0.2 attestation scopes itself to CB layers and the artifact declares its source-passthrough units explicitly rather than leaving them looking like a missing attestation. ROUTE STATUS: BACKED, measured on GB10/sm121 2026-08-03 -- native-confirmed via vLLM Marlin MoE. But ONLY off the default: the auto-selected DeepGEMM_MXFP4 backend asserts on the SF transformation, FlashInfer is gated to capability family 100, and the OAI Triton path is hard-excluded on SM12x (0/15 kernels). `--moe-backend marlin` is therefore part of the serving contract, not a tuning hint, and it travels with the artifact in its serving notes. No fused_mid_m block: a passthrough rung has no Gridbook decode prologue to fuse, so an empty backed set is the honest state, not a data gap."
     },
     {
       "id": "nvfp4_cb_quality_path",
@@ -108,10 +113,13 @@
       "activation_contract": "w4-bf16-bridge",
       "fallback_route": "cb_expand_fp4_v2 -> cb_bf16_grouped_gemm (CUTLASS 2.x DefaultGemmGrouped, arch::Sm80)",
       "fused_mid_m": {
-        "m_range": [9, 128],
+        "m_range": [
+          9,
+          128
+        ],
         "rungs_by_runtime_version": {}
       },
-      "detail": "The DEFAULT fp4-CB serving contract is NOT W4A4: for all dense M > 8 and all MoE T > 16 the rung expands to BF16 (2 bytes/weight) and feeds an Ampere-schedule grouped GEMM, so the served activation contract is the fp32-emulated group-16 RTN QDQ with a BF16 bridge, and there is no fused mid-M lane at any rung (gridbook ultraplan §2 causes b and c; the true-W4A4 fused kernel stays behind PRISMAQUANT_CB_FUSED_FP4[_MOE] and its six reconsideration gates, so it is deliberately absent from the backed set below). An empty rungs_by_runtime_version means every fp4-CB rung rides the fallback route — which is the honest current state, not a data gap. Gridbook 0.6.0 adds a SECOND fp4 fused route that is not the same thing as the one above: a contract-preserving decode-in-prologue mid-M lane (csrc/cb_fused_fp4v2_gemm.cu, dense-only, 9 <= M <= 128, decoded weights bit-identical to cb_expand_v2 at all 13 K12..K24 rungs so only the FP32 reduction order moves, measured 1.06-4.37x the bridge). It shipped OPT-IN behind PRISMAQUANT_CB_FP4_FUSED_MIDM=1 pending the served NATIVE-PARITY gate, and with the flag unset the dispatch is byte-for-byte the bridge. It REMAINS opt-in at Gridbook 0.7.0 — the version this release pins — with the flag and its gate unchanged (gridbook/fp4v2_fused_midm_lane.py), because 0.7.0's content is the deepseek_v4 serving contract (D0.1) and the post-0.6.0 review remediation, neither of which runs that gate. This spec's backed set describes what the DEFAULT contract serves, so it stays EMPTY for every fp4-CB rung: an opt-in route the operator must set an env flag to reach is available, not backed, and pricing a rung on a lane the default serve never takes is the exact P5b defect this data exists to prevent. Revisit only when that lane becomes default."
+      "detail": "The DEFAULT fp4-CB serving contract is NOT W4A4: for all dense M > 8 and all MoE T > 16 the rung expands to BF16 (2 bytes/weight) and feeds an Ampere-schedule grouped GEMM, so the served activation contract is the fp32-emulated group-16 RTN QDQ with a BF16 bridge, and there is no fused mid-M lane at any rung (gridbook ultraplan \u00a72 causes b and c; the true-W4A4 fused kernel stays behind PRISMAQUANT_CB_FUSED_FP4[_MOE] and its six reconsideration gates, so it is deliberately absent from the backed set below). An empty rungs_by_runtime_version means every fp4-CB rung rides the fallback route \u2014 which is the honest current state, not a data gap. Gridbook 0.6.0 adds a SECOND fp4 fused route that is not the same thing as the one above: a contract-preserving decode-in-prologue mid-M lane (csrc/cb_fused_fp4v2_gemm.cu, dense-only, 9 <= M <= 128, decoded weights bit-identical to cb_expand_v2 at all 13 K12..K24 rungs so only the FP32 reduction order moves, measured 1.06-4.37x the bridge). It shipped OPT-IN behind PRISMAQUANT_CB_FP4_FUSED_MIDM=1 pending the served NATIVE-PARITY gate, and with the flag unset the dispatch is byte-for-byte the bridge. It REMAINS opt-in at Gridbook 0.7.0 \u2014 the version this release pins \u2014 with the flag and its gate unchanged (gridbook/fp4v2_fused_midm_lane.py), because 0.7.0's content is the deepseek_v4 serving contract (D0.1) and the post-0.6.0 review remediation, neither of which runs that gate. This spec's backed set describes what the DEFAULT contract serves, so it stays EMPTY for every fp4-CB rung: an opt-in route the operator must set an env flag to reach is available, not backed, and pricing a rung on a lane the default serve never takes is the exact P5b defect this data exists to prevent. Revisit only when that lane becomes default."
     },
     {
       "id": "fp8_cb_fused_mid_m",
@@ -121,14 +129,38 @@
       "activation_contract": "w8a8-dynamic-e4m3",
       "fallback_route": "cb_expand_fp8 -> cutlass_scaled_mm (expand+GEMM, transient E4M3 round trip)",
       "fused_mid_m": {
-        "m_range": [9, 128],
+        "m_range": [
+          9,
+          128
+        ],
         "rungs_by_runtime_version": {
-          "0.5.0": [28, 32, 36, 40, 44, 48],
-          "0.6.0": [28, 32, 36, 40, 44, 48],
-          "0.7.0": [28, 32, 36, 40, 44, 48]
+          "0.5.0": [
+            28,
+            32,
+            36,
+            40,
+            44,
+            48
+          ],
+          "0.6.0": [
+            28,
+            32,
+            36,
+            40,
+            44,
+            48
+          ],
+          "0.7.0": [
+            28,
+            32,
+            36,
+            40,
+            44,
+            48
+          ]
         }
       },
-      "detail": "fp8-CB's fused prologue kernel consumes the SAME per-token dynamic E4M3 QDQ as its non-fused route, so the fused mid-M lane (9 <= M <= 128, measured 1.04x/1.26x/1.45x at M = 32/64/128) is a pure kernel substitution and ships as DEFAULT — but only for the rungs the consumer actually instantiates. Gridbook 0.5.0 instantiates K in {28,32,36,40,44,48} while production permits every K28..K48, so the published 27B K36..K47 ladder has five rungs silently taking expand+GEMM (gridbook ROADMAP K1.2 / ultraplan §3 P4). Gridbook 0.6.0 RESOLVED K1.2 and the set is unchanged because it was never incomplete: k % 4 == 0 is a structural law of the format plus TMA, not a build option — type_size = 4k is the packed-B TMA box's contiguous extent and must be a 16-byte multiple, and the fused mainloop decodes with one sub-table width CbSubW = k/4 while the format splits k over n_sub = 4 RAGGEDLY (widths k//4 + (i < k%4)), so at k37 the true widths are (10,9,9,9) and a uniform decode would be WRONG, not merely unaligned. The five off-law rungs on the 27B ladder are therefore permanently fallback-served, not pending. 0.6.0 also makes the set queryable (cb_fused_kbits(), gridbook/codec.py FP8_FUSED_KBITS) so it is a checked law rather than a transcription. Gridbook 0.7.0 declares the SAME set a third time, and for the same structural reason: FP8_FUSED_KBITS is still range(28, 49, 4) there, and 0.7.0's content (the deepseek_v4 serving contract D0.1, plus the post-0.6.0 review remediation) does not touch the fused mid-M rung law. When the runtime pin advances, ADD the version key rather than editing an existing list — a pinned version with no key here backs nothing, which is the fail-closed direction."
+      "detail": "fp8-CB's fused prologue kernel consumes the SAME per-token dynamic E4M3 QDQ as its non-fused route, so the fused mid-M lane (9 <= M <= 128, measured 1.04x/1.26x/1.45x at M = 32/64/128) is a pure kernel substitution and ships as DEFAULT \u2014 but only for the rungs the consumer actually instantiates. Gridbook 0.5.0 instantiates K in {28,32,36,40,44,48} while production permits every K28..K48, so the published 27B K36..K47 ladder has five rungs silently taking expand+GEMM (gridbook ROADMAP K1.2 / ultraplan \u00a73 P4). Gridbook 0.6.0 RESOLVED K1.2 and the set is unchanged because it was never incomplete: k % 4 == 0 is a structural law of the format plus TMA, not a build option \u2014 type_size = 4k is the packed-B TMA box's contiguous extent and must be a 16-byte multiple, and the fused mainloop decodes with one sub-table width CbSubW = k/4 while the format splits k over n_sub = 4 RAGGEDLY (widths k//4 + (i < k%4)), so at k37 the true widths are (10,9,9,9) and a uniform decode would be WRONG, not merely unaligned. The five off-law rungs on the 27B ladder are therefore permanently fallback-served, not pending. 0.6.0 also makes the set queryable (cb_fused_kbits(), gridbook/codec.py FP8_FUSED_KBITS) so it is a checked law rather than a transcription. Gridbook 0.7.0 declares the SAME set a third time, and for the same structural reason: FP8_FUSED_KBITS is still range(28, 49, 4) there, and 0.7.0's content (the deepseek_v4 serving contract D0.1, plus the post-0.6.0 review remediation) does not touch the fused mid-M rung law. When the runtime pin advances, ADD the version key rather than editing an existing list \u2014 a pinned version with no key here backs nothing, which is the fail-closed direction."
     }
   ]
 }

--- a/prismaquant/serving_profile_specs/nvfp4_cb.json
+++ b/prismaquant/serving_profile_specs/nvfp4_cb.json
@@ -7,6 +7,7 @@
     "id": "nvfp4_cb",
     "exporter": "prismaquant.export_nvfp4_cb",
     "codec_formats_from": ["prismaquant.export_nvfp4_cb:EXPORTABLE_FORMATS"],
+    "passthrough_formats": ["MXFP4_SOURCE", "FP8_BLOCK_UE8M0_SOURCE"],
     "reason": "exporter_cannot_emit",
     "detail": "The exporter's codec surface remains the structural upper bound: NVFP4_CB_K12..K24, research-compatible NVFP4_CB_S13..S16, FP8_CB_K28..K48, delegated NVFP4/FP8_DYNAMIC, FP8_SOURCE, and BF16. The production format rule below deliberately narrows that emittable set by excluding signed S13..S16; their decoder/export support remains available for legacy and explicitly research-scoped artifacts. INT4_W4A16 remains a registry-only research format until the approved Gridbook-owned packing/profile/loader/delegation work is implemented and validated. Anything outside the exporter declaration hard-fails rather than silently BF16-coercing a Linear and blowing the allocated byte budget."
   },
@@ -20,10 +21,12 @@
         "NVFP4",
         "FP8_DYNAMIC",
         "FP8_SOURCE",
+        "FP8_BLOCK_UE8M0_SOURCE",
+        "MXFP4_SOURCE",
         "BF16"
       ],
       "reason": "profile_mismatch",
-      "detail": "The production nvfp4_cb menu carries product-VQ NVFP4_CB_K12..K24 (fp4/E2M1 grid, two-tier-v2 serialized rate 1.78125..3.28125 bpw), product-VQ FP8_CB_K28..K48 (fp8/E4M3 grid, 3.5..6.0 index bpw plus the serialized per-output FP32 scale), and the native carriers. Signed S13..S16 remain codec-compatible but are research-only after losing 78.48% (609/776) of matched weight-MSE comparisons, so this production rule excludes them. Plain NVFP4 is W4A4 and FP8_DYNAMIC/FP8-CB are W8A8; comparisons therefore name the full activation/backend contract. FP8_SOURCE is passthrough-only and BF16 is unquantized passthrough. This allow-list proves only exporter/runtime legality; served KL/PPL and phase-specific performance remain external release gates recorded by the native-parity benchmark protocol."
+      "detail": "The production nvfp4_cb menu carries product-VQ NVFP4_CB_K12..K24 (fp4/E2M1 grid, two-tier-v2 serialized rate 1.78125..3.28125 bpw), product-VQ FP8_CB_K28..K48 (fp8/E4M3 grid, 3.5..6.0 index bpw plus the serialized per-output FP32 scale), and the native carriers. Signed S13..S16 remain codec-compatible but are research-only after losing 78.48% (609/776) of matched weight-MSE comparisons, so this production rule excludes them. Plain NVFP4 is W4A4 and FP8_DYNAMIC/FP8-CB are W8A8; comparisons therefore name the full activation/backend contract. FP8_SOURCE, FP8_BLOCK_UE8M0_SOURCE and MXFP4_SOURCE are passthrough-only and BF16 is unquantized passthrough. The three SOURCE carriers are a FAMILY, not three special cases: each ships the checkpoint's own bytes for the units whose source already IS that format, and allocator_candidates.SOURCE_PASSTHROUGH_CONTRACTS is the one table that says which source kind each requires. That source-kind gate — not this allow-list — is what keeps MXFP4_SOURCE off a bf16 embedding and BF16 off an mxfp4 expert; the entries here only state that the container can carry them at all. FP8_BLOCK_UE8M0_SOURCE is the DeepSeek-V3.1/V4 block-FP8 spelling (E4M3 elements, ONE-BYTE UE8M0 block exponents, 8.00049 bpw) and is deliberately distinct from FP8_SOURCE's FP32 weight_scale_inv plane (8.00195 bpw): same element grid, different on-disk contract, different byte count, and FP8_SOURCE's exporter widens its scale plane to FP32, which on a UE8M0 checkpoint would quadruple the scale bytes and emit a tensor the model's own loader does not expect. This allow-list proves only exporter/runtime legality; served KL/PPL and phase-specific performance remain external release gates recorded by the native-parity benchmark protocol."
     },
     {
       "id": "cb_packed_expert_stock_ct_unsupported",
@@ -36,6 +39,17 @@
       ],
       "reason": "runtime_unsupported",
       "detail": "The nvfp4_cb container's stock compressed-tensors delegation is DENSE-ONLY today: neither export_nvfp4_cb nor the Gridbook runtime carries a stock-CT packed-MoE emission/serving path (35B first-contact, 2026-07-19 \u2014 the exporter's stock-NVFP4 global-scale pass is 2-D and Gridbook's MoE method is CB-only). Packed expert stacks use CB rungs (per-expert weighted VQ, served by Gridbook) or the BF16 passthrough until that path is built AND serve-validated. This is a declared capability of the container, not a quality judgement on the formats."
+    },
+    {
+      "id": "mxfp4_source_is_routed_expert_only",
+      "when": {
+        "not_regex": "(^|[.])(?:mlp[.]|moe[.]|ffn[.])?experts([.]|$)"
+      },
+      "deny_formats": [
+        "MXFP4_SOURCE"
+      ],
+      "reason": "runtime_unsupported",
+      "detail": "MXFP4_SOURCE delegates to the MODEL'S OWN packed-expert loader (DeepseekV4's routed-expert path), which exists only for the routed stack \u2014 there is no native packed-MXFP4 load path for a dense attention or shared-expert Linear in this container. On the checkpoints where this matters the source-kind gate already reaches the same verdict (only the routed experts are stored as MXFP4), so this rule is a structural belt on top of a dtype fact, and it fires even on a hypothetical checkpoint that stored a dense Linear in the same packing. It is written as a NAME condition rather than scope=dense deliberately: filter_candidates_for_profile re-checks formats AFTER packed-group aggregation with packed_expert=None, and a scope=dense rule would fire on the aggregated super item (...experts.__packed_serving__...) and strip the format from the very unit it belongs on. The regex still matches that super name, so the deny correctly skips it."
     }
   ],
   "shape_rules": [
@@ -68,6 +82,24 @@
     }
   ],
   "serving_lanes": [
+    {
+      "id": "delegated_native_fp8_block_ue8m0",
+      "formats": [
+        "FP8_BLOCK_UE8M0_SOURCE"
+      ],
+      "activation_contract": "w8a8-dynamic-e4m3-block128-ue8m0",
+      "fallback_route": "delegated_native_fp8_block (the model's own block-FP8 path; no Gridbook codec in the dispatch)",
+      "detail": "SOURCE-PASSTHROUGH lane, not a CB one: the artifact ships the checkpoint's own E4M3 bytes and UE8M0 block exponents unchanged, and the serving side loads them exactly as it loads the released checkpoint. That is what makes this route BACKED without a new kernel — it is the route the source already serves on, so 'does a serve path exist' is answered by the model running at all. There is deliberately no fused_mid_m block: a passthrough rung has no Gridbook decode prologue to fuse, so an empty backed set here is the honest state rather than a data gap, and it resolves with rungs_source=lane_declares_no_fused_mid_m_lane. Byte contract: 8 bits/element plus one UE8M0 byte per 128x128 block = 8.00049 bpw, which the producer pins against the checkpoint's own header spans before an allocation ships (footprint.assignment_artifact_bytes refuses a span/closed-form disagreement)."
+    },
+    {
+      "id": "delegated_native_mxfp4",
+      "formats": [
+        "MXFP4_SOURCE"
+      ],
+      "activation_contract": "delegated-native-mxfp4-e2m1-group32-ue8m0",
+      "fallback_route": "route_pending (no validated Gridbook dispatch; the model's own routed-expert MXFP4 loader is the intended path)",
+      "detail": "SOURCE-PASSTHROUGH lane for the released checkpoint's own packed routed experts: nibble-packed E2M1 with per-32 E8M0 group scales, copied verbatim, served by the model's native DeepseekV4 routed-expert path rather than by any codebook decoder. It is declared as a DISTINCT lane precisely so P5b accounting never files these units under a CB contract they do not have — a unit on this lane has no CB activation contract at all, which is also why the K0.2 attestation scopes itself to CB layers and the artifact declares the source-passthrough groups explicitly rather than leaving them looking like a missing attestation. ROUTE STATUS: pending. The loader side is being built across the repo boundary and has not been serve-validated here, so allocator_candidates.ROUTE_PENDING_PASSTHROUGH_FORMATS lists this format and the exporter refuses to ship a selection containing it without an explicit override. The rung stays ON the menu regardless: an allocator that wants a route-pending passthrough is reporting a serving gap worth seeing, and masking the rung would hide exactly that signal while also removing the unit's only zero-error option. No fused_mid_m block, for the same reason as the lane above."
+    },
     {
       "id": "nvfp4_cb_quality_path",
       "formats_from": [

--- a/scripts/merge_dsv4_mxfp4_cost.py
+++ b/scripts/merge_dsv4_mxfp4_cost.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Merge the ≤4.25-bpw ladder cost run with the shipped v2 K14/K15/K36 table,
+and validate the interpolator against the columns both runs share.
+
+WHY A MERGE AT ALL. The v2 production run measured exactly three CB rungs
+(NVFP4_CB_K14, NVFP4_CB_K15, FP8_CB_K36) over all 43 layers. The mxfp4 run
+widens the expert menu to every rung at or under 4.25 bpw and prices it with
+the RD-ladder interpolator, which measures anchors + a holdout per family and
+FITS the rest. Those two tables overlap on K14/K15 — measured in one, fitted
+in the other — and that overlap is not a redundancy to discard. It is the only
+out-of-sample check on the interpolator that uses THIS model's real production
+rows rather than a synthetic fixture, so this script reports it before it
+merges, and merging always PREFERS the measured value.
+
+FP8_CB_K36 is kept from v2 even though 4.508 bpw is above the menu cap: it is
+dominated for experts (MXFP4_SOURCE is fewer bytes at exactly zero error) but
+it remains the body's measured option, and dropping a measured column because
+a different unit class cannot use it would be throwing away evidence.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import pickle
+import statistics
+from collections import defaultdict
+from pathlib import Path
+
+BAND_INTERPOLATED = "band_interpolated"
+
+
+def _load(path: Path) -> dict:
+    with open(path, "rb") as fh:
+        return pickle.load(fh)
+
+
+def _family(fmt: str) -> str:
+    if fmt.startswith("NVFP4_CB_"):
+        return "nvfp4_cb"
+    if fmt.startswith("FP8_CB_"):
+        return "fp8_cb"
+    return "other"
+
+
+def _dloss_like(entry: dict) -> float | None:
+    """The scalar the DP would price this row on, before any P5a gain."""
+    for key in ("predicted_dloss", "output_mse", "weight_mse"):
+        if key in entry:
+            try:
+                value = float(entry[key])
+            except (TypeError, ValueError):
+                continue
+            if math.isfinite(value):
+                return value
+    return None
+
+
+def validate_overlap(base: dict, new: dict) -> dict:
+    """Per-family relative error of FITTED vs MEASURED on shared columns.
+
+    This is the interpolator's error band, measured rather than assumed. The
+    comparison is restricted to rows the new run FITTED (``cost_source ==
+    band_interpolated``); a row the ladder's per-tensor holdout gate rejected
+    was re-measured, and comparing two measurements would flatter the fit.
+    """
+    base_costs = base["costs"]
+    new_costs = new["costs"]
+    per_family: dict[str, list[float]] = defaultdict(list)
+    per_format: dict[str, list[float]] = defaultdict(list)
+    n_fitted = 0
+    n_regated = 0
+    for name, new_row in new_costs.items():
+        base_row = base_costs.get(name)
+        if not base_row:
+            continue
+        for fmt, new_entry in new_row.items():
+            base_entry = base_row.get(fmt)
+            if not isinstance(base_entry, dict) or not isinstance(new_entry, dict):
+                continue
+            if new_entry.get("cost_source") != BAND_INTERPOLATED:
+                n_regated += 1
+                continue
+            n_fitted += 1
+            fitted = _dloss_like(new_entry)
+            measured = _dloss_like(base_entry)
+            if fitted is None or measured is None or measured <= 0.0:
+                continue
+            rel = (fitted - measured) / abs(measured)
+            if math.isfinite(rel):
+                per_family[_family(fmt)].append(rel)
+                per_format[fmt].append(rel)
+
+    def _summary(values: list[float]) -> dict:
+        if not values:
+            return {"n": 0}
+        absolute = [abs(v) for v in values]
+        return {
+            "n": len(values),
+            "mean_signed_rel_err": statistics.fmean(values),
+            "median_abs_rel_err": statistics.median(absolute),
+            "p90_abs_rel_err": sorted(absolute)[int(0.9 * (len(absolute) - 1))],
+            "max_abs_rel_err": max(absolute),
+        }
+
+    return {
+        "schema": "prismaquant.ladder_overlap_validation.v1",
+        "comparison": (
+            "new-run FITTED value vs v2-run MEASURED value, on the columns "
+            "both runs contain (NVFP4_CB_K14/K15); relative to the measured "
+            "value"
+        ),
+        "rows_fitted_and_comparable": n_fitted,
+        "rows_skipped_not_fitted": n_regated,
+        "by_family": {fam: _summary(v) for fam, v in sorted(per_family.items())},
+        "by_format": {f: _summary(v) for f, v in sorted(per_format.items())},
+    }
+
+
+def merge(base: dict, new: dict) -> tuple[dict, dict]:
+    """Union the two cost tables, preferring a MEASURED value over a fitted one."""
+    merged_costs: dict[str, dict] = {}
+    stats = {"measured_kept": 0, "fitted_kept": 0, "fitted_overridden": 0}
+    names = set(base["costs"]) | set(new["costs"])
+    for name in names:
+        row: dict[str, dict] = {}
+        row.update(base["costs"].get(name, {}))
+        for fmt, entry in new["costs"].get(name, {}).items():
+            existing = row.get(fmt)
+            if isinstance(existing, dict) and isinstance(entry, dict):
+                # Both runs priced this column. A measured value always wins:
+                # the fit exists to cover columns nobody measured, never to
+                # overwrite a measurement that already exists.
+                if entry.get("cost_source") == BAND_INTERPOLATED:
+                    stats["fitted_overridden"] += 1
+                    continue
+            row[fmt] = entry
+            if isinstance(entry, dict) and entry.get("cost_source") == BAND_INTERPOLATED:
+                stats["fitted_kept"] += 1
+            else:
+                stats["measured_kept"] += 1
+        merged_costs[name] = row
+    formats = sorted(set(base.get("formats", [])) | set(new.get("formats", [])))
+    merged = {
+        "costs": merged_costs,
+        "formats": formats,
+        "provenance": {
+            **(base.get("provenance") or {}),
+            "merged_from": ["v2_measured_k14_k15_k36", "mxfp4_ladder_run"],
+        },
+        "meta": {
+            **(base.get("meta") or {}),
+            "merge": stats,
+        },
+    }
+    return merged, stats
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", required=True, help="v2 measured cost pickle")
+    ap.add_argument("--new", required=True, help="ladder-run cost pickle")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--report", required=True)
+    args = ap.parse_args()
+
+    base = _load(Path(args.base))
+    new = _load(Path(args.new))
+    validation = validate_overlap(base, new)
+    merged, stats = merge(base, new)
+
+    with open(args.out, "wb") as fh:
+        pickle.dump(merged, fh)
+    report = {
+        "validation": validation,
+        "merge": stats,
+        "formats": merged["formats"],
+        "n_rows": len(merged["costs"]),
+    }
+    Path(args.report).write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_dsv4_mxfp4_cost.sh
+++ b/scripts/run_dsv4_mxfp4_cost.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# ============================================================================
+# run_dsv4_mxfp4_cost.sh — extend the DSv4-Flash cost table to the full
+#                          <= 4.25 bpw expert menu, resumably.
+# ============================================================================
+# The shipped v2 table measured three CB rungs (NVFP4_CB_K14/K15, FP8_CB_K36).
+# The source-MXFP4 passthrough puts a ZERO-ERROR rung at 4.25 bpw on the expert
+# menu, which dominates every costlier rung — so the useful menu is everything
+# at or under 4.25 bpw, and the old 2.3 -> 4.5 bpw void (which forced the
+# binary K15-vs-K36 jump at layers 39/40) gets filled with graded rungs the DP
+# can use to express partial protection.
+#
+# MEASUREMENT ECONOMY. 19 rungs x 33,325 Linears is not affordable and is not
+# necessary: PRISMAQUANT_CB_LADDER_INTERP=1 measures per-family ANCHORS plus a
+# HOLDOUT and fits the rest from the shared RD law. For this menu the splitter
+# picks
+#     fp4:  anchors K12/K18/K24, holdout K19  -> predicts 9 rungs
+#     fp8:  anchors K28/K31/K33, holdout K30  -> predicts 2 rungs
+# i.e. 8 measured columns instead of 19. Both families' MENU ENDPOINTS are
+# anchors, so the law only ever interpolates, never extrapolates. The fit is
+# gated PER TENSOR: a tensor whose law misses its holdout by more than
+# PRISMAQUANT_CB_LADDER_TOL has its predicted rungs MEASURED instead, so no
+# tensor ever receives an unvalidated price. Fitted rows are stamped
+# cost_source="band_interpolated" and stay distinguishable in the artifact.
+#
+# The run also re-prices K14/K15, which the v2 table already MEASURED. That
+# overlap is deliberate: it is the only out-of-sample check on the
+# interpolator that uses this model's real production rows, and
+# scripts/merge_dsv4_mxfp4_cost.py reports it before merging (merge always
+# prefers the measured value).
+#
+# RESUMABILITY. cost_shard_is_reusable fails closed on CB shards, so a single
+# re-invocation would re-measure every completed layer. This driver therefore
+# runs ONE LAYER PER CONTAINER into its own output pickle and skips layers
+# whose pickle already exists — an interrupt costs at most the layer in flight.
+# The per-layer skeleton reload is ~3 s against ~20 min of encode.
+#
+# Cost measurement is correctness-only (no timing claims), so it needs no
+# exclusive-GPU flock.
+# ============================================================================
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+RUN_ROOT="${RUN_ROOT:-/home/rob/dq-runs/dsv4-flash-0731}"
+MODEL_PATH="${MODEL_PATH:-${RUN_ROOT}/source}"
+WORK_DIR="${WORK_DIR:-${RUN_ROOT}/prod-cal-0p6-v2}"
+ART="${ART:-${WORK_DIR}/artifacts-mxfp4}"
+SHARDS="${SHARDS:-${ART}/shards}"
+LOGS="${LOGS:-${WORK_DIR}/logs-mxfp4}"
+IMAGE="${IMAGE:-gridbook:test}"
+CALIB_DIR="${CALIB_DIR:-/home/rob/dq-runs/calibration}"
+START_LAYER="${START_LAYER:-0}"
+END_LAYER="${END_LAYER:-43}"
+
+# Every nvfp4_cb-carriable rung at or under 4.25 bpw. MXFP4_SOURCE itself is
+# NOT here: it is a byte-copy contract the allocator synthesizes at zero cost,
+# so measuring it would burn GPU hours reproducing a zero.
+MENU="${MENU:-NVFP4_CB_K12,NVFP4_CB_K13,NVFP4_CB_K14,NVFP4_CB_K15,NVFP4_CB_K16,NVFP4_CB_K17,NVFP4_CB_K18,NVFP4_CB_K19,NVFP4_CB_K20,NVFP4_CB_K21,NVFP4_CB_K22,NVFP4_CB_K23,NVFP4_CB_K24,FP8_CB_K28,FP8_CB_K29,FP8_CB_K30,FP8_CB_K31,FP8_CB_K32,FP8_CB_K33}"
+
+mkdir -p "$SHARDS" "$LOGS"
+
+for L in $(seq "$START_LAYER" $(( END_LAYER - 1 ))); do
+  OUT="${SHARDS}/cost_L$(printf '%03d' "$L").pkl"
+  if [ -s "$OUT" ]; then
+    echo "[mxfp4-cost] layer ${L}: already done ($(stat -c%s "$OUT") B) — skipping"
+    continue
+  fi
+  echo "[mxfp4-cost] layer ${L}: measuring -> ${OUT}"
+  docker run --rm --name "pq-mxfp4-cost-L${L}" --gpus all --ipc=host \
+    -v "${RUN_ROOT}:${RUN_ROOT}" \
+    -v "${CALIB_DIR}:${CALIB_DIR}:ro" \
+    -v "${REPO}:/pq" -w /pq \
+    -e PYTHONPATH=/pq \
+    -e PRISMAQUANT_CB_EXT_DIR="${RUN_ROOT}/ext" \
+    -e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
+    -e PRISMAQUANT_ACTIVATION_FAIR_PRICING=1 \
+    -e PRISMAQUANT_CB_LADDER_INTERP=1 \
+    -e CB_CODEBOOK_SOURCE=lattice \
+    -e CB_SCALE_CODING=two_tier \
+    -e CB_SCALE_SWEEP=1 \
+    -e PRISMAQUANT_CB_ENCODE_TIER=balanced \
+    -e PRISMAQUANT_CB_COL_WEIGHTS="${ART}/cb_col_weights.pkl" \
+    -e PRISMAQUANT_UNROUTED_EXPERT_PROVENANCE="${ART}/cb_col_weights.pkl.provenance.json" \
+    --entrypoint bash "$IMAGE" -c "
+python3 -m prismaquant.incremental_measure_quant_cost \
+  --model ${MODEL_PATH} --cost-mode local \
+  --probe ${ART}/probe.pkl \
+  --activation-cache-dir ${WORK_DIR}/act \
+  --formats '${MENU}' \
+  --output ${OUT} \
+  --work-dir ${WORK_DIR}/work-mxfp4-L${L} \
+  --device cuda --dtype bf16 --mode batched --chunk-size 256 \
+  --layers-per-shard 1 --start-layer ${L} --end-layer $(( L + 1 )) \
+  --skip-missing-activations --no-include-lm-head" \
+    >> "${LOGS}/cost-L$(printf '%03d' "$L").log" 2>&1
+  echo "[mxfp4-cost] layer ${L}: done at $(date -Is)"
+done
+
+echo "[mxfp4-cost] all layers ${START_LAYER}..$(( END_LAYER - 1 )) present in ${SHARDS}"

--- a/tests/test_nvfp4_cb_streaming.py
+++ b/tests/test_nvfp4_cb_streaming.py
@@ -7,6 +7,7 @@ stock-CT scope gate. No GPU, no torch.compile (PRISMAQUANT_CB_ENCODE_COMPILE=0).
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import importlib
 import os
@@ -61,8 +62,8 @@ def _assert_offsets_consistent(path: Path) -> dict:
     """The streaming header must lay tensors out gap-free, in order, with
     data_offsets matching dtype x shape (requirement a)."""
     header, _ = _st_header(path)
-    _bytes = {"U8": 1, "I8": 1, "BOOL": 1, "F8_E4M3": 1, "F16": 2, "BF16": 2,
-              "I32": 4, "F32": 4, "I64": 8}
+    _bytes = {"U8": 1, "I8": 1, "BOOL": 1, "F8_E4M3": 1, "F8_E8M0": 1,
+              "F16": 2, "BF16": 2, "I32": 4, "F32": 4, "I64": 8}
     off = 0
     for name, meta in header.items():
         if name == "__metadata__":
@@ -1254,3 +1255,596 @@ def test_reuse_does_not_bypass_resume_gate(workdir):
         export_nvfp4_cb_streaming(
             mdl, ap, out, cw, device="cpu", reuse_prior=prior, reuse_verify=1
         )
+
+
+# --- source-passthrough family: byte-verbatim native lanes ------------------
+#
+# Two formats, one wire contract: the exporter copies the checkpoint's own
+# element plane and its own scale plane, under the checkpoint's own names,
+# without ever building a tensor. What these tests actually pin is that the
+# artifact's bytes ARE the source's bytes — a passthrough that re-serializes
+# "equivalently" is not a passthrough, and the failure is invisible to any
+# assertion phrased in terms of decoded values.
+
+_SOURCE_HID = 256          # CB needs logical in_features % 256 == 0
+_SOURCE_EXPERTS = 2
+_MXFP4_RECIPE = {"data_type": "fp4_e2m1", "bits": 4, "group_size": 32}
+_UE8M0_RECIPE = {"data_type": "fp8_e4m3", "bits": 8, "group_size": 128,
+                 "scale_fmt": "ue8m0"}
+_CB_RECIPE = {"data_type": "nvfp4_cb", "cb_k": 16}
+
+
+def _e8m0_plane(shape, generator) -> torch.Tensor:
+    """A real F8_E8M0 exponent plane (the dtype DSv4 ships), not a uint8 stand-in.
+
+    Built through a uint8 view because the exponent codes are what the format
+    is; going via a float cast would round-trip through values E8M0 cannot
+    represent and quietly change the bytes under test.
+    """
+    codes = torch.randint(110, 140, tuple(shape), generator=generator)
+    return codes.to(torch.uint8).view(torch.float8_e8m0fnu)
+
+
+def _dsv4_source_model(mdl: Path, *, mxfp4_layers=(1,), cb_layers=(0,),
+                       dense_ue8m0=True, seed=5) -> dict:
+    """A DSv4-Flash-shaped checkpoint at 1/1000 scale, in its own namespace.
+
+    Routed experts are nibble-packed MXFP4 (`.weight` I8 + `.scale` F8_E8M0)
+    on EVERY layer — which is the real checkpoint's state — so the CB layer
+    and the passthrough layer differ only in what the recipe asks for, not in
+    what is on disk. The dense body Linear is the UE8M0 block-FP8 spelling
+    (F8_E4M3 + F8_E8M0), the second member of the same passthrough family.
+    """
+    mdl.mkdir(parents=True, exist_ok=True)
+    hid = _SOURCE_HID
+    generator = torch.Generator().manual_seed(seed)
+    tensors: dict[str, torch.Tensor] = {}
+    for layer in sorted({*mxfp4_layers, *cb_layers}):
+        for expert in range(_SOURCE_EXPERTS):
+            for leaf in ("w1", "w3", "w2"):
+                base = f"layers.{layer}.ffn.experts.{expert}.{leaf}"
+                tensors[base + ".weight"] = torch.randint(
+                    -128, 128, (hid, hid // 2), dtype=torch.int8,
+                    generator=generator)
+                tensors[base + ".scale"] = _e8m0_plane(
+                    (hid, hid // 32), generator)
+    if dense_ue8m0:
+        tensors["layers.0.attn.wq_a.weight"] = (
+            torch.randn(hid, hid, generator=generator) * 0.3
+        ).to(torch.float8_e4m3fn)
+        tensors["layers.0.attn.wq_a.scale"] = _e8m0_plane((2, 2), generator)
+    tensors["norm.weight"] = torch.ones(hid, dtype=torch.bfloat16)
+    save_file(tensors, str(mdl / "model.safetensors"))
+    (mdl / "config.json").write_text(json.dumps({
+        "model_type": "deepseek_v4",
+        "architectures": ["DeepseekV4ForCausalLM"],
+        "hidden_size": hid,
+        "intermediate_size": hid,
+        "expert_dtype": "fp4",
+        "quantization_config": {
+            "quant_method": "fp8", "fmt": "e4m3",
+            "weight_block_size": [128, 128], "scale_fmt": "ue8m0",
+        },
+    }))
+    return tensors
+
+
+def _dsv4_recipe(*, mxfp4_layers=(1,), cb_layers=(0,), dense_ue8m0=True):
+    """Expanded per-tensor assignment + col_weights, as the allocator writes it."""
+    assignment: dict[str, object] = {}
+    col_weights: dict[str, torch.Tensor] = {}
+    generator = torch.Generator().manual_seed(11)
+    for layers, recipe in ((cb_layers, _CB_RECIPE),
+                           (mxfp4_layers, _MXFP4_RECIPE)):
+        for layer in layers:
+            for expert in range(_SOURCE_EXPERTS):
+                for proj in ("gate_proj", "up_proj", "down_proj"):
+                    qname = f"model.layers.{layer}.mlp.experts.{expert}.{proj}"
+                    assignment[qname] = recipe
+                    if recipe is _CB_RECIPE:
+                        col_weights[qname] = torch.rand(
+                            _SOURCE_HID, generator=generator) + 0.05
+    if dense_ue8m0:
+        assignment["model.layers.0.self_attn.wq_a"] = _UE8M0_RECIPE
+    return assignment, col_weights
+
+
+def _source_bytes(mdl: Path, name: str) -> bytes:
+    header, data0 = _st_header(mdl / "model.safetensors")
+    lo, hi = header[name]["data_offsets"]
+    raw = (mdl / "model.safetensors").read_bytes()
+    return raw[data0 + lo:data0 + hi]
+
+
+def _emitted_bytes(out: Path, name: str) -> bytes:
+    return _source_bytes(out, name)
+
+
+def _export_dsv4(workdir, out_name="out", **model_kwargs):
+    mdl = workdir / "src"
+    tensors = _dsv4_source_model(mdl, **model_kwargs)
+    assignment, col_weights = _dsv4_recipe(**model_kwargs)
+    path = workdir / f"{out_name}.json"
+    _assign(path, assignment)
+    out = workdir / out_name
+    counts = export_nvfp4_cb_streaming(
+        mdl, path, out, col_weights, device="cpu",
+        allow_route_pending_passthrough=True)
+    return mdl, out, tensors, dict(counts)
+
+
+def test_source_passthrough_streams_checkpoint_bytes_verbatim(workdir):
+    """The artifact's bytes ARE the checkpoint's bytes, per tensor, by digest."""
+    mdl, out, tensors, counts = _export_dsv4(workdir)
+    assert counts["MXFP4_SOURCE"] == _SOURCE_EXPERTS * 3
+    assert counts["FP8_BLOCK_UE8M0_SOURCE"] == 1
+
+    header = _assert_offsets_consistent(out / "model.safetensors")
+    source_header, _ = _st_header(mdl / "model.safetensors")
+    passthrough = [
+        f"layers.1.ffn.experts.{expert}.{leaf}.{plane}"
+        for expert in range(_SOURCE_EXPERTS)
+        for leaf in ("w1", "w3", "w2")
+        for plane in ("weight", "scale")
+    ] + ["layers.0.attn.wq_a.weight", "layers.0.attn.wq_a.scale"]
+    for name in passthrough:
+        # (a) the CHECKPOINT spelling, which is what the model's own loader
+        #     resolves — not the live `model.layers.N.mlp.experts.*` name.
+        assert name in header, name
+        # (b) dtype and shape untouched: no widening, no repacking.
+        assert header[name]["dtype"] == source_header[name]["dtype"], name
+        assert header[name]["shape"] == source_header[name]["shape"], name
+        # (c) the bytes themselves.
+        assert hashlib.sha256(_emitted_bytes(out, name)).hexdigest() == \
+            hashlib.sha256(_source_bytes(mdl, name)).hexdigest(), name
+
+    # The dtypes are asserted positively too, so a checkpoint that happened to
+    # ship F32 scales could not satisfy (b) vacuously.
+    assert header["layers.1.ffn.experts.0.w1.weight"]["dtype"] == "I8"
+    assert header["layers.1.ffn.experts.0.w1.scale"]["dtype"] == "F8_E8M0"
+    assert header["layers.0.attn.wq_a.weight"]["dtype"] == "F8_E4M3"
+    assert header["layers.0.attn.wq_a.scale"]["dtype"] == "F8_E8M0"
+
+
+def test_ue8m0_block_scale_is_not_widened_like_fp8_source(workdir):
+    """Regression guard on reusing the FP8_SOURCE branch for a UE8M0 source.
+
+    FP8_SOURCE renames `.weight_scale_inv` -> `.weight_scale` and casts it to
+    F32 because vLLM's stock block-FP8 path reads an fp32 plane. Doing that to
+    a one-byte UE8M0 plane would quadruple its size and emit a tensor the
+    checkpoint's own loader does not expect — and every decoded-value assertion
+    in the suite would still pass.
+    """
+    _mdl, out, _tensors, _counts = _export_dsv4(workdir)
+    header, _ = _st_header(out / "model.safetensors")
+    assert "layers.0.attn.wq_a.weight_scale" not in header
+    assert header["layers.0.attn.wq_a.scale"]["dtype"] == "F8_E8M0"
+    lo, hi = header["layers.0.attn.wq_a.scale"]["data_offsets"]
+    assert hi - lo == 2 * 2          # one byte per 128x128 block, not four
+
+
+def test_source_passthrough_expert_group_is_not_collapsed_or_ignored(workdir):
+    """A delegated group keeps its per-expert tensors and stays out of `ignore`.
+
+    The packed parent gridbook's CB loader anchors on does not exist on disk
+    for this route, so naming one would promise a stack that is never written;
+    and `ignore` means "unquantized, load as-is", which these 4.25 bpw tensors
+    are not.
+    """
+    _mdl, out, _tensors, _counts = _export_dsv4(workdir)
+    emitted = set(load_file(str(out / "model.safetensors")))
+    config = json.loads((out / "quant_config.json").read_text())
+
+    assert "layers.1.ffn.experts.gate_up_proj.cb_qweight" not in emitted
+    assert "layers.1.ffn.experts.down_proj.cb_qweight" not in emitted
+    assert "layers.1.ffn.experts.0.w1.weight" in emitted
+    # The CB layer is the control: there the collapse DID happen.
+    assert "layers.0.ffn.experts.gate_up_proj.cb_qweight" in emitted
+    assert not any(name.startswith("layers.0.ffn.experts.0.")
+                   for name in emitted)
+
+    ignored = set(config["ignore"])
+    assert not any(name.startswith("layers.1.ffn.experts") for name in ignored)
+    assert "layers.0.attn.wq_a" not in ignored
+
+    native = [group for group in config["config_groups"].values()
+              if group.get("source_format") == "MXFP4_SOURCE"]
+    assert len(native) == 1
+    assert native[0]["source_passthrough_id"] == "mxfp4_e2m1_ue8m0_g32"
+    assert native[0]["weights"]["scale_dtype"] == "uint8_e8m0"
+    # Routing is stated once, in the source_passthrough declaration.
+    assert "route" not in native[0] and "route_backed" not in native[0]
+    assert native[0]["input_activations"] is None
+    assert len(native[0]["targets"]) == _SOURCE_EXPERTS * 3
+
+
+def test_cb_expert_layer_beside_a_passthrough_layer_keeps_its_gates(workdir):
+    """The CB half of a mixed artifact is unaffected by the passthrough half."""
+    mdl, out, _tensors, counts = _export_dsv4(workdir)
+    assert counts["NVFP4_CB_K16"] == 2          # gate_up + down, collapsed
+
+    reference = workdir / "cb_only"
+    assignment, col_weights = _dsv4_recipe(
+        mxfp4_layers=(), cb_layers=(0,), dense_ue8m0=False)
+    path = workdir / "cb_only.json"
+    _assign(path, assignment)
+    export_nvfp4_cb_streaming(mdl, path, reference, col_weights, device="cpu")
+
+    mixed_tensors = load_file(str(out / "model.safetensors"))
+    cb_only_tensors = load_file(str(reference / "model.safetensors"))
+    for leaf in ("gate_up_proj", "down_proj"):
+        name = f"layers.0.ffn.experts.{leaf}.cb_qweight"
+        assert torch.equal(mixed_tensors[name], cb_only_tensors[name]), name
+
+    config = json.loads((out / "quant_config.json").read_text())
+    cb_groups = [group for group in config["config_groups"].values()
+                 if "scheme" in group]
+    assert len(cb_groups) == 1
+    assert cb_groups[0]["targets"] == [
+        "layers.0.ffn.experts.down_proj", "layers.0.ffn.experts.gate_up_proj"]
+
+
+def _pending_formats_in(counts) -> set[str]:
+    """Route-pending formats this export actually carries, per the contract table.
+
+    Read at call time, never pinned: the table is measurement-backed and its
+    verdicts move (2026-08-03 inverted both of them). A test that hardcodes
+    which format is pending stops testing the gate and starts testing the
+    measurement.
+    """
+    from prismaquant.allocator_candidates import (
+        ROUTE_PENDING_PASSTHROUGH_FORMATS,
+    )
+
+    return {fmt for fmt in counts if fmt in ROUTE_PENDING_PASSTHROUGH_FORMATS}
+
+
+def test_route_pending_ship_gate_follows_the_contract_table(workdir):
+    """Whatever the table currently marks pending is what must be refused.
+
+    Both branches assert something real, so this stays honest whichever way the
+    measured verdicts land.
+    """
+    mdl = workdir / "src"
+    _dsv4_source_model(mdl)
+    assignment, col_weights = _dsv4_recipe()
+    path = workdir / "a.json"
+    _assign(path, assignment)
+
+    shipped = export_nvfp4_cb_streaming(
+        mdl, path, workdir / "shipped", col_weights, device="cpu",
+        allow_route_pending_passthrough=True)
+    pending = _pending_formats_in(shipped)
+    config = json.loads(
+        (workdir / "shipped" / "quant_config.json").read_text())
+
+    out = workdir / "default"
+    if not pending:
+        # Nothing pending: the override must not be needed at all.
+        export_nvfp4_cb_streaming(mdl, path, out, col_weights, device="cpu")
+        assert "route_pending_passthrough_acknowledged" not in \
+            config["provenance"]
+        return
+    with pytest.raises(ValueError) as error:
+        export_nvfp4_cb_streaming(mdl, path, out, col_weights, device="cpu")
+    message = str(error.value)
+    for fmt in pending:
+        assert fmt in message
+    assert "--allow-route-pending-passthrough" in message
+    assert not out.exists() or not list(out.iterdir())
+    # The override was one flag on one machine; the artifact carries the fact.
+    assert config["provenance"][
+        "route_pending_passthrough_acknowledged"] == sorted(pending)
+
+
+def test_route_pending_ship_gate_refuses_a_format_the_table_marks_pending(
+    workdir, monkeypatch,
+):
+    """The gate itself, pinned independently of today's measured verdicts."""
+    from prismaquant import export_nvfp4_cb_streaming as streaming_module
+    from prismaquant.allocator_candidates import SOURCE_PASSTHROUGH_CONTRACTS
+
+    monkeypatch.setattr(
+        streaming_module, "ROUTE_PENDING_PASSTHROUGH_FORMATS",
+        frozenset({"MXFP4_SOURCE"}))
+    mdl = workdir / "src"
+    _dsv4_source_model(mdl, dense_ue8m0=False)
+    assignment, col_weights = _dsv4_recipe(dense_ue8m0=False)
+    path = workdir / "a.json"
+    _assign(path, assignment)
+    with pytest.raises(ValueError) as error:
+        export_nvfp4_cb_streaming(
+            mdl, path, workdir / "refused", col_weights, device="cpu")
+    message = str(error.value)
+    assert "MXFP4_SOURCE" in message
+    assert SOURCE_PASSTHROUGH_CONTRACTS[
+        "MXFP4_SOURCE"].serving_route in message
+    assert f"{_SOURCE_EXPERTS * 3} unit(s)" in message
+    export_nvfp4_cb_streaming(
+        mdl, path, workdir / "shipped", col_weights, device="cpu",
+        allow_route_pending_passthrough=True)
+
+
+# --- source_passthrough: the cross-repo declaration -------------------------
+
+def test_source_passthrough_declaration_names_every_delegated_unit(workdir):
+    from prismaquant.cb_export_config import (
+        SOURCE_PASSTHROUGH_DECLARATION_KEY,
+        SOURCE_PASSTHROUGH_DECLARATION_VERSION,
+        parse_source_passthrough_declaration,
+    )
+
+    _mdl, out, _tensors, _counts = _export_dsv4(workdir)
+    config = json.loads((out / "quant_config.json").read_text())
+    record = config[SOURCE_PASSTHROUGH_DECLARATION_KEY]
+    assert record == {
+        "version": SOURCE_PASSTHROUGH_DECLARATION_VERSION,
+        "units": {
+            "model.layers.0.self_attn.wq_a": "fp8_e4m3_ue8m0_block128",
+            "model.layers.1.mlp.experts": "mxfp4_e2m1_ue8m0_g32",
+        },
+    }
+    # The declaration is TOP-LEVEL, not an execution contract.
+    assert SOURCE_PASSTHROUGH_DECLARATION_KEY not in config.get(
+        "execution_contracts", {})
+    assert parse_source_passthrough_declaration(config) == record["units"]
+
+    # A routed-expert group is ONE unit even though it emits 12 tensors under
+    # per-expert names, and a dense body Linear is a legal unit too.
+    assert "model.layers.1.mlp.experts.0.gate_proj" not in record["units"]
+    # The CB layer is not in the declaration at all.
+    assert "model.layers.0.mlp.experts" not in record["units"]
+
+
+def test_source_passthrough_key_is_absent_from_an_all_cb_artifact(workdir):
+    """Absence of the key IS the legacy/all-CB signal — never an empty record."""
+    from prismaquant.cb_export_config import (
+        SOURCE_PASSTHROUGH_DECLARATION_KEY,
+        parse_source_passthrough_declaration,
+    )
+
+    mdl = workdir / "src"
+    _dsv4_source_model(mdl, mxfp4_layers=(), cb_layers=(0,),
+                       dense_ue8m0=False)
+    assignment, col_weights = _dsv4_recipe(
+        mxfp4_layers=(), cb_layers=(0,), dense_ue8m0=False)
+    path = workdir / "a.json"
+    _assign(path, assignment)
+    out = workdir / "cb_only"
+    export_nvfp4_cb_streaming(mdl, path, out, col_weights, device="cpu")
+    config = json.loads((out / "quant_config.json").read_text())
+    assert SOURCE_PASSTHROUGH_DECLARATION_KEY not in config
+    assert parse_source_passthrough_declaration(config) is None
+
+
+def test_source_passthrough_wire_ids_are_a_closed_enum_with_no_silent_gaps():
+    """A passthrough format with no wire id must stop the export.
+
+    A unit silently dropped from ``units`` reads to the consumer as "this is
+    CB" — the one wrong answer that loads.
+    """
+    from prismaquant.cb_export_config import (
+        DELEGATED_NATIVE_PASSTHROUGH_FORMATS,
+        SOURCE_PASSTHROUGH_WIRE_FORMATS,
+        SOURCE_PASSTHROUGH_WIRE_IDS,
+        source_passthrough_wire_id,
+    )
+
+    assert SOURCE_PASSTHROUGH_WIRE_IDS["MXFP4_SOURCE"] == \
+        "mxfp4_e2m1_ue8m0_g32"
+    assert SOURCE_PASSTHROUGH_WIRE_IDS["FP8_BLOCK_UE8M0_SOURCE"] == \
+        "fp8_e4m3_ue8m0_block128"
+    assert len(SOURCE_PASSTHROUGH_WIRE_FORMATS) == len(
+        SOURCE_PASSTHROUGH_WIRE_IDS)
+    # Every format that can reach the byte-verbatim emitter has an id.
+    missing = sorted(DELEGATED_NATIVE_PASSTHROUGH_FORMATS
+                     - set(SOURCE_PASSTHROUGH_WIRE_IDS))
+    assert missing == [], missing
+    # FP8_SOURCE is CT-normalized: it never enters this record, and asking for
+    # its wire id is a bug rather than a lookup miss to paper over.
+    with pytest.raises(ValueError, match="no wire id"):
+        source_passthrough_wire_id("FP8_SOURCE")
+
+
+def test_parse_source_passthrough_declaration_refuses_the_load_failure_cases():
+    from prismaquant.cb_export_config import (
+        SOURCE_PASSTHROUGH_DECLARATION_KEY as KEY,
+        parse_source_passthrough_declaration as parse,
+    )
+
+    def config(record):
+        return {"config_groups": {}, KEY: record}
+
+    good = {"version": 1,
+            "units": {"model.layers.1.mlp.experts": "mxfp4_e2m1_ue8m0_g32"}}
+    assert parse(config(good)) == good["units"]
+
+    with pytest.raises(ValueError, match="unsupported .* version"):
+        parse(config({**good, "version": 2}))
+    with pytest.raises(ValueError, match="must be an object"):
+        parse(config(["units"]))
+    with pytest.raises(ValueError, match="carries no units"):
+        parse(config({"version": 1, "units": {}}))
+    with pytest.raises(ValueError, match="string unit ids"):
+        parse(config({"version": 1, "units": {"a": 4}}))
+    with pytest.raises(ValueError, match="unknown format id"):
+        parse(config({"version": 1, "units": {"a": "mxfp4_source"}}))
+    # A unit claimed by BOTH gridbook's codec and the passthrough declaration.
+    contested = {
+        "config_groups": {
+            "group_0": {
+                "format": "NVFP4_CB_K16",
+                "scheme": {"grid": "fp4"},
+                "targets": ["model.layers.1.mlp.experts"],
+            },
+        },
+        KEY: good,
+    }
+    with pytest.raises(ValueError, match="claimed by BOTH"):
+        parse(contested)
+
+
+_RECONCILED = {
+    "cb_units": {"model.layers.0.mlp.experts"},
+    "passthrough_units": {"model.layers.1.mlp.experts"},
+    "cb_tensors": {"layers.0.ffn.experts.gate_up_proj.cb_qweight"},
+    "passthrough_tensors": {"layers.1.ffn.experts.0.w1.weight"},
+    "cb_modules": {"layers.0.ffn.experts"},
+    "passthrough_modules": {"layers.1.ffn.experts"},
+    "attested": {"layers.0.ffn.experts"},
+}
+
+
+def test_route_reconciliation_refuses_every_way_the_two_scopes_can_overlap():
+    """The producer-side invariant, as a predicate over the four set pairs.
+
+    Each case below is a state the artifact must never reach, and each would be
+    invisible in the emitted JSON — which is the point: the wire record no
+    longer carries ``cb_activation_contract``, so this is where the claim that
+    a delegated group's K0.2 absence is DELIBERATE actually gets proved.
+    """
+    from prismaquant.export_nvfp4_cb_streaming import assert_routes_reconcile
+
+    assert_routes_reconcile(**_RECONCILED)          # the reconciled state
+
+    for field, mutation, message in (
+        # One unit handed to two loaders.
+        ("passthrough_units", {"model.layers.0.mlp.experts"},
+         "claimed by BOTH"),
+        # Unit ids disjoint but a tensor emitted twice (a namespace bug).
+        ("passthrough_tensors", {"layers.0.ffn.experts.gate_up_proj.cb_qweight"},
+         "emitted by both"),
+        # A delegated group that somehow reached the K0.2 attestation.
+        ("attested", {"layers.1.ffn.experts"}, "AND declared"),
+        # An attested module no CB unit claims — a dropped/renamed group.
+        ("attested", {"layers.9.ffn.experts"}, "which no CB expert unit claims"),
+    ):
+        state = dict(_RECONCILED)
+        state[field] = mutation
+        with pytest.raises(AssertionError, match=message):
+            assert_routes_reconcile(**state)
+
+    # A routed-expert group left entirely on BF16 is on neither route and is
+    # correctly absent from both module sets.
+    assert_routes_reconcile(**{**_RECONCILED, "attested": set()})
+
+
+def test_producer_refuses_a_k02_attestation_of_a_delegated_group(
+    workdir, monkeypatch,
+):
+    """A delegated group must never appear in the K0.2 attestation.
+
+    This is what ``cb_activation_contract`` bought on the wire; the field is
+    gone but the invariant it protected is not. A delegated group's ABSENCE
+    from the K0.2 record is a DECLARATION, not a dropped attestation — which
+    only holds while the two scopes are provably disjoint.
+    """
+    from prismaquant import export_nvfp4_cb_streaming as streaming_module
+
+    mdl = workdir / "src"
+    _dsv4_source_model(mdl, dense_ue8m0=False)
+    assignment, col_weights = _dsv4_recipe(dense_ue8m0=False)
+    path = workdir / "a.json"
+    _assign(path, assignment)
+    # The delegated group's SERIALIZED module prefix — what K0.2 would name it.
+    monkeypatch.setattr(
+        streaming_module, "routed_moe_attested_module_names",
+        lambda record: ("layers.1.ffn.experts",))
+    with pytest.raises(AssertionError, match="AND declared"):
+        export_nvfp4_cb_streaming(
+            mdl, path, workdir / "conflict", col_weights, device="cpu",
+            allow_route_pending_passthrough=True)
+
+    # ... and an attested module that no CB unit claims is equally refused.
+    monkeypatch.setattr(
+        streaming_module, "routed_moe_attested_module_names",
+        lambda record: ("layers.9.ffn.experts",))
+    with pytest.raises(AssertionError, match="which no CB expert unit claims"):
+        export_nvfp4_cb_streaming(
+            mdl, path, workdir / "orphan", col_weights, device="cpu",
+            allow_route_pending_passthrough=True)
+
+
+def test_declared_units_and_cb_targets_are_disjoint_in_the_artifact(workdir):
+    """The shipped artifact never lets one unit be read by two loaders."""
+    _mdl, out, _tensors, _counts = _export_dsv4(workdir)
+    config = json.loads((out / "quant_config.json").read_text())
+    declared = set(config["source_passthrough"]["units"])
+    cb_targets = {
+        target
+        for group in config["config_groups"].values() if "scheme" in group
+        for target in group["targets"]
+    }
+    assert declared and cb_targets
+    assert not any(
+        target == unit or target.startswith(unit + ".")
+        for unit in declared for target in cb_targets)
+
+
+def test_k02_scope_reader_reads_the_attested_modules():
+    """The producer-side scope reader, on a real routed-MoE record."""
+    from prismaquant.nvfp4_activation_contract import (
+        CALIBRATION_SOURCE_SUPPLEMENTAL_MODULE_INPUT,
+        CALIBRATION_SOURCE_SUPPLEMENTAL_ROUTED_REPLAY,
+        FULL_E4M3_INPUT_GLOBAL_SCALE_POLICY,
+        NVFP4_ROUTED_MOE_STAGE_KEY,
+        build_execution_contract,
+        routed_moe_attested_module_names,
+    )
+
+    module = "model.layers.0.mlp.experts"
+    record, _scales = build_execution_contract(
+        {f"{module}.gate_up_proj": 4.0, f"{module}.down_proj": 8.0},
+        policy=FULL_E4M3_INPUT_GLOBAL_SCALE_POLICY,
+        calibration_sources={
+            f"{module}.gate_up_proj":
+                CALIBRATION_SOURCE_SUPPLEMENTAL_MODULE_INPUT,
+            f"{module}.down_proj":
+                CALIBRATION_SOURCE_SUPPLEMENTAL_ROUTED_REPLAY,
+        },
+    )
+    assert routed_moe_attested_module_names(record) == (module,)
+    assert len(routed_moe_attested_module_names(record)) == record[
+        NVFP4_ROUTED_MOE_STAGE_KEY]["module_count"]
+    # Absent / dense-only records attest nothing, and say so without raising.
+    assert routed_moe_attested_module_names(None) == ()
+    assert routed_moe_attested_module_names({"schema": "x"}) == ()
+
+
+def test_stream_writer_refuses_a_tensor_planned_by_two_emit_paths():
+    """A duplicate header name keeps one span while both blobs are written."""
+    writer = _StreamWriter()
+    writer.add("a.weight", torch.uint8, (4,), lambda: torch.zeros(4).to(
+        torch.uint8))
+    writer.add("a.weight", torch.uint8, (8,), lambda: torch.zeros(8).to(
+        torch.uint8))
+    with pytest.raises(AssertionError, match="planned twice"):
+        writer.write(Path("unused-never-created.safetensors"))
+
+
+def test_source_passthrough_recipes_round_trip_through_canonicalize_format():
+    """The recipe spelling the registry emits is the one the exporter reads.
+
+    Both new carriers sit one field away from a format that already existed —
+    MXFP4_SOURCE beside MXFP4, FP8_BLOCK_UE8M0_SOURCE beside FP8_SOURCE — and
+    collapsing either pair would silently ship the wrong on-disk contract.
+    """
+    from prismaquant import format_registry as fr
+    from prismaquant.layer_config import canonicalize_format
+
+    for name in ("MXFP4_SOURCE", "FP8_BLOCK_UE8M0_SOURCE", "FP8_SOURCE",
+                 "MXFP4", "MXFP8_E4M3", "FP8_E4M3"):
+        assert canonicalize_format(
+            fr.get_format(name).autoround_config()) == name, name
+    # The neighbours stay distinct on the ONE field that separates them.
+    assert canonicalize_format(
+        {"data_type": "fp8_e4m3", "bits": 8, "group_size": 128}) == "FP8_SOURCE"
+    assert canonicalize_format({
+        "data_type": "fp8_e4m3", "bits": 8, "group_size": 128,
+        "scale_fmt": "ue8m0"}) == "FP8_BLOCK_UE8M0_SOURCE"
+    assert canonicalize_format({"data_type": "mx_fp", "bits": 4}) == "MXFP4"
+    # MXFP4_SOURCE is the OCP-MX group-of-32 claim; another group is another
+    # contract, not a variant.
+    with pytest.raises(ValueError, match="group-of-32"):
+        canonicalize_format(
+            {"data_type": "fp4_e2m1", "bits": 4, "group_size": 16})

--- a/tests/test_prismaquant_export_native_compressed.py
+++ b/tests/test_prismaquant_export_native_compressed.py
@@ -1063,9 +1063,24 @@ class TestRoundTrip(unittest.TestCase):
             s.name for s in fr.REGISTRY.values()
             if s.family in ("nvfp4_cb", "fp8_cb")
         }
+        nvfp4_cb_container_passthroughs = {
+            # SOURCE-PASSTHROUGH carriers of the nvfp4_cb container. They have
+            # no compressed-tensors served-metadata path because they have no
+            # RENDER at all: the exporter copies the checkpoint's own bytes
+            # (packed MXFP4 + E8M0 group scales; E4M3 + UE8M0 block scales).
+            # "rendered == served" is trivially true and is pinned as the
+            # identity of both the weight and activation paths in
+            # test_registry_render_dequant_matches_served_metadata, and
+            # byte-for-byte against a real source slice in
+            # tests/test_nvfp4_cb_streaming.py. BF16 and FP8_SOURCE stay in
+            # `reconciled` — those two ARE compressed-tensors passthroughs.
+            "MXFP4_SOURCE",
+            "FP8_BLOCK_UE8M0_SOURCE",
+        }
         self.assertEqual(
             set(fr.REGISTRY),
-            reconciled | set(explicit_gaps) | gguf_lane | nvfp4_cb_lane,
+            reconciled | set(explicit_gaps) | gguf_lane | nvfp4_cb_lane
+            | nvfp4_cb_container_passthroughs,
         )
 
     def test_registry_render_dequant_matches_served_metadata(self):
@@ -1157,6 +1172,28 @@ class TestRoundTrip(unittest.TestCase):
                             live_bf16.float(),
                             served.bfloat16().float(),
                         )
+                        continue
+
+                    from prismaquant.allocator_candidates import (
+                        PASSTHROUGH_SOURCE_REQUIREMENTS,
+                    )
+                    if fmt in PASSTHROUGH_SOURCE_REQUIREMENTS:
+                        # The rest of the SOURCE-PASSTHROUGH family
+                        # (FP8_BLOCK_UE8M0_SOURCE, MXFP4_SOURCE, ...). There
+                        # is no render to compare against a serve: the
+                        # exporter copies the checkpoint's own bytes, so the
+                        # served values ARE the source values. The invariant
+                        # that must hold — and that would break if someone
+                        # gave one of these a real codec — is that BOTH sides
+                        # of the format are the identity, which is what makes
+                        # its Δloss exactly 0 by construction rather than by
+                        # measurement.
+                        spec = fr.get_format(fmt)
+                        torch.testing.assert_close(
+                            spec.quantize_dequantize(W), W)
+                        torch.testing.assert_close(
+                            spec.activation_quantize_dequantize(W), W)
+                        self.assertFalse(spec.act_quant_changes_input, fmt)
                         continue
 
                     self.fail(f"unhandled registered format {fmt}")

--- a/tests/test_serving_lane_metadata.py
+++ b/tests/test_serving_lane_metadata.py
@@ -271,9 +271,23 @@ def test_the_lane_catalog_is_reportable_and_names_its_runtime():
     assert catalog["schema"] == sp.SERVING_LANE_SCHEMA
     assert catalog["gridbook_runtime_version"] == "0.7.0"
     assert set(catalog["lanes"]) == {
-        "nvfp4_cb_quality_path", "fp8_cb_fused_mid_m"}
+        "nvfp4_cb_quality_path", "fp8_cb_fused_mid_m",
+        # The two SOURCE-PASSTHROUGH lanes. They are declared as lanes of
+        # their own precisely so P5b never files a passthrough unit under a
+        # CB activation contract it does not have.
+        "delegated_native_mxfp4", "delegated_native_fp8_block_ue8m0",
+    }
     assert catalog["lanes"]["fp8_cb_fused_mid_m"]["fused_mid_m_rungs"] == [
         28, 32, 36, 40, 44, 48]
+    # A passthrough lane backs no fused mid-M rung, and says so explicitly
+    # rather than leaving the field absent: there is no decode prologue to
+    # fuse, so an empty backed set is the honest state, not a data gap.
+    for lane_id in ("delegated_native_mxfp4",
+                    "delegated_native_fp8_block_ue8m0"):
+        lane = catalog["lanes"][lane_id]
+        assert lane["fused_mid_m_rungs"] == []
+        assert lane["fused_mid_m_rungs_source"] == (
+            "lane_declares_no_fused_mid_m_lane")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_serving_profiles.py
+++ b/tests/test_serving_profiles.py
@@ -524,12 +524,26 @@ def test_compressed_tensors_lane_declaration_matches_exporter_behaviour():
     # FP8/FP8_DYNAMIC/MXFP8 aliases before an assignment reaches the
     # exporter, so `_quantize_2d` is only ever handed a canonical name.
     w = torch.randn(64, 256, dtype=torch.bfloat16)
+    nvfp4_cb_emittable = lane_emittable_formats("nvfp4_cb")
     for fmt in sorted(fr.REGISTRY):
         if fmt in PASSTHROUGH_SOURCE_REQUIREMENTS:
-            # BF16 / FP8_SOURCE ship through the container's passthrough
-            # branches (plain bf16 tensor / verbatim fp8 + scale copy), not
-            # through the weight codec.
-            assert fmt in emittable, fmt
+            # Source passthroughs ship through a container's passthrough
+            # branch (plain bf16 tensor, verbatim fp8 + scale copy, verbatim
+            # packed-MXFP4 + E8M0 copy), never through the weight codec.
+            #
+            # Which CONTAINER carries which passthrough is a per-lane fact,
+            # not a global one: BF16 and FP8_SOURCE are compressed-tensors
+            # passthroughs, while FP8_BLOCK_UE8M0_SOURCE and MXFP4_SOURCE are
+            # nvfp4_cb-container passthroughs whose byte layouts the CT
+            # exporter has no emit path for. The invariant that must hold
+            # everywhere is the codec one — a passthrough is never quantized —
+            # plus "no orphans": every declared passthrough is emittable by
+            # SOME lane, so a format cannot be legal to allocate and
+            # impossible to ship.
+            if fmt not in emittable:
+                assert fmt in nvfp4_cb_emittable, fmt
+                with pytest.raises(ValueError):
+                    enc._quantize_2d(w, fmt)
             continue
         if fmt in emittable:
             assert enc._quantize_2d(w, fmt), fmt

--- a/tests/test_source_passthrough_family.py
+++ b/tests/test_source_passthrough_family.py
@@ -1,0 +1,336 @@
+"""Source-passthrough family: pricing, byte exactness, legality, allocation.
+
+The family's claim is narrow and total: for a unit whose stored bytes ALREADY
+are format F, shipping them unchanged costs exactly zero and occupies exactly
+the source slice. These tests pin both halves of that claim, the source-kind
+gate that decides where it applies, and the end-to-end consequence — that the
+allocator will spend a sensitive layer's budget on a passthrough and record the
+lane it rides.
+
+See docs/lanes/nvfp4-cb/source-passthrough.md.
+"""
+from __future__ import annotations
+
+import json
+import struct
+
+import pytest
+import torch
+
+import prismaquant.format_registry as fr
+from prismaquant.activation_fair_pricing import BRANCH_SOURCE_PASSTHROUGH
+from prismaquant.allocator_candidates import (
+    PASSTHROUGH_SOURCE_REQUIREMENTS,
+    ROUTE_PENDING_PASSTHROUGH_FORMATS,
+    SOURCE_PASSTHROUGH_CONTRACTS,
+    SOURCE_PASSTHROUGH_COST_SOURCE,
+    SOURCE_PASSTHROUGH_FORMATS,
+    build_candidates,
+    check_format_applicability,
+    cost_entry_activation_pricing_branch,
+    cost_entry_is_exact_by_construction,
+    cost_entry_is_source_passthrough,
+    cost_entry_predicted_dloss,
+    cost_entry_source,
+    cost_entry_uses_measured_output_mse,
+    selection_serving_lane_provenance,
+    synthesized_source_passthrough_cost_entry,
+)
+from prismaquant.serving_profiles import check_serving_format, serving_lane_route
+
+# The DSv4-Flash-0731 routed-expert and body shapes, and the byte counts the
+# checkpoint's own safetensors headers report for them. These are measurements,
+# not derivations: if the format arithmetic stops reproducing them, the artifact
+# budget is false and the floor accounting no longer cancels.
+EXPERT_W13_SHAPE = (2048, 4096)
+EXPERT_W13_BYTES = 4_194_304 + 262_144
+EXPERT_W2_SHAPE = (4096, 2048)
+EXPERT_W2_BYTES = 4_194_304 + 262_144
+BODY_WO_A_SHAPE = (8192, 4096)
+BODY_WO_A_BYTES = 33_554_432 + 2_048
+EXPERT_LAYER_BYTES = 3_422_552_064
+N_EXPERTS = 256
+
+
+# ---------------------------------------------------------------------------
+# 1. Registry + byte exactness
+# ---------------------------------------------------------------------------
+
+def test_every_contract_names_a_registered_identity_format():
+    """A contract may only name a format that is real, and that is a no-op.
+
+    The zero cost is justified ONLY by the exporter copying bytes. A format
+    whose weight or activation path actually transforms anything would be
+    priced at zero on a false premise, so the identity is checked here rather
+    than assumed by the pricing code.
+    """
+    probe = torch.randn(8, 128)
+    for name, contract in SOURCE_PASSTHROUGH_CONTRACTS.items():
+        spec = fr.get_format(name)
+        assert spec.name == name
+        assert contract.source_kind
+        assert contract.serving_route
+        torch.testing.assert_close(spec.quantize_dequantize(probe), probe)
+        torch.testing.assert_close(
+            spec.activation_quantize_dequantize(probe), probe)
+        # act_bits absent/>=16 is the dtype-level fact the bit-exact and
+        # P5a machinery both key off.
+        assert not spec.act_quant_changes_input, name
+
+
+def test_derived_views_agree_with_the_contract_table():
+    assert PASSTHROUGH_SOURCE_REQUIREMENTS == {
+        n: c.source_kind for n, c in SOURCE_PASSTHROUGH_CONTRACTS.items()}
+    assert SOURCE_PASSTHROUGH_FORMATS == {
+        n for n, c in SOURCE_PASSTHROUGH_CONTRACTS.items()
+        if c.zero_cost_by_construction}
+    assert ROUTE_PENDING_PASSTHROUGH_FORMATS == {
+        n for n, c in SOURCE_PASSTHROUGH_CONTRACTS.items()
+        if not c.route_backed}
+
+
+@pytest.mark.parametrize("fmt,shape,expected", [
+    ("MXFP4_SOURCE", EXPERT_W13_SHAPE, EXPERT_W13_BYTES),
+    ("MXFP4_SOURCE", EXPERT_W2_SHAPE, EXPERT_W2_BYTES),
+    ("FP8_BLOCK_UE8M0_SOURCE", BODY_WO_A_SHAPE, BODY_WO_A_BYTES),
+])
+def test_footprint_reproduces_the_checkpoints_own_bytes(fmt, shape, expected):
+    assert fr.get_format(fmt).memory_bytes_for_shape(shape) == expected
+
+
+def test_mxfp4_expert_layer_totals_match_the_checkpoint():
+    """One DSv4 expert layer is 256 experts x {w1, w3, w2}."""
+    per_expert = 2 * EXPERT_W13_BYTES + EXPERT_W2_BYTES
+    assert N_EXPERTS * per_expert == EXPERT_LAYER_BYTES
+    assert 43 * EXPERT_LAYER_BYTES == 147_169_738_752
+
+
+def test_the_two_fp8_block_formats_are_not_interchangeable():
+    """FP8_SOURCE and FP8_BLOCK_UE8M0_SOURCE differ in the scale plane.
+
+    Same E4M3 elements and same 128x128 block, but FP32 scales vs one-byte
+    UE8M0 exponents. Treating them as one format charges 4x the scale bytes
+    and — worse on the export side — widens a UE8M0 plane to FP32, emitting a
+    tensor the model's own loader does not expect.
+    """
+    fp32_scaled = fr.get_format("FP8_SOURCE")
+    ue8m0 = fr.get_format("FP8_BLOCK_UE8M0_SOURCE")
+    assert fp32_scaled.scale_block_shape == ue8m0.scale_block_shape == (128, 128)
+    assert fp32_scaled.scale_bits == 32 and ue8m0.scale_bits == 8
+    assert (fp32_scaled.memory_bytes_for_shape(BODY_WO_A_SHAPE)
+            > ue8m0.memory_bytes_for_shape(BODY_WO_A_SHAPE))
+    assert ue8m0.memory_bytes_for_shape(BODY_WO_A_SHAPE) == BODY_WO_A_BYTES
+    assert PASSTHROUGH_SOURCE_REQUIREMENTS["FP8_SOURCE"] != (
+        PASSTHROUGH_SOURCE_REQUIREMENTS["FP8_BLOCK_UE8M0_SOURCE"])
+
+
+# ---------------------------------------------------------------------------
+# 2. Pricing: exact by construction, and not by measurement
+# ---------------------------------------------------------------------------
+
+def test_synthesized_entry_prices_at_zero_with_passthrough_provenance():
+    entry = synthesized_source_passthrough_cost_entry("MXFP4_SOURCE")
+    stats = {"h_trace": 12345.0, "n_params": 1 << 20}
+    assert entry["cost_source"] == SOURCE_PASSTHROUGH_COST_SOURCE
+    assert cost_entry_is_source_passthrough(entry, "MXFP4_SOURCE")
+    assert cost_entry_is_exact_by_construction(entry, "MXFP4_SOURCE")
+    # Zero even against a large h_trace: the price is not an estimate that
+    # happens to be small, it is the identity transform on the reference.
+    assert cost_entry_predicted_dloss(
+        stats, entry, format_name="MXFP4_SOURCE") == 0.0
+    # Neither measured nor weight-only.
+    assert not cost_entry_uses_measured_output_mse(
+        stats, entry, "MXFP4_SOURCE")
+    assert cost_entry_source(stats, entry, "MXFP4_SOURCE") == (
+        SOURCE_PASSTHROUGH_COST_SOURCE)
+    assert cost_entry_activation_pricing_branch(
+        stats, entry, "MXFP4_SOURCE") == BRANCH_SOURCE_PASSTHROUGH
+
+
+def test_passthrough_provenance_cannot_be_forged_for_another_format():
+    """The cost_source string alone proves nothing.
+
+    A hand-written or stale cost table must not be able to claim exactness for
+    an activation-quantizing rung by writing the magic string into it — that
+    would price a 4-bit W4A4 rung at the DP's global minimum on no evidence,
+    the exact defect `cost_entry_prices_unmeasured_activation_at_zero` exists
+    to prevent.
+    """
+    forged = {"cost_source": SOURCE_PASSTHROUGH_COST_SOURCE,
+              "predicted_dloss": 0.0}
+    assert not cost_entry_is_source_passthrough(forged, "NVFP4_CB_K14")
+    assert not cost_entry_is_exact_by_construction(forged, "NVFP4_CB_K14")
+    assert not cost_entry_is_source_passthrough(forged, "NOT_A_FORMAT")
+    # ...and a passthrough format still needs the provenance to claim it.
+    assert not cost_entry_is_source_passthrough(
+        {"weight_mse": 0.0}, "MXFP4_SOURCE")
+
+
+# ---------------------------------------------------------------------------
+# 3. Legality: the source-kind gate, in both directions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("fmt,kind,legal", [
+    ("MXFP4_SOURCE", "mxfp4", True),
+    ("MXFP4_SOURCE", "fp8_ue8m0", False),
+    ("MXFP4_SOURCE", "bf16", False),
+    ("FP8_BLOCK_UE8M0_SOURCE", "fp8_ue8m0", True),
+    ("FP8_BLOCK_UE8M0_SOURCE", "mxfp4", False),
+    ("FP8_BLOCK_UE8M0_SOURCE", "fp8", False),
+    ("BF16", "bf16", True),
+    ("BF16", "mxfp4", False),
+])
+def test_passthrough_is_legal_exactly_where_the_source_is_that_format(
+        fmt, kind, legal):
+    verdict = check_format_applicability(
+        EXPERT_W13_SHAPE if fmt == "MXFP4_SOURCE" else BODY_WO_A_SHAPE,
+        fmt,
+        qname=("model.layers.3.mlp.experts.0.gate_proj"
+               if fmt == "MXFP4_SOURCE" else "model.layers.3.self_attn.wq_a"),
+        source_kind=kind,
+        target_profile="nvfp4_cb",
+    )
+    assert verdict.legal is legal, (fmt, kind, verdict.reason, verdict.detail)
+    if not legal:
+        assert verdict.reason == "source_dtype_mismatch"
+
+
+def test_production_profile_allows_mxfp4_on_experts_and_denies_it_elsewhere():
+    """Ship-intent: the production nvfp4_cb profile permits the rung."""
+    assert check_serving_format(
+        "nvfp4_cb", "model.layers.39.mlp.experts.0.gate_proj",
+        "MXFP4_SOURCE").legal
+    # The aggregated packed super item is still an expert unit. This is the
+    # trap the rule's not_regex form exists to avoid: filter_candidates_for_
+    # profile re-checks with packed_expert=None after aggregation, and a
+    # scope="dense" rule would have stripped the format from the very unit it
+    # belongs on.
+    assert check_serving_format(
+        "nvfp4_cb",
+        "model.layers.39.mlp.experts.__packed_serving__.gate_up_proj",
+        "MXFP4_SOURCE").legal
+    denied = check_serving_format(
+        "nvfp4_cb", "model.layers.39.self_attn.wq_a", "MXFP4_SOURCE")
+    assert not denied.legal and denied.reason == "runtime_unsupported"
+
+
+def test_lane_metadata_declares_a_distinct_delegated_native_route():
+    lane = serving_lane_route("nvfp4_cb", "MXFP4_SOURCE").as_dict()
+    assert lane["lane_id"] == "delegated_native_mxfp4"
+    assert lane["rung"] is None
+    assert lane["fused_mid_m_backed"] is False
+    # NOT a CB contract — that is the whole point of a separate lane.
+    assert "cb" not in lane["activation_contract"]
+    cb_lane = serving_lane_route("nvfp4_cb", "NVFP4_CB_K14").as_dict()
+    assert cb_lane["lane_id"] != lane["lane_id"]
+    assert cb_lane["activation_contract"] != lane["activation_contract"]
+
+
+def test_mxfp4_route_is_declared_pending_not_backed():
+    """Honesty gate: the rung ships on the menu, but not silently."""
+    assert "MXFP4_SOURCE" in ROUTE_PENDING_PASSTHROUGH_FORMATS
+    assert "FP8_BLOCK_UE8M0_SOURCE" not in ROUTE_PENDING_PASSTHROUGH_FORMATS
+    assert not SOURCE_PASSTHROUGH_CONTRACTS["MXFP4_SOURCE"].route_backed
+
+
+# ---------------------------------------------------------------------------
+# 4. Allocation integration
+# ---------------------------------------------------------------------------
+
+def _expert_tables(n_layers=2, n_experts=2):
+    """A miniature DSv4-shaped MoE: per-expert 2-D Linears, mxfp4 source.
+
+    Layer 1 is made far more sensitive than layer 0 (h_trace 1000x), so a DP
+    that respects cost must protect it.
+    """
+    stats, costs, manifest = {}, {}, {}
+    for layer in range(n_layers):
+        for expert in range(n_experts):
+            for proj, shape in (("gate_proj", EXPERT_W13_SHAPE),
+                                ("up_proj", EXPERT_W13_SHAPE),
+                                ("down_proj", EXPERT_W2_SHAPE)):
+                name = f"model.layers.{layer}.mlp.experts.{expert}.{proj}"
+                stats[name] = {
+                    "h_trace": 1.0 if layer == 0 else 1000.0,
+                    "n_params": shape[0] * shape[1],
+                    "out_features": shape[0], "in_features": shape[1],
+                }
+                costs[name] = {
+                    "NVFP4_CB_K14": {"weight_mse": 1e-3, "output_mse": 2e-3,
+                                     "output_mse_measured": True},
+                    "FP8_CB_K36": {"weight_mse": 1e-5, "output_mse": 2e-5,
+                                   "output_mse_measured": True},
+                }
+                manifest[name] = "mxfp4"
+    return stats, costs, manifest
+
+
+def test_allocator_synthesizes_a_zero_cost_passthrough_candidate():
+    """The cost table has NO MXFP4_SOURCE column and never will."""
+    stats, costs, manifest = _expert_tables()
+    from prismaquant.nvfp4_cb_footprint import CBSerializationContext
+
+    ctx = CBSerializationContext(
+        scale_coding="two_tier", codebook_source="lattice",
+        scale_sweep=True, encode_tier="balanced")
+    specs = [fr.get_format(f) for f in
+             ("NVFP4_CB_K14", "FP8_CB_K36", "MXFP4_SOURCE")]
+    cands = build_candidates(
+        stats, costs, specs, source_manifest=manifest,
+        target_profile="nvfp4_cb", cb_serialization_context=ctx)
+    assert cands, "no candidates built"
+    for name, rows in cands.items():
+        by_fmt = {c.fmt: c for c in rows}
+        assert "MXFP4_SOURCE" in by_fmt, name
+        passthrough = by_fmt["MXFP4_SOURCE"]
+        assert passthrough.predicted_dloss == 0.0
+        assert passthrough.activation_pricing == BRANCH_SOURCE_PASSTHROUGH
+        assert passthrough.serving_lane.lane_id == "delegated_native_mxfp4"
+        # Exact source bytes for the unit, weight + E8M0 scale plane.
+        expected = (EXPERT_W2_BYTES if name.endswith("down_proj")
+                    else EXPERT_W13_BYTES)
+        assert passthrough.memory_bytes == expected
+        # ...and it strictly dominates the costlier lossy rung.
+        k36 = by_fmt["FP8_CB_K36"]
+        assert passthrough.memory_bytes < k36.memory_bytes
+        assert passthrough.predicted_dloss < k36.predicted_dloss
+
+
+def test_passthrough_is_not_offered_where_the_source_is_something_else():
+    stats, costs, manifest = _expert_tables()
+    manifest = {name: "bf16" for name in manifest}
+    from prismaquant.nvfp4_cb_footprint import CBSerializationContext
+
+    ctx = CBSerializationContext(
+        scale_coding="two_tier", codebook_source="lattice",
+        scale_sweep=True, encode_tier="balanced")
+    specs = [fr.get_format(f) for f in ("NVFP4_CB_K14", "MXFP4_SOURCE")]
+    masks: list[dict] = []
+    cands = build_candidates(
+        stats, costs, specs, source_manifest=manifest,
+        target_profile="nvfp4_cb", cb_serialization_context=ctx,
+        mask_records=masks)
+    for rows in cands.values():
+        assert "MXFP4_SOURCE" not in {c.fmt for c in rows}
+    assert masks and all(
+        m["reason"] == "source_dtype_mismatch"
+        for m in masks if m["format"] == "MXFP4_SOURCE")
+
+
+def test_selection_records_the_delegated_native_lane():
+    """A shipped selection must name the lane every unit rides."""
+    assignment = {
+        "model.layers.0.mlp.experts.0.gate_proj": "NVFP4_CB_K14",
+        "model.layers.1.mlp.experts.0.gate_proj": "MXFP4_SOURCE",
+    }
+    prov = selection_serving_lane_provenance(
+        assignment, None, "nvfp4_cb")
+    assert prov["units_total"] == 2
+    assert "MXFP4_SOURCE" in prov["by_format"]
+    route = prov["by_format"]["MXFP4_SOURCE"]["route"]
+    assert route["lane_id"] == "delegated_native_mxfp4"
+    # The passthrough unit is NOT counted under a CB activation contract.
+    assert set(prov["activation_contracts"]) == {
+        route["activation_contract"],
+        prov["by_format"]["NVFP4_CB_K14"]["route"]["activation_contract"],
+    }

--- a/tests/test_source_passthrough_family.py
+++ b/tests/test_source_passthrough_family.py
@@ -249,9 +249,28 @@ def test_route_status_follows_the_measurement_not_the_intuition():
     assert not body.route_backed
     # Both carry the evidence for their verdict.
     assert mxfp4.route_evidence and body.route_evidence
-    # Blocked/pending rungs stay ON the menu but gate the export.
-    assert "FP8_BLOCK_UE8M0_SOURCE" in ROUTE_PENDING_PASSTHROUGH_FORMATS
-    assert "MXFP4_SOURCE" not in ROUTE_PENDING_PASSTHROUGH_FORMATS
+
+
+def test_export_gate_set_is_derived_from_route_status_not_transcribed():
+    """The MECHANISM, stated table-agnostically.
+
+    Deliberately separate from the verdict pin above. When the serving side
+    unblocks a route the verdict pin SHOULD fail — someone must consciously
+    update it and its evidence — but this must not, because the rule "anything
+    not measurably backed gates the export" does not change when a single
+    format's verdict does. Asserting today's membership here instead would
+    make one edit look like two failures and invite fixing it by transcribing
+    the new answer.
+    """
+    assert ROUTE_PENDING_PASSTHROUGH_FORMATS == {
+        name for name, contract in SOURCE_PASSTHROUGH_CONTRACTS.items()
+        if contract.route_status != ROUTE_STATUS_BACKED
+    }
+    # ...and `backed` is the ONLY status that ships without an override, so a
+    # future third non-backed status inherits the gate rather than escaping it.
+    for name, contract in SOURCE_PASSTHROUGH_CONTRACTS.items():
+        gated = name in ROUTE_PENDING_PASSTHROUGH_FORMATS
+        assert gated is (not contract.route_backed), name
 
 
 def test_wire_format_ids_are_the_closed_cross_repo_enum():

--- a/tests/test_source_passthrough_family.py
+++ b/tests/test_source_passthrough_family.py
@@ -21,6 +21,10 @@ import prismaquant.format_registry as fr
 from prismaquant.activation_fair_pricing import BRANCH_SOURCE_PASSTHROUGH
 from prismaquant.allocator_candidates import (
     PASSTHROUGH_SOURCE_REQUIREMENTS,
+    PASSTHROUGH_WIRE_FORMAT_IDS,
+    ROUTE_STATUS_BACKED,
+    ROUTE_STATUS_BLOCKED,
+    passthrough_serving_notes,
     ROUTE_PENDING_PASSTHROUGH_FORMATS,
     SOURCE_PASSTHROUGH_CONTRACTS,
     SOURCE_PASSTHROUGH_COST_SOURCE,
@@ -226,11 +230,51 @@ def test_lane_metadata_declares_a_distinct_delegated_native_route():
     assert cb_lane["activation_contract"] != lane["activation_contract"]
 
 
-def test_mxfp4_route_is_declared_pending_not_backed():
-    """Honesty gate: the rung ships on the menu, but not silently."""
-    assert "MXFP4_SOURCE" in ROUTE_PENDING_PASSTHROUGH_FORMATS
-    assert "FP8_BLOCK_UE8M0_SOURCE" not in ROUTE_PENDING_PASSTHROUGH_FORMATS
-    assert not SOURCE_PASSTHROUGH_CONTRACTS["MXFP4_SOURCE"].route_backed
+def test_route_status_follows_the_measurement_not_the_intuition():
+    """The measured sm121 verdicts, which came out the opposite way round.
+
+    "The released checkpoint already serves this way, so the route exists"
+    is false for the BODY passthrough and true for the EXPERT one — and only
+    off the default backend. Pinning both directions here keeps a plausible
+    guess from quietly replacing the measurement.
+    """
+    mxfp4 = SOURCE_PASSTHROUGH_CONTRACTS["MXFP4_SOURCE"]
+    body = SOURCE_PASSTHROUGH_CONTRACTS["FP8_BLOCK_UE8M0_SOURCE"]
+    assert mxfp4.route_status == ROUTE_STATUS_BACKED
+    assert mxfp4.route_backed
+    # BACKED only WITH a requirement; a backed route whose requirement is
+    # unmet serves no better than a blocked one, so it must be declared.
+    assert mxfp4.route_requirement == "vllm --moe-backend marlin"
+    assert body.route_status == ROUTE_STATUS_BLOCKED
+    assert not body.route_backed
+    # Both carry the evidence for their verdict.
+    assert mxfp4.route_evidence and body.route_evidence
+    # Blocked/pending rungs stay ON the menu but gate the export.
+    assert "FP8_BLOCK_UE8M0_SOURCE" in ROUTE_PENDING_PASSTHROUGH_FORMATS
+    assert "MXFP4_SOURCE" not in ROUTE_PENDING_PASSTHROUGH_FORMATS
+
+
+def test_wire_format_ids_are_the_closed_cross_repo_enum():
+    """Registry names are ours; wire ids are a contract with the loader."""
+    assert PASSTHROUGH_WIRE_FORMAT_IDS == {
+        "MXFP4_SOURCE": "mxfp4_e2m1_ue8m0_g32",
+        "FP8_BLOCK_UE8M0_SOURCE": "fp8_e4m3_ue8m0_block128",
+    }
+    # Every format the allocator can SYNTHESIZE must be shippable, i.e. must
+    # have a wire id — otherwise the DP can select something the artifact
+    # cannot declare.
+    for name in SOURCE_PASSTHROUGH_FORMATS:
+        assert name in PASSTHROUGH_WIRE_FORMAT_IDS, name
+
+
+def test_serving_notes_carry_requirement_and_evidence():
+    notes = passthrough_serving_notes()
+    assert notes["MXFP4_SOURCE"]["requirement"] == "vllm --moe-backend marlin"
+    assert notes["MXFP4_SOURCE"]["route_status"] == ROUTE_STATUS_BACKED
+    assert notes["FP8_BLOCK_UE8M0_SOURCE"]["route_status"] == (
+        ROUTE_STATUS_BLOCKED)
+    for entry in notes.values():
+        assert entry["evidence"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
For any serving unit, the cheapest honest option is to keep the bytes the checkpoint already has. That option was not on the menu: `FP8_SOURCE` and `BF16` were two hand-written special cases, and DSv4-Flash's routed experts — 147 GB of nibble-packed MXFP4 — had no way to ship unchanged at all.

## The format family

`SOURCE_PASSTHROUGH_CONTRACTS` is the one table; adding a newly encountered native format is a table entry, not a new code path. Two new formats, both from a header-only census of the released checkpoint:

| format | unit | encoding | bpw |
| --- | --- | --- | --- |
| `MXFP4_SOURCE` | routed experts | nibble-packed E2M1 in I8 + E8M0 group scales | 4.25 |
| `FP8_BLOCK_UE8M0_SOURCE` | body | E4M3 + one-byte UE8M0 block exponents at 128x128 | 8.00049 |

The census also corrected two live defects: the source-kind scan keyed on "has a scale sibling" and stamped `fp8`, classifying 33,024 MXFP4 experts as `FP8_SOURCE`-compatible (an 8.002 bpw format declared legal on a 4.25 bpw unit); and the body is not `FP8_SOURCE` at all — same E4M3 grid, but UE8M0 exponents rather than an FP32 `weight_scale_inv` plane.

## Zero-cost candidates, with bytes pinned to the checkpoint

Every cost in this pipeline is measured against the dequantized source, so shipping the source bytes is the identity transform on the reference: `predicted_dloss` is `0.0` with provenance `cost_source="source_passthrough"`. No cost table will ever carry a column for a byte-copy contract, so the allocator *synthesizes* the candidate rather than dropping the unit's only zero-error option. The claim cannot be forged — the provenance string is honoured only for a declared passthrough format whose activation path is the identity.

Bytes are pinned against the checkpoint rather than trusted. The floor subtracts a passthrough unit's real header span while the body would add its closed-form byte count; those are two different computations, so `assignment_artifact_bytes` charges the span and refuses an allocation where the two disagree instead of letting the artifact budget drift.

## Measured route verdicts, and they inverted

Both route verdicts were guesses, and both were wrong. Measured on GB10/sm121:

* **`MXFP4_SOURCE`** — assumed pending, is **BACKED**, but only via vLLM's Marlin MoE backend. The auto-selected `DeepGEMM_MXFP4` asserts on the SF transformation, FlashInfer is gated to capability family 100, and the OAI Triton path is hard-excluded on SM12x (0/15 kernels).
* **`FP8_BLOCK_UE8M0_SOURCE`** — assumed backed, is **BLOCKED**. Every route is dead: `deep_gemm` assert, cutlass `scaled_mm` rejects the block layout, triton `KeyError` on `float8_e8m0fnu`, flashinfer gate is sm90-exact, marlin-linear is `<=sm89`.

The second is the load-bearing finding: CB re-encoding of the body is the only way DSv4-Flash serves on this box at all. The body's CB rungs are architectural, not merely economical.

So `route_backed: bool` was the wrong shape — it cannot distinguish "nobody looked" from "we looked and it is dead", and it has nowhere to put the condition that makes a backed route actually fire. It becomes **`route_status`** (backed / pending / blocked) plus **`route_requirement`** and **`route_evidence`**. A verdict without its evidence is a rumour, and a backed route whose requirement is unmet serves no better than a blocked one, so the requirement ships with the artifact rather than living in a run book.

Policy is unchanged and deliberate: a blocked or pending rung stays *on* the menu. The export is what fails closed — the ship gate reads `ROUTE_PENDING_PASSTHROUGH_FORMATS` at call time, so `FP8_BLOCK_UE8M0_SOURCE` now needs `--allow-route-pending-passthrough` and `MXFP4_SOURCE` ships without one.

## Exporter lane

Passthrough tensors are stream-copied, never materialized: `_LazySkeleton` gains the `raw_slice` (path, offset, nbytes) accessor `_PriorArtifact` already had, so a 3.4 GB expert layer moves through the 16 MiB chunked copy path without ever becoming a tensor. E8M0 scale planes are copied **verbatim** — the `FP8_SOURCE` branch widens its scale plane to FP32, which here would quadruple the scale bytes and emit a tensor the model's own loader does not expect.

`quant_config.json` gains a top-level `"source_passthrough": {"version": 1, "units": {...}}`, matching the consumer reader exactly (see the companion gridbook PR). Absence of the key means "legacy all-CB artifact", so it is omitted entirely rather than emitted empty — an empty units map would be a positive claim that nothing is delegated, which is a different statement. `build_quant_config` round-trips its own output through the consumer's parser before the file exists: every refusal that parser implements is a load failure at the other end, so the producer must never be the one to generate one.

A passthrough expert group is deliberately **not** collapsed into the packed `gate_up_proj`/`down_proj` parents — that collapse names a stack for gridbook's CB loader to anchor on, and a passthrough group has no CB loader and no packed parent. The uniformity check still runs first, so a layer mixing a CB rung with a passthrough is refused rather than silently split across two loaders. K0.2 stays honest via `assert_routes_reconcile`: no unit on both routes, no tensor emitted by both, no attested module also passthrough, no attested module unclaimed by CB.

## CB-ladder band interpolator

The cost stage's RD-ladder interpolation stamps `cost_source="band_interpolated"`, gated per tensor by a holdout check — a tensor whose law is rejected has its predicted rungs dropped rather than interpolated. `drop_interpolated_candidates_dominated_by_measured` removes an interpolated candidate only when a measured one is both no larger in bytes and within `band` relative Δloss, where `band` must be the measured holdout error from this run's own gate. Both conditions are required, so a genuine trade survives rather than being discarded on noise alone.

## Also fixes a pre-existing silent corruption

`_StreamWriter.write` built its header as a dict, so two emit paths claiming one tensor name kept only the **last** span while both blobs were still written — a file whose offsets are wrong from that point on, with no error. It now raises. Independent of this feature; the passthrough lane just made it reachable by adding tens of thousands of names from a second namespace.

## Tests

Suite: **2717 passed, 96 skipped**, +43 net new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUHqNEHMu7FAJQSNGCZhqW
