### PR TITLE
fix(tests): glm5_next parity NaN — the polyfill leaves from-config expert weights uninitialized

### DIFF
--- a/prismaquant/__init__.py
+++ b/prismaquant/__init__.py
@@ -12,6 +12,8 @@ Current production path:
 Older cross-layer allocators are archived under archive/cross_layer_2026-05-09
 for artifact replay and comparison.
 """
+import contextlib as _contextlib
+
 from .format_registry import FormatSpec, REGISTRY, register_format
 
 # Resolved from installed metadata rather than duplicated here, so
@@ -100,9 +102,21 @@ def _polyfill_transformers() -> None:
         # rotary modules to expose `compute_default_rope_parameters`,
         # which older remote modeling files (MiniMax M2/M2.7) don't
         # provide. No-op it globally at import time.
+        #
+        # The no-op is only sound for callers that overwrite every
+        # parameter afterwards. A caller that *uses* a from-config model
+        # -- a test fixture, an eval harness building a random reference --
+        # gets whatever the allocator last left in the pages backing the
+        # parameters a modeling file allocates with a bare `torch.empty()`
+        # (transformers' own `nn.Linear`/`nn.Embedding` still self-init in
+        # their constructors; the raw `nn.Parameter(torch.empty(...))` ones
+        # do not). Keep the real method reachable so such a caller can
+        # restore it -- see `genuine_weight_initialization` below.
         import transformers.modeling_utils as _mu
         if hasattr(_mu, "PreTrainedModel") and \
                 not getattr(_mu.PreTrainedModel, "_prismaquant_init_noop", False):
+            _mu.PreTrainedModel._prismaquant_real_initialize_weights = (
+                _mu.PreTrainedModel._initialize_weights)
             _mu.PreTrainedModel._initialize_weights = (
                 lambda self, *a, **kw: None)
             _mu.PreTrainedModel._prismaquant_init_noop = True
@@ -161,6 +175,45 @@ def _polyfill_transformers() -> None:
         _register_qwen3()
     except Exception:
         pass
+
+
+@_contextlib.contextmanager
+def genuine_weight_initialization():
+    """Build a model the way transformers would, inside a PrismaQuant process.
+
+    `_polyfill_transformers` no-ops `PreTrainedModel._initialize_weights`
+    for the whole process at import time, because every PrismaQuant load
+    path builds a `from_config` skeleton and then overwrites every
+    parameter from the checkpoint. That makes `from_config` construction
+    silently return **uninitialized** parameters for any tensor the
+    modeling file allocates as a bare `nn.Parameter(torch.empty(...))` --
+    routed-expert weights and hyper-connection tensors are the common
+    cases -- and heap contents are neither reproducible nor guaranteed
+    finite, so a forward on such a model can be fine on one run and `nan`
+    on the next.
+
+    Wrap a from-config construction in this context manager when the model
+    it returns is used as-is:
+
+        with genuine_weight_initialization():
+            model = SomeForCausalLM(config)
+
+    A no-op when the polyfill never applied (older transformers, or an
+    import that raised), so callers need not test for it.
+    """
+    import transformers.modeling_utils as _mu
+
+    real = getattr(
+        _mu.PreTrainedModel, "_prismaquant_real_initialize_weights", None)
+    if real is None:
+        yield
+        return
+    patched = _mu.PreTrainedModel._initialize_weights
+    _mu.PreTrainedModel._initialize_weights = real
+    try:
+        yield
+    finally:
+        _mu.PreTrainedModel._initialize_weights = patched
 
 
 _ensure_triton_cache_writable()

--- a/tests/test_genuine_weight_initialization.py
+++ b/tests/test_genuine_weight_initialization.py
@@ -1,0 +1,103 @@
+"""`prismaquant` no-ops weight init process-wide; this is the documented undo.
+
+`prismaquant/__init__.py::_polyfill_transformers` replaces
+`PreTrainedModel._initialize_weights` with a no-op at import time. That is
+sound for PrismaQuant's own loaders, which build a `from_config` skeleton and
+then overwrite every parameter from the checkpoint. It is unsound for any
+caller that *uses* a from-config model: every tensor a modeling file allocates
+as a bare `nn.Parameter(torch.empty(...))` then keeps whatever the allocator
+last left in that page -- not reproducible, and not guaranteed finite.
+
+That is not hypothetical. It reached CI as a NaN in
+`test_glm5_next_streamed_forward_parity.py::test_long_sequence_parity_per_layer_type[dsa_only]`
+(run 33284249771: py3.11 failed, py3.12 passed, same commit and same torch and
+transformers), where the uninitialized tensors were the routed-expert
+`mlp.experts.gate_up_proj` / `down_proj`.
+
+So the polyfill must keep the real method reachable, and the undo must be
+exception-safe -- leaking the real `_initialize_weights` back into the process
+would silently re-cost every subsequent PrismaQuant model load.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("transformers")
+
+from transformers.modeling_utils import PreTrainedModel  # noqa: E402
+
+from prismaquant import genuine_weight_initialization  # noqa: E402
+
+
+def _polyfilled() -> bool:
+    return bool(getattr(PreTrainedModel, "_prismaquant_init_noop", False))
+
+
+def test_the_polyfill_keeps_the_real_initializer_reachable():
+    if not _polyfilled():
+        pytest.skip("the transformers polyfill did not apply in this build")
+    assert getattr(
+        PreTrainedModel, "_prismaquant_real_initialize_weights", None
+    ) is not None, (
+        "the polyfill overwrote _initialize_weights without keeping the real "
+        "method, so nothing in the process can build an initialized "
+        "from-config model any more"
+    )
+
+
+def test_the_context_manager_swaps_the_method_and_puts_it_back():
+    if not _polyfilled():
+        pytest.skip("the transformers polyfill did not apply in this build")
+    real = PreTrainedModel._prismaquant_real_initialize_weights
+    noop = PreTrainedModel._initialize_weights
+    assert noop is not real
+
+    with genuine_weight_initialization():
+        assert PreTrainedModel._initialize_weights is real
+    assert PreTrainedModel._initialize_weights is noop
+
+
+def test_the_context_manager_restores_on_an_exception():
+    if not _polyfilled():
+        pytest.skip("the transformers polyfill did not apply in this build")
+    noop = PreTrainedModel._initialize_weights
+    with pytest.raises(RuntimeError, match="construction failed"):
+        with genuine_weight_initialization():
+            raise RuntimeError("construction failed")
+    assert PreTrainedModel._initialize_weights is noop
+
+
+def test_weight_init_actually_runs_inside_the_context_manager():
+    """The contract is behavioural: `_init_weights` must be reached."""
+    from transformers import PretrainedConfig
+
+    class _Config(PretrainedConfig):
+        model_type = "prismaquant_init_probe"
+
+    class _Model(PreTrainedModel):
+        config_class = _Config
+        base_model_prefix = "probe"
+
+        def __init__(self, config):
+            super().__init__(config)
+            self.linear = torch.nn.Linear(2, 2)
+            self.initialized = []
+            self.post_init()
+
+        def _init_weights(self, module):
+            self.initialized.append(type(module).__name__)
+
+    outside = _Model(_Config())
+    with genuine_weight_initialization():
+        inside = _Model(_Config())
+
+    assert inside.initialized, (
+        "`_init_weights` never ran inside genuine_weight_initialization(); "
+        "the from-config model would carry uninitialized parameters"
+    )
+    if _polyfilled():
+        assert not outside.initialized, (
+            "`_init_weights` ran outside the context manager -- the polyfill "
+            "under test is not actually in effect, so this test proves nothing"
+        )

--- a/tests/test_glm5_next_streamed_forward_parity.py
+++ b/tests/test_glm5_next_streamed_forward_parity.py
@@ -37,6 +37,7 @@ glm5 = pytest.importorskip(
     reason="glm5_next requires transformers >= 5.16",
 )
 
+from prismaquant import genuine_weight_initialization  # noqa: E402
 from prismaquant.cost_streaming import StreamedCausalLM  # noqa: E402
 from prismaquant.model_profiles.glm5_next import Glm5NextProfile  # noqa: E402
 
@@ -107,20 +108,59 @@ def _tiny_config():
     )
 
 
-def _build_tiny_model():
-    torch.manual_seed(20260826)
-    config = _tiny_config()
-    model = glm5.Glm5NextForConditionalGeneration(config)
+def _build_model(config):
+    """Construct the reference model with every parameter initialized.
+
+    `genuine_weight_initialization` is load-bearing, not decoration.
+    Importing anything from `prismaquant` no-ops
+    `PreTrainedModel._initialize_weights` process-wide
+    (`prismaquant/__init__.py::_polyfill_transformers`), which is sound for
+    PrismaQuant's own loaders -- they overwrite every parameter from a
+    checkpoint straight afterwards -- and unsound here, where the
+    from-config model IS the subject.  Without the restore, every tensor
+    the modeling file allocates as a bare `nn.Parameter(torch.empty(...))`
+    keeps whatever the allocator last left in that page: on this config the
+    routed-expert `mlp.experts.gate_up_proj` / `down_proj`, measured at
+    ~2e17 on one run and non-finite on another.  Those weights feed BOTH
+    sides of the parity comparison, so a bad page NaNs the reference and
+    the streamed pass alike and the divergence reads `nan` at every context
+    octave -- which is how it reached CI (run 33284249771, py3.11 failed
+    and py3.12 passed on the same commit, same torch and transformers).
+
+    A parity assertion cannot see that: `nan != nan` on both sides looks
+    exactly like a wiring defect.  So the finiteness check below fails
+    closed and names the mechanism instead.
+    """
+    with genuine_weight_initialization():
+        model = glm5.Glm5NextForConditionalGeneration(config)
     model = model.to(torch.float32).eval()
     for parameter in model.parameters():
         parameter.requires_grad_(False)
-    # `from_config` leaves several mHC / KDA parameters at whatever
-    # `_init_weights` produced; a degenerate (all-zero or all-equal) tensor
-    # would make a wrong wiring agree with a right one by accident.
+    # `_init_weights` leaves several mHC / KDA parameters at a constant;
+    # a degenerate (all-zero or all-equal) tensor would make a wrong wiring
+    # agree with a right one by accident.
     for name, parameter in model.named_parameters():
         if name.endswith((".fn", ".base", ".scale", ".dt_bias", ".A_log")):
             parameter.copy_(torch.randn_like(parameter) * 0.05)
+    unset = [
+        name
+        for name, tensor in (
+            list(model.named_parameters()) + list(model.named_buffers())
+        )
+        if tensor is not None and not torch.isfinite(tensor).all()
+    ]
+    assert not unset, (
+        "the reference model was built with non-finite tensors, so both "
+        "sides of the parity comparison are garbage and the divergence "
+        "below would read `nan` rather than localize a wiring defect; "
+        f"offending tensors: {unset[:8]}"
+    )
     return model
+
+
+def _build_tiny_model():
+    torch.manual_seed(20260826)
+    return _build_model(_tiny_config())
 
 
 def _streamed_runner(model):
@@ -350,13 +390,7 @@ def test_long_sequence_parity_per_layer_type(layer_types, mlp_layer_types):
     config.text_config.layer_types = list(layer_types)
     config.text_config.mlp_layer_types = list(mlp_layer_types)
     config.text_config.indexer_types = ["full", "full"]
-    model = glm5.Glm5NextForConditionalGeneration(config)
-    model = model.to(torch.float32).eval()
-    for parameter in model.parameters():
-        parameter.requires_grad_(False)
-    for name, parameter in model.named_parameters():
-        if name.endswith((".fn", ".base", ".scale", ".dt_bias", ".A_log")):
-            parameter.copy_(torch.randn_like(parameter) * 0.05)
+    model = _build_model(config)
 
     streamed, reference, profile = _long_parity(model)
     worst = max(block["max_abs_divergence"] for block in profile)


### PR DESCRIPTION
## Verdict

**Not a sparse-attention defect.** The `dsa_only` NaN in run 33284249771 is an
**import-order / polyfill artifact that only affects tests** (category (c)),
manifesting through a gap in the test's own weight-repair list (a (b) component).
Nothing on a serving path changes; the streamed forward is exonerated by
measurement, not by argument.

## Where the NaN is born

`prismaquant/__init__.py::_polyfill_transformers` replaces
`transformers.modeling_utils.PreTrainedModel._initialize_weights` with a global
no-op (before this PR, `prismaquant/__init__.py:106-107`). That is sound for every
PrismaQuant load path — they build a `from_config` skeleton and immediately
overwrite every parameter from the checkpoint — but it is *not* sound for a caller
that then **uses** the from-config model.

`nn.Linear` / `nn.Embedding` initialize themselves in their constructors, so most
of the model is fine. The tensors a modeling file allocates as a bare
`nn.Parameter(torch.empty(...))` are not: their only initializer is
`_init_weights`, which the no-op prevents from running. In GLM-5.3-Flash those are
the routed-expert weights —
`transformers/models/glm5_next/modeling_glm5_next.py:1394`
(`init.normal_(module.gate_up_proj, ...)`) — so
`model.language_model.layers.N.mlp.experts.gate_up_proj` and `.down_proj` ship
whatever the allocator last left in those pages.

Measured, tiny config, `dsa_only`:

| build | non-finite / huge params |
|---|---|
| without `import prismaquant` | 0 |
| with `import prismaquant` (`init_noop: True`) | 8-10 params at ~1.8e17-2.0e17, incl. `layers.1.mlp.experts.gate_up_proj` (1.99e17) and `.down_proj` (1.80e17); some runs non-finite outright |

`tests/test_glm5_next_streamed_forward_parity.py` already knew the model came out
under-initialized: it re-randomized parameters matching a hand-listed suffix set
`(".fn", ".base", ".scale", ".dt_bias", ".A_log")`. That list does not contain the
expert tensors. Under
`torch.utils.deterministic.fill_uninitialized_memory = True` the miss is exact and
reproducible: 14 uninitialized tensors (dsa/dsa), 18 (kda/kda), 16 (mixed), of
which exactly **2 per variant** fall outside the repair list — always the two
routed-expert tensors.

## Why this is not a wiring bug (ruling out (a))

The 2x2 of `fill_uninitialized_memory` x suffix-repair:

| fill | repair | reference forward | streamed forward | worst divergence | result |
|---|---|---|---|---|---|
| True | False | **NaN** | NaN | `nan` | FAIL |
| True | True | finite | finite | `0.000e+00` | PASS |
| False | * | finite | finite | small | PASS |

`ref_nan=True` is the exoneration: the *reference* upstream forward NaNs too, so
the assertion at `:363` was comparing garbage to garbage. `nan != nan` on both
sides is indistinguishable from a wiring defect, which is exactly how it read.
Corroborating: the CI divergence table reads `nan` at **every** context octave
including `1-1` — no long-range or sparse-index defect can NaN position 1.

## Why it looked like a regression (it is not)

- Both CI jobs installed identical `torch 2.13.0+cpu` and `transformers 5.16.1`;
  the only library difference between the green py3.12 job and the red py3.11 job
  is numpy (2.4.6 vs 2.5.2). No library-version explanation survives.
- The two commits merged between `e05f4b2` and `1ca4c7d` are **exonerated**:
  `c198593` (a tolerance derivation in a test file) and `3921f2b` (re-stamped
  SHA256 constants) can only perturb the heap, which is the whole mechanism.
  They are also why the visible failure count *changed*: on `e05f4b2` both
  interpreters failed the same 3 tests, and those two commits fixed exactly those
  3 — leaving the pre-existing latent flake as the only line left standing.
- Reproduced identically on `e05f4b2`: same 5 failed / 3 passed, same 5 test ids.
  This is latent, not new.

## Reproduction

py3.11, `torch 2.13.0+cpu`, `transformers 5.16.1`, `PYTHONPATH=.`,
`CUDA_VISIBLE_DEVICES=""`. `scratch/pytest_fill.py` is a 3-line wrapper that sets
`torch.utils.deterministic.fill_uninitialized_memory = True` and delegates to
`pytest.main(sys.argv[1:])` — the deterministic stand-in for whatever the py3.11
CI heap happened to contain.

```
# FAILS on 1ca4c7d and on e05f4b2 -> 5 failed, 3 passed
python scratch/pytest_fill.py tests/test_glm5_next_streamed_forward_parity.py -q -p no:cacheprovider

# PASSES on the same commits -> 8 passed
python -m pytest tests/test_glm5_next_streamed_forward_parity.py -q -p no:cacheprovider
```

That divergence **is** the flake. On this branch both commands give `8 passed`.

## The fix

Two halves, no tolerance touched (`worst < 1e-3` is unchanged — NaN is not a
tolerance problem):

1. `prismaquant/__init__.py` — the polyfill now **preserves** the real method as
   `PreTrainedModel._prismaquant_real_initialize_weights` before installing the
   no-op, and exports a `genuine_weight_initialization()` context manager that
   restores it for the duration of a construction. The no-op itself is unchanged,
   so no PrismaQuant load path changes behaviour. (Restoring the real
   `_initialize_weights` and letting `post_init()` drive it is the only correct
   form: calling `_init_weights` manually binds the wrong config and raises
   `AttributeError: 'Glm5NextConfig' object has no attribute 'initializer_range'`.)
2. `tests/test_glm5_next_streamed_forward_parity.py` — the model build, previously
   duplicated in two places, is now one helper that builds inside the context
   manager and ends with a **fail-closed guard**: any non-finite parameter or
   buffer aborts with a message saying both sides of the comparison are garbage,
   rather than letting it surface as `nan` divergence. The suffix re-randomization
   is kept (it perturbs constants `_init_weights` deliberately sets, so a wrong
   wiring cannot agree with a right one by accident) but is no longer load-bearing
   for finiteness.

`tests/test_genuine_weight_initialization.py` (new) covers preservation, swap,
restore-on-exception, and the behavioural check that `_init_weights` actually runs
inside the CM and does not outside it. Mutation-checked: deleting the two
preservation lines from `prismaquant/__init__.py` fails 3 of the 4 new tests.

## Out of scope

On this aarch64 box a 14-file model-building subset shows 7 failures **with and
without** the amplifier, present on `e05f4b2` too, and the two spot-checked files
pass when run alone. That is the pre-existing order-dependent set already recorded
as `suite_has_order_dependent_failures`; unrelated to this NaN, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F46Tr8Az6t2Ky3sRExZ5y
