### PR TITLE
Measure per-output-row quantization-error dispersion (tier-3 pilot)

### DIFF
--- a/prismaquant/row_dispersion.py
+++ b/prismaquant/row_dispersion.py
@@ -1,0 +1,317 @@
+"""Per-output-row quantization-error dispersion measurements.
+
+This module is research measurement tooling for the tier-3 row-splitting
+pilot.  It deliberately has no cache, model-loading, or serving dependency:
+callers provide one activation matrix and two versions of one Linear weight.
+"""
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+
+
+def _measurement_dtype(*tensors: torch.Tensor) -> torch.dtype:
+    """Return a stable matmul dtype without needlessly widening float32."""
+    dtype = tensors[0].dtype
+    for tensor in tensors[1:]:
+        dtype = torch.promote_types(dtype, tensor.dtype)
+    if not dtype.is_floating_point:
+        raise TypeError("row-dispersion inputs must have floating-point dtype")
+    if dtype in (torch.float16, torch.bfloat16):
+        return torch.float32
+    return dtype
+
+
+def _validated_inputs(
+    X: torch.Tensor,
+    W: torch.Tensor,
+    W_hat: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    X = torch.as_tensor(X)
+    W = torch.as_tensor(W)
+    W_hat = torch.as_tensor(W_hat)
+    if X.ndim != 2 or W.ndim != 2 or W_hat.ndim != 2:
+        raise ValueError(
+            "X, W, and W_hat must be 2-D; got "
+            f"{tuple(X.shape)}, {tuple(W.shape)}, {tuple(W_hat.shape)}"
+        )
+    if W.shape != W_hat.shape:
+        raise ValueError(
+            f"W and W_hat shapes differ: {tuple(W.shape)} != "
+            f"{tuple(W_hat.shape)}"
+        )
+    if X.shape[1] != W.shape[1]:
+        raise ValueError(
+            f"activation width {X.shape[1]} != weight width {W.shape[1]}"
+        )
+    if not (X.device == W.device == W_hat.device):
+        raise ValueError(
+            "X, W, and W_hat must be on the same device; got "
+            f"{X.device}, {W.device}, {W_hat.device}"
+        )
+    dtype = _measurement_dtype(X, W, W_hat)
+    return X.to(dtype=dtype), W.to(dtype=dtype), W_hat.to(dtype=dtype)
+
+
+def per_row_error(
+    X: torch.Tensor,
+    W: torch.Tensor,
+    W_hat: torch.Tensor,
+) -> torch.Tensor:
+    """Measure activation-output SSE independently for every output row.
+
+    For ``X`` shaped ``[samples, in_features]`` and weights shaped
+    ``[out_features, in_features]``, the returned vector is
+
+    ``e[r] = ||X @ (W[r] - W_hat[r])||_2^2``.
+
+    Accumulation is float64 even when the matmul is float32.  Consequently,
+    summing the vector is the exact row decomposition (up to floating-point
+    reduction order) of ``||X @ (W - W_hat).T||_F^2``.
+    """
+    X, W, W_hat = _validated_inputs(X, W, W_hat)
+    output_error = X @ (W - W_hat).T
+    return output_error.square().sum(dim=0, dtype=torch.float64)
+
+
+def assert_error_decomposition(
+    X: torch.Tensor,
+    W: torch.Tensor,
+    W_hat: torch.Tensor,
+    e: torch.Tensor | None = None,
+    *,
+    rtol: float = 1e-6,
+    atol: float = 1e-8,
+) -> None:
+    """Assert that per-row errors sum to the full-matrix output error."""
+    X, W, W_hat = _validated_inputs(X, W, W_hat)
+    if e is None:
+        e = per_row_error(X, W, W_hat)
+    else:
+        e = torch.as_tensor(e, device=X.device, dtype=torch.float64)
+    if e.ndim != 1 or e.numel() != W.shape[0]:
+        raise ValueError(
+            f"e must have shape ({W.shape[0]},), got {tuple(e.shape)}"
+        )
+    full = (X @ (W - W_hat).T).square().sum(dtype=torch.float64)
+    torch.testing.assert_close(e.sum(), full, rtol=rtol, atol=atol)
+
+
+# A descriptive alias for callers that prefer the helper name to mirror the
+# measured function.  Both names intentionally execute the same assertion.
+assert_per_row_error_decomposition = assert_error_decomposition
+
+
+def _error_vector(e: torch.Tensor | Iterable[float], name: str) -> torch.Tensor:
+    values = torch.as_tensor(e, dtype=torch.float64)
+    if values.ndim != 1 or values.numel() == 0:
+        raise ValueError(f"{name} must be a non-empty 1-D vector")
+    if not bool(torch.isfinite(values).all()):
+        raise ValueError(f"{name} must contain only finite values")
+    if bool((values < 0).any()):
+        raise ValueError(f"{name} must be non-negative")
+    return values
+
+
+def tail_metrics(e: torch.Tensor | Iterable[float]) -> dict[str, float]:
+    """Summarize the location and unevenness of a non-negative error vector.
+
+    Percentiles use linear interpolation.  The coefficient of variation is
+    population standard deviation divided by the mean.  For sorted values
+    ``x_(i)`` with one-based rank ``i``, Gini is computed by the cumulative
+    closed form
+
+    ``G = 2 * sum(i * x_(i)) / (n * sum(x)) - (n + 1) / n``.
+
+    The all-zero vector is defined to have CV and Gini zero and p99/p50 one.
+    If p50 is zero but p99 is positive, the percentile ratio is infinite.
+    """
+    values = _error_vector(e, "e")
+    quantiles = torch.quantile(
+        values, torch.tensor([0.50, 0.90, 0.99], dtype=torch.float64)
+    )
+    p50, p90, p99 = (float(value) for value in quantiles)
+    mean = float(values.mean())
+    maximum = float(values.max())
+    if p50 == 0.0:
+        ratio = 1.0 if p99 == 0.0 else float("inf")
+    else:
+        ratio = p99 / p50
+    coefficient_of_variation = (
+        0.0 if mean == 0.0 else float(values.std(unbiased=False)) / mean
+    )
+
+    total = float(values.sum())
+    if total == 0.0:
+        gini = 0.0
+    else:
+        sorted_values = values.sort().values
+        ranks = torch.arange(
+            1, values.numel() + 1, dtype=torch.float64, device=values.device
+        )
+        n = values.numel()
+        gini = float(
+            2.0 * (ranks * sorted_values).sum() / (n * sorted_values.sum())
+            - (n + 1.0) / n
+        )
+        # Roundoff can put a mathematically bounded statistic a few ulps out.
+        gini = min(1.0, max(0.0, gini))
+
+    return {
+        "p50": p50,
+        "p90": p90,
+        "p99": p99,
+        "max": maximum,
+        "mean": mean,
+        "ratio_p99_over_p50": ratio,
+        "coefficient_of_variation": coefficient_of_variation,
+        "gini": gini,
+    }
+
+
+def _split_point(
+    *,
+    fraction: float,
+    routed_rows: int,
+    row_count: int,
+    total_error: float,
+    byte_cheap_per_row: float,
+    byte_expensive_per_row: float,
+) -> dict[str, float | int]:
+    return {
+        "fraction": float(fraction),
+        "routed_rows": int(routed_rows),
+        "realized_fraction": float(routed_rows / row_count),
+        "total_error": float(total_error),
+        "total_bytes": float(
+            (row_count - routed_rows) * byte_cheap_per_row
+            + routed_rows * byte_expensive_per_row
+        ),
+    }
+
+
+def split_prize_curve(
+    e_cheap: torch.Tensor | Iterable[float],
+    e_expensive: torch.Tensor | Iterable[float],
+    byte_cheap_per_row: float,
+    byte_expensive_per_row: float,
+    fractions: Iterable[float],
+) -> dict[str, Any]:
+    """Compute the analytic error/byte curve for a two-format row split.
+
+    For each requested fraction, ``ceil(f * n_rows)`` rows with the largest
+    cheap-format errors are routed to the expensive format.  This convention
+    makes a non-zero pilot fraction inspect at least one row.  The selected
+    sets are nested as the fraction grows.
+
+    Rows where ``e_expensive > e_cheap`` are returned under ``violations``
+    with both measured values and their excess.  They are never clamped or
+    hidden.  When there are no such rows, an internal assertion guards the
+    mathematical invariant that total error cannot increase with routed-row
+    count; a failed assertion then indicates an implementation/numeric defect.
+    """
+    cheap = _error_vector(e_cheap, "e_cheap")
+    expensive = _error_vector(e_expensive, "e_expensive")
+    if cheap.shape != expensive.shape:
+        raise ValueError(
+            f"error-vector shapes differ: {tuple(cheap.shape)} != "
+            f"{tuple(expensive.shape)}"
+        )
+    byte_cheap_per_row = float(byte_cheap_per_row)
+    byte_expensive_per_row = float(byte_expensive_per_row)
+    for name, value in (
+        ("byte_cheap_per_row", byte_cheap_per_row),
+        ("byte_expensive_per_row", byte_expensive_per_row),
+    ):
+        if not math.isfinite(value) or value < 0:
+            raise ValueError(f"{name} must be finite and non-negative")
+
+    requested_fractions = [float(fraction) for fraction in fractions]
+    for fraction in requested_fractions:
+        if not math.isfinite(fraction) or not 0.0 <= fraction <= 1.0:
+            raise ValueError(f"fractions must lie in [0, 1], got {fraction}")
+
+    row_count = cheap.numel()
+    order = torch.argsort(cheap, descending=True, stable=True)
+    cheap_total = float(cheap.sum())
+    expensive_total = float(expensive.sum())
+
+    def total_for_count(routed_rows: int) -> float:
+        if routed_rows == 0:
+            return cheap_total
+        if routed_rows == row_count:
+            return expensive_total
+        top = order[:routed_rows]
+        bottom = order[routed_rows:]
+        return float(expensive[top].sum() + cheap[bottom].sum())
+
+    points: list[dict[str, float | int]] = []
+    for fraction in requested_fractions:
+        routed_rows = min(row_count, int(math.ceil(fraction * row_count)))
+        points.append(_split_point(
+            fraction=fraction,
+            routed_rows=routed_rows,
+            row_count=row_count,
+            total_error=total_for_count(routed_rows),
+            byte_cheap_per_row=byte_cheap_per_row,
+            byte_expensive_per_row=byte_expensive_per_row,
+        ))
+
+    uniform_cheap = _split_point(
+        fraction=0.0,
+        routed_rows=0,
+        row_count=row_count,
+        total_error=cheap_total,
+        byte_cheap_per_row=byte_cheap_per_row,
+        byte_expensive_per_row=byte_expensive_per_row,
+    )
+    uniform_expensive = _split_point(
+        fraction=1.0,
+        routed_rows=row_count,
+        row_count=row_count,
+        total_error=expensive_total,
+        byte_cheap_per_row=byte_cheap_per_row,
+        byte_expensive_per_row=byte_expensive_per_row,
+    )
+
+    violation_indices = torch.nonzero(expensive > cheap).flatten().tolist()
+    violations = [
+        {
+            "row": int(index),
+            "cheap_error": float(cheap[index]),
+            "expensive_error": float(expensive[index]),
+            "excess_error": float(expensive[index] - cheap[index]),
+        }
+        for index in violation_indices
+    ]
+
+    counts = sorted({0, row_count, *(int(p["routed_rows"]) for p in points)})
+    totals = [total_for_count(count) for count in counts]
+    scale = max(1.0, *(abs(total) for total in totals))
+    tolerance = 1e-12 * scale
+    monotone_non_increasing = all(
+        right <= left + tolerance for left, right in zip(totals, totals[1:])
+    )
+    if not violations:
+        assert monotone_non_increasing, (
+            "row-wise-better expensive errors produced a non-monotone split "
+            "curve"
+        )
+
+    return {
+        "row_count": row_count,
+        "selection": "descending_e_cheap",
+        "rounding": "ceil_fraction_times_rows",
+        "points": points,
+        "uniform_references": {
+            "cheap_everywhere": uniform_cheap,
+            "expensive_everywhere": uniform_expensive,
+        },
+        "violations": violations,
+        "rowwise_better": not violations,
+        "monotone_non_increasing": monotone_non_increasing,
+    }
+

--- a/scripts/tier3_row_dispersion_pilot.py
+++ b/scripts/tier3_row_dispersion_pilot.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Run the CPU-only tier-3 within-Linear row-dispersion pilot.
+
+Examples::
+
+    PYTHONPATH=. python3 scripts/tier3_row_dispersion_pilot.py \
+      --weights synthetic:64x128 --acts synthetic:256x128 \
+      --quantized cheap=synthetic:64x128:0.10 \
+                  expensive=synthetic:64x128:0.03 \
+      --bytes-per-row cheap=64 --bytes-per-row expensive=128 \
+      --out /path/to/output
+
+``LABEL=PATH`` sources accept a single-tensor ``.pt`` or ``.safetensors``
+file.  Append ``::tensor_key`` to select from a multi-tensor file.  Synthetic
+weight/activation specs are ``synthetic:ROWSxCOLS``.  A synthetic
+reconstruction adds deterministic shared noise to W and may append its noise
+scale, as in ``synthetic:ROWSxCOLS:0.05``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from itertools import combinations
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+from prismaquant.row_dispersion import (
+    assert_error_decomposition,
+    per_row_error,
+    split_prize_curve,
+    tail_metrics,
+)
+
+DEFAULT_FRACTIONS = (0.01, 0.02, 0.05, 0.10, 0.20)
+_SYNTHETIC = re.compile(
+    r"^synthetic:(?P<rows>\d+)[xX](?P<cols>\d+)"
+    r"(?::(?P<noise>\d+(?:\.\d+)?(?:[eE][-+]?\d+)?))?$"
+)
+_LABEL = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _parse_synthetic(spec: str) -> tuple[int, int, float | None] | None:
+    match = _SYNTHETIC.fullmatch(spec)
+    if match is None:
+        return None
+    rows, cols = int(match.group("rows")), int(match.group("cols"))
+    if rows <= 0 or cols <= 0:
+        raise ValueError("synthetic dimensions must be positive")
+    noise = match.group("noise")
+    return rows, cols, None if noise is None else float(noise)
+
+
+def _single_tensor(payload: Any, *, source: str, key: str | None) -> torch.Tensor:
+    if isinstance(payload, torch.Tensor):
+        if key is not None:
+            raise ValueError(f"{source} is a bare tensor; ::{key} is invalid")
+        return payload
+    if isinstance(payload, dict):
+        tensors = {str(name): value for name, value in payload.items()
+                   if isinstance(value, torch.Tensor)}
+        if key is not None:
+            if key not in tensors:
+                raise KeyError(f"tensor {key!r} not found in {source}")
+            return tensors[key]
+        if len(tensors) == 1:
+            return next(iter(tensors.values()))
+        raise ValueError(
+            f"{source} contains {len(tensors)} tensors; select one with ::KEY"
+        )
+    raise TypeError(f"{source} did not contain a tensor")
+
+
+def _load_tensor(source: str) -> torch.Tensor:
+    path_text, separator, key = source.rpartition("::")
+    if not separator:
+        path_text, key = source, None
+    path = Path(path_text)
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    suffix = path.suffix.lower()
+    if suffix in {".pt", ".pth", ".pkl"}:
+        payload = torch.load(path, map_location="cpu", weights_only=True)
+    elif suffix == ".safetensors":
+        from safetensors.torch import load_file
+
+        payload = load_file(str(path), device="cpu")
+    else:
+        raise ValueError(
+            f"unsupported tensor file {path}; expected .pt or .safetensors"
+        )
+    return _single_tensor(payload, source=str(path), key=key).detach().cpu()
+
+
+def _load_base(source: str, *, seed: int) -> torch.Tensor:
+    synthetic = _parse_synthetic(source)
+    if synthetic is None:
+        return _load_tensor(source)
+    rows, cols, noise = synthetic
+    if noise is not None:
+        raise ValueError("noise scale is valid only for synthetic reconstructions")
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    return torch.randn(rows, cols, generator=generator, dtype=torch.float64)
+
+
+def _load_reconstruction(source: str, W: torch.Tensor) -> torch.Tensor:
+    synthetic = _parse_synthetic(source)
+    if synthetic is None:
+        return _load_tensor(source)
+    rows, cols, noise = synthetic
+    if (rows, cols) != tuple(W.shape):
+        raise ValueError(
+            f"synthetic reconstruction shape {(rows, cols)} != W {tuple(W.shape)}"
+        )
+    scale = 0.05 if noise is None else noise
+    if scale < 0:
+        raise ValueError("synthetic reconstruction noise must be non-negative")
+    # Every synthetic format uses the same perturbation direction.  Changing
+    # scale therefore gives a row-wise ordered pair suitable for smoke tests.
+    generator = torch.Generator(device="cpu").manual_seed(2)
+    perturbation = torch.randn(
+        W.shape, generator=generator, dtype=W.dtype, device="cpu"
+    )
+    return W + scale * perturbation
+
+
+def _labeled_source(value: str) -> tuple[str, str]:
+    label, separator, source = value.partition("=")
+    if not separator or not label or not source:
+        raise argparse.ArgumentTypeError(
+            f"expected LABEL=SOURCE for --quantized, got {value!r}"
+        )
+    if not _LABEL.fullmatch(label):
+        raise argparse.ArgumentTypeError(
+            f"format label {label!r} must match {_LABEL.pattern}"
+        )
+    return label, source
+
+
+def _label_float(value: str) -> tuple[str, float]:
+    label, separator, raw = value.partition("=")
+    if not separator or not _LABEL.fullmatch(label):
+        raise argparse.ArgumentTypeError(
+            f"expected LABEL=FLOAT for --bytes-per-row, got {value!r}"
+        )
+    try:
+        number = float(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+    if not np.isfinite(number) or number < 0:
+        raise argparse.ArgumentTypeError("bytes per row must be finite and non-negative")
+    return label, number
+
+
+def _fractions(value: str) -> list[float]:
+    try:
+        fractions = [float(item) for item in value.split(",") if item.strip()]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+    if not fractions or any(not 0.0 <= fraction <= 1.0 for fraction in fractions):
+        raise argparse.ArgumentTypeError("fractions must be a comma-separated list in [0, 1]")
+    return fractions
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--weights", required=True, help="W tensor path or synthetic:NxK")
+    parser.add_argument("--acts", required=True, help="X tensor path or synthetic:SxK")
+    parser.add_argument(
+        "--quantized", required=True, nargs="+", type=_labeled_source,
+        metavar="LABEL=SOURCE",
+        help="one or more reconstructed weights, each with a format label",
+    )
+    parser.add_argument(
+        "--bytes-per-row", action="append", default=[], type=_label_float,
+        metavar="LABEL=BYTES",
+        help=("serialized format cost per output row; defaults to the dense "
+              "reconstruction tensor's row bytes"),
+    )
+    parser.add_argument(
+        "--fractions", type=_fractions,
+        default=list(DEFAULT_FRACTIONS),
+        help="comma-separated routed-row fractions (default: 0.01,0.02,0.05,0.1,0.2)",
+    )
+    parser.add_argument("--out", required=True, type=Path, help="output directory")
+    return parser
+
+
+def _print_table(formats: dict[str, dict[str, Any]]) -> None:
+    header = (
+        f"{'format':<20} {'mean':>12} {'p99':>12} {'p99/p50':>12} "
+        f"{'CV':>10} {'Gini':>10} {'B/row':>12}"
+    )
+    print(header)
+    print("-" * len(header))
+    for label, record in formats.items():
+        metrics = record["tail_metrics"]
+        print(
+            f"{label:<20} {metrics['mean']:12.5g} {metrics['p99']:12.5g} "
+            f"{metrics['ratio_p99_over_p50']:12.5g} "
+            f"{metrics['coefficient_of_variation']:10.4f} "
+            f"{metrics['gini']:10.4f} {record['bytes_per_row']:12.3f}"
+        )
+
+
+def _json_safe(value: Any) -> Any:
+    """Replace non-finite floats with JSON ``null`` recursively."""
+    if isinstance(value, float) and not np.isfinite(value):
+        return None
+    if isinstance(value, dict):
+        return {key: _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    W = _load_base(args.weights, seed=0)
+    X = _load_base(args.acts, seed=1)
+    if W.ndim != 2 or X.ndim != 2 or X.shape[1] != W.shape[1]:
+        raise ValueError(
+            f"expected W [N,K] and X [S,K], got {tuple(W.shape)} and {tuple(X.shape)}"
+        )
+
+    byte_overrides = dict(args.bytes_per_row)
+    unknown_overrides = set(byte_overrides) - {label for label, _ in args.quantized}
+    if unknown_overrides:
+        raise ValueError(
+            "--bytes-per-row names absent from --quantized: "
+            + ", ".join(sorted(unknown_overrides))
+        )
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    errors: dict[str, torch.Tensor] = {}
+    format_records: dict[str, dict[str, Any]] = {}
+    for label, source in args.quantized:
+        if label in errors:
+            raise ValueError(f"duplicate format label {label!r}")
+        W_hat = _load_reconstruction(source, W)
+        if W_hat.shape != W.shape:
+            raise ValueError(
+                f"{label} reconstruction shape {tuple(W_hat.shape)} != W {tuple(W.shape)}"
+            )
+        W_hat = W_hat.to(dtype=W.dtype, device="cpu")
+        error = per_row_error(X, W, W_hat)
+        assert_error_decomposition(X, W, W_hat, error)
+        error_file = f"{label}_per_row_error.npy"
+        np.save(args.out / error_file, error.numpy())
+        bytes_per_row = byte_overrides.get(
+            label, float(W_hat[0].numel() * W_hat.element_size())
+        )
+        errors[label] = error
+        format_records[label] = {
+            "source": source,
+            "error_file": error_file,
+            "total_error": float(error.sum()),
+            "bytes_per_row": bytes_per_row,
+            "bytes_per_row_source": (
+                "cli_override" if label in byte_overrides else "dense_reconstruction"
+            ),
+            "tail_metrics": tail_metrics(error),
+        }
+
+    ordered_labels = sorted(errors, key=lambda label: (format_records[label]["bytes_per_row"], label))
+    prize_curves = []
+    for cheap_label, expensive_label in combinations(ordered_labels, 2):
+        prize_curves.append({
+            "cheap_format": cheap_label,
+            "expensive_format": expensive_label,
+            "curve": split_prize_curve(
+                errors[cheap_label],
+                errors[expensive_label],
+                format_records[cheap_label]["bytes_per_row"],
+                format_records[expensive_label]["bytes_per_row"],
+                args.fractions,
+            ),
+        })
+
+    summary = {
+        "schema": "prismaquant.row_dispersion.v1",
+        "inputs": {
+            "weights": args.weights,
+            "weights_shape": list(W.shape),
+            "acts": args.acts,
+            "acts_shape": list(X.shape),
+        },
+        "fractions": args.fractions,
+        "formats": format_records,
+        "prize_curves": prize_curves,
+    }
+    (args.out / "summary.json").write_text(
+        json.dumps(_json_safe(summary), indent=2, sort_keys=True, allow_nan=False)
+        + "\n",
+        encoding="utf-8",
+    )
+    _print_table(format_records)
+    if prize_curves:
+        violations = sum(
+            len(item["curve"]["violations"]) for item in prize_curves
+        )
+        print(f"\nprize curves: {len(prize_curves)}; row-wise violations: {violations}")
+    print(f"wrote {args.out / 'summary.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_row_dispersion.py
+++ b/tests/test_row_dispersion.py
@@ -1,0 +1,148 @@
+"""CPU-only tests for the tier-3 within-Linear row-dispersion pilot."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from prismaquant.row_dispersion import (
+    assert_error_decomposition,
+    per_row_error,
+    split_prize_curve,
+    tail_metrics,
+)
+
+
+@pytest.mark.parametrize(
+    ("samples", "rows", "columns"),
+    [(1, 3, 2), (5, 7, 11), (13, 9, 17), (4, 5, 7)],
+)
+def test_per_row_error_exactly_decomposes_full_output_error(
+    samples, rows, columns
+):
+    generator = torch.Generator().manual_seed(samples * rows * columns)
+    X = torch.randn(samples, columns, generator=generator, dtype=torch.float64)
+    W = torch.randn(rows, columns, generator=generator, dtype=torch.float64)
+    W_hat = W + 0.07 * torch.randn(
+        rows, columns, generator=generator, dtype=torch.float64
+    )
+
+    errors = per_row_error(X, W, W_hat)
+    full = (X @ (W - W_hat).T).square().sum()
+
+    assert errors.shape == (rows,)
+    assert errors.sum().item() == pytest.approx(full.item(), rel=1e-13, abs=1e-14)
+    assert_error_decomposition(X, W, W_hat, errors, rtol=1e-13, atol=1e-14)
+
+
+def test_tail_metrics_uniform_distribution_has_no_dispersion():
+    metrics = tail_metrics(torch.full((16,), 3.0))
+    assert metrics["p50"] == 3.0
+    assert metrics["p90"] == 3.0
+    assert metrics["p99"] == 3.0
+    assert metrics["ratio_p99_over_p50"] == 1.0
+    assert metrics["coefficient_of_variation"] == 0.0
+    assert metrics["gini"] == pytest.approx(0.0, abs=1e-15)
+
+
+def test_tail_metrics_single_spike_has_known_gini():
+    values = torch.tensor([0.0] * 7 + [8.0])
+    metrics = tail_metrics(values)
+    assert metrics["mean"] == 1.0
+    assert metrics["max"] == 8.0
+    assert metrics["gini"] == pytest.approx(7 / 8, abs=1e-15)
+    assert metrics["coefficient_of_variation"] == pytest.approx(7 ** 0.5)
+    assert metrics["ratio_p99_over_p50"] == float("inf")
+
+
+def test_tail_metrics_hand_computable_percentile_ratio():
+    # Linear interpolation: p50=1 and p99 lies 90% of the way from 1 to 11.
+    values = [1.0] * 9 + [11.0]
+    metrics = tail_metrics(values)
+    assert metrics["p50"] == 1.0
+    assert metrics["p90"] == pytest.approx(2.0)
+    assert metrics["p99"] == pytest.approx(10.1)
+    assert metrics["ratio_p99_over_p50"] == pytest.approx(10.1)
+
+
+def test_prize_curve_is_monotone_and_accounts_for_bytes_and_endpoints():
+    cheap = torch.tensor([10.0, 8.0, 6.0, 4.0])
+    expensive = torch.tensor([5.0, 4.0, 3.0, 2.0])
+    curve = split_prize_curve(cheap, expensive, 2.0, 5.0, [0, 0.25, 0.5, 1])
+
+    assert curve["rowwise_better"] is True
+    assert curve["monotone_non_increasing"] is True
+    assert curve["violations"] == []
+    assert [point["total_error"] for point in curve["points"]] == [28, 23, 19, 14]
+    assert [point["total_bytes"] for point in curve["points"]] == [8, 11, 14, 20]
+
+    references = curve["uniform_references"]
+    assert references["cheap_everywhere"]["total_error"] == float(cheap.sum())
+    assert references["cheap_everywhere"]["total_bytes"] == 8.0
+    assert references["expensive_everywhere"]["total_error"] == float(
+        expensive.sum()
+    )
+    assert references["expensive_everywhere"]["total_bytes"] == 20.0
+
+
+def test_prize_curve_surfaces_rows_where_expensive_is_worse():
+    curve = split_prize_curve(
+        [3.0, 2.0, 1.0], [2.0, 4.0, 0.5], 10.0, 20.0, [0, 1 / 3, 1]
+    )
+    assert curve["rowwise_better"] is False
+    assert curve["violations"] == [{
+        "row": 1,
+        "cheap_error": 2.0,
+        "expensive_error": 4.0,
+        "excess_error": 2.0,
+    }]
+    # The endpoint is the measured expensive total, including the regression;
+    # no clamp silently replaces it with the cheap value.
+    assert curve["uniform_references"]["expensive_everywhere"]["total_error"] == 6.5
+
+
+def test_cli_smoke_writes_vectors_and_summary(tmp_path):
+    root = Path(__file__).resolve().parents[1]
+    out = tmp_path / "row-dispersion"
+    env = dict(os.environ, CUDA_VISIBLE_DEVICES="", PYTHONPATH=str(root))
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(root / "scripts" / "tier3_row_dispersion_pilot.py"),
+            "--weights", "synthetic:7x5",
+            "--acts", "synthetic:11x5",
+            "--quantized",
+            "cheap=synthetic:7x5:0.20",
+            "expensive=synthetic:7x5:0.05",
+            "--bytes-per-row", "cheap=10",
+            "--bytes-per-row", "expensive=20",
+            "--fractions", "0,0.25,1",
+            "--out", str(out),
+        ],
+        cwd=root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "format" in completed.stdout
+    assert "prize curves: 1" in completed.stdout
+
+    cheap = np.load(out / "cheap_per_row_error.npy")
+    expensive = np.load(out / "expensive_per_row_error.npy")
+    assert cheap.shape == expensive.shape == (7,)
+    assert np.all(expensive <= cheap)
+
+    summary = json.loads((out / "summary.json").read_text(encoding="utf-8"))
+    assert summary["schema"] == "prismaquant.row_dispersion.v1"
+    assert summary["inputs"]["weights_shape"] == [7, 5]
+    assert set(summary["formats"]) == {"cheap", "expensive"}
+    assert summary["prize_curves"][0]["curve"]["rowwise_better"] is True
+    assert summary["prize_curves"][0]["curve"]["violations"] == []


### PR DESCRIPTION
Research measurement tooling for the tier-3 within-Linear row-splitting question: **is a Linear's quantization error concentrated in a minority of output rows, enough that splitting one Linear across two formats would pay?**

## Deliberately dependency-free

`prismaquant/row_dispersion.py` has **no cache, model-loading, or serving dependency**. A caller hands it one activation matrix and two versions of one Linear weight; it returns per-row error dispersion. That isolation is what makes it safe to add mid-wave — it cannot perturb the exporter, allocator, or cost paths that the rest of this queue touches.

Measurement dtype is promoted only as far as the inputs require, so a float32 pair is not needlessly widened, and non-floating inputs are rejected rather than silently coerced.

## The pilot driver

`scripts/tier3_row_dispersion_pilot.py` is CPU-only and runs without a checkpoint: `LABEL=PATH` sources accept single-tensor `.pt`/`.safetensors` (with `::tensor_key` for multi-tensor files), and `synthetic:ROWSxCOLS` specs generate deterministic reconstructions so the pilot is reproducible without any artifact on disk. Per-format `--bytes-per-row` is supplied explicitly, so the cost side of the trade is an input rather than an assumption baked into the tool.

## Tests

10 tests (`tests/test_row_dispersion.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUHqNEHMu7FAJQSNGCZhqW