### PR TITLE
chore(dsv4-w8a16): re-freeze the export-source closure after per-file review

### DIFF
--- a/prismaquant/dsv4_w8a16_export_handoff.py
+++ b/prismaquant/dsv4_w8a16_export_handoff.py
@@ -418,9 +418,133 @@ _PUBLISHED_FILES = frozenset({
 # Sequencing: because these four span several commits, the re-stamp covering
 # them belongs in the LAST commit that touches any of them, or the gate is red
 # at every intermediate commit.
+#
+# RE-FROZEN 2026-08-29 for five changes -- the four the 2026-08-28 note left
+# deliberately unstamped, plus the export file's post-merge delta -- each
+# reviewed against THIS handoff rather than merely re-hashed.  This section
+# closes that note's open item: every digest below is again a HEAD blob on a
+# clean worktree.  For each file the reviewed delta is exactly
+# `git diff 93d340a..HEAD -- <file>`, because `93d340a` is the blob every
+# previous stamp named.  This commit touches no other closure file, so it IS
+# the last commit touching any of them and the sequencing rule holds.
+#   export_nvfp4_cb_streaming.py -- the origin/main side of merge `24366aa`,
+#     i.e. PR #86 (`09bc72a`): three hunks, all written for a WRAPPED-MoE
+#     (Qwen3.5-VLM) source whose skeleton speaks a live namespace.
+#     (1) Expert-group keys in that live namespace are rekeyed to the recipe
+#     spelling.  DSv4's per-expert regex
+#     `^model[.]layers[.]N[.]mlp[.]experts[.]i[.](gate|up|down)_proj$` matches
+#     ONLY the live-bridge spelling, so `_plan_expert_stacks` already keys
+#     DSv4 groups by exactly that recipe prefix; `_prefix in (_recipe, _ck)`
+#     holds and nothing is rekeyed.  The recipe->checkpoint map the hunk
+#     builds is injective on this lane (`layers.N.ffn.experts` <-
+#     `model.layers.N.mlp.experts`, N preserved), so neither ambiguity
+#     `raise` can fire.
+#     (2) A packed-stack export name is now taken from that map.  Verified
+#     directly against `DeepseekV4Profile`: for both stacks the new
+#     `f"{ckpt_prefix}.{leaf}"` and the old `_export_base_name(...,
+#     assume_resolvable=True)` return the SAME string
+#     (`layers.3.ffn.experts.gate_up_proj`, `...down_proj`).
+#     (3) `_delegated_target_name` rewrites only names beginning
+#     `language_model.`; DSv4's `to_vllm_internal_name` never emits that
+#     prefix, and the hunk deliberately leaves the bare-`layers.`
+#     DSv4-class case alone.  No emitted tensor name, config target or byte
+#     changes on this lane.
+#   model_profiles/base.py -- `b35ed53` adds three accessors:
+#     `concat_merge_groups()` (empty unless the spec declares
+#     `concat_merges`), `runtime_loads_source_fp8()` (False) and
+#     `requires_multimodal_skeleton()` (False).  Each default is the
+#     fail-closed value: no concat bridge, no runtime-side FP8 dequant
+#     carve-out, no multimodal skeleton.  `Glm5NextProfile` is the ONLY
+#     override of any of the three; `DeepseekV4Profile` subclasses
+#     `ModelProfile` directly and all three resolve to the base
+#     implementation (verified by attribute lookup on the MRO), and
+#     `specs/glm5_next.json` is the only spec in the tree declaring
+#     `concat_merges` -- so `concat_merge_groups()` returns `()` here and
+#     every consumer (`layer_streaming._build_concat_merger`,
+#     `export_native_compressed`) is a no-op on this lane.
+#   model_profiles/registry.py -- `b35ed53` registers `Qwen4ExpProfile`
+#     (priority 200) and `Glm5NextProfile` (priority 210), both AFTER
+#     DeepSeek-v4's 170, and each `matches()` claims only `qwen4_exp*` /
+#     `glm5_next*` model types and `Qwen4Exp*` / `Glm5Next*` architectures --
+#     disjoint from `deepseek_v4`, so detection is unchanged.  The same
+#     commit makes `detect_profile` refuse a `model_path` that is not an
+#     existing directory.  That can only turn an absent-path run into a loud
+#     refusal, and an absent path was never a valid DSv4 export (it would
+#     have fallen through to `DefaultProfile` and mis-named every tensor).
+#   layer_streaming.py -- `0c87d8d`.  This lane DOES execute the streamed
+#     read, so each piece is argued, not dismissed as unreached.
+#     * Threaded intra-layer gather (default ON).  The job list is built in
+#       `by_shard` order and `_split_pairs` cuts each shard's pairs into
+#       CONTIGUOUS chunks, and `out.update(fut.result())` consumes futures in
+#       that same order -- so the assembled dict has identical contents AND
+#       identical key order to the serial loop.  Each worker opens its own
+#       `safe_open` handle and applies the same dtype cast and contiguity
+#       fix; `.result()` re-raises, and a new count check refuses a partially
+#       gathered layer rather than installing it.
+#       `PRISMAQUANT_LAYER_READ_THREADS=1` restores the byte-identical serial
+#       read.  Only the order pages fault in changes; no tensor value can.
+#     * Post-gather view compaction: clones any tensor whose storage exceeds
+#       2x its own bytes.  `detach().clone().contiguous()` preserves dtype,
+#       shape and every element, and it runs AFTER the last in-place step
+#       (the batched FP8 dequant, then the expert packer), so nothing
+#       downstream loses a write-through it relied on.  Resident bytes
+#       change; read bytes do not.
+#     * `LayerCache` pressure-eviction rework (`_drop`, the new prefetch-pin
+#       phase, the `_pinned_until_read` discard and `evicted_pinned`
+#       counter).  It decides WHICH cached layers are dropped under host
+#       memory pressure; a dropped layer is re-read from the same shards.
+#       This moves cache hit/miss/eviction telemetry and wall-clock, never a
+#       weight.
+#     * `has_dsa` in `_compute_attention_mask` is doubly inert.
+#       `deepseek_sparse_attention` is transformers' `glm5_next` layer type;
+#       DSv4-Flash's own `DEEPSEEK_V4_LAYER_TYPES` is `{sliding_attention,
+#       compressed_sparse_attention, heavily_compressed_attention}`, so
+#       `has_dsa` is False -- and `sliding_attention` already made
+#       `has_sliding` True, so the guarded early return was not taken before
+#       the change either.  The added `masks` entry is unreachable here.
+#   production_weight_cache.py -- `f7970e7`.  This lane DOES call
+#     `fill_packed_expert_cache_entries`, so likewise argued.
+#     * Packed experts now carry their own render-score and render-gate
+#       records (`_packed_expert_render_score_record` /
+#       `_packed_expert_render_gate_record`, summing the dense path's own
+#       `_render_score_record` over experts).  Scoring is READ-ONLY: every
+#       access is `detach().to(...)`, `.t()`, `.pow(2).mean()`; no in-place
+#       write reaches `packed_param` or `rendered`, so the tensor stored is
+#       the tensor that was rendered.  All four helpers it leans on
+#       (`_render_score_record`, `_render_score_record_key`,
+#       `_write_render_score_sidecar`, `_summarize_render_gate_records`)
+#       already existed at the previous freeze, and the CB-pair admission's
+#       `render_score=` kwarg was already the dense path's.
+#     * `_needs_work` now also counts a missing render score.  On a resumed
+#       build that runs an activation capture it previously skipped, but the
+#       resume branch still `continue`s WITHOUT re-rendering: it scores the
+#       shard bytes already on disk (a `torch.load(...,
+#       weights_only=True)` read).  `activation_max_abs` keeps its "first
+#       calibrated scale wins" `is None` guard, so the scale the shipped
+#       rung calibrated cannot be clobbered by the extra pass either.
+#     * `_finalize_packed_expert_cache_metadata` recomputes
+#       `requested_entries` and the `render_scores` / `render_gates` /
+#       `packed_expert_coverage` scopes from the cache.  It rewrites cache
+#       METADATA only, and it can turn a stale-counter refusal of the exact
+#       union into a pass, never the reverse -- the same direction the
+#       2026-08-15 `artifact_completeness.py` bullet accepted.  Pruning is
+#       bounded to `all_packed_fullnames`, so dense and MTP records are
+#       outside its reach by construction.
+#     * Device probe: the first NON-meta parameter instead of
+#       `next(model.parameters())`.  Identical whenever the first parameter
+#       is non-meta, which is every case a DSv4 export ever completed; where
+#       it differs the old value was a `meta` device, which no successful
+#       render used.
+#     * `del src, overrides, render_acts, eval_acts, eval_gw` (and `w_rtn`
+#       when `E > 0`) at the end of the batched branch.  Every one of those
+#       names is dead at that point -- verified by scanning the remainder of
+#       the function for a read -- and each is reassigned at the top of the
+#       next iteration, so a mistake would be a loud `NameError`, never a
+#       silent byte.  It frees GPU transients; `rendered` and `packed_param`,
+#       the two tensors the score and the store consume, survive.
 _FROZEN_EXPORT_SOURCE_SHA256 = {
     "prismaquant/export_nvfp4_cb_streaming.py": (
-        "0714e841ebe0c1960186bbc20deeb367bd4737d0475d198bd653e9a400a5c54f"
+        "dfffc634a7275e76a4c4b3bd0299e8b0775673dca23f6f5c56ca31f8b748b8a5"
     ),
     "prismaquant/cb_export_config.py": (
         "3aa767bba9e689d50234730846a1671088ec0b16278d18aa6fa2693815294412"
@@ -435,10 +559,10 @@ _FROZEN_EXPORT_SOURCE_SHA256 = {
         "fb20303ed1b017a5a7f3a035d5ef43880822d775e252c28a08f32a67f8104c95"
     ),
     "prismaquant/model_profiles/base.py": (
-        "f9a89bfa4aa19447bb30346e95bbb0ea1da054d18faebbddbeefd4f8534187e6"
+        "147699331599870a8ba153ae5132f5bda1f32f5ba4e0298a784c3084df05207a"
     ),
     "prismaquant/model_profiles/registry.py": (
-        "3b88ee0d37521dd0a6c0a9a905af02d4109b4ccdec1e7a4c41a4b817f496f2be"
+        "5da03be05dafd7e804be9588854bfeabed2aec29b76ea2f6c6cbef2c6067188d"
     ),
     "prismaquant/model_profiles/deepseek_v4.py": (
         "6368f5657fbfb3b77a886e9bc0c589885d9240c49fdb77635d4bf2a74164b6f6"
@@ -450,10 +574,10 @@ _FROZEN_EXPORT_SOURCE_SHA256 = {
         "d9a06483d008bf2361b0522bc258ab291db870d1c2432f9d4cd8d7a8cbacefbe"
     ),
     "prismaquant/layer_streaming.py": (
-        "5344f30043be08baf0c1509d77be511f6d2fbe963ce4d7b32afd8072a48a9da4"
+        "e2d947fe9ba98c612e13a9abe66dbb70aaadde83b0b0db394d100cbff82378c1"
     ),
     "prismaquant/production_weight_cache.py": (
-        "1cc27e3b64043f9873da528ae2aa128e37c15be303109509f713b8d738c59f36"
+        "c0c2aa9c322e2c5aa264d786d8df26166908fc47290ab14ae996c207370d7263"
     ),
     "prismaquant/nvfp4_cb_footprint.py": (
         "96bc38a7ab18c6d2401ed2b66141eef9809409c78468f8ceb16c0891b9701547"


### PR DESCRIPTION
Clears two of main's three inherited CI failures — `test_exact_w8a16_handoff_returns_read_only_receipt` and `test_tracked_frozen_export_sources_match_reviewed_bytes`. (The third is PR #90.)

The frozen closure had drifted on **5 of 15 files**. This gate's own doctrine is that each stamp is *"reviewed against THIS handoff rather than merely re-hashed"*, and it explicitly named `layer_streaming.py` and `production_weight_cache.py` as paths DSv4 W8A16 **executes** — so those two are argued, not dismissed.

## Baseline

Every previous stamp names blob `93d340a`, so `git diff 93d340a..HEAD -- <file>` is exactly the reviewed-bytes → current-bytes delta. `09bc72a` (PR #86) and `93d340a` sit on different branch lines joined by merge `24366aa`, so `09bc72a..HEAD` is a misleading view.

## Verdicts

| File | Change | Verdict |
|---|---|---|
| `export_nvfp4_cb_streaming.py` | PR #86 wrapped-MoE (Qwen3.5-VLM) hunks | Inert |
| `model_profiles/base.py` | 3 new fail-closed accessors | Inert |
| `model_profiles/registry.py` | 2 registrations + `is_dir()` refusal | Inert |
| `layer_streaming.py` | threaded gather, view compaction, eviction rework, `has_dsa` | **Inert (lane executes it)** |
| `production_weight_cache.py` | packed-expert render scoring + metadata finalizer | **Inert (lane executes it)** |

Selected arguments:

- **`has_dsa` is doubly inert.** `deepseek_sparse_attention` is transformers' *glm5_next* layer type; `DEEPSEEK_V4_LAYER_TYPES` is `{compressed_sparse_attention, heavily_compressed_attention, sliding_attention}` — verified in `vendored/transformers_deepseek_v4/configuration_deepseek_v4.py:21-27`. And `sliding_attention` already made `has_sliding` true, so the guarded early return was not taken before the change either.
- **Threaded gather preserves order, not just contents.** Jobs built in `by_shard` order, `_split_pairs` cuts contiguous chunks, `out.update(fut.result())` consumes in that order; per-worker `safe_open`; `.result()` re-raises; a new count check refuses a partial layer; `PRISMAQUANT_LAYER_READ_THREADS=1` restores serial.
- **Render scoring is read-only** — `detach().to(...)`, `.t()`, `.pow(2).mean()`; the stored tensor is the rendered tensor. The resume branch still `continue`s without re-rendering.

## Caveats stated in the prose, not hidden

- The `production_weight_cache.py` finalizer and `layer_streaming.py` eviction counters **do** change cache metadata and can flip a stale-counter union refusal to a pass — never the reverse. Same direction as the pin's own 2026-08-15 `artifact_completeness.py` precedent, cited in the section.
- `_canonical_qname` / `_export_base_name` live in `export_nvfp4_cb.py`, which is **not** in the 15-file closure. One hunk's inertness depends on a helper the pin does not hash — a pre-existing gap in the declared release boundary, flagged rather than silently relied on.

## Verification

`tests/test_dsv4_w8a16_export_handoff.py`: **6 passed, 0 failed.**

Sequencing: this commit touches no other closure file, so it is trivially the last commit touching any of them — the pin's own rule holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F46Tr8Az6t2Ky3sRExZ5y