### PR TITLE
fix(tests): derive the Fisher quadratic-form tolerance from fp32 precision

### DIFF
--- a/tests/test_math_reunderwrite_pins.py
+++ b/tests/test_math_reunderwrite_pins.py
@@ -76,16 +76,46 @@ def test_kl_fisher_probe_covariance_closed_form():
 
 
 def test_fisher_quadratic_form_exact():
+    """`fisher_quadratic_form` equals 0.5 * dz~^T (diag(p~) - p~p~^T) dz~.
+
+    The reference is computed in **float64**, and the tolerance is derived from
+    float32 precision rather than pinned to a magic constant.
+
+    Both choices are load-bearing.  The implementation evaluates the variance
+    form ``sum p (dz - mean)^2`` while the identity above is the explicit
+    matrix form; they are algebraically identical but reassociate differently
+    in float32.  An earlier version of this test compared the two *float32*
+    expressions against an absolute ``1e-10``.  That bound sits BELOW the
+    float32 noise floor of the quantity itself -- at the T=0.5 scale of 0.2509
+    one float32 ulp is ~1.5e-8 -- so it asserted nothing about the math and
+    everything about summation order.  It passed on aarch64, where the two
+    paths happen to reassociate bit-identically (observed |lhs - rhs| = 0), and
+    failed on x86-64 CI at 7.45e-09, which is sub-ulp and therefore not an
+    error at all.
+
+    Comparing against float64 instead makes the assertion the real claim -- the
+    float32 implementation is correct to float32 precision -- and is strictly
+    stronger than the old one, which could not catch both float32 paths being
+    wrong together.  16 ulps covers the softmax plus a 6-element reduction
+    chain; the observed error is ~5.5e-09 against a 4.8e-07 bound, and any
+    genuine algebraic error would be larger by orders of magnitude.
+    """
     probs = torch.tensor([0.4, 0.25, 0.15, 0.1, 0.06, 0.04])
     z = torch.log(probs).view(1, 6)
     dz = torch.tensor([0.31, -0.52, 0.17, 0.02, -0.44, 0.63]).view(1, 6)
+    float32_eps = torch.finfo(torch.float32).eps
     for temperature in (1.0, 0.5):
         lhs = fisher_quadratic_form(z, dz, temperature=temperature)
-        p_tilde = torch.softmax(z / temperature, dim=-1).squeeze(0)
-        dz_tilde = (dz / temperature).squeeze(0)
+
+        p_tilde = torch.softmax(z.double() / temperature, dim=-1).squeeze(0)
+        dz_tilde = (dz.double() / temperature).squeeze(0)
         fisher = torch.diag(p_tilde) - torch.outer(p_tilde, p_tilde)
-        rhs = 0.5 * (dz_tilde @ fisher @ dz_tilde)
-        assert abs(lhs.item() - rhs.item()) <= 1e-10
+        exact = 0.5 * (dz_tilde @ fisher @ dz_tilde)
+
+        tolerance = 16.0 * float32_eps * abs(exact.item())
+        assert abs(lhs.item() - exact.item()) <= tolerance, (
+            f"T={temperature}: |{lhs.item():.10g} - {exact.item():.10g}| "
+            f"exceeds {tolerance:.4g} (16 float32 ulps at this scale)")
 
 
 def test_bit_split_ceil_first_pinned():


### PR DESCRIPTION
One of main's three inherited CI failures.

`tests/test_math_reunderwrite_pins.py::test_fisher_quadratic_form_exact` fails on x86-64 CI at `7.45e-09 <= 1e-10` and passes on aarch64. **Neither outcome was about the math.**

## Cause

`fisher_quadratic_form` evaluates the variance form `Σ p (dz − mean)²`; the test's reference evaluated the explicit matrix form `0.5 · dz̃ᵀ(diag(p̃) − p̃p̃ᵀ)dz̃`. Algebraically identical, but they reassociate differently in float32.

The `1e-10` bound sits **below the float32 noise floor of the quantity itself** — at the T=0.5 scale of 0.2509, one float32 ulp is ~1.5e-8, so 7.45e-09 is sub-ulp and not an error. Measured on aarch64: `|lhs − rhs| = 0` exactly, with both sitting 5.5e-09 from the float64 value. It passed here only by the accident that both paths reassociate identically on this ISA.

## Fix

Compare against a **float64** reference, with the tolerance derived from `torch.finfo(torch.float32).eps` (16 ulps — softmax plus a 6-element reduction chain). Principle 2: the only acceptable constants come from the numerical precision of a dtype.

This asserts the real claim — the float32 implementation is correct to float32 precision — and is **strictly stronger** than what it replaced, which could not catch both float32 paths being wrong together.

## Verification

Load-bearing checked by perturbing the *implementation*, not the fixture:

| relative perturbation | T=1.0 | T=0.5 |
|---|---|---|
| 1e-7 | within tol | within tol |
| 1e-6 | within tol | within tol |
| 1e-5 | **CAUGHT** | **CAUGHT** |
| 1e-4 | **CAUGHT** | **CAUGHT** |

Matches the 1.9e-6 relative bound 16 ulps implies. Observed error 5.5e-09 against a 4.8e-07 bound.

`tests/test_math_reunderwrite_pins.py`: 12 passed.

No `docs/ARCHITECTURE.md` change — no default, stage, format, lane, or ship gate is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F46Tr8Az6t2Ky3sRExZ5y