### PR TITLE
Declare the block-FP8 floor instead of dropping its scale planes

### DIFF
--- a/prismaquant/artifact_completeness.py
+++ b/prismaquant/artifact_completeness.py
@@ -90,6 +90,10 @@ class CompletenessReport:
 
     #: route-pending formats the producer explicitly acknowledged shipping
     route_pending_acknowledged: list[str] = field(default_factory=list)
+    #: namespaces the producer recorded as deliberately OMITTED. An absence
+    #: covered by one of these is intentional; an absence not covered by one is
+    #: a dropped tensor, which is the failure this module exists to catch.
+    excluded_namespaces: list[str] = field(default_factory=list)
 
     @property
     def ok(self) -> bool:
@@ -253,10 +257,25 @@ def check_artifact_completeness(
         (quant_config.get("provenance") or {}).get(
             "route_pending_passthrough_acknowledged") or ())
 
+    excluded = [
+        str(prefix) for prefix in
+        ((quant_config.get("provenance") or {}).get("excluded_namespaces")
+         or ())
+    ]
     report = CompletenessReport(
         declared_units=dict(raw_declared),
         route_pending_acknowledged=acknowledged,
+        excluded_namespaces=excluded,
     )
+    # A declared unit whose tensors are absent because its namespace was
+    # excluded is an intended absence, not a broken promise. Drop those
+    # declarations before checking, so "declared but no tensor" keeps meaning
+    # the one thing that IS a bug.
+    if excluded:
+        declared = {
+            unit: wire for unit, wire in declared.items()
+            if not any(unit.startswith(prefix) for prefix in excluded)
+        }
 
     def _scale_unit(name: str) -> str | None:
         for suffix in _SCALE_SUFFIXES:

--- a/prismaquant/artifact_completeness.py
+++ b/prismaquant/artifact_completeness.py
@@ -1,0 +1,417 @@
+"""Post-export gate: every quantized weight in an artifact has a decoder.
+
+THE FAILURE CLASS THIS EXISTS TO MAKE IMPOSSIBLE. An exported artifact is a
+promise that each tensor can be read back. The promise is carried by three
+different mechanisms — a CB config group, a ``source_passthrough`` declaration,
+or an ``ignore`` entry meaning "plain unquantized floats" — and nothing used to
+check that every tensor is covered by exactly one of them, correctly.
+
+A block-FP8 weight that no allocation target claimed fell through all three: it
+was copied verbatim (right), its ``.scale`` sibling was skipped as "consumed
+with its weight" though nothing consumed it (wrong — the scale was DROPPED),
+and it was listed in ``ignore`` (wrong — it is not unquantized). A consumer
+honouring that reads fp8 bytes into a bf16 parameter, passes the size check
+because the element counts agree, applies no scale, and serves weights that are
+each off by their own power of two. Nothing raises. On DSv4-Flash that was 43
+``attn.wo_a`` + 21 ``attn.indexer.wq_b`` units — 1.44 GB, silently wrong.
+
+So this module asks the question the exporter's own asserts could not: **for
+every scale-bearing weight tensor actually present in the artifact, which
+mechanism decodes it, and is that mechanism complete?** It reads only the
+artifact — safetensors headers and ``quant_config.json``, never the source
+checkpoint — because that is exactly what a consumer has.
+
+Cheap by construction: safetensors headers only, no tensor data, so it runs on
+a 92 GB artifact in about the time it takes to open the shards.
+
+Run standalone::
+
+    python -m prismaquant.artifact_completeness /path/to/artifact
+"""
+from __future__ import annotations
+
+import json
+import struct
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+__all__ = [
+    "ArtifactIncomplete",
+    "CompletenessReport",
+    "check_artifact_completeness",
+    "read_artifact_header",
+]
+
+#: Element dtypes that CANNOT be read without a scale plane. A tensor stored in
+#: one of these is meaningless on its own, so shipping it without a decoding
+#: mechanism is the bug this module detects.
+_SCALE_BEARING_DTYPES = frozenset({"F8_E4M3", "F8_E5M2"})
+
+#: Scale-plane dtypes, recognized so an orphan scale is reported against the
+#: unit it belongs to rather than as a mystery tensor.
+_SCALE_PLANE_DTYPES = frozenset({"F8_E8M0"})
+
+#: Suffixes a scale plane ships under. Three lanes, three spellings, all of
+#: them live in real artifacts: ``.scale`` is the checkpoint's own (byte-
+#: verbatim passthrough), ``.weight_scale`` is what the re-quant lanes and
+#: compressed-tensors write, ``.weight_scale_inv`` is the legacy block-FP8
+#: sibling. The gate pairs a weight with whichever one is present rather than
+#: assuming a lane.
+_SCALE_SUFFIXES = (".scale", ".weight_scale", ".weight_scale_inv")
+
+
+class ArtifactIncomplete(AssertionError):
+    """An artifact contains a tensor no declared mechanism can decode."""
+
+
+@dataclass
+class CompletenessReport:
+    """What each scale-bearing tensor resolved to. Empty lists == healthy."""
+
+    #: unit -> wire id, from the artifact's own declaration
+    declared_units: dict[str, str] = field(default_factory=dict)
+    #: units resolved through a CB config group
+    cb_units: list[str] = field(default_factory=list)
+    #: declared passthrough units, weight + scale both present
+    passthrough_units: list[str] = field(default_factory=list)
+    #: verbatim units in a namespace no serving stack builds (e.g. DSv4 `mtp.`)
+    verbatim_namespace_units: list[str] = field(default_factory=list)
+
+    # --- the four ways an artifact can be incomplete -------------------------
+    #: scale-bearing weights claimed by NO mechanism at all
+    undeclared: list[str] = field(default_factory=list)
+    #: scale-bearing weights declared `ignore`, i.e. claimed to be unquantized
+    fp8_in_ignore: list[str] = field(default_factory=list)
+    #: declared passthrough units whose scale plane is MISSING from the artifact
+    missing_scale: list[str] = field(default_factory=list)
+    #: scale planes present whose weight is not declared passthrough
+    orphan_scale: list[str] = field(default_factory=list)
+
+    #: route-pending formats the producer explicitly acknowledged shipping
+    route_pending_acknowledged: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not (self.undeclared or self.fp8_in_ignore
+                    or self.missing_scale or self.orphan_scale)
+
+    def failure_text(self) -> str:
+        parts: list[str] = []
+        if self.fp8_in_ignore:
+            parts.append(
+                f"{len(self.fp8_in_ignore)} scale-bearing weight(s) are listed "
+                f"in `ignore`, which claims they are plain unquantized floats. "
+                f"A consumer will cast them to bf16 with NO scale applied and "
+                f"raise nothing: {sorted(self.fp8_in_ignore)[:5]}")
+        if self.missing_scale:
+            parts.append(
+                f"{len(self.missing_scale)} declared passthrough unit(s) are "
+                f"missing their scale plane, so the declaration promises a "
+                f"decode the artifact cannot perform: "
+                f"{sorted(self.missing_scale)[:5]}")
+        if self.orphan_scale:
+            parts.append(
+                f"{len(self.orphan_scale)} scale plane(s) belong to no "
+                f"declared unit — either the weight was dropped or its "
+                f"declaration was: {sorted(self.orphan_scale)[:5]}")
+        if self.undeclared:
+            parts.append(
+                f"{len(self.undeclared)} scale-bearing weight(s) are claimed "
+                f"by no mechanism at all (not CB, not declared passthrough, "
+                f"not a verbatim namespace): {sorted(self.undeclared)[:5]}")
+        return "; ".join(parts)
+
+
+def read_artifact_header(artifact_dir: str | Path) -> dict[str, dict]:
+    """``{tensor name: safetensors metadata}`` across every shard. Headers only."""
+
+    root = Path(artifact_dir)
+    index = root / "model.safetensors.index.json"
+    if index.exists():
+        shards = sorted(set(json.loads(index.read_text())["weight_map"].values()))
+    else:
+        shards = ["model.safetensors"]
+    header: dict[str, dict] = {}
+    for shard in shards:
+        path = root / shard
+        with open(path, "rb") as handle:
+            (length,) = struct.unpack("<Q", handle.read(8))
+            entries = json.loads(handle.read(length))
+        for name, meta in entries.items():
+            if name != "__metadata__":
+                header[name] = meta
+    return header
+
+
+def _checkpoint_spellings(unit: str, profile) -> set[str]:
+    """Every checkpoint spelling a declaration/config-group key can denote.
+
+    THE TWO NAMESPACES. A unit that the ALLOCATOR chose is named in the recipe
+    namespace (``model.layers.0.self_attn.wq_a``), because that is where the
+    DP's decisions live. A unit that only the EXPORTER saw — a floor unit, or
+    a config-group target — is named in the checkpoint namespace
+    (``layers.0.attn.wq_a``), because that is what is on disk. Both spellings
+    denote the same tensor and both appear in real artifacts.
+
+    This gate therefore normalizes rather than demanding the artifact be
+    internally uniform: making the producer emit one spelling everywhere is a
+    real improvement, but it is a different change, and a completeness gate
+    that failed every mixed-vintage artifact would be useless for finding the
+    bug it exists to find. ``source_tensor_name`` is the producer's own
+    recipe->checkpoint map, so the normalization is the profile's answer, not
+    a guess.
+    """
+
+    spellings = {unit}
+    if profile is None:
+        return spellings
+    try:
+        spellings.add(profile.source_tensor_name(unit))
+        # Several rename rules are anchored on a trailing dot (they rewrite a
+        # leaf's PARENT), so a bare unit name misses them.
+        spellings.add(profile.source_tensor_name(unit + ".").rstrip("."))
+    except Exception:                      # pragma: no cover - defensive
+        pass
+    return spellings
+
+
+def _detect_profile_quietly(artifact_dir: Path):
+    """The artifact's own profile, or None. Never fatal: the gate must still
+    run on an artifact whose architecture this build does not know."""
+
+    try:
+        from prismaquant.model_profiles import detect_profile
+
+        return detect_profile(str(artifact_dir))
+    except Exception:                      # pragma: no cover - defensive
+        return None
+
+
+def _group_claimed_units(quant_config: dict) -> set[str]:
+    """Units ANY config group claims, un-anchored from regex spellings.
+
+    Deliberately not limited to CB groups. A config group is a decoding
+    mechanism whatever its flavour — a CB ``scheme``, a ``source-passthrough``
+    layout record, a ``gridbook-native`` re-quant group, or a stock
+    compressed-tensors scheme — and this gate's question is only "is there
+    one", not "which". Narrowing it to CB would report every stock-delegated
+    and re-quantized fp8 unit as undeclared, which is noise that would get the
+    gate switched off.
+    """
+
+    claimed: set[str] = set()
+    for group in (quant_config.get("config_groups") or {}).values():
+        if not isinstance(group, dict):
+            continue
+        for target in group.get("targets") or ():
+            name = str(target)
+            if name.startswith("re:^") and name.endswith("$"):
+                name = name[len("re:^"):-1].replace("[.]", ".")
+            claimed.add(name)
+    return claimed
+
+
+def check_artifact_completeness(
+    artifact_dir: str | Path,
+    *,
+    verbatim_prefixes: tuple[str, ...] = ("mtp.",),
+) -> CompletenessReport:
+    """Classify every scale-bearing weight in the artifact, or explain why not.
+
+    ``verbatim_prefixes`` names namespaces whose tensors ship undeclared ON
+    PURPOSE because no serving stack builds those modules — DSv4-Flash's
+    ``mtp.*`` DSpark blocks are the motivating case. They must still ship their
+    scale planes (an incomplete block is useless later), so they are checked
+    for weight/scale pairing but exempt from needing a declaration.
+    """
+
+    root = Path(artifact_dir)
+    quant_config = json.loads((root / "quant_config.json").read_text())
+    header = read_artifact_header(root)
+
+    profile = _detect_profile_quietly(root)
+    raw_declared = dict(
+        (quant_config.get("source_passthrough") or {}).get("units") or {})
+    # Resolve every declaration/ignore/CB key into the checkpoint namespace the
+    # tensor names actually use, so a recipe-spelled declaration still counts.
+    declared: dict[str, str] = {}
+    for unit, wire in raw_declared.items():
+        for spelling in _checkpoint_spellings(str(unit), profile):
+            declared[spelling] = str(wire)
+    ignored = {
+        spelling
+        for entry in (quant_config.get("ignore") or ())
+        for spelling in _checkpoint_spellings(str(entry), profile)
+    }
+    group_claimed = {
+        spelling
+        for entry in _group_claimed_units(quant_config)
+        for spelling in _checkpoint_spellings(entry, profile)
+    }
+    acknowledged = list(
+        (quant_config.get("provenance") or {}).get(
+            "route_pending_passthrough_acknowledged") or ())
+
+    report = CompletenessReport(
+        declared_units=dict(raw_declared),
+        route_pending_acknowledged=acknowledged,
+    )
+
+    def _scale_unit(name: str) -> str | None:
+        for suffix in _SCALE_SUFFIXES:
+            if name.endswith(suffix):
+                return name[: -len(suffix)]
+        return None
+
+    present_scales = {
+        name for name, meta in header.items()
+        if _scale_unit(name) is not None
+        and meta.get("dtype") in _SCALE_PLANE_DTYPES
+    }
+    #: unit -> the scale plane(s) actually present for it, whatever the lane
+    #: spelled them.
+    scales_by_unit: dict[str, set[str]] = {}
+    for name in present_scales:
+        scales_by_unit.setdefault(_scale_unit(name), set()).add(name)
+    claimed_scales: set[str] = set()
+
+    for name, meta in sorted(header.items()):
+        if meta.get("dtype") not in _SCALE_BEARING_DTYPES:
+            continue
+        if not name.endswith(".weight"):
+            continue
+        unit = name[: -len(".weight")]
+        unit_scales = scales_by_unit.get(unit, set())
+
+        if any(unit.startswith(prefix) for prefix in verbatim_prefixes):
+            report.verbatim_namespace_units.append(unit)
+            if unit_scales:
+                claimed_scales |= unit_scales
+            else:
+                # A verbatim block shipped without its scale is a future
+                # re-export, so it is still a failure — just not a serving one.
+                report.missing_scale.append(unit)
+            continue
+
+        if _unit_variants(unit) & declared.keys():
+            report.passthrough_units.append(unit)
+            if unit_scales:
+                claimed_scales |= unit_scales
+            else:
+                report.missing_scale.append(unit)
+            if _unit_variants(unit) & ignored:
+                # Both statements cannot be true, and `ignore` is the one that
+                # loses the scale.
+                report.fp8_in_ignore.append(unit)
+            continue
+
+        if _unit_variants(unit) & ignored:
+            # THE ORIGINAL BUG. `ignore` means "plain unquantized floats", and
+            # this tensor is not that. Checked before the config-group test so
+            # a unit that is somehow both still reports the contradiction.
+            report.fp8_in_ignore.append(unit)
+            continue
+        if _claimed_by_self_or_ancestor(unit, group_claimed):
+            report.cb_units.append(unit)
+            claimed_scales |= unit_scales
+            continue
+        report.undeclared.append(unit)
+
+    for scale_key in sorted(present_scales - claimed_scales):
+        unit = _scale_unit(scale_key)
+        if any(unit.startswith(prefix) for prefix in verbatim_prefixes):
+            continue
+        if _claimed_by_self_or_ancestor(unit, declared):
+            continue
+        if _claimed_by_self_or_ancestor(unit, group_claimed):
+            # An expert stack keeps its per-expert source scale planes only
+            # when the stack was NOT collapsed; either way a group claims
+            # them, so they are not orphans.
+            continue
+        report.orphan_scale.append(scale_key)
+
+    return report
+
+
+#: Module components a config-group target may COLLAPSE away. A shared-MLP
+#: block lives under ``…mlp.shared_mlp.<leaf>`` / ``…mlp.shared_experts.<leaf>``
+#: on disk, but its target is written against the collapsed ``…mlp.<leaf>``.
+#: Gridbook bridges the same gap at load (``_alias_collapsed_shared_prefixes``),
+#: so recognizing it here is matching the consumer, not inventing a rule.
+_COLLAPSIBLE_COMPONENTS = ("shared_mlp", "shared_experts")
+
+
+def _unit_variants(unit: str) -> set[str]:
+    """Every spelling of *unit* a target may legitimately be written as."""
+
+    variants = {unit}
+    parts = unit.split(".")
+    for index, part in enumerate(parts):
+        if part in _COLLAPSIBLE_COMPONENTS:
+            variants.add(".".join(parts[:index] + parts[index + 1:]))
+    return variants
+
+
+def _claimed_by_self_or_ancestor(unit: str, claimed) -> bool:
+    """Whether *unit* or any dotted ancestor of it appears in *claimed*.
+
+    Routed-expert groups are declared ONCE for the whole stack
+    (``layers.1.ffn.experts``) while their tensors are per-expert,
+    per-projection (``layers.1.ffn.experts.0.w1.scale``). Walking ancestors is
+    what lets one declaration cover the 768 planes it is actually about,
+    without letting a declaration for a NEIGHBOURING module claim them —
+    ancestry is tested on dotted boundaries, so ``experts2`` never matches
+    ``experts``.
+    """
+
+    for variant in _unit_variants(unit):
+        if variant in claimed:
+            return True
+        parts = variant.split(".")
+        for cut in range(len(parts) - 1, 0, -1):
+            if ".".join(parts[:cut]) in claimed:
+                return True
+    return False
+
+
+def assert_artifact_complete(artifact_dir: str | Path, **kwargs) -> CompletenessReport:
+    """:func:`check_artifact_completeness`, raising on any incompleteness."""
+
+    report = check_artifact_completeness(artifact_dir, **kwargs)
+    if not report.ok:
+        raise ArtifactIncomplete(
+            f"{artifact_dir}: {report.failure_text()}")
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Check that every quantized weight in an artifact has a "
+                    "decoder (headers only; safe on a multi-GB artifact).")
+    parser.add_argument("artifact")
+    parser.add_argument(
+        "--verbatim-prefix", action="append", default=None,
+        help="namespace shipped undeclared on purpose (default: 'mtp.')")
+    args = parser.parse_args(argv)
+
+    prefixes = tuple(args.verbatim_prefix or ("mtp.",))
+    report = check_artifact_completeness(args.artifact,
+                                         verbatim_prefixes=prefixes)
+    print(f"declared passthrough units : {len(report.passthrough_units)}")
+    print(f"verbatim-namespace units   : "
+          f"{len(report.verbatim_namespace_units)}")
+    if report.route_pending_acknowledged:
+        print(f"route-pending acknowledged : "
+              f"{sorted(report.route_pending_acknowledged)}")
+    if report.ok:
+        print("COMPLETE: every scale-bearing weight has a decoder")
+        return 0
+    print("INCOMPLETE: " + report.failure_text())
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    raise SystemExit(main())

--- a/prismaquant/cb_export_config.py
+++ b/prismaquant/cb_export_config.py
@@ -711,6 +711,7 @@ def build_quant_config(
     requant_target_name: TargetName = _identity_target,
     source_passthrough_units: Mapping[str, str] | None = None,
     route_pending_passthrough_acknowledged: Iterable[str] = (),
+    excluded_namespaces: Iterable[str] = (),
     weight_only_stock_targets: Iterable[str] = (),
     streaming_provenance: bool | None = None,
     include_tensor_formats: bool = False,
@@ -878,6 +879,14 @@ def build_quant_config(
         # artifact has to carry the fact that it was used, or "was this shipped
         # knowing no serve route existed?" is unanswerable from the artifact.
         provenance["route_pending_passthrough_acknowledged"] = acknowledged
+    excluded = sorted(set(str(prefix) for prefix in excluded_namespaces))
+    if excluded:
+        # An artifact that is MISSING a namespace has to say so. Otherwise
+        # "were these tensors omitted on purpose, or lost?" is unanswerable
+        # from the artifact — and those two have opposite remedies (re-export
+        # vs. nothing). The completeness gate reads this to tell an intended
+        # absence from a dropped one.
+        provenance["excluded_namespaces"] = excluded
     if cb_render_identity is not None:
         provenance["cb_render_identity"] = cb_render_identity
     if include_tensor_formats:

--- a/prismaquant/export_nvfp4_cb_streaming.py
+++ b/prismaquant/export_nvfp4_cb_streaming.py
@@ -58,6 +58,7 @@ import os
 import pickle
 import re
 import struct
+import sys
 from collections import Counter
 from functools import wraps
 from pathlib import Path
@@ -1243,6 +1244,143 @@ def assert_routes_reconcile(*, cb_units, passthrough_units, cb_tensors,
             "which no CB expert unit claims")
 
 
+#: Block geometry the ``fp8_e4m3_ue8m0_block128`` wire id NAMES. A checkpoint
+#: whose declared block is anything else stores a different contract under the
+#: same element dtype, so it must not borrow this id.
+_FP8_UE8M0_DECLARED_BLOCK = (128, 128)
+
+#: Registry format a floor block-FP8 unit is declared as. One spelling, so the
+#: wire id it maps to stays the table's decision rather than this module's.
+_FP8_BLOCK_UE8M0_FORMAT = "FP8_BLOCK_UE8M0_SOURCE"
+
+#: Env spelling of ``--allow-route-pending-passthrough``, so a driver script
+#: can pass the acknowledgement without editing the command line it builds.
+_ROUTE_PENDING_ACK_ENV = "PQ_ALLOW_ROUTE_PENDING"
+
+
+def _route_pending_ack_from_env() -> bool:
+    """Read the env form of the route-pending acknowledgement.
+
+    DEFAULTS OFF, and off for every value except exactly ``"1"`` — an
+    acknowledgement that "0"/"false"/"" could switch on would be the opposite
+    of deliberate. It announces itself on stderr when it fires, because the
+    one failure mode an env knob has that a flag does not is being inherited
+    silently by an invocation nobody meant to acknowledge for.
+    """
+
+    if os.environ.get(_ROUTE_PENDING_ACK_ENV) != "1":
+        return False
+    print(f"[export-stream] {_ROUTE_PENDING_ACK_ENV}=1 -> "
+          f"--allow-route-pending-passthrough is ON for this invocation; "
+          f"route-pending passthrough units will ship with the "
+          f"acknowledgement recorded in the artifact provenance.",
+          file=sys.stderr, flush=True)
+    return True
+
+
+def _floor_block_fp8_units(
+    skeleton,
+    *,
+    emitted_bases: set[str],
+    consumed_expert_bases: set[str],
+    claimed_qnames: set[str],
+    profile,
+    subset_prefixes,
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Block-FP8 units the recipe never allocated, which must be DECLARED.
+
+    Returns ``({checkpoint qname: scale checkpoint key},
+    {scale checkpoint key: checkpoint qname})``.
+
+    THE BUG THIS EXISTS TO CLOSE. A weight that no allocation target claims
+    falls to the verbatim copy loop below. That loop was written for BF16
+    norms and buffers, for which "copy the tensor and list it in ``ignore``"
+    is exactly right. For a block-FP8 weight it was silently wrong in two
+    compounding ways: the loop skips ``.scale`` siblings as "consumed with
+    their fp8 weight" — but nothing consumed them, because the weight was
+    never a target — so the scale plane was DROPPED; and the weight was then
+    declared ``ignore``, i.e. unquantized. A consumer honouring that
+    declaration allocates a bf16 parameter, the size assertion passes because
+    the element counts match, and the fp8 bytes are cast to bf16 with no scale
+    applied. Every block is then wrong by its own power of two, with no error
+    raised anywhere. Measured on DSv4-Flash: 43 ``attn.wo_a`` + 21
+    ``attn.indexer.wq_b`` units, 1.44 GB, silently corrupted.
+
+    So a floor block-FP8 unit ships its weight AND its scale, and is declared
+    ``fp8_e4m3_ue8m0_block128`` rather than ignored — the same delegated-native
+    route an ALLOCATED passthrough unit of that format would get. Nothing about
+    the bytes differs between the two cases; only whether the DP happened to
+    choose the unit, which is not a property the consumer can see or should
+    have to.
+
+    MEMBERSHIP IS NARROW, AND DELIBERATELY SO. A unit qualifies only when the
+    checkpoint pairs an ``F8_E4M3`` weight with an ``F8_E8M0`` scale over the
+    declared 128x128 block. That excludes, by construction rather than by
+    name: MXFP4 nibble-packs (int8/uint8 elements), BF16/F32 verbatim tensors
+    (no scale plane, and for which the ``ignore`` cast IS correct), and any
+    architecture whose declared block is not 128x128. Prefixes the profile
+    ships verbatim-and-undeclared (``source_passthrough_prefixes``, e.g. DSv4's
+    ``mtp.*``) are excluded too: those are units no serving stack builds, so
+    declaring them would assert a route nobody exercises.
+    """
+
+    scale_map = skeleton._fp8_scale_inv_map
+    block = getattr(scale_map, "block", None)
+    _verbatim = getattr(profile, "source_passthrough_prefixes", None)
+    verbatim_prefixes = tuple(_verbatim()) if callable(_verbatim) else ()
+
+    units: dict[str, str] = {}
+    for _live, entry in scale_map.items():
+        scale_key = entry[1]
+        if not scale_key.endswith(".scale"):
+            # Legacy `.weight_scale_inv` checkpoints normalize through the
+            # FP8_SOURCE lane and never reach this fallback.
+            continue
+        ckpt_qname = scale_key[: -len(".scale")]
+        weight_key = ckpt_qname + ".weight"
+        if weight_key not in skeleton:
+            continue
+        if subset_prefixes is not None and not any(
+                weight_key.startswith(p) for p in subset_prefixes):
+            continue
+        if any(ckpt_qname.startswith(p) for p in verbatim_prefixes):
+            continue                      # profile ships these undeclared
+        if weight_key in emitted_bases or weight_key in consumed_expert_bases:
+            continue                      # a target already claimed it
+        canon = _canonical_qname(ckpt_qname, profile)
+        if ckpt_qname in claimed_qnames or canon in claimed_qnames:
+            continue
+        if skeleton.get_dtype(weight_key) is not torch.float8_e4m3fn:
+            continue                      # not a block-FP8 element plane
+        if skeleton.get_dtype(scale_key) is not torch.float8_e8m0fnu:
+            continue                      # not a UE8M0 scale plane
+        # Geometry is asserted rather than assumed: the wire id NAMES a
+        # 128x128 block, and a declaration that misdescribes the grid is
+        # worse than no declaration at all — it loads, and it is wrong.
+        if tuple(block or ()) != _FP8_UE8M0_DECLARED_BLOCK:
+            raise ValueError(
+                f"{ckpt_qname}: unallocated block-FP8 unit, but the "
+                f"checkpoint declares weight_block_size {block!r} rather "
+                f"than {list(_FP8_UE8M0_DECLARED_BLOCK)}. The "
+                f"fp8_e4m3_ue8m0_block128 wire id names the 128x128 grid, so "
+                f"this unit cannot be declared under it. Shipping it "
+                f"undeclared is refused: it would be cast to bf16 without "
+                f"its scale.")
+        w_shape = skeleton.get_shape(weight_key)
+        s_shape = skeleton.get_shape(scale_key)
+        expected = tuple(-(-int(d) // b)
+                         for d, b in zip(w_shape, _FP8_UE8M0_DECLARED_BLOCK))
+        if tuple(s_shape) != expected:
+            raise ValueError(
+                f"{ckpt_qname}: block-FP8 scale grid {tuple(s_shape)} does "
+                f"not match weight {tuple(w_shape)} at "
+                f"{_FP8_UE8M0_DECLARED_BLOCK} (expected {expected}). A "
+                f"transposed grid is numel-compatible and would mis-scale "
+                f"every block.")
+        units[ckpt_qname] = scale_key
+    return units, {scale: unit for unit, scale in units.items()}
+
+
 def _reject_disabled_reuse_before_output_transaction(function):
     """Preserve the quarantine gate ahead of any resume/output interpretation."""
     signature = inspect.signature(function)
@@ -2299,14 +2437,28 @@ def export_nvfp4_cb_streaming(
     resolved_source_scale_keys = {
         entry[1] for entry in skeleton._fp8_scale_inv_map.values()
     }
+    # FLOOR block-FP8: units no allocation target claimed. They ship weight AND
+    # scale and get DECLARED, instead of losing their scale to the skip below
+    # and being cast to bf16 under an `ignore` entry. See
+    # `_floor_block_fp8_units` for the failure this closes.
+    floor_fp8_units, floor_fp8_scale_owner = _floor_block_fp8_units(
+        skeleton,
+        emitted_bases=emitted_bases,
+        consumed_expert_bases=consumed_expert_bases,
+        claimed_qnames=(cb_targets_set | source_set | native_source_set
+                        | stock_set),
+        profile=profile,
+        subset_prefixes=subset_prefixes,
+    )
     for name in skeleton.keys():
         if subset_prefixes is not None and \
                 not any(name.startswith(p) for p in subset_prefixes):
             continue   # outside the declared subset (e.g. non-MTP body layers)
         if name in emitted_bases or name in consumed_expert_bases:
             continue
-        if name in resolved_source_scale_keys or name.endswith(
-            ".weight_scale_inv"
+        if name not in floor_fp8_scale_owner and (
+            name in resolved_source_scale_keys
+            or name.endswith(".weight_scale_inv")
         ):
             continue   # consumed with its fp8 weight, or an unused sidecar
         if name.endswith(".weight"):
@@ -2330,7 +2482,13 @@ def export_nvfp4_cb_streaming(
         dtype = skeleton.get_dtype(name)
         writer.add(name, dtype, shape, (lambda k=name: skeleton.load(k)
                                         .contiguous()))
-        if ckpt_qname is not None and len(shape) >= 2:
+        # A declared floor block-FP8 unit must NOT land in `ignore`: the two
+        # statements contradict each other, and `ignore` is the one that
+        # silently loses the scale.  Its scale plane rides this same loop (it
+        # is exempted from the skip above) and needs no entry of its own.
+        if ckpt_qname is not None and ckpt_qname in floor_fp8_units:
+            counts["floor_fp8_declared"] += 1
+        elif ckpt_qname is not None and len(shape) >= 2:
             ignore.append(ckpt_qname)
         counts["copied"] += 1
 
@@ -2534,6 +2692,43 @@ def export_nvfp4_cb_streaming(
         }
 
     _declared_passthrough_units = _source_passthrough_units()
+    # Floor block-FP8 units join the SAME declaration as allocated passthrough
+    # units. They differ only in how they got here — the DP chose one and
+    # skipped the other — and that distinction is invisible to, and irrelevant
+    # for, the consumer: identical bytes, identical wire id, identical route.
+    # Floor units face the SAME ship gate as allocated passthrough units, and
+    # record the SAME acknowledgement. They reach it later only because
+    # membership depends on what the planning pass consumed; the rule is
+    # identical. Note the asymmetry with an allocated rung: shipping this one
+    # undeclared is not a fallback, it is the bug — it drops the scale planes.
+    # So the choice here is "declare and acknowledge" or "stop", never
+    # "declare nothing and continue".
+    if floor_fp8_units and _FP8_BLOCK_UE8M0_FORMAT in \
+            ROUTE_PENDING_PASSTHROUGH_FORMATS:
+        route_pending[_FP8_BLOCK_UE8M0_FORMAT] += len(floor_fp8_units)
+        if not allow_route_pending_passthrough:
+            raise ValueError(
+                f"refusing to ship a route-pending source passthrough: "
+                f"{_FP8_BLOCK_UE8M0_FORMAT} -> lane "
+                f"{SOURCE_PASSTHROUGH_CONTRACTS[_FP8_BLOCK_UE8M0_FORMAT].serving_route} "
+                f"({len(floor_fp8_units)} unallocated unit(s) the recipe "
+                f"never assigned, e.g. "
+                f"{sorted(floor_fp8_units)[:3]}). These are block-FP8 weights "
+                f"with UE8M0 scale planes; they MUST be declared, because the "
+                f"alternative is not 'ship them plainly' but 'ship them with "
+                f"their scales dropped and silently cast to bf16'. Pass "
+                f"--allow-route-pending-passthrough "
+                f"(allow_route_pending_passthrough=True) to ship knowingly; "
+                f"the acknowledgement is recorded in the artifact's "
+                f"provenance.")
+    for _floor_unit in floor_fp8_units:
+        _previous = _declared_passthrough_units.get(_floor_unit)
+        if _previous not in (None, _FP8_BLOCK_UE8M0_FORMAT):
+            raise ValueError(
+                f"{_floor_unit}: reached the verbatim floor as block-FP8 but "
+                f"is already declared {_previous!r}; one unit has one "
+                f"contract")
+        _declared_passthrough_units[_floor_unit] = _FP8_BLOCK_UE8M0_FORMAT
     assert_routes_reconcile(
         **_route_reconciliation_sets(_declared_passthrough_units))
 
@@ -2637,6 +2832,21 @@ def export_nvfp4_cb_streaming(
             else None
         ),
     )
+    # FINAL GATE, read back off the PUBLISHED artifact rather than from the
+    # planning state that produced it. Everything above knows what it meant to
+    # write; this asks the only question a consumer can ask — for every
+    # scale-bearing weight actually on disk, is there a mechanism that decodes
+    # it? Headers only, so it costs a few opens even on a 92 GB artifact.
+    from prismaquant.artifact_completeness import assert_artifact_complete
+
+    _verbatim = getattr(profile, "source_passthrough_prefixes", None)
+    verbatim_prefixes = tuple(_verbatim()) if callable(_verbatim) else ("mtp.",)
+    completeness = assert_artifact_complete(
+        out_dir, verbatim_prefixes=verbatim_prefixes)
+    print(f"[export-cb-stream] completeness: "
+          f"{len(completeness.passthrough_units)} declared passthrough, "
+          f"{len(completeness.verbatim_namespace_units)} verbatim-namespace "
+          f"unit(s); no orphan scale planes", flush=True)
     return dict(counts)
 
 
@@ -2798,10 +3008,13 @@ def main(argv=None) -> None:
     ap.add_argument(
         "--allow-route-pending-passthrough",
         action="store_true",
+        default=_route_pending_ack_from_env(),
         help="ship a source-passthrough rung whose serve route is not yet "
-        "validated (allocator_candidates.ROUTE_PENDING_PASSTHROUGH_FORMATS, "
-        "today MXFP4_SOURCE -> lane delegated_native_mxfp4). Refused by "
-        "default; the acknowledgement is recorded in the artifact provenance.",
+        "validated (allocator_candidates.ROUTE_PENDING_PASSTHROUGH_FORMATS). "
+        "Refused by default; the acknowledgement is recorded in the artifact "
+        f"provenance. May also be set with {_ROUTE_PENDING_ACK_ENV}=1 so a "
+        "driver script can pass it explicitly; the env form announces itself "
+        "on stderr and is OFF unless set to exactly '1'.",
     )
     ap.add_argument(
         "--scale-coding",

--- a/prismaquant/export_nvfp4_cb_streaming.py
+++ b/prismaquant/export_nvfp4_cb_streaming.py
@@ -1257,6 +1257,92 @@ _FP8_BLOCK_UE8M0_FORMAT = "FP8_BLOCK_UE8M0_SOURCE"
 #: can pass the acknowledgement without editing the command line it builds.
 _ROUTE_PENDING_ACK_ENV = "PQ_ALLOW_ROUTE_PENDING"
 
+#: Env spelling of ``--exclude-namespace``: comma-separated tensor-name
+#: prefixes to OMIT from the artifact entirely.
+_EXCLUDE_NAMESPACES_ENV = "PQ_EXPORT_EXCLUDE_NAMESPACES"
+
+
+def _exclude_namespaces_from_env() -> tuple[str, ...]:
+    """Read the env form of the namespace exclusion list. Empty by default.
+
+    Empty means "exclude nothing", which is the pre-existing behaviour, so an
+    unset or blank variable cannot change what an export produces.
+    """
+
+    raw = os.environ.get(_EXCLUDE_NAMESPACES_ENV, "")
+    prefixes = tuple(part.strip() for part in raw.split(",") if part.strip())
+    if prefixes:
+        print(f"[export-stream] {_EXCLUDE_NAMESPACES_ENV} -> omitting "
+              f"namespace(s) {list(prefixes)} from this artifact entirely.",
+              file=sys.stderr, flush=True)
+    return prefixes
+
+
+def _validate_namespace_exclusions(
+    exclude_namespaces,
+    *,
+    assignment,
+    profile,
+) -> tuple[str, ...]:
+    """Normalize the exclusion list, refusing anything the recipe allocated.
+
+    OMISSION IS ONLY LEGAL FOR THE FLOOR. A verbatim tensor is one the
+    allocator never reasoned about, so dropping it changes the artifact's
+    contents and nothing else. An ALLOCATED unit is different in kind: the DP
+    priced it, spent budget on it, and the selection's achieved-bits and
+    predicted loss are both computed as though it ships. Silently omitting one
+    would make the artifact disagree with the recipe that justifies it, and
+    the discrepancy would surface as a missing-weights error at load, long
+    after the number it invalidated was reported. So this is a hard refusal
+    rather than a warning: an exclusion that collides with the recipe means
+    the operator meant something else.
+
+    Both namespaces are checked, because a prefix is written in whichever
+    spelling the operator has in hand (``mtp.`` is a checkpoint spelling; the
+    recipe would say ``model.mtp.``), and a prefix that misses only because it
+    was written in the other vintage would be a silent no-op.
+    """
+
+    prefixes = tuple(
+        str(prefix).strip() for prefix in (exclude_namespaces or ())
+        if str(prefix).strip()
+    )
+    if not prefixes:
+        return ()
+
+    collisions: dict[str, list[str]] = {}
+    for qname in assignment:
+        spellings = {str(qname)}
+        checkpoint = _canonical_qname(str(qname), profile)
+        if checkpoint:
+            spellings.add(checkpoint)
+        source = getattr(profile, "source_tensor_name", None)
+        if callable(source):
+            try:
+                spellings.add(source(str(qname)))
+            except Exception:              # pragma: no cover - defensive
+                pass
+        for prefix in prefixes:
+            if any(name.startswith(prefix) for name in spellings):
+                collisions.setdefault(prefix, []).append(str(qname))
+
+    if collisions:
+        detail = "; ".join(
+            f"{prefix!r} matches {len(names)} allocated unit(s) "
+            f"e.g. {sorted(names)[:3]}"
+            for prefix, names in sorted(collisions.items())
+        )
+        raise ValueError(
+            f"refusing to exclude a namespace the recipe allocates: {detail}. "
+            f"Namespace exclusion omits tensors from the artifact entirely, "
+            f"which is only sound for FLOOR units the allocator never priced. "
+            f"An allocated unit's bytes are already counted in the "
+            f"selection's achieved bits and predicted loss, so dropping it "
+            f"here would make the artifact contradict the recipe that "
+            f"justifies it. Re-run the allocation without these units, or "
+            f"narrow the exclusion prefix.")
+    return prefixes
+
 
 def _route_pending_ack_from_env() -> bool:
     """Read the env form of the route-pending acknowledgement.
@@ -1286,6 +1372,7 @@ def _floor_block_fp8_units(
     claimed_qnames: set[str],
     profile,
     subset_prefixes,
+    excluded_namespaces: tuple[str, ...] = (),
 ) -> tuple[dict[str, str], dict[str, str]]:
     """Block-FP8 units the recipe never allocated, which must be DECLARED.
 
@@ -1343,6 +1430,8 @@ def _floor_block_fp8_units(
         if subset_prefixes is not None and not any(
                 weight_key.startswith(p) for p in subset_prefixes):
             continue
+        if any(ckpt_qname.startswith(p) for p in excluded_namespaces):
+            continue                      # omitted from the artifact entirely
         if any(ckpt_qname.startswith(p) for p in verbatim_prefixes):
             continue                      # profile ships these undeclared
         if weight_key in emitted_bases or weight_key in consumed_expert_bases:
@@ -1422,6 +1511,7 @@ def export_nvfp4_cb_streaming(
     reuse_verify: int = 3,
     allow_unstamped_research: bool = False,
     allow_route_pending_passthrough: bool = False,
+    exclude_namespaces: list[str] | tuple[str, ...] | None = None,
     activation_cache_dir: str | Path | None = None,
     activation_scale_policy: str | None = None,
 ) -> dict[str, int]:
@@ -1521,6 +1611,15 @@ def export_nvfp4_cb_streaming(
     # reduction here, once, before anything reads the assignment.
     assignment, expert_stack_members, expert_stack_report = (
         _collapse_per_expert_assignment(assignment, expert_groups, profile)
+    )
+    # Namespace exclusion is validated against the COLLAPSED assignment, i.e.
+    # the units as the allocator actually decided them, so a per-expert entry
+    # cannot hide a collision behind its expanded spelling.
+    excluded_namespaces = _validate_namespace_exclusions(
+        exclude_namespaces if exclude_namespaces is not None
+        else _exclude_namespaces_from_env(),
+        assignment=assignment,
+        profile=profile,
     )
     if expert_stack_members:
         col_weights = _packed_expert_col_weights(
@@ -2449,11 +2548,19 @@ def export_nvfp4_cb_streaming(
                         | stock_set),
         profile=profile,
         subset_prefixes=subset_prefixes,
+        excluded_namespaces=excluded_namespaces,
     )
     for name in skeleton.keys():
         if subset_prefixes is not None and \
                 not any(name.startswith(p) for p in subset_prefixes):
             continue   # outside the declared subset (e.g. non-MTP body layers)
+        if any(name.startswith(p) for p in excluded_namespaces):
+            # OMITTED ENTIRELY: no tensor, no index entry, no `ignore` line, no
+            # declaration. The prefix test is on the raw checkpoint key, so a
+            # unit's scale and other companions leave with it automatically
+            # rather than by a second rule that could disagree.
+            counts["excluded"] += 1
+            continue
         if name in emitted_bases or name in consumed_expert_bases:
             continue
         if name not in floor_fp8_scale_owner and (
@@ -2763,6 +2870,7 @@ def export_nvfp4_cb_streaming(
         requant_target_name=_base_name,
         source_passthrough_units=_declared_passthrough_units,
         route_pending_passthrough_acknowledged=sorted(route_pending),
+        excluded_namespaces=excluded_namespaces,
         weight_only_stock_targets=sidecar_stock,
         streaming_provenance=True,
         include_tensor_formats=False,
@@ -2843,6 +2951,11 @@ def export_nvfp4_cb_streaming(
     verbatim_prefixes = tuple(_verbatim()) if callable(_verbatim) else ("mtp.",)
     completeness = assert_artifact_complete(
         out_dir, verbatim_prefixes=verbatim_prefixes)
+    if excluded_namespaces:
+        print(f"[export-cb-stream] excluded namespace(s) "
+              f"{list(excluded_namespaces)}: {counts['excluded']} tensor(s) "
+              f"omitted from the artifact (recorded in provenance)",
+              flush=True)
     print(f"[export-cb-stream] completeness: "
           f"{len(completeness.passthrough_units)} declared passthrough, "
           f"{len(completeness.verbatim_namespace_units)} verbatim-namespace "
@@ -3017,6 +3130,18 @@ def main(argv=None) -> None:
         "on stderr and is OFF unless set to exactly '1'.",
     )
     ap.add_argument(
+        "--exclude-namespace",
+        action="append",
+        default=None,
+        dest="exclude_namespaces",
+        help="OMIT every tensor whose checkpoint name starts with this prefix "
+        "from the artifact entirely — no tensor, no index entry, no `ignore` "
+        "line, no declaration. Repeatable. Legal only for floor/verbatim "
+        "tensors: a prefix matching any unit the layer_config allocates is a "
+        f"hard refusal. May also be set with {_EXCLUDE_NAMESPACES_ENV} as a "
+        "comma-separated list; empty/unset excludes nothing.",
+    )
+    ap.add_argument(
         "--scale-coding",
         default=cb.SCALE_CODING_TWO_TIER,
         choices=[cb.SCALE_CODING_V1, cb.SCALE_CODING_TWO_TIER],
@@ -3066,6 +3191,7 @@ def main(argv=None) -> None:
         reuse_verify=reuse_verify,
         allow_unstamped_research=args.allow_unstamped_research,
         allow_route_pending_passthrough=args.allow_route_pending_passthrough,
+        exclude_namespaces=args.exclude_namespaces,
         activation_cache_dir=args.activation_cache_dir,
         activation_scale_policy=args.activation_scale_policy)
     size = sum(p.stat().st_size for p in Path(args.out).glob("*")) / 1e9

--- a/scripts/run_dsv4_flash_92gb.sh
+++ b/scripts/run_dsv4_flash_92gb.sh
@@ -218,6 +218,23 @@ DOCKER_COMMON=(
   -e CB_SCALE_SWEEP=1
   -e PRISMAQUANT_CB_ENCODE_TIER=balanced
   # PRISMAQUANT_EXPERT_COST_SAMPLE intentionally NOT set — see header.
+  #
+  # VALUE-LESS forwards: `-e NAME` passes the HOST's value through when the
+  # variable is set and passes nothing at all when it is not. That is the
+  # property wanted here — the launch wrapper decides, per invocation, and the
+  # script needs no per-run edit and carries no default of its own. Writing
+  # `-e NAME=` instead would define them as empty INSIDE the container, which
+  # is a different statement and, for an acknowledgement flag, the wrong one.
+  #
+  #   PQ_ALLOW_ROUTE_PENDING=1        acknowledge shipping a route-pending
+  #                                   passthrough (the exporter refuses
+  #                                   otherwise, and records the
+  #                                   acknowledgement in artifact provenance)
+  #   PQ_EXPORT_EXCLUDE_NAMESPACES    comma-separated tensor-name prefixes to
+  #                                   OMIT from the artifact entirely
+  #                                   (e.g. `mtp.`); empty/unset changes nothing
+  -e PQ_ALLOW_ROUTE_PENDING
+  -e PQ_EXPORT_EXCLUDE_NAMESPACES
 )
 
 run_probe() {

--- a/tests/test_nvfp4_cb_streaming.py
+++ b/tests/test_nvfp4_cb_streaming.py
@@ -2184,3 +2184,155 @@ def test_floor_block_fp8_refuses_to_ship_unacknowledged(workdir):
         export_nvfp4_cb_streaming(
             mdl, path, workdir / "refused", col_weights, device="cpu",
             allow_route_pending_passthrough=False)
+
+
+# --- namespace exclusion: omitting a floor namespace entirely ---------------
+
+
+def _dsv4_source_with_mtp(mdl: Path, **kwargs) -> dict:
+    """The DSv4 fixture plus an `mtp.*` block, so exclusion has a target."""
+    tensors = _dsv4_source_model(mdl, **kwargs)
+    generator = torch.Generator().manual_seed(77)
+    hid = _SOURCE_HID
+    extra = {
+        "mtp.0.attn.wq_a.weight": (
+            torch.randn(hid, hid, generator=generator) * 0.3
+        ).to(torch.float8_e4m3fn),
+        "mtp.0.attn.wq_a.scale": _e8m0_plane((2, 2), generator),
+        "mtp.0.attn_norm.weight": torch.ones(hid, dtype=torch.bfloat16),
+    }
+    for expert in range(_SOURCE_EXPERTS):
+        for leaf in ("w1", "w3", "w2"):
+            base = f"mtp.0.ffn.experts.{expert}.{leaf}"
+            extra[base + ".weight"] = torch.randint(
+                -128, 128, (hid, hid // 2), dtype=torch.int8,
+                generator=generator)
+            extra[base + ".scale"] = _e8m0_plane((hid, hid // 32), generator)
+    tensors.update(extra)
+    save_file(tensors, str(mdl / "model.safetensors"))
+    return tensors
+
+
+def _export_with_exclusions(workdir, out_name, exclusions, **model_kwargs):
+    mdl = workdir / f"src_{out_name}"
+    _dsv4_source_with_mtp(mdl, **model_kwargs)
+    assignment, col_weights = _dsv4_recipe(**model_kwargs)
+    path = workdir / f"{out_name}.json"
+    _assign(path, assignment)
+    out = workdir / out_name
+    counts = export_nvfp4_cb_streaming(
+        mdl, path, out, col_weights, device="cpu",
+        allow_route_pending_passthrough=True,
+        exclude_namespaces=exclusions)
+    return mdl, out, dict(counts)
+
+
+def test_namespace_exclusion_removes_it_everywhere_and_changes_nothing_else(
+        workdir):
+    """`mtp.*` gone from tensors, index and config; the rest byte-identical."""
+    _mdl, kept, _ = _export_with_exclusions(workdir, "kept", None)
+    mdl, dropped, counts = _export_with_exclusions(
+        workdir, "dropped", ["mtp."])
+
+    kept_header, _ = _st_header(kept / "model.safetensors")
+    dropped_header, _ = _st_header(dropped / "model.safetensors")
+
+    # (a) gone from the tensor set / index entirely.
+    assert any(n.startswith("mtp.") for n in kept_header)
+    assert not any(n.startswith("mtp.") for n in dropped_header)
+
+    # (b) gone from every declaration surface too, not just the payload.
+    dropped_config = json.loads((dropped / "quant_config.json").read_text())
+    serialized = json.dumps(dropped_config)
+    assert "mtp." not in serialized.replace('"excluded_namespaces": ["mtp."]',
+                                            ""), \
+        "an excluded namespace must not survive in ignore/targets/units"
+    assert dropped_config["provenance"]["excluded_namespaces"] == ["mtp."]
+
+    # (c) the byte total drops by exactly the excluded namespace's size.
+    def _payload(header):
+        return sum(meta["data_offsets"][1] - meta["data_offsets"][0]
+                   for name, meta in header.items() if name != "__metadata__")
+
+    excluded_bytes = sum(
+        meta["data_offsets"][1] - meta["data_offsets"][0]
+        for name, meta in kept_header.items()
+        if name.startswith("mtp."))
+    assert excluded_bytes > 0
+    assert _payload(kept_header) - _payload(dropped_header) == excluded_bytes
+
+    # (d) EVERYTHING else is byte-identical — exclusion removes, never rewrites.
+    shared = {n for n in kept_header
+              if not n.startswith("mtp.") and n != "__metadata__"}
+    assert shared == {n for n in dropped_header if n != "__metadata__"}
+    for name in sorted(shared):
+        assert hashlib.sha256(_emitted_bytes(kept, name)).hexdigest() == \
+            hashlib.sha256(_emitted_bytes(dropped, name)).hexdigest(), name
+
+
+def test_namespace_exclusion_defaults_to_nothing(workdir, monkeypatch):
+    """Unset env and unset argument both mean 'exclude nothing'."""
+    from prismaquant.export_nvfp4_cb_streaming import (
+        _EXCLUDE_NAMESPACES_ENV,
+        _exclude_namespaces_from_env,
+    )
+
+    monkeypatch.delenv(_EXCLUDE_NAMESPACES_ENV, raising=False)
+    assert _exclude_namespaces_from_env() == ()
+    for blank in ("", "   ", ",", " , "):
+        monkeypatch.setenv(_EXCLUDE_NAMESPACES_ENV, blank)
+        assert _exclude_namespaces_from_env() == ()
+    monkeypatch.setenv(_EXCLUDE_NAMESPACES_ENV, " mtp. , visual. ")
+    assert _exclude_namespaces_from_env() == ("mtp.", "visual.")
+
+    # Back to unset before exporting: with no argument AND no env, the export
+    # must keep everything. (Leaving the variable set above would exclude
+    # `mtp.` through the env path — which is the knob working, but not what
+    # this test is about.)
+    monkeypatch.delenv(_EXCLUDE_NAMESPACES_ENV, raising=False)
+    _mdl, out, _ = _export_with_exclusions(workdir, "default", None)
+    header, _ = _st_header(out / "model.safetensors")
+    assert any(name.startswith("mtp.") for name in header)
+    config = json.loads((out / "quant_config.json").read_text())
+    assert "excluded_namespaces" not in config["provenance"]
+
+
+def test_namespace_exclusion_refuses_an_allocated_unit(workdir):
+    """Excluding something the recipe priced must hard-fail, not silently drop.
+
+    The allocated unit's bytes are already counted in the selection's achieved
+    bits and predicted loss, so omitting it would make the artifact contradict
+    the recipe that justifies it.
+    """
+    with pytest.raises(ValueError, match="allocates"):
+        _export_with_exclusions(workdir, "illegal", ["layers.0."])
+
+
+def test_namespace_exclusion_refuses_via_the_recipe_spelling_too(workdir):
+    """A prefix written in the RECIPE vintage must collide just the same."""
+    with pytest.raises(ValueError, match="allocates"):
+        _export_with_exclusions(workdir, "illegal2", ["model.layers.0."])
+
+
+def test_excluded_namespace_absence_is_valid_to_the_completeness_gate(workdir):
+    """Absent-and-excluded passes; the same absence unrecorded still fails."""
+    from prismaquant.artifact_completeness import (
+        assert_artifact_complete,
+        check_artifact_completeness,
+    )
+
+    _mdl, dropped, _ = _export_with_exclusions(workdir, "gate", ["mtp."])
+    report = assert_artifact_complete(dropped)
+    assert report.excluded_namespaces == ["mtp."]
+
+    # Strip the record: the artifact is byte-identical, but nothing now says
+    # the absence was intended. A weight whose scale is missing must fail
+    # again, which is what proves the exemption is the RECORD and not the
+    # prefix.
+    _mdl2, kept, _ = _export_with_exclusions(workdir, "gate2", None)
+    tensors = load_file(str(kept / "model.safetensors"))
+    tensors.pop("mtp.0.attn.wq_a.scale")
+    save_file(tensors, str(kept / "model.safetensors"))
+    report = check_artifact_completeness(kept)
+    assert not report.ok
+    assert "mtp.0.attn.wq_a" in report.missing_scale

--- a/tests/test_nvfp4_cb_streaming.py
+++ b/tests/test_nvfp4_cb_streaming.py
@@ -1286,7 +1286,7 @@ def _e8m0_plane(shape, generator) -> torch.Tensor:
 
 
 def _dsv4_source_model(mdl: Path, *, mxfp4_layers=(1,), cb_layers=(0,),
-                       dense_ue8m0=True, seed=5) -> dict:
+                       dense_ue8m0=True, floor_fp8=False, seed=5) -> dict:
     """A DSv4-Flash-shaped checkpoint at 1/1000 scale, in its own namespace.
 
     Routed experts are nibble-packed MXFP4 (`.weight` I8 + `.scale` F8_E8M0)
@@ -1313,6 +1313,16 @@ def _dsv4_source_model(mdl: Path, *, mxfp4_layers=(1,), cb_layers=(0,),
             torch.randn(hid, hid, generator=generator) * 0.3
         ).to(torch.float8_e4m3fn)
         tensors["layers.0.attn.wq_a.scale"] = _e8m0_plane((2, 2), generator)
+    if floor_fp8:
+        # THE wo_a SHAPE: a block-FP8 body Linear the recipe never mentions.
+        # Identical on disk to the `dense_ue8m0` unit above — element plane
+        # plus UE8M0 scale plane — and different only in that no allocation
+        # target claims it, which is precisely the distinction that used to
+        # cost it its scale plane and earn it an `ignore` entry.
+        tensors["layers.0.attn.wo_a.weight"] = (
+            torch.randn(hid, hid, generator=generator) * 0.3
+        ).to(torch.float8_e4m3fn)
+        tensors["layers.0.attn.wo_a.scale"] = _e8m0_plane((2, 2), generator)
     tensors["norm.weight"] = torch.ones(hid, dtype=torch.bfloat16)
     save_file(tensors, str(mdl / "model.safetensors"))
     (mdl / "config.json").write_text(json.dumps({
@@ -1329,7 +1339,8 @@ def _dsv4_source_model(mdl: Path, *, mxfp4_layers=(1,), cb_layers=(0,),
     return tensors
 
 
-def _dsv4_recipe(*, mxfp4_layers=(1,), cb_layers=(0,), dense_ue8m0=True):
+def _dsv4_recipe(*, mxfp4_layers=(1,), cb_layers=(0,), dense_ue8m0=True,
+                 floor_fp8=False):
     """Expanded per-tensor assignment + col_weights, as the allocator writes it."""
     assignment: dict[str, object] = {}
     col_weights: dict[str, torch.Tensor] = {}
@@ -1346,6 +1357,8 @@ def _dsv4_recipe(*, mxfp4_layers=(1,), cb_layers=(0,), dense_ue8m0=True):
                             _SOURCE_HID, generator=generator) + 0.05
     if dense_ue8m0:
         assignment["model.layers.0.self_attn.wq_a"] = _UE8M0_RECIPE
+    # `floor_fp8` is deliberately NOT given an assignment entry: the whole
+    # point of that fixture arm is a unit the recipe never mentions.
     return assignment, col_weights
 
 
@@ -1370,6 +1383,13 @@ def _export_dsv4(workdir, out_name="out", **model_kwargs):
     counts = export_nvfp4_cb_streaming(
         mdl, path, out, col_weights, device="cpu",
         allow_route_pending_passthrough=True)
+    # Every DSv4 artifact these tests produce goes through the completeness
+    # gate, so a future change that drops a scale plane or mislabels a unit
+    # fails in whichever test produced it rather than only in the one test
+    # written to look for that.
+    from prismaquant.artifact_completeness import assert_artifact_complete
+
+    assert_artifact_complete(out)
     return mdl, out, tensors, dict(counts)
 
 
@@ -1468,7 +1488,14 @@ def test_cb_expert_layer_beside_a_passthrough_layer_keeps_its_gates(workdir):
         mxfp4_layers=(), cb_layers=(0,), dense_ue8m0=False)
     path = workdir / "cb_only.json"
     _assign(path, assignment)
-    export_nvfp4_cb_streaming(mdl, path, reference, col_weights, device="cpu")
+    # The recipe drops `wq_a`, but the SOURCE still has it — so in this export
+    # it is a floor block-FP8 unit and needs the same acknowledgement any
+    # route-pending passthrough does. Before floor units were declared, this
+    # call silently produced a reference artifact with `wq_a`'s scale plane
+    # dropped and the unit listed in `ignore`; the comparison below still
+    # passed because it only reads the CB tensors.
+    export_nvfp4_cb_streaming(mdl, path, reference, col_weights, device="cpu",
+                              allow_route_pending_passthrough=True)
 
     mixed_tensors = load_file(str(out / "model.safetensors"))
     cb_only_tensors = load_file(str(reference / "model.safetensors"))
@@ -1982,3 +2009,178 @@ def test_mxfp8_requant_declaration_parses_on_the_producer_side(workdir):
     config = json.loads((out / "quant_config.json").read_text())
     parsed = parse_source_passthrough_declaration(config)
     assert parsed["model.layers.0.self_attn.wq_a"] == "mxfp8_e4m3_e8m0_g32"
+
+
+# --- floor block-FP8: units the recipe never allocated ----------------------
+#
+# The bug these pin, stated once: a block-FP8 weight that no allocation target
+# claims used to reach the verbatim copy loop, lose its `.scale` sibling to a
+# skip meant for scales the CB/source lanes had already consumed, and be
+# declared `ignore` — i.e. "plain unquantized floats". A consumer honouring
+# that casts fp8 to bf16 with no scale, passes every size check, and serves
+# weights each off by their own power of two. On DSv4-Flash: 43 `attn.wo_a` +
+# 21 `attn.indexer.wq_b` units, 1.44 GB, no error raised anywhere.
+
+
+def test_floor_block_fp8_ships_its_scale_and_is_declared_not_ignored(workdir):
+    """Weight AND scale present, declared passthrough, absent from `ignore`."""
+    mdl, out, tensors, counts = _export_dsv4(workdir, floor_fp8=True)
+
+    header = _assert_offsets_consistent(out / "model.safetensors")
+    quant_config = json.loads((out / "quant_config.json").read_text())
+
+    unit = "layers.0.attn.wo_a"
+    # (a) BOTH planes ship, byte-for-byte. A weight without its scale is not a
+    #     smaller artifact, it is an unreadable one.
+    for plane in ("weight", "scale"):
+        name = f"{unit}.{plane}"
+        assert name in header, f"{name} missing from the artifact"
+        assert header[name]["dtype"] == \
+            _st_header(mdl / "model.safetensors")[0][name]["dtype"], name
+        assert hashlib.sha256(_emitted_bytes(out, name)).hexdigest() == \
+            hashlib.sha256(_source_bytes(mdl, name)).hexdigest(), name
+
+    # (b) declared under the wire id the consumer routes on.
+    declared = (quant_config.get("source_passthrough") or {}).get("units") or {}
+    assert declared.get(unit) == "fp8_e4m3_ue8m0_block128", declared
+
+    # (c) and NOT claimed to be unquantized. This is the assertion that would
+    #     have caught the original bug on its own.
+    assert unit not in (quant_config.get("ignore") or []), \
+        "a declared block-FP8 unit must not also be listed in `ignore`"
+
+    assert counts["floor_fp8_declared"] == 1
+
+
+def test_floor_block_fp8_declaration_survives_the_completeness_gate(workdir):
+    from prismaquant.artifact_completeness import assert_artifact_complete
+
+    _, out, _, _ = _export_dsv4(workdir, floor_fp8=True)
+    report = assert_artifact_complete(out)
+    assert "layers.0.attn.wo_a" in report.passthrough_units
+    # Route-pending is an honest recorded state, not a reason to fail: the
+    # producer said out loud which lane it shipped into.
+    assert report.route_pending_acknowledged
+
+
+def test_completeness_gate_catches_the_original_silent_corruption(workdir):
+    """The regression pin: reproduce the OLD artifact shape, demand a failure.
+
+    Built by editing a healthy artifact back into the broken state (drop the
+    scale plane, move the unit from the declaration into `ignore`) rather than
+    by reverting the exporter, so the gate is tested against the artifact the
+    bug actually produced.
+    """
+    from prismaquant.artifact_completeness import (
+        ArtifactIncomplete,
+        check_artifact_completeness,
+    )
+
+    _, out, _, _ = _export_dsv4(workdir, floor_fp8=True)
+    unit = "layers.0.attn.wo_a"
+
+    quant_config = json.loads((out / "quant_config.json").read_text())
+    quant_config["source_passthrough"]["units"].pop(unit)
+    quant_config.setdefault("ignore", []).append(unit)
+    (out / "quant_config.json").write_text(json.dumps(quant_config))
+
+    # Drop the scale plane exactly as the old skip did.
+    tensors = load_file(str(out / "model.safetensors"))
+    tensors.pop(f"{unit}.scale")
+    save_file(tensors, str(out / "model.safetensors"))
+
+    report = check_artifact_completeness(out)
+    assert not report.ok
+    assert unit in report.fp8_in_ignore
+    with pytest.raises(ArtifactIncomplete, match="ignore"):
+        from prismaquant.artifact_completeness import assert_artifact_complete
+        assert_artifact_complete(out)
+
+
+def test_completeness_gate_catches_a_declared_unit_with_no_scale(workdir):
+    """Declaring a decode the artifact cannot perform is its own failure."""
+    from prismaquant.artifact_completeness import check_artifact_completeness
+
+    _, out, _, _ = _export_dsv4(workdir, floor_fp8=True)
+    tensors = load_file(str(out / "model.safetensors"))
+    tensors.pop("layers.0.attn.wo_a.scale")
+    save_file(tensors, str(out / "model.safetensors"))
+
+    report = check_artifact_completeness(out)
+    assert not report.ok
+    assert "layers.0.attn.wo_a" in report.missing_scale
+
+
+def test_completeness_gate_passes_a_healthy_artifact_without_floor_units(
+        workdir):
+    """No false positives on the shape the exporter already produced."""
+    from prismaquant.artifact_completeness import assert_artifact_complete
+
+    _, out, _, _ = _export_dsv4(workdir)
+    assert_artifact_complete(out)
+
+
+def test_floor_block_fp8_scale_bytes_are_a_negligible_budget_delta(workdir):
+    """Item 4: declaring the floor costs the scale planes and nothing else.
+
+    Block-128 means one scale byte per 16,384 weight elements, so the fix
+    cannot plausibly move a byte budget — but "cannot plausibly" is exactly
+    the kind of claim that should be measured against the artifact rather
+    than argued, since it is what stands between the fix and the 1.06 MB of
+    headroom tonight's 92 GB selection actually has.
+    """
+    _, out_declared, _, _ = _export_dsv4(
+        workdir, out_name="declared", floor_fp8=True)
+    header = _assert_offsets_consistent(out_declared / "model.safetensors")
+
+    weight = header["layers.0.attn.wo_a.weight"]
+    scale = header["layers.0.attn.wo_a.scale"]
+
+    def _nbytes(meta):
+        lo, hi = meta["data_offsets"]
+        return hi - lo
+
+    weight_bytes, scale_bytes = _nbytes(weight), _nbytes(scale)
+    elements = 1
+    for dim in weight["shape"]:
+        elements *= dim
+    # One E8M0 byte per 128x128 block.
+    assert scale_bytes * (128 * 128) == elements
+    assert scale_bytes / weight_bytes < 1e-3, (
+        f"scale plane is {scale_bytes}B against a {weight_bytes}B weight; "
+        f"block-128 should make it ~1/16384 of the element plane")
+
+
+def test_route_pending_ack_env_defaults_off_and_needs_exactly_one(monkeypatch):
+    """The acknowledgement must never be ambient."""
+    from prismaquant.export_nvfp4_cb_streaming import (
+        _ROUTE_PENDING_ACK_ENV,
+        _route_pending_ack_from_env,
+    )
+
+    monkeypatch.delenv(_ROUTE_PENDING_ACK_ENV, raising=False)
+    assert _route_pending_ack_from_env() is False
+    for value in ("0", "", "true", "yes", "TRUE", "2"):
+        monkeypatch.setenv(_ROUTE_PENDING_ACK_ENV, value)
+        assert _route_pending_ack_from_env() is False, value
+    monkeypatch.setenv(_ROUTE_PENDING_ACK_ENV, "1")
+    assert _route_pending_ack_from_env() is True
+
+
+def test_floor_block_fp8_refuses_to_ship_unacknowledged(workdir):
+    """Without the acknowledgement the export STOPS — it does not ship plainly.
+
+    The asymmetry worth pinning: for an allocated rung, refusing means the DP
+    picks something else. For a floor unit there is no something else, so the
+    refusal has to be loud rather than a quiet downgrade to `ignore`.
+    """
+    mdl = workdir / "src"
+    _dsv4_source_model(mdl, floor_fp8=True)
+    assignment, col_weights = _dsv4_recipe(floor_fp8=True)
+    path = workdir / "recipe.json"
+    _assign(path, assignment)
+
+    with pytest.raises(ValueError, match="route-pending source passthrough"):
+        export_nvfp4_cb_streaming(
+            mdl, path, workdir / "refused", col_weights, device="cpu",
+            allow_route_pending_passthrough=False)


### PR DESCRIPTION
## The bug (present in artifacts already on disk)

A block-FP8 weight that **no allocation target claimed** reached the verbatim copy
loop, which was written for BF16 norms and buffers. For those, "copy the tensor and
list it in `ignore`" is right. For a block-FP8 weight it was wrong twice, and the two
errors compounded into silence:

- the loop skips `.scale` siblings as *"consumed with their fp8 weight"* — but nothing
  consumed this one, because the weight was never a target. **The scale plane was dropped.**
- the weight was then listed in `ignore`, i.e. declared to be plain unquantized floats.

A consumer honouring that allocates a bf16 parameter, **passes the size assertion**
because the element counts agree, and casts the fp8 bytes **with no scale applied**.
Every 128×128 block ends up wrong by its own power of two. Nothing raises.

On DSv4-Flash: **43 × `attn.wo_a` + 21 × `attn.indexer.wq_b`, 1.44 GB**. Confirmed in
artifacts already on disk — `export-smoke/artifact_attn_FP8_CB_K36` ships
`layers.0.attn.wo_a.weight` as F8_E4M3 with **no `.scale` beside it** and the unit in
`ignore`, while the source checkpoint has the scale.

## The fix

A floor block-FP8 unit ships its weight **and** its scale, and is declared
`fp8_e4m3_ue8m0_block128` — the same delegated-native route an *allocated* passthrough
unit of that format already gets. Nothing about the bytes differs between the two cases;
only whether the DP happened to choose the unit, which is not a property the consumer
can see or should have to.

Membership is narrow **by construction, not by name**: an F8_E4M3 weight paired with an
F8_E8M0 scale over the checkpoint's declared 128×128 block. That excludes MXFP4
nibble-packs (int8 elements) and BF16/F32 verbatim tensors (no scale plane — the
`ignore` cast IS correct for them). A non-128×128 declared block is a **refusal**, not a
silent skip: declaring the wrong grid loads, and is wrong.

`mtp.*` stays verbatim-undeclared per the DSpark audit — vLLM 0.24 builds no module for
those blocks, so declaring them would assert a route nobody exercises.

## Route-pending, honestly recorded

No route-table edits — main's three-state record stands. These units face the **same**
ship gate as an allocated passthrough and record the **same** provenance
acknowledgement. One asymmetry is worth naming: for an allocated rung, refusing means
the DP picks something else; for a floor unit **there is no something else**, so the
refusal is loud rather than a quiet downgrade back to `ignore`.

`PQ_ALLOW_ROUTE_PENDING=1` is an env spelling of `--allow-route-pending-passthrough` for
driver scripts. Off for every value except exactly `"1"`, and it announces itself on
stderr — the one failure mode an env knob has that a flag does not is being inherited by
an invocation nobody meant to acknowledge for.

## The gate (the part that matters)

`prismaquant/artifact_completeness.py` reads a **published** artifact — safetensors
headers and `quant_config.json`, never the source — and asks the only question a
consumer can ask: *for every scale-bearing weight actually on disk, which mechanism
decodes it, and is that mechanism complete?* Four failure modes: fp8-in-`ignore`,
declared-but-missing-scale, orphan scale plane, claimed-by-nothing.

It runs at the end of **every** export and inside the test helper **every** DSv4 fixture
goes through, so this class now fails in whichever test produced it rather than only in
a test written to look for it. Headers only — a few file opens even on 92 GB. Also
runnable standalone:

```
python -m prismaquant.artifact_completeness /path/to/artifact
```

Pointed at the two smoke artifacts on disk, it reports exactly the bug above.

## Byte accounting

Block-128 means **one scale byte per 16,384 weight elements**, so the 64 restored scale
planes are ~90 KB-class against the 1.06 MB of headroom the 92 GB selection has. Asserted
against the emitted header rather than argued.

## Namespace note (surfaced, not fixed here)

Units are spelled in several legitimate vintages at once — recipe
(`model.layers.0.self_attn.wq_a`) for allocator-chosen units, checkpoint
(`layers.0.attn.wq_a`) for exporter-only ones, and the collapsed shared-MLP form that
config-group targets use. The gate normalizes through the profile's own
recipe→checkpoint map rather than demanding internal uniformity. Making the producer
emit one spelling everywhere is a real improvement and a **separate** change; a gate
that failed every mixed-vintage artifact would be useless for finding this bug.

Worth a follow-up: an allocated DSv4 passthrough unit would be declared
`model.layers.N.self_attn.wq_a`, which does **not** match vLLM's serving prefix
`model.layers.N.attn.wq_a`. Latent today (no DSv4 artifact has shipped passthrough
units), but it will bite the first one that does.

## Tests

Full suite green locally (2771 passed). New coverage: floor unit ships both planes
byte-verbatim + declared + absent from `ignore`; the completeness gate catches the
original shape, a declared-but-scaleless unit, and passes healthy artifacts; the env
knob defaults off and needs exactly `"1"`; unacknowledged export refuses loudly.

One pre-existing test needed the acknowledgement added — it was silently producing a
reference artifact **with** this bug, and only passed because it compared CB tensors.

Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUHqNEHMu7FAJQSNGCZhqW