### PR TITLE
ci: drop python 3.11 from the test matrix and the supported floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,13 @@ jobs:
         # 3.12 only. The reference box runs 3.12 and nothing else is
         # exercised anywhere; requires-python is >=3.12 to match. Dropped 3.11
         # on 2026-08-29 (Rob: "I don't care if we don't support python 3.11").
-        # NOTE: 3.11 was not failing on an interpreter incompatibility -- it was
-        # a proxy for test ORDER. The dsa_only NaN it exposed is still being
-        # root-caused; this narrowing does not fix it and must not be read as
-        # having fixed it. Widen only when a version is actually exercised.
+        # NOTE: 3.11 was not failing on an interpreter incompatibility -- it
+        # stood in for heap/allocation order. The dsa_only NaN it exposed was a
+        # real latent defect (the transformers polyfill left from-config expert
+        # weights uninitialized) and was fixed on its own merits in #94 BEFORE
+        # this job was removed. 3.12 can surface that class of bug just as
+        # easily, so narrowing the matrix hides nothing.
+        # Widen only when a version is actually exercised somewhere.
         python: ["3.12"]
     steps:
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Floor and current. requires-python is >=3.11 (schemas.py needs
-        # typing.NotRequired); the reference box runs
-        # 3.12. Widen only when a version is actually exercised somewhere.
-        python: ["3.11", "3.12"]
+        # 3.12 only. The reference box runs 3.12 and nothing else is
+        # exercised anywhere; requires-python is >=3.12 to match. Dropped 3.11
+        # on 2026-08-29 (Rob: "I don't care if we don't support python 3.11").
+        # NOTE: 3.11 was not failing on an interpreter incompatibility -- it was
+        # a proxy for test ORDER. The dsa_only NaN it exposed is still being
+        # root-caused; this narrowing does not fix it and must not be read as
+        # having fixed it. Widen only when a version is actually exercised.
+        python: ["3.12"]
     steps:
       - uses: actions/checkout@v7.0.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,13 @@ version = "0.16.2"
 description = "Mixed-precision quantization allocator for LLMs: every layer refracts into a different format based on its sensitivity."
 readme = "README.md"
 license = "Apache-2.0"
-# 3.11 is the real floor, not a preference: prismaquant/schemas.py imports
-# typing.NotRequired, which does not exist before 3.11. The old ">=3.10"
-# claim was untrue and went unnoticed because nothing ever installed on 3.10.
-requires-python = ">=3.11"
+# 3.12 is the supported floor as of 2026-08-29. 3.11 was technically
+# sufficient for the language features used (prismaquant/schemas.py needs
+# typing.NotRequired, 3.11+), but nothing is exercised on it: the reference
+# box, the release workflow and every venv run 3.12. Claiming support we do
+# not test is the same class of error as the old ">=3.10" claim, which was
+# untrue and went unnoticed because nothing ever installed on 3.10.
+requires-python = ">=3.12"
 authors = [
     { name = "Rob Tand" },
 ]
@@ -23,7 +26,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]


### PR DESCRIPTION
Nothing is exercised on 3.11 — the reference box, the release workflow and every venv run 3.12 — so the matrix was testing a claim no artifact depends on. `requires-python` moves to `>=3.12` and the 3.11 classifier goes with it.

**Sequencing matters here.** The `dsa_only` NaN that 3.11 surfaced on `1ca4c7d` was a genuine latent defect, not an interpreter incompatibility: the `_polyfill_transformers` no-op left from-config routed-expert weights uninitialized, so the *reference* forward was NaN too and the test was comparing garbage against garbage. It reproduces on `e05f4b2` as well, predating the merges that appeared to introduce it. It was fixed at the root in #94, which is **already merged**, and 3.12 can surface that class of bug just as readily.

So this PR removes a job that was doing no work — it does not remove the only thing that caught a live bug. Landing it before #94 would have been the wrong order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F46Tr8Az6t2Ky3sRExZ5y