### PR TITLE
fix: the public repo defaulted DATASET to a path in my home directory

### DIFF
--- a/docs/design/runtime_flags.md
+++ b/docs/design/runtime_flags.md
@@ -18,6 +18,46 @@ versioned Gridbook source at the commit current on the reconciliation date
 its reading `file:line`; when a flag has several readers the row cites the one
 that decides behaviour and notes the others.
 
+## 0. Calibration corpus (`DATASET`, `PRISMAQUANT_CALIBRATION_DIR`)
+
+Calibration corpora are **built, not vendored** — the repo ships the builder,
+not the bytes, because the corpora are large and the mix is a methodological
+choice a user should make deliberately.
+
+| var | default | meaning |
+|---|---|---|
+| `PRISMAQUANT_CALIBRATION_DIR` | `<repo>/calibration` | where corpora live |
+| `DATASET` | `$PRISMAQUANT_CALIBRATION_DIR/diverse-v1.jsonl` | probe/cost/render calibration |
+| `EXPERT_GATE_DATASET` | `$PRISMAQUANT_CALIBRATION_DIR/xdom-gate-v1.jsonl` | MoE-only cross-domain GPTQ-vs-RTN gate corpus; must be DISJOINT from `DATASET`; set empty for the historical same-corpus gate |
+| `VALIDATED_FRONTIER_DATASET` | `$DATASET` | held-out KL selection corpus |
+
+`DATASET` accepts three things (`sensitivity_probe.load_calibration`): a local
+`.jsonl` (rows of `{"text": ...}` or `{"messages": [...]}`), a local `.txt`
+(one sample per line), or a HuggingFace dataset id.
+
+Build the default corpus with:
+
+```bash
+python tools/build_diverse_calibration.py \
+  --tokenizer <model dir or HF id> \
+  --output "$PRISMAQUANT_CALIBRATION_DIR/diverse-v1.jsonl"
+```
+
+It is a 40/20/20/20 prose/code/math/multilingual mix drawn from public HF
+datasets at pinned revisions, with a manifest as its first row, so it
+regenerates reproducibly on any machine. `--tokenizer` is required: rows are
+built to a token budget, so a corpus is only reusable across models whose
+tokenizers agree.
+
+**A local path that does not exist now fails immediately** and says so. It
+previously fell through to the HuggingFace loader, which reported
+`Dataset '/home/.../diverse-v1.jsonl' doesn't exist on the Hub or cannot be
+accessed` — an error naming a filesystem path as a dataset id, which reads as
+"you failed to download something" when in fact nothing is downloadable.
+There is no `xdom-gate-v1` builder in the repo yet; on a dense model that
+corpus is unused, and on MoE set `EXPERT_GATE_DATASET` to your own disjoint
+corpus (or empty, accepting the weaker same-corpus gate).
+
 All performance-critical paths can be tuned at runtime via env vars.
 Most proven probe/cost/export flags default ON and exist mostly for opt-out /
 debugging. CUDA graph flags are different: assignment-KL graph capture defaults

--- a/prismaquant/run-pipeline.sh
+++ b/prismaquant/run-pipeline.sh
@@ -216,13 +216,22 @@ if [[ "$EXPORT_CONTAINER" == "gguf" || "$EXPORT_CONTAINER" == "nvfp4_cb" ]]; the
 else
   : "${ACTIVATION_ROWS_LIMIT:=256}"
 fi
-: "${DATASET:=/home/rob/dq-runs/calibration/diverse-v1.jsonl}"
+# Calibration corpora live OUTSIDE the repo (they are built, not vendored) and
+# their location is one knob. It used to default to an absolute path under a
+# developer's home directory, which is unreachable for everyone else and failed
+# with a HuggingFace "dataset doesn't exist on the Hub" error naming that path
+# — see the fail-fast in sensitivity_probe.load_calibration. Point
+# PRISMAQUANT_CALIBRATION_DIR wherever you keep them, or set DATASET directly
+# to any .jsonl / .txt / HF dataset id.
+PIPELINE_SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+: "${PRISMAQUANT_CALIBRATION_DIR:=${PIPELINE_SCRIPT_DIR%/}/../calibration}"
+: "${DATASET:=${PRISMAQUANT_CALIBRATION_DIR%/}/diverse-v1.jsonl}"
 # MINOR-M2: packed-MoE experts use a cross-domain held-out corpus for the
 # GPTQ-vs-RTN do-no-harm gate (the served-validated recipe — arm E in
 # moe_expert_gptq_vs_rtn — beat same-corpus/in-sample gating). Must be DISJOINT
 # from DATASET. Ignored for dense models (no packed experts). Set empty to
 # reproduce the historical same-corpus in-sample gate.
-: "${EXPERT_GATE_DATASET:=/home/rob/dq-runs/calibration/xdom-gate-v1.jsonl}"
+: "${EXPERT_GATE_DATASET:=${PRISMAQUANT_CALIBRATION_DIR%/}/xdom-gate-v1.jsonl}"
 : "${DEVICE:=cuda}"
 : "${EXPORT_DEVICE:=cuda}"   # CUDA ~10× faster than CPU on NVFP4 packing
 # TARGET_PROFILE is deliberately UNSET by default (re-vet R11 / debt D4). A

--- a/prismaquant/sensitivity_probe.py
+++ b/prismaquant/sensitivity_probe.py
@@ -2315,6 +2315,27 @@ def load_calibration(tokenizer, source: str, n_samples: int,
     """
     import os
 
+    # A local-file source that does not exist must NOT fall through to the
+    # HuggingFace loader. It used to: the `.jsonl`/`.txt` branches were guarded
+    # by os.path.exists, so a missing file skipped to the generic `else` and
+    # HF reported `Dataset '/home/.../diverse-v1.jsonl' doesn't exist on the
+    # Hub` -- an error that names a filesystem path as a dataset id and sends
+    # the reader looking for something to download. Nothing is downloadable;
+    # the file is simply absent.
+    if (source.endswith((".jsonl", ".txt")) or os.sep in source) \
+            and not os.path.exists(source):
+        raise FileNotFoundError(
+            f"calibration file not found: {source}\n"
+            "This is a local path, not a HuggingFace dataset id, so there is "
+            "nothing to download. Either:\n"
+            "  * build the default corpus:  python tools/"
+            "build_diverse_calibration.py --output <path> --tokenizer <model>\n"
+            "  * point DATASET at your own .jsonl ({\"text\": ...} or "
+            "{\"messages\": [...]} rows) or .txt (one sample per line)\n"
+            "  * point DATASET at a HuggingFace dataset id "
+            "(e.g. ultrachat_200k)"
+        )
+
     texts: list[str] = []
     if source.endswith(".jsonl") and os.path.exists(source):
         with open(source) as f:

--- a/tools/build_diverse_calibration.py
+++ b/tools/build_diverse_calibration.py
@@ -9,14 +9,26 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import random
 from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Any
 
 
-DEFAULT_OUTPUT = "/home/rob/dq-runs/calibration/diverse-v1.jsonl"
-DEFAULT_TOKENIZER = "/home/rob/.cache/huggingface/qwen36-27b-bf16"
+# Repo-relative, and overridable by the same knob run-pipeline.sh reads, so the
+# builder and the pipeline agree on where corpora live without either of them
+# naming a developer's home directory.
+DEFAULT_OUTPUT = str(
+    Path(os.environ.get(
+        "PRISMAQUANT_CALIBRATION_DIR",
+        Path(__file__).resolve().parents[1] / "calibration",
+    )) / "diverse-v1.jsonl"
+)
+# No default: the corpus is tokenized to a target length, so it is only
+# reusable across models whose tokenizers agree. Guessing one silently ties the
+# corpus to a model the caller never named.
+DEFAULT_TOKENIZER = None
 DEFAULT_ROWS = 256
 DEFAULT_TARGET_TOKENS = 4096
 DEFAULT_SEED = 20260509
@@ -345,7 +357,9 @@ def write_jsonl(
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output", default=DEFAULT_OUTPUT)
-    parser.add_argument("--tokenizer", default=DEFAULT_TOKENIZER)
+    parser.add_argument("--tokenizer", default=DEFAULT_TOKENIZER,
+                        required=DEFAULT_TOKENIZER is None,
+                        help="model dir or HF id whose tokenizer defines the token budget")
     parser.add_argument("--rows", type=int, default=DEFAULT_ROWS)
     parser.add_argument("--target-tokens", type=int, default=DEFAULT_TARGET_TOKENS)
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED)


### PR DESCRIPTION
Reported by someone trying to run the repo from a clean clone: `run-pipeline.sh`
hardcoded `DATASET=/home/rob/dq-runs/calibration/diverse-v1.jsonl`, so on any
other machine the probe fell through to the HuggingFace loader and died with

    Dataset '/home/rob/dq-runs/calibration/diverse-v1.jsonl' doesn't exist on the Hub

which names a local path as if it were a dataset id and says nothing about what
to do. Two separate defects, both fixed here.

**The defaults pointed at my home directory.** `DATASET` and
`EXPERT_GATE_DATASET` now resolve relative to the script's own location via a
new `PRISMAQUANT_CALIBRATION_DIR`, so a clone works from wherever it is checked
out. `tools/build_diverse_calibration.py` likewise: `--output` is env-driven
repo-relative, and `--tokenizer` is now required rather than defaulting to a
model path only I have.

**A missing local file was silently treated as a Hub id.** `load_calibration`
now fails closed when the source looks like a path (a `.jsonl`/`.txt` suffix, or
any separator) and does not exist, and the message says how to proceed:

    calibration file not found: .../diverse-v1.jsonl
    This is a local path, not a HuggingFace dataset id, so there is nothing to
    download. Either:
      * build the default corpus:  python tools/build_diverse_calibration.py --output <path> --tokenizer <model>
      * point DATASET at your own .jsonl ({"text": ...} or {"messages": [...]} rows) or .txt (one sample per line)
      * point DATASET at a HuggingFace dataset id (e.g. ultrachat_200k)

The corpus itself was already reproducible — the builder's manifest names public
HF datasets at pinned revisions (fineweb-edu, github-code-corpus-sample,
open-web-math, flores200) in a 40/20/20/20 prose/code/math/multilingual mix — so
the fix is to make it findable and buildable, not to ship a blob.

`docs/design/runtime_flags.md` gains a "Calibration corpus" section documenting
the four variables, the builder command, and the honest note that no builder
ships for `xdom-gate-v1` (the MoE expert-gate corpus) yet.

`tests/test_docs_staleness.py` + `tests/test_architecture_doc.py`: 18 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZbSLixmqwxwbSV6v1MApK