### PR TITLE
Fail-closed review deltas on the wrapped-MoE FP8-source export (follow-up to #86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,18 @@
   errors:
   - `moe_imatrix._load_tensors` refused every float8 tensor instead of
     fulfilling the serialized scale contract it named: it now loads the
-    `<name>_scale_inv` companion and dequantizes exactly — using the
-    checkpoint's declared `weight_block_size` when present (partial
-    trailing blocks handled exactly), exact-division inference when not,
-    and refusal when neither is unambiguous. The original refusal stands
-    for tensors lacking the companion. Tests: contract round-trip,
-    declared-block partial-trailing exactness, undeclared-ambiguous
-    refusal.
+    `<name>_scale_inv` companion and dequantizes exactly on the
+    checkpoint's declared `weight_block_size` (partial trailing blocks
+    handled exactly), read through the streaming loader's
+    `_declared_weight_block_size` so the packed-expert replay and the
+    layer-streaming load cannot disagree about one checkpoint. An
+    undeclared block size REFUSES rather than inferring the grid by
+    division: a 200-row weight over a 2-row scale plane divides exactly
+    at 100 and is equally a 128-block tiling with a partial trailing
+    block, and the two dequants differ on every row from 128 up. The
+    original refusal stands for tensors lacking the companion. Tests:
+    contract round-trip, declared-block partial-trailing exactness,
+    undeclared refusal, non-tiling (transposed) scale-plane refusal.
   - `export_nvfp4_cb_streaming`: for a wrapped source the group planner's
     regex-matched key lands in the LIVE module-tree namespace
     (`language_model.model.*`) — neither the recipe spelling
@@ -27,17 +32,33 @@
     ship verbatim into `ignore`. Live-spelled keys are now normalized to
     the RECIPE spelling derived from the group's own member tensors;
     recipe- and checkpoint-keyed groups (DSv4-class sources) are left
-    exactly as planned (`test_nvfp4_cb_streaming` passes in full).
+    exactly as planned (`test_nvfp4_cb_streaming` passes in full), and a
+    collision on the normalized key or on the recipe-to-checkpoint bridge
+    refuses rather than silently declining to normalize.
     Packed expert stack tensors are named by their group's checkpoint
     prefix via a member-derived recipe-to-checkpoint bridge (a
     recipe-spelled stack falls through gridbook's top-level loader to the
-    arch loader and dies). Delegated (stock-CT) config-group targets are
-    tower-relative in THIS container — measured on gridbook 0.8.11 +
-    pristine vLLM 0.27.1, where live-tree spellings leave the module
-    unquantized and gridbook refuses fail-closed at load. The vanilla
-    compressed-tensors container (`export_native_compressed`) is
-    untouched: its shipped wrapper artifacts correctly keep live-tree
-    targets, which vanilla vLLM matches.
+    arch loader and dies). Delegated (stock-CT) and source-passthrough
+    config-group targets now ship in the CANONICAL namespace in THIS
+    container — the profile's vLLM-internal rename with the wrapper
+    canonicalized (`language_model.model.` to `model.`,
+    `language_model.<rest>` to `model.<rest>`), mirroring the pinned
+    consumer's `gridbook/config.py::_canonical_prefix` /
+    `_candidate_bases`, which try a serving prefix as given *and* in
+    canonical form. A canonical target resolves from every namespace
+    vintage; a full live-tree target resolves only from its own, which is
+    what left the delegated Linears unquantized until gridbook refused
+    them fail-closed at load (measured on gridbook 0.8.11/0.9.0 +
+    pristine vLLM 0.27.1). The vanilla compressed-tensors container
+    (`export_native_compressed`) is untouched: its shipped wrapper
+    artifacts correctly keep live-tree targets, which vanilla vLLM
+    matches. `docs/ARCHITECTURE.md` §6.2 records the three namespaces and
+    which consumer each emission speaks to.
+
+    Scope note: FP8 sources whose scales are stored as `.scale` siblings
+    rather than `<name>_scale_inv` (DSv4-class, handled elsewhere by the
+    profile's `fp8_scale_pairs`) still hit the packed-expert replay's
+    original refusal — unchanged, and not covered by this fix.
 
 ## 0.16.2 — 2026-08-22
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,18 @@
 # PrismaQuant Architecture
 
-As of: 2026-08-21 · `merge/proven-rescues` — stamps follow, newest first, each recording
-its own branch and date. Re-stamped (2026-08-21, `merge/proven-rescues`) for the
+As of: 2026-08-29 · `review/pr86` — stamps follow, newest first, each recording
+its own branch and date. Re-stamped (2026-08-29, `review/pr86`) for the
+**codebook lane's namespace contract** (§6.2): delegated (stock-CT) and
+source-passthrough group targets now ship in the CANONICAL namespace rather
+than the full live-tree spelling, mirroring the pinned consumer's
+`_canonical_prefix`/`_candidate_bases`; live-spelled expert-group keys are
+normalized to the recipe spelling and collisions refuse; packed expert stacks
+are named by their group's checkpoint prefix. Same commit fulfils the FP8
+serialized-scale contract in the packed-expert imatrix replay
+(`moe_imatrix._load_tensors`), reading the dequant grid through the streaming
+loader's `_declared_weight_block_size` so the two paths cannot disagree about
+one checkpoint. Reported and implemented by smb209 (PR #86). Previously
+re-stamped (2026-08-21, `merge/proven-rescues`) for the Re-stamped (2026-08-21, `merge/proven-rescues`) for the
 **Gridbook 0.8.11 PRODUCER pin**: the producer pin
 (`gridbook_runtime_pin.json`) advanced 0.8.5/v3 → 0.8.11/v4 at commit
 `187c721`, in lockstep with the serving pin, and a new test
@@ -2804,6 +2815,42 @@ regex pinned to that layer index** (`_constrain_per_expert_projection_regex` `:7
 `_pin_regex_to_layer` `:7339-7347`, emission `:7779-7800`), with on-disk leaves translated
 through `_vllm_moe_scheme_projection_names` `:4503-4525` so LFM2.5's `w1/w3/w2` are advertised
 as `gate_proj/up_proj/down_proj` (`:7980-7994`).
+
+**Namespaces on the codebook lane (`export_nvfp4_cb_streaming`).** A wrapped
+source puts three spellings of one module in play: the CHECKPOINT
+(`model.language_model.layers.N.*`, the bytes on disk), the LIVE module tree
+(`language_model.model.layers.N.*`, what the skeleton and the group planner
+see), and the RECIPE (`model.layers.N.*`, what the allocator's `layer_config`
+and `_resolve_target` speak). Which one an emission uses is a property of the
+*consumer*, not a style choice:
+
+- **CB group targets** keep the CHECKPOINT spelling (`_cb_target_name`
+  `:5026`, `_base_name` `:3172`) — the names their tensors were written under.
+- **Delegated (stock-CT) and source-passthrough group targets** are emitted in
+  the CANONICAL namespace (`_delegated_target_name` `:5034`): the profile's
+  vLLM-internal rename with the wrapper canonicalized
+  (`language_model.model.` → `model.`, `language_model.<rest>` →
+  `model.<rest>`). This mirrors — and is cited from, not asserted about — the
+  pinned consumer's `gridbook/config.py::_canonical_prefix` /
+  `_candidate_bases`, which try a serving prefix as given *and* in canonical
+  form. A canonical target therefore resolves from every namespace vintage;
+  a full live-tree target resolves only from its own, which on a wrapped
+  Qwen3.5 source left the delegated Linears unquantized until gridbook refused
+  them fail-closed at weight load. Scoped to this container:
+  `export_native_compressed` keeps live-tree targets, which vanilla
+  compressed-tensors matches.
+- **Expert-group keys** are normalized to the RECIPE spelling when the planner
+  matched a live name (`:2960`), derived from the group's own member tensors;
+  recipe- and checkpoint-keyed groups (DSv4-class) are left exactly as
+  planned, and a collision on either the normalized key or the
+  recipe→checkpoint bridge refuses. Packed expert stacks are then *named* by
+  their group's checkpoint prefix, because the packed parent is not a
+  checkpoint leaf and gridbook's top-level loader rename
+  (`moe_toplevel_loader::_hf_mapper_rename`) reuses the model's own
+  `hf_to_vllm_mapper`, i.e. checkpoint prefixes only.
+- Consequence for the contract below: on a wrapped source, per-expert (Tier-2)
+  config files address groups in the RECIPE namespace. Unchanged for
+  DSv4-class sources.
 
 **PROPOSED per-expert CB producer contract (v1; consumer reconciliation
 pending).** `export_nvfp4_cb_streaming --per-expert-config <json>` consumes the

--- a/prismaquant/export_nvfp4_cb_streaming.py
+++ b/prismaquant/export_nvfp4_cb_streaming.py
@@ -2972,12 +2972,29 @@ def export_nvfp4_cb_streaming(
         for _prefix, _projs in expert_groups.items():
             _recipe, _ck = _member_prefixes(_projs)
             if _recipe is not None and _ck is not None:
-                _canon_to_ckpt_prefix.setdefault(_recipe, _ck)
+                _prior = _canon_to_ckpt_prefix.setdefault(_recipe, _ck)
+                if _prior != _ck:
+                    raise ValueError(
+                        f"expert group {_prefix!r} maps recipe prefix "
+                        f"{_recipe!r} to checkpoint prefix {_ck!r}, but "
+                        f"{_prior!r} already claims it; the recipe->checkpoint "
+                        "bridge names packed stacks and cannot be ambiguous"
+                    )
             _key = _prefix
-            if (_recipe is not None
-                    and _prefix not in (_recipe, _ck)
-                    and _recipe not in expert_groups
-                    and _recipe not in _rekeyed):
+            if _recipe is not None and _prefix not in (_recipe, _ck):
+                # Live-spelled: normalization is not optional. A group left
+                # under the live key KeyErrors the coverage gate and ships
+                # every consumed per-expert source verbatim into `ignore`
+                # (the "31511 copied tensors, 82 GB" failure), so a taken
+                # recipe key refuses here rather than silently declining to
+                # rekey.
+                if _recipe in expert_groups or _recipe in _rekeyed:
+                    raise ValueError(
+                        f"expert group {_prefix!r} normalizes to recipe "
+                        f"prefix {_recipe!r}, which another group already "
+                        "occupies; two expert groups cannot share one "
+                        "decision-unit prefix"
+                    )
                 _key = _recipe
             _rekeyed[_key] = _projs
         expert_groups = _rekeyed
@@ -5015,20 +5032,38 @@ def export_nvfp4_cb_streaming(
         return physical
 
     def _delegated_target_name(qname: str) -> str:
-        # MEASURED on the serving stack (vLLM 0.27.1 + gridbook 0.8.11,
-        # wrapped Qwen3.5 sources): find_matched_target matches quant-config
-        # targets against the LANGUAGE-TOWER-RELATIVE module path, so
-        # canonical `model.layers.*` spellings match and full live-tree
-        # spellings (`language_model.model.*`) leave the module unquantized —
-        # which gridbook then refuses fail-closed at weight load. Keep the
-        # profile's internal renames but strip the wrapper prefix.
+        # Delegated (stock-CT) groups are claimed in the CANONICAL target
+        # namespace. Not asserted about the consumer — cited from it: the
+        # pinned codebook runtime resolves a serving prefix through
+        # `gridbook/config.py::_candidate_bases`, which tries the prefix as
+        # given AND the canonical form `_canonical_prefix` produces
+        # (`language_model.model.` -> `model.`, `language_model.<rest>` ->
+        # `model.<rest>`). A canonical target therefore matches from every
+        # namespace vintage, while a full live-tree spelling matches only its
+        # own — which on a wrapped Qwen3.5 source left the delegated Linears
+        # unquantized until gridbook refused them fail-closed at weight load
+        # ("resolved to plain bf16 parameter"; measured on vLLM 0.27.1 +
+        # gridbook 0.8.11/0.9.0, PR #86).
+        #
+        # Scoped to this container: `export_native_compressed` keeps live-tree
+        # targets, which vanilla compressed-tensors matches. The namespace a
+        # target must use is a property of the consuming quant method.
+        #
+        # Only the two `language_model.` rules are mirrored. `_canonical_prefix`
+        # also lifts a bare `layers.` (DSv4-class) — left alone here so that
+        # lane's shipped export metadata is unchanged; `_candidate_bases` tries
+        # the as-given spelling first, so it resolves either way.
         name = (
             profile.to_vllm_internal_name(qname)
             if profile is not None
             else qname
         )
+        if name.startswith("language_model.model."):
+            return name[len("language_model."):]
         if name.startswith("language_model."):
-            name = name[len("language_model."):]
+            # e.g. `language_model.lm_head` -> `model.lm_head`; a bare strip
+            # would produce `lm_head`, which matches neither vintage.
+            return "model." + name[len("language_model."):]
         return name
 
     def _decision_unit_id(qname: str) -> str:

--- a/prismaquant/moe_imatrix.py
+++ b/prismaquant/moe_imatrix.py
@@ -96,25 +96,30 @@ def _weight_map(model_path: Path) -> dict[str, str]:
     raise FileNotFoundError(f"no safetensors index under {model_path}")
 
 
-_WEIGHT_BLOCK_CACHE: dict[str, tuple[int, int] | None] = {}
+_WEIGHT_BLOCK_CACHE: dict[str, tuple[int, int]] = {}
 
 
-def _weight_block_size(model_path: Path) -> tuple[int, int] | None:
-    """The checkpoint's declared FP8 block tiling, or None if undeclared."""
+def _weight_block_size(model_path: Path) -> tuple[int, int]:
+    """The checkpoint's declared FP8 block tiling.
+
+    One checkpoint, one contract: this defers to the streaming loader's
+    `_declared_weight_block_size`, which REFUSES a checkpoint that pairs
+    fp8 weights with scale tensors but declares no `weight_block_size`
+    rather than inferring the grid from the scale-plane shape. Inference
+    is unsafe even when it divides exactly -- a 200-row weight against a
+    2-row scale plane divides exactly at 100 and is equally a 128-block
+    tiling with a partial trailing block, and the two dequants differ on
+    every row from 128 up. Two mechanisms that disagree about one
+    checkpoint is the defect this avoids; the packed-expert replay and
+    the streaming load must read the same grid.
+
+    Cached per path because `_load_tensors` asks once per FP8 tensor.
+    """
+    from .layer_streaming import _declared_weight_block_size
+
     key = str(model_path)
     if key not in _WEIGHT_BLOCK_CACHE:
-        blocks = None
-        cfg_path = Path(model_path) / "config.json"
-        if cfg_path.exists():
-            cfg = json.loads(cfg_path.read_text())
-            for holder in (cfg, cfg.get("text_config") or {}):
-                qc = holder.get("quantization_config") or {}
-                raw = qc.get("weight_block_size")
-                if (isinstance(raw, (list, tuple)) and len(raw) == 2
-                        and all(isinstance(v, int) and v > 0 for v in raw)):
-                    blocks = (int(raw[0]), int(raw[1]))
-                    break
-        _WEIGHT_BLOCK_CACHE[key] = blocks
+        _WEIGHT_BLOCK_CACHE[key] = _declared_weight_block_size(key)
     return _WEIGHT_BLOCK_CACHE[key]
 
 
@@ -154,27 +159,14 @@ def _load_tensors(
                             scale = sf.get_tensor(scale_key)
                     o, i = tensor.shape
                     so, si = scale.shape
-                    blocks = _weight_block_size(model_path)
-                    if blocks is not None:
-                        b0, b1 = blocks
-                        if (-(-o // b0), -(-i // b1)) != (so, si):
-                            raise ValueError(
-                                f"{k}: scale plane {so}x{si} does not tile "
-                                f"weight {o}x{i} at the checkpoint's declared "
-                                f"weight_block_size {blocks}"
-                            )
-                    elif o % so == 0 and i % si == 0:
-                        # No declared block size: exact division is the only
-                        # unambiguous inference. A partial trailing block
-                        # cannot be detected without the declaration, so a
-                        # non-divisible shape refuses below.
-                        b0, b1 = o // so, i // si
-                    else:
+                    # Raises when the checkpoint declares no block size --
+                    # the grid is read from the checkpoint, never guessed.
+                    b0, b1 = _weight_block_size(model_path)
+                    if (-(-o // b0), -(-i // b1)) != (so, si):
                         raise ValueError(
-                            f"{k}: weight {o}x{i} is not tiled evenly by its "
-                            f"scale plane {so}x{si} and the checkpoint "
-                            "declares no weight_block_size; refusing to guess "
-                            "where the partial trailing block falls"
+                            f"{k}: scale plane {so}x{si} does not tile "
+                            f"weight {o}x{i} at the checkpoint's declared "
+                            f"weight_block_size {(b0, b1)}"
                         )
                     tensor = (
                         tensor.to(torch.float32)

--- a/tests/test_moe_imatrix.py
+++ b/tests/test_moe_imatrix.py
@@ -310,16 +310,19 @@ def test_nvfp4_cb_profile_denies_stock_formats_on_packed_experts():
 def test_load_tensors_dequantizes_fp8_with_serialized_scale_contract(tmp_path):
     """An FP8-source MoE checkpoint carries block-wise `weight_scale_inv`
     companions; `_load_tensors` must fulfill that contract (exact block
-    dequant) rather than refusing every float8 tensor — and the refusal
+    dequant) rather than refusing every float8 tensor -- and the refusal
     must stand for a tensor whose companion is genuinely absent.
 
     First FP8-source MoE through the packed-expert replay path
     (Qwen3.6-35B-A3B-FP8, fmt e4m3, 128x128 block scales); verified
     block-exact against a manual dequant before the fix shipped a build."""
+    import json
+
+    import pytest
     import torch
     from safetensors.torch import save_file
 
-    from prismaquant.moe_imatrix import _load_tensors
+    from prismaquant.moe_imatrix import _WEIGHT_BLOCK_CACHE, _load_tensors
 
     torch.manual_seed(0)
     w = torch.randn(256, 384)
@@ -332,6 +335,10 @@ def test_load_tensors_dequantizes_fp8_with_serialized_scale_contract(tmp_path):
     save_file({good: q, good + "_scale_inv": scale,
                bare: q.clone()}, str(tmp_path / shard))
     wm = {good: shard, good + "_scale_inv": shard, bare: shard}
+    (tmp_path / "config.json").write_text(json.dumps(
+        {"quantization_config": {"quant_method": "fp8",
+                                 "weight_block_size": [128, 128]}}))
+    _WEIGHT_BLOCK_CACHE.clear()
 
     out = _load_tensors(tmp_path, wm, [good], dtype=torch.float32)
     expect = (q.to(torch.float32)
@@ -339,7 +346,6 @@ def test_load_tensors_dequantizes_fp8_with_serialized_scale_contract(tmp_path):
               .repeat_interleave(128, 1)[:384])
     assert torch.equal(out[good], expect)
 
-    import pytest
     with pytest.raises(ValueError, match="serialized scale contract"):
         _load_tensors(tmp_path, wm, [bare])
 
@@ -347,8 +353,15 @@ def test_load_tensors_dequantizes_fp8_with_serialized_scale_contract(tmp_path):
 def test_load_tensors_partial_trailing_block_with_declared_size(tmp_path):
     """With the checkpoint's declared weight_block_size, a partial trailing
     block dequantizes exactly (128-blocks over 200 rows: rows 128-199 get
-    scale row 1, not a uniformly mis-inferred 100-row tiling). Without the
-    declaration, a non-divisible shape refuses rather than guesses."""
+    scale row 1, not a uniformly mis-inferred 100-row tiling).
+
+    Undeclared, the replay REFUSES -- it does not fall back to inferring the
+    grid by division. 200 rows over a 2-row scale plane divides exactly at
+    100 and is equally a 128-block tiling with a partial trailing block, and
+    the two dequants differ on every row from 128 up, so an inferred grid is
+    a silent calibration corruption. The refusal is the streaming loader's
+    `_declared_weight_block_size` -- one contract for one checkpoint, shared
+    with the layer-streaming load path."""
     import json
 
     import pytest
@@ -374,19 +387,35 @@ def test_load_tensors_partial_trailing_block_with_declared_size(tmp_path):
               .repeat_interleave(128, 1)[:384])
     assert torch.equal(out[k], expect)
 
-    # Same tensors, no declaration: 200 rows / 2 scale rows is formally
-    # divisible but AMBIGUOUS against a 128-block convention -- the exact
-    # silent-mis-scale case. Only exact division is accepted undeclared, and
-    # this shape is exact (100x128), so it loads under the inferred tiling;
-    # the truly non-divisible undeclared case refuses.
-    (tmp_path / "config.json").unlink()
+    # Same tensors, no declaration: exactly the ambiguous case above.
+    (tmp_path / "config.json").write_text(json.dumps(
+        {"quantization_config": {"quant_method": "fp8"}}))
     _WEIGHT_BLOCK_CACHE.clear()
-    q2 = torch.randn(200, 385).to(torch.float8_e4m3fn)   # 385 % 3 != 0
-    k2 = "model.layers.0.mlp.experts.1.up_proj.weight"
-    save_file({k: q, k + "_scale_inv": scale,
-               k2: q2, k2 + "_scale_inv": scale.clone()},
-              str(tmp_path / "m.safetensors"))
-    wm[k2] = "m.safetensors"
-    wm[k2 + "_scale_inv"] = "m.safetensors"
-    with pytest.raises(ValueError, match="refusing to guess"):
-        _load_tensors(tmp_path, wm, [k2])
+    with pytest.raises(RuntimeError, match="weight_block_size"):
+        _load_tensors(tmp_path, wm, [k])
+    _WEIGHT_BLOCK_CACHE.clear()
+
+
+def test_load_tensors_refuses_scale_plane_that_does_not_tile(tmp_path):
+    """A declared grid that does not tile the weight is a transposed or
+    mismatched scale plane; it must refuse rather than broadcast."""
+    import json
+
+    import pytest
+    import torch
+    from safetensors.torch import save_file
+
+    from prismaquant.moe_imatrix import _WEIGHT_BLOCK_CACHE, _load_tensors
+
+    q = torch.randn(256, 384).to(torch.float8_e4m3fn)
+    scale = torch.rand(3, 2) + 0.5               # transposed grid
+    k = "model.layers.0.mlp.experts.0.down_proj.weight"
+    save_file({k: q, k + "_scale_inv": scale}, str(tmp_path / "m.safetensors"))
+    wm = {k: "m.safetensors", k + "_scale_inv": "m.safetensors"}
+    (tmp_path / "config.json").write_text(json.dumps(
+        {"quantization_config": {"quant_method": "fp8",
+                                 "weight_block_size": [128, 128]}}))
+    _WEIGHT_BLOCK_CACHE.clear()
+    with pytest.raises(ValueError, match="does not tile"):
+        _load_tensors(tmp_path, wm, [k])
+    _WEIGHT_BLOCK_CACHE.clear()


### PR DESCRIPTION
Three review deltas on top of #86, all in the same direction: one contract per checkpoint, and refuse where the merged code inferred. Full rationale is in the commit message; the short form:

1. **The FP8 dequant grid is read, never inferred.** `moe_imatrix._weight_block_size` now defers to `layer_streaming._declared_weight_block_size`, which refuses a checkpoint that pairs fp8 weights with scale tensors but declares no `weight_block_size`. #86 inferred the grid by exact division when undeclared, and its own test comment names the hole: 200 rows over a 2-row scale plane divides exactly at 100 and is equally a 128-block tiling with a partial trailing block, and the two dequants differ on every row from 128 up. The packed-expert replay and the layer-streaming load can no longer disagree about one checkpoint.

2. **Delegated targets are canonical, not stripped.** `_delegated_target_name` mirrors `gridbook/config.py::_canonical_prefix` (`:233`, reached from `_candidate_bases` `:263`) instead of stripping the `language_model.` literal. The strip mapped `language_model.lm_head` to `lm_head`, which matches neither vintage the consumer tries. The bare `layers.` lift that function also performs is deliberately not mirrored, so DSv4-class export metadata is unchanged.

3. **Expert-group rekeying fails closed.** A live-spelled group whose recipe key is already occupied, and a recipe prefix claimed by two different checkpoint prefixes, both raise instead of silently leaving the group under the unbridgeable live key.

`docs/ARCHITECTURE.md` §6.2 records the three namespaces on the codebook lane and which consumer each emission speaks to (principle 13); the provenance block is re-stamped. The CHANGELOG carries the scope note that FP8 sources storing scales as `.scale` siblings (DSv4-class) still hit the replay's original refusal.

Tests on the merge into `main` at 0.16.2: `test_moe_imatrix` (10, one added for a non-tiling scale plane), `test_nvfp4_cb_streaming`, `test_qwen3_5_text_only_namespace`, `test_artifact_completeness_namespaces`, `test_routed_expert_namespace_aliasing`, `test_cb_export_config`, `test_docs_staleness`, `test_architecture_doc` = 145 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WPRMxg9DaR1ctRMBgCKpS