### PR TITLE
Fix hybrid linear-attention masking in layer streaming for Qwen3.5/3.6 on transformers >= 5.15

### DIFF
--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -2032,7 +2032,14 @@ def _compute_attention_mask(
     # helper), so both route through _recurrent_padding_mask here.
     has_linear = "linear_attention" in layer_types
     has_conv = "conv" in layer_types
-    if cfg is None or not (has_sliding or has_linear or has_conv):
+    # A schedule declaring non-attention blocks needs the per-type dict
+    # path even without linear/sliding/conv layers — otherwise the single
+    # dense mask from the early return below would be fed to moe/mlp
+    # blocks too.
+    has_nonattn = any(lt in _NON_ATTENTION_BLOCK_TYPES
+                      for lt in layer_types)
+    if cfg is None or not (has_sliding or has_linear or has_conv
+                           or has_nonattn):
         return _make_causal_mask(hidden.size(1), hidden.device, hidden.dtype)
 
     try:

--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -1746,11 +1746,11 @@ def _embed_prefix(base_model: nn.Module, full_path: str) -> str:
 
 
 def _layer_attention_type(layer: nn.Module):
-    # `.block_type` is the transformers>=5.15 name for what `.layer_type`
-    # was before the linear-attn refactor (huggingface/transformers#47630);
-    # `.linear_attn` is the recurrent child module on Qwen3.5/3.6 DeltaNet
-    # hybrid layers, which carries its own `layer_type`/`layer_idx` (the
-    # outer layer has no `self_attn`/`attention` on those layers).
+    # `.block_type` is the transformers>=5.13 name for what `.layer_type`
+    # was on hybrid decoder layers up to 5.12; `.linear_attn` is the
+    # recurrent child module on Qwen3.5/3.6 DeltaNet hybrid layers, which
+    # carries its own `layer_type`/`layer_idx` (the outer layer has no
+    # `self_attn`/`attention` on those layers).
     lt = (
         getattr(layer, "layer_type", None)
         or getattr(layer, "block_type", None)
@@ -1934,11 +1934,20 @@ def _make_causal_mask(seqlen: int, device: torch.device, dtype: torch.dtype):
 
 def _recurrent_padding_mask(inputs_embeds: torch.Tensor,
                             attention_mask: torch.Tensor | None):
-    """Fallback for ``masking_utils.create_recurrent_attention_mask`` on
-    transformers versions that predate it (< 5.14).
+    """Recurrent-mask contract for linear-attention/conv hybrid layers.
 
-    Mirrors the upstream helper's observable contract exactly (source:
-    transformers v5.15.0 ``masking_utils.create_recurrent_attention_mask``):
+    Used on EVERY transformers version (deliberately not delegating to
+    ``masking_utils.create_recurrent_attention_mask``): the upstream helper
+    first appears in transformers 5.13, but 5.13.0-5.14.1 ship it with the
+    pre-fix contract — it returns ``None`` whenever
+    ``past_key_values.has_previous_state()``, including a padded multi-token
+    cached continuation (silently corrupting the recurrent state), and has
+    no single-token special case. Only 5.15/current trims-and-keeps the 2D
+    mask for a padded continuation. Helper *presence* is therefore not a
+    usable compatibility gate; implementing the current contract locally is.
+
+    Mirrors the current upstream contract exactly (source: transformers
+    v5.15.0 ``masking_utils.create_recurrent_attention_mask``):
 
     - ``None`` when the incoming mask is missing or not a 2D padding mask
       (a custom 4D mask carries no padding signal for the recurrence);
@@ -1965,18 +1974,14 @@ def _recurrent_padding_mask(inputs_embeds: torch.Tensor,
     return attention_mask[:, -inputs_embeds.shape[1]:].contiguous()
 
 
-def _linear_attention_mask(mask_kwargs: dict, hidden: torch.Tensor,
-                           attention_mask: torch.Tensor | None):
-    """Recurrent-mask contract for ``linear_attention`` layers: the upstream
-    ``create_recurrent_attention_mask`` when the installed transformers ships
-    it (>= 5.14), else the contract-identical ``_recurrent_padding_mask``."""
-    try:
-        from transformers.masking_utils import (
-            create_recurrent_attention_mask,
-        )
-    except ImportError:
-        return _recurrent_padding_mask(hidden, attention_mask)
-    return create_recurrent_attention_mask(**mask_kwargs)
+# Block types a hybrid schedule may declare that consume NO attention mask
+# at all (pure feed-forward blocks). Upstream dispatches masks via
+# ``causal_mask_mapping.get(block_type)``, so these receive ``None`` — e.g.
+# Nemotron-H declares ["linear_attention", "moe", "full_attention", "mlp"].
+# Deliberately an explicit allowlist rather than a "not *_attention"
+# heuristic: anything NOT listed here and not buildable stays absent from
+# the mask dict and fails closed in ``_call_layer``. Extend per family.
+_NON_ATTENTION_BLOCK_TYPES = frozenset({"moe", "mlp"})
 
 
 def _compute_attention_mask(
@@ -1998,21 +2003,22 @@ def _compute_attention_mask(
     - ``linear_attention`` (Qwen3.5/Qwen3.6 DeltaNet-style recurrent
       hybrids) — NOT a variant of causal attention at all. The recurrence
       is already causal by construction; what the layer needs is the
-      recurrent-mask contract of HuggingFace's
-      ``masking_utils.create_recurrent_attention_mask``: a 2D
+      recurrent-mask contract of current HuggingFace
+      ``masking_utils.create_recurrent_attention_mask`` (>= 5.15): a 2D
       ``[batch, local_seq]`` padding mask trimmed to the current forward's
       sequence, or ``None`` whenever masking would be a no-op (non-2D
-      input, single-token decode, all-ones batch). We call the upstream
-      helper when the installed transformers ships it (>= 5.14) and
-      otherwise apply ``_recurrent_padding_mask``, a fallback with the
-      same observable contract, so PrismaQuant's locked transformers 5.8
-      environment behaves identically. Feeding these layers the dense
-      ``[1, 1, T, T]`` causal mask instead — the bug this branch fixes —
-      broadcasts wrongly against ``hidden_states`` inside
-      ``apply_mask_to_padding_states`` and raises a tensor-size mismatch
-      on the last dim (hidden_size vs. seqlen); an un-trimmed growing
-      cache-continuation mask can mismatch the same way, which is why the
-      raw incoming mask is not passed through either.
+      input, single-token decode, all-ones batch). We always apply the
+      local ``_recurrent_padding_mask`` shim implementing that contract —
+      see its docstring for why the upstream helper is not called even
+      when present (5.13/5.14 ship it with the broken pre-fix contract).
+      Feeding these layers the dense ``[1, 1, T, T]`` causal mask instead
+      — the bug this branch fixes — broadcasts wrongly against
+      ``hidden_states`` inside ``apply_mask_to_padding_states`` and, on
+      transformers >= 5.15 (which removed the padding-mask shape guard),
+      raises a tensor-size mismatch on the last dim (hidden_size vs.
+      seqlen); an un-trimmed growing cache-continuation mask can mismatch
+      the same way, which is why the raw incoming mask is not passed
+      through either.
 
     Both hybrid kinds return the same ``{layer_type: mask}`` mapping shape;
     ``_call_layer`` selects the right entry per layer via its
@@ -2021,8 +2027,12 @@ def _compute_attention_mask(
     cfg = getattr(base_model, "config", None)
     layer_types = tuple(getattr(cfg, "layer_types", ()) or ())
     has_sliding = "sliding_attention" in layer_types
+    # "conv" shares the recurrent-mask contract upstream
+    # (LAYER_PATTERN_TO_MASK_FUNCTION_MAPPING maps both to the recurrent
+    # helper), so both route through _recurrent_padding_mask here.
     has_linear = "linear_attention" in layer_types
-    if cfg is None or not (has_sliding or has_linear):
+    has_conv = "conv" in layer_types
+    if cfg is None or not (has_sliding or has_linear or has_conv):
         return _make_causal_mask(hidden.size(1), hidden.device, hidden.dtype)
 
     try:
@@ -2080,13 +2090,23 @@ def _compute_attention_mask(
             if lt in layer_types and lt not in masks:
                 masks[lt] = masks["sliding_attention"]
 
-    if has_linear:
-        # DeltaNet/Mamba-style linear-attention layers must never receive
-        # a dense additive mask — route them through the recurrent-mask
-        # contract instead (see docstring).
-        masks["linear_attention"] = _linear_attention_mask(
-            mask_kwargs, hidden, attention_mask
-        )
+    if has_linear or has_conv:
+        # DeltaNet/Mamba-style recurrent layers must never receive a dense
+        # additive mask — route them through the recurrent-mask contract
+        # (see _recurrent_padding_mask on why this is always the local
+        # shim, never the upstream helper).
+        recurrent = _recurrent_padding_mask(hidden, attention_mask)
+        if has_linear:
+            masks["linear_attention"] = recurrent
+        if has_conv:
+            masks["conv"] = recurrent
+
+    # Declared non-attention blocks (moe/mlp) receive None, mirroring
+    # upstream's `.get(block_type)` dispatch. Any OTHER declared type we
+    # cannot build stays absent and fails closed in _call_layer.
+    for lt in layer_types:
+        if lt in _NON_ATTENTION_BLOCK_TYPES and lt not in masks:
+            masks[lt] = None
 
     return masks
 

--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -1746,11 +1746,17 @@ def _embed_prefix(base_model: nn.Module, full_path: str) -> str:
 
 
 def _layer_attention_type(layer: nn.Module):
+    # `.block_type` is the transformers>=5.15 name for what `.layer_type`
+    # was before the linear-attn refactor (huggingface/transformers#47630);
+    # `.linear_attn` is the recurrent child module on Qwen3.5/3.6 DeltaNet
+    # hybrid layers, which carries its own `layer_type`/`layer_idx` (the
+    # outer layer has no `self_attn`/`attention` on those layers).
     lt = (
         getattr(layer, "layer_type", None)
         or getattr(layer, "block_type", None)
         or getattr(getattr(layer, "self_attn", None), "layer_type", None)
         or getattr(getattr(layer, "attention", None), "layer_type", None)
+        or getattr(getattr(layer, "linear_attn", None), "layer_type", None)
     )
     if lt is not None:
         return lt
@@ -1764,7 +1770,7 @@ def _layer_attention_type(layer: nn.Module):
     # Generic fallback: config.layer_types[layer_idx] when both exist.
     idx = getattr(layer, "layer_idx", None)
     if idx is None:
-        for attn_name in ("self_attn", "attention"):
+        for attn_name in ("self_attn", "attention", "linear_attn"):
             idx = getattr(getattr(layer, attn_name, None), "layer_idx", None)
             if idx is not None:
                 break
@@ -1773,18 +1779,8 @@ def _layer_attention_type(layer: nn.Module):
     lts = getattr(cfg, "layer_types", None) if cfg is not None else None
     if idx is not None and lts is not None and 0 <= int(idx) < len(lts):
         return lts[int(idx)]
-    # Qwen3.5/Qwen3.6 DeltaNet convention (transformers>=5.15.0): the
-    # decoder layer exposes no `layer_type`/`block_type`-driven idx match
-    # reachable above for its recurrent layers (no `self_attn`/`attention`
-    # at all on those layers, so the idx-fallback above can't fire either).
-    # Detect structurally instead: `.linear_attn` present -> recurrent
-    # (Qwen3_5GatedDeltaNet); `.self_attn`/`.attention` present -> dense.
-    # Unambiguous for this family; does not change resolution for any
-    # model that doesn't expose `.linear_attn`.
-    if hasattr(layer, "linear_attn"):
-        return "linear_attention"
-    if hasattr(layer, "self_attn") or hasattr(layer, "attention"):
-        return "full_attention"
+    # No guessing beyond this point: an unresolved layer type stays None so
+    # `_call_layer` fails closed instead of silently assuming semantics.
     return None
 
 
@@ -1936,6 +1932,53 @@ def _make_causal_mask(seqlen: int, device: torch.device, dtype: torch.dtype):
     return mask.unsqueeze(0).unsqueeze(0)
 
 
+def _recurrent_padding_mask(inputs_embeds: torch.Tensor,
+                            attention_mask: torch.Tensor | None):
+    """Fallback for ``masking_utils.create_recurrent_attention_mask`` on
+    transformers versions that predate it (< 5.14).
+
+    Mirrors the upstream helper's observable contract exactly (source:
+    transformers v5.15.0 ``masking_utils.create_recurrent_attention_mask``):
+
+    - ``None`` when the incoming mask is missing or not a 2D padding mask
+      (a custom 4D mask carries no padding signal for the recurrence);
+    - ``None`` for a single-token decode step (a generated token is never
+      padding);
+    - ``None`` for an all-ones mask (un-padded batch — the masking multiply
+      would be a no-op), skipped only outside trace/compile;
+    - otherwise the mask trimmed to the trailing ``inputs_embeds.shape[1]``
+      positions — so a growing cache-continuation mask aligns with the
+      current forward's local sequence — made contiguous.
+    """
+    if attention_mask is None or attention_mask.ndim != 2:
+        return None
+    if inputs_embeds.shape[1] == 1:
+        return None
+    try:
+        from transformers.masking_utils import is_tracing
+        tracing = is_tracing(attention_mask)
+    except Exception:
+        tracing = torch.jit.is_tracing() or isinstance(
+            attention_mask, torch.fx.Proxy)
+    if not tracing and torch.all(attention_mask == 1):
+        return None
+    return attention_mask[:, -inputs_embeds.shape[1]:].contiguous()
+
+
+def _linear_attention_mask(mask_kwargs: dict, hidden: torch.Tensor,
+                           attention_mask: torch.Tensor | None):
+    """Recurrent-mask contract for ``linear_attention`` layers: the upstream
+    ``create_recurrent_attention_mask`` when the installed transformers ships
+    it (>= 5.14), else the contract-identical ``_recurrent_padding_mask``."""
+    try:
+        from transformers.masking_utils import (
+            create_recurrent_attention_mask,
+        )
+    except ImportError:
+        return _recurrent_padding_mask(hidden, attention_mask)
+    return create_recurrent_attention_mask(**mask_kwargs)
+
+
 def _compute_attention_mask(
     base_model: nn.Module,
     hidden: torch.Tensor,
@@ -1954,18 +1997,22 @@ def _compute_attention_mask(
       ``full_attention``'s ``create_causal_mask``, just windowed.
     - ``linear_attention`` (Qwen3.5/Qwen3.6 DeltaNet-style recurrent
       hybrids) — NOT a variant of causal attention at all. The recurrence
-      is already causal by construction, so the "mask" HuggingFace's
-      ``apply_mask_to_padding_states()`` wants is the RAW 2D
-      ``[batch, seq_len]`` padding mask (or ``None`` for an unpadded
-      batch), used only to zero padding positions before the scan. This
-      mirrors ``Qwen3_5TextModel._update_linear_attn_mask()`` (minus its
-      cache-position/all-ones fast path — a pure no-op already subsumed by
-      ``apply_mask_to_padding_states``'s own ``shape[0] > 1 and
-      shape[1] > 1`` guard). Feeding it the dense ``[1, 1, T, T]`` causal
-      mask instead — the bug this branch fixes — broadcasts wrongly
-      against ``hidden_states`` inside ``apply_mask_to_padding_states``
-      (``hidden_states * attention_mask[:, :, None]``) and raises a
-      tensor-size mismatch on the last dim (hidden_size vs. seqlen).
+      is already causal by construction; what the layer needs is the
+      recurrent-mask contract of HuggingFace's
+      ``masking_utils.create_recurrent_attention_mask``: a 2D
+      ``[batch, local_seq]`` padding mask trimmed to the current forward's
+      sequence, or ``None`` whenever masking would be a no-op (non-2D
+      input, single-token decode, all-ones batch). We call the upstream
+      helper when the installed transformers ships it (>= 5.14) and
+      otherwise apply ``_recurrent_padding_mask``, a fallback with the
+      same observable contract, so PrismaQuant's locked transformers 5.8
+      environment behaves identically. Feeding these layers the dense
+      ``[1, 1, T, T]`` causal mask instead — the bug this branch fixes —
+      broadcasts wrongly against ``hidden_states`` inside
+      ``apply_mask_to_padding_states`` and raises a tensor-size mismatch
+      on the last dim (hidden_size vs. seqlen); an un-trimmed growing
+      cache-continuation mask can mismatch the same way, which is why the
+      raw incoming mask is not passed through either.
 
     Both hybrid kinds return the same ``{layer_type: mask}`` mapping shape;
     ``_call_layer`` selects the right entry per layer via its
@@ -2034,13 +2081,12 @@ def _compute_attention_mask(
                 masks[lt] = masks["sliding_attention"]
 
     if has_linear:
-        # DeltaNet/Mamba-style linear-attention layers: pass the raw
-        # incoming padding mask through untouched (see docstring). This is
-        # deliberately *not* `_make_causal_mask(...)` — linear-attention
-        # layers must never receive a dense additive mask, only the 2D
-        # padding mask (or None) that `apply_mask_to_padding_states`
-        # expects.
-        masks["linear_attention"] = attention_mask
+        # DeltaNet/Mamba-style linear-attention layers must never receive
+        # a dense additive mask — route them through the recurrent-mask
+        # contract instead (see docstring).
+        masks["linear_attention"] = _linear_attention_mask(
+            mask_kwargs, hidden, attention_mask
+        )
 
     return masks
 

--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -1748,6 +1748,7 @@ def _embed_prefix(base_model: nn.Module, full_path: str) -> str:
 def _layer_attention_type(layer: nn.Module):
     lt = (
         getattr(layer, "layer_type", None)
+        or getattr(layer, "block_type", None)
         or getattr(getattr(layer, "self_attn", None), "layer_type", None)
         or getattr(getattr(layer, "attention", None), "layer_type", None)
     )
@@ -1772,6 +1773,18 @@ def _layer_attention_type(layer: nn.Module):
     lts = getattr(cfg, "layer_types", None) if cfg is not None else None
     if idx is not None and lts is not None and 0 <= int(idx) < len(lts):
         return lts[int(idx)]
+    # Qwen3.5/Qwen3.6 DeltaNet convention (transformers>=5.15.0): the
+    # decoder layer exposes no `layer_type`/`block_type`-driven idx match
+    # reachable above for its recurrent layers (no `self_attn`/`attention`
+    # at all on those layers, so the idx-fallback above can't fire either).
+    # Detect structurally instead: `.linear_attn` present -> recurrent
+    # (Qwen3_5GatedDeltaNet); `.self_attn`/`.attention` present -> dense.
+    # Unambiguous for this family; does not change resolution for any
+    # model that doesn't expose `.linear_attn`.
+    if hasattr(layer, "linear_attn"):
+        return "linear_attention"
+    if hasattr(layer, "self_attn") or hasattr(layer, "attention"):
+        return "full_attention"
     return None
 
 
@@ -1932,14 +1945,37 @@ def _compute_attention_mask(
 ):
     """Return the streaming attention mask for a full forward pass.
 
-    Most models use one full causal mask. Gemma3/Gemma4-style hybrid models
-    declare ``config.layer_types`` with both ``full_attention`` and
-    ``sliding_attention``; those must receive the same per-type mask mapping
-    that HuggingFace's model.forward builds.
+    Most models use one full causal mask. Hybrid models declare
+    ``config.layer_types`` mixing ``full_attention`` with one of:
+
+    - ``sliding_attention`` (Gemma3/Gemma4-style windowed attention) — needs
+      the dense additive mask from HuggingFace's own ``masking_utils``
+      (``create_sliding_window_causal_mask``), same family as
+      ``full_attention``'s ``create_causal_mask``, just windowed.
+    - ``linear_attention`` (Qwen3.5/Qwen3.6 DeltaNet-style recurrent
+      hybrids) — NOT a variant of causal attention at all. The recurrence
+      is already causal by construction, so the "mask" HuggingFace's
+      ``apply_mask_to_padding_states()`` wants is the RAW 2D
+      ``[batch, seq_len]`` padding mask (or ``None`` for an unpadded
+      batch), used only to zero padding positions before the scan. This
+      mirrors ``Qwen3_5TextModel._update_linear_attn_mask()`` (minus its
+      cache-position/all-ones fast path — a pure no-op already subsumed by
+      ``apply_mask_to_padding_states``'s own ``shape[0] > 1 and
+      shape[1] > 1`` guard). Feeding it the dense ``[1, 1, T, T]`` causal
+      mask instead — the bug this branch fixes — broadcasts wrongly
+      against ``hidden_states`` inside ``apply_mask_to_padding_states``
+      (``hidden_states * attention_mask[:, :, None]``) and raises a
+      tensor-size mismatch on the last dim (hidden_size vs. seqlen).
+
+    Both hybrid kinds return the same ``{layer_type: mask}`` mapping shape;
+    ``_call_layer`` selects the right entry per layer via its
+    ``layer.layer_type``.
     """
     cfg = getattr(base_model, "config", None)
     layer_types = tuple(getattr(cfg, "layer_types", ()) or ())
-    if cfg is None or "sliding_attention" not in layer_types:
+    has_sliding = "sliding_attention" in layer_types
+    has_linear = "linear_attention" in layer_types
+    if cfg is None or not (has_sliding or has_linear):
         return _make_causal_mask(hidden.size(1), hidden.device, hidden.dtype)
 
     try:
@@ -1949,7 +1985,8 @@ def _compute_attention_mask(
         )
     except Exception as exc:
         raise RuntimeError(
-            "sliding-window layer_types require transformers masking_utils"
+            "sliding-window/linear-attention layer_types require "
+            "transformers masking_utils"
         ) from exc
 
     mask_kwargs = {
@@ -1960,7 +1997,7 @@ def _compute_attention_mask(
         "position_ids": position_ids,
     }
     sliding_mask_kwargs = dict(mask_kwargs)
-    if getattr(cfg, "use_bidirectional_attention", False):
+    if has_sliding and getattr(cfg, "use_bidirectional_attention", False):
         try:
             from transformers.models.gemma3.modeling_gemma3 import (
                 _bidirectional_window_overlay,
@@ -1977,23 +2014,34 @@ def _compute_attention_mask(
             cfg.sliding_window
         )
 
-    masks = {
-        "full_attention": create_causal_mask(**mask_kwargs),
-        "sliding_attention": create_sliding_window_causal_mask(
+    masks = {"full_attention": create_causal_mask(**mask_kwargs)}
+
+    if has_sliding:
+        masks["sliding_attention"] = create_sliding_window_causal_mask(
             **sliding_mask_kwargs
-        ),
-    }
-    # DSv4-Flash: the compress-ratio ladder yields layer types beyond the
-    # Gemma pair — compressed_sparse_attention (ratio 4) and
-    # heavily_compressed_attention (ratio 128). In probe mode every
-    # compressed variant degrades to sliding-window-only attention (the
-    # vendored layer stubs out the compressor and skips the long-range
-    # branch), and the vendored root feeds one sliding-window mask to all
-    # layers. Alias exactly those two types to the sliding mask; any
-    # other unknown layer type still fails loudly downstream.
-    for lt in ("compressed_sparse_attention", "heavily_compressed_attention"):
-        if lt in layer_types and lt not in masks:
-            masks[lt] = masks["sliding_attention"]
+        )
+        # DSv4-Flash: the compress-ratio ladder yields layer types beyond
+        # the Gemma pair — compressed_sparse_attention (ratio 4) and
+        # heavily_compressed_attention (ratio 128). In probe mode every
+        # compressed variant degrades to sliding-window-only attention
+        # (the vendored layer stubs out the compressor and skips the
+        # long-range branch), and the vendored root feeds one
+        # sliding-window mask to all layers. Alias exactly those two types
+        # to the sliding mask; any other unknown layer type still fails
+        # loudly downstream.
+        for lt in ("compressed_sparse_attention", "heavily_compressed_attention"):
+            if lt in layer_types and lt not in masks:
+                masks[lt] = masks["sliding_attention"]
+
+    if has_linear:
+        # DeltaNet/Mamba-style linear-attention layers: pass the raw
+        # incoming padding mask through untouched (see docstring). This is
+        # deliberately *not* `_make_causal_mask(...)` — linear-attention
+        # layers must never receive a dense additive mask, only the 2D
+        # padding mask (or None) that `apply_mask_to_padding_states`
+        # expects.
+        masks["linear_attention"] = attention_mask
+
     return masks
 
 

--- a/tests/test_linear_attention_mask_routing.py
+++ b/tests/test_linear_attention_mask_routing.py
@@ -295,3 +295,30 @@ def test_mixed_schedule_non_attention_blocks_get_none():
     with pytest.raises(RuntimeError, match="known layer_type"):
         _call_layer(unknown, hidden, position_embeddings=None,
                     attention_mask=masks2, position_ids=position_ids)
+
+
+def test_nonattention_schedule_without_recurrent_layers_takes_dict_path():
+    # Self-found adjacent gap: a schedule declaring moe/mlp WITHOUT any
+    # linear/sliding/conv layer must still take the per-type dict path —
+    # the single-dense-mask early return would otherwise feed the dense
+    # mask to the non-attention blocks too.
+    cfg = PreTrainedConfig()
+    cfg.is_causal = True
+    cfg.layer_types = ["full_attention", "moe", "mlp"]
+    cfg._attn_implementation = "eager"
+    hidden = torch.zeros(1, 4, 8)
+    position_ids = torch.arange(4).unsqueeze(0)
+
+    masks = _compute_attention_mask(_Base(cfg), hidden, position_ids)
+
+    assert isinstance(masks, dict)
+    assert masks["moe"] is None and masks["mlp"] is None
+    assert masks["full_attention"].shape == (1, 1, 4, 4)
+
+    # non-regression: a plain all-full schedule keeps the bare dense mask
+    cfg2 = PreTrainedConfig()
+    cfg2.is_causal = True
+    cfg2.layer_types = ["full_attention", "full_attention"]
+    cfg2._attn_implementation = "eager"
+    bare = _compute_attention_mask(_Base(cfg2), hidden, position_ids)
+    assert not isinstance(bare, dict) and bare.shape == (1, 1, 4, 4)

--- a/tests/test_linear_attention_mask_routing.py
+++ b/tests/test_linear_attention_mask_routing.py
@@ -1,0 +1,224 @@
+"""Linear-attention (recurrent) hybrid masking and layer-type resolution.
+
+Pins the PR #80 review contract. Two halves:
+
+- `linear_attention` layers are routed through transformers'
+  recurrent-mask contract (`masking_utils.create_recurrent_attention_mask`
+  when the installed transformers ships it, the contract-identical
+  `_recurrent_padding_mask` fallback on the locked transformers 5.8):
+  2D padding mask trimmed to the local sequence, `None` whenever masking
+  would be a no-op — never the dense additive causal mask, never the raw
+  un-trimmed growing mask.
+- layer-type resolution covers the transformers>=5.15 `.block_type` rename
+  and the Qwen3.5/3.6 `linear_attn` child module through the existing
+  attribute/index/config lookups, and an otherwise unknown layer still
+  fails closed instead of being guessed structurally.
+
+No transformers modeling dependency — fakes only, same as
+test_multilayer_rope_forward.py.
+"""
+import pytest
+import torch
+import torch.nn as nn
+from transformers import PreTrainedConfig
+
+from prismaquant.layer_streaming import (
+    _call_layer,
+    _compute_attention_mask,
+    _layer_attention_type,
+    _linear_attention_mask,
+)
+
+
+# --- fakes -----------------------------------------------------------------
+class _Base(nn.Module):
+    def __init__(self, config=None):
+        super().__init__()
+        self.config = config
+
+
+class _RecorderLayer(nn.Module):
+    """Records the attention_mask it actually received."""
+    def __init__(self, *, block_type=None, layer_type=None):
+        super().__init__()
+        if block_type is not None:
+            self.block_type = block_type
+        if layer_type is not None:
+            self.layer_type = layer_type
+        self.received_mask = "UNSET"
+
+    def forward(self, *, hidden_states, **kw):
+        self.received_mask = kw.get("attention_mask")
+        return hidden_states
+
+
+def _hybrid_cfg():
+    cfg = PreTrainedConfig()
+    cfg.is_causal = True
+    cfg.layer_types = ["full_attention", "linear_attention"]
+    cfg._attn_implementation = "eager"
+    return cfg
+
+
+def _mask_kwargs(cfg, hidden, pad, position_ids=None):
+    return {
+        "config": cfg,
+        "inputs_embeds": hidden,
+        "attention_mask": pad,
+        "past_key_values": None,
+        "position_ids": position_ids,
+    }
+
+
+# --- layer-type resolution -------------------------------------------------
+@pytest.mark.parametrize("lt", ["linear_attention", "full_attention"])
+def test_block_type_resolves(lt):
+    # transformers>=5.15: Qwen3_5DecoderLayer stores `.block_type`
+    layer = nn.Module()
+    layer.block_type = lt
+    assert _layer_attention_type(layer) == lt
+
+
+@pytest.mark.parametrize("lt", ["linear_attention", "sliding_attention"])
+def test_legacy_layer_type_still_resolves(lt):
+    # transformers<5.15 name — must keep working unchanged
+    layer = nn.Module()
+    layer.layer_type = lt
+    assert _layer_attention_type(layer) == lt
+
+
+def test_linear_attn_child_layer_type_resolves():
+    # Qwen3_5GatedDeltaNet carries its own `layer_type`; the outer layer
+    # exposes neither layer_type/block_type nor self_attn/attention.
+    layer = nn.Module()
+    layer.linear_attn = nn.Module()
+    layer.linear_attn.layer_type = "linear_attention"
+    assert _layer_attention_type(layer) == "linear_attention"
+
+
+def test_linear_attn_child_layer_idx_config_resolves():
+    # ...and its `layer_idx` feeds the generic config.layer_types fallback.
+    layer = nn.Module()
+    layer.linear_attn = nn.Module()
+    layer.linear_attn.layer_idx = 1
+    layer.config = _hybrid_cfg()
+    assert _layer_attention_type(layer) == "linear_attention"
+
+
+def test_unknown_self_attn_layer_fails_closed():
+    # A layer whose type cannot be resolved must stay unresolved (None) and
+    # make _call_layer raise — never silently assume full_attention.
+    layer = _RecorderLayer()
+    layer.self_attn = nn.Module()
+    assert _layer_attention_type(layer) is None
+    with pytest.raises(RuntimeError, match="known layer_type"):
+        _call_layer(layer, torch.zeros(1, 2, 4),
+                    position_embeddings=None,
+                    attention_mask={"full_attention": None},
+                    position_ids=None)
+
+
+# --- recurrent-mask contract (direct) --------------------------------------
+def test_continuation_mask_trims_to_local_sequence():
+    cfg = _hybrid_cfg()
+    hidden = torch.zeros(2, 4, 8)
+    # growing cache-continuation mask: 6 total positions, local seq is 4
+    pad = torch.tensor([[1, 1, 0, 1, 1, 1],
+                        [0, 0, 1, 1, 1, 1]])
+    out = _linear_attention_mask(_mask_kwargs(cfg, hidden, pad), hidden, pad)
+    assert out.shape == (2, 4)
+    assert torch.equal(out, pad[:, -4:])
+    assert out.is_contiguous()
+
+
+def test_single_token_decode_returns_none():
+    cfg = _hybrid_cfg()
+    hidden = torch.zeros(1, 1, 8)
+    # decode step continuing a cached, left-padded prompt: not all-ones,
+    # longer than the local sequence — None purely because local seq == 1
+    pad = torch.tensor([[0, 1, 1, 1, 1, 1]])
+    assert _linear_attention_mask(
+        _mask_kwargs(cfg, hidden, pad), hidden, pad) is None
+
+
+def test_non_2d_mask_returns_none():
+    cfg = _hybrid_cfg()
+    hidden = torch.zeros(1, 4, 8)
+    pad4d = torch.zeros(1, 1, 4, 4)
+    assert _linear_attention_mask(
+        _mask_kwargs(cfg, hidden, pad4d), hidden, pad4d) is None
+
+
+def test_missing_mask_returns_none():
+    cfg = _hybrid_cfg()
+    hidden = torch.zeros(1, 4, 8)
+    assert _linear_attention_mask(
+        _mask_kwargs(cfg, hidden, None), hidden, None) is None
+
+
+# --- routing through _compute_attention_mask -------------------------------
+def test_left_padded_mask_routes_2d_to_linear():
+    cfg = _hybrid_cfg()
+    base = _Base(cfg)
+    hidden = torch.zeros(1, 4, 8)
+    position_ids = torch.arange(4).unsqueeze(0)
+    pad = torch.tensor([[0, 1, 1, 1]])
+
+    masks = _compute_attention_mask(base, hidden, position_ids,
+                                    attention_mask=pad)
+
+    lin = masks["linear_attention"]
+    assert lin is not None and lin.ndim == 2  # never the dense 4D mask
+    assert torch.equal(lin, pad)
+    assert lin.is_contiguous()
+    assert masks["full_attention"].shape == (1, 1, 4, 4)
+
+
+def test_all_ones_mask_routes_none_to_linear():
+    cfg = _hybrid_cfg()
+    base = _Base(cfg)
+    hidden = torch.zeros(1, 4, 8)
+    position_ids = torch.arange(4).unsqueeze(0)
+
+    masks = _compute_attention_mask(base, hidden, position_ids,
+                                    attention_mask=torch.ones(1, 4))
+
+    assert masks["linear_attention"] is None
+    assert masks["full_attention"].shape == (1, 1, 4, 4)
+
+
+def test_sliding_full_mapping_non_regression():
+    # Gemma-style hybrid must be untouched by the linear-attention branch.
+    cfg = PreTrainedConfig()
+    cfg.is_causal = True
+    cfg.layer_types = ["sliding_attention", "full_attention"]
+    cfg.sliding_window = 2
+    cfg._attn_implementation = "eager"
+    base = _Base(cfg)
+    hidden = torch.zeros(1, 4, 8)
+    position_ids = torch.arange(4).unsqueeze(0)
+
+    masks = _compute_attention_mask(base, hidden, position_ids)
+
+    assert set(masks) == {"sliding_attention", "full_attention"}
+    assert masks["full_attention"].shape == (1, 1, 4, 4)
+    assert masks["sliding_attention"].shape == (1, 1, 4, 4)
+    assert float(masks["full_attention"][0, 0, 3, 0]) == 0.0
+    assert float(masks["sliding_attention"][0, 0, 3, 0]) < -1e20
+
+
+# --- end-to-end selection through _call_layer ------------------------------
+def test_call_layer_delivers_recurrent_mask_to_linear_layer():
+    pad = torch.tensor([[0, 1, 1, 1]])
+    dense = torch.zeros(1, 1, 4, 4)
+    masks = {"full_attention": dense, "linear_attention": pad}
+
+    linear = _RecorderLayer(block_type="linear_attention")
+    _call_layer(linear, torch.zeros(1, 4, 8), position_embeddings=None,
+                attention_mask=masks, position_ids=None)
+    assert linear.received_mask is pad
+
+    full = _RecorderLayer(block_type="full_attention")
+    _call_layer(full, torch.zeros(1, 4, 8), position_embeddings=None,
+                attention_mask=masks, position_ids=None)
+    assert full.received_mask is dense

--- a/tests/test_linear_attention_mask_routing.py
+++ b/tests/test_linear_attention_mask_routing.py
@@ -2,14 +2,15 @@
 
 Pins the PR #80 review contract. Two halves:
 
-- `linear_attention` layers are routed through transformers'
-  recurrent-mask contract (`masking_utils.create_recurrent_attention_mask`
-  when the installed transformers ships it, the contract-identical
-  `_recurrent_padding_mask` fallback on the locked transformers 5.8):
+- `linear_attention` layers are routed through the CURRENT (transformers
+  >= 5.15) recurrent-mask contract, always via the local
+  `_recurrent_padding_mask` shim — never the upstream helper, whose
+  5.13/5.14 incarnation still has the pre-fix cache-state contract:
   2D padding mask trimmed to the local sequence, `None` whenever masking
   would be a no-op — never the dense additive causal mask, never the raw
-  un-trimmed growing mask.
-- layer-type resolution covers the transformers>=5.15 `.block_type` rename
+  un-trimmed growing mask, and identical semantics with or without a
+  populated cache.
+- layer-type resolution covers the transformers>=5.13 `.block_type` rename
   and the Qwen3.5/3.6 `linear_attn` child module through the existing
   attribute/index/config lookups, and an otherwise unknown layer still
   fails closed instead of being guessed structurally.
@@ -26,7 +27,7 @@ from prismaquant.layer_streaming import (
     _call_layer,
     _compute_attention_mask,
     _layer_attention_type,
-    _linear_attention_mask,
+    _recurrent_padding_mask,
 )
 
 
@@ -60,20 +61,10 @@ def _hybrid_cfg():
     return cfg
 
 
-def _mask_kwargs(cfg, hidden, pad, position_ids=None):
-    return {
-        "config": cfg,
-        "inputs_embeds": hidden,
-        "attention_mask": pad,
-        "past_key_values": None,
-        "position_ids": position_ids,
-    }
-
-
 # --- layer-type resolution -------------------------------------------------
 @pytest.mark.parametrize("lt", ["linear_attention", "full_attention"])
 def test_block_type_resolves(lt):
-    # transformers>=5.15: Qwen3_5DecoderLayer stores `.block_type`
+    # transformers>=5.13: hybrid decoder layers store `.block_type`
     layer = nn.Module()
     layer.block_type = lt
     assert _layer_attention_type(layer) == lt
@@ -81,7 +72,7 @@ def test_block_type_resolves(lt):
 
 @pytest.mark.parametrize("lt", ["linear_attention", "sliding_attention"])
 def test_legacy_layer_type_still_resolves(lt):
-    # transformers<5.15 name — must keep working unchanged
+    # transformers<=5.12 name — must keep working unchanged
     layer = nn.Module()
     layer.layer_type = lt
     assert _layer_attention_type(layer) == lt
@@ -120,40 +111,33 @@ def test_unknown_self_attn_layer_fails_closed():
 
 # --- recurrent-mask contract (direct) --------------------------------------
 def test_continuation_mask_trims_to_local_sequence():
-    cfg = _hybrid_cfg()
     hidden = torch.zeros(2, 4, 8)
     # growing cache-continuation mask: 6 total positions, local seq is 4
     pad = torch.tensor([[1, 1, 0, 1, 1, 1],
                         [0, 0, 1, 1, 1, 1]])
-    out = _linear_attention_mask(_mask_kwargs(cfg, hidden, pad), hidden, pad)
+    out = _recurrent_padding_mask(hidden, pad)
     assert out.shape == (2, 4)
     assert torch.equal(out, pad[:, -4:])
     assert out.is_contiguous()
 
 
 def test_single_token_decode_returns_none():
-    cfg = _hybrid_cfg()
     hidden = torch.zeros(1, 1, 8)
     # decode step continuing a cached, left-padded prompt: not all-ones,
     # longer than the local sequence — None purely because local seq == 1
     pad = torch.tensor([[0, 1, 1, 1, 1, 1]])
-    assert _linear_attention_mask(
-        _mask_kwargs(cfg, hidden, pad), hidden, pad) is None
+    assert _recurrent_padding_mask(hidden, pad) is None
 
 
 def test_non_2d_mask_returns_none():
-    cfg = _hybrid_cfg()
     hidden = torch.zeros(1, 4, 8)
     pad4d = torch.zeros(1, 1, 4, 4)
-    assert _linear_attention_mask(
-        _mask_kwargs(cfg, hidden, pad4d), hidden, pad4d) is None
+    assert _recurrent_padding_mask(hidden, pad4d) is None
 
 
 def test_missing_mask_returns_none():
-    cfg = _hybrid_cfg()
     hidden = torch.zeros(1, 4, 8)
-    assert _linear_attention_mask(
-        _mask_kwargs(cfg, hidden, None), hidden, None) is None
+    assert _recurrent_padding_mask(hidden, None) is None
 
 
 # --- routing through _compute_attention_mask -------------------------------
@@ -222,3 +206,92 @@ def test_call_layer_delivers_recurrent_mask_to_linear_layer():
     _call_layer(full, torch.zeros(1, 4, 8), position_embeddings=None,
                 attention_mask=masks, position_ids=None)
     assert full.received_mask is dense
+
+
+# --- shim-only guarantee (5.13/5.14 old-helper regression) ------------------
+def test_routing_never_consults_upstream_helper(monkeypatch):
+    # transformers 5.13/5.14 ship create_recurrent_attention_mask with the
+    # pre-fix contract (None whenever the cache has previous state, no
+    # single-token case). The routing must therefore NEVER consult the
+    # upstream helper, on any version — booby-trap it and exercise both
+    # semantics Rob's review names: padded multi-token and single-token.
+    try:
+        import transformers.masking_utils as mu
+    except ImportError:  # pragma: no cover
+        mu = None
+    if mu is not None and hasattr(mu, "create_recurrent_attention_mask"):
+        def _trap(**kwargs):
+            pytest.fail("upstream create_recurrent_attention_mask must not "
+                        "be consulted (5.13/5.14 ship the pre-fix contract)")
+        monkeypatch.setattr(mu, "create_recurrent_attention_mask", _trap)
+
+    cfg = _hybrid_cfg()
+    base = _Base(cfg)
+
+    # padded multi-token: 2D mask kept and (trivially) trimmed, NOT None
+    hidden = torch.zeros(1, 4, 8)
+    pad = torch.tensor([[0, 1, 1, 1]])
+    masks = _compute_attention_mask(base, hidden, torch.arange(4).unsqueeze(0),
+                                    attention_mask=pad)
+    assert torch.equal(masks["linear_attention"], pad)
+
+    # single-token step: None
+    hidden1 = torch.zeros(1, 1, 8)
+    masks1 = _compute_attention_mask(base, hidden1, torch.zeros(1, 1,
+                                                                dtype=torch.long),
+                                     attention_mask=torch.ones(1, 1))
+    assert masks1["linear_attention"] is None
+
+
+def test_cached_continuation_contract_is_cache_state_independent():
+    # The old 5.13/5.14 helper returned None whenever
+    # past_key_values.has_previous_state() — silently dropping padding from
+    # a multi-token cached continuation. The current contract (and our
+    # shim, which takes no cache argument at all — by design) must keep and
+    # trim the mask regardless of cache state.
+    hidden = torch.zeros(2, 4, 8)
+    continuation = torch.tensor([[1, 1, 0, 1, 1, 1],
+                                 [0, 0, 1, 1, 1, 1]])  # 6 cached+new, 4 local
+    out = _recurrent_padding_mask(hidden, continuation)
+    assert out is not None and torch.equal(out, continuation[:, -4:])
+
+
+# --- non-attention blocks in a mixed hybrid schedule ------------------------
+def test_mixed_schedule_non_attention_blocks_get_none():
+    # Nemotron-H-style schedule: moe/mlp blocks consume no attention mask —
+    # upstream dispatches them None via `.get(block_type)`. An unknown
+    # *attention* type still fails closed.
+    cfg = PreTrainedConfig()
+    cfg.is_causal = True
+    cfg.layer_types = ["linear_attention", "moe", "full_attention", "mlp"]
+    cfg._attn_implementation = "eager"
+    base = _Base(cfg)
+    hidden = torch.zeros(1, 4, 8)
+    position_ids = torch.arange(4).unsqueeze(0)
+    pad = torch.tensor([[0, 1, 1, 1]])
+
+    masks = _compute_attention_mask(base, hidden, position_ids,
+                                    attention_mask=pad)
+
+    assert masks["moe"] is None and masks["mlp"] is None
+    assert torch.equal(masks["linear_attention"], pad)
+    assert masks["full_attention"].shape == (1, 1, 4, 4)
+
+    moe = _RecorderLayer(block_type="moe")
+    _call_layer(moe, hidden, position_embeddings=None,
+                attention_mask=masks, position_ids=position_ids)
+    assert moe.received_mask is None
+
+    # a declared but unbuildable attention type stays fail-closed
+    cfg2 = PreTrainedConfig()
+    cfg2.is_causal = True
+    cfg2.layer_types = ["linear_attention", "quantum_attention",
+                        "full_attention"]
+    cfg2._attn_implementation = "eager"
+    masks2 = _compute_attention_mask(_Base(cfg2), hidden, position_ids,
+                                     attention_mask=pad)
+    assert "quantum_attention" not in masks2
+    unknown = _RecorderLayer(block_type="quantum_attention")
+    with pytest.raises(RuntimeError, match="known layer_type"):
+        _call_layer(unknown, hidden, position_embeddings=None,
+                    attention_mask=masks2, position_ids=position_ids)

--- a/tests/test_qwen35_linear_attention_integration.py
+++ b/tests/test_qwen35_linear_attention_integration.py
@@ -1,0 +1,135 @@
+"""Integration: streaming forward through REAL Qwen3.5 hybrid layers.
+
+The fakes in test_linear_attention_mask_routing.py pin the contract; this
+file pins it against transformers' actual Qwen3_5 modules (tiny random-weight
+hybrid, CPU) — the family whose transformers>=5.15 refactor (`.block_type`
+rename, `apply_mask_to_padding_states` without a shape guard) motivated the
+fix. The forward-path tests run on every transformers version that ships
+qwen3_5 (the locked 5.8 environment included — same contract, pre-refactor
+attribute names); the two assertions specific to the 5.15 refactor
+(`.block_type`/child `layer_type`, guardless ``apply_mask_to_padding_states``)
+are version-gated.
+"""
+import pytest
+import torch
+
+pytest.importorskip(
+    "transformers.models.qwen3_5",
+    reason="qwen3_5 modeling not available in this transformers version",
+)
+
+import transformers
+from packaging.version import parse as _parse_version
+
+_POST_REFACTOR = _parse_version(
+    transformers.__version__) >= _parse_version("5.15.0")
+
+from transformers.models.qwen3_5 import Qwen3_5TextConfig
+from transformers.models.qwen3_5.modeling_qwen3_5 import (
+    Qwen3_5DecoderLayer,
+    Qwen3_5TextRotaryEmbedding,
+)
+
+from prismaquant.layer_streaming import (
+    _call_layer,
+    _compute_attention_mask,
+    _layer_attention_type,
+)
+
+
+def _tiny_hybrid():
+    cfg = Qwen3_5TextConfig(
+        hidden_size=64, intermediate_size=128, num_hidden_layers=2,
+        num_attention_heads=4, num_key_value_heads=2, head_dim=16,
+        layer_types=["linear_attention", "full_attention"],
+        linear_num_value_heads=4, linear_num_key_heads=2,
+        linear_key_head_dim=16, linear_value_head_dim=16,
+        linear_conv_kernel_dim=4,
+        vocab_size=128, max_position_embeddings=64,
+    )
+    cfg._attn_implementation = "eager"
+    torch.manual_seed(0)
+    layers = [Qwen3_5DecoderLayer(cfg, i) for i in range(2)]
+    rotary = Qwen3_5TextRotaryEmbedding(cfg)
+
+    class _Base(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = cfg
+
+    return cfg, _Base(), layers, rotary
+
+
+def _stream(base, layers, rotary, hidden, attention_mask):
+    position_ids = torch.arange(hidden.size(1)).unsqueeze(0).expand(
+        hidden.size(0), -1)
+    masks = _compute_attention_mask(base, hidden, position_ids,
+                                    attention_mask=attention_mask)
+    pe = rotary(hidden, position_ids)
+    out = hidden
+    for layer in layers:
+        out = _call_layer(layer, out, position_embeddings=pe,
+                          attention_mask=masks, position_ids=position_ids)
+    return masks, out
+
+
+def test_real_layers_resolve():
+    # Passes pre- and post-refactor: `.layer_type` on 5.8, `.block_type`
+    # (plus the recurrent child's own attributes) from 5.15 on.
+    _, _, layers, _ = _tiny_hybrid()
+    assert _layer_attention_type(layers[0]) == "linear_attention"
+    assert _layer_attention_type(layers[1]) == "full_attention"
+
+
+@pytest.mark.skipif(not _POST_REFACTOR,
+                    reason="`.block_type` rename landed in transformers 5.15")
+def test_post_refactor_child_carries_fallback_attributes():
+    _, _, layers, _ = _tiny_hybrid()
+    assert layers[0].block_type == "linear_attention"
+    assert layers[0].linear_attn.layer_type == "linear_attention"
+    assert layers[0].linear_attn.layer_idx == 0
+
+
+def test_streaming_forward_left_padded_batch():
+    _, base, layers, rotary = _tiny_hybrid()
+    hidden = torch.randn(2, 6, 64)
+    pad = torch.tensor([[0, 0, 1, 1, 1, 1],
+                        [1, 1, 1, 1, 1, 1]])
+
+    masks, out = _stream(base, layers, rotary, hidden, pad)
+
+    lin = masks["linear_attention"]
+    assert lin is not None and lin.ndim == 2 and torch.equal(lin, pad)
+    assert out.shape == hidden.shape
+    assert bool(torch.isfinite(out).all())
+
+
+def test_streaming_forward_unpadded_batch():
+    _, base, layers, rotary = _tiny_hybrid()
+    hidden = torch.randn(1, 6, 64)
+
+    # all-ones → linear_attention mask is None; forward must still work
+    masks, out = _stream(base, layers, rotary, hidden, torch.ones(1, 6))
+
+    assert masks["linear_attention"] is None
+    assert out.shape == hidden.shape
+    assert bool(torch.isfinite(out).all())
+
+
+@pytest.mark.skipif(
+    not _POST_REFACTOR,
+    reason="pre-5.15 apply_mask_to_padding_states still shape-guards "
+           "non-2D masks, so the dense mask is silently ignored there")
+def test_dense_mask_crashes_real_linear_layer():
+    # Documents the pre-fix failure mode this branch removes: a dense
+    # [1, 1, T, T] additive mask fed to a real GatedDeltaNet layer
+    # broadcasts against hidden_states and raises a trailing-dim mismatch.
+    _, _, layers, rotary = _tiny_hybrid()
+    hidden = torch.randn(1, 6, 64)
+    position_ids = torch.arange(6).unsqueeze(0)
+    pe = rotary(hidden, position_ids)
+    dense = torch.zeros(1, 1, 6, 6)
+    with pytest.raises(RuntimeError, match="must match the size"):
+        layers[0](hidden_states=hidden, attention_mask=dense,
+                  position_ids=position_ids, past_key_values=None,
+                  use_cache=False, position_embeddings=pe)

--- a/tests/test_qwen35_linear_attention_integration.py
+++ b/tests/test_qwen35_linear_attention_integration.py
@@ -2,9 +2,9 @@
 
 The fakes in test_linear_attention_mask_routing.py pin the contract; this
 file pins it against transformers' actual Qwen3_5 modules (tiny random-weight
-hybrid, CPU) — the family whose transformers>=5.15 refactor (`.block_type`
-rename, `apply_mask_to_padding_states` without a shape guard) motivated the
-fix. The forward-path tests run on every transformers version that ships
+hybrid, CPU) — the family whose transformers hybrid refactors (`.block_type` rename in
+5.13, removal of the `apply_mask_to_padding_states` shape guard in 5.15)
+motivated the fix. The forward-path tests run on every transformers version that ships
 qwen3_5 (the locked 5.8 environment included — same contract, pre-refactor
 attribute names); the two assertions specific to the 5.15 refactor
 (`.block_type`/child `layer_type`, guardless ``apply_mask_to_padding_states``)
@@ -21,8 +21,9 @@ pytest.importorskip(
 import transformers
 from packaging.version import parse as _parse_version
 
-_POST_REFACTOR = _parse_version(
-    transformers.__version__) >= _parse_version("5.15.0")
+_TV = _parse_version(transformers.__version__)
+_HAS_BLOCK_TYPE = _TV >= _parse_version("5.13.0")   # .block_type + child attrs
+_GUARDLESS_MASK = _TV >= _parse_version("5.15.0")   # padding-mask shape guard removed
 
 from transformers.models.qwen3_5 import Qwen3_5TextConfig
 from transformers.models.qwen3_5.modeling_qwen3_5 import (
@@ -35,6 +36,30 @@ from prismaquant.layer_streaming import (
     _compute_attention_mask,
     _layer_attention_type,
 )
+
+
+@pytest.fixture(autouse=True)
+def _force_pure_torch_kernels(monkeypatch):
+    """Keep the CPU integration CPU-safe in CUDA-toolkit environments.
+
+    transformers selects `causal_conv1d`/`fla` extensions by package
+    availability, not tensor device — in a cu130 stack the installed CUDA
+    extension gets picked for CPU tensors and fails with
+    `Expected x.is_cuda()`. The kernel-dispatch wrappers keep the pure
+    PyTorch implementation reachable via `__wrapped__`; unwrap them so the
+    test always runs the torch path, everywhere. No-op in clean CPU envs
+    and on transformers versions without those wrappers."""
+    import transformers.models.qwen3_5.modeling_qwen3_5 as m
+    for name in ("causal_conv1d_fn", "causal_conv1d_update",
+                 "chunk_gated_delta_rule", "recurrent_gated_delta_rule"):
+        fn = getattr(m, name, None)
+        if fn is None:
+            continue
+        inner = fn
+        while hasattr(inner, "__wrapped__"):
+            inner = inner.__wrapped__
+        if inner is not fn:
+            monkeypatch.setattr(m, name, inner)
 
 
 def _tiny_hybrid():
@@ -74,15 +99,15 @@ def _stream(base, layers, rotary, hidden, attention_mask):
 
 
 def test_real_layers_resolve():
-    # Passes pre- and post-refactor: `.layer_type` on 5.8, `.block_type`
-    # (plus the recurrent child's own attributes) from 5.15 on.
+    # Passes pre- and post-refactor: `.layer_type` up to 5.12, `.block_type`
+    # (plus the recurrent child's own attributes) from 5.13 on.
     _, _, layers, _ = _tiny_hybrid()
     assert _layer_attention_type(layers[0]) == "linear_attention"
     assert _layer_attention_type(layers[1]) == "full_attention"
 
 
-@pytest.mark.skipif(not _POST_REFACTOR,
-                    reason="`.block_type` rename landed in transformers 5.15")
+@pytest.mark.skipif(not _HAS_BLOCK_TYPE,
+                    reason="`.block_type` rename landed in transformers 5.13")
 def test_post_refactor_child_carries_fallback_attributes():
     _, _, layers, _ = _tiny_hybrid()
     assert layers[0].block_type == "linear_attention"
@@ -117,7 +142,7 @@ def test_streaming_forward_unpadded_batch():
 
 
 @pytest.mark.skipif(
-    not _POST_REFACTOR,
+    not _GUARDLESS_MASK,
     reason="pre-5.15 apply_mask_to_padding_states still shape-guards "
            "non-2D masks, so the dense mask is silently ignored there")
 def test_dense_mask_crashes_real_linear_layer():

--- a/tests/test_qwen35_linear_attention_integration.py
+++ b/tests/test_qwen35_linear_attention_integration.py
@@ -44,14 +44,34 @@ def _force_pure_torch_kernels(monkeypatch):
 
     transformers selects `causal_conv1d`/`fla` extensions by package
     availability, not tensor device — in a cu130 stack the installed CUDA
-    extension gets picked for CPU tensors and fails with
-    `Expected x.is_cuda()`. The kernel-dispatch wrappers keep the pure
-    PyTorch implementation reachable via `__wrapped__`; unwrap them so the
-    test always runs the torch path, everywhere. No-op in clean CPU envs
-    and on transformers versions without those wrappers."""
+    extension gets picked for CPU tensors. Transformers <=5.14 binds raw
+    optional-extension globals/classes onto each DeltaNet instance at
+    construction; 5.15 wraps module-level torch fallbacks and dispatches
+    through them.
+
+    Select the package-provided PyTorch implementation for both layouts
+    before `_tiny_hybrid()` constructs its layers."""
     import transformers.models.qwen3_5.modeling_qwen3_5 as m
+
+    # <=5.14: replace the raw optional-extension globals that __init__ copies
+    # onto Qwen3_5GatedDeltaNet. A None full-convolution function selects the
+    # module's nn.Conv1d branch; the other globals have explicit torch twins.
+    if hasattr(m, "torch_causal_conv1d_update"):
+        monkeypatch.setattr(m, "causal_conv1d_fn", None)
+        monkeypatch.setattr(m, "causal_conv1d_update",
+                            m.torch_causal_conv1d_update)
+        monkeypatch.setattr(m, "chunk_gated_delta_rule",
+                            m.torch_chunk_gated_delta_rule)
+        monkeypatch.setattr(m, "fused_recurrent_gated_delta_rule",
+                            m.torch_recurrent_gated_delta_rule)
+        monkeypatch.setattr(m, "FusedRMSNormGated", None)
+        return
+
+    # >=5.15: the module-level fallbacks are kernel-dispatch wrappers whose
+    # undecorated PyTorch implementation remains reachable via __wrapped__.
     for name in ("causal_conv1d_fn", "causal_conv1d_update",
-                 "chunk_gated_delta_rule", "recurrent_gated_delta_rule"):
+                 "torch_chunk_gated_delta_rule",
+                 "torch_recurrent_gated_delta_rule"):
         fn = getattr(m, name, None)
         if fn is None:
             continue


### PR DESCRIPTION
Hi Rob — first: thanks for AURA. We've been running PrismaQuant as the production quantization method for dense Qwen3.6 on a DGX Spark (GB10) and an RTX 5090, and the KL-Fisher allocation has held up to every measurement we've thrown at it. This PR fixes the one thing that broke when our environment resolved a newer transformers than your lockfile pins.

**What breaks**

With `transformers>=5.15.0` and a hybrid model whose `config.layer_types` mixes `full_attention` with `linear_attention` (Qwen3.5/3.6 GatedDeltaNet), the layer-streaming forward crashes. Two bugs in the same code path, found in sequence because the second was masked by the first:

1. `_compute_attention_mask()` only special-cases `sliding_attention` (Gemma3/4). Any other hybrid falls through to a single dense `[1,1,T,T]` causal mask fed to every layer — including `linear_attention` layers, whose `apply_mask_to_padding_states()` expects the raw 2D `[batch, seq_len]` padding mask (or `None` for an unpadded batch), same as HF's own `Qwen3_5TextModel._update_linear_attn_mask()`. The recurrence is already causal by construction; the dense mask broadcasts against `hidden_states` and crashes with a trailing-dim mismatch (hidden_size vs. seq_len). Thematically related to transformers#47087 (padding-mask correctness for linear-attention hybrids on cache continuation) — different failure mode, same subsystem.

2. Fixing (1) exposed the second: `_layer_attention_type()`'s attribute probe returns `None` for `linear_attention` layers on transformers >= 5.15.0. Upstream transformers#47630 ("Refactor all linear attn models & native kernels fallback", merged 2026-08-05) renamed the attribute `Qwen3_5DecoderLayer` stores from `.layer_type` to `.block_type` (confirmed via source diff, 5.14.1 vs 5.15.0), and these layers carry no `self_attn`/`attention` for the idx-fallback to key off — so `_call_layer`'s "don't silently guess" guard raises.

**The fix** (`layer_streaming.py` + two test files; reworked after review)

- `_compute_attention_mask()` branches independently on `has_sliding` / `has_linear` (plus `conv` and declared non-attention block types) and routes `linear_attention`/`conv` through the current (transformers >= 5.15) recurrent-mask contract, always via a local shim (`_recurrent_padding_mask`) — deliberately never the upstream helper, whose 5.13/5.14 incarnation ships the pre-fix cache-state contract. Contract: `None` for missing/non-2D/single-token/all-ones cases, growing continuation masks trimmed to the local sequence, contiguous result. Declared `moe`/`mlp` blocks receive `None` (upstream `.get()` parity, explicit allowlist); anything else unresolvable stays fail-closed.
- `_layer_attention_type()` adds `layer.block_type` to the primary probe and resolves the Qwen3.5/3.6 recurrent child via the existing lookups (`linear_attn.layer_type`, `linear_attn.layer_idx` + `config.layer_types`). No structural guessing; unknown layers keep failing closed.
- Regression tests for both halves, runnable under 5.8 (fallback arm) and >= 5.15 (helper arm), plus an integration file against real `Qwen3_5` modules.

Your `uv.lock` pins `transformers==5.8.0`, where the rename hasn't happened and the bug stays latent, so stock environments are unaffected. `pyproject.toml` allows `>=5.0` with no upper bound, though, so any fresh resolution hits it. `layer_streaming.py` is byte-identical between v0.10.0 and v0.11.0; the patch was developed against 0.10.0 and re-verified against this branch's base (branch since rebased onto 0.12.0 main).

**Validation**

Beyond reproducing and clearing the crash, we ran the patched pipeline end-to-end: Qwen3.6-27b dense quantized with AURA (mixed NVFP4-MLP + FP8-attn + NVFP4-KV, ~5.5 bpp) under transformers 5.15.0 + this patch, then a paired battery against your `prismaaura55` reference, both served sequentially on the same GB10:

- GSM8K, n=250 screening: 97.2% vs 95.6% (Δ +1.6 pp; McNemar exact p=0.34 — statistical parity, discordant 7/3)
- long-context needle: 9/9 both; determinism: 5/5 both

So the patched masking path reproduces your reference quality at screening level; the full n=1319 run is queued and I'll drop the result here when it lands. Write-up with raw JSON: **[local-ai-lab write-up](https://github.com/TechPrototyper/local-ai-lab/blob/master/notes/qwen36-aura-head-to-head.md)**.

Happy to add a regression test for the layer-type resolution if you'd like one, or reshape anything to fit the codebase's conventions. And genuinely: AURA is doing on our hardware exactly what the method promises — glad to be building on it.

