### PR TITLE
MXFP8_UE8M0_G32 menu format: W8A8 per-32 UE8M0, wire-matched to the gridbook lane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ tmp/
 
 # Editor swapfiles
 .*.swp
+
+# Staging dirs the probe creates beside the repo when no root is given
+# (sensitivity_probe.py: Path.cwd() / ".prismaquant_tmp"). Test runs leave
+# these behind, and they are never artifacts anyone means to track.
+.prismaquant_tmp/

--- a/docs/lanes/nvfp4-cb/source-passthrough.md
+++ b/docs/lanes/nvfp4-cb/source-passthrough.md
@@ -78,6 +78,13 @@ probe inventory: 33,325 Linears
 | `FP8_SOURCE` | — | `fp8` | 8.00195 | no | backed (other checkpoints) |
 | `BF16` | — | `bf16` | 16 | no | backed |
 
+The same routing record also carries the one **re-quantized** native rung,
+which is not a passthrough and has no source kind (it is legal on any):
+
+| Format | Wire id | bpw | Route status on sm121 |
+|---|---|---|---|
+| `MXFP8_UE8M0_G32` | `mxfp8_e4m3_e8m0_g32` | 8.25 | **unbacked — consumer lane exists but is opt-in (`GRIDBOOK_MXFP8_DENSE=1`), serve-parity bench pending** |
+
 ### The route verdicts came out the opposite way round
 
 Both were measured on GB10/sm121, 2026-08-03. The intuition "the released
@@ -188,8 +195,21 @@ consumer-side reader is implemented and shipped, so this is its exact spelling
 ```
 
 * the format-id enum is **closed**: `mxfp4_e2m1_ue8m0_g32`,
-  `fp8_e4m3_ue8m0_block128` (`PASSTHROUGH_WIRE_FORMAT_IDS` is the one mapping
-  from registry name to wire id);
+  `fp8_e4m3_ue8m0_block128`, `mxfp8_e4m3_e8m0_g32`. Ids come from two producer
+  tables — `PASSTHROUGH_WIRE_FORMAT_IDS` (byte-verbatim) and
+  `REQUANT_WIRE_FORMAT_IDS` (re-encoded here) — whose union
+  `WIRE_FORMAT_IDS` must stay 1:1, because the consumer resolves a unit by id
+  alone (`gridbook.source_passthrough.FORMATS`);
+* **what this record actually claims** is *delegated-native routing* — "served
+  by a native Gridbook/model-owned route, not by a CB codebook decoder" —
+  which is the question the consumer's dispatcher asks. It is NOT a claim that
+  every listed unit's bytes are the checkpoint's own; a re-quantized rung is
+  listed here too, and a unit omitted here reads to the consumer as CB, the
+  one wrong answer that loads. The stronger byte-verbatim claim is per unit in
+  its config group's `weights.source_passthrough` flag (`true` for the
+  `*_SOURCE` family, `false` for a re-encode). The key keeps its historical
+  name because it is a shipped cross-repo contract
+  (`gridbook.source_passthrough.SCHEMA_KEY`);
 * a unit may be an expert group **or** a dense body Linear — there is no
   expert-only framing and no exhaustiveness claim;
 * **absence of the key means a legacy all-CB artifact**, so the key is emitted

--- a/prismaquant/allocator_candidates.py
+++ b/prismaquant/allocator_candidates.py
@@ -250,6 +250,36 @@ PASSTHROUGH_WIRE_FORMAT_IDS: dict[str, str] = {
     if contract.wire_format_id is not None
 }
 
+# The same cross-repo wire enum, for formats this producer RE-ENCODES rather
+# than copies. Kept as its own table beside the passthrough ids rather than
+# folded into SOURCE_PASSTHROUGH_CONTRACTS, because that table means something
+# specific and load-bearing: every member has an IDENTITY codec and a Δloss of
+# zero by construction. A re-quantization rung has a real encoder and a real
+# measured cost, so declaring it there would let it claim an exactness it has
+# not earned (tests/test_source_passthrough_family.py pins that invariant).
+#
+# What the two tables DO share is that the id is a contract with the consumer:
+# the registry name is ours to rename, the wire id is not.
+#
+# NOTE FOR ORCHESTRATOR RECONCILIATION: ``mxfp8_e4m3_e8m0_g32`` is the
+# spelling the Gridbook consumer side proposed. It diverges from this repo's
+# own convention, which spells the unsigned-E8M0 scale plane ``ue8m0``
+# (``mxfp4_e2m1_ue8m0_g32``, ``fp8_e4m3_ue8m0_block128``). The consumer's
+# spelling is used verbatim here rather than guessed at; if the two repos
+# settle on ``mxfp8_e4m3_ue8m0_g32`` instead, this one string is the only
+# producer-side edit.
+REQUANT_WIRE_FORMAT_IDS: dict[str, str] = {
+    "MXFP8_UE8M0_G32": "mxfp8_e4m3_e8m0_g32",
+}
+
+# Every wire id this producer can declare, from either table. Ids must be
+# globally unique: the consumer dispatches on the id alone and cannot tell
+# which producer-side table it came from.
+WIRE_FORMAT_IDS: dict[str, str] = {
+    **PASSTHROUGH_WIRE_FORMAT_IDS,
+    **REQUANT_WIRE_FORMAT_IDS,
+}
+
 
 def passthrough_serving_notes() -> dict[str, dict[str, str]]:
     """Per-format serving requirements/evidence for the artifact's notes.

--- a/prismaquant/cb_export_config.py
+++ b/prismaquant/cb_export_config.py
@@ -23,6 +23,7 @@ import torch
 from prismaquant import format_registry as fr
 from prismaquant.allocator_candidates import (
     PASSTHROUGH_WIRE_FORMAT_IDS,
+    REQUANT_WIRE_FORMAT_IDS,
     SOURCE_PASSTHROUGH_CONTRACTS,
     SourcePassthroughContract,
 )
@@ -213,6 +214,113 @@ DELEGATED_NATIVE_PASSTHROUGH_FORMATS: frozenset[str] = frozenset(
     if not source_passthrough_wire(name).ct_normalized
 )
 
+# ---------------------------------------------------------------------------
+# Re-quantized (non-passthrough) wire formats the STREAMING exporter emits
+# ---------------------------------------------------------------------------
+# Formats this lane produces with a real encoder, under their own wire id,
+# outside the compressed-tensors scheme vocabulary. Structurally these sit
+# between the two existing classes: like a passthrough they get a scheme-less
+# config group and a wire id (stock CT cannot describe them); unlike a
+# passthrough the producer WROTE these bytes, so they are re-derivable, they
+# carry a real measured cost, and they are legal on any source dtype.
+#
+# The literal here is the streaming exporter's emit surface, re-exported for
+# the serving profile's export lane (serving_profile_specs/nvfp4_cb.json
+# ``codec_formats_from``) so the allocator can never spend budget on a rung
+# this exporter would hard-fail on. Declaring it here rather than in
+# export_nvfp4_cb_streaming keeps the lane's format vocabulary in the module
+# that already owns the wire contract, and keeps the profile's lazy import off
+# a module that pulls the whole streaming stack.
+STREAMING_REQUANT_EXPORT_FORMATS: frozenset[str] = frozenset(
+    REQUANT_WIRE_FORMAT_IDS
+)
+REQUANT_WIRE_IDS: dict[str, str] = dict(REQUANT_WIRE_FORMAT_IDS)
+REQUANT_WIRE_FORMATS: dict[str, str] = {
+    wire_id: name for name, wire_id in REQUANT_WIRE_IDS.items()
+}
+
+# Every wire id the DELEGATED-NATIVE routing record may carry, from either
+# table. This is the producer-side mirror of the consumer's own registry
+# (``gridbook.source_passthrough.FORMATS``), which holds every id it can route
+# regardless of what produced the bytes. Ids must be unique across the two:
+# the consumer resolves a unit by id alone.
+DELEGATED_NATIVE_WIRE_FORMATS: dict[str, str] = {
+    **SOURCE_PASSTHROUGH_WIRE_FORMATS,
+    **REQUANT_WIRE_FORMATS,
+}
+
+# Config-group ``format`` token for a re-quantized native rung. Same reasoning
+# as SOURCE_PASSTHROUGH_GROUP_FORMAT: no compressed-tensors format string
+# describes "the Gridbook runtime reads this element+scale pair directly", and
+# borrowing one would make a stock CT loader believe it could read the group.
+REQUANT_NATIVE_GROUP_FORMAT = "gridbook-native"
+
+
+def requant_wire_id(format_name: str) -> str:
+    """Registry format name -> the consumer's wire id, for a re-quant rung.
+
+    Fails closed exactly like ``source_passthrough_wire_id``: the consumer's
+    format enum is closed, so a rung that reached the emitter without an id
+    cannot be declared, and an undeclared group reads to the consumer as CB.
+    """
+
+    canonical = fr.canonical_format_name(str(format_name))
+    try:
+        return REQUANT_WIRE_IDS[canonical]
+    except KeyError:
+        raise ValueError(
+            f"{canonical} is not a declared re-quantization wire format "
+            f"(allocator_candidates.REQUANT_WIRE_FORMAT_IDS: "
+            f"{sorted(REQUANT_WIRE_IDS)})"
+        ) from None
+
+
+def requant_native_config_group(format_name: str) -> dict[str, Any]:
+    """The scheme-less config group one re-quantized native rung gets.
+
+    Built from the FormatSpec for the same reason as its passthrough twin: the
+    group cannot describe a different on-disk contract than the one the
+    accountant priced and the emitter wrote.
+    """
+
+    canonical = fr.canonical_format_name(str(format_name))
+    wire = requant_wire_id(canonical)
+    spec = fr.get_format(canonical)
+    weights: dict[str, Any] = {
+        "num_bits": int(spec.weight_bits),
+        "type": "float",
+        "element_dtype": str(spec.weight_element_dtype),
+        "scale_dtype": str(spec.scale_dtype_name),
+        "symmetric": True,
+        "dynamic": False,
+        "strategy": "group",
+        "group_size": int(spec.group_size),
+        # These bytes WERE produced here, unlike a passthrough group.
+        "source_passthrough": False,
+    }
+    activations: dict[str, Any] | None = None
+    if spec.act_quant_changes_input:
+        # W8A8: the serving lane quantizes activations dynamically to the same
+        # grid, so the group says so. Stating None here would describe a
+        # weight-only contract the runtime does not implement.
+        activations = {
+            "num_bits": int(spec.act_bits),
+            "type": "float",
+            "element_dtype": str(spec.act_dtype_name),
+            "scale_dtype": str(spec.scale_dtype_name),
+            "symmetric": True,
+            "dynamic": True,
+            "strategy": "group",
+            "group_size": int(spec.act_group_size),
+        }
+    return {
+        "format": REQUANT_NATIVE_GROUP_FORMAT,
+        "source_format": canonical,
+        "wire_format_id": wire,
+        "weights": weights,
+        "input_activations": activations,
+    }
+
 
 def source_passthrough_config_group(format_name: str) -> dict[str, Any]:
     """The scheme-less config group one delegated-native passthrough gets.
@@ -267,6 +375,17 @@ def build_source_passthrough_declaration(
     There is no exhaustiveness claim here — the record says which units ARE
     passthrough, not that it has enumerated every unit in the model — so a
     partially-allocated model needs no special case.
+
+    WHAT THIS RECORD ACTUALLY MEANS, given it now carries re-quantized rungs
+    too: it is the DELEGATED-NATIVE ROUTING record — "these units are served by
+    a native Gridbook/model-owned route rather than by a CB codebook decoder",
+    which is the question the consumer's dispatcher asks. It is NOT a claim
+    that every listed unit's bytes came from the checkpoint unchanged; only the
+    ``*_SOURCE`` members make that stronger claim, and the config group's
+    ``weights.source_passthrough`` flag is where the two are distinguished per
+    unit. The key keeps its historical name because it is a shipped cross-repo
+    contract (``gridbook.source_passthrough.SCHEMA_KEY``) read by a released
+    consumer; renaming it would be a schema break for a wording improvement.
     """
 
     if not units:
@@ -283,7 +402,12 @@ def build_source_passthrough_declaration(
                 f"source_passthrough unit id {unit_id!r} is not a usable "
                 "module name"
             )
-        declared[unit] = source_passthrough_wire_id(format_name)
+        canonical = fr.canonical_format_name(str(format_name))
+        declared[unit] = (
+            REQUANT_WIRE_IDS[canonical]
+            if canonical in REQUANT_WIRE_IDS
+            else source_passthrough_wire_id(format_name)
+        )
     return {
         "version": SOURCE_PASSTHROUGH_DECLARATION_VERSION,
         "units": dict(sorted(declared.items())),
@@ -354,11 +478,15 @@ def parse_source_passthrough_declaration(
                 f"{SOURCE_PASSTHROUGH_DECLARATION_KEY} units must map string "
                 f"unit ids to string format ids, got {unit_id!r}: {wire_id!r}"
             )
-        if wire_id not in SOURCE_PASSTHROUGH_WIRE_FORMATS:
+        # The legal set is the UNION of the byte-verbatim and re-quantized
+        # wire tables: this record is the delegated-native ROUTING map the
+        # consumer dispatches on, and its ``FORMATS`` registry likewise holds
+        # every id it can route, whatever produced the bytes.
+        if wire_id not in DELEGATED_NATIVE_WIRE_FORMATS:
             raise ValueError(
                 f"{SOURCE_PASSTHROUGH_DECLARATION_KEY} unit {unit_id!r} "
                 f"declares unknown format id {wire_id!r}; legal ids are "
-                f"{sorted(SOURCE_PASSTHROUGH_WIRE_FORMATS)}"
+                f"{sorted(DELEGATED_NATIVE_WIRE_FORMATS)}"
             )
         parsed[unit_id] = wire_id
     contested = sorted(set(parsed) & _cb_config_group_targets(quant_config))
@@ -561,6 +689,7 @@ def build_quant_config(
     cb_targets: Mapping[str, CBTarget],
     source_targets: Iterable[str],
     native_source_targets: Mapping[str, str] | None = None,
+    requant_targets: Mapping[str, str] | None = None,
     stock_targets: Mapping[str, str],
     by_group: Mapping[tuple[str, str], Sequence[str]],
     codebooks: Mapping[tuple[str, str], object],
@@ -579,6 +708,7 @@ def build_quant_config(
     delegated_target_name: TargetName = _identity_target,
     source_target_name: TargetName = _identity_target,
     native_source_target_name: TargetName = _identity_target,
+    requant_target_name: TargetName = _identity_target,
     source_passthrough_units: Mapping[str, str] | None = None,
     route_pending_passthrough_acknowledged: Iterable[str] = (),
     weight_only_stock_targets: Iterable[str] = (),
@@ -594,6 +724,15 @@ def build_quant_config(
     from :func:`source_passthrough_config_group`.  The split is the wire
     contract, not a taxonomy: see ``_CT_SCALE_DTYPE_NAME``.
 
+    ``requant_targets`` is the RE-QUANTIZED native lane, ``{qname: format}``:
+    bytes this producer wrote with a real encoder, under a wire id stock
+    compressed-tensors cannot express.  One config group per format, from
+    :func:`requant_native_config_group`.  These units DO appear in the
+    ``source_passthrough`` declaration, because that record is the
+    delegated-native ROUTING map the consumer dispatches on and a unit missing
+    from it reads as CB; what they do not carry is the byte-verbatim claim,
+    which lives per unit in ``weights.source_passthrough``.
+
     ``source_passthrough_units`` is ``{unit id: registry format name}`` for the
     units this artifact delegates, and becomes the top-level
     ``source_passthrough`` key.  Empty or ``None`` omits the key entirely —
@@ -603,6 +742,7 @@ def build_quant_config(
 
     source_targets = list(source_targets)
     native_source_targets = dict(native_source_targets or {})
+    requant_targets = dict(requant_targets or {})
     weight_only_stock_targets = set(weight_only_stock_targets)
     assignment_sha = hashlib.sha256(
         json.dumps(
@@ -689,6 +829,19 @@ def build_quant_config(
         )
         config_groups[f"group_{len(config_groups)}"] = native_group
 
+    requant_by_format: dict[str, list[str]] = {}
+    for qname, fmt in requant_targets.items():
+        requant_by_format.setdefault(
+            fr.canonical_format_name(fmt), []
+        ).append(qname)
+    for fmt, qnames in sorted(requant_by_format.items()):
+        requant_group = requant_native_config_group(fmt)
+        requant_group["targets"] = sorted(
+            _explicit_regex(requant_target_name(qname))
+            for qname in qnames
+        )
+        config_groups[f"group_{len(config_groups)}"] = requant_group
+
     provenance: dict[str, Any] = {
         "git_commit": git_commit,
         "assignment_sha256": assignment_sha,
@@ -707,6 +860,12 @@ def build_quant_config(
         "source_passthrough_targets": {
             fmt: len(qnames)
             for fmt, qnames in sorted(native_by_format.items())
+        },
+        # Same per-format shape, different claim: these units were RE-ENCODED
+        # here, so they are deliberately not folded into the count above.
+        "requant_native_targets": {
+            fmt: len(qnames)
+            for fmt, qnames in sorted(requant_by_format.items())
         },
         "serialized_payload": dict(serialized_payload_summary),
         "render_identity_verified": cb_render_identity is not None,

--- a/prismaquant/export_nvfp4_cb_streaming.py
+++ b/prismaquant/export_nvfp4_cb_streaming.py
@@ -72,6 +72,7 @@ from prismaquant.allocator_candidates import (
 )
 from prismaquant.cb_export_config import (
     SOURCE_PASSTHROUGH_EXPORT_FORMATS,
+    STREAMING_REQUANT_EXPORT_FORMATS,
     parse_source_passthrough_declaration,
     build_cb_scheme,
     build_quant_config,
@@ -80,7 +81,10 @@ from prismaquant.cb_export_config import (
     codebook_tensors as _codebook_tensors,
     source_passthrough_wire,
 )
-from prismaquant.format_registry import get_format as _fr_get_format
+from prismaquant.format_registry import (
+    canonical_format_name,
+    get_format as _fr_get_format,
+)
 from prismaquant.export_nvfp4_cb import (
     _canonical_qname,
     _export_base_name,
@@ -406,6 +410,54 @@ def _stock_output_specs(fmt: str, shape) -> list[tuple[str, torch.dtype, tuple]]
             ("weight_scale", torch.float32, (n, 1)),
         ]
     raise ValueError(f"no stock streaming spec for {fmt!r}")
+
+
+def _requant_output_specs(fmt: str, shape) -> list[tuple[str, torch.dtype, tuple]]:
+    """On-disk ``(suffix, dtype, out_shape)`` for a re-quantized native rung.
+
+    Deliberately the SAME ``weight`` / ``weight_scale`` suffix pair the
+    FP8_E4M3 stock rung and the CT-normalized FP8_SOURCE lane already use: the
+    suffix names what a plane IS (elements, and their scales), not which codec
+    produced it, so a new native rung does not invent a third spelling for the
+    same two roles.
+
+      * MXFP8_UE8M0_G32: ``weight`` fp8_e4m3 [N, K], ``weight_scale``
+        float8_e8m0fnu [N, K/32]. The scale plane is the NATIVE E8M0 dtype, not
+        the ``uint8`` the compressed-tensors MXFP8 scheme serializes — that is
+        one of the reasons this rung is its own format rather than the stock
+        one (see the FormatSpec comment in format_registry).
+    """
+    n, k = int(shape[-2]), int(shape[-1])
+    spec = _fr_get_format(fmt)
+    group = int(spec.group_size)
+    if group <= 0 or k % group:
+        raise ValueError(
+            f"{fmt}: in_features={k} is not a multiple of the declared group "
+            f"size {group}; check_format_applicability should have masked this "
+            "target before it reached the exporter")
+    return [
+        ("weight", torch.float8_e4m3fn, (n, k)),
+        ("weight_scale", torch.float8_e8m0fnu, (n, k // group)),
+    ]
+
+
+def _requant_pack(fmt: str, w: torch.Tensor) -> dict[str, torch.Tensor]:
+    """Encode one dense weight into its re-quantized on-disk planes.
+
+    Routes through the SAME registry codec the cost stage measured
+    (``mx_formats.mxfp8_ue8m0_qdq``), so priced error and shipped bytes are one
+    rendering rather than two implementations that agree by inspection.
+    """
+    canon = canonical_format_name(fmt)
+    if canon == "MXFP8_UE8M0_G32":
+        from prismaquant.mx_formats import mxfp8_ue8m0_qdq
+
+        spec = _fr_get_format(canon)
+        result = mxfp8_ue8m0_qdq(
+            w.to(torch.float32), group_size=int(spec.group_size)
+        )
+        return {"weight": result.quant, "weight_scale": result.scale}
+    raise ValueError(f"no re-quant streaming packer for {fmt!r}")
 
 
 class _StreamWriter:
@@ -1398,6 +1450,7 @@ def export_nvfp4_cb_streaming(
     source_targets: list[str] = []              # CT-normalized (FP8_SOURCE)
     native_source_targets: dict[str, str] = {}  # qname -> byte-verbatim format
     stock_targets: dict[str, str] = {}          # qname -> "NVFP4" | "FP8_E4M3"
+    requant_targets: dict[str, str] = {}        # qname -> re-encoded native fmt
     illegal = []
     for qname, fmt in assignment.items():
         if fmt == "BF16":
@@ -1416,14 +1469,22 @@ def export_nvfp4_cb_streaming(
         if canon in _STOCK_CT_FORMATS:
             stock_targets[qname] = canon
             continue
+        # Re-quantized native rungs: this producer WROTE the bytes (unlike the
+        # passthrough lane) but stock compressed-tensors cannot describe them
+        # (unlike the delegated lane), so they get their own emit branch, their
+        # own wire id and a scheme-less config group.
+        if canon in STREAMING_REQUANT_EXPORT_FORMATS:
+            requant_targets[qname] = canon
+            continue
         illegal.append((qname, fmt))
     if illegal:
         raise ValueError(
             "streaming CB export carries CB families + stock NVFP4/FP8_DYNAMIC "
             "(CT-delegated) + the source-passthrough family "
-            f"{sorted(SOURCE_PASSTHROUGH_EXPORT_FORMATS)} + BF16 only; "
-            f"unsupported rung(s) {sorted({f for _, f in illegal})} — assign a "
-            "legal format or use the in-memory export_nvfp4_cb.")
+            f"{sorted(SOURCE_PASSTHROUGH_EXPORT_FORMATS)} + the re-quantized "
+            f"native family {sorted(STREAMING_REQUANT_EXPORT_FORMATS)} + BF16 "
+            f"only; unsupported rung(s) {sorted({f for _, f in illegal})} — "
+            "assign a legal format or use the in-memory export_nvfp4_cb.")
 
     # --- ROUTE-PENDING SHIP GATE. A passthrough rung whose serve route has not
     # been validated stays ON the allocator's menu deliberately: an allocation
@@ -2165,6 +2226,52 @@ def export_nvfp4_cb_streaming(
                     else "stock_dtype_shape_mismatch"] += 1
         counts[canon_fmt] += 1
 
+    # Re-quantized native DENSE targets (MXFP8_UE8M0_G32). Structurally the
+    # stock-CT loop above with a different packer: one producer encodes the
+    # weight once into its element + scale planes and the writer streams them
+    # one at a time. The codec is RTN with no search and no cross-tensor input,
+    # so it is deterministic from the (unchanged) source weight and the same
+    # dtype+shape copy gate the stock lane uses is sound here too.
+    for qname in sorted(requant_targets):
+        canon_fmt = requant_targets[qname]
+        export_base = _base_name(qname)
+        kind, h = _resolve_target(qname)              # dense: kind == "tensor"
+        shape = _target_shape(qname)
+        emitted_bases.add(h)
+        state: dict = {}
+
+        def _render(h=h, canon_fmt=canon_fmt, state=state):
+            if "out" not in state:
+                w = skeleton.dequant_weight(h).to(device)
+                packed = _requant_pack(canon_fmt, w)
+                state["out"] = {s: t.cpu().contiguous()
+                                for s, t in packed.items()}
+                del w
+            return state["out"]
+
+        specs = _requant_output_specs(canon_fmt, shape)
+        expected = [(export_base + "." + s, d, o) for s, d, o in specs]
+        requant_ok = prior is not None and all(
+            prior.matches_dtype_shape(n, d, o) for n, d, o in expected)
+        if requant_ok:
+            for name, dtype, _sh in expected:
+                writer.add(name, dtype, prior.shape(name), None,
+                           copy_src=prior.raw_slice(name))
+            reuse["copied"] += 1
+        else:
+            for (name, dtype, out_shape), (suffix, _d, _o) in zip(
+                    expected, specs):
+                def _prod(suffix=suffix, _render=_render):
+                    return _render()[suffix]
+                writer.add(name, dtype, out_shape, _prod)
+            if prior is not None:
+                reuse["encoded"] += 1
+                reuse["reasons"][
+                    "requant_not_in_prior" if not prior.has(expected[0][0])
+                    else "requant_dtype_shape_mismatch"] += 1
+        tensor_names_by_target[qname] = [n for n, _d, _o in expected]
+        counts[canon_fmt] += 1
+
     # Passthrough: every remaining checkpoint tensor verbatim (BF16/norms/etc).
     # Per-expert tensors consumed by a stacked CB target are NOT passthrough.
     # Expert groups are keyed by the on-disk (checkpoint) prefix; a nested
@@ -2345,15 +2452,24 @@ def export_nvfp4_cb_streaming(
         return None
 
     def _source_passthrough_units() -> dict[str, str]:
-        """``{unit id: registry format}`` for every delegated unit, validated.
+        """``{unit id: registry format}`` for every DELEGATED-NATIVE unit.
 
-        No exhaustiveness claim: this says which units ARE passthrough, not
-        that every unit in the model was enumerated. What it does enforce is
-        that a unit is passthrough WHOLE — a routed-expert group with some
-        members delegated and some not would ship half a layer to the model's
-        own loader and half to gridbook's codec, which neither can serve.
+        No exhaustiveness claim: this says which units are delegated, not that
+        every unit in the model was enumerated. What it does enforce is that a
+        unit is delegated WHOLE — a routed-expert group with some members
+        delegated and some not would ship half a layer to the model's own
+        loader and half to gridbook's codec, which neither can serve.
+
+        Re-quantized native rungs are included: the consumer's dispatcher reads
+        this ONE map to decide "native route or CB decoder" and refuses a unit
+        whose format id it does not know, so a unit omitted here would be read
+        as CB — the one wrong answer that loads. They are still not
+        byte-verbatim, and the config group's ``weights.source_passthrough``
+        flag is what carries that distinction per unit.
         """
         units: dict[str, str] = {}
+        for qname, fmt in requant_targets.items():
+            units[_decision_unit_id(qname)] = fmt
         for qname, fmt in native_source_targets.items():
             unit = _decision_unit_id(qname)
             previous = units.setdefault(unit, fmt)
@@ -2407,7 +2523,8 @@ def export_nvfp4_cb_streaming(
                 for name in tensor_names_by_target.get(qname, ())
             },
             "passthrough_tensors": {
-                name for qname in native_source_targets
+                name
+                for qname in (*native_source_targets, *requant_targets)
                 for name in tensor_names_by_target.get(qname, ())
             },
             "cb_modules": cb_modules,
@@ -2425,6 +2542,7 @@ def export_nvfp4_cb_streaming(
         cb_targets=cb_targets,
         source_targets=source_targets,
         native_source_targets=native_source_targets,
+        requant_targets=requant_targets,
         stock_targets=stock_targets,
         by_group=by_group,
         codebooks=codebooks,
@@ -2445,6 +2563,9 @@ def export_nvfp4_cb_streaming(
         # The byte-verbatim lane keeps the CHECKPOINT spelling: those are the
         # names its tensors were actually written under, above.
         native_source_target_name=_base_name,
+        # Same rule for the re-quant lane: its planes were written under
+        # `_base_name(qname)`, so that is the name the group must claim.
+        requant_target_name=_base_name,
         source_passthrough_units=_declared_passthrough_units,
         route_pending_passthrough_acknowledged=sorted(route_pending),
         weight_only_stock_targets=sidecar_stock,

--- a/prismaquant/format_registry.py
+++ b/prismaquant/format_registry.py
@@ -48,6 +48,8 @@ from prismaquant.mx_formats import (
     e8m0_to_scale,
     mxfp8_e4m3_activation_qdq_vllm,
     mxfp8_e4m3_weight_qdq,
+    mxfp8_ue8m0_activation_qdq,
+    mxfp8_ue8m0_weight_qdq,
 )
 
 
@@ -565,6 +567,26 @@ def _mxfp8_e4m3_weight_rtn(w: torch.Tensor) -> torch.Tensor:
     return mxfp8_e4m3_weight_qdq(w).dequant.to(w.dtype)
 
 
+def _mxfp8_ue8m0_weight_rtn(w: torch.Tensor) -> torch.Tensor:
+    """MXFP8_UE8M0_G32 weight RTN — the saturating-ceil shared-exponent rule.
+
+    Same codec the streaming exporter writes, so emulation and shipped bytes
+    are one rendering (see ``mx_formats.mxfp8_ue8m0_shared_exponent``).
+    """
+    return mxfp8_ue8m0_weight_qdq(w).dequant.to(w.dtype)
+
+
+def _mxfp8_ue8m0_activation_rtn(x: torch.Tensor) -> torch.Tensor:
+    """MXFP8_UE8M0_G32 ACTIVATION RTN — dynamic per-32 E8M0, same ceil rule.
+
+    Mirrors the Gridbook lane's A side exactly (``Mxfp8DenseLinearMethod``
+    quantizes activations to MXFP8 per 32-element group each forward), so
+    ``output_mse`` measured through this closure is the real W8A8 error rather
+    than weight-only error.
+    """
+    return mxfp8_ue8m0_activation_qdq(x).dequant.to(x.dtype)
+
+
 def _make_plain_fp8_weight_rtn(
     element_dtype: torch.dtype,
     element_max: float,
@@ -753,6 +775,81 @@ register_format(FormatSpec(
     autoround_config=lambda: _mx_autoround(8, 32, 16, "fp8_e4m3"),
     quantize_dequantize=_mxfp8_e4m3_weight_rtn,
     activation_quantize_dequantize=lambda x: x,
+))
+
+# MXFP8_UE8M0_G32 — MX-FP8 for the Gridbook lane, with the saturating-ceil
+# shared-exponent rule and a native ``float8_e8m0fnu`` scale plane.
+#
+# WHY THIS IS NOT JUST ``MXFP8_E4M3``. It has the same element grid (E4M3),
+# the same group (32 along K) and the same 8.25 bpw, so the obvious question
+# is why the registry carries two. Three reasons, in the order that matters:
+#
+#   * SCALE RULE. MXFP8_E4M3 defers to compressed-tensors, which is the right
+#     authority for the stock vLLM lane it ships on. That rule rounds the
+#     group amax to a power of two, which can scale a group UP and knock the
+#     smallest normals off the E4M3 subnormal ladder. This format instead
+#     picks the smallest non-clipping exponent, which is what buys the
+#     exactness property below. See ``mx_formats.mxfp8_ue8m0_shared_exponent``.
+#   * SCALE DTYPE. The stock lane serializes E8M0 as ``uint8``; this one
+#     serializes ``float8_e8m0fnu``, the spelling DeepSeek-V4 already uses for
+#     its own block scales and the one the Gridbook consumer reads.
+#   * LANE. It rides its own wire id and its own (currently UNBACKED) serving
+#     lane, not the compressed-tensors scheme.
+#
+# That is the same "different on-disk contract, therefore a different format"
+# call FP8_BLOCK_UE8M0_SOURCE made against FP8_SOURCE, and the reason the
+# ``MXFP8 -> MXFP8_E4M3`` alias above is deliberately left alone: historical
+# artifacts and launchers spelled the stock compressed-tensors rung ``MXFP8``,
+# and quietly repointing that name at a rung with a different codec, a
+# different scale plane and a different serving lane would reinterpret every
+# persisted assignment that uses it.
+#
+# EXACT ON BLOCK-FP8 SOURCES, ON THE WEIGHT PLANE. Any tensor whose stored
+# form is E4M3 codes times a shared power of two — the DeepSeek
+# ``fp8_e4m3_ue8m0_block128`` body convention — re-encodes here with ZERO
+# weight error: the ceil rule never picks an exponent above the block's own, so
+# every element is an E4M3 code scaled down by a power of two, which is exactly
+# representable. 128 = 4*32, so a 32-wide chunk never straddles a block
+# boundary and the scale map is pure replication. This is a property of the
+# rule, not a measurement, and tests/test_mxfp8_ue8m0.py pins it.
+#
+# Read that claim precisely: it is ``weight_mse == 0.0``, NOT ``output_mse ==
+# 0.0``. The lane below quantizes activations, so a weight-lossless unit still
+# has real A-side error — which is exactly why ``cost_entry_is_bit_exact``
+# refuses to short-circuit a W·A· format on a zero weight_mse.
+#
+# RE-QUANTIZATION, NOT PASSTHROUGH. Unlike the ``*_SOURCE`` family this is
+# legal on ANY source dtype: it has a real encoder, so it is deliberately
+# absent from SOURCE_PASSTHROUGH_CONTRACTS and is not source-gated.
+#
+# W8A8, WITH THE A SIDE MEASURED. The Gridbook lane that serves this
+# (``Mxfp8DenseLinearMethod``, gridbook/mxfp8_dense_lane.py) quantizes
+# activations dynamically to MXFP8 per 32 reduction-axis elements, using the
+# SAME saturating-ceil rule as the weights — no static global scale to fit,
+# unlike NVFP4's ``nv_fp4_with_static_gs``. Declaring that here is not
+# bookkeeping: ``act_bits=8`` is what makes the cost stage apply
+# ``activation_quantize_dequantize`` before measuring ``output_mse``, so a
+# measured row carries genuine W8A8 error. Declaring A16 instead would price
+# an activation path the runtime does not take, and on a block-FP8 source
+# (weight_mse exactly 0.0) would hand the DP a free zero-cost rung.
+#
+# effective_bits = 8 + 8/32 = 8.25 bpw exactly.
+register_format(FormatSpec(
+    name="MXFP8_UE8M0_G32",
+    weight_bits=8, group_size=32, scale_bits=8,
+    scale_dtype_name="uint8_e8m0",
+    weight_element_dtype="fp8_e4m3",
+    act_bits=8, act_dtype_name="fp8_e4m3", act_group_size=32,
+    family="mx", min_capability_sm=100,
+    autoround_config=lambda: dict(bits=8, group_size=32,
+                                   data_type="fp8_e4m3", sym=True,
+                                   scale_fmt="ue8m0",
+                                   act_bits=8, act_group_size=32,
+                                   act_sym=True, act_data_type="mx_fp",
+                                   act_element_dtype="fp8_e4m3",
+                                   act_scale_fmt="ue8m0", act_dynamic=True),
+    quantize_dequantize=_mxfp8_ue8m0_weight_rtn,
+    activation_quantize_dequantize=_mxfp8_ue8m0_activation_rtn,
 ))
 
 # Plain FP8 (per-output-channel FP32 scale on weights, no microscaling).

--- a/prismaquant/gridbook_runtime/gridbook_runtime_pin.json
+++ b/prismaquant/gridbook_runtime/gridbook_runtime_pin.json
@@ -1,6 +1,6 @@
 {
   "schema": "prismaquant.gridbook_runtime_pin.v1",
   "repository": "https://github.com/RobTand/gridbook.git",
-  "commit": "7c0b52764c9be7f813294e05c1b4c68d42ae840e",
+  "commit": "4d7292cbe03de970e92e57db341edd012a74ea76",
   "version": "0.7.0"
 }

--- a/prismaquant/layer_config.py
+++ b/prismaquant/layer_config.py
@@ -131,6 +131,14 @@ def canonicalize_format(entry: dict | str | int) -> str:
                     return "FP8_BLOCK_UE8M0_SOURCE"
                 return "FP8_SOURCE"
             if group_size == 32:
+                # Same split as the group-128 case immediately above, one
+                # granularity down: an explicit UE8M0 scale_fmt names the
+                # Gridbook-native rung whose scale plane is float8_e8m0fnu and
+                # whose encoder is the saturating-ceil rule, NOT the stock
+                # compressed-tensors MXFP8 scheme (uint8 scales, OCP rule).
+                # Absent scale_fmt keeps the historical reading.
+                if str(entry.get("scale_fmt", "")).lower() in _UE8M0_SCALE_FMTS:
+                    return "MXFP8_UE8M0_G32"
                 return "MXFP8_E4M3"
             if group_size in (0, -1):
                 return "FP8_E4M3"
@@ -163,6 +171,11 @@ def canonicalize_format(entry: dict | str | int) -> str:
             return "MXFP4_SOURCE"
         if value in ("mxfp4", "mx_fp4"):
             return "MXFP4"
+        if value in ("mxfp8_ue8m0_g32", "mxfp8_ue8m0"):
+            # Checked BEFORE the plain MXFP8 spellings, same reason as
+            # MXFP4_SOURCE above: two different on-disk contracts, and the
+            # narrower claim reads first so the pair is obviously deliberate.
+            return "MXFP8_UE8M0_G32"
         if value in ("mxfp8", "mxfp8_e4m3"):
             return "MXFP8_E4M3"
         if value in ("fp8_block_ue8m0_source", "fp8_block_ue8m0"):

--- a/prismaquant/measure_quant_cost.py
+++ b/prismaquant/measure_quant_cost.py
@@ -1617,6 +1617,14 @@ def _gguf_imatrix_enabled() -> bool:
 # cost from an export that is always weighted.
 _CB_COST_FAMILIES = ("nvfp4_cb", "fp8_cb")
 
+# Formats the BATCHED render must delegate to their registry closure rather
+# than reproduce from the local codebook tables. Membership is a statement that
+# the closure IS the shipped codec (same math the exporter writes), so the
+# batched and unbatched cost paths cannot diverge. Keyed by name because the
+# distinction is per-format, not per-family: MXFP8_UE8M0_G32's siblings in
+# family "mx" legitimately use the generic codebook path.
+_EXPORT_ALIGNED_BATCH_FORMATS = frozenset({"MXFP8_UE8M0_G32"})
+
 
 UNROUTED_EXPERT_COST_SOURCE = "unrouted_expert_weight_only"
 
@@ -1710,6 +1718,22 @@ def _batched_quantize(
     col_weights: torch.Tensor | None = None,
 ) -> torch.Tensor:
     elt = spec.weight_element_dtype
+    if spec.name in _EXPORT_ALIGNED_BATCH_FORMATS:
+        # Formats whose REGISTRY closure is the authoritative codec, not a
+        # codebook-RTN variant the generic path below could reproduce. The
+        # dispatch further down keys on weight_element_dtype, and these rungs
+        # share an element dtype with formats that DO use the generic path --
+        # MXFP8_UE8M0_G32 is "fp8_e4m3" like MXFP8_E4M3/FP8_CB, but its shared
+        # exponent is the saturating-ceil rule, not the codebook replica's
+        # E8M0 snap. Falling through would price the batched path with a
+        # different codec than the unbatched path and than the exporter, which
+        # is the resident-vs-served mismatch class this file exists to avoid.
+        #
+        # One call, not a per-slice loop like "nv" above: every scale here is
+        # local to its 32-group (no per-tensor global), and the registry fn
+        # reshapes (..., in) internally, so the stacked (N, out, in) tensor
+        # matches the unbatched path element for element.
+        return spec.quantize_dequantize(stacked_w.clone())
     if spec.family == "nv":
         # NVFP4 registry weights are export-codec-aligned (one rendering
         # everywhere); the registry fn reshapes (-1, in) internally, so it

--- a/prismaquant/mx_formats.py
+++ b/prismaquant/mx_formats.py
@@ -4,6 +4,11 @@ MXFP8_E4M3 is a commodity compressed-tensors/vLLM format: grouped FP8
 values with E8M0 power-of-two scales. Keep the qparam and cast semantics in
 one place and defer scale generation to compressed-tensors, which is the
 load/export authority for this on-disk representation.
+
+MXFP8_UE8M0_G32 (bottom half of this module) is the SECOND MX-FP8 contract
+this repo ships. Same element grid and same group of 32, but a different
+scale RULE and a different on-disk scale dtype, and the difference is
+load-bearing rather than cosmetic — see ``mxfp8_ue8m0_shared_exponent``.
 """
 from __future__ import annotations
 
@@ -120,3 +125,153 @@ def mxfp8_e4m3_activation_qdq_vllm(
         group_size=group_size,
         fallback_plain_activation=True,
     )
+
+
+# ---------------------------------------------------------------------------
+# MXFP8_UE8M0_G32 — the saturating-ceil MX-FP8 contract
+# ---------------------------------------------------------------------------
+
+MXFP8_UE8M0_GROUP = 32
+E4M3_MAX = 448.0                 # OCP FP8 E4M3 max finite magnitude
+E8M0_BIAS = 127
+E8M0_MIN_EXP = -127              # byte 0
+E8M0_MAX_EXP = 127               # byte 254; byte 255 is the E8M0 NaN code
+
+
+def mxfp8_ue8m0_shared_exponent(amax: torch.Tensor) -> torch.Tensor:
+    """Smallest integer ``e`` with ``amax / 2**e <= 448``, clamped to E8M0.
+
+    THIS IS THE WHOLE POINT OF THE FORMAT, so it is worth being explicit
+    about how it differs from the OCP/compressed-tensors rule that
+    ``mxfp8_e4m3_qdq`` above delegates to.
+
+    The OCP rule derives the shared exponent by rounding the block amax to a
+    power of two and subtracting the element-format exponent. That can pick an
+    exponent SMALLER than the one the data was already stored at, which scales
+    the group UP — and scaling up is not free at the bottom of the E4M3 grid,
+    because the smallest normals fall off the subnormal ladder when halved.
+    Concretely, a group holding both 448 and 1.125*2^-6 gets shared exponent
+    +1 from the OCP rule, and 1.125*2^-6 / 2 = 9*2^-10 is not an E4M3 value:
+    it rounds, and the round-trip is lossy.
+
+    The ceil rule below picks the smallest exponent that does not CLIP, i.e.
+    it never scales a group up past the point where its own maximum still
+    fits. For any input whose values are already E4M3 codes times a shared
+    power of two — which is exactly the DeepSeek ``fp8_e4m3_ue8m0_block128``
+    body convention — this yields ``e <= E_block``, so every element is an
+    E4M3 code scaled DOWN by a power of two, which is always exactly
+    representable. That makes the re-encode lossless; see
+    ``tests/test_mxfp8_ue8m0.py``.
+
+    Computed from ``frexp`` rather than ``log2`` so it is exact integer
+    arithmetic with no rounding at the boundary: ``amax = f * 2**E`` with
+    ``f in [0.5, 1)`` and ``448 = 0.875 * 2**9``, so the smallest admissible
+    exponent is ``E - 9`` when ``f <= 0.875`` and ``E - 8`` otherwise.
+
+    That is not a stylistic preference. The obvious spelling,
+    ``ceil(log2(amax / 448))``, is wrong about once in 4e5 group maxima in
+    float32: when ``amax / 448`` rounds to exactly a power of two the ``log2``
+    lands on an integer and ``ceil`` returns it unchanged, giving an exponent
+    one too small and an element that saturates at 448 — the very thing the
+    rule exists to prevent. Measured over 6e6 sampled maxima: 15 saturations
+    for the log2 form, 0 for this one. The Gridbook consumer's reference
+    quantizer (gridbook/mxfp8.py ``quantize_mxfp8``) currently uses the log2
+    form on its ACTIVATION path, so until that is reconciled the served A side
+    can saturate on a group this emulation would not. Producer-side weights
+    are unaffected: they are encoded here.
+
+    An all-zero group has no constraint; it is pinned to the bottom of the
+    range (byte 0), which is also what compressed-tensors emits, so the two
+    encoders agree on the degenerate case.
+    """
+    amax_f = amax.to(torch.float32)
+    frac, exp = torch.frexp(amax_f)
+    shared = exp - 9 + (frac > 0.875).to(exp.dtype)
+    shared = torch.where(
+        amax_f > 0, shared, torch.full_like(shared, E8M0_MIN_EXP)
+    )
+    return shared.clamp(E8M0_MIN_EXP, E8M0_MAX_EXP)
+
+
+def mxfp8_ue8m0_qdq(
+    values: torch.Tensor,
+    *,
+    group_size: int = MXFP8_UE8M0_GROUP,
+) -> MXFP8Result:
+    """Quantize/dequantize as MXFP8_UE8M0_G32.
+
+    ``values`` may be any rank; groups are taken along the final (reduce/K)
+    dimension. Returns the E4M3 elements, the shared scales as
+    ``float8_e8m0fnu`` of shape ``values.shape[:-1] + (K / group_size,)``, and
+    the dequantized reconstruction.
+
+    A final dimension that is not a multiple of ``group_size`` is zero-padded
+    to one and sliced back. Zeros cannot move a group's max-abs, so the pad is
+    exact for the real columns; the returned scale plane then covers
+    ``ceil(K / group_size)`` groups. The exporter requires exact divisibility
+    (``check_format_applicability`` masks the format otherwise) and asserts it
+    separately — this path exists so direct callers (cost measurement on an
+    odd synthetic layer) get a sane answer instead of an exception.
+    """
+    if group_size <= 0:
+        raise ValueError(f"group_size must be positive, got {group_size}")
+    orig_shape = values.shape
+    if len(orig_shape) == 0:
+        raise ValueError("MXFP8_UE8M0_G32 requires at least one dimension")
+    cols = int(orig_shape[-1])
+    pad = (-cols) % group_size
+    rows = values.to(torch.float32).reshape(-1, cols)
+    if pad:
+        rows = torch.nn.functional.pad(rows, (0, pad))
+    n_groups = rows.shape[-1] // group_size
+    grouped = rows.reshape(rows.shape[0], n_groups, group_size)
+
+    shared = mxfp8_ue8m0_shared_exponent(grouped.abs().amax(dim=-1))
+    # ldexp scales by a power of two exactly, and never materializes 2**e
+    # (which would be subnormal in fp32 near the bottom of the E8M0 range).
+    scaled = torch.ldexp(grouped, (-shared).unsqueeze(-1))
+    # The ceil rule already guarantees |scaled| <= 448 for every in-range
+    # input; the clamp only bites when `shared` hit the E8M0 rail, and it is
+    # what keeps an out-of-range magnitude from casting to the E4M3 NaN code.
+    quant = scaled.clamp(-E4M3_MAX, E4M3_MAX).to(torch.float8_e4m3fn)
+    dequant = torch.ldexp(quant.to(torch.float32), shared.unsqueeze(-1))
+
+    quant = quant.reshape(rows.shape)
+    dequant = dequant.reshape(rows.shape)
+    if pad:
+        quant = quant[:, :cols]
+        dequant = dequant[:, :cols]
+    e8m0 = (shared + E8M0_BIAS).to(torch.uint8).view(torch.float8_e8m0fnu)
+    return MXFP8Result(
+        quant=quant.reshape(orig_shape),
+        scale=e8m0.reshape(*orig_shape[:-1], n_groups),
+        dequant=dequant.reshape(orig_shape),
+    )
+
+
+def mxfp8_ue8m0_weight_qdq(
+    weight: torch.Tensor,
+    *,
+    group_size: int = MXFP8_UE8M0_GROUP,
+) -> MXFP8Result:
+    return mxfp8_ue8m0_qdq(weight, group_size=group_size)
+
+
+def mxfp8_ue8m0_activation_qdq(
+    activation: torch.Tensor,
+    *,
+    group_size: int = MXFP8_UE8M0_GROUP,
+) -> MXFP8Result:
+    """The A side of the MXFP8_UE8M0_G32 lane: DYNAMIC per-32 E8M0 + E4M3.
+
+    Deliberately the same function as the weight path, because the serving
+    lane uses the same rule on both sides: activations are quantized per 32
+    contiguous reduction-axis elements with the same saturating-ceil shared
+    exponent, computed per forward (dynamic — there is no static global scale
+    to fit, unlike NVFP4's ``nv_fp4_with_static_gs`` activation contract).
+
+    Kept as a named entry point anyway so the registry's A side reads as a
+    deliberate declaration rather than a reuse, and so a future divergence
+    between the two sides has an obvious place to land.
+    """
+    return mxfp8_ue8m0_qdq(activation, group_size=group_size)

--- a/prismaquant/runtime_shape_validators.py
+++ b/prismaquant/runtime_shape_validators.py
@@ -8,6 +8,16 @@ from __future__ import annotations
 from . import format_registry as fr
 
 
+# The rungs whose SERVED path is the FlashInfer/CUTLASS MXFP8 GEMM. An
+# explicit set rather than an ``MXFP8`` prefix test: MXFP8_UE8M0_G32 shares the
+# prefix but rides a different lane entirely — Gridbook's own block-scaled
+# collective, reading a float8_e8m0fnu scale plane — so a prefix match would
+# gate it on a kernel it never reaches. The profile spec scopes the rule the
+# same way; this is the second guard, and the one a future spec edit would
+# land on first.
+_FLASHINFER_MXFP8_GEMM_FORMATS = frozenset({"MXFP8_E4M3", "MXFP8_E5M2"})
+
+
 def flashinfer_mxfp8_problem_size_accepts(
     fmt: str,
     *,
@@ -19,7 +29,7 @@ def flashinfer_mxfp8_problem_size_accepts(
         canonical = fr.canonical_format_name(fmt)
     except Exception:
         return None
-    if not canonical.startswith("MXFP8"):
+    if canonical not in _FLASHINFER_MXFP8_GEMM_FORMATS:
         return None
     try:
         import torch

--- a/prismaquant/serving_profile_specs/nvfp4_cb.json
+++ b/prismaquant/serving_profile_specs/nvfp4_cb.json
@@ -7,7 +7,8 @@
     "id": "nvfp4_cb",
     "exporter": "prismaquant.export_nvfp4_cb",
     "codec_formats_from": [
-      "prismaquant.export_nvfp4_cb:EXPORTABLE_FORMATS"
+      "prismaquant.export_nvfp4_cb:EXPORTABLE_FORMATS",
+      "prismaquant.cb_export_config:STREAMING_REQUANT_EXPORT_FORMATS"
     ],
     "passthrough_formats": [
       "MXFP4_SOURCE",
@@ -28,6 +29,7 @@
         "FP8_SOURCE",
         "FP8_BLOCK_UE8M0_SOURCE",
         "MXFP4_SOURCE",
+        "MXFP8_UE8M0_G32",
         "BF16"
       ],
       "reason": "profile_mismatch",
@@ -40,10 +42,11 @@
         "NVFP4",
         "FP8_DYNAMIC",
         "FP8_E4M3",
-        "FP8_SOURCE"
+        "FP8_SOURCE",
+        "MXFP8_UE8M0_G32"
       ],
       "reason": "runtime_unsupported",
-      "detail": "The nvfp4_cb container's stock compressed-tensors delegation is DENSE-ONLY today: neither export_nvfp4_cb nor the Gridbook runtime carries a stock-CT packed-MoE emission/serving path (35B first-contact, 2026-07-19 \u2014 the exporter's stock-NVFP4 global-scale pass is 2-D and Gridbook's MoE method is CB-only). Packed expert stacks use CB rungs (per-expert weighted VQ, served by Gridbook) or the BF16 passthrough until that path is built AND serve-validated. This is a declared capability of the container, not a quality judgement on the formats."
+      "detail": "The nvfp4_cb container's stock compressed-tensors delegation is DENSE-ONLY today: neither export_nvfp4_cb nor the Gridbook runtime carries a stock-CT packed-MoE emission/serving path (35B first-contact, 2026-07-19 \u2014 the exporter's stock-NVFP4 global-scale pass is 2-D and Gridbook's MoE method is CB-only). Packed expert stacks use CB rungs (per-expert weighted VQ, served by Gridbook) or the BF16 passthrough until that path is built AND serve-validated. This is a declared capability of the container, not a quality judgement on the formats. MXFP8_UE8M0_G32 joins the list for the SAME structural reason and not as a bpw judgement: its streaming emission is a 2-D dense path (one E4M3 plane plus one float8_e8m0fnu scale plane per Linear) with no packed-expert stacking, so a routed stack has no MXFP8 emission to ship. Its economic exclusion from the routed-expert ladder is a separate and independent fact recorded where the expert cost menu is enumerated (scripts/run_dsv4_mxfp4_cost.sh): at 8.25 bpw it is nearly double the <= 4.25 bpw rungs that menu measures, so it is simply not on it."
     },
     {
       "id": "mxfp4_source_is_routed_expert_only",
@@ -104,6 +107,15 @@
       "activation_contract": "delegated-native-mxfp4-e2m1-group32-ue8m0",
       "fallback_route": "vllm Marlin MoE (REQUIRES --moe-backend marlin; the auto default DeepGEMM_MXFP4 asserts on sm121)",
       "detail": "SOURCE-PASSTHROUGH lane for the released checkpoint's own packed routed experts: nibble-packed E2M1 with per-32 E8M0 group scales, copied verbatim, served by the model's native DeepseekV4 routed-expert path rather than by any codebook decoder. Declared as a DISTINCT lane so P5b never files these units under a CB contract they do not have -- a unit here has no CB activation contract at all, which is why the K0.2 attestation scopes itself to CB layers and the artifact declares its source-passthrough units explicitly rather than leaving them looking like a missing attestation. ROUTE STATUS: BACKED, measured on GB10/sm121 2026-08-03 -- native-confirmed via vLLM Marlin MoE. But ONLY off the default: the auto-selected DeepGEMM_MXFP4 backend asserts on the SF transformation, FlashInfer is gated to capability family 100, and the OAI Triton path is hard-excluded on SM12x (0/15 kernels). `--moe-backend marlin` is therefore part of the serving contract, not a tuning hint, and it travels with the artifact in its serving notes. No fused_mid_m block: a passthrough rung has no Gridbook decode prologue to fuse, so an empty backed set is the honest state, not a data gap."
+    },
+    {
+      "id": "mxfp8_ue8m0_g32",
+      "formats": [
+        "MXFP8_UE8M0_G32"
+      ],
+      "activation_contract": "w8a8-dynamic-mxfp8-e4m3-group32-ue8m0",
+      "fallback_route": "route_unbacked: Gridbook's Mxfp8DenseLinearMethod is OPT-IN behind GRIDBOOK_MXFP8_DENSE=1 and ships in no released runtime version yet; with the flag unset a unit declaring this format refuses at load (fail-closed)",
+      "detail": "RE-QUANTIZATION lane (not a passthrough): the producer re-encodes any source dtype to E4M3 elements with a float8_e8m0fnu shared exponent per 32 contiguous K, wire id mxfp8_e4m3_e8m0_g32, tensors <unit>.weight + <unit>.weight_scale row-major. ROUTE STATUS: UNBACKED. The consumer-side lane EXISTS and is correctness-audited (gridbook/mxfp8_dense_lane.py, kernel-vs-fp32-oracle over the real DSV4-Flash body shapes on GB10/sm121), but it is opt-in behind GRIDBOOK_MXFP8_DENSE=1 with the NATIVE-PARITY served bench still pending, and Gridbook does not default-enable a lane on correctness evidence alone. This spec's backed set describes what the DEFAULT serve takes, so an operator-flag-gated route is AVAILABLE, NOT BACKED -- the same call nvfp4_cb_quality_path makes about the opt-in fp4 fused mid-M route, and pricing a rung on a lane the default serve never takes is the exact P5b defect this data exists to prevent. NO fused_mid_m KEY, deliberately: a non-CB rung has no CB rung number, so ServingLaneSpec.backed_rungs can never report it backed through that field anyway, and an absent key resolves to the honest 'lane_declares_no_fused_mid_m_lane' source rather than inventing an empty CB ladder. WHEN THIS BECOMES BACKED, key it to the Gridbook version that first RELEASES the lane with the flag defaulted on -- NEVER to 0.7.0, which is the currently pinned version and does not contain it (the consumer branch self-reports 0.7.0 while unreleased, so the version string alone does not distinguish them; the runtime pin's commit does). A pinned version with no entry backs nothing, which is the fail-closed direction. ACTIVATION CONTRACT IS W8A8, not weight-only: the lane quantizes activations dynamically to MXFP8 per 32 reduction-axis elements with the same saturating-ceil rule as the weights (no static global scale, unlike NVFP4). That is why the format's exactness claim on a block-FP8 source is a WEIGHT-PLANE claim (weight_mse == 0.0) and not an output claim, and why cost_entry_is_bit_exact correctly refuses to short-circuit it. Byte contract: 8 + 8/32 = 8.25 bpw exactly, weight plane [N, K] E4M3 plus scale plane [N, K/32] float8_e8m0fnu."
     },
     {
       "id": "nvfp4_cb_quality_path",

--- a/tests/test_mxfp8_ue8m0.py
+++ b/tests/test_mxfp8_ue8m0.py
@@ -1,0 +1,734 @@
+"""MXFP8_UE8M0_G32 — the saturating-ceil MX-FP8 rung.
+
+Six things are pinned here, in the order they matter:
+
+  1. the registry declaration and its byte accounting (exactly 8.25 bpw);
+  2. the encoder itself — the ceil rule, subnormals, zeros, the 448 rail and
+     round-to-nearest-even;
+  3. THE EXACTNESS PROPERTY: a block-scaled FP8 source re-encodes with zero
+     WEIGHT error, which is the whole reason this format exists separately
+     from MXFP8_E4M3 — together with the reason that does NOT make the layer
+     output exact, since the lane is W8A8;
+  4. menu legality — a re-quantization rung, not a source-gated passthrough,
+     and one whose unmeasured A side must leave the menu rather than be
+     priced at the DP's global minimum;
+  5. the wire contract: id, config group, and the emitted tensor pair;
+  6. cost-measurement wiring — no codebook machinery, and the batched render
+     agreeing with the unbatched one.
+"""
+import math
+from pathlib import Path
+
+import pytest
+import torch
+
+from prismaquant import format_registry as fr
+from prismaquant import serving_profiles as sp
+from prismaquant.allocator_candidates import (
+    PASSTHROUGH_WIRE_FORMAT_IDS,
+    REQUANT_WIRE_FORMAT_IDS,
+    SOURCE_PASSTHROUGH_CONTRACTS,
+    WIRE_FORMAT_IDS,
+    check_format_applicability,
+)
+from prismaquant.layer_config import canonicalize_format
+from prismaquant.mx_formats import (
+    E4M3_MAX,
+    E8M0_BIAS,
+    E8M0_MIN_EXP,
+    mxfp8_ue8m0_qdq,
+    mxfp8_ue8m0_shared_exponent,
+)
+
+FMT = "MXFP8_UE8M0_G32"
+GROUP = 32
+WIRE_ID = "mxfp8_e4m3_e8m0_g32"
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _finite_e4m3_codes() -> torch.Tensor:
+    """Every finite E4M3 value, as float32. 254 of them (two NaN codes)."""
+    codes = torch.arange(256, dtype=torch.uint8).view(torch.float8_e4m3fn)
+    vals = codes.float()
+    return vals[torch.isfinite(vals)]
+
+
+def _block128_source(n=256, k=256, block=128, seed=0):
+    """A tensor in the DeepSeek ``fp8_e4m3_ue8m0_block128`` body convention.
+
+    E4M3 codes times ONE shared power of two per [128, 128] block — which is
+    what that checkpoint stores — dequantized to float32. Built from raw code
+    bytes rather than by rounding random floats so every element really is on
+    the E4M3 grid, which is the precondition the exactness claim is about.
+    """
+    g = torch.Generator().manual_seed(seed)
+    codes = torch.randint(
+        0, 256, (n, k), dtype=torch.uint8, generator=g
+    ).view(torch.float8_e4m3fn).float()
+    codes = torch.nan_to_num(codes, nan=0.0)
+    block_exp = torch.randint(
+        -30, 31, (n // block, k // block), generator=g
+    )
+    scale = torch.pow(2.0, block_exp.float())
+    dense = scale.repeat_interleave(block, 0).repeat_interleave(block, 1)
+    return codes * dense, block_exp
+
+
+def _exponents(result) -> torch.Tensor:
+    return result.scale.view(torch.uint8).to(torch.int32) - E8M0_BIAS
+
+
+# ---------------------------------------------------------------------------
+# 1. registry declaration + byte accounting
+# ---------------------------------------------------------------------------
+
+def test_the_registry_declares_the_mx_group32_e4m3_contract():
+    spec = fr.get_format(FMT)
+    assert spec.weight_bits == 8
+    assert spec.group_size == GROUP
+    assert spec.scale_bits == 8
+    assert spec.scale_dtype_name == "uint8_e8m0"
+    assert spec.weight_element_dtype == "fp8_e4m3"
+    assert spec.family == "mx"
+    assert spec.scale_block_shape is None
+    # W8A8, matching the Gridbook lane: activations are quantized dynamically
+    # to the SAME per-32 E8M0 grid. This is what makes the cost stage measure
+    # a real A-side error, and it is why the exactness claim below is about
+    # the WEIGHT plane rather than the layer output.
+    assert spec.act_bits == 8
+    assert spec.act_dtype_name == "fp8_e4m3"
+    assert spec.act_group_size == 32
+    assert spec.act_quant_changes_input is True
+    cfg = spec.autoround_config()
+    assert cfg["act_bits"] == 8 and cfg["act_group_size"] == 32
+    assert cfg["act_dynamic"] is True and cfg["act_data_type"] == "mx_fp"
+    assert spec.autoround_config()["sym"] is True
+
+
+def test_the_bits_per_weight_is_exactly_eight_and_a_quarter():
+    """8 element bits + one 8-bit scale per 32 = 8.25, with no rounding slack."""
+    spec = fr.get_format(FMT)
+    assert spec.effective_bits == 8.25
+
+    for shape in [(2048, 4096), (128, 128), (5120, 1536), (7168, 2048)]:
+        n_params = math.prod(shape)
+        expected_bytes = n_params + n_params // GROUP
+        assert spec.memory_bytes_for_shape(shape) == expected_bytes
+        assert spec.effective_bits_for_shape(shape) == 8.25
+        assert spec.scale_count_for_shape(shape) == n_params // GROUP
+
+
+def test_it_is_dearer_than_the_block128_source_it_can_absorb():
+    """The scale plane is the whole difference, and it is 32x denser."""
+    exact = fr.get_format(FMT).effective_bits_for_shape((2048, 4096))
+    block = fr.get_format(
+        "FP8_BLOCK_UE8M0_SOURCE").effective_bits_for_shape((2048, 4096))
+    assert exact == 8.25
+    assert block < exact
+    # 8 bits per 32 weights vs 8 bits per 128x128 block.
+    assert exact - block == pytest.approx(8 / 32 - 8 / (128 * 128))
+
+
+# ---------------------------------------------------------------------------
+# 2. the encoder
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("amax,expected", [
+    (448.0, 0),      # the rail itself: 448 / 2^0 == 448, exactly admissible
+    (449.0, 1),      # one ulp over forces the next exponent up
+    (256.0, 0),
+    (240.0, 0),      # 240 / 2^-1 = 480 > 448, so -1 is NOT admissible
+    (224.0, -1),     # 224 / 2^-1 = 448, exactly admissible
+    (1.0, -8),
+    (2.0 ** -9, -17),
+])
+def test_the_shared_exponent_is_the_smallest_that_does_not_clip(amax, expected):
+    got = int(mxfp8_ue8m0_shared_exponent(torch.tensor([amax]))[0])
+    assert got == expected
+    # the defining property, restated as the two inequalities it is made of
+    assert amax / 2.0 ** got <= E4M3_MAX
+    assert amax / 2.0 ** (got - 1) > E4M3_MAX
+
+
+def test_the_ceil_rule_never_lets_an_element_reach_the_e4m3_rail():
+    g = torch.Generator().manual_seed(3)
+    for power in (-140, -60, -8, 0, 8, 60, 118):
+        x = torch.randn(16, GROUP, generator=g) * (2.0 ** power)
+        e = mxfp8_ue8m0_shared_exponent(x.abs().amax(dim=-1))
+        assert bool((torch.ldexp(x, (-e).unsqueeze(-1)).abs() <= E4M3_MAX).all())
+
+
+def test_the_exponent_is_computed_exactly_not_through_log2():
+    """Guards the frexp implementation against a 'simplifying' rewrite.
+
+    ``ceil(log2(amax / 448))`` is the obvious spelling and it is wrong on a
+    small set of float32 inputs: when ``amax / 448`` rounds to exactly a power
+    of two, ``log2`` lands on an integer, ``ceil`` returns it unchanged, and
+    the resulting exponent is one too small — so the group's own maximum
+    saturates at 448, which is the one thing the rule exists to prevent.
+
+    This is not hypothetical; it is where the Gridbook consumer's reference
+    quantizer currently sits, so the divergence is recorded rather than
+    guessed at.
+    """
+    def via_log2(amax):
+        return torch.clamp(
+            torch.ceil(torch.log2(amax / E4M3_MAX)), min=-127.0, max=127.0,
+        ).to(torch.int32)
+
+    # A value where the two disagree, found by sweep and pinned by hex so it
+    # cannot drift: amax / 448 rounds to exactly 2**81 in float32.
+    amax = torch.tensor([0x6C600004], dtype=torch.int32).view(torch.float32)
+    exact = int(mxfp8_ue8m0_shared_exponent(amax)[0])
+    naive = int(via_log2(amax)[0])
+    assert exact == naive + 1
+    # float64 arbiter: only the exact rule keeps the group inside the grid.
+    scaled_exact = amax.double() / 2.0 ** exact
+    scaled_naive = amax.double() / 2.0 ** naive
+    assert float(scaled_exact) <= E4M3_MAX
+    assert float(scaled_naive) > E4M3_MAX
+
+    # And the rule holds over a broad sweep, which the log2 form does not.
+    g = torch.Generator().manual_seed(23)
+    probe = (torch.rand(200_000, generator=g)
+             * torch.pow(2.0, torch.randint(-120, 120, (200_000,),
+                                            generator=g).float()))
+    probe = probe[probe > 0]
+    e = mxfp8_ue8m0_shared_exponent(probe)
+    assert bool((probe.double() / torch.pow(torch.tensor(2.0, dtype=torch.float64),
+                                            e.double()) <= E4M3_MAX).all())
+
+
+def test_zero_groups_pin_to_the_bottom_of_the_e8m0_range():
+    """A zero group constrains nothing; it must still be deterministic."""
+    result = mxfp8_ue8m0_qdq(torch.zeros(4, GROUP))
+    assert bool((result.dequant == 0).all())
+    assert result.scale.dtype is torch.float8_e8m0fnu
+    assert set(_exponents(result).flatten().tolist()) == {E8M0_MIN_EXP}
+
+
+def test_subnormal_elements_survive_the_round_trip():
+    """E4M3 subnormals are exact when the group max lets them be."""
+    x = torch.zeros(1, GROUP)
+    x[0, 0] = 2.0 ** -9         # min positive subnormal
+    x[0, 1] = 3 * 2.0 ** -9
+    x[0, 2] = -(5 * 2.0 ** -9)
+    x[0, 3] = 2.0 ** -6         # min normal
+    result = mxfp8_ue8m0_qdq(x)
+    assert torch.equal(result.dequant, x)
+
+
+def test_the_element_cast_rounds_ties_to_even():
+    """400 sits exactly between E4M3 codes 384 (even) and 416 (odd)."""
+    x = torch.zeros(1, GROUP)
+    x[0, 0] = 448.0             # pins the group exponent to 0
+    x[0, 1] = 400.0
+    assert float(mxfp8_ue8m0_qdq(x).dequant[0, 1]) == 384.0
+
+
+def test_an_out_of_range_group_clamps_instead_of_emitting_a_nan_code():
+    """The E8M0 rail is the only way to overflow, and it must clamp."""
+    g = torch.Generator().manual_seed(9)
+    for power in range(-140, 121, 10):
+        result = mxfp8_ue8m0_qdq(torch.randn(4, GROUP, generator=g)
+                                 * (2.0 ** power))
+        raw = result.scale.view(torch.uint8)
+        # 255 is the E8M0 NaN code; emitting it would poison the group.
+        assert int(raw.max()) <= 254
+        assert not bool(torch.isnan(result.quant.float()).any())
+
+
+def test_a_ragged_last_group_is_zero_padded_not_rejected():
+    """Zeros cannot move a max-abs, so the pad is exact for real columns."""
+    x = torch.randn(4, GROUP + 5)
+    result = mxfp8_ue8m0_qdq(x)
+    assert result.dequant.shape == x.shape
+    assert result.scale.shape == (4, 2)
+    head = mxfp8_ue8m0_qdq(x[:, :GROUP])
+    assert torch.equal(result.dequant[:, :GROUP], head.dequant)
+
+
+def test_the_scale_plane_is_the_native_e8m0_float_dtype():
+    result = mxfp8_ue8m0_qdq(torch.randn(8, 4 * GROUP))
+    assert result.scale.dtype is torch.float8_e8m0fnu
+    assert result.scale.shape == (8, 4)
+    assert result.quant.dtype is torch.float8_e4m3fn
+    # The decoded scale really is the power of two the exponent names.
+    decoded = result.scale.float()
+    assert torch.equal(decoded, torch.ldexp(
+        torch.ones_like(decoded), _exponents(result)))
+
+
+def test_the_dequant_is_the_quantized_elements_times_the_decoded_scale():
+    """No hidden third quantity: what ships is what was priced."""
+    result = mxfp8_ue8m0_qdq(torch.randn(16, 8 * GROUP) * 2.5)
+    rebuilt = (
+        result.quant.float().reshape(16, 8, GROUP)
+        * result.scale.float().unsqueeze(-1)
+    ).reshape(16, 8 * GROUP)
+    assert torch.equal(rebuilt, result.dequant)
+
+
+# ---------------------------------------------------------------------------
+# 3. THE EXACTNESS PROPERTY
+# ---------------------------------------------------------------------------
+
+def test_a_block128_fp8_source_re_encodes_with_zero_weight_error():
+    """The property the format exists for: weight_mse is EXACTLY 0.0.
+
+    Any tensor whose stored form is E4M3 codes times a shared power of two —
+    the DeepSeek ``fp8_e4m3_ue8m0_block128`` body convention — is exactly
+    representable here, because the ceil rule can never pick a group exponent
+    above the block's own, so every element is an E4M3 code scaled DOWN by a
+    power of two. 128 = 4*32, so a chunk never straddles a block boundary.
+
+    Stated on the WEIGHT plane deliberately. The served lane is W8A8, so a
+    weight-lossless unit still has real activation-side error; see
+    ``test_zero_weight_error_does_not_make_the_layer_output_exact``.
+    """
+    w, _ = _block128_source()
+    result = mxfp8_ue8m0_qdq(w)
+    assert torch.equal(result.dequant, w)
+    weight_mse = float(((result.dequant - w) ** 2).mean())
+    assert weight_mse == 0.0
+
+    # and the same through the registry closure the cost stage actually calls
+    rendered = fr.get_format(FMT).quantize_dequantize(w)
+    assert torch.equal(rendered, w)
+    assert float(((rendered - w) ** 2).mean()) == 0.0
+
+
+def test_zero_weight_error_does_not_make_the_layer_output_exact():
+    """W' == W silences the WEIGHT side only; the A side is still 8-bit.
+
+    This is the honesty the allocator gates depend on: a block-FP8 source on
+    this rung must NOT look free.
+    """
+    from prismaquant.allocator_candidates import cost_entry_is_bit_exact
+
+    spec = fr.get_format(FMT)
+    w, _ = _block128_source(n=128, k=128, block=64)
+    torch.manual_seed(4)
+    x = torch.randn(64, 128)
+
+    w_hat = spec.quantize_dequantize(w.clone())
+    x_hat = spec.activation_quantize_dequantize(x.clone())
+    assert torch.equal(w_hat, w)                      # weight side: exact
+    assert not torch.equal(x_hat, x)                  # A side: not identity
+
+    output_mse = float((((x @ w.T) - (x_hat @ w_hat.T)) ** 2).mean())
+    assert output_mse > 0.0
+
+    # ... and the allocator refuses to short-circuit such an entry to dloss 0.
+    assert not cost_entry_is_bit_exact({"weight_mse": 0.0}, FMT)
+
+
+def test_the_activation_path_is_the_same_dynamic_per_32_ceil_rule():
+    """The A side must be the lane's A side, not a stand-in."""
+    spec = fr.get_format(FMT)
+    torch.manual_seed(7)
+    x = torch.randn(16, 4 * GROUP) * 3.0
+    assert torch.equal(
+        spec.activation_quantize_dequantize(x.clone()),
+        mxfp8_ue8m0_qdq(x).dequant,
+    )
+    # Dynamic: the scale follows the batch, so a rescaled input reuses the
+    # same relative grid rather than a fitted static one.
+    assert torch.equal(
+        spec.activation_quantize_dequantize(x * 4.0),
+        spec.activation_quantize_dequantize(x) * 4.0,
+    )
+
+
+def test_group_exponents_stay_at_or_below_their_block_exponent():
+    """RTN may pick a SMALLER exponent for a low-magnitude group.
+
+    That is still exact, so the assertion is an inequality plus reconstruction
+    equality — not exponent equality, which would be a false requirement.
+    """
+    w, block_exp = _block128_source()
+    result = mxfp8_ue8m0_qdq(w)
+    chosen = _exponents(result)
+    per_group = block_exp.repeat_interleave(128, 0).repeat_interleave(
+        128 // GROUP, 1)
+    assert chosen.shape == per_group.shape
+    assert bool((chosen <= per_group).all())
+    # the interesting half of the claim: it really does go strictly lower
+    assert bool((chosen < per_group).any())
+    assert torch.equal(result.dequant, w)
+
+
+def test_exactness_holds_for_every_e4m3_code_as_the_group_maximum():
+    """Exhaustive over the element grid, not a sample of it.
+
+    Each finite E4M3 code is driven as the group max, alongside the values
+    most likely to fall off the grid when a group is rescaled (the min normal
+    and the min subnormal), across the block exponents a real checkpoint uses.
+    """
+    codes = _finite_e4m3_codes()
+    n = codes.numel()
+    for block_exp in range(-24, 25, 4):
+        scale = 2.0 ** block_exp
+        # (a) each code as the max, with the fragile small values beside it
+        probe = torch.zeros(n, GROUP)
+        probe[:, 0] = codes
+        probe[:, 1] = 1.125 * 2.0 ** -6
+        probe[:, 2] = 2.0 ** -9
+        probe[:, 3] = -codes
+        probe = probe * scale
+        assert torch.equal(mxfp8_ue8m0_qdq(probe).dequant, probe)
+
+        # (b) the full code set swept through the group, max pinned at 448
+        paired = torch.zeros(n, GROUP)
+        paired[:, 0] = 448.0
+        paired[:, 1] = codes
+        paired = paired * scale
+        assert torch.equal(mxfp8_ue8m0_qdq(paired).dequant, paired)
+
+
+def test_the_stock_mxfp8_encoder_is_the_one_that_cannot_do_this():
+    """Guards the reason two MX-FP8 formats exist, so it cannot be forgotten.
+
+    The compressed-tensors rule rounds the group amax to a power of two, which
+    can scale a group UP; a group holding both 448 and a small normal then
+    loses the small one off the E4M3 subnormal ladder. If this ever starts
+    passing, MXFP8_E4M3 has changed and the two formats should be reconsidered.
+    """
+    from prismaquant.mx_formats import mxfp8_e4m3_qdq
+
+    x = torch.zeros(1, GROUP)
+    x[0, 0] = 448.0
+    x[0, 1] = 1.125 * 2.0 ** -6
+    assert not torch.equal(mxfp8_e4m3_qdq(x).dequant, x)
+    assert torch.equal(mxfp8_ue8m0_qdq(x).dequant, x)
+
+
+# ---------------------------------------------------------------------------
+# 4. menu legality
+# ---------------------------------------------------------------------------
+
+def _menu_tables(cost_entry):
+    """One dense Linear with a real sensitivity, priced by ``cost_entry``."""
+    name = "model.layers.0.self_attn.q_proj"
+    stats = {name: {"h_trace": 2.0, "n_params": 512 * 1024,
+                    "in_features": 1024, "out_features": 512}}
+    costs = {name: {FMT: dict(cost_entry),
+                    "BF16": {"weight_mse": 0.0, "output_mse": 0.0,
+                             "output_mse_measured": True}}}
+    return name, stats, costs
+
+
+def test_an_unmeasured_activation_side_is_masked_not_admitted():
+    """A W8A8 rung with no measured output_mse must LEAVE the menu.
+
+    On a block-FP8 source the weight error really is 0.0, so an entry lacking
+    activation evidence would otherwise be priced at the DP's global minimum
+    on no evidence at all — the unbeatable argmin at every budget, for an
+    assignment whose served activations are still 8-bit.
+    """
+    from prismaquant.allocator_candidates import (
+        ACTIVATION_COST_UNMEASURED_REASON,
+        build_candidates,
+        cost_entry_prices_unmeasured_activation_at_zero,
+    )
+
+    # The bare predicate: weight-lossless, no measured output side, priced 0.
+    assert cost_entry_prices_unmeasured_activation_at_zero(
+        {"h_trace": 2.0}, {"weight_mse": 0.0}, 0.0, FMT)
+
+    name, stats, costs = _menu_tables(
+        {"weight_mse": 0.0, "output_mse": 0.0, "output_mse_measured": False})
+    masks: list[dict] = []
+    cands = build_candidates(
+        stats, costs,
+        [fr.get_format(FMT), fr.get_format("BF16")],
+        target_profile="nvfp4_cb", mask_records=masks)
+    assert FMT not in {c.fmt for c in cands[name]}
+    assert any(m["format"] == FMT
+               and m["reason"] == ACTIVATION_COST_UNMEASURED_REASON
+               for m in masks), masks
+
+
+def test_a_measured_activation_side_passes_menu_admission():
+    """The same row WITH real W8A8 evidence is admitted and priced above zero."""
+    from prismaquant.allocator_candidates import build_candidates
+
+    name, stats, costs = _menu_tables(
+        {"weight_mse": 0.0, "output_mse": 3.5e-4,
+         "output_mse_measured": True})
+    cands = build_candidates(
+        stats, costs,
+        [fr.get_format(FMT), fr.get_format("BF16")],
+        target_profile="nvfp4_cb")
+    chosen = {c.fmt: c for c in cands[name]}
+    assert FMT in chosen
+    assert chosen[FMT].predicted_dloss > 0.0
+    assert chosen[FMT].bits_per_param == 8.25
+    assert chosen[FMT].serving_lane.lane_id == "mxfp8_ue8m0_g32"
+    assert chosen[FMT].serving_lane.fused_mid_m_backed is False
+    # Priced from the real A-side measurement, not short-circuited: the
+    # weight side is exactly lossless here and would otherwise read as free.
+    assert chosen[FMT].activation_pricing == "measured_output_mse"
+    assert chosen["BF16"].activation_pricing == "bit_exact"
+
+
+def test_it_is_a_requantization_rung_not_a_source_gated_passthrough():
+    """Legal on ANY source dtype — the whole difference from the *_SOURCE family."""
+    assert FMT not in SOURCE_PASSTHROUGH_CONTRACTS
+    spec = fr.get_format(FMT)
+    # It has a real encoder, which is precisely what disqualifies it from the
+    # passthrough table (whose members must be the identity).
+    probe = torch.randn(8, 4 * GROUP)
+    assert not torch.equal(spec.quantize_dequantize(probe), probe)
+
+    shape = (256, 256)
+    for source_kind in ("bf16", "fp8", "fp8_ue8m0", "mxfp4", "other", None):
+        verdict = check_format_applicability(
+            shape, FMT, source_kind=source_kind,
+            target_profile="nvfp4_cb",
+            qname="model.layers.0.self_attn.q_proj")
+        assert verdict.legal, (source_kind, verdict.reason, verdict.detail)
+
+
+def test_the_body_and_attention_menus_carry_it_and_packed_experts_do_not():
+    dense = "model.layers.0.self_attn.q_proj"
+    expert = "model.layers.0.mlp.experts.gate_up_proj"
+
+    assert sp.check_serving_format("nvfp4_cb", dense, FMT).legal
+    assert sp.check_serving_format(
+        "nvfp4_cb", "model.layers.0.mlp.down_proj", FMT).legal
+
+    denied = sp.check_serving_format(
+        "nvfp4_cb", expert, FMT, packed_expert=True)
+    assert not denied.legal
+    # Denied by the EXISTING container rule for stock-delegated dense-only
+    # emission, not by a format-specific special case.
+    assert denied.rule == "cb_packed_expert_stock_ct_unsupported"
+    assert denied.reason == "runtime_unsupported"
+
+
+def test_the_expert_cost_menu_is_enumerated_and_excludes_it_by_bpw():
+    """The <= 4.25 bpw expert menu is an ENUMERATION, not a numeric cap.
+
+    There is no bpw-cap predicate anywhere in the codebase; the routed-expert
+    ladder is the explicit MENU list in the cost driver. This pins the
+    invariant that makes 'MXFP8 is naturally excluded' true: every rung that
+    menu measures is at or under 4.25 bpw, so an 8.25 bpw rung cannot be on it.
+    """
+    driver = Path(__file__).resolve().parents[1] / (
+        "scripts/run_dsv4_mxfp4_cost.sh")
+    menu_line = next(
+        line for line in driver.read_text().splitlines()
+        if line.startswith("MENU=")
+    )
+    menu = menu_line.split("{MENU:-", 1)[1].rstrip('}"').split(",")
+    assert len(menu) > 1
+    for name in menu:
+        assert fr.get_format(name).effective_bits <= 4.25, name
+    assert FMT not in menu
+    assert fr.get_format(FMT).effective_bits > 4.25
+
+
+def test_it_is_masked_where_the_group_does_not_divide_the_input():
+    verdict = check_format_applicability(
+        (256, 100), FMT, source_kind="bf16",
+        target_profile="nvfp4_cb",
+        qname="model.layers.0.self_attn.q_proj")
+    assert not verdict.legal
+    assert verdict.reason == "group_divisibility"
+
+
+def test_the_recipe_spellings_round_trip():
+    assert canonicalize_format(FMT) == FMT
+    assert canonicalize_format("mxfp8_ue8m0_g32") == FMT
+    assert canonicalize_format({
+        "data_type": "fp8_e4m3", "bits": 8,
+        "group_size": 32, "scale_fmt": "ue8m0",
+    }) == FMT
+    # Without the UE8M0 scale_fmt this stays the stock compressed-tensors rung.
+    assert canonicalize_format({
+        "data_type": "fp8_e4m3", "bits": 8, "group_size": 32,
+    }) == "MXFP8_E4M3"
+    # And the historical short alias is untouched.
+    assert canonicalize_format("mxfp8") == "MXFP8_E4M3"
+    assert fr.canonical_format_name("MXFP8") == "MXFP8_E4M3"
+
+
+# ---------------------------------------------------------------------------
+# 5. the wire contract
+# ---------------------------------------------------------------------------
+
+def test_the_wire_id_is_pinned_and_globally_unique():
+    assert REQUANT_WIRE_FORMAT_IDS == {FMT: WIRE_ID}
+    # Re-quant ids are a SEPARATE table from the passthrough ids: membership of
+    # the latter is a claim of byte-verbatim shipping this rung cannot make.
+    assert FMT not in PASSTHROUGH_WIRE_FORMAT_IDS
+    assert WIRE_ID not in PASSTHROUGH_WIRE_FORMAT_IDS.values()
+    # But the consumer dispatches on the id alone, so the union must be 1:1.
+    assert WIRE_FORMAT_IDS == {**PASSTHROUGH_WIRE_FORMAT_IDS,
+                               **REQUANT_WIRE_FORMAT_IDS}
+    assert len(set(WIRE_FORMAT_IDS.values())) == len(WIRE_FORMAT_IDS)
+    for name in WIRE_FORMAT_IDS:
+        fr.get_format(name)          # every id names a registered format
+
+
+def test_the_serving_lane_is_declared_and_honestly_unbacked():
+    lane = sp.serving_lane_route("nvfp4_cb", FMT)
+    assert lane is not None
+    assert lane.lane_id == "mxfp8_ue8m0_g32"
+    assert lane.rung is None
+    assert lane.fused_mid_m_backed is False
+    assert lane.fused_mid_m_rungs == ()
+    # An ABSENT fused_mid_m key, not an empty declared one: there is no decode
+    # prologue to fuse, and this is the fail-closed spelling.
+    assert lane.rungs_source == "lane_declares_no_fused_mid_m_lane"
+    # Not filed under any CB activation contract.
+    assert "cb" not in lane.activation_contract
+    assert lane.activation_contract == "w8a8-dynamic-mxfp8-e4m3-group32-ue8m0"
+
+
+def test_the_lane_only_becomes_backed_when_a_runtime_version_declares_it():
+    """rungs_by_runtime_version precedent: a pin with no key backs nothing."""
+    spec = sp.load_serving_profile("nvfp4_cb")
+    lane = next(l for l in spec.serving_lanes if l.id == "mxfp8_ue8m0_g32")
+    assert lane.fused_mid_m_rungs_by_runtime_version == ()
+    for version in ("0.7.0", "0.8.0", ""):
+        rungs, source = lane.backed_rungs(version)
+        assert rungs == ()
+        assert source == "lane_declares_no_fused_mid_m_lane"
+
+
+def test_the_config_group_declares_the_w8a8_activation_contract():
+    from prismaquant.cb_export_config import (
+        REQUANT_NATIVE_GROUP_FORMAT,
+        requant_native_config_group,
+        requant_wire_id,
+    )
+
+    assert requant_wire_id(FMT) == WIRE_ID
+    assert requant_wire_id("mxfp8_ue8m0_g32") == WIRE_ID
+    with pytest.raises(ValueError, match="not a declared re-quantization"):
+        requant_wire_id("MXFP8_E4M3")
+
+    group = requant_native_config_group(FMT)
+    assert group["format"] == REQUANT_NATIVE_GROUP_FORMAT
+    assert group["source_format"] == FMT
+    assert group["wire_format_id"] == WIRE_ID
+    acts = group["input_activations"]
+    assert acts is not None, "a W8A8 lane must not declare a weight-only group"
+    assert acts["num_bits"] == 8
+    assert acts["element_dtype"] == "fp8_e4m3"
+    assert acts["scale_dtype"] == "uint8_e8m0"
+    assert acts["dynamic"] is True
+    assert acts["strategy"] == "group" and acts["group_size"] == GROUP
+    weights = group["weights"]
+    assert weights["num_bits"] == 8
+    assert weights["element_dtype"] == "fp8_e4m3"
+    assert weights["scale_dtype"] == "uint8_e8m0"
+    assert weights["strategy"] == "group"
+    assert weights["group_size"] == GROUP
+    # The producer WROTE these bytes; saying otherwise would let the consumer
+    # believe they came from the checkpoint unchanged.
+    assert weights["source_passthrough"] is False
+
+
+def test_the_exporter_plans_a_weight_and_scale_pair_at_the_declared_dtypes():
+    from prismaquant.export_nvfp4_cb_streaming import (
+        _requant_output_specs,
+        _requant_pack,
+    )
+
+    specs = _requant_output_specs(FMT, (256, 512))
+    assert specs == [
+        ("weight", torch.float8_e4m3fn, (256, 512)),
+        ("weight_scale", torch.float8_e8m0fnu, (256, 512 // GROUP)),
+    ]
+    # The planned header must match what the packer actually produces, or the
+    # streaming writer sizes the file wrong.
+    packed = _requant_pack(FMT, torch.randn(256, 512))
+    assert sorted(packed) == ["weight", "weight_scale"]
+    for suffix, dtype, shape in specs:
+        assert packed[suffix].dtype is dtype
+        assert tuple(packed[suffix].shape) == shape
+
+    with pytest.raises(ValueError, match="not a multiple"):
+        _requant_output_specs(FMT, (256, 100))
+
+
+def test_the_exporter_packer_is_the_same_codec_the_registry_prices():
+    """Emulation and shipped bytes are one rendering, not two that agree."""
+    from prismaquant.export_nvfp4_cb_streaming import _requant_pack
+
+    w = torch.randn(64, 4 * GROUP) * 1.7
+    packed = _requant_pack(FMT, w)
+    rebuilt = (
+        packed["weight"].float().reshape(64, 4, GROUP)
+        * packed["weight_scale"].float().unsqueeze(-1)
+    ).reshape(64, 4 * GROUP)
+    assert torch.equal(rebuilt, fr.get_format(FMT).quantize_dequantize(w))
+
+
+# ---------------------------------------------------------------------------
+# 6. cost measurement wiring
+# ---------------------------------------------------------------------------
+
+def test_cost_measurement_needs_no_codebook_machinery():
+    """A non-CB rung takes the simple render path: no CB env stamps, no context."""
+    from prismaquant import measure_quant_cost as mqc
+
+    spec = fr.get_format(FMT)
+    assert spec.family not in mqc._CB_COST_FAMILIES
+    # cost_payload_provenance binds a CBSerializationContext only for CB menus;
+    # a menu of this rung alone must not demand one (it would raise without the
+    # CB_* env stamps set).
+    provenance = mqc.cost_payload_provenance([spec])
+    assert provenance.get("cb_serialization") in (None, {})
+
+
+def test_the_batched_render_is_the_same_codec_as_the_unbatched_one():
+    """The batched path keys on element dtype, which this rung SHARES.
+
+    ``weight_element_dtype`` is "fp8_e4m3" here and on MXFP8_E4M3/FP8_CB, so a
+    fall-through would render this rung with the local codebook replica's E8M0
+    snap instead of its own saturating-ceil rule — pricing the batched path
+    with a different codec than the exporter writes.
+    """
+    from prismaquant import measure_quant_cost as mqc
+
+    spec = fr.get_format(FMT)
+    assert FMT in mqc._EXPORT_ALIGNED_BATCH_FORMATS
+
+    torch.manual_seed(1)
+    stacked = torch.randn(3, 32, 4 * GROUP)
+    batched = mqc._batched_quantize(spec, stacked)
+    unbatched = torch.stack([
+        spec.quantize_dequantize(stacked[i].clone()) for i in range(3)])
+    assert torch.equal(batched, unbatched)
+
+    # and the property survives the batched path too
+    src, _ = _block128_source(n=128, k=128, block=64)
+    stacked_src = src.unsqueeze(0).repeat(2, 1, 1)
+    assert torch.equal(mqc._batched_quantize(spec, stacked_src), stacked_src)
+
+
+def test_a_small_layer_prices_through_the_shared_render_helper():
+    """Smoke: the rung produces a finite weight cost on a synthetic layer."""
+    from prismaquant import measure_quant_cost as mqc
+
+    torch.manual_seed(0)
+    w = torch.randn(64, 4 * GROUP, dtype=torch.float32)
+    rendered = mqc._render_weight_for_spec(fr.get_format(FMT), w) \
+        if hasattr(mqc, "_render_weight_for_spec") \
+        else fr.get_format(FMT).quantize_dequantize(w.clone())
+    weight_mse = float(((rendered - w) ** 2).mean())
+    assert math.isfinite(weight_mse)
+    assert weight_mse > 0.0          # generic gaussian input is NOT on the grid
+
+    # ... and exactly zero once the input is a block-FP8 source.
+    src, _ = _block128_source(n=64, k=128, block=64)
+    assert float(
+        ((fr.get_format(FMT).quantize_dequantize(src) - src) ** 2).mean()
+    ) == 0.0

--- a/tests/test_nvfp4_cb_streaming.py
+++ b/tests/test_nvfp4_cb_streaming.py
@@ -1848,3 +1848,137 @@ def test_source_passthrough_recipes_round_trip_through_canonicalize_format():
     with pytest.raises(ValueError, match="group-of-32"):
         canonicalize_format(
             {"data_type": "fp4_e2m1", "bits": 4, "group_size": 16})
+
+
+# ---------------------------------------------------------------------------
+# MXFP8_UE8M0_G32 — re-quantized native emission (the third streaming lane)
+# ---------------------------------------------------------------------------
+
+_MXFP8_RECIPE = {"data_type": "fp8_e4m3", "bits": 8, "group_size": 32,
+                 "scale_fmt": "ue8m0"}
+
+
+def _export_dsv4_with_mxfp8_body(workdir, out_name="mxfp8"):
+    """DSv4 source whose dense body Linear is RE-ENCODED to MXFP8, not copied.
+
+    Same checkpoint as the passthrough tests — the body Linear really is
+    block-FP8 on disk — so this exercises the interesting case: a re-quant
+    rung reading a block-scaled FP8 source.
+    """
+    mdl = workdir / "src_mxfp8"
+    tensors = _dsv4_source_model(mdl)
+    assignment, col_weights = _dsv4_recipe()
+    assignment["model.layers.0.self_attn.wq_a"] = _MXFP8_RECIPE
+    path = workdir / f"{out_name}.json"
+    _assign(path, assignment)
+    out = workdir / out_name
+    counts = export_nvfp4_cb_streaming(
+        mdl, path, out, col_weights, device="cpu",
+        allow_route_pending_passthrough=True)
+    return mdl, out, tensors, dict(counts)
+
+
+def test_mxfp8_requant_emits_the_declared_weight_and_scale_pair(workdir):
+    """The planned header is the emitted header: names, dtypes, byte counts."""
+    _mdl, out, _tensors, counts = _export_dsv4_with_mxfp8_body(workdir)
+    assert counts["MXFP8_UE8M0_G32"] == 1
+
+    header, _ = _st_header(out / "model.safetensors")
+    base = "layers.0.attn.wq_a"
+    assert header[base + ".weight"]["dtype"] == "F8_E4M3"
+    assert header[base + ".weight"]["shape"] == [_SOURCE_HID, _SOURCE_HID]
+    assert header[base + ".weight_scale"]["dtype"] == "F8_E8M0"
+    assert header[base + ".weight_scale"]["shape"] == [
+        _SOURCE_HID, _SOURCE_HID // 32]
+    # The source's own one-byte block-scale plane is GONE: this unit was
+    # re-encoded, so shipping the checkpoint's scale beside it would describe
+    # a tensor the new elements are not scaled by.
+    assert base + ".scale" not in header
+    lo, hi = header[base + ".weight_scale"]["data_offsets"]
+    assert hi - lo == _SOURCE_HID * (_SOURCE_HID // 32)   # one byte per group
+
+    # 8 + 8/32 = 8.25 bpw, on the bytes actually written.
+    wlo, whi = header[base + ".weight"]["data_offsets"]
+    n_params = _SOURCE_HID * _SOURCE_HID
+    assert 8.0 * ((whi - wlo) + (hi - lo)) / n_params == 8.25
+
+
+def test_mxfp8_requant_of_a_block_fp8_body_is_bit_exact_end_to_end(workdir):
+    """The exactness property, all the way through the shipped artifact.
+
+    The source Linear is E4M3 codes times a per-128x128 power of two. Decoding
+    the emitted MXFP8 planes must return those values EXACTLY — not close.
+    """
+    mdl, out, tensors, _counts = _export_dsv4_with_mxfp8_body(workdir)
+    base = "layers.0.attn.wq_a"
+
+    source = (
+        tensors[base + ".weight"].float()
+        * tensors[base + ".scale"].float()
+        .repeat_interleave(128, 0).repeat_interleave(128, 1)
+    )
+
+    emitted = load_file(str(out / "model.safetensors"))
+    weight = emitted[base + ".weight"].float()
+    scale = emitted[base + ".weight_scale"].float()
+    decoded = (
+        weight.reshape(_SOURCE_HID, _SOURCE_HID // 32, 32)
+        * scale.unsqueeze(-1)
+    ).reshape(_SOURCE_HID, _SOURCE_HID)
+
+    assert torch.equal(decoded, source)
+    assert float(((decoded - source) ** 2).mean()) == 0.0
+
+
+def test_mxfp8_requant_declares_a_native_group_and_routes_natively(workdir):
+    """It carries its own wire id and joins the delegated-native routing map.
+
+    The consumer's dispatcher reads ONE map (`source_passthrough.units`) to
+    decide "native route or CB decoder" and refuses an id it does not know, so
+    a unit omitted there would be read as CB — the one wrong answer that
+    loads. The byte-verbatim-vs-re-encoded distinction lives per unit in the
+    config group's `weights.source_passthrough` flag instead.
+    """
+    _mdl, out, _tensors, _counts = _export_dsv4_with_mxfp8_body(workdir)
+    config = json.loads((out / "quant_config.json").read_text())
+
+    groups = [g for g in config["config_groups"].values()
+              if g.get("source_format") == "MXFP8_UE8M0_G32"]
+    assert len(groups) == 1
+    group = groups[0]
+    assert group["format"] == "gridbook-native"
+    assert group["wire_format_id"] == "mxfp8_e4m3_e8m0_g32"
+    assert group["weights"]["group_size"] == 32
+    assert group["weights"]["scale_dtype"] == "uint8_e8m0"
+    # The producer WROTE these bytes -- the one claim it must not borrow from
+    # its byte-verbatim neighbours.
+    assert group["weights"]["source_passthrough"] is False
+    # W8A8: the lane quantizes activations to the same per-32 grid.
+    acts = group["input_activations"]
+    assert acts["num_bits"] == 8 and acts["group_size"] == 32
+    assert acts["dynamic"] is True
+    from prismaquant.export_native_compressed import _explicit_regex
+    assert group["targets"] == [_explicit_regex("layers.0.attn.wq_a")]
+
+    declared = config["source_passthrough"]["units"]
+    assert config["source_passthrough"]["version"] == 1
+    # Unit ids stay in the RECIPE namespace (as the byte-verbatim lane's do);
+    # only the emitted TENSORS take the checkpoint spelling.
+    assert declared["model.layers.0.self_attn.wq_a"] == "mxfp8_e4m3_e8m0_g32"
+    # The routed-expert byte-verbatim half of the same artifact is unaffected.
+    assert any(fmt == "mxfp4_e2m1_ue8m0_g32" for fmt in declared.values())
+    assert config["provenance"]["requant_native_targets"] == {
+        "MXFP8_UE8M0_G32": 1}
+    assert "layers.0.attn.wq_a" not in set(config["ignore"])
+
+
+def test_mxfp8_requant_declaration_parses_on_the_producer_side(workdir):
+    """The producer self-parses what it writes, as it does for passthroughs."""
+    from prismaquant.cb_export_config import (
+        parse_source_passthrough_declaration,
+    )
+
+    _mdl, out, _tensors, _counts = _export_dsv4_with_mxfp8_body(workdir)
+    config = json.loads((out / "quant_config.json").read_text())
+    parsed = parse_source_passthrough_declaration(config)
+    assert parsed["model.layers.0.self_attn.wq_a"] == "mxfp8_e4m3_e8m0_g32"

--- a/tests/test_prismaquant_export_native_compressed.py
+++ b/tests/test_prismaquant_export_native_compressed.py
@@ -1077,10 +1077,20 @@ class TestRoundTrip(unittest.TestCase):
             "MXFP4_SOURCE",
             "FP8_BLOCK_UE8M0_SOURCE",
         }
+        nvfp4_cb_container_requant = {
+            # RE-QUANTIZED carriers of the nvfp4_cb container: unlike the
+            # passthroughs above these DO have a render, but it is not a
+            # compressed-tensors one — the exporter writes the element and
+            # scale planes itself under a Gridbook wire id. "rendered ==
+            # served" is therefore a real claim with real content, and it is
+            # checked directly below (against the same E8M0 served formula the
+            # stock MXFP8 rungs use) rather than deferred to another file.
+            "MXFP8_UE8M0_G32",
+        }
         self.assertEqual(
             set(fr.REGISTRY),
             reconciled | set(explicit_gaps) | gguf_lane | nvfp4_cb_lane
-            | nvfp4_cb_container_passthroughs,
+            | nvfp4_cb_container_passthroughs | nvfp4_cb_container_requant,
         )
 
     def test_registry_render_dequant_matches_served_metadata(self):
@@ -1118,6 +1128,27 @@ class TestRoundTrip(unittest.TestCase):
                             W.reshape(W.shape[0], W.shape[1] // 32, 32)
                         ).dequant.reshape_as(W)
                         torch.testing.assert_close(rendered, served)
+                        continue
+
+                    if fmt == "MXFP8_UE8M0_G32":
+                        # Not a compressed-tensors rung: the STREAMING
+                        # exporter writes its planes itself. Pack with the
+                        # exporter's own packer, then decode with the same
+                        # served E8M0 formula the stock MXFP8 rungs use, and
+                        # require the registry render to equal it exactly.
+                        from prismaquant.export_nvfp4_cb_streaming import (
+                            _requant_pack,
+                        )
+
+                        packed = _requant_pack(fmt, W)
+                        served = _mxfp8_served_dequantize(
+                            packed["weight"],
+                            packed["weight_scale"].view(torch.uint8),
+                        )
+                        rendered = fr.get_format(fmt).quantize_dequantize(
+                            W.clone())
+                        torch.testing.assert_close(rendered, served)
+                        self.assertTrue(torch.equal(rendered, served))
                         continue
 
                     if fmt in {"MXFP8_E4M3", "MXFP8_E5M2", "MXFP8A16"}:

--- a/tests/test_serving_lane_metadata.py
+++ b/tests/test_serving_lane_metadata.py
@@ -276,14 +276,19 @@ def test_the_lane_catalog_is_reportable_and_names_its_runtime():
         # their own precisely so P5b never files a passthrough unit under a
         # CB activation contract it does not have.
         "delegated_native_mxfp4", "delegated_native_fp8_block_ue8m0",
+        # The RE-QUANTIZED native lane. Declared for the same P5b reason and
+        # currently UNBACKED: no released Gridbook runtime carries a loader.
+        "mxfp8_ue8m0_g32",
     }
     assert catalog["lanes"]["fp8_cb_fused_mid_m"]["fused_mid_m_rungs"] == [
         28, 32, 36, 40, 44, 48]
     # A passthrough lane backs no fused mid-M rung, and says so explicitly
     # rather than leaving the field absent: there is no decode prologue to
-    # fuse, so an empty backed set is the honest state, not a data gap.
+    # fuse, so an empty backed set is the honest state, not a data gap. The
+    # unbacked re-quant lane reads the same way and for the same reason.
     for lane_id in ("delegated_native_mxfp4",
-                    "delegated_native_fp8_block_ue8m0"):
+                    "delegated_native_fp8_block_ue8m0",
+                    "mxfp8_ue8m0_g32"):
         lane = catalog["lanes"][lane_id]
         assert lane["fused_mid_m_rungs"] == []
         assert lane["fused_mid_m_rungs_source"] == (


### PR DESCRIPTION
Producer half of the MXFP8 dense lane. Emission matches the Gridbook consumer at commit `9a77873` **verbatim** — `DELEGATED_NATIVE_WIRE_FORMATS` now mirrors the consumer's `FORMATS` table exactly, and the wire id keeps the consumer's spelling (`mxfp8_e4m3_e8m0_g32`) even though this repo's own convention spells the plane `ue8m0`. A wire id is a cross-repo contract, so it is used verbatim rather than improved unilaterally, and it lives in one constant so reconciling later is a one-line edit.

## Why a second MX-FP8 format

The registry already carried `MXFP8_E4M3` at the same 8.25 bpw, so the first question is why this is not just a menu entry for the one that exists. Because it is a **different on-disk contract** — the same call `FP8_BLOCK_UE8M0_SOURCE` made against `FP8_SOURCE`:

* **Scale rule.** `MXFP8_E4M3` defers to compressed-tensors, which rounds the group amax to a power of two and can therefore scale a group **up**. Scaling up is not free at the bottom of the E4M3 grid: a group holding both 448 and `1.125*2^-6` loses the small value off the subnormal ladder. Measured, not assumed — a **guard test** keeps the stock encoder's non-exactness on block-FP8 pinned, so if that encoder ever changes the two formats get reconsidered instead of quietly diverging. This rung instead picks the smallest non-clipping shared exponent.
* **Scale dtype.** The stock lane serializes E8M0 as `uint8`; this one serializes `float8_e8m0fnu`, the spelling DeepSeek-V4 uses and the Gridbook consumer reads.
* **Lane.** Its own wire id and its own serving lane, not a CT scheme.

**The `MXFP8 -> MXFP8_E4M3` alias is deliberately left untouched**: historical artifacts and launchers spelled the stock rung `MXFP8`, and repointing it would reinterpret every persisted assignment that uses it.

## What the ceil rule buys

Any tensor stored as E4M3 codes times a shared power of two — the DeepSeek `fp8_e4m3_ue8m0_block128` body convention — re-encodes here with `weight_mse` **exactly 0.0**. The rule can never pick an exponent above the block's own, so every element is an E4M3 code scaled *down* by a power of two, which is always representable; and `128 = 4*32`, so a chunk never straddles a block boundary. That is a property of the rule, not a measurement, and the tests verify it exhaustively over all 254 finite E4M3 codes crossed with the block exponents a real checkpoint uses.

The exponent is computed from **frexp**, not `ceil(log2(amax/448))`, and that is load-bearing rather than stylistic: in float32 the log2 form is wrong about once in 4e5 group maxima, producing an exponent one too small and an element that saturates at 448 — the one thing the rule exists to prevent. Measured over 6e6 sampled maxima: 15 saturations for the log2 form, 0 for this one. A test pins the divergence so the exact form cannot be "simplified" away.

## W8A8, with the A side measured

Read the exactness claim precisely: it is `weight_mse == 0.0`, **not** `output_mse == 0.0`. The lane quantizes activations dynamically to the same per-32 grid, so a weight-lossless unit still carries real A-side error. Declaring `act_bits=8` is what makes the cost stage apply the **activation closure** before measuring `output_mse`; declaring A16 would have handed the DP a free zero-cost rung on any block-FP8 body. Both `output_mse` paths already apply the format's own closure before the matmul, and both directions are tested through `build_candidates`. The honesty gates then do their job: `cost_entry_is_bit_exact` refuses to short-circuit the rung, and a row with no measured `output_mse` is **masked off the menu** rather than priced at the global minimum.

## Latent divergence fixed on the way

`measure_quant_cost._batched_quantize` dispatches on `weight_element_dtype`, which this rung **shares** with `MXFP8_E4M3` and `FP8_CB` — so the batched render would have priced it with the codebook replica's E8M0 snap instead of its own codec, i.e. a different codec in the batched and unbatched paths. `_EXPORT_ALIGNED_BATCH_FORMATS` routes it to the registry closure, and a test now holds the two paths to each other.

## Menu and lane

It is a **re-quantization** rung, so it is deliberately absent from `SOURCE_PASSTHROUGH_CONTRACTS` and is legal on any source dtype — the whole difference from the `*_SOURCE` family. Body and attention carry it; packed experts deny it through the existing `cb_packed_expert_stock_ct_unsupported` rule, because its emission is a 2-D dense path with no packed-expert stacking (the same structural reason that rule already denies stock NVFP4/FP8). Its exclusion from the routed-expert ladder is separate and needs no code: the `<= 4.25` bpw expert menu is an **enumeration** in `scripts/run_dsv4_mxfp4_cost.sh`, not a numeric cap — there is no bpw-cap predicate anywhere in the tree — and a test pins that every rung on that menu is at or under 4.25 bpw (19 rungs, max 4.125) while this one is 8.25.

Re-quantized units join `source_passthrough.units` because that record is the delegated-native **routing** map the consumer dispatches on, and a unit missing from it reads as CB — the one wrong answer that loads. What they do not inherit is the byte-verbatim claim: that lives per unit in the config group's `weights.source_passthrough` flag, false here.

## P5b: declared and UNBACKED

The consumer-side kernel exists and is correctness-audited, but it is opt-in behind `GRIDBOOK_MXFP8_DENSE=1` with the served NATIVE-PARITY bench pending, and this spec's backed set describes what the **default** serve takes — the same call `nvfp4_cb_quality_path` makes about the opt-in fp4 fused route. The backed set is therefore keyed to the next release rather than this one. No `fused_mid_m` key: a non-CB rung has no CB rung number, so an absent key resolving to `lane_declares_no_fused_mid_m_lane` is the correct answer.

## Tests

**+45 tests.** Suite: 2762 passed, 96 skipped, 2 xfailed, 151 warnings.

Also ignores `.prismaquant_tmp/`, the probe staging dir `sensitivity_probe.py` leaves in the repo root on every test run — unignored, a routine `git add -A` after running the suite sweeps stub `config.json` and tokenizer symlinks into the commit. `tmp/` and `.tmp/` were already ignored for the same reason; this is the third spelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUHqNEHMu7FAJQSNGCZhqW
