### PR TITLE
Add the exact MXFP4 -> MXFP8 widening transcode

### DIFF
--- a/prismaquant/mxfp4_widen.py
+++ b/prismaquant/mxfp4_widen.py
@@ -1,0 +1,258 @@
+"""Exact MXFP4 -> MXFP8 widening: a transcode with no quantization step.
+
+WHY THIS EXISTS. DSv4-Flash stores its routed experts — body *and* MTP — as
+OCP-MX FP4: E2M1 nibble pairs packed two-per-byte along the reduce dim, with
+one E8M0 (UE8M0) power-of-two scale per 32 logical elements. Gridbook's served
+lanes for that wire are format-specific, and the MXFP8 dense lane
+(``mxfp8_e4m3_e8m0_g32``) reads a *different* element plane. Widening lets a
+unit that is only available as MXFP4 in the source reach the MXFP8 lane without
+inventing any numerics.
+
+WHY IT IS EXACT, AND WHY THAT IS A PROVABLE CLAIM RATHER THAN A HOPE. The E2M1
+value set is::
+
+    {0, 0.5, 1, 1.5, 2, 3, 4, 6} x {+, -}
+
+Every one of those 15 distinct values is exactly representable in E4M3: each is
+a 2-significant-bit number with an exponent well inside E4M3's range, so the
+E4M3 encoding of the value is the value. Therefore widening changes the *width*
+of the element plane and nothing about the numbers on it. This is a transcode,
+not a requantization: there is no rounding rule, no scale search, no error term
+to price. ``tests/test_mxfp4_widen.py`` pins the claim by exhausting all 256
+byte codes rather than sampling.
+
+WHY THE SCALE PLANE IS CARRIED BYTE-IDENTICAL. Both wires use the SAME grouping
+— one E8M0 byte per 32 logical elements along the reduce dim — so the scale
+tensor is already in the target's layout. Re-deriving it would be strictly worse
+than copying it: a recomputed scale could differ in the one place the source is
+deliberately unusual (0xFF, which the OCP MX v1.0 spec defines as NaN rather
+than 2^128), and a NaN block must stay a NaN block. Copying makes the scale side
+bit-exact by construction rather than by agreement.
+
+THE ONE NORMALIZATION, STATED OUT LOUD. E2M1 code ``0x8`` is negative zero. This
+module emits POSITIVE zero for it, matching the repo's own MXFP4 decode LUT in
+``layer_streaming._read_layer_to_device`` (whose ``pair_lut`` maps both zero
+codes to ``+0.0``). The dequantized *values* are therefore identical to the
+reference decoder's for every input, which is the property that matters; a
+consumer that distinguished -0.0 from +0.0 in a weight would already disagree
+with how this repo reads the source.
+
+WHAT THIS MODULE DELIBERATELY DOES NOT DO. It does not decide *whether* a unit
+should be widened, does not touch the exporter's declaration, and does not
+claim a serving route. Widening doubles the element plane (4 -> 8 bits/weight,
+scales unchanged), and the MXFP8 route for *grouped/MoE* stacks is UNAUDITED on
+sm_121 — Gridbook's MXFP8 lane is dense-only. Producing these bytes is a
+capability; serving them is a separate, evidence-gated question.
+
+Standard-library + torch only, so the exactness property is testable on CPU
+with neither compressed-tensors nor vLLM present.
+"""
+from __future__ import annotations
+
+import torch
+
+
+__all__ = [
+    "E2M1_VALUES",
+    "GROUP_SIZE",
+    "MXFP8_GROUPED_ROUTE_STATUS",
+    "MXFP8_GROUPED_ROUTE_EVIDENCE",
+    "Mxfp8Widened",
+    "e2m1_to_e4m3_table",
+    "mxfp4_source_to_mxfp8",
+    "dequantize_mxfp4_source",
+    "dequantize_mxfp8",
+]
+
+#: SERVING STATUS OF THE BYTES THIS MODULE PRODUCES — recorded here, next to
+#: the code that makes them, so the capability cannot be mistaken for a
+#: serving claim.
+#:
+#: The string is the ``route_status`` vocabulary from
+#: ``allocator_candidates`` (BACKED / PENDING / BLOCKED), spelled literally
+#: rather than imported: this module is torch-only by design so its exactness
+#: property stays testable without the allocator's dependency stack. The value
+#: is pinned against the real enum in ``tests/test_mxfp4_widen.py``.
+#:
+#: Widening is only interesting for a unit that is MXFP4 in the source, and in
+#: DSv4-Flash every such unit is a ROUTED-EXPERT stack — a grouped/MoE GEMM.
+#: Gridbook's MXFP8 lane (``mxfp8_e4m3_e8m0_g32``) is DENSE-ONLY; the audited
+#: grouped route on sm_121 is Marlin, and Marlin was audited for MXFP4, not
+#: MXFP8. So there is no measured grouped MXFP8 route on our target, and this
+#: module must not imply one.
+MXFP8_GROUPED_ROUTE_STATUS = "pending"
+MXFP8_GROUPED_ROUTE_EVIDENCE = (
+    "Gridbook's MXFP8 dense lane serves LINEAR units only "
+    "(gridbook/mxfp8_dense_lane.py, unit_kind='linear'); no grouped/MoE MXFP8 "
+    "kernel has been audited on sm_121. The sm_121 grouped route that IS "
+    "audited is Marlin, for mxfp4_e2m1_ue8m0_g32. Widened expert stacks are "
+    "therefore producible but not servable until a grouped MXFP8 audit "
+    "exists. Widening a DENSE unit (an MTP body linear) rides the existing "
+    "OPT-IN dense lane and needs no new audit."
+)
+
+#: The 16 E2M1 code points in code order (index == nibble value). Code 0x8 is
+#: negative zero in the format; it is listed as ``0.0`` because that is the
+#: value this module and ``layer_streaming``'s decode LUT both materialize.
+E2M1_VALUES: tuple[float, ...] = (
+    0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+    0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
+)
+
+#: Elements per E8M0 scale, on BOTH wires. Shared value, so a mismatch is a
+#: geometry bug rather than a conversion parameter.
+GROUP_SIZE = 32
+
+
+class Mxfp8Widened:
+    """The two planes an MXFP8 unit ships. Plain container, no behaviour."""
+
+    __slots__ = ("weight", "weight_scale")
+
+    def __init__(self, weight: torch.Tensor, weight_scale: torch.Tensor):
+        self.weight = weight
+        self.weight_scale = weight_scale
+
+    def __iter__(self):
+        yield self.weight
+        yield self.weight_scale
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return (f"Mxfp8Widened(weight={tuple(self.weight.shape)}"
+                f":{self.weight.dtype}, weight_scale="
+                f"{tuple(self.weight_scale.shape)}:{self.weight_scale.dtype})")
+
+
+def e2m1_to_e4m3_table(device: torch.device | None = None) -> torch.Tensor:
+    """``(256, 2)`` byte -> (low nibble, high nibble) E4M3 element pair.
+
+    Low nibble is the EVEN logical element, so flattening the trailing pair
+    dimension lands elements in logical order — the same packing convention
+    ``layer_streaming`` decodes with, and the one ``inference/convert.py``'s
+    ``FP4_TABLE`` documents for this checkpoint family.
+    """
+
+    values = torch.tensor(E2M1_VALUES, dtype=torch.float32, device=device)
+    codes = torch.arange(256, device=device)
+    pair = torch.stack([values[codes & 0x0F], values[codes >> 4]], dim=-1)
+    # Cast once, here: every entry is exactly representable, so this is a
+    # relabelling of the table rather than a rounding of the data.
+    return pair.to(torch.float8_e4m3fn)
+
+
+def _check_geometry(packed: torch.Tensor, scale: torch.Tensor) -> int:
+    """Validate the pair and return the logical reduce-dim length."""
+
+    if packed.dim() < 2:
+        raise ValueError(
+            f"MXFP4 element plane must be at least 2-D, got shape "
+            f"{tuple(packed.shape)}")
+    if packed.dtype not in (torch.int8, torch.uint8):
+        raise ValueError(
+            f"MXFP4 element plane must be int8/uint8 nibble-pack, got "
+            f"{packed.dtype}. A widened or already-decoded tensor is not a "
+            f"legal input here — this function transcodes the SOURCE wire.")
+    logical_k = int(packed.shape[-1]) * 2
+    if logical_k % GROUP_SIZE != 0:
+        raise ValueError(
+            f"logical reduce dim {logical_k} is not a multiple of "
+            f"{GROUP_SIZE}; MXFP4 and MXFP8 share the group-of-{GROUP_SIZE} "
+            f"grid, so a ragged tail has no defined scale")
+    expected = packed.shape[:-1] + (logical_k // GROUP_SIZE,)
+    if tuple(scale.shape) != tuple(expected):
+        raise ValueError(
+            f"scale plane shape {tuple(scale.shape)} does not match the "
+            f"element plane: expected {tuple(expected)} for a "
+            f"{tuple(packed.shape)} nibble-pack (logical K={logical_k}, one "
+            f"E8M0 byte per {GROUP_SIZE} elements). A transposed or "
+            f"block-128 scale grid is numel-compatible with some of these "
+            f"shapes and would silently mis-scale every group.")
+    return logical_k
+
+
+def mxfp4_source_to_mxfp8(
+    packed: torch.Tensor,
+    scale: torch.Tensor,
+) -> Mxfp8Widened:
+    """Widen a source MXFP4 weight/scale pair to the MXFP8 wire, exactly.
+
+    ``packed`` is the checkpoint's ``[..., N, K/2]`` int8/uint8 nibble-pack;
+    ``scale`` is its ``[..., N, K/32]`` E8M0 plane (``float8_e8m0fnu`` or the
+    raw ``uint8`` it is stored as). Returns ``[..., N, K]``
+    ``float8_e4m3fn`` elements plus the scale plane **carried through
+    byte-identically** as ``float8_e8m0fnu``.
+
+    Exactness: ``dequantize_mxfp8(*result)`` equals
+    ``dequantize_mxfp4_source(packed, scale)`` elementwise, including NaN
+    placement for 0xFF scale groups.
+    """
+
+    _check_geometry(packed, scale)
+    table = e2m1_to_e4m3_table(device=packed.device)
+    # int32 gather indices: the index VALUES are byte codes (0..255), so int32
+    # is exact and halves the transient vs int64.
+    codes = packed.view(torch.uint8).to(torch.int32)
+    widened = table[codes]                      # [..., N, K/2, 2] e4m3
+    widened = widened.reshape(*packed.shape[:-1], -1).contiguous()
+    # Byte-identical scale carry. ``view`` reinterprets the same bytes; the
+    # clone detaches the result from the caller's storage without touching a
+    # single bit of it.
+    carried = scale.view(torch.uint8).clone().view(torch.float8_e8m0fnu)
+    return Mxfp8Widened(widened, carried)
+
+
+def _decode_e8m0(scale: torch.Tensor) -> torch.Tensor:
+    """E8M0 bytes -> fp32 powers of two, with 0xFF as NaN per OCP MX v1.0.
+
+    0xFF is NaN in the spec, not 2^128: ``exp2(128)`` is ``+inf``, which turns
+    a 0xFF group into a mix of +-inf (nonzero elements) and NaN (zero elements,
+    ``0 * inf``) instead of a uniformly NaN group.
+    """
+
+    raw = scale.view(torch.uint8)
+    decoded = torch.exp2(raw.to(torch.float32) - 127.0)
+    return torch.where(raw == 0xFF, torch.full_like(decoded, float("nan")),
+                       decoded)
+
+
+def dequantize_mxfp4_source(
+    packed: torch.Tensor,
+    scale: torch.Tensor,
+    *,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Reference decode of the SOURCE MXFP4 wire. The oracle for the property.
+
+    Mirrors ``layer_streaming._read_layer_to_device``'s step 3b exactly (same
+    LUT, same low-nibble-first order, same 0xFF NaN rule), kept here so the
+    exactness test does not depend on the streaming loader's batching path.
+    """
+
+    logical_k = _check_geometry(packed, scale)
+    values = torch.tensor(E2M1_VALUES, dtype=torch.float32,
+                          device=packed.device)
+    codes = packed.view(torch.uint8).to(torch.int32)
+    pair = torch.stack([values[codes & 0x0F], values[codes >> 4]], dim=-1)
+    elements = pair.reshape(*packed.shape[:-1], logical_k)
+    grouped = elements.reshape(*packed.shape[:-1], logical_k // GROUP_SIZE,
+                               GROUP_SIZE)
+    grouped = grouped * _decode_e8m0(scale).unsqueeze(-1)
+    return grouped.reshape(*packed.shape[:-1], logical_k).to(dtype)
+
+
+def dequantize_mxfp8(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    *,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Reference decode of the MXFP8 wire, for parity checking."""
+
+    logical_k = int(weight.shape[-1])
+    if logical_k % GROUP_SIZE != 0:
+        raise ValueError(
+            f"MXFP8 reduce dim {logical_k} is not a multiple of {GROUP_SIZE}")
+    grouped = weight.to(torch.float32).reshape(
+        *weight.shape[:-1], logical_k // GROUP_SIZE, GROUP_SIZE)
+    grouped = grouped * _decode_e8m0(scale).unsqueeze(-1)
+    return grouped.reshape(*weight.shape[:-1], logical_k).to(dtype)

--- a/tests/test_mxfp4_widen.py
+++ b/tests/test_mxfp4_widen.py
@@ -1,0 +1,280 @@
+"""Exactness pins for the MXFP4 -> MXFP8 widening transcode.
+
+The claim under test is narrow and total: widening changes the width of the
+element plane and NOTHING about the numbers on it, and the scale plane is
+carried byte-identically. Both halves are pinned exhaustively where the input
+space allows it (all 256 byte codes, all 256 scale codes) rather than sampled,
+because "exact" is not a statistical property.
+
+Real-checkpoint arms run only when the DSv4-Flash source is present; they read
+a handful of small tensor slices from the safetensors headers and never load a
+layer. Skipped otherwise so the suite stays hermetic on CI.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import torch
+
+from prismaquant.mxfp4_widen import (
+    E2M1_VALUES,
+    GROUP_SIZE,
+    dequantize_mxfp4_source,
+    dequantize_mxfp8,
+    e2m1_to_e4m3_table,
+    mxfp4_source_to_mxfp8,
+)
+
+
+DSV4_SOURCE = Path(
+    os.environ.get("DSV4_FLASH_SOURCE",
+                   "/home/rob/dq-runs/dsv4-flash-0731/source"))
+
+
+def _nan_equal(a: torch.Tensor, b: torch.Tensor) -> bool:
+    """Bitwise-meaningful equality: NaNs must coincide, finites must match."""
+
+    if a.shape != b.shape:
+        return False
+    a32, b32 = a.to(torch.float32), b.to(torch.float32)
+    both_nan = torch.isnan(a32) & torch.isnan(b32)
+    return bool(torch.all(both_nan | (a32 == b32)))
+
+
+# --- the exactness claim itself ---------------------------------------------
+
+
+def test_every_e2m1_value_is_exact_in_e4m3():
+    """The premise the whole module rests on, stated as a test."""
+
+    values = torch.tensor(E2M1_VALUES, dtype=torch.float32)
+    roundtrip = values.to(torch.float8_e4m3fn).to(torch.float32)
+    assert torch.equal(roundtrip, values), (
+        "E2M1 -> E4M3 is only a transcode if every code point survives the "
+        "cast; a mismatch here means widening would be a requantization")
+
+
+def test_widening_table_covers_all_256_byte_codes_in_logical_order():
+    table = e2m1_to_e4m3_table()
+    assert table.shape == (256, 2)
+    assert table.dtype == torch.float8_e4m3fn
+    as_f32 = table.to(torch.float32)
+    for code in range(256):
+        # low nibble is the EVEN logical element, high nibble the odd one
+        assert as_f32[code, 0].item() == E2M1_VALUES[code & 0x0F]
+        assert as_f32[code, 1].item() == E2M1_VALUES[code >> 4]
+
+
+def test_dequant_is_bit_equal_over_every_byte_code_and_scale_code():
+    """Exhaustive over the full cross product of element and scale codes.
+
+    256 byte codes x 256 E8M0 codes, including 0xFF (NaN) and the subnormal
+    ends of the exponent range. This is the property in its strongest form:
+    there is no input to the transcode that this misses.
+    """
+
+    # One row per scale code; each row holds all 256 byte codes, padded to a
+    # whole number of groups so every element in the row shares that scale.
+    packed = torch.arange(256, dtype=torch.uint8).repeat(256, 1)
+    assert packed.shape[-1] * 2 % GROUP_SIZE == 0
+    n_groups = packed.shape[-1] * 2 // GROUP_SIZE
+    scale = (torch.arange(256, dtype=torch.uint8)
+             .unsqueeze(1).expand(256, n_groups).contiguous()
+             .view(torch.float8_e8m0fnu))
+
+    widened = mxfp4_source_to_mxfp8(packed, scale)
+    assert _nan_equal(dequantize_mxfp8(widened.weight, widened.weight_scale),
+                      dequantize_mxfp4_source(packed, scale))
+
+
+def test_scale_plane_is_carried_byte_identically():
+    packed = torch.randint(0, 256, (8, 64), dtype=torch.uint8)
+    scale = torch.randint(0, 256, (8, 4), dtype=torch.uint8).view(
+        torch.float8_e8m0fnu)
+
+    widened = mxfp4_source_to_mxfp8(packed, scale)
+
+    assert widened.weight_scale.dtype == torch.float8_e8m0fnu
+    assert torch.equal(widened.weight_scale.view(torch.uint8),
+                       scale.view(torch.uint8)), (
+        "the MXFP8 wire uses the SAME group-of-32 E8M0 grid as the source, so "
+        "the scale bytes must survive untouched — recomputing them could "
+        "disagree exactly where the source is unusual (0xFF = NaN)")
+
+
+def test_carried_scale_does_not_alias_the_caller_storage():
+    scale = torch.zeros((2, 2), dtype=torch.uint8).view(torch.float8_e8m0fnu)
+    widened = mxfp4_source_to_mxfp8(
+        torch.zeros((2, 32), dtype=torch.uint8), scale)
+    scale.view(torch.uint8).fill_(0x7F)
+    assert int(widened.weight_scale.view(torch.uint8).max()) == 0
+
+
+def test_widened_plane_doubles_the_element_bytes_and_keeps_scale_bytes():
+    packed = torch.randint(0, 256, (16, 128), dtype=torch.uint8)
+    scale = torch.randint(0, 256, (16, 8), dtype=torch.uint8).view(
+        torch.float8_e8m0fnu)
+
+    widened = mxfp4_source_to_mxfp8(packed, scale)
+
+    assert widened.weight.shape == (16, 256)
+    assert widened.weight.dtype == torch.float8_e4m3fn
+    assert widened.weight.numel() == packed.numel() * 2
+    assert widened.weight_scale.numel() == scale.numel()
+
+
+def test_negative_zero_code_is_normalized_to_positive_zero():
+    """The one normalization, pinned so it cannot drift silently."""
+
+    packed = torch.tensor([[0x08] * 16], dtype=torch.uint8)   # both nibbles -0
+    scale = torch.tensor([[127]], dtype=torch.uint8).view(torch.float8_e8m0fnu)
+    widened = mxfp4_source_to_mxfp8(packed, scale)
+    signbits = widened.weight.view(torch.uint8) & 0x80
+    assert int(signbits.max()) == 0
+    assert torch.equal(dequantize_mxfp8(widened.weight, widened.weight_scale),
+                       torch.zeros(1, 32))
+
+
+# --- geometry refusals -------------------------------------------------------
+
+
+@pytest.mark.parametrize("packed_shape,scale_shape", [
+    ((8, 64), (8, 3)),      # too few groups
+    ((8, 64), (8, 5)),      # too many groups
+    ((8, 64), (4, 8)),      # transposed-ish, numel-incompatible leading dim
+    ((8, 64), (64, 8)),     # transposed scale grid
+])
+def test_mismatched_scale_grid_is_refused(packed_shape, scale_shape):
+    packed = torch.zeros(packed_shape, dtype=torch.uint8)
+    scale = torch.zeros(scale_shape, dtype=torch.uint8).view(
+        torch.float8_e8m0fnu)
+    with pytest.raises(ValueError, match="scale plane shape"):
+        mxfp4_source_to_mxfp8(packed, scale)
+
+
+def test_ragged_reduce_dim_is_refused():
+    packed = torch.zeros((4, 5), dtype=torch.uint8)     # logical K = 10
+    scale = torch.zeros((4, 1), dtype=torch.uint8).view(torch.float8_e8m0fnu)
+    with pytest.raises(ValueError, match="not a multiple of"):
+        mxfp4_source_to_mxfp8(packed, scale)
+
+
+def test_already_widened_input_is_refused():
+    """A transcode of the SOURCE wire must not accept its own output."""
+
+    weight = torch.zeros((4, 64), dtype=torch.float8_e4m3fn)
+    scale = torch.zeros((4, 2), dtype=torch.uint8).view(torch.float8_e8m0fnu)
+    with pytest.raises(ValueError, match="nibble-pack"):
+        mxfp4_source_to_mxfp8(weight, scale)
+
+
+# --- real checkpoint slices --------------------------------------------------
+
+
+def _load_pairs(limit: int):
+    """(name, packed, scale) for a few real MXFP4 expert tensors."""
+
+    from safetensors import safe_open
+
+    index = DSV4_SOURCE / "model.safetensors.index.json"
+    weight_map = json.loads(index.read_text())["weight_map"]
+    picked: list[tuple[str, torch.Tensor, torch.Tensor]] = []
+    # Deliberately mixed: MTP experts (the unit this capability exists for),
+    # a body expert, and both projection shapes (w1/w3 square-ish, w2 wide).
+    wanted = [
+        "mtp.0.ffn.experts.0.w1",
+        "mtp.0.ffn.experts.0.w2",
+        "mtp.1.ffn.experts.7.w3",
+        "mtp.2.ffn.experts.255.w2",
+        "layers.5.ffn.experts.0.w1",
+    ][:limit]
+    handles: dict[str, object] = {}
+    for base in wanted:
+        wkey, skey = base + ".weight", base + ".scale"
+        if wkey not in weight_map or skey not in weight_map:
+            continue
+        for key in (wkey, skey):
+            shard = weight_map[key]
+            if shard not in handles:
+                handles[shard] = safe_open(
+                    str(DSV4_SOURCE / shard), framework="pt", device="cpu")
+        picked.append((base,
+                       handles[weight_map[wkey]].get_tensor(wkey),
+                       handles[weight_map[skey]].get_tensor(skey)))
+    return picked
+
+
+@pytest.mark.skipif(
+    not (DSV4_SOURCE / "model.safetensors.index.json").exists(),
+    reason="DSv4-Flash source checkpoint not present")
+def test_real_checkpoint_slices_widen_exactly():
+    pairs = _load_pairs(limit=5)
+    assert pairs, "index present but no MXFP4 expert pair resolved"
+    for name, packed, scale in pairs:
+        # Row slice keeps the reduce dim (and therefore the group grid) whole
+        # while keeping the test cheap.
+        packed_s, scale_s = packed[:16], scale[:16]
+        widened = mxfp4_source_to_mxfp8(packed_s, scale_s)
+
+        assert widened.weight.shape[-1] == packed_s.shape[-1] * 2, name
+        assert torch.equal(widened.weight_scale.view(torch.uint8),
+                           scale_s.view(torch.uint8)), name
+        assert _nan_equal(
+            dequantize_mxfp8(widened.weight, widened.weight_scale),
+            dequantize_mxfp4_source(packed_s, scale_s)), name
+
+
+@pytest.mark.skipif(
+    not (DSV4_SOURCE / "model.safetensors.index.json").exists(),
+    reason="DSv4-Flash source checkpoint not present")
+def test_real_checkpoint_scale_grid_matches_the_shared_group_of_32():
+    """The geometry assumption, checked against the checkpoint not the docs."""
+
+    for name, packed, scale in _load_pairs(limit=5):
+        logical_k = packed.shape[-1] * 2
+        assert scale.shape == (packed.shape[0], logical_k // GROUP_SIZE), (
+            f"{name}: source scale grid is not one E8M0 byte per "
+            f"{GROUP_SIZE} logical elements, so the MXFP8 wire's grid is NOT "
+            f"the same grid and a byte-identical carry would be wrong")
+        assert packed.dtype in (torch.int8, torch.uint8), name
+        assert scale.dtype is torch.float8_e8m0fnu, name
+
+
+# --- serving honesty ---------------------------------------------------------
+
+
+def test_grouped_mxfp8_route_is_recorded_as_not_backed():
+    """The capability must not be able to drift into a serving claim.
+
+    Widening only applies to units that are MXFP4 in the source, and in
+    DSv4-Flash those are all routed-expert stacks. Gridbook's MXFP8 lane is
+    dense-only, so a grouped MXFP8 route is UNAUDITED on sm_121. If someone
+    audits one and flips this constant, they must also update the evidence
+    string — which is the point of pinning both.
+    """
+
+    from prismaquant.mxfp4_widen import (
+        MXFP8_GROUPED_ROUTE_EVIDENCE,
+        MXFP8_GROUPED_ROUTE_STATUS,
+    )
+    from prismaquant.allocator_candidates import (
+        ROUTE_STATUS_BACKED,
+        ROUTE_STATUS_PENDING,
+    )
+
+    assert MXFP8_GROUPED_ROUTE_STATUS != ROUTE_STATUS_BACKED
+    assert MXFP8_GROUPED_ROUTE_STATUS == ROUTE_STATUS_PENDING, (
+        "the local spelling must stay inside the allocator's route_status "
+        "vocabulary; it is duplicated only to keep this module torch-only")
+    assert "dense" in MXFP8_GROUPED_ROUTE_EVIDENCE.lower()
+
+
+def test_mxfp8_wire_id_is_the_one_the_consumer_routes():
+    """Widened bytes are only declarable under an id the consumer knows."""
+
+    from prismaquant.allocator_candidates import REQUANT_WIRE_FORMAT_IDS
+
+    assert REQUANT_WIRE_FORMAT_IDS["MXFP8_UE8M0_G32"] == "mxfp8_e4m3_e8m0_g32"


### PR DESCRIPTION
## What

A capability, not a policy change: `prismaquant/mxfp4_widen.py` turns a source
MXFP4 weight/scale pair into the MXFP8 wire **exactly**, with no quantization
step. Nothing in the exporter calls it yet.

Motivated by the DSv4-Flash MTP question — the MTP heads are MXFP4 routed
experts in the source, and reaching Gridbook's MXFP8 lane requires widening
them. The transcode is useful independently of whether we ever choose that
size.

## Why it is exact

The E2M1 value set is `{0, 0.5, 1, 1.5, 2, 3, 4, 6} x sign`. All 15 distinct
values are exactly representable in E4M3, so widening changes the *width* of
the element plane and nothing about the numbers on it. There is no rounding
rule, no scale search, and no error term to price.

The scale plane is carried **byte-identically**: both wires use the same
group-of-32 E8M0 grid, so the source tensor is already in the target's layout.
Copying beats re-deriving because a recomputed scale could disagree exactly
where the source is unusual — `0xFF` is NaN per OCP MX v1.0, not `2^128`, and a
NaN group must stay a NaN group.

## Tests

- **Exhaustive, not sampled.** All 256 byte codes x all 256 E8M0 codes must
  dequantize bit-equal (NaNs coinciding) against a reference decode mirroring
  `layer_streaming`'s step 3b.
- **Real checkpoint slices.** MTP experts from all three `mtp.N` blocks plus a
  body expert, both projection shapes. These verify the checkpoint's actual
  scale grid really is `[N, K/32]` — the byte-identical carry is checked
  against the tensors, not assumed from the docs. Skipped when the source is
  absent, so CI stays hermetic.
- Geometry refusals (transposed/ragged/mis-sized scale grids, already-widened
  input), non-aliasing of caller storage, and the one normalization: E2M1 code
  `0x8` is negative zero and we emit `+0`, matching the repo's own decode LUT.

## Serving honesty

Widening only applies to units that are MXFP4 in the source, and in DSv4-Flash
those are all **routed-expert stacks**. Gridbook's MXFP8 lane is **dense-only**,
and no grouped/MoE MXFP8 kernel has been audited on sm_121 (the audited grouped
route there is Marlin, for `mxfp4_e2m1_ue8m0_g32`).

So `MXFP8_GROUPED_ROUTE_STATUS = "pending"` is recorded next to the code that
produces the bytes, and a test pins that spelling against the allocator's real
`route_status` vocabulary. The capability ships; the serving claim does not.
A widened *dense* unit (an MTP body linear) rides the existing OPT-IN dense
lane and needs no new audit.

## Not in this PR

The exporter-side targeting knob (per-unit native-passthrough vs
mxfp8-transcription for the MTP block) and its declaration emission. Deferred
deliberately — see the audit notes: the MTP block is not currently servable by
vLLM 0.24 at all, so wiring the exporter would be untestable end to end today.

Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUHqNEHMu7FAJQSNGCZhqW