### PR TITLE
Stage the dual-variant DP drivers for the mid-rung and body-route questions

### DIFF
--- a/scripts/run_dsv4_mxfp4_dual_alloc.sh
+++ b/scripts/run_dsv4_mxfp4_dual_alloc.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# ============================================================================
+# run_dsv4_mxfp4_dual_alloc.sh — the two DP variants the mid-rung question needs
+# ============================================================================
+# Both run against ONE merged cost table: the K12-K18 probe columns (experts,
+# holdout-validated interpolation) merged over the v2 measured table (which
+# supplies FP8_CB_K36 for the body). The merge always PREFERS a measured value
+# over a fitted one, and reports the overlap validation before merging.
+#
+#   (a) shippable-today   menu WITHOUT FP8_BLOCK_UE8M0_SOURCE.
+#                         The body passthrough route is measured-blocked on
+#                         sm121, so this is the honest answer against the
+#                         5812.11 baseline.
+#
+#   (b) contingent        menu WITH it. CONTINGENT on the gridbook MXFP8 lane
+#                         merging, releasing, and passing its native-parity
+#                         bench -- it is on an unmerged opt-in branch, so the
+#                         producer-side route_status deliberately stays
+#                         `blocked` and is NOT flipped here. (b) is produced by
+#                         widening the MENU, not by editing the route table:
+#                         a blocked rung stays on the allocator's menu by
+#                         construction and the gate lives at export, so no
+#                         contract edit is needed to price the counterfactual.
+#
+# Neither variant writes to artifacts/, artifacts-mxfp4-sm121/, or
+# cost_full.pkl. Both are CPU-only -- they must not be run while a GPU tenant
+# needs the box, but they do not take the flock.
+# ============================================================================
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUN_ROOT="${RUN_ROOT:-/home/rob/dq-runs/dsv4-flash-0731}"
+WORK="${WORK:-${RUN_ROOT}/prod-cal-0p6-v2}"
+ART="${ART:-${WORK}/artifacts-mxfp4}"
+PROBE="${PROBE:-${ART}/probe-k12k18}"
+IMAGE="${IMAGE:-gridbook:test}"
+
+EXPERT_MENU="NVFP4_CB_K12,NVFP4_CB_K13,NVFP4_CB_K14,NVFP4_CB_K15,NVFP4_CB_K16,NVFP4_CB_K17,NVFP4_CB_K18"
+MENU_A="${EXPERT_MENU},FP8_CB_K36,MXFP4_SOURCE"
+MENU_B="${MENU_A},FP8_BLOCK_UE8M0_SOURCE"
+PARETO="${PARETO:-1.80,1.90,2.00,2.04,2.08,2.12,2.15,2.17,2.20,2.25,2.30,2.40,2.50,2.75,3.00,3.50,4.00,4.25,4.50}"
+
+# --- 1. merge + overlap validation ----------------------------------------
+# K14/K17/K13 are FITTED in the probe and K14 is MEASURED in v2, so the merge
+# report carries a real out-of-sample error band for the interpolator.
+echo "[dual] merging probe over v2 (measured always wins)"
+python3 "${REPO}/scripts/merge_dsv4_mxfp4_cost.py" \
+  --base "${WORK}/artifacts/cost_full.pkl" \
+  --new  "${PROBE}/cost_k12k18.pkl" \
+  --out  "${PROBE}/cost_merged.pkl" \
+  --report "${PROBE}/merge_report.json"
+
+run_variant() {
+  local tag="$1" menu="$2" out="${PROBE}/alloc-${1}"
+  mkdir -p "$out"
+  ln -sfn "${ART}/probe.pkl" "$out/probe.pkl"
+  ln -sfn "${ART}/cb_col_weights.pkl" "$out/cb_col_weights.pkl"
+  echo "[dual] variant ${tag}: ${menu}"
+  docker run --rm --name "pq-mxfp4-alloc-${tag}" --gpus all --ipc=host \
+    -v "${RUN_ROOT}:${RUN_ROOT}" -v "${REPO}:/pq" -w /pq \
+    -e PYTHONPATH=/pq \
+    -e PRISMAQUANT_CB_EXT_DIR="${RUN_ROOT}/ext" \
+    -e PRISMAQUANT_ACTIVATION_FAIR_PRICING=1 \
+    -e CB_CODEBOOK_SOURCE=lattice -e CB_SCALE_CODING=two_tier \
+    -e CB_SCALE_SWEEP=1 -e PRISMAQUANT_CB_ENCODE_TIER=balanced \
+    --entrypoint bash "$IMAGE" -c "
+python3 -m prismaquant.allocator \
+  --probe $out/probe.pkl \
+  --costs ${PROBE}/cost_merged.pkl \
+  --model ${RUN_ROOT}/source \
+  --formats '${menu}' \
+  --target-bits 2.17 --pareto-targets '${PARETO}' \
+  --target-disk-gb 92 --artifact-overhead-reserve-bytes 268435456 \
+  --target-profile nvfp4_cb \
+  --cb-scale-coding two_tier --cb-codebook-source lattice \
+  --cb-scale-sweep 1 --cb-encode-tier balanced \
+  --cb-col-weights $out/cb_col_weights.pkl \
+  --layer-config $out/layer_config.json \
+  --bit-attribution-json $out/bit_attribution.json \
+  --pareto-csv $out/pareto.csv" > "${WORK}/logs-mxfp4/alloc-${tag}.log" 2>&1
+  echo "[dual] variant ${tag} done -> $out/selection.json"
+}
+
+run_variant a "$MENU_A"
+run_variant b "$MENU_B"
+echo "[dual] both variants complete; summarise with scripts/summarise_dual_alloc.py"

--- a/scripts/summarise_dual_alloc.py
+++ b/scripts/summarise_dual_alloc.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Summarise the two DP variants: does the DP use mid rungs, and what do they buy?
+
+Reports, per variant: the expert layer map, the BODY split (the question the
+incidental K12-K18 body columns exist to answer), Delta-loss against the
+5812.11 shippable baseline, bytes, and the serving lanes every unit rides.
+
+Also runs the MXFP8 dominance check. That one is decided by arithmetic rather
+than by the DP, and deliberately so: MXFP8_E4M3 is registered W8A8
+(``act_bits=8``), so even with exact weights on a block-128 source the
+allocator REFUSES to short-circuit it to zero -- an activation-quantizing
+format with no measured ``output_mse`` is excluded from the menu rather than
+priced at the DP's global minimum. So the DP cannot be asked to confirm the
+comparison; what it can do is show the mask record, which is the mechanism.
+The dominance itself is unambiguous: 8.25 bpw versus 8.00049 bpw at the same
+zero weight error is 3.1% more bytes for nothing.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+SHIPPABLE_BASELINE = 5812.11
+ALL_CB_BASELINE = 6553.987851366602
+N_BODY_ALLOCATABLE = 301          # probe inventory; 89 further F8_E4M3 tensors
+N_BODY_FLOOR_ONLY = 89            # are not probeable and ship source-format
+
+
+def fmt_of(cfg: dict) -> str:
+    if not isinstance(cfg, dict):
+        return str(cfg)
+    dt, k = cfg.get("data_type"), cfg.get("cb_k")
+    if dt == "nvfp4_cb":
+        return f"NVFP4_CB_K{k}"
+    if dt == "fp8_cb":
+        return f"FP8_CB_K{k}"
+    if dt == "fp4_e2m1":
+        return "MXFP4_SOURCE"
+    if dt == "fp8_e4m3" and cfg.get("scale_fmt") == "ue8m0":
+        return "FP8_BLOCK_UE8M0_SOURCE"
+    return str(dt)
+
+
+def summarise(root: Path, tag: str) -> dict:
+    lc = json.loads((root / "layer_config.json").read_text())
+    sel = json.loads((root / "selection.json").read_text())
+    experts: dict[int, set[str]] = defaultdict(set)
+    body: Counter[str] = Counter()
+    for name, cfg in lc.items():
+        if name == "__prismaquant__":
+            continue
+        f = fmt_of(cfg)
+        m = re.match(r"model\.layers\.(\d+)\.mlp\.experts\.", name)
+        if m:
+            experts[int(m.group(1))].add(f)
+        else:
+            body[f] += 1
+    by_fmt: dict[str, list[int]] = defaultdict(list)
+    for layer in sorted(experts):
+        fmts = sorted(experts[layer])
+        assert len(fmts) == 1, f"layer {layer} is not format-uniform: {fmts}"
+        by_fmt[fmts[0]].append(layer)
+    dloss = float(sel["predicted_dloss"])
+    mid_rungs = {f for f in by_fmt if re.fullmatch(r"NVFP4_CB_K(1[2367]|18)", f)}
+    return {
+        "variant": tag,
+        "expert_layer_map": {k: v for k, v in sorted(by_fmt.items())},
+        "expert_uses_mid_rungs": sorted(mid_rungs),
+        "n_expert_layers_on_mid_rungs": sum(
+            len(by_fmt[f]) for f in mid_rungs),
+        "body_split": dict(body.most_common()),
+        "body_allocatable": N_BODY_ALLOCATABLE,
+        "body_floor_only_not_allocatable": N_BODY_FLOOR_ONLY,
+        "predicted_dloss": dloss,
+        "vs_shippable_baseline_pct": round(
+            100 * (1 - dloss / SHIPPABLE_BASELINE), 3),
+        "vs_all_cb_baseline_pct": round(
+            100 * (1 - dloss / ALL_CB_BASELINE), 3),
+        "bytes": {
+            k: sel.get(k) for k in (
+                "predicted_whole_artifact_upper_bound_gb",
+                "predicted_floor_gb",
+                "predicted_body_tensor_payload_gb",
+                "selection_headroom_gb",
+                "chosen_achieved_bits",
+            )
+        },
+        "lane_units": sel.get("serving_lane_provenance", {}).get(
+            "activation_contracts", {}),
+    }
+
+
+def mxfp8_dominance() -> dict:
+    """8.25 bpw MXFP8 re-encode vs 8.00049 bpw source passthrough."""
+    import prismaquant.format_registry as fr
+
+    shape = (8192, 4096)                      # layers.N.attn.wo_a
+    mx = fr.get_format("MXFP8_E4M3")
+    src = fr.get_format("FP8_BLOCK_UE8M0_SOURCE")
+    mx_b = mx.memory_bytes_for_shape(shape)
+    src_b = src.memory_bytes_for_shape(shape)
+    return {
+        "question": "can an MXFP8 re-encode ever beat the source passthrough?",
+        "answer": "no -- strictly dominated",
+        "mxfp8_bpw": round(mx.effective_bits, 5),
+        "passthrough_bpw": round(src.effective_bits, 5),
+        "bytes_on_wo_a": {"mxfp8": mx_b, "passthrough": src_b},
+        "extra_bytes_pct": round(100 * (mx_b / src_b - 1), 3),
+        "both_zero_weight_error_on_block128_source": True,
+        "why_the_dp_cannot_confirm_it": (
+            "MXFP8_E4M3 is registered W8A8 (act_bits=8), so "
+            "cost_entry_is_bit_exact refuses to short-circuit it even with "
+            "exact weights, and with no measured output_mse "
+            "cost_entry_prices_unmeasured_activation_at_zero EXCLUDES it from "
+            "the menu rather than pricing an unmeasured activation cost at "
+            "the DP's global minimum. The exclusion is the correct behaviour, "
+            "not a gap: the comparison is settled by bytes at equal error."
+        ),
+    }
+
+
+def main() -> None:
+    probe = Path(sys.argv[1] if len(sys.argv) > 1 else
+                 "/home/rob/dq-runs/dsv4-flash-0731/prod-cal-0p6-v2/"
+                 "artifacts-mxfp4/probe-k12k18")
+    out = {
+        "schema": "prismaquant.dsv4_mxfp4_dual_allocation.v1",
+        "baselines": {
+            "all_cb": ALL_CB_BASELINE,
+            "shippable_mxfp4_experts_only": SHIPPABLE_BASELINE,
+        },
+        "mxfp8_dominance": mxfp8_dominance(),
+    }
+    for tag, note in (
+        ("a", "shippable today; body passthrough route measured-blocked"),
+        ("b", "CONTINGENT on the gridbook MXFP8 lane merging + releasing + "
+              "passing native-parity; producer route_status stays 'blocked'"),
+    ):
+        root = probe / f"alloc-{tag}"
+        if (root / "selection.json").is_file():
+            out[f"variant_{tag}"] = {**summarise(root, tag), "note": note}
+        else:
+            out[f"variant_{tag}"] = {"status": "not run", "note": note}
+    merge_report = probe / "merge_report.json"
+    if merge_report.is_file():
+        out["interpolator_validation"] = json.loads(
+            merge_report.read_text()).get("validation")
+    (probe / "DUAL_RESULT.json").write_text(json.dumps(out, indent=2) + "\n")
+    print(json.dumps(out, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Purely additive: two scripts, 241 insertions, no existing file touched.

The K12-K18 probe answers "are graded mid rungs worth measuring". Turning that into a decision needs two allocations differing in exactly one thing — whether `FP8_BLOCK_UE8M0_SOURCE` is on the menu.

* **(a) shippable today** — the body passthrough route is measured-blocked on sm121, so this is the honest answer against the 5812.11 baseline.
* **(b) contingent** — what the same allocation becomes once the gridbook MXFP8 lane merges, releases, and passes its native-parity bench.

(b) is produced by **widening the menu, not by editing the route table**. A blocked rung stays on the allocator's menu by construction and the gate lives at export, so the counterfactual can be priced without asserting a backing that does not exist yet. The producer-side `route_status` stays `blocked` until the release it is keyed to actually ships — pricing a future is fine, declaring it is not.

`scripts/summarise_dual_alloc.py` reports what the question turns on: whether the DP uses mid rungs at all, how many expert layers land on them, and the body split (the incidental K12-K18 body columns answer whether the DP still demotes body units to CB once passthrough is legal).

It also settles the MXFP8 dominance check by **arithmetic rather than by the DP**, on purpose. `MXFP8_E4M3` is registered W8A8, so an activation-quantizing format with exact weights and no measured `output_mse` is excluded from the menu rather than short-circuited to zero — the allocator cannot be asked to confirm the comparison, because the exclusion is the guard working. The answer is unambiguous without it: 8.25 bpw against 8.00049 bpw at the same zero weight error is 3.119% more bytes for nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUHqNEHMu7FAJQSNGCZhqW