### PR TITLE
feat(trellis): wire 7 of 8 seam links; the anchors' currency stays a refusal

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,30 @@
 # PrismaQuant Architecture
 
-As of: 2026-08-29 · `claude/trellis-continuous-surface` — stamps follow, newest
+As of: 2026-08-29 · `claude/trellis-seam-wiring` — stamps follow, newest
 first, each recording its own branch and date. Re-stamped (2026-08-29,
-`claude/trellis-continuous-surface`) for the **trellis seam correction**
+`claude/trellis-seam-wiring`) for the **trellis seam wiring** (§4.9): seven of
+the eight `UNWIRED_LINKS` are now wired, each with a behaviour test, so an
+enabled seam builds the menu instead of refusing outright. Both super-item
+aggregators build each menu from the MEMBERS' candidate lists rather than from
+`FormatSpec` objects (`_super_menu_format_names`) — the silent gap that dropped
+every rung from every coupled unit; `format_rank` is extended from the
+candidate menu by exact serialized rate so `promote_serving_units` can rank a
+selected rung; exact bytes travel in `_memory_bytes_by_format` written by the
+seam and read by the payload filter, `footprint`, `compute_achieved`,
+`kl_measurement` and bit attribution, each refusing pointedly rather than
+falling back to a closed form (**no TCQ `FormatSpec` is registered, and that is
+the design** — a rung's bytes are not a function of `(name, shape)`); and the
+run's **attested** `COST_MODE` plus the surface provenance (manifest sha256,
+currency, anchor activation contract) now travel into `layer_config.json`'s
+`__prismaquant__` block. The eighth link — the anchors' weighted-SSE currency —
+is not plumbing and stays a refusal (`_require_run_currency`). Because both
+aggregators are default-path code, `tests/test_super_item_menu_byte_identity.py`
+and its golden fixture were generated and committed **before** the change and
+re-run after: digest
+`033adb45e71a51b831f5335047fa56e5fb00dc3137894a983fa0146bf456197d`, unchanged.
+Earlier same-day stamp (`claude/trellis-continuous-surface`) for the
+**trellis seam correction** — *superseded by the wiring stamp above: the
+outright refusal and the eight-entry ledger it describes are history*
 (§4.9): the seam that landed earlier the same day is now **fail-closed** when
 enabled, and this document's claim that it made trellis rungs "pass the same
 legality, aggregation and byte accounting every other candidate does" is
@@ -3392,7 +3414,8 @@ is now the ONE seam that does, and it is off by default.
 **The flag, and what it does today.** `PRISMAQUANT_TRELLIS_SURFACE=<manifest.json>`.
 Unset, `augment_candidates` returns its input object unchanged, so a run
 without the flag executes exactly the path it executed before the seam existed
-— the `PRISMAQUANT_FISHER_CAP_MULTIPLIER` precedent (§ P6). **Set, it refuses.**
+— the `PRISMAQUANT_FISHER_CAP_MULTIPLIER` precedent (§ P6). **Set, it builds
+the menu, and refuses only on the anchors' currency.**
 
 > **Correction (2026-08-29, same day).** The first version of this section said
 > the seam's placement inside `allocator_candidates.build_candidates` meant
@@ -3400,49 +3423,81 @@ without the flag executes exactly the path it executed before the seam existed
 > other candidate does." That was **false on all three counts**, and it is the
 > § P13 "currency is not truth" case in its own doc: the paragraph was written
 > in the same commit as the code and was wrong about it. The seam appends
-> AFTER the per-spec legality loop, so it never runs
-> `check_stats_format_applicability` nor the `_memory_bytes_by_format` write at
-> `allocator_candidates.py:1950`; aggregation drops every rung; byte accounting
-> `KeyError`s. `trellis_menu.UNWIRED_LINKS` is now the authoritative list —
-> eight entries, each with a file:line — and it is the text of the refusal.
+> AFTER the per-spec legality loop, so it never ran the
+> `_memory_bytes_by_format` write at `allocator_candidates.py:1950`;
+> aggregation dropped every rung; byte accounting `KeyError`d.
+> `trellis_menu.UNWIRED_LINKS` is the authoritative list, and the seam refused
+> as a whole while it held eight entries.
 
-The eight, in the order a run would hit them: no TCQ `FormatSpec`
-(`format_registry.py:1267-1272`); the exact assignment-payload filter falling
-through to `fr.get_format` because nothing writes `_memory_bytes_by_format` for
-a TCQ row, which kills the allocator inside the Pareto sweep **before**
-`layer_config.json` and makes the pointed refusals in `layer_config` and the
-exporter unreachable (`allocator.py:3369-3386`); fused-sibling aggregation
-building super-item menus by iterating `FormatSpec` objects
-(`allocator_candidates.py:2464`); the identical packed-expert construction
-(`:2701`); `promote_serving_units`' `format_rank` lookup, which does not crash
-today only because aggregation guarantees a TCQ unit is a lone ungrouped
-Linear (`allocator_solver.py:340-342`); the byte-budget path's own registry
-lookup (`footprint.py:1183`); `build_candidates` being called with neither
-`cost_mode=` nor `trellis_provenance=`, so the currency gate compares against
-`os.environ.get("COST_MODE","aura")` — a variable `run-pipeline.sh` sets with
-`:=` and never exports — and the manifest identity and anchor contract are
-discarded rather than travelling with the assignment (`allocator.py:2756`,
-§§ P12/P14); and the anchors' currency being weighted SSE under an activation
-second moment, an output-MSE proxy and **not** the AURA KL-adjoint the DP ranks
-in (`trellis_rate_surface.py:43-52`).
+**Seven of the eight were wired later the same day; one is left, and it is not
+a wiring gap.**
 
-**Why refuse as a whole rather than wire it halfway.** The eight do not fail
-alike. The registry gaps crash **loudly**; the aggregation gaps are **silent** —
-they drop every rung from every fused and packed group and hand back a
-plausible frontier in which only `o_proj` and `down_proj` could carry one. A
-partial fix that removed the crashes would trade the loud failure for the
-silent one, and the packed-expert case was worse still: a hand-rolled 2-tuple
-shape priced a 128-expert row as one expert (a **128×** underprice, reported as
-"0 unit(s) skipped"), while the guard meant to catch it read a stats key
-nothing writes. Both are fixed — the seam now uses
-`allocator_solver._shape_from_stats` and
+| was | now |
+|---|---|
+| no TCQ `FormatSpec` (`format_registry.py:1267-1272`) | **still true, on purpose** — see *Why no TCQ `FormatSpec`* below. Exact bytes travel in `_memory_bytes_by_format` instead, and every site that would have resolved the registry refuses pointedly. |
+| the exact assignment-payload filter falls through to `fr.get_format` (`allocator.py:3369-3386`) | prefers the recorded map (it always did); a TCQ row with no recorded bytes now raises a pointed `AssertionError` naming what is missing, instead of a registry `KeyError`. `layer_config.canonicalize_format` round-trips `TCQ_*`, so the exporter's own refusal is now REACHABLE. |
+| fused-sibling aggregation iterates `FormatSpec` objects (`allocator_candidates.py:2464`) | both aggregators build each super item's menu from `_super_menu_format_names(formats, member_intersection)`: the run's spec names first, in order, then any registry-free format EVERY member offers. Registry-free rungs are priced as the exact sum of the member candidates' bytes and Δloss, with an aggregated hedge of 0.0 (the solver `Candidate` carries no stderr, so fabricating one would be a claim). |
+| the identical packed-expert construction (`:2701`) | same helper, same contract. The seam still refuses packed-expert ROWS (no per-expert trellis render exists), so no manifest reaches this path today; the aggregation contract is tested by injection. |
+| `promote_serving_units`' `format_rank` lookup (`allocator_solver.py:340-342`) | `allocator._extend_format_rank_with_candidate_menu` extends the rank table from the CANDIDATE MENU by each registry-free format's exact aggregate serialized rate (`8·Σbytes/Σparams`) — the same quantity `_serialized_format_rates` computes for a spec, so "higher rank" keeps meaning "more bytes on this model" (§ P2). Byte-identical no-op when every candidate format is a spec. The solver's lookup now names the rank table on a miss instead of raising a bare `KeyError`. |
+| the byte-budget path's own registry lookup (`footprint.py:1183`) | a TCQ branch before the final `else` reads `_memory_bytes_by_format` and **refuses** when it is absent — same doctrine as the CB branch above it, no closed-form fallback. |
+| `build_candidates` called with neither `cost_mode=` nor `trellis_provenance=` (`allocator.py:2756`) | both are passed. The cost mode is the **attested** one: `cost_data["provenance"]["cost_mode"]` (re-vet R2), never `os.environ` — `run-pipeline.sh` assigns `COST_MODE` with `:=` and never exports it. The provenance (manifest **sha256**, declared currency, the run's objective currency, the anchor activation contract, lane/route status) lands in `layer_config.json`'s `__prismaquant__` block under `trellis_surface`, present only when the seam contributed (§§ P12/P14, § P6). |
+| the anchors' currency is weighted SSE under an activation second moment (`trellis_rate_surface.py:43-52`) | **the one remaining entry**, and the surviving refusal. |
+
+**Why the last one stays a refusal.** It is not plumbing. The ladder's measured
+anchors are weighted SSE under a per-input-channel activation second moment —
+an output-MSE proxy — while an `aura` run's DP ranks the KL-adjoint. No code
+change converts one into the other; AURA-priced anchors are a **dW-supply**
+problem (`aura_cost`'s two dW sources both require a registered format).
+`trellis_menu._require_run_currency` therefore compares the manifest's declared
+`currency` against `COST_MODE_OBJECTIVE_CURRENCY[cost_mode]` — the same
+`COST_RENDER × COST_OBJECTIVE` decomposition `run-pipeline.sh` resolves, so the
+expected value is definitional rather than chosen (§ P2) — and refuses with
+`TrellisSeamUnwiredError`. An **unstamped** cost table is refused too, rather
+than compared against a default.
+
+**Why refuse as a whole rather than wire it halfway (the reasoning that held
+until the links landed).** The eight did not fail alike. The registry gaps
+crashed **loudly**; the aggregation gaps were **silent** — they dropped every
+rung from every fused and packed group and handed back a plausible frontier in
+which only `o_proj` and `down_proj` could carry one. A partial fix that removed
+only the crashes would have traded the loud failure for the silent one. The
+packed-expert case was worse still: a hand-rolled 2-tuple shape priced a
+128-expert row as one expert (a **128×** underprice, reported as "0 unit(s)
+skipped"), while the guard meant to catch it read a stats key nothing writes.
+Both are fixed — the seam uses `allocator_solver._shape_from_stats` and
 `allocator_candidates._stats_indicates_packed_expert`, and refuses a packed row
-with a counted reason — but the fix is inside `build_trellis_menu`, which is
-research-reachable and cannot reach an artifact.
+with a counted reason.
 
-**So: `build_trellis_menu` builds a correctly priced menu; `augment_candidates`
-refuses.** Enabling the surface means landing the eight links with tests that
-exercise behaviour and then deleting the refusal — not passing a flag.
+**Why no TCQ `FormatSpec`.** The obvious alternative — register a minimal spec
+so every registry lookup just works — is unavailable as a matter of arithmetic,
+not taste. `FormatSpec.memory_bytes_for_shape` is a closed form over
+`weight_bits` / `scale_bits` / `group_size`; a rung's exact size needs the
+layout, the per-column schedule and the alphabet directory
+(`trellis_footprint.trellis_tensor_payload_breakdown`: 16-byte row-stride
+alignment, an 88-byte wire header, a nibble schedule plane, block offsets under
+`tight_offsets`, a family-specific scale plane), all per-campaign manifest
+data. `(name, shape)` therefore does not determine the bytes, and a registered
+spec could only be **plausible and wrong** — silently consumed by
+`_serialized_format_rates`, `footprint` and the payload filter, which is
+exactly the failure this seam exists to prevent. It would also expose TCQ to
+every `act_quant_changes_input` / `quantize_dequantize` consumer with no render
+behind it. So the bytes ride the `Candidate` and `_memory_bytes_by_format` —
+the repo's existing single mechanism (§ P8) — `fr.get_format("TCQ_…")` keeps
+raising, and the cost is N pointed refusals instead of one registry entry. Each
+refuses where a closed form would have guessed.
+
+**Principle-6 evidence for the aggregation change.** Both aggregators are
+default-path code. `tests/test_super_item_menu_byte_identity.py` +
+`tests/fixtures/super_item_menu_golden.json` were generated and committed
+**against the unmodified functions**, and pin every super item's whole menu in
+order (fmt, `bits_per_param`, `memory_bytes`, `predicted_dloss`, both
+serialized identities, `activation_pricing`, `serving_lane`, all floats by
+`repr`), the `_memory_bytes_by_format` map, the whole `costs_ext` row including
+`predicted_dloss_stderr`, and the pass-through row names — across five
+scenarios covering both aggregators, `PRISMAQUANT_COST_UCB_Z` at 0 and 1.5,
+calibrated gains, activation fair pricing and the role-split packed profile.
+Golden digest `033adb45e71a51b831f5335047fa56e5fb00dc3137894a983fa0146bf456197d`,
+unchanged after the change.
 
 **Why a manifest, not a `FORMATS` enum entry.** A trellis rung is
 `(family, body_rate_q256, layout, schedule, alphabets)`, and the wire carries
@@ -3481,8 +3536,11 @@ which is where per-member layout identity belongs.
    trellis rung has no `FormatSpec` and no RTN `quantize_dequantize`, because
    nothing renders one).
 2. *An objective the run is not pricing in.* The manifest declares `cost_mode`
-   and `currency`; a mismatch with the run refuses. One DP prices in one
-   currency.
+   and `currency`; **both** are checked against the run and a mismatch refuses.
+   One DP prices in one currency. The run's cost mode comes from the cost
+   table's own provenance stamp, not the environment, and the currency it
+   implies is `COST_MODE_OBJECTIVE_CURRENCY[cost_mode]`. This is the surviving
+   `UNWIRED_LINKS` entry.
 3. *An unstated activation contract.* The manifest must declare the contract
    its dloss numbers were measured under, and it is stamped on the provenance
    payload. The hull anchors were priced **W\*A16** while both families' native
@@ -3503,15 +3561,26 @@ surface lets the DP see the continuum, report where bytes would go, and price
 the choice in exact serialized bytes. Promoting it to an artifact needs a
 render mechanism and a runtime attestation first; both are open (§12).
 
-Gate: `tests/test_trellis_menu.py` (15), on top of the surface's own 69.
-Two of the original 13 asserted on **source text** — that the string
-`trellis_menu.augment_candidates` appeared in `build_candidates` — which passes
-whether or not the call does anything, and did pass while the enabled path
-could not produce an assignment at all. They now assert observed behaviour: the
-seam raises `TrellisSeamUnwiredError` naming every entry of `UNWIRED_LINKS`, a
-128-expert row is skipped-with-reason rather than underpriced, and the two
-cheapest ledger entries are re-checked against the code so a stale entry fails
-the suite.
+Gate: `tests/test_trellis_menu.py` (31) +
+`tests/test_super_item_menu_byte_identity.py` (3), on top of the surface's own
+69. **Every one asserts behaviour.** Four earlier tests in this file asserted
+source text — that the string `trellis_menu.augment_candidates` appeared in
+`build_candidates`, that `"for spec in formats:"` occurred at least twice in
+`allocator_candidates.py`, that two literals appeared in the exporter — and all
+of them passed while the enabled path could not produce an assignment at all.
+They are replaced by tests that call the code: `build_candidates` with the flag
+set really installs rungs and records their bytes; a fused super item really
+offers the rung both siblings share, at the exact sum of their bytes and Δloss,
+with the registry menu still first; a packed group really keeps a registry-free
+format its members share (by injection, since the seam refuses packed rows);
+`promote_serving_units` really runs on an assignment containing a rung and
+really names the rank table when one is unranked; `footprint` really prices a
+rung from the recorded bytes and really refuses without them;
+`_coerce_runtime_legal_assignment` really raises the pointed export refusal;
+`canonicalize_format` really round-trips a `TCQ_*` name and really rejects an
+unparseable one; and a weighted-SSE manifest really refuses with the surviving
+link named. `UNWIRED_LINKS` itself is asserted to hold exactly that one entry,
+so a stale ledger fails the suite.
 
 ## 5. Formats & render
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,11 +9,15 @@ aggregators build each menu from the MEMBERS' candidate lists rather than from
 `FormatSpec` objects (`_super_menu_format_names`) — the silent gap that dropped
 every rung from every coupled unit; `format_rank` is extended from the
 candidate menu by exact serialized rate so `promote_serving_units` can rank a
-selected rung; exact bytes travel in `_memory_bytes_by_format` written by the
-seam and read by the payload filter, `footprint`, `compute_achieved`,
-`kl_measurement` and bit attribution, each refusing pointedly rather than
-falling back to a closed form (**no TCQ `FormatSpec` is registered, and that is
-the design** — a rung's bytes are not a function of `(name, shape)`); and the
+selected rung; exact bytes travel in `_memory_bytes_by_format`, written by the
+seam and preferred by every byte reader inside the allocator process — the
+payload filter and `footprint` refuse pointedly when it is absent, and
+`compute_achieved` and bit attribution prefer it rather than guessing a closed
+form (**no TCQ `FormatSpec` is registered, and that is the design** — a rung's
+bytes are not a function of `(name, shape)`). That map is **process-local**: it
+is never written back to `probe.pkl`, so the seam's reach is allocation-time
+only and a TCQ assignment handed to a later stage (`kl_measurement`, export)
+fails at the registry lookup — by design, and the next wiring frontier. Finally the
 run's **attested** `COST_MODE` plus the surface provenance (manifest sha256,
 currency, anchor activation contract) now travel into `layer_config.json`'s
 `__prismaquant__` block. The eighth link — the anchors' weighted-SSE currency —
@@ -3443,6 +3447,15 @@ a wiring gap.**
 | `build_candidates` called with neither `cost_mode=` nor `trellis_provenance=` (`allocator.py:2756`) | both are passed. The cost mode is the **attested** one: `cost_data["provenance"]["cost_mode"]` (re-vet R2), never `os.environ` — `run-pipeline.sh` assigns `COST_MODE` with `:=` and never exports it. The provenance (manifest **sha256**, declared currency, the run's objective currency, the anchor activation contract, lane/route status) lands in `layer_config.json`'s `__prismaquant__` block under `trellis_surface`, present only when the seam contributed (§§ P12/P14, § P6). |
 | the anchors' currency is weighted SSE under an activation second moment (`trellis_rate_surface.py:43-52`) | **the one remaining entry**, and the surviving refusal. |
 
+**Reach: allocation-time only, and deliberately.** `_memory_bytes_by_format` is
+written into the in-memory probe stats; nothing rewrites `probe.pkl`, so the
+exact bytes do not survive the allocator process. Every later stage
+(`kl_measurement.assignment_bit_total`, `production_recache`, export) resolves a
+format through the registry first, so a TCQ assignment that escapes into one
+fails at that lookup rather than being priced by a closed form. Wiring the seam
+did not make a trellis rung shippable and was not meant to: an exportable rung
+needs a render and a P14 runtime attestation, neither of which exists.
+
 **Why the last one stays a refusal.** It is not plumbing. The ladder's measured
 anchors are weighted SSE under a per-input-channel activation second moment —
 an output-MSE proxy — while an `aura` run's DP ranks the KL-adjoint. No code
@@ -3497,7 +3510,11 @@ serialized identities, `activation_pricing`, `serving_lane`, all floats by
 scenarios covering both aggregators, `PRISMAQUANT_COST_UCB_Z` at 0 and 1.5,
 calibrated gains, activation fair pricing and the role-split packed profile.
 Golden digest `033adb45e71a51b831f5335047fa56e5fb00dc3137894a983fa0146bf456197d`,
-unchanged after the change.
+unchanged after the change. A passing golden is not yet evidence, so
+`test_the_golden_is_load_bearing` mutates the aggregators' menu-order helper at
+runtime — the same SET of formats in a different DP order, the minimal
+perturbation an order-blind record would miss — and asserts the digest MOVES
+(to `0d7b2edf…`) and returns on restore.
 
 **Why a manifest, not a `FORMATS` enum entry.** A trellis rung is
 `(family, body_rate_q256, layout, schedule, alphabets)`, and the wire carries

--- a/prismaquant/allocator.py
+++ b/prismaquant/allocator.py
@@ -129,6 +129,7 @@ from .fixed_head import (
     is_lm_head_name,
     parse_allow_pinned,
 )
+from .trellis_formats import parse_trellis_format_name
 from .nvfp4_cb_footprint import (
     CB_ASSIGNMENT_IDENTITIES_FIELD,
     CB_TENSOR_IDENTITY_FIELD,
@@ -251,6 +252,68 @@ def _sort_specs_by_serialized_rate(
         sorted(specs, key=lambda spec: (rates[spec.name], spec.name)),
         rates,
     )
+
+
+def _extend_format_rank_with_candidate_menu(
+    format_rank: dict[str, int],
+    rank_rates: Mapping[str, float],
+    stats: Mapping[str, Mapping],
+    candidates: Mapping[str, list],
+) -> tuple[dict[str, int], dict[str, float]]:
+    """Rank menu formats that have no ``FormatSpec``, by their exact rate.
+
+    ``promote_serving_units`` indexes ``format_rank`` for EVERY assigned
+    format of a coupled unit, so a format the registry cannot resolve is a
+    live ``KeyError`` the moment super-item aggregation stops dropping such
+    formats.  The rank is not a preference to invent (principle 2): it is
+    the same quantity :func:`_serialized_format_rates` computes for a
+    ``FormatSpec`` -- aggregate exact serialized bits per parameter over the
+    shapes that can carry it -- read off the candidates that already hold
+    those exact bytes, because a format with no spec has no closed form to
+    ask.  "Higher rank" therefore keeps meaning "more bytes on this model",
+    which is exactly the invariant promotion relies on.
+
+    Existing names keep their relative order: they were sorted ascending by
+    ``(rate, name)``, so re-sorting them by ``(rate, current index)`` is the
+    identity.  With no registry-free format in the menu the returned rank is
+    the input rank, key for key.
+    """
+    spec_names = set(format_rank)
+    bytes_by_fmt: dict[str, int] = {}
+    params_by_fmt: dict[str, int] = {}
+    for unit, menu in candidates.items():
+        entry = stats.get(unit)
+        n_params = int(entry.get("n_params", 0) or 0) if isinstance(entry, Mapping) else 0
+        for cand in menu:
+            if cand.fmt in spec_names:
+                continue
+            bytes_by_fmt[cand.fmt] = (
+                bytes_by_fmt.get(cand.fmt, 0) + int(cand.memory_bytes))
+            params_by_fmt[cand.fmt] = params_by_fmt.get(cand.fmt, 0) + n_params
+    if not bytes_by_fmt:
+        return format_rank, dict(rank_rates)
+    # Keyed by the RANK table, not the rate table: a rate the rank never
+    # carried must not become a rank entry as a side effect.
+    rates = {name: float(rank_rates[name]) for name in format_rank}
+    for fmt_name, total_bytes in bytes_by_fmt.items():
+        total_params = params_by_fmt.get(fmt_name, 0)
+        if total_params <= 0:
+            raise AssertionError(
+                f"[alloc] cannot rank {fmt_name!r}: it is offered by "
+                f"{sum(1 for m in candidates.values() if any(c.fmt == fmt_name for c in m))} "
+                "unit(s) whose stats carry no n_params, so its exact "
+                "serialized rate is undefined. A menu format with no "
+                "FormatSpec must be priced from the candidates that hold "
+                "its bytes; there is no closed form to fall back to."
+            )
+        rates[fmt_name] = 8.0 * total_bytes / float(total_params)
+    order = {name: i for i, name in enumerate(
+        sorted(format_rank, key=format_rank.__getitem__))}
+    merged = sorted(
+        rates,
+        key=lambda name: (rates[name], order.get(name, len(order)), name),
+    )
+    return {name: i for i, name in enumerate(merged)}, rates
 _RD_LOG_LINEAR_R2_THRESHOLD = 0.99
 
 
@@ -2753,6 +2816,15 @@ def main():
             print(line, flush=True)
 
     candidate_mask_records: list[dict] = []
+    # The run's objective, ATTESTED: the cost stage stamps the pipeline
+    # COST_MODE that produced this table into provenance (re-vet R2). It is
+    # not read from os.environ -- run-pipeline.sh assigns COST_MODE with `:=`
+    # and never exports it, so an environment read here would compare the
+    # trellis manifest's declared objective against a default the run may
+    # never have used.
+    run_cost_mode = str(
+        (cost_data.get("provenance") or {}).get("cost_mode", "") or "")
+    trellis_provenance: dict = {}
     candidates = build_candidates(
         stats, costs, specs_sorted, calibrated_gains,
         source_manifest=source_manifest,
@@ -2760,8 +2832,27 @@ def main():
         mask_records=candidate_mask_records,
         cb_serialization_context=cb_serialization_context,
         activation_pricing=activation_pricing,
+        cost_mode=run_cost_mode,
+        trellis_provenance=trellis_provenance,
     )
     print(f"[alloc] candidates built for {len(candidates)} Linears")
+    # Formats with no FormatSpec can now be in the menu (the trellis seam is
+    # the only producer today). promote_serving_units indexes format_rank for
+    # every assigned format of a coupled unit, so the rank table has to cover
+    # the MENU, not the registry. No-op when every candidate format is a spec.
+    format_rank, _rank_serialized_rates = _extend_format_rank_with_candidate_menu(
+        format_rank, _rank_serialized_rates, stats, candidates)
+    if trellis_provenance:
+        print(
+            "[alloc] trellis surface: "
+            f"{trellis_provenance.get('candidates_added', 0)} rungs added "
+            f"across {trellis_provenance.get('units_in_menu', 0)} units "
+            f"(manifest {trellis_provenance.get('manifest_sha256', '?')[:12]}, "
+            f"currency {trellis_provenance.get('currency', '?')}, "
+            f"anchors measured at "
+            f"{trellis_provenance.get('anchor_activation_contract', '?')})",
+            flush=True,
+        )
 
     fixed_format_assignment: dict[str, str] = {}
     fixed_stats: dict[str, dict] = {}
@@ -2811,6 +2902,9 @@ def main():
             # own predicted_dloss/cost_source precedence while making the
             # absence of body activation transfer explicit.
             activation_pricing=None,
+            # Pinned menu: the format is an operator declaration, not a
+            # DP choice, so the research surface has nothing to offer it.
+            apply_trellis_surface=False,
         )
         missing_head_candidates = [
             name for name in head_probe_names
@@ -2897,6 +2991,9 @@ def main():
             mask_records=candidate_mask_records,
             cb_serialization_context=cb_serialization_context,
             activation_pricing=activation_pricing,
+            # Pinned menu: the format is an operator declaration, not a
+            # DP choice, so the research surface has nothing to offer it.
+            apply_trellis_surface=False,
         )
         missing_mtp_candidates = [
             name for name in mtp_names
@@ -2969,6 +3066,9 @@ def main():
                 mask_records=candidate_mask_records,
                 cb_serialization_context=cb_serialization_context,
                 activation_pricing=activation_pricing,
+                # Pinned menu: the format is an operator declaration,
+                # not a DP choice, so the surface has nothing to offer.
+                apply_trellis_surface=False,
             )
             visual_aux_candidates = {
                 name: cand for name in visual_cost_names
@@ -3379,6 +3479,26 @@ def main():
                         ),
                     )
                 continue
+            if parse_trellis_format_name(fmt) is not None:
+                # A trellis rung's exact bytes are NOT a function of (name,
+                # shape): the wire's body stride, block offsets, per-column
+                # schedule plane and alphabet directory are campaign data
+                # (trellis_footprint.trellis_tensor_payload_breakdown), which
+                # is why no FormatSpec can supply them and why the seam
+                # records them on the candidate and in
+                # _memory_bytes_by_format. Reaching here means this stats
+                # entry never saw the seam's write, so the only honest
+                # answers are these bytes or none -- not a closed form that
+                # would be plausible and wrong.
+                raise AssertionError(
+                    f"[alloc] {name} is assigned {fmt}, a trellis rung, but "
+                    "its stats entry carries no '_memory_bytes_by_format' "
+                    "row for it. Exact trellis bytes need the layout, the "
+                    "per-column schedule and the alphabets the surface "
+                    "manifest declares; the format registry has no spec that "
+                    "can compute them. This assignment was built from stats "
+                    "the trellis seam did not write."
+                )
             shape = _shape_from_stats(entry)
             payload_bytes, _identity, _sidecar_identity = serialized_candidate_payload(
                 fr.get_format(fmt),
@@ -5090,6 +5210,18 @@ def main():
     for name, fmt in assignment_expanded.items():
         if fmt in format_specs:
             layer_cfg[name] = format_specs[fmt].autoround_config()
+        elif parse_trellis_format_name(fmt) is not None:
+            # The closed TCQ_<grid>_R<q256> name IS the recipe: the family
+            # and the body rate round-trip out of it
+            # (trellis_formats.parse_trellis_format_name), and everything
+            # else a render would need -- layout, schedule, alphabets -- is
+            # campaign data no autoround_config dict has ever carried. Emit
+            # the name as a string entry (layer_config.canonicalize_format
+            # round-trips it) so the assignment is readable and the
+            # exporter's pointed trellis refusal is REACHABLE, instead of
+            # dying here on a registry lookup that can never succeed.
+            layer_cfg[name] = fmt
+            continue
         else:
             # Visual format outside the body's format set (e.g., user
             # passed --formats NVFP4,BF16 plus --visual-format MXFP8_E4M3).
@@ -5184,6 +5316,18 @@ def main():
         **({
             "serve_constraints": final_serve_feasibility.as_dict(),
         } if final_serve_feasibility is not None else {}),
+        # Only when the trellis seam actually contributed rungs, so a run
+        # without it writes byte-identical layer-config metadata. What
+        # travels: the manifest's sha256 (identity, not a path that may be
+        # rewritten), the currency the anchors were fitted in, the activation
+        # contract they were MEASURED under, and the resolved serving lane /
+        # route status. Principles 12 and 14: the anchor contract is a claim
+        # about what was measured and what a runtime does, so it must ride
+        # WITH the assignment rather than be recomputed downstream from a
+        # manifest the consumer may not have.
+        **({
+            "trellis_surface": dict(trellis_provenance),
+        } if trellis_provenance else {}),
     }
 
     out = Path(args.layer_config)

--- a/prismaquant/allocator_candidates.py
+++ b/prismaquant/allocator_candidates.py
@@ -1780,6 +1780,7 @@ def build_candidates(stats: dict, costs: dict, formats: list[fr.FormatSpec],
                      activation_pricing: ActivationFairPricing | None = None,
                      cost_mode: str | None = None,
                      trellis_provenance: dict | None = None,
+                     apply_trellis_surface: bool = True,
                      ) -> dict[str, list[Candidate]]:
     """Build runtime-legal format candidates for every measured Linear.
 
@@ -1800,6 +1801,13 @@ def build_candidates(stats: dict, costs: dict, formats: list[fr.FormatSpec],
     candidate, so the concrete route — activation contract, whether the
     consumer's fused mid-M kernel backs this rung, fallback — travels WITH
     the choice instead of being reconstructed from the format name later.
+
+    ``apply_trellis_surface`` gates the opt-in trellis seam at the end. It is
+    ``False`` only for the PINNED menus (lm_head / MTP / visual), whose single
+    format is an operator declaration rather than a DP choice: building a
+    research menu the caller will never consult would record bytes and count
+    rungs for a decision nobody makes. It is not a format ban — the body menu,
+    which is what the DP solves, always sees the surface.
     """
     gains = calibrated_gains or {}
     out: dict[str, list[Candidate]] = {}
@@ -2023,18 +2031,26 @@ def build_candidates(stats: dict, costs: dict, formats: list[fr.FormatSpec],
     # Continuous trellis rate surface (opt-in, research). Unset
     # PRISMAQUANT_TRELLIS_SURFACE returns `out` unchanged and this run is
     # byte-identical to one built before the seam existed. The rungs it adds
-    # are ordinary multi-choice candidates priced in exact serialized bytes;
-    # the DP, the fused/packed aggregation and the byte budget need no change.
-    out = trellis_menu.augment_candidates(
-        out,
-        stats,
-        cost_mode=(
-            cost_mode
-            if cost_mode is not None
-            else os.environ.get("COST_MODE", "aura")
-        ),
-        provenance_out=trellis_provenance,
-    )
+    # are ordinary multi-choice candidates priced in exact serialized bytes:
+    # super-item aggregation intersects the MEMBERS' menus (so a rung survives
+    # a fused/packed group), format_rank is extended from those menus by exact
+    # serialized rate, and the exact bytes the seam records in
+    # `_memory_bytes_by_format` are what the byte budget and the payload
+    # filter read. `cost_mode` is the run's ATTESTED objective from the cost
+    # table's provenance; the environment fallback exists only for direct
+    # callers that hold no cost payload, and the seam refuses an empty one
+    # rather than defaulting.
+    if apply_trellis_surface:
+        out = trellis_menu.augment_candidates(
+            out,
+            stats,
+            cost_mode=(
+                cost_mode
+                if cost_mode is not None
+                else os.environ.get("COST_MODE", "")
+            ),
+            provenance_out=trellis_provenance,
+        )
     return out
 
 
@@ -2296,6 +2312,43 @@ def _member_serving_lane(
     return None
 
 
+def _super_menu_format_names(
+    formats: "list[fr.FormatSpec]",
+    member_menu_intersection: set[str],
+) -> tuple[str, ...]:
+    """The format names a super item's menu must consider, in DP order.
+
+    Both aggregators used to build each super item's menu by iterating the
+    run's ``FormatSpec`` OBJECTS.  A super item's menu is a property of its
+    MEMBERS' candidate lists, not of the registry, and the two differ exactly
+    when a candidate's format has no ``FormatSpec`` -- which is what the
+    trellis seam adds.  Iterating specs therefore dropped every such rung
+    from every fused-sibling and packed-expert group while it survived on
+    every ungrouped Linear, silently: no error, just a menu missing an
+    option.  (On a dense model that left only ``o_proj`` and ``down_proj``
+    able to hold one.)
+
+    Returns the run's spec names FIRST, in the order they were given, then
+    any registry-free format every member offers, sorted.  With an
+    all-registry menu the ``extra`` tail is empty and the result is exactly
+    ``[spec.name for spec in formats]``, so the iteration -- and therefore
+    the emitted menu, byte for byte -- is unchanged
+    (``tests/test_super_item_menu_byte_identity.py``).
+    """
+    spec_names = tuple(spec.name for spec in formats)
+    extra = sorted(set(member_menu_intersection) - set(spec_names))
+    return spec_names + tuple(extra)
+
+
+def _registry_free_menu_names(
+    formats: "list[fr.FormatSpec]",
+    member_menu_intersection: set[str],
+) -> tuple[str, ...]:
+    """The tail of :func:`_super_menu_format_names`: names with no FormatSpec."""
+    spec_names = {spec.name for spec in formats}
+    return tuple(sorted(set(member_menu_intersection) - spec_names))
+
+
 _FUSED_SIBLING_MARKER = ".__siblings__."
 
 
@@ -2378,6 +2431,27 @@ def aggregate_fused_siblings(
             "_memory_bytes_by_format": {},
         }
 
+        # The menu comes from the MEMBERS, not the registry. Hoisted above
+        # the cost loop because the registry-free tail is priced from the
+        # member candidates rather than from ``costs`` (there is no cost row
+        # to resolve for a format the cost stage never measured).
+        member_by_name = {
+            member: {
+                candidate.fmt: candidate for candidate in candidates[member]
+            }
+            for member in members
+        }
+        member_format_sets = [
+            {c.fmt for c in candidates.get(m, [])}
+            for m in members
+        ]
+        if member_format_sets:
+            member_format_intersection = set.intersection(*member_format_sets)
+        else:
+            member_format_intersection = set()
+        menu_names = _super_menu_format_names(
+            formats, member_format_intersection)
+
         super_cost = {}
         super_cost_entry_fmt: dict[str, str] = {}
         for spec in formats:
@@ -2434,16 +2508,39 @@ def aggregate_fused_siblings(
                 # The members' penalties are already inside base_pred; mark
                 # the super entry so a re-price cannot square the correction.
                 super_cost[spec.name][APPLIED_MARKER_KEY] = True
+
+        # Registry-free formats every member offers. Their Δloss and bytes
+        # were priced by whatever built the member candidate (the trellis
+        # seam, from a measured rate surface), so the super item's price is
+        # the exact sum of the member candidates -- the SAME construction
+        # aggregate_packed_serving_groups uses for every format, and the same
+        # additive Fisher argument this function's docstring makes. There is
+        # no ``costs`` row to resolve and no per-member stderr to convert:
+        # the solver Candidate carries no stderr, so the honest aggregated
+        # hedge is 0.0 rather than a fabricated one.
+        for fmt_name in _registry_free_menu_names(
+                formats, member_format_intersection):
+            sum_pred = sum(
+                float(member_by_name[m][fmt_name].predicted_dloss)
+                for m in members
+            )
+            super_cost[fmt_name] = {
+                "weight_mse": (
+                    sum_pred / (0.5 * sum_h) if sum_h > 0 else 0.0),
+                "predicted_dloss": sum_pred,
+                "predicted_dloss_stderr": 0.0,
+            }
+            if activation_pricing is not None:
+                # The applied penalty is the identity: penalty_for consults
+                # act_quant_changes_input, which a format with no FormatSpec
+                # cannot assert. Marking it applied states that the members'
+                # prices are final, exactly as the loop above does -- it does
+                # NOT claim an activation measurement this rung never had.
+                # What the rung WAS measured under travels on the candidate's
+                # provenance instead (trellis_menu's third refusal).
+                super_cost[fmt_name][APPLIED_MARKER_KEY] = True
         costs_ext[super_name] = super_cost
 
-        member_format_sets = [
-            {c.fmt for c in candidates.get(m, [])}
-            for m in members
-        ]
-        if member_format_sets:
-            member_format_intersection = set.intersection(*member_format_sets)
-        else:
-            member_format_intersection = set()
         if not member_format_intersection:
             raise AssertionError(
                 _fused_group_menu_error(
@@ -2457,40 +2554,34 @@ def aggregate_fused_siblings(
                 )
             )
 
-        member_by_name = {
-            member: {
-                candidate.fmt: candidate for candidate in candidates[member]
-            }
-            for member in members
-        }
         cands = []
-        for spec in formats:
-            if spec.name not in member_format_intersection:
+        for fmt_name in menu_names:
+            if fmt_name not in member_format_intersection:
                 continue
-            entry = super_cost.get(spec.name)
+            entry = super_cost.get(fmt_name)
             if entry is None or "error" in entry:
                 continue
             total_bytes = sum(
-                int(member_by_name[m][spec.name].memory_bytes) for m in members
+                int(member_by_name[m][fmt_name].memory_bytes) for m in members
             )
             serialized_identities = sorted({
                 identity
                 for m in members
-                for identity in (member_by_name[m][spec.name].serialized_identity,)
+                for identity in (member_by_name[m][fmt_name].serialized_identity,)
                 if identity is not None
             })
             serialized_sidecar_identities = sorted({
                 identity
                 for m in members
                 for identity in (
-                    member_by_name[m][spec.name].serialized_sidecar_identity,
+                    member_by_name[m][fmt_name].serialized_sidecar_identity,
                 )
                 if identity is not None
             })
             bits_per_param = 8.0 * total_bytes / max(n_params, 1)
-            stats_ext[super_name]["_memory_bytes_by_format"][spec.name] = total_bytes
-            entry_fmt = super_cost_entry_fmt.get(spec.name, spec.name)
-            gain = float(gains.get(spec.name, gains.get(entry_fmt, 1.0)))
+            stats_ext[super_name]["_memory_bytes_by_format"][fmt_name] = total_bytes
+            entry_fmt = super_cost_entry_fmt.get(fmt_name, fmt_name)
+            gain = float(gains.get(fmt_name, gains.get(entry_fmt, 1.0)))
             # gain·(base + z·stderr_agg) == gain·base + z·sqrt(Σ (stderr·gain)²)
             # for the single group-wide gain this path applies, i.e. exactly the
             # packed path's construction. At z == 0 this is gain·sum_pred,
@@ -2500,14 +2591,14 @@ def aggregate_fused_siblings(
                 + ucb_z * float(entry.get("predicted_dloss_stderr", 0.0))
             ) * gain
             cands.append(Candidate(
-                fmt=spec.name,
+                fmt=fmt_name,
                 bits_per_param=bits_per_param,
                 memory_bytes=total_bytes,
                 predicted_dloss=max(predicted, 0.0),
                 activation_pricing=_member_activation_branch(
-                    member_by_name, members, spec.name),
+                    member_by_name, members, fmt_name),
                 serving_lane=_member_serving_lane(
-                    member_by_name, members, spec.name),
+                    member_by_name, members, fmt_name),
                 serialized_identity=(
                     json.dumps(serialized_identities, separators=(",", ":"))
                     if serialized_identities else None
@@ -2698,14 +2789,14 @@ def aggregate_packed_serving_groups(
         memory_by_fmt: dict[str, int] = {}
         super_cost: dict[str, dict] = {}
         cands: list[Candidate] = []
-        for spec in formats:
-            if spec.name not in common_fmts:
+        for fmt_name in _super_menu_format_names(formats, common_fmts):
+            if fmt_name not in common_fmts:
                 continue
             total_bytes = sum(
-                int(member_cands[m][spec.name].memory_bytes) for m in members
+                int(member_cands[m][fmt_name].memory_bytes) for m in members
             )
             sum_pred = sum(
-                float(member_cands[m][spec.name].predicted_dloss)
+                float(member_cands[m][fmt_name].predicted_dloss)
                 for m in members
             )
             # UCB hedge (PRISMAQUANT_COST_UCB_Z > 0): each member candidate
@@ -2720,48 +2811,48 @@ def aggregate_packed_serving_groups(
             # P5a: member candidates were priced WITH the family penalty, so
             # the hedge conversion must scale each member's stderr by the same
             # factor or it would over-subtract the linear hedge it is undoing.
-            act_penalty = _activation_penalty(spec.name, activation_pricing)
+            act_penalty = _activation_penalty(fmt_name, activation_pricing)
             for m in members:
                 entry, entry_fmt = _resolve_cost_entry(
-                    costs.get(m, {}), spec.name)
+                    costs.get(m, {}), fmt_name)
                 member_terms.append((
                     stats[m],
                     entry,
-                    float(member_cands[m][spec.name].predicted_dloss),
-                    float(gains.get(spec.name, gains.get(entry_fmt, 1.0)))
+                    float(member_cands[m][fmt_name].predicted_dloss),
+                    float(gains.get(fmt_name, gains.get(entry_fmt, 1.0)))
                     * act_penalty,
                 ))
             hedge_linear, stderr_agg = _super_item_ucb_hedge(
                 member_terms, ucb_z)
             base_pred = sum_pred - hedge_linear
             hedged_pred = base_pred + ucb_z * stderr_agg
-            memory_by_fmt[spec.name] = total_bytes
-            super_cost[spec.name] = {
+            memory_by_fmt[fmt_name] = total_bytes
+            super_cost[fmt_name] = {
                 "predicted_dloss": base_pred,
                 "predicted_dloss_stderr": stderr_agg,
             }
             if activation_pricing is not None:
-                super_cost[spec.name][APPLIED_MARKER_KEY] = True
+                super_cost[fmt_name][APPLIED_MARKER_KEY] = True
             cands.append(Candidate(
-                fmt=spec.name,
+                fmt=fmt_name,
                 bits_per_param=8.0 * total_bytes / max(n_params, 1),
                 memory_bytes=total_bytes,
                 predicted_dloss=max(hedged_pred, 0.0),
                 activation_pricing=_member_activation_branch(
-                    member_cands, members, spec.name),
+                    member_cands, members, fmt_name),
                 serving_lane=_member_serving_lane(
-                    member_cands, members, spec.name),
+                    member_cands, members, fmt_name),
                 serialized_identity=(
                     json.dumps(sorted({
                         identity
                         for m in members
                         for identity in (
-                            member_cands[m][spec.name].serialized_identity,
+                            member_cands[m][fmt_name].serialized_identity,
                         )
                         if identity is not None
                     }), separators=(",", ":"))
                     if any(
-                        member_cands[m][spec.name].serialized_identity is not None
+                        member_cands[m][fmt_name].serialized_identity is not None
                         for m in members
                     ) else None
                 ),
@@ -2770,13 +2861,13 @@ def aggregate_packed_serving_groups(
                         identity
                         for m in members
                         for identity in (
-                            member_cands[m][spec.name]
+                            member_cands[m][fmt_name]
                             .serialized_sidecar_identity,
                         )
                         if identity is not None
                     }), separators=(",", ":"))
                     if any(
-                        member_cands[m][spec.name]
+                        member_cands[m][fmt_name]
                         .serialized_sidecar_identity is not None
                         for m in members
                     ) else None

--- a/prismaquant/allocator_solver.py
+++ b/prismaquant/allocator_solver.py
@@ -337,15 +337,38 @@ def _promote_group_components(
     for name in out:
         components.setdefault(find(name), []).append(name)
 
+    def rank_of(fmt: str) -> int:
+        """``format_rank[fmt]``, with the reason a miss is a caller bug.
+
+        The rank table is built from the run's FormatSpec menu, but this
+        promotes whatever the DP ASSIGNED — and a menu can legally contain a
+        format with no FormatSpec (the trellis seam's TCQ rungs). A bare
+        KeyError here reads as a corrupt assignment; it is really a rank
+        table built from the registry instead of from the candidate menu.
+        ``allocator._extend_format_rank_with_candidate_menu`` is the fix.
+        """
+        try:
+            return format_rank[fmt]
+        except KeyError:
+            raise KeyError(
+                f"promote_serving_units has no rank for assigned format "
+                f"{fmt!r}. format_rank must cover every format the CANDIDATE "
+                "MENU can produce, not only the ones with a FormatSpec: "
+                "promotion compares ranks across a coupled unit's members, "
+                "so an unranked format makes the unit unpromotable. Extend "
+                "the rank table from the candidates' exact serialized rates "
+                "(allocator._extend_format_rank_with_candidate_menu)."
+            ) from None
+
     for members in components.values():
         if len(members) < 2:
             continue
-        best_fmt = max((out[member] for member in members), key=lambda fmt: format_rank[fmt])
+        best_fmt = max((out[member] for member in members), key=rank_of)
         if all(_member_allows(best_fmt, member, legal_formats)
                for member in members):
-            best_rank = format_rank[best_fmt]
+            best_rank = rank_of(best_fmt)
             for member in members:
-                if format_rank[out[member]] < best_rank:
+                if rank_of(out[member]) < best_rank:
                     out[member] = best_fmt
             continue
         # The max-rank assignment cannot run on every member of an atomic

--- a/prismaquant/footprint.py
+++ b/prismaquant/footprint.py
@@ -65,6 +65,7 @@ from typing import Iterable, Mapping
 
 from . import format_registry as fr
 from .allocator_solver import _shape_from_stats
+from .trellis_formats import parse_trellis_format_name
 from .nvfp4_cb_footprint import (
     CBSerializationContext,
     cb_assignment_payload_breakdown,
@@ -1181,6 +1182,27 @@ def assignment_artifact_bytes(
                 )
             cb_assignment[qname] = name
             cb_shapes[qname] = shape
+        elif parse_trellis_format_name(name) is not None:
+            # A trellis rung's exact bytes are campaign data, not a closed
+            # form over (name, shape): the body stride, block offsets, the
+            # per-column schedule plane and the alphabet directory all come
+            # from the surface manifest (see
+            # trellis_tensor_payload_breakdown). The allocator records them
+            # per unit in `_memory_bytes_by_format`, which is where this
+            # reads them; there is no FormatSpec that could answer, so a
+            # missing map is refused rather than approximated. Same doctrine
+            # as the CB branch above.
+            memory_map = entry.get("_memory_bytes_by_format")
+            if not isinstance(memory_map, dict) or name not in memory_map:
+                raise ValueError(
+                    f"[footprint] {context}: {qname} is assigned the trellis "
+                    f"rung {name}, whose exact bytes depend on the layout, "
+                    "per-column schedule and alphabets its surface manifest "
+                    "declares -- no FormatSpec can compute them. The stats "
+                    "entry carries no '_memory_bytes_by_format' row for it, "
+                    "so these bytes were never measured for this unit."
+                )
+            body_quant += int(memory_map[name])
         else:
             body_quant += fr.get_format(name).memory_bytes_for_shape(shape)
         if name == "NVFP4":

--- a/prismaquant/layer_config.py
+++ b/prismaquant/layer_config.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 from prismaquant.cb_layout import ACCEPTED_CB_FORMAT_NAMES
 from prismaquant.schemas import validate_layer_config_payload
+# torch-free, stdlib-only (see its imports): safe for this module's contract.
+from prismaquant.trellis_formats import parse_trellis_format_name
 
 
 def strip_weight(name: str) -> str:
@@ -168,6 +170,15 @@ def canonicalize_format(entry: dict | str | int) -> str:
         raise ValueError(f"unsupported scheme: {entry!r}")
     if isinstance(entry, str):
         value = entry.lower()
+        if parse_trellis_format_name(value.upper()) is not None:
+            # Trellis (TCQ) rungs. The closed ``TCQ_<grid>_R<q256>`` name is
+            # the whole recipe the parser can validate, and it round-trips
+            # here for one reason: nothing downstream renders or exports a
+            # trellis assignment, and the refusals that say so live in
+            # export_native_compressed. A generic "unsupported format string"
+            # here would make those pointed refusals unreachable and report a
+            # research assignment as a parse error.
+            return value.upper()
         if value.upper() in _GGUF_FORMAT_NAMES:
             return value.upper()
         if value.upper() in _NVFP4_CB_FORMAT_NAMES:

--- a/prismaquant/trellis_menu.py
+++ b/prismaquant/trellis_menu.py
@@ -10,18 +10,55 @@ names a manifest file.  Unset, :func:`augment_candidates` returns its input
 unchanged and the run is byte-identical to one built without this module
 (principle 6, the ``PRISMAQUANT_FISHER_CAP_MULTIPLIER`` precedent).
 
-STATUS: THE MENU IS BUILT, THE SEAM IS NOT WIRED
-------------------------------------------------
-:func:`build_trellis_menu` produces a correctly priced menu.  The production
-seam :func:`augment_candidates` **refuses** when the flag is set, because
-eight links between that menu and a shipped assignment do not exist -- see
-:data:`UNWIRED_LINKS`, which is the refusal message and the re-enable
-checklist.  The first version of this module (40d3e15) claimed the seam's
-placement inside ``build_candidates`` meant trellis rungs "pass the same
-legality, aggregation and byte accounting every other candidate does".  That
-was false on all three counts and is the reason the refusal exists: the
-registry gaps crash loudly, but the aggregation gaps are SILENT, and a partial
-fix would trade the loud failure for the silent one.
+STATUS: WIRED FOR ALLOCATION, REFUSED ON CURRENCY, NEVER EXPORTED
+-----------------------------------------------------------------
+:func:`build_trellis_menu` produces a correctly priced menu and
+:func:`augment_candidates` now installs it.  The first version of this module
+(40d3e15) claimed the seam's placement inside ``build_candidates`` meant
+trellis rungs "pass the same legality, aggregation and byte accounting every
+other candidate does".  That was false on all three counts; the module then
+refused as a whole, because the registry gaps crashed loudly while the
+aggregation gaps were SILENT and a partial fix trades the loud failure for
+the silent one.
+
+Seven of those eight links were wired on 2026-08-29, each with a behaviour
+test:
+
+* super-item aggregation builds each menu from the MEMBERS' candidate lists
+  (``_super_menu_format_names``), so a rung survives a fused or packed group;
+* ``format_rank`` is extended from the candidate menu by exact serialized
+  rate, so ``promote_serving_units`` can rank a selected rung;
+* exact bytes travel in ``_memory_bytes_by_format`` -- written here, read by
+  the payload filter, ``footprint``, ``compute_achieved``, ``kl_measurement``
+  and bit attribution -- with a POINTED refusal at each site rather than a
+  registry fallback, because no ``FormatSpec`` can express these bytes;
+* the run's attested ``COST_MODE`` and the menu's provenance are threaded
+  from ``allocator.py`` into the layer-config metadata block.
+
+The eighth is not a link.  It is the anchors' **currency**
+(:data:`UNWIRED_LINKS`), and no plumbing turns a weighted-SSE anchor into an
+AURA-priced one, so it stays a refusal (:func:`_require_run_currency`).
+
+WHY NO TCQ ``FormatSpec``
+-------------------------
+The obvious alternative -- register a minimal TCQ ``FormatSpec`` so every
+site that resolves a format through the registry just works -- is not
+available, and not as a matter of taste.  ``FormatSpec.memory_bytes_for_shape``
+is a closed form over ``weight_bits`` / ``scale_bits`` / ``group_size``, while
+a rung's exact size needs the layout, the per-column schedule and the alphabet
+directory (``trellis_footprint.trellis_tensor_payload_breakdown``: 16-byte row
+stride alignment, an 88-byte wire header, a nibble schedule plane, block
+offsets under ``tight_offsets``, and a family-specific scale plane).  Those are
+per-campaign manifest data, so ``(name, shape)`` does not determine the bytes
+and a registered spec could only be plausible and WRONG -- silently consumed
+by ``_serialized_format_rates``, ``footprint`` and the payload filter, which
+is precisely the failure this module exists to prevent.  It would also expose
+TCQ to every ``act_quant_changes_input`` / ``quantize_dequantize`` consumer
+with no render behind it.  So exact bytes ride the ``Candidate`` and
+``_memory_bytes_by_format`` -- the repo's existing single mechanism -- and
+``fr.get_format('TCQ_...')`` keeps raising ``KeyError``.  The cost is N
+pointed refusals instead of one registry entry; each one refuses where a
+closed form would have guessed.
 
 WHY A MANIFEST AND NOT A ``FORMATS`` ENUM ENTRY
 ----------------------------------------------
@@ -72,8 +109,9 @@ report what it would choose, and price the choice in exact serialized bytes.
 """
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 from dataclasses import dataclass, replace
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -116,45 +154,20 @@ class TrellisSeamUnwiredError(TrellisMenuError):
     """The production seam is enabled but the DP cannot honour a TCQ rung."""
 
 
-#: Every link between a built trellis menu and a shipped assignment that does
-#: NOT exist yet, verified at 58eb69d.  This list is the refusal message and
-#: the re-enable checklist; it is also what ``docs/ARCHITECTURE.md`` 4.9 cites
-#: instead of the claim it used to make.  Delete an entry only when a test
-#: exercises the behaviour it names -- not when the code merely looks present.
+#: The links between a built trellis menu and a shipped assignment that still
+#: do NOT exist.  This list is the refusal message and the re-enable
+#: checklist; it is also what ``docs/ARCHITECTURE.md`` 4.9 cites instead of
+#: the claim it used to make.  Delete an entry only when a test exercises the
+#: behaviour it names -- not when the code merely looks present.
+#:
+#: Seven of the original eight were wired on 2026-08-29 and their entries
+#: removed together with the tests that exercise them
+#: (``tests/test_trellis_menu.py``, ``tests/test_super_item_menu_byte_identity.py``).
+#: What remains is the CURRENCY question, which is not a wiring gap at all:
+#: no plumbing turns a weighted-SSE anchor into an AURA-priced one.  It is
+#: enforced by :func:`_require_run_currency`, so an enabled seam now refuses
+#: on the currency mismatch rather than on missing links.
 UNWIRED_LINKS: tuple[tuple[str, str], ...] = (
-    ("format_registry.py:1267-1272",
-     "no TCQ name is a FormatSpec; fr.get_format('TCQ_E2M1_R640') KeyErrors, "
-     "so every site that resolves an assigned format through the registry "
-     "fails on a selected rung"),
-    ("allocator.py:3369-3386",
-     "the exact assignment-payload filter finds no '_memory_bytes_by_format' "
-     "entry for a TCQ row and falls through to fr.get_format -- the allocator "
-     "dies inside the Pareto sweep, before layer_config.json is written; the "
-     "pointed refusals in layer_config.canonicalize_format and "
-     "export_native_compressed are therefore unreachable"),
-    ("allocator_candidates.py:2464",
-     "fused-sibling aggregation builds each super-item menu by iterating "
-     "FormatSpec objects, so every trellis rung is dropped from every fused "
-     "group (probe: members offered TCQ_E2M1_R640, super item offered only "
-     "BF16/NVFP4)"),
-    ("allocator_candidates.py:2701",
-     "packed-expert aggregation has the identical construction, so no MoE "
-     "expert group can carry a rung either; between the two, on a dense model "
-     "only o_proj and down_proj could ever hold one"),
-    ("allocator_solver.py:340-342",
-     "promote_serving_units' format_rank lookup does not KeyError today only "
-     "because aggregation guarantees a TCQ unit is a lone ungrouped Linear; "
-     "fixing aggregation without it makes that crash live"),
-    ("footprint.py:1183",
-     "the byte-budget (--target-disk-gb) path has its own registry lookup "
-     "that KeyErrors on TCQ independently of the payload filter"),
-    ("allocator.py:2756",
-     "build_candidates is called with neither cost_mode= nor "
-     "trellis_provenance=, so the currency gate below compares against "
-     "os.environ.get('COST_MODE','aura') -- a variable run-pipeline.sh sets "
-     "with := and never exports (:438) -- and the manifest identity, anchor "
-     "currency and anchor activation contract are discarded instead of "
-     "travelling with the assignment (principles 12 and 14)"),
     ("trellis_rate_surface.py:43-52",
      "the anchors' currency is weighted SSE under a per-input-channel "
      "activation second moment -- an output-MSE proxy, explicitly NOT the "
@@ -165,11 +178,30 @@ UNWIRED_LINKS: tuple[tuple[str, str], ...] = (
 )
 
 
+#: ``COST_MODE`` is a spelling over ``COST_RENDER x COST_OBJECTIVE`` (re-vet
+#: R3).  The objective half IS the currency a ``predicted_dloss`` is
+#: denominated in, so the run's currency is a definitional function of its
+#: attested cost mode -- not a threshold anyone picks (principle 2).  This is
+#: the same case block ``run-pipeline.sh`` resolves the axes with (its
+#: ``case "$COST_MODE"``); a mode outside it has no declared objective and is
+#: refused rather than defaulted.
+COST_MODE_OBJECTIVE_CURRENCY: Mapping[str, str] = {
+    "local": "weight-recon",
+    "production-render-score": "render-score",
+    "production-render": "render-score",
+    "aura": "aura-adjoint",
+}
+
+
 @dataclass(frozen=True)
 class TrellisSurfaceManifest:
     """A campaign's measured trellis anchors, plus what they were measured on."""
 
     path: Path
+    #: SHA-256 of the manifest bytes. The IDENTITY that travels with the
+    #: assignment: a path is a name that can be rewritten, moved, or point at
+    #: different bytes on the machine that reads the layer_config.
+    sha256: str
     cost_mode: str
     currency: str
     target_profile: str
@@ -199,7 +231,13 @@ def load_manifest(path: str | os.PathLike[str]) -> TrellisSurfaceManifest:
 
     resolved = Path(path)
     try:
-        payload = json.loads(resolved.read_text())
+        raw = resolved.read_bytes()
+    except FileNotFoundError as exc:
+        raise TrellisMenuError(
+            f"{TRELLIS_SURFACE_ENV}={resolved} does not exist"
+        ) from exc
+    try:
+        payload = json.loads(raw)
     except FileNotFoundError as exc:
         raise TrellisMenuError(
             f"{TRELLIS_SURFACE_ENV}={resolved} does not exist"
@@ -229,6 +267,7 @@ def load_manifest(path: str | os.PathLike[str]) -> TrellisSurfaceManifest:
         raise TrellisMenuError("rungs_per_unit must be at least 2")
     return TrellisSurfaceManifest(
         path=resolved,
+        sha256=hashlib.sha256(raw).hexdigest(),
         cost_mode=str(_require(payload, "cost_mode")),
         currency=str(_require(payload, "currency")),
         target_profile=str(_require(payload, "target_profile")),
@@ -268,6 +307,56 @@ def _profile_declares_platform(profile_id: str) -> str:
             f"were measured on."
         )
     return str(platform)
+
+
+def _require_run_currency(manifest: TrellisSurfaceManifest,
+                          cost_mode: str) -> str:
+    """Refuse a surface whose anchors are not in the run's currency.
+
+    This is the surviving entry of :data:`UNWIRED_LINKS` and the one refusal
+    an enabled seam still hits in practice.  It is not plumbing: the ladder's
+    measured anchors are weighted SSE under a per-input-channel activation
+    second moment -- an output-MSE proxy -- while an ``aura`` run's DP ranks
+    the KL-adjoint.  A DP that ranks a weighted-SSE rung against an
+    AURA-priced NVFP4 rung is not solving any stated objective, and no amount
+    of wiring changes what the anchors measured.  Producing AURA-priced
+    anchors is a dW-supply problem (``aura_cost``'s two dW sources both need
+    a registered format), owned elsewhere.
+
+    Returns the run's objective currency on success.
+    """
+
+    if not cost_mode:
+        raise TrellisMenuError(
+            "the cost table carries no provenance['cost_mode'] stamp "
+            "(re-vet R2), so this run's objective is unknown and the "
+            "manifest's declared currency cannot be checked against it. "
+            "Re-run the cost stage with --cost-mode; an unstamped table is "
+            "refused rather than compared against a default."
+        )
+    expected = COST_MODE_OBJECTIVE_CURRENCY.get(cost_mode)
+    if expected is None:
+        raise TrellisMenuError(
+            f"COST_MODE={cost_mode!r} names no objective in "
+            f"COST_MODE_OBJECTIVE_CURRENCY "
+            f"({sorted(COST_MODE_OBJECTIVE_CURRENCY)}), so the currency its "
+            f"predicted_dloss is denominated in is undeclared. A trellis "
+            f"surface cannot be admitted to a run whose objective has no name."
+        )
+    if manifest.currency != expected:
+        raise TrellisSeamUnwiredError(
+            f"trellis surface declares currency {manifest.currency!r}, but "
+            f"COST_MODE={cost_mode!r} prices in {expected!r}. This is "
+            f"UNWIRED_LINKS[0] and it is not a plumbing gap: the measured "
+            f"trellis anchors are weighted SSE under a per-input-channel "
+            f"activation second moment (trellis_rate_surface.py:43-52), an "
+            f"output-MSE proxy, NOT the AURA KL-adjoint the production DP "
+            f"ranks in. Ranking rungs measured under one objective against "
+            f"candidates priced under another solves neither. AURA-priced "
+            f"anchors are a dW-supply problem (aura_cost's two dW sources "
+            f"both require a registered format), not a flag."
+        )
+    return expected
 
 
 def _achievable_q256(columns: int, family, low: int, high: int,
@@ -414,6 +503,7 @@ def build_trellis_menu(
             f"One DP prices in one currency; ranking rungs measured under two "
             f"objectives against each other solves neither."
         )
+    run_currency = _require_run_currency(manifest, cost_mode)
     platform = _profile_declares_platform(manifest.target_profile)
 
     added = 0
@@ -481,7 +571,39 @@ def build_trellis_menu(
                 )
             seen.add(fmt)
             base = record.to_solver_candidate()
-            candidates[unit_name].append(replace(base, fmt=fmt))
+            cand = replace(base, fmt=fmt)
+            candidates[unit_name].append(cand)
+            # The SAME exact-bytes channel build_candidates writes for a
+            # FormatSpec row (allocator_candidates:1950), and the reason no
+            # TCQ FormatSpec is needed: a rung's serialized size is not a
+            # function of (name, shape) -- it needs the layout, the
+            # per-column schedule plane and the alphabet directory this
+            # manifest declares (trellis_tensor_payload_breakdown) -- so the
+            # bytes travel from where they were computed instead of being
+            # recomputed from a closed form that cannot express them. Every
+            # downstream byte path already PREFERS this map over the registry
+            # (allocator's payload filter, footprint, compute_achieved,
+            # kl_measurement, bit attribution), so writing it is what wires
+            # them, and one mechanism stays one mechanism (principle 8).
+            if isinstance(stat, MutableMapping):
+                stat.setdefault(
+                    "_memory_bytes_by_format", {})[fmt] = int(cand.memory_bytes)
+                if cand.serialized_identity is not None:
+                    stat.setdefault(
+                        "_serialized_identity_by_format",
+                        {})[fmt] = cand.serialized_identity
+                    stat.setdefault(
+                        "_serialized_sidecar_identity_by_format",
+                        {})[fmt] = cand.serialized_sidecar_identity
+            else:
+                raise TrellisMenuError(
+                    f"{unit_name}: stats entry is a read-only "
+                    f"{type(stat).__name__}, so the rung's exact bytes cannot "
+                    f"be recorded in '_memory_bytes_by_format'. Every "
+                    f"downstream byte path reads them from there and no "
+                    f"FormatSpec can recompute them; a menu whose bytes "
+                    f"cannot be recorded must not be built."
+                )
             added += 1
         if records:
             covered.append(unit_name)
@@ -489,8 +611,17 @@ def build_trellis_menu(
     payload = {
         "schema": TRELLIS_MENU_PROVENANCE_SCHEMA,
         "manifest_path": str(manifest.path),
+        # IDENTITY, not location: a consumer holding the layer_config can
+        # check it has the same anchors, on a machine where the path means
+        # nothing (principle 12).
+        "manifest_sha256": manifest.sha256,
         "cost_mode": manifest.cost_mode,
         "currency": manifest.currency,
+        # The objective this RUN prices in, resolved from the cost table's
+        # own provenance stamp. Recorded next to the manifest's declared
+        # currency so the equality the gate enforced is auditable from the
+        # assignment alone rather than re-derived.
+        "run_objective_currency": run_currency,
         "target_profile": manifest.target_profile,
         "target_platform": platform,
         # The contract the anchors' dloss was MEASURED under. The hull that
@@ -552,42 +683,45 @@ def augment_candidates(
     manifest_path: str | None = None,
     provenance_out: dict | None = None,
 ) -> dict[str, list[Candidate]]:
-    """The production seam: a no-op when unset, a REFUSAL when set.
+    """The production seam: a no-op when unset, a built menu when set.
 
     Unset, this returns its input object unchanged and the run is
-    byte-identical to one built without this module -- that half is real and
-    is what ships.
+    byte-identical to one built without this module -- that half was always
+    real and is what ships.
 
-    Set, it refuses.  :func:`build_trellis_menu` builds a correctly priced
-    menu, but eight links between that menu and a shipped assignment do not
-    exist (:data:`UNWIRED_LINKS`), and they do not fail the same way: the
-    registry gaps crash loudly inside the Pareto sweep, while the aggregation
-    gaps are SILENT -- they would drop every rung from every fused and packed
-    group and hand back a plausible-looking frontier in which only o_proj and
-    down_proj could carry a rung.  A partial fix that removed only the crashes
-    would convert the loud failures into that silent one, which is why this
-    refuses as a whole rather than being wired halfway (principle 1: the
-    measurement must be right, not the symptom suppressed).
+    Set, it now builds the menu.  Until 2026-08-29 it refused outright,
+    because eight links between a built menu and a shipped assignment did not
+    exist and they did not fail the same way: the registry gaps crashed
+    loudly inside the Pareto sweep, while the aggregation gaps were SILENT --
+    they dropped every rung from every fused and packed group and handed back
+    a plausible-looking frontier in which only ``o_proj`` and ``down_proj``
+    could carry one.  Refusing as a whole was right precisely because a
+    partial fix converts the loud failures into that silent one.
 
-    Enabling the surface therefore means landing those links with tests that
-    exercise behaviour, then deleting this refusal -- not passing a flag.
-    Until then :func:`build_trellis_menu` is reachable directly, for research
-    and for the tests, where a wrong menu cannot reach a shipped artifact.
+    Seven of those links are now wired, each with a test that exercises the
+    behaviour rather than the source text.  The eighth is not a link at all:
+    the anchors' currency (:data:`UNWIRED_LINKS`).  No plumbing turns a
+    weighted-SSE anchor into an AURA-priced one, so that stays a refusal --
+    raised by :func:`_require_run_currency` inside the build, against the
+    run's ATTESTED cost mode.
+
+    Two things this still does not do: render and export.
+    ``ProductionWeightCache`` has no trellis mechanism and
+    ``export_native_compressed`` refuses a TCQ assignment outright.  A
+    selected rung is a research result -- an exactly priced report of what
+    the DP would choose -- not a shippable artifact.
     """
 
     resolved_path = manifest_path or os.environ.get(TRELLIS_SURFACE_ENV)
     if not resolved_path:
         return candidates
 
-    links = "\n".join(f"  - {where}: {what}" for where, what in UNWIRED_LINKS)
-    raise TrellisSeamUnwiredError(
-        f"{TRELLIS_SURFACE_ENV}={resolved_path} was set, but the allocator "
-        f"cannot honour a trellis rung end-to-end. Eight links are missing:\n"
-        f"{links}\n"
-        f"Build the menu directly with trellis_menu.build_trellis_menu() for "
-        f"research. Do not remove this refusal to reach a selectable run: the "
-        f"aggregation gaps are silent, so the run would look successful and "
-        f"allocate wrongly."
+    return build_trellis_menu(
+        candidates,
+        stats,
+        cost_mode=cost_mode,
+        manifest_path=resolved_path,
+        provenance_out=provenance_out,
     )
 
 

--- a/tests/fixtures/super_item_menu_golden.json
+++ b/tests/fixtures/super_item_menu_golden.json
@@ -1,0 +1,820 @@
+{
+ "digest": "033adb45e71a51b831f5335047fa56e5fb00dc3137894a983fa0146bf456197d",
+ "menu": [
+  "NVFP4",
+  "FP8_E4M3",
+  "BF16"
+ ],
+ "scenarios": {
+  "fused_hedged_gained_priced": {
+   "passthrough_rows": [
+    "model.layers.0.mlp.down_proj",
+    "model.layers.0.self_attn.o_proj"
+   ],
+   "super_items": {
+    "model.layers.0.mlp.__siblings__.model__layers__0__mlp__gate_up_proj": {
+     "cost_rows": {
+      "BF16": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.0",
+       "predicted_dloss_stderr": "0.0",
+       "weight_mse": "0.0"
+      },
+      "FP8_E4M3": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.0013679500000000002",
+       "predicted_dloss_stderr": "0.0004187997880849512",
+       "weight_mse": "0.001954214285714286"
+      },
+      "NVFP4": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.034387",
+       "predicted_dloss_stderr": "0.010527627700484096",
+       "weight_mse": "0.04912428571428572"
+      }
+     },
+     "members": [
+      "model.layers.0.mlp.gate_proj",
+      "model.layers.0.mlp.up_proj"
+     ],
+     "memory_bytes_by_format": {
+      "BF16": 180355072,
+      "FP8_E4M3": 90265600,
+      "NVFP4": 50724864
+     },
+     "menu": [
+      {
+       "activation_pricing": "weight_only_activation_calibrated",
+       "bits_per_param": "4.5",
+       "fmt": "NVFP4",
+       "memory_bytes": 50724864,
+       "predicted_dloss": "0.061719483107393155",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "weight_only_activation_calibrated",
+       "bits_per_param": "8.0078125",
+       "fmt": "FP8_E4M3",
+       "memory_bytes": 90265600,
+       "predicted_dloss": "0.0017566117202721357",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "bit_exact",
+       "bits_per_param": "16.0",
+       "fmt": "BF16",
+       "memory_bytes": 180355072,
+       "predicted_dloss": "0.0",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      }
+     ],
+     "n_params": 90177536
+    },
+    "model.layers.0.self_attn.__siblings__.model__layers__0__self_attn__qkv_proj": {
+     "cost_rows": {
+      "BF16": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.0",
+       "predicted_dloss_stderr": "0.0",
+       "weight_mse": "0.0"
+      },
+      "FP8_E4M3": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.0010545750000000003",
+       "predicted_dloss_stderr": "0.0003353411173715505",
+       "weight_mse": "0.0014061000000000004"
+      },
+      "NVFP4": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.026509500000000005",
+       "predicted_dloss_stderr": "0.008429675794477507",
+       "weight_mse": "0.03534600000000001"
+      }
+     },
+     "members": [
+      "model.layers.0.self_attn.k_proj",
+      "model.layers.0.self_attn.q_proj",
+      "model.layers.0.self_attn.v_proj"
+     ],
+     "memory_bytes_by_format": {
+      "BF16": 50331648,
+      "FP8_E4M3": 25190400,
+      "NVFP4": 14155776
+     },
+     "menu": [
+      {
+       "activation_pricing": "weight_only_activation_calibrated",
+       "bits_per_param": "4.5",
+       "fmt": "NVFP4",
+       "memory_bytes": 14155776,
+       "predicted_dloss": "0.04815943684081101",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "weight_only_activation_calibrated",
+       "bits_per_param": "8.0078125",
+       "fmt": "FP8_E4M3",
+       "memory_bytes": 25190400,
+       "predicted_dloss": "0.001370676274930447",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "bit_exact",
+       "bits_per_param": "16.0",
+       "fmt": "BF16",
+       "memory_bytes": 50331648,
+       "predicted_dloss": "0.0",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      }
+     ],
+     "n_params": 25165824
+    }
+   }
+  },
+  "fused_plain": {
+   "passthrough_rows": [
+    "model.layers.0.mlp.down_proj",
+    "model.layers.0.self_attn.o_proj"
+   ],
+   "super_items": {
+    "model.layers.0.mlp.__siblings__.model__layers__0__mlp__gate_up_proj": {
+     "cost_rows": {
+      "BF16": {
+       "predicted_dloss": "0.0",
+       "predicted_dloss_stderr": "0.0",
+       "weight_mse": "0.0"
+      },
+      "FP8_E4M3": {
+       "predicted_dloss": "0.001255",
+       "predicted_dloss_stderr": "0.0003842199890687626",
+       "weight_mse": "0.0017928571428571431"
+      },
+      "NVFP4": {
+       "predicted_dloss": "0.0251",
+       "predicted_dloss_stderr": "0.007684399781375251",
+       "weight_mse": "0.03585714285714286"
+      }
+     },
+     "members": [
+      "model.layers.0.mlp.gate_proj",
+      "model.layers.0.mlp.up_proj"
+     ],
+     "memory_bytes_by_format": {
+      "BF16": 180355072,
+      "FP8_E4M3": 90265600,
+      "NVFP4": 50724864
+     },
+     "menu": [
+      {
+       "activation_pricing": "weight_only_uncalibrated",
+       "bits_per_param": "4.5",
+       "fmt": "NVFP4",
+       "memory_bytes": 50724864,
+       "predicted_dloss": "0.0251",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "weight_only_uncalibrated",
+       "bits_per_param": "8.0078125",
+       "fmt": "FP8_E4M3",
+       "memory_bytes": 90265600,
+       "predicted_dloss": "0.001255",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "bit_exact",
+       "bits_per_param": "16.0",
+       "fmt": "BF16",
+       "memory_bytes": 180355072,
+       "predicted_dloss": "0.0",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      }
+     ],
+     "n_params": 90177536
+    },
+    "model.layers.0.self_attn.__siblings__.model__layers__0__self_attn__qkv_proj": {
+     "cost_rows": {
+      "BF16": {
+       "predicted_dloss": "0.0",
+       "predicted_dloss_stderr": "0.0",
+       "weight_mse": "0.0"
+      },
+      "FP8_E4M3": {
+       "predicted_dloss": "0.0009675",
+       "predicted_dloss_stderr": "0.00030765240125830317",
+       "weight_mse": "0.0012900000000000001"
+      },
+      "NVFP4": {
+       "predicted_dloss": "0.01935",
+       "predicted_dloss_stderr": "0.006153048025166064",
+       "weight_mse": "0.0258"
+      }
+     },
+     "members": [
+      "model.layers.0.self_attn.k_proj",
+      "model.layers.0.self_attn.q_proj",
+      "model.layers.0.self_attn.v_proj"
+     ],
+     "memory_bytes_by_format": {
+      "BF16": 50331648,
+      "FP8_E4M3": 25190400,
+      "NVFP4": 14155776
+     },
+     "menu": [
+      {
+       "activation_pricing": "weight_only_uncalibrated",
+       "bits_per_param": "4.5",
+       "fmt": "NVFP4",
+       "memory_bytes": 14155776,
+       "predicted_dloss": "0.01935",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "weight_only_uncalibrated",
+       "bits_per_param": "8.0078125",
+       "fmt": "FP8_E4M3",
+       "memory_bytes": 25190400,
+       "predicted_dloss": "0.0009675",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "bit_exact",
+       "bits_per_param": "16.0",
+       "fmt": "BF16",
+       "memory_bytes": 50331648,
+       "predicted_dloss": "0.0",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      }
+     ],
+     "n_params": 25165824
+    }
+   }
+  },
+  "packed_hedged_gained_priced": {
+   "passthrough_rows": [
+    "model.layers.0.self_attn.o_proj"
+   ],
+   "super_items": {
+    "model.layers.0.mlp.experts.0.__packed_serving__.model__layers__0__mlp__experts": {
+     "cost_rows": {
+      "BF16": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.0",
+       "predicted_dloss_stderr": "0.0"
+      },
+      "FP8_E4M3": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.0020718720000000006",
+       "predicted_dloss_stderr": "0.00037297958867476926"
+      },
+      "NVFP4": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.07279632000000003",
+       "predicted_dloss_stderr": "0.013104835381064503"
+      }
+     },
+     "members": [
+      "model.layers.0.mlp.experts.0.w1",
+      "model.layers.0.mlp.experts.0.w2",
+      "model.layers.0.mlp.experts.0.w3",
+      "model.layers.0.mlp.experts.1.w1",
+      "model.layers.0.mlp.experts.1.w2",
+      "model.layers.0.mlp.experts.1.w3",
+      "model.layers.0.mlp.experts.2.w1",
+      "model.layers.0.mlp.experts.2.w2",
+      "model.layers.0.mlp.experts.2.w3"
+     ],
+     "memory_bytes_by_format": {
+      "BF16": 28311552,
+      "FP8_E4M3": 14198784,
+      "NVFP4": 7962624
+     },
+     "menu": [
+      {
+       "activation_pricing": "weight_only_activation_calibrated",
+       "bits_per_param": "4.5",
+       "fmt": "NVFP4",
+       "memory_bytes": 7962624,
+       "predicted_dloss": "0.09245357307159678",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "weight_only_activation_calibrated",
+       "bits_per_param": "8.024305555555555",
+       "fmt": "FP8_E4M3",
+       "memory_bytes": 14198784,
+       "predicted_dloss": "0.0026313413830121547",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "bit_exact",
+       "bits_per_param": "16.0",
+       "fmt": "BF16",
+       "memory_bytes": 28311552,
+       "predicted_dloss": "0.0",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      }
+     ],
+     "n_params": 14155776
+    },
+    "model.layers.1.mlp.experts.0.__packed_serving__.model__layers__1__mlp__experts": {
+     "cost_rows": {
+      "BF16": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.0",
+       "predicted_dloss_stderr": "0.0"
+      },
+      "FP8_E4M3": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.005999796000000002",
+       "predicted_dloss_stderr": "0.0007613413972719467"
+      },
+      "NVFP4": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.21080601000000002",
+       "predicted_dloss_stderr": "0.026750133205649652"
+      }
+     },
+     "members": [
+      "model.layers.1.mlp.experts.0.w1",
+      "model.layers.1.mlp.experts.0.w2",
+      "model.layers.1.mlp.experts.0.w3",
+      "model.layers.1.mlp.experts.1.w1",
+      "model.layers.1.mlp.experts.1.w2",
+      "model.layers.1.mlp.experts.1.w3",
+      "model.layers.1.mlp.experts.2.w1",
+      "model.layers.1.mlp.experts.2.w2",
+      "model.layers.1.mlp.experts.2.w3"
+     ],
+     "memory_bytes_by_format": {
+      "BF16": 28311552,
+      "FP8_E4M3": 14198784,
+      "NVFP4": 7962624
+     },
+     "menu": [
+      {
+       "activation_pricing": "weight_only_activation_calibrated",
+       "bits_per_param": "4.5",
+       "fmt": "NVFP4",
+       "memory_bytes": 7962624,
+       "predicted_dloss": "0.2509312098084745",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "weight_only_activation_calibrated",
+       "bits_per_param": "8.024305555555555",
+       "fmt": "FP8_E4M3",
+       "memory_bytes": 14198784,
+       "predicted_dloss": "0.007141808095907922",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "bit_exact",
+       "bits_per_param": "16.0",
+       "fmt": "BF16",
+       "memory_bytes": 28311552,
+       "predicted_dloss": "0.0",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      }
+     ],
+     "n_params": 14155776
+    }
+   }
+  },
+  "packed_plain": {
+   "passthrough_rows": [
+    "model.layers.0.self_attn.o_proj"
+   ],
+   "super_items": {
+    "model.layers.0.mlp.experts.0.__packed_serving__.model__layers__0__mlp__experts": {
+     "cost_rows": {
+      "BF16": {
+       "predicted_dloss": "0.0",
+       "predicted_dloss_stderr": "0.0"
+      },
+      "FP8_E4M3": {
+       "predicted_dloss": "0.0021600000000000005",
+       "predicted_dloss_stderr": "0.0003888444419044717"
+      },
+      "NVFP4": {
+       "predicted_dloss": "0.04320000000000001",
+       "predicted_dloss_stderr": "0.007776888838089434"
+      }
+     },
+     "members": [
+      "model.layers.0.mlp.experts.0.w1",
+      "model.layers.0.mlp.experts.0.w2",
+      "model.layers.0.mlp.experts.0.w3",
+      "model.layers.0.mlp.experts.1.w1",
+      "model.layers.0.mlp.experts.1.w2",
+      "model.layers.0.mlp.experts.1.w3",
+      "model.layers.0.mlp.experts.2.w1",
+      "model.layers.0.mlp.experts.2.w2",
+      "model.layers.0.mlp.experts.2.w3"
+     ],
+     "memory_bytes_by_format": {
+      "BF16": 28311552,
+      "FP8_E4M3": 14198784,
+      "NVFP4": 7962624
+     },
+     "menu": [
+      {
+       "activation_pricing": "weight_only_uncalibrated",
+       "bits_per_param": "4.5",
+       "fmt": "NVFP4",
+       "memory_bytes": 7962624,
+       "predicted_dloss": "0.04320000000000001",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "weight_only_uncalibrated",
+       "bits_per_param": "8.024305555555555",
+       "fmt": "FP8_E4M3",
+       "memory_bytes": 14198784,
+       "predicted_dloss": "0.0021600000000000005",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "bit_exact",
+       "bits_per_param": "16.0",
+       "fmt": "BF16",
+       "memory_bytes": 28311552,
+       "predicted_dloss": "0.0",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      }
+     ],
+     "n_params": 14155776
+    },
+    "model.layers.1.mlp.experts.0.__packed_serving__.model__layers__1__mlp__experts": {
+     "cost_rows": {
+      "BF16": {
+       "predicted_dloss": "0.0",
+       "predicted_dloss_stderr": "0.0"
+      },
+      "FP8_E4M3": {
+       "predicted_dloss": "0.006255",
+       "predicted_dloss_stderr": "0.0007937253933193773"
+      },
+      "NVFP4": {
+       "predicted_dloss": "0.12510000000000002",
+       "predicted_dloss_stderr": "0.015874507866387545"
+      }
+     },
+     "members": [
+      "model.layers.1.mlp.experts.0.w1",
+      "model.layers.1.mlp.experts.0.w2",
+      "model.layers.1.mlp.experts.0.w3",
+      "model.layers.1.mlp.experts.1.w1",
+      "model.layers.1.mlp.experts.1.w2",
+      "model.layers.1.mlp.experts.1.w3",
+      "model.layers.1.mlp.experts.2.w1",
+      "model.layers.1.mlp.experts.2.w2",
+      "model.layers.1.mlp.experts.2.w3"
+     ],
+     "memory_bytes_by_format": {
+      "BF16": 28311552,
+      "FP8_E4M3": 14198784,
+      "NVFP4": 7962624
+     },
+     "menu": [
+      {
+       "activation_pricing": "weight_only_uncalibrated",
+       "bits_per_param": "4.5",
+       "fmt": "NVFP4",
+       "memory_bytes": 7962624,
+       "predicted_dloss": "0.12510000000000002",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "weight_only_uncalibrated",
+       "bits_per_param": "8.024305555555555",
+       "fmt": "FP8_E4M3",
+       "memory_bytes": 14198784,
+       "predicted_dloss": "0.006255",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "bit_exact",
+       "bits_per_param": "16.0",
+       "fmt": "BF16",
+       "memory_bytes": 28311552,
+       "predicted_dloss": "0.0",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      }
+     ],
+     "n_params": 14155776
+    }
+   }
+  },
+  "packed_role_split_hedged": {
+   "passthrough_rows": [
+    "model.layers.0.self_attn.o_proj"
+   ],
+   "super_items": {
+    "model.layers.0.mlp.experts.0.__packed_serving__.model__layers__0__mlp__experts::role:down_proj": {
+     "cost_rows": {
+      "BF16": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.0",
+       "predicted_dloss_stderr": "0.0"
+      },
+      "FP8_E4M3": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.0006906240000000004",
+       "predicted_dloss_stderr": "0.00021533986592361395"
+      },
+      "NVFP4": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.02426544000000001",
+       "predicted_dloss_stderr": "0.007566080234943323"
+      }
+     },
+     "members": [
+      "model.layers.0.mlp.experts.0.w2",
+      "model.layers.0.mlp.experts.1.w2",
+      "model.layers.0.mlp.experts.2.w2"
+     ],
+     "memory_bytes_by_format": {
+      "BF16": 9437184,
+      "FP8_E4M3": 4743168,
+      "NVFP4": 2654208
+     },
+     "menu": [
+      {
+       "activation_pricing": "weight_only_activation_calibrated",
+       "bits_per_param": "4.5",
+       "fmt": "NVFP4",
+       "memory_bytes": 2654208,
+       "predicted_dloss": "0.03561456035241499",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "weight_only_activation_calibrated",
+       "bits_per_param": "8.041666666666666",
+       "fmt": "FP8_E4M3",
+       "memory_bytes": 4743168,
+       "predicted_dloss": "0.0010136337988854213",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "bit_exact",
+       "bits_per_param": "16.0",
+       "fmt": "BF16",
+       "memory_bytes": 9437184,
+       "predicted_dloss": "0.0",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      }
+     ],
+     "n_params": 4718592
+    },
+    "model.layers.0.mlp.experts.0.__packed_serving__.model__layers__0__mlp__experts::role:gate_up_proj": {
+     "cost_rows": {
+      "BF16": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.0",
+       "predicted_dloss_stderr": "0.0"
+      },
+      "FP8_E4M3": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.0013812480000000007",
+       "predicted_dloss_stderr": "0.00030453655890877874"
+      },
+      "NVFP4": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.04853088000000002",
+       "predicted_dloss_stderr": "0.01070005328225986"
+      }
+     },
+     "members": [
+      "model.layers.0.mlp.experts.0.w1",
+      "model.layers.0.mlp.experts.0.w3",
+      "model.layers.0.mlp.experts.1.w1",
+      "model.layers.0.mlp.experts.1.w3",
+      "model.layers.0.mlp.experts.2.w1",
+      "model.layers.0.mlp.experts.2.w3"
+     ],
+     "memory_bytes_by_format": {
+      "BF16": 18874368,
+      "FP8_E4M3": 9455616,
+      "NVFP4": 5308416
+     },
+     "menu": [
+      {
+       "activation_pricing": "weight_only_activation_calibrated",
+       "bits_per_param": "4.5",
+       "fmt": "NVFP4",
+       "memory_bytes": 5308416,
+       "predicted_dloss": "0.0645809599233898",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "weight_only_activation_calibrated",
+       "bits_per_param": "8.015625",
+       "fmt": "FP8_E4M3",
+       "memory_bytes": 9455616,
+       "predicted_dloss": "0.0018380528383631688",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "bit_exact",
+       "bits_per_param": "16.0",
+       "fmt": "BF16",
+       "memory_bytes": 18874368,
+       "predicted_dloss": "0.0",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      }
+     ],
+     "n_params": 9437184
+    },
+    "model.layers.1.mlp.experts.0.__packed_serving__.model__layers__1__mlp__experts::role:down_proj": {
+     "cost_rows": {
+      "BF16": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.0",
+       "predicted_dloss_stderr": "0.0"
+      },
+      "FP8_E4M3": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.0019999320000000003",
+       "predicted_dloss_stderr": "0.00043956066066016424"
+      },
+      "NVFP4": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.07026867",
+       "predicted_dloss_stderr": "0.015444196607140174"
+      }
+     },
+     "members": [
+      "model.layers.1.mlp.experts.0.w2",
+      "model.layers.1.mlp.experts.1.w2",
+      "model.layers.1.mlp.experts.2.w2"
+     ],
+     "memory_bytes_by_format": {
+      "BF16": 9437184,
+      "FP8_E4M3": 4743168,
+      "NVFP4": 2654208
+     },
+     "menu": [
+      {
+       "activation_pricing": "weight_only_activation_calibrated",
+       "bits_per_param": "4.5",
+       "fmt": "NVFP4",
+       "memory_bytes": 2654208,
+       "predicted_dloss": "0.09343496491071027",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "weight_only_activation_calibrated",
+       "bits_per_param": "8.041666666666666",
+       "fmt": "FP8_E4M3",
+       "memory_bytes": 4743168,
+       "predicted_dloss": "0.0026592729909902467",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "bit_exact",
+       "bits_per_param": "16.0",
+       "fmt": "BF16",
+       "memory_bytes": 9437184,
+       "predicted_dloss": "0.0",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      }
+     ],
+     "n_params": 4718592
+    },
+    "model.layers.1.mlp.experts.0.__packed_serving__.model__layers__1__mlp__experts::role:gate_up_proj": {
+     "cost_rows": {
+      "BF16": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.0",
+       "predicted_dloss_stderr": "0.0"
+      },
+      "FP8_E4M3": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.0039998640000000005",
+       "predicted_dloss_stderr": "0.000621632647791282"
+      },
+      "NVFP4": {
+       "activation_pricing_applied": true,
+       "predicted_dloss": "0.14053734",
+       "predicted_dloss_stderr": "0.021841392301774173"
+      }
+     },
+     "members": [
+      "model.layers.1.mlp.experts.0.w1",
+      "model.layers.1.mlp.experts.0.w3",
+      "model.layers.1.mlp.experts.1.w1",
+      "model.layers.1.mlp.experts.1.w3",
+      "model.layers.1.mlp.experts.2.w1",
+      "model.layers.1.mlp.experts.2.w3"
+     ],
+     "memory_bytes_by_format": {
+      "BF16": 18874368,
+      "FP8_E4M3": 9455616,
+      "NVFP4": 5308416
+     },
+     "menu": [
+      {
+       "activation_pricing": "weight_only_activation_calibrated",
+       "bits_per_param": "4.5",
+       "fmt": "NVFP4",
+       "memory_bytes": 5308416,
+       "predicted_dloss": "0.17329942845266127",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "weight_only_activation_calibrated",
+       "bits_per_param": "8.015625",
+       "fmt": "FP8_E4M3",
+       "memory_bytes": 9455616,
+       "predicted_dloss": "0.004932312971686923",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      },
+      {
+       "activation_pricing": "bit_exact",
+       "bits_per_param": "16.0",
+       "fmt": "BF16",
+       "memory_bytes": 18874368,
+       "predicted_dloss": "0.0",
+       "serialized_identity": null,
+       "serialized_sidecar_identity": null,
+       "serving_lane": null
+      }
+     ],
+     "n_params": 9437184
+    }
+   }
+  }
+ },
+ "schema": "prismaquant.super_item_menu_golden.v1"
+}

--- a/tests/test_super_item_menu_byte_identity.py
+++ b/tests/test_super_item_menu_byte_identity.py
@@ -1,0 +1,423 @@
+"""Byte-identity gate on the two super-item aggregators (principle 6).
+
+``aggregate_fused_siblings`` and ``aggregate_packed_serving_groups`` are
+DEFAULT-PATH code: every production allocation runs both.  This module pins
+their output -- every super item's whole menu, byte for byte and float for
+float -- against a golden digest committed BEFORE the trellis-seam wiring
+touched either function, so a change to those functions that perturbs an
+existing scalar-only menu fails here instead of silently re-allocating a
+27B artifact.
+
+What is pinned, per scenario:
+
+* every super item's candidate list, IN ORDER, with ``fmt``,
+  ``bits_per_param``, ``memory_bytes``, ``predicted_dloss``,
+  ``serialized_identity``, ``serialized_sidecar_identity``,
+  ``activation_pricing`` and ``serving_lane`` -- floats by ``repr`` so the
+  comparison is exact rather than tolerance-based;
+* ``stats_ext[super]["_memory_bytes_by_format"]`` (the exact-bytes map every
+  downstream byte path prefers) and the whole ``costs_ext[super]`` row,
+  including ``predicted_dloss_stderr`` and the applied-pricing marker;
+* the pass-through rows' names, so a change cannot quietly move a Linear
+  into or out of a group.
+
+The scenarios deliberately cover the branches the wiring work touches: both
+aggregators, ``PRISMAQUANT_COST_UCB_Z`` at 0 and non-zero (the hedge
+conversion), calibrated gains, activation fair pricing, and the role-split
+packed profile.
+
+Regenerate ONLY when a behaviour change is intended and argued::
+
+    PYTHONPATH=. python tests/test_super_item_menu_byte_identity.py --regen
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from unittest import mock
+
+from prismaquant import format_registry as fr
+from prismaquant.activation_fair_pricing import (
+    REASON_CALIBRATED,
+    ActivationFairPricing,
+    FamilyCalibration,
+)
+from prismaquant.allocator_candidates import (
+    _FUSED_SIBLING_MARKER,
+    _PACKED_GROUP_MARKER,
+    aggregate_fused_siblings,
+    aggregate_packed_serving_groups,
+    build_candidates,
+    packed_role_split_profile,
+)
+
+GOLDEN_PATH = Path(__file__).with_name("fixtures") / "super_item_menu_golden.json"
+
+MENU = ("NVFP4", "FP8_E4M3", "BF16")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: a dense attention+MLP block and a packed-MoE layer
+# ---------------------------------------------------------------------------
+class _DenseProfile:
+    def fused_sibling_group(self, name: str) -> str | None:
+        if name.endswith((".q_proj", ".k_proj", ".v_proj")):
+            return name.rsplit(".", 1)[0] + ".qkv_proj"
+        if name.endswith((".gate_proj", ".up_proj")):
+            return name.rsplit(".", 1)[0] + ".gate_up_proj"
+        return None
+
+
+class _PackedProfile:
+    """Two MoE layers of 3 experts x {w1, w3, w2}, grouped per layer."""
+
+    def packed_expert_format_group(self, name: str) -> str | None:
+        if ".experts." not in name:
+            return None
+        return name.split(".experts.")[0] + ".experts"
+
+    def packed_expert_role_group(self, name: str) -> str | None:
+        if name.endswith((".w1", ".w3")):
+            return "gate_up_proj"
+        if name.endswith(".w2"):
+            return "down_proj"
+        return None
+
+
+def _row(d_out: int, d_in: int, h_trace: float, mse: float,
+         stderr: float) -> tuple[dict, dict]:
+    stats = {
+        "h_trace": h_trace,
+        "h_trace_raw": h_trace * 1.5,
+        "h_w2_sum": h_trace * 0.25,
+        "w_max_abs": 0.75,
+        "w_norm_sq": float(d_out * d_in) * 1e-4,
+        "n_params": d_out * d_in,
+        "in_features": d_in,
+        "out_features": d_out,
+        "n_tokens_seen": 4096,
+    }
+    costs = {
+        "NVFP4": {
+            "weight_mse": mse,
+            "predicted_dloss": 0.5 * h_trace * mse,
+            "predicted_dloss_stderr": stderr,
+        },
+        "FP8_E4M3": {
+            "weight_mse": mse * 0.05,
+            "predicted_dloss": 0.5 * h_trace * mse * 0.05,
+            "predicted_dloss_stderr": stderr * 0.05,
+        },
+        "BF16": {
+            "weight_mse": 0.0,
+            "predicted_dloss": 0.0,
+            "predicted_dloss_stderr": 0.0,
+        },
+    }
+    return stats, costs
+
+
+def _dense_inputs() -> tuple[dict, dict]:
+    layer = "model.layers.0"
+    shapes = {
+        "self_attn.q_proj": (4096, 4096),
+        "self_attn.k_proj": (1024, 4096),
+        "self_attn.v_proj": (1024, 4096),
+        "self_attn.o_proj": (4096, 4096),
+        "mlp.gate_proj": (11008, 4096),
+        "mlp.up_proj": (11008, 4096),
+        "mlp.down_proj": (4096, 11008),
+    }
+    h = {
+        "self_attn.q_proj": 0.5, "self_attn.k_proj": 0.3,
+        "self_attn.v_proj": 0.7, "self_attn.o_proj": 0.4,
+        "mlp.gate_proj": 0.8, "mlp.up_proj": 0.6, "mlp.down_proj": 0.9,
+    }
+    mse = {
+        "self_attn.q_proj": 0.021, "self_attn.k_proj": 0.017,
+        "self_attn.v_proj": 0.033, "self_attn.o_proj": 0.011,
+        "mlp.gate_proj": 0.041, "mlp.up_proj": 0.029, "mlp.down_proj": 0.013,
+    }
+    stderr = {
+        "self_attn.q_proj": 0.0031, "self_attn.k_proj": 0.0011,
+        "self_attn.v_proj": 0.0052, "self_attn.o_proj": 0.0007,
+        "mlp.gate_proj": 0.0063, "mlp.up_proj": 0.0044, "mlp.down_proj": 0.0019,
+    }
+    stats: dict = {}
+    costs: dict = {}
+    for leaf, shape in shapes.items():
+        name = f"{layer}.{leaf}"
+        stats[name], costs[name] = _row(
+            shape[0], shape[1], h[leaf], mse[leaf], stderr[leaf])
+    return stats, costs
+
+
+def _packed_inputs() -> tuple[dict, dict]:
+    stats: dict = {}
+    costs: dict = {}
+    for layer in (0, 1):
+        for expert in range(3):
+            for leaf, (d_out, d_in) in (
+                ("w1", (768, 2048)),
+                ("w3", (768, 2048)),
+                ("w2", (2048, 768)),
+            ):
+                name = f"model.layers.{layer}.mlp.experts.{expert}.{leaf}"
+                seed = layer * 7 + expert * 3 + len(leaf)
+                stats[name], costs[name] = _row(
+                    d_out, d_in,
+                    0.2 + 0.05 * seed,
+                    0.01 + 0.002 * seed,
+                    0.0004 * (seed + 1),
+                )
+    # One dense row that must pass through untouched.
+    stats["model.layers.0.self_attn.o_proj"], \
+        costs["model.layers.0.self_attn.o_proj"] = _row(
+            4096, 4096, 0.4, 0.011, 0.0007)
+    return stats, costs
+
+
+def _pricing() -> ActivationFairPricing:
+    def fit(family: str, penalty: float) -> FamilyCalibration:
+        return FamilyCalibration(
+            family=family,
+            n_rows=8,
+            penalty=penalty,
+            log2_penalty=0.0,
+            log2_stdev=0.0,
+            log2_stderr=0.0,
+            log2_residual_min=0.0,
+            log2_residual_max=0.0,
+            formats=(),
+            per_format_log2_penalty=(),
+            rung_dependence_log2_range=0.0,
+            sample=(),
+            rows_digest="test",
+        )
+
+    return ActivationFairPricing(
+        enabled=True,
+        reason=REASON_CALIBRATED,
+        families={"nv": fit("nv", 1.37), "fp": fit("fp", 1.09)},
+        measured_rows_by_family={"nv": 8, "fp": 8},
+        weight_only_rows_by_family={"nv": 4, "fp": 4},
+        uncalibrated_families=(),
+    )
+
+
+GAINS = {"NVFP4": 1.23, "FP8_E4M3": 0.88}
+
+
+def _specs() -> list:
+    return [fr.REGISTRY[name] for name in MENU]
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+def _run_fused(ucb_z: str, *, gains, pricing):
+    stats, costs = _dense_inputs()
+    specs = _specs()
+    with mock.patch.dict(os.environ, {"PRISMAQUANT_COST_UCB_Z": ucb_z}):
+        cands = build_candidates(
+            stats, costs, specs, calibrated_gains=gains,
+            activation_pricing=pricing)
+        return aggregate_fused_siblings(
+            stats, costs, specs, cands, _DenseProfile(),
+            calibrated_gains=gains, activation_pricing=pricing)
+
+
+def _run_packed(ucb_z: str, *, gains, pricing, role_split: bool):
+    stats, costs = _packed_inputs()
+    specs = _specs()
+    profile = _PackedProfile()
+    if role_split:
+        profile = packed_role_split_profile(profile)
+    with mock.patch.dict(os.environ, {"PRISMAQUANT_COST_UCB_Z": ucb_z}):
+        cands = build_candidates(
+            stats, costs, specs, calibrated_gains=gains,
+            activation_pricing=pricing)
+        return aggregate_packed_serving_groups(
+            stats, costs, specs, cands, profile,
+            calibrated_gains=gains, activation_pricing=pricing)
+
+
+SCENARIOS = {
+    "fused_plain": lambda: _run_fused("0", gains=None, pricing=None),
+    "fused_hedged_gained_priced": lambda: _run_fused(
+        "1.5", gains=GAINS, pricing=_pricing()),
+    "packed_plain": lambda: _run_packed(
+        "0", gains=None, pricing=None, role_split=False),
+    "packed_hedged_gained_priced": lambda: _run_packed(
+        "1.5", gains=GAINS, pricing=_pricing(), role_split=False),
+    "packed_role_split_hedged": lambda: _run_packed(
+        "1.5", gains=GAINS, pricing=_pricing(), role_split=True),
+}
+
+
+# ---------------------------------------------------------------------------
+# Canonical serialization
+# ---------------------------------------------------------------------------
+def _num(value):
+    """Exact serialization of a float: repr round-trips, str() may not."""
+    if isinstance(value, bool) or value is None:
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return repr(value)
+    return str(value)
+
+
+def _candidate_payload(cand) -> dict:
+    return {
+        "fmt": cand.fmt,
+        "bits_per_param": _num(cand.bits_per_param),
+        "memory_bytes": int(cand.memory_bytes),
+        "predicted_dloss": _num(cand.predicted_dloss),
+        "serialized_identity": cand.serialized_identity,
+        "serialized_sidecar_identity": cand.serialized_sidecar_identity,
+        "activation_pricing": (
+            None if cand.activation_pricing is None
+            else str(cand.activation_pricing)
+        ),
+        "serving_lane": (
+            None if cand.serving_lane is None else repr(cand.serving_lane)
+        ),
+    }
+
+
+def _scenario_payload(triple) -> dict:
+    stats_ext, costs_ext, cands_ext = triple
+    supers = sorted(
+        n for n in cands_ext
+        if _FUSED_SIBLING_MARKER in n or _PACKED_GROUP_MARKER in n
+    )
+    passthrough = sorted(set(cands_ext) - set(supers))
+    payload = {
+        "super_items": {},
+        "passthrough_rows": passthrough,
+    }
+    for name in supers:
+        payload["super_items"][name] = {
+            # IN ORDER: menu order is the DP's tie-break, so a reordering is
+            # a behaviour change even when every field matches as a set.
+            "menu": [_candidate_payload(c) for c in cands_ext[name]],
+            "memory_bytes_by_format": {
+                fmt: int(nbytes) for fmt, nbytes
+                in sorted(stats_ext[name]["_memory_bytes_by_format"].items())
+            },
+            "cost_rows": {
+                fmt: {k: _num(v) for k, v in sorted(row.items())}
+                for fmt, row in sorted(costs_ext[name].items())
+            },
+            "n_params": int(stats_ext[name]["n_params"]),
+            "members": sorted(
+                stats_ext[name].get("_fused_siblings")
+                or stats_ext[name].get("_packed_group_members")
+                or []
+            ),
+        }
+    return payload
+
+
+def _build_payload() -> dict:
+    return {
+        "schema": "prismaquant.super_item_menu_golden.v1",
+        "menu": list(MENU),
+        "scenarios": {
+            name: _scenario_payload(build())
+            for name, build in sorted(SCENARIOS.items())
+        },
+    }
+
+
+def _canonical(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def digest(payload: dict) -> str:
+    return hashlib.sha256(_canonical(payload).encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+def test_super_item_menus_are_byte_identical_to_the_golden():
+    assert GOLDEN_PATH.exists(), (
+        f"{GOLDEN_PATH} is missing. It is the pre-change record of what the "
+        "two aggregators produce; regenerate it only with an argued "
+        "behaviour change."
+    )
+    golden = json.loads(GOLDEN_PATH.read_text())
+    current = _build_payload()
+    for name in sorted(golden["scenarios"]):
+        assert name in current["scenarios"], f"scenario {name} disappeared"
+        assert current["scenarios"][name] == golden["scenarios"][name], (
+            f"super-item menu changed in scenario {name!r}: the aggregators "
+            "are default-path code and this is the principle-6 gate"
+        )
+    assert digest(current) == golden["digest"], (
+        "aggregate digest changed even though every recorded scenario "
+        "matched -- a scenario was added or removed"
+    )
+
+
+def test_the_golden_actually_exercises_both_aggregators_and_the_hedge():
+    """A golden that recorded nothing would pass the test above forever."""
+    payload = _build_payload()
+    fused = payload["scenarios"]["fused_plain"]["super_items"]
+    packed = payload["scenarios"]["packed_plain"]["super_items"]
+    assert len(fused) == 2, sorted(fused)
+    assert all(_FUSED_SIBLING_MARKER in n for n in fused)
+    assert len(packed) == 2, sorted(packed)
+    assert all(_PACKED_GROUP_MARKER in n for n in packed)
+    # Every super item offers the whole 3-rung menu, so the pin covers the
+    # per-format loop rather than a single surviving format.
+    for group in (fused, packed):
+        for entry in group.values():
+            assert [c["fmt"] for c in entry["menu"]] == list(MENU)
+            assert sorted(entry["memory_bytes_by_format"]) == sorted(MENU)
+
+    # The hedge scenario must actually differ from the unhedged one, or the
+    # UCB conversion is untested.
+    plain = payload["scenarios"]["fused_plain"]["super_items"]
+    hedged = payload["scenarios"]["fused_hedged_gained_priced"]["super_items"]
+    assert set(plain) == set(hedged)
+    differs = [
+        name for name in plain
+        if plain[name]["menu"] != hedged[name]["menu"]
+    ]
+    assert differs, "UCB z / gains / activation pricing changed nothing"
+    for name in plain:
+        row = hedged[name]["cost_rows"]["NVFP4"]
+        assert float(row["predicted_dloss_stderr"]) > 0.0
+
+    # Role-split really splits: 2 layers x 2 roles = 4 units, not 2.
+    split = payload["scenarios"]["packed_role_split_hedged"]["super_items"]
+    assert len(split) == 4, sorted(split)
+
+
+def test_passthrough_rows_are_not_swallowed_by_either_aggregator():
+    payload = _build_payload()
+    fused = payload["scenarios"]["fused_plain"]
+    assert fused["passthrough_rows"] == [
+        "model.layers.0.mlp.down_proj",
+        "model.layers.0.self_attn.o_proj",
+    ]
+    packed = payload["scenarios"]["packed_plain"]
+    assert packed["passthrough_rows"] == ["model.layers.0.self_attn.o_proj"]
+
+
+if __name__ == "__main__":  # pragma: no cover - regeneration entry point
+    import sys
+
+    if "--regen" not in sys.argv:
+        raise SystemExit("pass --regen to rewrite the golden")
+    _payload = _build_payload()
+    _payload["digest"] = digest(_payload)
+    GOLDEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+    GOLDEN_PATH.write_text(json.dumps(_payload, indent=1, sort_keys=True) + "\n")
+    print(f"wrote {GOLDEN_PATH} digest={_payload['digest']}")

--- a/tests/test_super_item_menu_byte_identity.py
+++ b/tests/test_super_item_menu_byte_identity.py
@@ -38,6 +38,7 @@ import os
 from pathlib import Path
 from unittest import mock
 
+from prismaquant import allocator_candidates as alloc_cand
 from prismaquant import format_registry as fr
 from prismaquant.activation_fair_pricing import (
     REASON_CALIBRATED,
@@ -398,6 +399,36 @@ def test_the_golden_actually_exercises_both_aggregators_and_the_hedge():
     # Role-split really splits: 2 layers x 2 roles = 4 units, not 2.
     split = payload["scenarios"]["packed_role_split_hedged"]["super_items"]
     assert len(split) == 4, sorted(split)
+
+
+def test_the_golden_is_load_bearing():
+    """A passing golden is not evidence until a driver change makes it fail.
+
+    Mutate the aggregators' menu-order helper at runtime -- same SET of
+    formats, different DP order, the minimal perturbation an order-blind
+    record would miss -- and the digest must move.  Restoring it must bring
+    the recorded digest back, so the check is the fixture's, not the run's.
+    """
+    golden = json.loads(GOLDEN_PATH.read_text())
+    assert digest(_build_payload()) == golden["digest"]
+
+    original = alloc_cand._super_menu_format_names
+
+    def reordered(formats, member_menu_intersection):
+        return tuple(sorted(original(formats, member_menu_intersection)))
+
+    with mock.patch.object(
+        alloc_cand, "_super_menu_format_names", reordered
+    ):
+        mutated = digest(_build_payload())
+    assert mutated != golden["digest"], (
+        "reordering every super item's menu did not change the recorded "
+        "payload -- the golden does not pin what it claims to pin"
+    )
+    assert digest(_build_payload()) == golden["digest"], (
+        "the golden did not return to its recorded value after the mutation "
+        "was undone"
+    )
 
 
 def test_passthrough_rows_are_not_swallowed_by_either_aggregator():

--- a/tests/test_super_item_menu_byte_identity.py
+++ b/tests/test_super_item_menu_byte_identity.py
@@ -13,8 +13,8 @@ What is pinned, per scenario:
 * every super item's candidate list, IN ORDER, with ``fmt``,
   ``bits_per_param``, ``memory_bytes``, ``predicted_dloss``,
   ``serialized_identity``, ``serialized_sidecar_identity``,
-  ``activation_pricing`` and ``serving_lane`` -- floats by ``repr`` so the
-  comparison is exact rather than tolerance-based;
+  ``activation_pricing`` and ``serving_lane`` -- floats by ``repr``, which
+  round-trips exactly, so the fixture records the full float64 value;
 * ``stats_ext[super]["_memory_bytes_by_format"]`` (the exact-bytes map every
   downstream byte path prefers) and the whole ``costs_ext[super]`` row,
   including ``predicted_dloss_stderr`` and the applied-pricing marker;
@@ -26,6 +26,34 @@ aggregators, ``PRISMAQUANT_COST_UCB_Z`` at 0 and non-zero (the hedge
 conversion), calibrated gains, activation fair pricing, and the role-split
 packed profile.
 
+How each field is compared
+--------------------------
+
+Everything that decides BYTES or DP STRUCTURE is compared EXACTLY: menu order,
+``fmt``, ``memory_bytes``, ``_memory_bytes_by_format``, ``n_params``, the
+member lists, both serialized identities, ``activation_pricing``,
+``serving_lane``, the applied-pricing marker and the pass-through row names.
+Those are ints, bools, ``None`` and identity strings -- there is no float
+question to ask about them, and they are what the exported artifact is made of.
+
+The four ACCUMULATED float fields (``_FLOAT_FIELDS``) are compared to float64
+precision instead.  They must be compared, not dropped: the DP ranks on
+``predicted_dloss``, so a structure-only gate would miss a real cost regression
+entirely.  But pinning them to the LAST bit pins the reduction implementation
+rather than the aggregation:
+
+    a 9-member packed group's ``predicted_dloss`` is one builtin ``sum()``
+    over floats, and CPython 3.12 gave that ``sum()`` Neumaier compensated
+    summation (gh-100425) where 3.11 sums naively left-to-right.  Same
+    aggregation, same inputs, 1-2 ulp apart.  Measured: swapping ONLY the
+    summation algorithm reproduces all eight divergent values exactly,
+    including the three CI reported.  (That CI report blamed a numpy skew.
+    There is no numpy anywhere in this call chain.)
+
+An exact pin on those four therefore asserted summation order, not the
+property this module exists to protect -- the same defect, and the same fix,
+as ``tests/test_math_reunderwrite_pins.py`` (PR #90).
+
 Regenerate ONLY when a behaviour change is intended and argued::
 
     PYTHONPATH=. python tests/test_super_item_menu_byte_identity.py --regen
@@ -35,6 +63,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import sys
 from pathlib import Path
 from unittest import mock
 
@@ -57,6 +86,37 @@ from prismaquant.allocator_candidates import (
 GOLDEN_PATH = Path(__file__).with_name("fixtures") / "super_item_menu_golden.json"
 
 MENU = ("NVFP4", "FP8_E4M3", "BF16")
+
+# Fields ``_num`` renders as a float ``repr``.  Every OTHER leaf in the payload
+# is an int, a bool, ``None`` or an identity string and is compared exactly.
+_FLOAT_FIELDS = frozenset({
+    "bits_per_param",
+    "predicted_dloss",
+    "predicted_dloss_stderr",
+    "weight_mse",
+})
+
+# Principle 2: the bound comes from the dtype, not from what made the test
+# pass.  These are Python floats, i.e. IEEE-754 binary64, so the unit is
+# ``sys.float_info.epsilon`` (2.22e-16).
+#
+# 16 ulps covers the longest chain any pinned field accumulates over.  The
+# worst case is a packed group's hedged ``predicted_dloss``: per member, the
+# cost-entry product chain (0.5 * h_trace * mse, then the calibrated gain and
+# the per-family activation penalty) is ~5 roundings; those 9 member terms are
+# then summed (a 9-term reduction, <= 9 roundings naive, ~2 with the 3.12
+# compensated sum); the linear hedge is subtracted and ``z * sqrt(sum stderr^2)``
+# added, another ~4.  ~18 roundings at <= 0.5 ulp each, over an all-positive
+# sum whose condition number is 1, is a bound near 9 ulps; 16 is the next
+# power of two above it and matches the multiplier PR #90 derived the same way.
+#
+# Measured against the 3.11 reduction, the worst divergence across all five
+# scenarios is 1.5 ulps in these units (2.0 ulps of the value's own spacing),
+# against a bound of 16 -- so the tolerance is neither tuned to the observed
+# noise nor a headroom guess.  ``test_the_golden_is_load_bearing`` records how
+# large a driver perturbation the bound still catches.
+_FLOAT_TOLERANCE_ULPS = 16.0
+_FLOAT64_EPS = sys.float_info.epsilon
 
 
 # ---------------------------------------------------------------------------
@@ -340,13 +400,85 @@ def _canonical(payload: dict) -> str:
 
 
 def digest(payload: dict) -> str:
+    """Provenance stamp written by ``--regen``.
+
+    NOT the gate.  It hashes the float ``repr``s, so it moves on a 1-ulp
+    reduction difference; ``compare_to_golden`` is what the tests assert.
+    """
     return hashlib.sha256(_canonical(payload).encode()).hexdigest()
+
+
+def _float_mismatch(current: str, golden: str) -> str | None:
+    """Compare one accumulated float field to float64 precision.
+
+    Returns ``None`` when they agree, else a description.  A golden of exactly
+    ``0.0`` gets a tolerance of exactly 0.0 -- a bit-exact rung must stay
+    bit-exact, and this falls out of the relative form rather than needing a
+    special case.
+    """
+    cur = float(current)
+    gold = float(golden)
+    if cur == gold:
+        return None
+    tol = _FLOAT_TOLERANCE_ULPS * _FLOAT64_EPS * abs(gold)
+    delta = abs(cur - gold)
+    if delta <= tol:
+        return None
+    ulps = delta / max(abs(gold) * _FLOAT64_EPS, 5e-324)
+    return (f"{current} != {golden} (delta {delta:.6g} = {ulps:.1f} ulps, "
+            f"bound {tol:.6g} = {_FLOAT_TOLERANCE_ULPS:.0f} ulps)")
+
+
+def _walk(current, golden, path: str, field: str, out: list[str]) -> None:
+    if isinstance(golden, dict):
+        if not isinstance(current, dict):
+            out.append(f"{path}: expected an object, got {type(current).__name__}")
+            return
+        # Both directions: a key ADDED by the driver is a behaviour change too.
+        for key in sorted(set(golden) - set(current)):
+            out.append(f"{path}/{key}: missing (golden has {golden[key]!r})")
+        for key in sorted(set(current) - set(golden)):
+            out.append(f"{path}/{key}: added (value {current[key]!r})")
+        for key in sorted(set(golden) & set(current)):
+            _walk(current[key], golden[key], f"{path}/{key}", key, out)
+        return
+    if isinstance(golden, list):
+        if not isinstance(current, list):
+            out.append(f"{path}: expected a list, got {type(current).__name__}")
+            return
+        if len(current) != len(golden):
+            out.append(
+                f"{path}: length {len(current)} != {len(golden)} -- the menu "
+                "order and membership are pinned exactly")
+            return
+        for i, (c, g) in enumerate(zip(current, golden)):
+            _walk(c, g, f"{path}[{i}]", field, out)
+        return
+    if (field in _FLOAT_FIELDS
+            and isinstance(current, str) and isinstance(golden, str)):
+        problem = _float_mismatch(current, golden)
+        if problem is not None:
+            out.append(f"{path}: {problem}")
+        return
+    if current != golden:
+        out.append(f"{path}: {current!r} != {golden!r}")
+
+
+def compare_to_golden(current: dict, golden: dict) -> list[str]:
+    """Every mismatch between a built payload and the fixture, or ``[]``.
+
+    THE gate.  Exact on every structural field; float64-precision on the four
+    accumulated float fields.
+    """
+    out: list[str] = []
+    _walk(current["scenarios"], golden["scenarios"], "", "", out)
+    return out
 
 
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
-def test_super_item_menus_are_byte_identical_to_the_golden():
+def test_super_item_menus_match_the_golden():
     assert GOLDEN_PATH.exists(), (
         f"{GOLDEN_PATH} is missing. It is the pre-change record of what the "
         "two aggregators produce; regenerate it only with an argued "
@@ -354,15 +486,19 @@ def test_super_item_menus_are_byte_identical_to_the_golden():
     )
     golden = json.loads(GOLDEN_PATH.read_text())
     current = _build_payload()
-    for name in sorted(golden["scenarios"]):
-        assert name in current["scenarios"], f"scenario {name} disappeared"
-        assert current["scenarios"][name] == golden["scenarios"][name], (
-            f"super-item menu changed in scenario {name!r}: the aggregators "
-            "are default-path code and this is the principle-6 gate"
-        )
-    assert digest(current) == golden["digest"], (
-        "aggregate digest changed even though every recorded scenario "
-        "matched -- a scenario was added or removed"
+
+    # What the digest assertion this replaces actually claimed to catch. Both
+    # directions, so an ADDED scenario is caught as well as a removed one.
+    assert sorted(current["scenarios"]) == sorted(golden["scenarios"]), (
+        "the scenario set changed: "
+        f"added {sorted(set(current['scenarios']) - set(golden['scenarios']))}, "
+        f"removed {sorted(set(golden['scenarios']) - set(current['scenarios']))}"
+    )
+
+    problems = compare_to_golden(current, golden)
+    assert not problems, (
+        "super-item menu changed -- the aggregators are default-path code and "
+        "this is the principle-6 gate:\n  " + "\n  ".join(problems)
     )
 
 
@@ -404,30 +540,56 @@ def test_the_golden_actually_exercises_both_aggregators_and_the_hedge():
 def test_the_golden_is_load_bearing():
     """A passing golden is not evidence until a driver change makes it fail.
 
-    Mutate the aggregators' menu-order helper at runtime -- same SET of
-    formats, different DP order, the minimal perturbation an order-blind
-    record would miss -- and the digest must move.  Restoring it must bring
-    the recorded digest back, so the check is the fixture's, not the run's.
+    Two teeth, one per half of the comparison, and both mutate the DRIVER --
+    never the fixture, which would only prove the comparator can read its own
+    output.
+
+    STRUCTURAL: reorder every super item's menu (same SET of formats, different
+    DP order -- the minimal perturbation an order-blind record would miss).
+    No float tolerance can absorb this, and none should.
+
+    NUMERIC: scale every member's predicted dloss by 1 + 1e-12.  This is the
+    tooth the tolerance could blunt, so it is asserted in-tree rather than
+    only recorded in a commit message.  1e-12 relative sits ~280x above the
+    3.55e-15 bound and ~3000x above the largest reduction difference measured
+    (1.5 ulps), so it can neither flake nor pass.  Bisected on this tree:
+    1e-14 is CAUGHT (56 mismatches), 1e-15 is NOT -- the gate resolves a
+    driver change nine orders of magnitude finer than the 1e-5 / 1e-6
+    threshold PR #90 settled for in float32.
     """
     golden = json.loads(GOLDEN_PATH.read_text())
-    assert digest(_build_payload()) == golden["digest"]
+    assert not compare_to_golden(_build_payload(), golden)
 
-    original = alloc_cand._super_menu_format_names
+    original_menu = alloc_cand._super_menu_format_names
 
     def reordered(formats, member_menu_intersection):
-        return tuple(sorted(original(formats, member_menu_intersection)))
+        return tuple(sorted(original_menu(formats, member_menu_intersection)))
 
     with mock.patch.object(
         alloc_cand, "_super_menu_format_names", reordered
     ):
-        mutated = digest(_build_payload())
-    assert mutated != golden["digest"], (
-        "reordering every super item's menu did not change the recorded "
-        "payload -- the golden does not pin what it claims to pin"
+        assert compare_to_golden(_build_payload(), golden), (
+            "reordering every super item's menu did not fail the comparison "
+            "-- the golden does not pin what it claims to pin"
+        )
+
+    original_dloss = alloc_cand.cost_entry_predicted_dloss
+
+    def perturbed(*args, **kwargs):
+        return original_dloss(*args, **kwargs) * (1.0 + 1e-12)
+
+    with mock.patch.object(
+        alloc_cand, "cost_entry_predicted_dloss", perturbed
+    ):
+        problems = compare_to_golden(_build_payload(), golden)
+    assert problems, (
+        "a 1e-12 relative change to every member's predicted dloss did not "
+        "fail the comparison -- the float tolerance is too loose to be a gate"
     )
-    assert digest(_build_payload()) == golden["digest"], (
-        "the golden did not return to its recorded value after the mutation "
-        "was undone"
+
+    assert not compare_to_golden(_build_payload(), golden), (
+        "the golden did not compare clean again after the mutations were "
+        "undone"
     )
 
 

--- a/tests/test_trellis_menu.py
+++ b/tests/test_trellis_menu.py
@@ -5,23 +5,32 @@ The failure modes this guards are not arithmetic. They are:
   * the flag being anything other than a byte-identical no-op when unset,
   * a rung addressed by a per-tensor key, which silently collapses every
     fused/packed serving unit back to individual rows,
+  * a rung dropped from a coupled unit's menu because aggregation iterated
+    the REGISTRY instead of the members' candidate lists -- silent, and the
+    reason the seam refused as a whole until 2026-08-29,
   * allocating against ``_capability_gate`` on a profile that declares no
     ``target_platform``, where the gate returns legal without comparing
     anything,
   * mixing two objectives in one DP,
+  * a byte path falling through to a closed form that cannot express a
+    trellis wire, and
   * an allocation-time-only surface reaching export as if it were shippable.
+
+Every test here asserts BEHAVIOUR. Two earlier tests in this file asserted
+source text -- one counted ``"for spec in formats:"`` occurrences, one
+grepped the exporter -- and both passed while the enabled seam could not
+produce an assignment at all. They are replaced below by tests that call the
+code.
 """
 
 from __future__ import annotations
 
-import inspect
 import json
-import pathlib
 
 import pytest
 
 from prismaquant import trellis_menu as tm
-from prismaquant.allocator_solver import Candidate
+from prismaquant.allocator_solver import Candidate, promote_serving_units
 from prismaquant.trellis_formats import (
     E4M3_FAMILY,
     LAYOUT_TIGHT_OFFSETS,
@@ -32,7 +41,12 @@ from prismaquant.trellis_formats import (
 
 PROFILE = "trellis_research_sm121"
 COST_MODE = "aura"
-CURRENCY = "aura_adjoint"
+#: The objective ``COST_MODE=aura`` prices in. Spelled exactly as
+#: ``run-pipeline.sh`` resolves ``COST_OBJECTIVE``; the seam refuses anything
+#: else, which is the surviving UNWIRED_LINKS entry.
+CURRENCY = "aura-adjoint"
+#: What the measured trellis ladder ACTUALLY denominates its anchors in.
+LADDER_CURRENCY = "weighted_sse_activation_second_moment"
 
 
 def alphabet(rate: int) -> list[int]:
@@ -96,25 +110,56 @@ def scalar_menu(units):
 
 def stats_for(units):
     return {
-        unit: {"out_features": rows, "in_features": cols}
+        unit: {
+            "out_features": rows,
+            "in_features": cols,
+            "n_params": rows * cols,
+            "h_trace": 0.5,
+        }
         for unit, (rows, cols) in units.items()
     }
+
+
+def costs_for(units):
+    return {
+        unit: {
+            "BF16": {"weight_mse": 0.0, "predicted_dloss": 0.0},
+            "NVFP4": {"weight_mse": 0.02, "predicted_dloss": 5.0e-3},
+        }
+        for unit in units
+    }
+
+
+class _QKVProfile:
+    def fused_sibling_group(self, name: str) -> str | None:
+        if name.endswith((".q_proj", ".k_proj", ".v_proj")):
+            return name.rsplit(".", 1)[0] + ".qkv_proj"
+        return None
 
 
 UNIT_A = "model.layers.0.self_attn.q_proj"
 UNIT_B = "model.layers.0.self_attn.k_proj"
 
 
+# ---------------------------------------------------------------------------
+# The unset flag
+# ---------------------------------------------------------------------------
 def test_unset_flag_is_a_byte_identical_no_op(monkeypatch):
     monkeypatch.delenv(tm.TRELLIS_SURFACE_ENV, raising=False)
     units = {UNIT_A: (1024, 512)}
     menu = scalar_menu(units)
+    stats = stats_for(units)
     before = {k: list(v) for k, v in menu.items()}
-    out = tm.augment_candidates(menu, stats_for(units), cost_mode=COST_MODE)  # noqa: E501 -- the seam, deliberately
+    out = tm.augment_candidates(menu, stats, cost_mode=COST_MODE)  # the seam
     assert out is menu
     assert out == before
+    # and nothing was recorded on the stats either
+    assert "_memory_bytes_by_format" not in stats[UNIT_A]
 
 
+# ---------------------------------------------------------------------------
+# The built menu
+# ---------------------------------------------------------------------------
 def test_flag_adds_rungs_named_by_the_closed_tcq_spelling(tmp_path):
     units = {UNIT_A: (1024, 512)}
     menu = scalar_menu(units)
@@ -175,6 +220,9 @@ def test_fused_siblings_share_format_names_at_equal_rungs(tmp_path):
     assert ident_a != ident_b
 
 
+# ---------------------------------------------------------------------------
+# The refusals the manifest exists to make possible
+# ---------------------------------------------------------------------------
 def test_profile_without_target_platform_is_refused(tmp_path):
     """`research` declares no platform, so `_capability_gate` cannot fire."""
 
@@ -197,6 +245,68 @@ def test_cost_mode_mismatch_is_refused(tmp_path):
         )
 
 
+def test_the_ladders_own_currency_is_the_surviving_refusal(tmp_path):
+    """UNWIRED_LINKS[0], and the only one left.
+
+    A surface whose anchors were measured in the ladder's weighted SSE -- an
+    output-MSE proxy -- cannot be ranked against AURA-priced NVFP4 rungs. No
+    plumbing fixes that, so it is a refusal rather than a link, and the
+    message must name where the currency comes from.
+    """
+
+    units = {UNIT_A: (1024, 512)}
+    menu = scalar_menu(units)
+    path = write_manifest(tmp_path, units, currency=LADDER_CURRENCY)
+    with pytest.raises(tm.TrellisSeamUnwiredError) as exc:
+        tm.build_trellis_menu(
+            menu, stats_for(units), cost_mode=COST_MODE, manifest_path=path,
+        )
+    message = str(exc.value)
+    assert LADDER_CURRENCY in message
+    assert "aura-adjoint" in message
+    for where, _what in tm.UNWIRED_LINKS:
+        assert where in message
+    # Nothing was added on the way to the refusal.
+    assert not [c for c in menu[UNIT_A] if c.fmt.startswith("TCQ_")]
+
+
+def test_the_only_remaining_unwired_link_is_the_currency():
+    """The ledger is a claim about the code; seven entries are gone."""
+
+    assert [where for where, _ in tm.UNWIRED_LINKS] == [
+        "trellis_rate_surface.py:43-52"
+    ]
+
+
+def test_an_unstamped_cost_table_is_refused_not_defaulted(tmp_path):
+    """re-vet R2: the run's objective is attested, or the surface is refused.
+
+    Comparing against ``os.environ.get('COST_MODE', 'aura')`` was the old
+    behaviour and it compared against a default no run ever exported.
+    """
+
+    units = {UNIT_A: (1024, 512)}
+    menu = scalar_menu(units)
+    path = write_manifest(tmp_path, units, cost_mode="")
+    with pytest.raises(tm.TrellisMenuError, match=r"provenance\['cost_mode'\]"):
+        tm.build_trellis_menu(
+            menu, stats_for(units), cost_mode="", manifest_path=path,
+        )
+
+
+def test_a_cost_mode_with_no_declared_objective_is_refused(tmp_path):
+    units = {UNIT_A: (1024, 512)}
+    menu = scalar_menu(units)
+    path = write_manifest(tmp_path, units, cost_mode="grouped-kl")
+    with pytest.raises(tm.TrellisMenuError, match="names no objective"):
+        tm.build_trellis_menu(
+            menu, stats_for(units), cost_mode="grouped-kl", manifest_path=path,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Skips that must be counted, not silent
+# ---------------------------------------------------------------------------
 def test_single_anchor_is_refused(tmp_path):
     """One anchor brackets nothing; interpolation would become extrapolation."""
 
@@ -242,6 +352,30 @@ def test_unit_absent_from_the_scalar_menu_is_reported(tmp_path):
     assert prov["candidates_added"] == 0
 
 
+def test_a_packed_expert_row_is_refused_not_underpriced(tmp_path):
+    """The 128x underprice, which was silent.
+
+    The seam used to build a 2-tuple shape and read a ``packed_expert`` key
+    nothing writes, so a 128-expert row was priced as a single expert and
+    reported as ``0 unit(s) skipped``.  A rung that looks 128x cheaper than it
+    is is the most dangerous shape of wrong: the DP takes it and the frontier
+    looks plausible.
+    """
+
+    units = {UNIT_A: (1024, 512)}
+    stats = stats_for(units)
+    stats[UNIT_A] = dict(stats[UNIT_A], num_experts=128)
+    menu = scalar_menu(units)
+    prov: dict = {}
+    tm.build_trellis_menu(
+        menu, stats, cost_mode=COST_MODE,
+        manifest_path=write_manifest(tmp_path, units),
+        provenance_out=prov,
+    )
+    assert not [c for c in menu[UNIT_A] if c.fmt.startswith("TCQ_")]
+    assert "packed-expert" in prov["units_skipped"][UNIT_A]
+
+
 def test_bad_schema_is_refused(tmp_path):
     path = tmp_path / "bad.json"
     path.write_text(json.dumps({"schema": "something.else.v9"}))
@@ -269,84 +403,421 @@ def test_assignment_has_trellis_finds_rungs():
     assert tm.assignment_has_trellis({"x": "NVFP4"}) == []
 
 
-def test_the_production_seam_refuses_when_the_flag_is_set(tmp_path, monkeypatch):
-    """Behaviour, not source text.
+# ---------------------------------------------------------------------------
+# Link 1: no TCQ FormatSpec, on purpose -- the bytes ride the stats instead
+# ---------------------------------------------------------------------------
+def test_no_tcq_name_is_a_formatspec_and_that_is_the_design():
+    """A registered spec could only be plausible and WRONG.
 
-    The previous version of this test asserted that the string
-    ``trellis_menu.augment_candidates`` appeared in ``build_candidates``'s
-    source.  That passes whether or not the call does anything, and it passed
-    while the enabled path could not produce an assignment at all.  This asserts
-    what a caller observes.
-    """
-
-    from prismaquant import allocator_candidates as ac
-
-    units = {UNIT_A: (1024, 512)}
-    manifest = write_manifest(tmp_path, units)
-    monkeypatch.setenv(tm.TRELLIS_SURFACE_ENV, str(manifest))
-    with pytest.raises(tm.TrellisSeamUnwiredError) as exc:
-        tm.augment_candidates(
-            scalar_menu(units), stats_for(units), cost_mode=COST_MODE)
-    message = str(exc.value)
-    # The refusal must name every missing link, or it becomes the same kind of
-    # confident-and-wrong claim it replaced.
-    for where, _what in tm.UNWIRED_LINKS:
-        assert where in message
-    # ...and the seam is still reached from inside build_candidates, so a run
-    # with the flag set fails loudly rather than ignoring it.
-    assert "cost_mode" in inspect.signature(ac.build_candidates).parameters
-
-
-def test_the_unwired_links_are_still_unwired():
-    """The ledger is a claim about the code; check the two cheapest entries.
-
-    If either of these starts passing, the corresponding UNWIRED_LINKS entry is
-    stale and must be deleted along with -- not before -- its refusal.
+    ``FormatSpec.memory_bytes_for_shape`` is a closed form over weight/scale
+    bits; a rung's exact size needs the layout, the per-column schedule and
+    the alphabet directory the manifest declares. So the registry keeps
+    refusing -- but ``canonical_format_name`` must still pass the name
+    through unchanged, or every byte path would look up a mangled key.
     """
 
     from prismaquant import format_registry as fr
 
     with pytest.raises(KeyError):
         fr.get_format("TCQ_E2M1_R640")
-    from prismaquant import allocator_candidates as ac
-
-    aggregation = pathlib.Path(ac.__file__).read_text().count(
-        "for spec in formats:")
-    assert aggregation >= 2, (
-        "fused and packed aggregation still iterate FormatSpec objects; if "
-        "this changed, re-verify links 3 and 4 before deleting them"
-    )
+    assert fr.canonical_format_name("TCQ_E2M1_R640") == "TCQ_E2M1_R640"
 
 
-def test_a_packed_expert_row_is_refused_not_underpriced(tmp_path):
-    """The 128x underprice, which was silent.
+def test_the_seam_records_exact_bytes_where_every_byte_path_reads_them(tmp_path):
+    """Links 1/2/6, at the source: ``_memory_bytes_by_format``.
 
-    The seam used to build a 2-tuple shape and read a ``packed_expert`` key
-    nothing writes, so a 128-expert row was priced as a single expert and
-    reported as ``0 unit(s) skipped``.  A rung that looks 128x cheap than it is
-    is the most dangerous shape of wrong: the DP takes it and the frontier
-    looks plausible.
+    ``build_candidates`` writes this map for every FormatSpec row and the
+    allocator's payload filter, ``footprint``, ``compute_achieved``,
+    ``kl_measurement`` and bit attribution all PREFER it over the registry.
+    Writing it from the seam is what wires all of them at once.
     """
 
     units = {UNIT_A: (1024, 512)}
-    stats = stats_for(units)
-    stats[UNIT_A] = dict(stats[UNIT_A], num_experts=128)
     menu = scalar_menu(units)
-    prov: dict = {}
+    stats = stats_for(units)
     tm.build_trellis_menu(
         menu, stats, cost_mode=COST_MODE,
         manifest_path=write_manifest(tmp_path, units),
-        provenance_out=prov,
     )
-    assert not [c for c in menu[UNIT_A] if c.fmt.startswith("TCQ_")]
-    assert "packed-expert" in prov["units_skipped"][UNIT_A]
+    recorded = stats[UNIT_A]["_memory_bytes_by_format"]
+    rungs = [c for c in menu[UNIT_A] if c.fmt.startswith("TCQ_")]
+    assert rungs
+    for cand in rungs:
+        assert recorded[cand.fmt] == int(cand.memory_bytes)
+    # The per-tensor recipe identity is recorded alongside, same as CB.
+    identities = stats[UNIT_A]["_serialized_identity_by_format"]
+    assert identities[rungs[0].fmt] == rungs[0].serialized_identity
+
+
+def test_footprint_prices_a_trellis_row_from_the_recorded_bytes(tmp_path):
+    """Link 6: the byte-budget path, which has its own registry lookup."""
+
+    from prismaquant import footprint as fp
+
+    units = {UNIT_A: (1024, 512)}
+    menu = scalar_menu(units)
+    stats = stats_for(units)
+    tm.build_trellis_menu(
+        menu, stats, cost_mode=COST_MODE,
+        manifest_path=write_manifest(tmp_path, units),
+    )
+    rung = next(c for c in menu[UNIT_A] if c.fmt.startswith("TCQ_"))
+    info = fp.assignment_artifact_bytes(
+        {UNIT_A: rung.fmt},
+        stats,
+        source_total_bytes=10_000_000,
+        source_manifest=None,
+        regime="bf16",
+    )
+    assert info["body_quant_bytes"] == int(rung.memory_bytes)
+
+
+def test_footprint_refuses_a_trellis_row_it_has_no_measured_bytes_for():
+    """No closed-form fallback: a missing map is refused, not approximated."""
+
+    from prismaquant import footprint as fp
+
+    stats = {UNIT_A: {"out_features": 1024, "in_features": 512,
+                      "n_params": 1024 * 512}}
+    with pytest.raises(ValueError, match="_memory_bytes_by_format"):
+        fp.assignment_artifact_bytes(
+            {UNIT_A: "TCQ_E4M3_R1024"},
+            stats,
+            source_total_bytes=10_000_000,
+            source_manifest=None,
+            regime="bf16",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Links 3 and 4: super-item aggregation over MEMBER menus
+# ---------------------------------------------------------------------------
+def test_a_fused_super_item_offers_the_rung_its_members_share(tmp_path):
+    """Link 3, end to end through the real seam.
+
+    Before this, ``aggregate_fused_siblings`` built each super item's menu by
+    iterating FormatSpec OBJECTS, so a rung both members offered was dropped
+    from the group with no error -- on a dense model that left only
+    ``o_proj`` and ``down_proj`` able to hold one.
+    """
+
+    from prismaquant import format_registry as fr
+    from prismaquant.allocator_candidates import (
+        _FUSED_SIBLING_MARKER,
+        aggregate_fused_siblings,
+    )
+
+    units = {UNIT_A: (1024, 512), UNIT_B: (256, 512)}
+    menu = scalar_menu(units)
+    stats = stats_for(units)
+    tm.build_trellis_menu(
+        menu, stats, cost_mode=COST_MODE,
+        manifest_path=write_manifest(tmp_path, units),
+    )
+    shared = sorted(
+        ({c.fmt for c in menu[UNIT_A]} & {c.fmt for c in menu[UNIT_B]})
+        - {"BF16", "NVFP4"}
+    )
+    assert shared, "the fixture must give the siblings a shared rung"
+
+    specs = [fr.REGISTRY["NVFP4"], fr.REGISTRY["BF16"]]
+    stats_ext, _costs_ext, cands_ext = aggregate_fused_siblings(
+        stats, costs_for(units), specs, menu, _QKVProfile())
+    super_name = next(n for n in cands_ext if _FUSED_SIBLING_MARKER in n)
+    offered = {c.fmt: c for c in cands_ext[super_name]}
+    for fmt in shared:
+        assert fmt in offered, f"{fmt} was dropped from the fused group"
+        # Exact sums of the members', not a re-derived estimate.
+        assert offered[fmt].memory_bytes == sum(
+            next(c.memory_bytes for c in menu[u] if c.fmt == fmt)
+            for u in (UNIT_A, UNIT_B)
+        )
+        assert offered[fmt].predicted_dloss == pytest.approx(sum(
+            next(c.predicted_dloss for c in menu[u] if c.fmt == fmt)
+            for u in (UNIT_A, UNIT_B)
+        ))
+        # And the exact bytes are recorded where the byte paths read them.
+        assert (stats_ext[super_name]["_memory_bytes_by_format"][fmt]
+                == offered[fmt].memory_bytes)
+    # The registry menu still comes FIRST, so an all-registry run is
+    # unchanged (tests/test_super_item_menu_byte_identity.py pins that).
+    assert [c.fmt for c in cands_ext[super_name]][:2] == ["NVFP4", "BF16"]
+
+
+class _PackedProfile:
+    def packed_expert_format_group(self, name: str) -> str | None:
+        if ".experts." not in name:
+            return None
+        return name.split(".experts.")[0] + ".experts"
+
+
+def test_a_packed_group_offers_a_registry_free_format_its_members_share():
+    """Link 4, by injection.
+
+    The seam REFUSES packed-expert rows (no per-expert trellis render
+    exists), so no manifest can put a rung on a packed group today. The
+    aggregation contract is still the thing under test, and it is exercised
+    with synthetic registry-free candidates: what must not happen is a
+    format every member offers vanishing from the group's menu.
+    """
+
+    from prismaquant import format_registry as fr
+    from prismaquant.allocator_candidates import (
+        _PACKED_GROUP_MARKER,
+        aggregate_packed_serving_groups,
+    )
+
+    members = [
+        f"model.layers.0.mlp.experts.{i}.{leaf}"
+        for i in range(2) for leaf in ("w1", "w2")
+    ]
+    stats = {m: {"n_params": 4096, "h_trace": 0.3,
+                 "out_features": 64, "in_features": 64} for m in members}
+    costs = {m: {"BF16": {"weight_mse": 0.0, "predicted_dloss": 0.0},
+                 "NVFP4": {"weight_mse": 0.02, "predicted_dloss": 1e-3}}
+             for m in members}
+    fake = "TCQ_E4M3_R1024"
+    cands = {
+        m: [
+            Candidate(fmt="BF16", bits_per_param=16.0,
+                      memory_bytes=8192, predicted_dloss=0.0),
+            Candidate(fmt="NVFP4", bits_per_param=4.5,
+                      memory_bytes=2304, predicted_dloss=1e-3),
+            Candidate(fmt=fake, bits_per_param=4.0,
+                      memory_bytes=2048, predicted_dloss=7e-4),
+        ]
+        for m in members
+    }
+    specs = [fr.REGISTRY["NVFP4"], fr.REGISTRY["BF16"]]
+    stats_ext, _costs_ext, cands_ext = aggregate_packed_serving_groups(
+        stats, costs, specs, cands, _PackedProfile())
+    super_name = next(n for n in cands_ext if _PACKED_GROUP_MARKER in n)
+    offered = {c.fmt: c for c in cands_ext[super_name]}
+    assert fake in offered, "registry-free rung dropped from the packed group"
+    assert offered[fake].memory_bytes == 2048 * len(members)
+    assert offered[fake].predicted_dloss == pytest.approx(7e-4 * len(members))
+    assert stats_ext[super_name]["_memory_bytes_by_format"][fake] == \
+        2048 * len(members)
+    assert [c.fmt for c in cands_ext[super_name]] == ["NVFP4", "BF16", fake]
+
+
+def test_a_registry_free_format_only_some_members_offer_is_not_aggregated():
+    """The intersection is still the contract: no member may be unpriced."""
+
+    from prismaquant import format_registry as fr
+    from prismaquant.allocator_candidates import (
+        _PACKED_GROUP_MARKER,
+        aggregate_packed_serving_groups,
+    )
+
+    members = ["model.layers.0.mlp.experts.0.w1",
+               "model.layers.0.mlp.experts.1.w1"]
+    stats = {m: {"n_params": 4096, "h_trace": 0.3} for m in members}
+    costs = {m: {"BF16": {"weight_mse": 0.0, "predicted_dloss": 0.0}}
+             for m in members}
+    cands = {
+        members[0]: [
+            Candidate(fmt="BF16", bits_per_param=16.0,
+                      memory_bytes=8192, predicted_dloss=0.0),
+            Candidate(fmt="TCQ_E4M3_R1024", bits_per_param=4.0,
+                      memory_bytes=2048, predicted_dloss=7e-4),
+        ],
+        members[1]: [
+            Candidate(fmt="BF16", bits_per_param=16.0,
+                      memory_bytes=8192, predicted_dloss=0.0),
+        ],
+    }
+    specs = [fr.REGISTRY["BF16"]]
+    _stats_ext, _costs_ext, cands_ext = aggregate_packed_serving_groups(
+        stats, costs, specs, cands, _PackedProfile())
+    super_name = next(n for n in cands_ext if _PACKED_GROUP_MARKER in n)
+    assert [c.fmt for c in cands_ext[super_name]] == ["BF16"]
+
+
+# ---------------------------------------------------------------------------
+# Link 5: promotion can rank a selected rung
+# ---------------------------------------------------------------------------
+def test_promotion_ranks_a_trellis_rung_by_its_exact_serialized_rate():
+    """Link 5 lives or dies on format_rank covering the MENU."""
+
+    from prismaquant.allocator import _extend_format_rank_with_candidate_menu
+
+    stats = {UNIT_A: {"n_params": 1024 * 512},
+             UNIT_B: {"n_params": 256 * 512}}
+    # 4.0 bits/param exactly: below NVFP4 (4.5) and BF16 (16.0).
+    cands = {
+        unit: [
+            Candidate(fmt="NVFP4", bits_per_param=4.5,
+                      memory_bytes=int(stats[unit]["n_params"] * 4.5 / 8),
+                      predicted_dloss=1e-3),
+            Candidate(fmt="BF16", bits_per_param=16.0,
+                      memory_bytes=stats[unit]["n_params"] * 2,
+                      predicted_dloss=0.0),
+            Candidate(fmt="TCQ_E4M3_R1024", bits_per_param=4.0,
+                      memory_bytes=int(stats[unit]["n_params"] * 4.0 / 8),
+                      predicted_dloss=2e-3),
+        ]
+        for unit in (UNIT_A, UNIT_B)
+    }
+    rank, rates = _extend_format_rank_with_candidate_menu(
+        {"NVFP4": 0, "BF16": 1}, {"NVFP4": 4.5, "BF16": 16.0}, stats, cands)
+    assert rates["TCQ_E4M3_R1024"] == pytest.approx(4.0)
+    # Ranked BELOW NVFP4 because it really is fewer bytes on this model.
+    assert rank["TCQ_E4M3_R1024"] < rank["NVFP4"] < rank["BF16"]
+
+    # ...and promotion now runs instead of raising KeyError, lifting the
+    # cheaper sibling onto the unit's max-rank format.
+    out = promote_serving_units(
+        {UNIT_A: "TCQ_E4M3_R1024", UNIT_B: "NVFP4"},
+        rank,
+        profile=_QKVProfile(),
+        include_moe=False,
+    )
+    assert out == {UNIT_A: "NVFP4", UNIT_B: "NVFP4"}
+
+
+def test_an_all_registry_menu_leaves_the_rank_table_untouched():
+    """Principle 6: the extension is a no-op when nothing needs it."""
+
+    from prismaquant.allocator import _extend_format_rank_with_candidate_menu
+
+    stats = {UNIT_A: {"n_params": 4096}}
+    cands = {UNIT_A: [Candidate(fmt="NVFP4", bits_per_param=4.5,
+                                memory_bytes=2304, predicted_dloss=1e-3)]}
+    original = {"NVFP4": 0, "BF16": 1}
+    rank, rates = _extend_format_rank_with_candidate_menu(
+        original, {"NVFP4": 4.5, "BF16": 16.0}, stats, cands)
+    assert rank == original
+    assert rates == {"NVFP4": 4.5, "BF16": 16.0}
+
+
+def test_promotion_names_the_rank_table_when_a_format_is_unranked():
+    """A bare KeyError reads as a corrupt assignment; it is a rank-table bug."""
+
+    with pytest.raises(KeyError, match="CANDIDATE MENU"):
+        promote_serving_units(
+            {UNIT_A: "TCQ_E4M3_R1024", UNIT_B: "NVFP4"},
+            {"NVFP4": 0, "BF16": 1},
+            profile=_QKVProfile(),
+            include_moe=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Links 2 and 7: the assignment travels, and export refuses it
+# ---------------------------------------------------------------------------
+def test_layer_config_round_trips_a_trellis_assignment():
+    """Link 2's tail: the exporter's pointed refusal must be REACHABLE.
+
+    A generic "unsupported format string" in ``canonicalize_format`` would
+    turn a research assignment into a parse error and hide the one message
+    that explains why there is no export path.
+    """
+
+    from prismaquant.layer_config import (
+        LAYER_CONFIG_META_KEY,
+        canonicalize_assignment,
+        canonicalize_format,
+    )
+    from prismaquant.schemas import validate_layer_config_payload
+
+    payload = {
+        UNIT_A: "TCQ_E4M3_R1024",
+        UNIT_B: {"data_type": "nv_fp", "bits": 4},
+        LAYER_CONFIG_META_KEY: {
+            "schema": "prismaquant.layer_config_meta.v1",
+            "trellis_surface": {"manifest_sha256": "0" * 64},
+        },
+    }
+    validate_layer_config_payload(payload, "<test>")
+    assert canonicalize_format("TCQ_E4M3_R1024") == "TCQ_E4M3_R1024"
+    assert canonicalize_format("tcq_e4m3_r1024") == "TCQ_E4M3_R1024"
+    assert canonicalize_assignment(payload) == {
+        UNIT_A: "TCQ_E4M3_R1024", UNIT_B: "NVFP4",
+    }
+
+
+def test_an_unparseable_tcq_spelling_is_still_refused():
+    from prismaquant.layer_config import canonicalize_format
+
+    with pytest.raises(ValueError, match="unsupported format string"):
+        canonicalize_format("TCQ_E9M9_R1024")
 
 
 def test_export_refuses_a_trellis_assignment():
-    """Allocation-time reach only: there is no render and no attestation."""
+    """Allocation-time reach only: there is no render and no attestation.
+
+    Behaviour, not a grep: the previous version of this test asserted two
+    string literals appeared in the exporter's source, which would pass even
+    if the branch were unreachable.
+    """
 
     from prismaquant import export_native_compressed as ex
 
-    text = pathlib.Path(ex.__file__).read_text()
-    assert "parse_trellis_format_name(fmt_canonical) is not None" in text
-    assert "ProductionWeightCache renders no trellis wire" in text
+    with pytest.raises(ValueError) as exc:
+        ex._coerce_runtime_legal_assignment(
+            "/nonexistent-source-model",
+            {UNIT_A: "TCQ_E4M3_R1024"},
+            None,
+        )
+    message = str(exc.value)
+    assert "renders no trellis wire" in message
+    assert "activation-contract" in message
+
+
+def test_the_provenance_carries_the_manifest_identity_and_the_run_currency(
+        tmp_path):
+    """Link 7: what must travel WITH the assignment (principles 12 and 14)."""
+
+    units = {UNIT_A: (1024, 512)}
+    menu = scalar_menu(units)
+    prov: dict = {}
+    path = write_manifest(tmp_path, units)
+    tm.build_trellis_menu(
+        menu, stats_for(units), cost_mode=COST_MODE,
+        manifest_path=path, provenance_out=prov,
+    )
+    assert len(prov["manifest_sha256"]) == 64
+    assert prov["manifest_sha256"] == tm.load_manifest(path).sha256
+    assert prov["currency"] == CURRENCY
+    assert prov["run_objective_currency"] == CURRENCY
+    assert prov["anchor_activation_contract"] == "W8A16"
+    assert prov["research_only"] is True
+    assert prov["exportable"] is False
+    # Rewriting the manifest changes the identity, which is the point of
+    # hashing bytes rather than recording a path.
+    payload = manifest_payload(units)
+    payload["rungs_per_unit"] = 5
+    (tmp_path / "surface.json").write_text(json.dumps(payload))
+    assert tm.load_manifest(path).sha256 != prov["manifest_sha256"]
+
+
+def test_the_production_seam_installs_the_menu_when_the_flag_is_set(
+        tmp_path, monkeypatch):
+    """The seam itself, through ``build_candidates`` -- behaviour, not source.
+
+    An earlier test asserted the string ``trellis_menu.augment_candidates``
+    appeared in ``build_candidates``'s source. That passes whether or not the
+    call does anything, and it did pass while the enabled path could not
+    produce an assignment at all.
+    """
+
+    from prismaquant import format_registry as fr
+    from prismaquant.allocator_candidates import build_candidates
+
+    units = {UNIT_A: (1024, 512)}
+    monkeypatch.setenv(
+        tm.TRELLIS_SURFACE_ENV, write_manifest(tmp_path, units))
+    stats = stats_for(units)
+    prov: dict = {}
+    out = build_candidates(
+        stats, costs_for(units),
+        [fr.REGISTRY["NVFP4"], fr.REGISTRY["BF16"]],
+        cost_mode=COST_MODE,
+        trellis_provenance=prov,
+    )
+    rungs = [c for c in out[UNIT_A] if c.fmt.startswith("TCQ_")]
+    assert rungs, "the seam did not install the menu"
+    assert prov["candidates_added"] == len(rungs)
+    assert stats[UNIT_A]["_memory_bytes_by_format"][rungs[0].fmt] == \
+        int(rungs[0].memory_bytes)


### PR DESCRIPTION
## What lands

`prismaquant/trellis_menu.py` shipped with `UNWIRED_LINKS`, an eight-entry ledger
that was both the refusal message and the re-enable checklist: with
`PRISMAQUANT_TRELLIS_SURFACE` set, the seam refused outright. This branch wires
**seven of those eight links**, each with a test that exercises the behaviour
rather than the source text, so an enabled seam builds the menu. **The eighth
entry stays, and stays refusing** — details below.

The seam's reach is unchanged in one respect that matters: it does not render,
export, or serve. `ProductionWeightCache` has no trellis mechanism and
`export_native_compressed` refuses a TCQ assignment. A selected rung is an
exactly priced report of what the DP would choose, not a shippable artifact.
The exact-bytes map is process-local — nothing rewrites `probe.pkl` — so a TCQ
assignment escaping into a later stage fails at the registry lookup. That is the
next wiring frontier, and `docs/ARCHITECTURE.md` §4.9 says so.

## The seven links that are wired

**Links 3 and 4, the silent ones, on the default path.**
`aggregate_fused_siblings` and `aggregate_packed_serving_groups`
(`prismaquant/allocator_candidates.py`) built each super-item menu by iterating
`FormatSpec` objects, so any candidate whose format has no registry spec was
dropped from every fused and packed group with no error. Both now build the menu
from the members' candidate lists through `_super_menu_format_names`: the run's
spec names first, in order, then any registry-free format every member offers,
sorted. A registry-free rung is priced as the exact sum of the member
candidates' bytes and `predicted_dloss` — the packed path's existing
construction — with an aggregated stderr of 0.0, because the solver `Candidate`
carries no stderr and fabricating one would be a claim.

**Link 5.** `allocator._extend_format_rank_with_candidate_menu` extends
`format_rank` from the candidate menu by each registry-free format's exact
aggregate serialized rate, `8*sum(bytes)/sum(params)` — the same quantity
`_serialized_format_rates` computes for a spec — so "higher rank" keeps meaning
"more bytes on this model". Existing names keep their relative order, and an
all-registry menu returns the input table key for key.
`promote_serving_units` now names the rank table on a miss instead of raising a
bare `KeyError` that reads as a corrupt assignment.

**Links 1, 2 and 6: no TCQ `FormatSpec` is registered, deliberately.**
`FormatSpec.memory_bytes_for_shape` is a closed form over
`weight_bits` / `scale_bits` / `group_size`, while a rung's exact size needs the
layout, the per-column schedule and the alphabet directory the manifest declares
(`trellis_footprint.trellis_tensor_payload_breakdown`). `(name, shape)` does not
determine the bytes, so a registered spec could only be plausible and wrong —
silently consumed by `_serialized_format_rates`, `footprint` and the payload
filter — and it would expose TCQ to every `act_quant_changes_input` /
`quantize_dequantize` consumer with no render behind it. Instead the seam writes
the exact bytes into `_memory_bytes_by_format`, the repo's existing single
mechanism (principle 8), which the payload filter, `footprint`,
`compute_achieved` and bit attribution already prefer. The payload filter
(`prismaquant/allocator.py`) and `footprint.py` refuse pointedly when the map is
absent instead of falling through to `fr.get_format`.
`layer_config.canonicalize_format` round-trips `TCQ_<grid>_R<q256>` so the
exporter's pointed refusal is reachable. The cost is N pointed refusals instead
of one registry entry, and each one refuses where a closed form would have
guessed.

**Link 7.** The run's cost mode is the **attested** one from the cost table's
provenance (re-vet R2), never `os.environ` — `run-pipeline.sh` assigns
`COST_MODE` with `:=` and never exports it. The surface provenance (manifest
SHA-256, declared currency, the run's objective currency, anchor activation
contract) travels into `layer_config.json`'s `__prismaquant__` block under
`trellis_surface`, present only when the seam contributed (principles 12, 14
and 6).

The pinned menus — `lm_head`, MTP, visual — pass `apply_trellis_surface=False`:
their single format is an operator declaration, not a DP choice.

## The eighth link is not wired, and it is not a wiring gap

`UNWIRED_LINKS` keeps exactly one entry, `trellis_rate_surface.py:43-52`
(`prismaquant/trellis_menu.py:170`).

The ladder's measured anchors are **weighted SSE under a per-input-channel
activation second moment** — an output-MSE proxy. The production DP ranks
`predicted_dloss` in the **AURA KL-adjoint**. A DP that ranks a weighted-SSE
trellis rung against an AURA-priced NVFP4 rung is not solving any stated
objective, and no amount of plumbing changes what the anchors measured.
Producing AURA-priced anchors is a dW-supply problem: `aura_cost`'s two dW
sources, `ProductionWeightCache` and `fr.get_format(...).quantize_dequantize`,
both require a registered format. That work is owned elsewhere, and the size of
the gap is under measurement on a second box as this PR opens. Nothing here
should be relaxed on the strength of an expectation about that result.

`_require_run_currency` (`prismaquant/trellis_menu.py:312`) is the enforcement.
It compares the manifest's declared currency against
`COST_MODE_OBJECTIVE_CURRENCY[cost_mode]` — the same `COST_RENDER x
COST_OBJECTIVE` decomposition `run-pipeline.sh` resolves — so the expected value
is definitional rather than chosen (principle 2). Two adjacent refusals come
with it: an unstamped cost table is refused rather than compared against a
default, and a cost mode that names no objective is refused rather than
defaulted. An enabled seam on an `aura` run therefore refuses on the currency,
which is the honest failure, instead of refusing on missing links, which was the
placeholder.

## Default-path safety (principle 6)

Both aggregators are default-path code: every production allocation runs both.
`tests/test_super_item_menu_byte_identity.py` and its golden fixture were
generated and committed against the **unmodified** aggregators in the first
commit of this branch, then re-run after the change. The digest is unchanged:
`033adb45e71a51b831f5335047fa56e5fb00dc3137894a983fa0146bf456197d`.

The golden pins every super item's whole menu in order — `fmt`,
`bits_per_param`, `memory_bytes`, `predicted_dloss`, both serialized identities,
`activation_pricing` and `serving_lane`, floats by `repr` so the comparison is
exact rather than tolerance-based — plus `_memory_bytes_by_format` and the whole
`costs_ext` row including `predicted_dloss_stderr`. Scenarios cover both
aggregators, `PRISMAQUANT_COST_UCB_Z` at zero and non-zero, calibrated gains,
activation fair pricing, and the role-split packed profile.

A golden that passes is not evidence until a deliberate change to the driver
makes it fail. `test_the_golden_is_load_bearing` reorders every super item's
menu at runtime — the same set of formats, a different DP order, the minimal
perturbation an order-blind record would miss — and asserts the digest moves
(`033adb45...` to `0d7b2edf...`) and returns when the mutation is undone.

## Documentation (principle 13)

`docs/ARCHITECTURE.md` §4.9 is rewritten in the same commit as the code, and the
provenance block is re-stamped at the head of the file. The second commit
corrects two claims in that stamp that were loose in the direction the section
exists to prevent:

- `kl_measurement` does **not** read `_memory_bytes_by_format` for a TCQ row.
  Its byte helper takes a resolved `FormatSpec`, so the `specs_by_name` lookup
  raises first. `compute_achieved` and bit attribution prefer the map but do not
  refuse pointedly; only the payload filter and `footprint` do.
- The map is process-local, so the seam's reach is allocation-time only.

The merge commit changes nothing normative: the default path is byte-identical
by the golden, and the seam is env-gated and off unless
`PRISMAQUANT_TRELLIS_SURFACE` names a manifest. No further doc edit is owed.

## Tests

- `tests/test_trellis_menu.py`: 31 tests, up from 15, all behaviour. Four
  earlier source-text assertions are gone — the `for spec in formats:` count,
  the exporter greps, the `build_candidates` signature check — replaced by tests
  that call the code.
- `tests/test_super_item_menu_byte_identity.py` and
  `tests/fixtures/super_item_menu_golden.json`: new, described above.
- Full suite on the merged branch, CPU-only
  (`PYTHONPATH=. CUDA_VISIBLE_DEVICES="" pytest tests/ -q --timeout=300`,
  Python 3.12): **5510 passed, 143 skipped, 3 xfailed, 179 subtests passed,
  0 failed** in 892 s. The skips are the CUDA-gated tests.

## Merge base

Merged, not rebased, so the P6 evidence in `d08f3d9`'s message stays attached to
the commit arrangement it cites. `origin/main` at `1ca4c7d` brings in PR #90 and
PR #91; both touch files this branch does not
(`tests/test_math_reunderwrite_pins.py`,
`prismaquant/dsv4_w8a16_export_handoff.py`), and the merge had no conflicts.

## How to verify

```bash
PYTHONPATH=. CUDA_VISIBLE_DEVICES="" pytest \
  tests/test_trellis_menu.py \
  tests/test_super_item_menu_byte_identity.py \
  tests/test_docs_staleness.py \
  tests/test_architecture_doc.py -q
```

`test_the_only_remaining_unwired_link_is_the_currency` and
`test_the_ladders_own_currency_is_the_surviving_refusal` are the two that pin
the eighth link open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F46Tr8Az6t2Ky3sRExZ5y


## CI status: py3.12 green, py3.11 red, and the py3.11 failure is this PR's

Run [33285583387](https://github.com/RobTand/prismaquant/actions/runs/33285583387):
`import surface` passes, `pinned Gridbook contract` passes,
`tests (py3.12, cpu)` passes, `tests (py3.11, cpu)` **fails**.

The two py3.11 failures are the new byte-identity tests:

```
FAILED tests/test_super_item_menu_byte_identity.py::test_super_item_menus_are_byte_identical_to_the_golden
  - super-item menu changed in scenario 'packed_hedged_gained_priced'
FAILED tests/test_super_item_menu_byte_identity.py::test_the_golden_is_load_bearing
  - assert '43c261df...' == '033adb45...'
2 failed, 5499 passed, 154 skipped, 3 xfailed, 179 subtests passed
```

**What actually differs is 1 to 2 ULP of float64.** Reading the assertion diff,
every changed field is a `predicted_dloss` whose `repr` moved in the last digit:

| golden (recorded on 3.12) | py3.11 run | ULP | relative |
|---|---|---|---|
| `0.002071872` | `0.0020718720000000006` | 1 | 2.09e-16 |
| `0.002631341383012154` | `0.0026313413830121547` | 2 | 3.30e-16 |
| `0.21080600999999996` | `0.21080601000000002` | 2 | 2.63e-16 |

Those are float64 epsilon (2.22e-16). The structural-looking blocks in the
pytest diff are `pprint` key ordering between the JSON-loaded golden and the
freshly built payload, not missing or added entries: the menus, the members,
the byte counts and `n_params` are identical.

So the gate is doing exactly what it says — it compares floats by `repr`, which
is environment-exact, not tolerance-based — and the arithmetic associates
differently under the py3.11 job's resolved dependency set. That is a real
property of the gate that a reviewer should decide about. Three dispositions,
none of them taken here:

1. Leave it. `main` is separately narrowing the CI matrix to 3.12
   (the workflow header records "3.11 was not failing on an interpreter
   incompatibility — it was a proxy for test ORDER").
2. Serialize at float64's guaranteed round-trip decimal precision
   (`DBL_DIG` = 15 significant digits) instead of `repr`'s 17. That constant
   comes from the dtype, which is the one source principle 2 allows, but it
   requires regenerating the golden from the pre-change aggregators to keep the
   P6 evidence chain intact.
3. Record the golden per interpreter.

Regenerating the fixture against the current code to make the failure go away is
**not** on that list. A fixture edited until it passes stops being evidence
("mutate the driver, not the fixture").

For the pre-existing baseline: `main` at `1ca4c7d` — this PR's merge base — is
itself red on the same arm, with a different test:
[run 33284249771](https://github.com/RobTand/prismaquant/actions/runs/33284249771),
`tests (py3.11, cpu)` fails
`test_glm5_next_streamed_forward_parity.py::test_long_sequence_parity_per_layer_type[dsa_only]`
(`diverges by nan`) while `tests (py3.12, cpu)` passes. That failure does not
appear on this branch's py3.11 run, and this branch touches nothing in that
file.
