### PR TITLE
feat(model-walk): the discovery walker as a fail-closed export gate

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,38 @@
 # PrismaQuant Architecture
 
-As of: 2026-08-29 · `docs/architecture-currency-20260829` — stamps follow, newest
+As of: 2026-08-29 · `rescue/walker-export-gate` — stamps follow, newest
 first, each recording its own branch and date. Re-stamped (2026-08-29,
+`rescue/walker-export-gate`) for
+**the discovery walker as a fail-closed export gate** (§8.8,
+`prismaquant/model_walk.py`): the R5 design contract's remaining open half —
+wiring the walk as an export gate — is closed; the probe/cost/footprint/
+read-traffic migration onto its edge list stays a separate workstream.
+`run-pipeline.sh` stage **[3d]** (`python3 -m prismaquant.model_walk`) runs
+before EVERY export lane (GGUF, CB, compressed-tensors) and refuses (`exit 2`)
+on an unclaimed matmul-fed node, an unresolved floating multiplicand, an
+unknown walk-failure kind, or a decided-but-unpriced contradiction, deciding
+from STRUCTURED fields only (`artifacts/model_walk.json`, gate schema
+`prismaquant.model_walk_gate.v1`). The explicit override
+(`PRISMAQUANT_WALK_GATE_OVERRIDE=<reason>`) excuses trace incompleteness ONLY
+(DSv4's data-dependent scalar aborts the fake trace) and is stamped; claim
+failures have no override — they are fixed by pinning with reasons in
+`ModelProfile.walk_claim_rules()`. Same commit: the walk became a cacheable
+artifact (`SCHEMA prismaquant.model_walk.v1`; envelope `{schema, provenance,
+result}`, atomic write, fail-closed reload on foreign schema / execution
+mismatch / claim-rule digest mismatch), carrying trace-time provenance
+(model+config identity, versions, input contract) and the serialized applied
+rule list; byte semantics are pinned as LOGICAL-TOTAL with the
+`per_device_bytes(total, tp_degree, policy)` seam for Tensor-Parallel
+(decision unit: whole logical tensor; dispositions are TP-invariant; the
+future group/shard misalignment refusal lands as an unknown-until-implemented
+walk-failure kind that already refuses). The R5 profile sweep's findings land
+here too: universal base rules now pin MoE router gates and decide packed
+expert stacks (six/seven profiles were unclaimed; gemma4's router was
+decided-but-never-priced — wrong polarity inside the claim table itself, now
+pinned like every other router), and the gate surfaces that contradiction
+class structurally.
+
+Earlier stamp (2026-08-29,
 `docs/architecture-currency-20260829`) for a **§8.4 conformance-matrix
 correction on `glm5_next`**, found by a principle-13 sweep of `origin/main`
 rather than by a test — the two doc gates were green across both drifts. (i) The
@@ -19,8 +50,9 @@ quantized formats outside the three module families PR #53906 wires a
 `b4a8846` refresh, so it is the § P13 "currency is not truth" case: this file
 was re-stamped in lockstep while carrying a false statement about a serving
 default. Nothing else in the window crossed the trigger; the reasoning is in the
-commit message. Re-stamped (2026-08-29,
-`claude/trellis-continuous-surface`) for the **trellis seam correction**
+commit message.
+
+Earlier stamp (2026-08-29, `claude/trellis-continuous-surface`) for the **trellis seam correction**
 (§4.9): the seam that landed earlier the same day is now **fail-closed** when
 enabled, and this document's claim that it made trellis rungs "pass the same
 legality, aggregation and byte accounting every other candidate does" is
@@ -1629,6 +1661,7 @@ which is what the rows touched since are keyed on.
 | **4/4 D** | Production cache build / recache for the selected assignment, including exact non-BF16 `mtp.*` renders synthesized through the profile from `act/` | `production_recache` or `build_production_cache --recache-layer-config --activation-cache-dir act/`; all direct builder calls receive the remaining profile pins | `production_weight_cache_frontier_<digest>_recached.pkl`, `production_weight_cache_recached.pkl` / `…_raw.pkl` and their shard directories | settings-hash `production-cache-recached`, `frontier-recache`, `production-cache-raw`, including the resolved head policy | `PRODUCTION_CACHE=1`; explicit quantized MTP fails closed without exact source/module/activation coverage |
 | **4/4 D×N (manual)** | Exact multi-host cache striping and set union. Plan whole-layer/auxiliary qname groups, run independent allowlisted cache builds, manifest and verify each portable bundle, union, then verify again after transfer | `prismaquant.production_cache_stripes`; `build_production_cache --include-qnames-file`; `prismaquant.union_production_cache {manifest,verify-shard,union,verify}` | `stripe-plan.json`, `stripe-NN.qnames.txt`, per-worker cache bundles, final `production_weight_cache.pkl` + content-addressed `weights/` + `union_manifest.json` | campaign identity binds source, calibration, full producer code, settings, render semantics, and assignment or stripe-plan coverage | operator workflow, not a `run-pipeline.sh` default; native materialized formats only (§5.4) |
 | **3c** | AURA additivity report — `residual = measured_end_KL − Σ predicted_dloss`, stamped into `cost.pkl` `provenance["additivity"]` (§4.3) | `prismaquant.aura_additivity_gate` (+ optional `validate_assignments_kl` under `AURA_ADDITIVITY_GATE=measure`) | `artifacts/aura_additivity.json`, `aura_additivity_kl.json` (measure only); `logs/aura_additivity*.log` | none — non-blocking report, skip-if-exists on the KL half | `COST_MODE=aura`, `AURA_ADDITIVITY_GATE≠0` |
+| **3d** | Discovery-walker export gate (§8.8) — meta-load + one fake forward against the profile's claim rules; refuses the run before ANY export lane on an unclaimed matmul-fed node / unresolved floating multiplicand / unknown walk-failure kind / decided-but-unpriced contradiction, decided from structured fields only. Override env excuses trace incompleteness ONLY (stamped); claims have no override | `prismaquant.model_walk` (`python3 -m prismaquant.model_walk`) | `artifacts/model_walk.json`; `logs/model_walk.log` | none — always runs; it is the gate | every lane; knobs `WALK_GATE_SEQLEN=8`, `WALK_GATE_EXECUTION=fake`, `PRISMAQUANT_WALK_GATE_OVERRIDE=<reason>` |
 | **4/4 E-gguf** | GGUF skeleton + export + llama.cpp smoke | `convert_hf_to_gguf.py` (`1461-1464`), `prismaquant.export_gguf` (`1469-1493`), `llama-completion` (`1500-1516`) | `artifacts/skeleton.gguf`, `exported.gguf` | settings-hash `gguf-skeleton` (`1488`); export always runs | GGUF lane; **exits 0** |
 | **4/4 E-cb** | CB col-weights + codebook export | `harvest_cb_col_weights "[4/4]"`, `export_nvfp4_cb[_streaming]` | `exported_nvfp4_cb/` in **~1 GiB safetensors shards** (`EXPORT_SHARD_BYTES`, default `1073741824`) + `.pqcb` codebook sidecar | settings-hash `cb-col-weights`; export always runs | CB lane; no in-lane serving smoke; **exits 0** |
 | **RTX4090 strict build (operator campaign)** | Run the ordinary per-Linear pipeline under the dense Qwen3.8 context-first policy, prove the exact 1,199-tensor/615-Linear source census, then replay config ownership and finalized artifact headers/sidecar before publication | `scripts/run_qwen38_rtx4090_fp8_cb_18gb.sh` → `run-pipeline.sh` + `rtx4090_qwen38_policy` + `rtx4090_artifact_census` | strict top-level `format: fp8_cb` lattice artifact, exact policy/runtime-contract/source-identity stamps, complete tensor-format assignment, and strict `rtx4090.fp8_cb` shipcard slot | no special cache: streamed AURA, the existing activation cache, probe-derived full-corpus imatrix, `ProductionWeightCache`, prefetch, allocator, and CB exporter remain authoritative and identity-bound | opt-in `TARGET_PROFILE=qwen38_rtx4090_fp8_cb`; exact menu FP8-CB K4..K48 step 4 + `FP8_E4M3` + BF16, `CB_CODEBOOK_SOURCE_SCOPE=none`, `CB_ACTIVATION_SCOPE=none`, fixed BF16 `lm_head`/MTP, and a non-forceable complete-publication ceiling of 18,000,000,000 bytes; currently refuses because the available sm89 lane-v2 rows are compile-only |
@@ -6204,12 +6237,41 @@ the probe's enumeration. `DeepseekV4Profile.walk_claim_rules()` now pins each
 with its reason (plus the compressor/indexer Linears the serve contract keeps
 source-format).
 
-This build ships the API and the conformance surface only
-(`tests/test_model_walk.py`) — **no consumer is wired**. The intended end
-state per the design doc: the walker's edge list becomes the single
-enumeration the probe, cost, footprint, and read-traffic stages derive from,
-and the walk runs at new-architecture intake and again at export as a gate.
-Consumer migration is separate, deliberate work.
+The gate half of the contract is WIRED (2026-08-22, `walker/r5-export-gate`):
+`run-pipeline.sh` stage **[3d]** runs `python3 -m prismaquant.model_walk
+--model $MODEL_PATH` on a meta load immediately before EVERY export lane and
+refuses the run (`exit 2`, `set -e`) when :func:`evaluate_walk_gate` — the
+gate over :class:`WalkResult` in the same module, schema
+`prismaquant.model_walk_gate.v1` — reports an unclaimed matmul-fed node, an
+unresolved floating multiplicand, an unknown walk-failure kind, or a
+decided-but-unpriced node. The verdict is STRUCTURED: refusal kinds plus
+per-entry `(node, op, equation, module)` lists in
+`artifacts/model_walk.json`; prose (`detail`, `refusal_reason`) explains to
+humans and nothing branches on it. The per-run override
+(`PRISMAQUANT_WALK_GATE_OVERRIDE=<reason>`) excuses trace incompleteness only
+— DSv4's DSA scalar aborts the fake trace today — and is stamped into the
+report; claim failures have no override. Because identity and dispositions
+live on whole logical tensors, Tensor-Parallel degree cannot move the gate's
+universe; byte fields are pinned as logical totals behind the explicit
+`per_device_bytes(total, tp_degree, policy)` seam, and any future walk-failure
+kind (e.g. quantization-group vs shard-boundary misalignment) refuses on
+today's gate via the unknown-kind catch-all. Walks are also cacheable now:
+`save_walk`/`load_walk` wrap the payload in `{schema,
+prismaquant.model_walk.v1, provenance, result}` with fail-closed reload
+(foreign schema, execution mismatch, claim-rule digest mismatch) and
+trace-time provenance (model+config digest, versions, input contract, applied
+rule list). The same commit landed the R5 sweep's claim-table fixes: universal
+base rules pin router gates (hy_v3, qwen3_5, laguna, minimax_m2, qwen3-moe;
+DSv4 keeps its specific pins) and decide packed expert stacks (seven
+`*Experts` families), and gemma4's router — decided by rule 9 while the
+probe's own name exclusion made pricing impossible, i.e. wrong polarity
+inside the claim table — is pinned like every other router; the gate's
+`find_decided_but_unpriced` checker turns that contradiction class into a
+refusal so it cannot recur silently.
+
+Still open per the design doc: migrating probe/cost/footprint/read-traffic
+onto the walker's edge list — separate, deliberate work (the consumption-API
+design lives in the R5 reports).
 
 ## 9. Serving lanes
 

--- a/prismaquant/README.md
+++ b/prismaquant/README.md
@@ -15,6 +15,7 @@ declarative contract layer, not the executor.
 | Probe | `incremental_probe` |
 | Cost | `incremental_measure_quant_cost`, `production_render_cost`, `aura_cost` (`COST_MODE=aura`), `expert_empirical_cost` (MoE hybrid), `aura_additivity_gate` (trust-region check) |
 | Allocate | `allocator` |
+| Walk gate | `model_walk` (R5 discovery walker: intake walk + fail-closed export gate, `python3 -m prismaquant.model_walk --model <dir>`) |
 | Cache | `build_production_cache`, `production_recache` |
 | Select | `validate_assignments_kl`, `select_validated_frontier` |
 | Export | `export_native_compressed` (compressed-tensors), `export_gguf` / `export_gguf_direct` (GGUF), `export_nvfp4_cb` / `export_nvfp4_cb_streaming` (codebook, served by the separately released [Gridbook](https://github.com/RobTand/gridbook) package) |

--- a/prismaquant/model_profiles/base.py
+++ b/prismaquant/model_profiles/base.py
@@ -1408,8 +1408,17 @@ class ModelProfile(ABC):
         8. **exclude** — 0-D/1-D floating tensors (norm scales, biases,
            rotary frequency tables): never a GEMM multiplicand; immutable
            floor bytes.
-        9. **decide** — every remaining ``nn.Linear`` weight (subclasses
-           included, matched through the MRO): the allocator's domain.
+        9. **pin** — MoE router gates, matched by router-class family:
+           the routing logits are matmul-fed but never priced (a route flip
+           is not a smooth cost). DSv4's per-class pins predate this and
+           keep their own reasons; this rule covers every other family the
+           R5 sweep found (hy_v3, qwen3_5, laguna, minimax_m2, qwen3-moe)
+           plus name-excluded Linear routers (gemma4).
+        10. **decide** — packed expert stacks on an ``*Experts`` owner:
+            priced through the packed-expert Fisher path, so they are
+            allocator decisions like any other unit.
+        11. **decide** — every remaining ``nn.Linear`` weight (subclasses
+            included, matched through the MRO): the allocator's domain.
 
         Override to extend, not to weaken: profiles append architecture
         rules (or prepend more specific ones) and return the base list for
@@ -1476,6 +1485,32 @@ class ModelProfile(ABC):
             "0-D/1-D tensor (norm scale, bias, rotary table): never a GEMM "
             "multiplicand; immutable floor bytes",
             max_ndim=1,
+        ))
+        # Router gates, universal form (R5 sweep 2026-08-22): every packed-MoE
+        # family in current transformers carries its router as a bare
+        # Parameter (or a name-excluded Linear — gemma4's Gemma4TextRouter)
+        # whose routing logits are matmul-fed but never priced. DSv4 pinned
+        # exactly this slot per-class; the pattern is universal, so the base
+        # table claims it once by class-name family. A route flip is not a
+        # smooth cost: pin, with the debt named.
+        rules.append(ClaimRule(
+            "pin",
+            "MoE router gate: routing logits are matmul-fed but never "
+            "priced — a route flip is not a smooth cost; held at source "
+            "precision as a named debt",
+            predicate=lambda node: "router" in node.module_class.lower(),
+        ))
+        # Packed expert stacks (R5 sweep finding 2): one 3-D Parameter per
+        # stack on an `*Experts` module, priced through the packed-expert
+        # Fisher path (install_packed_expert_hooks), not by per-Linear
+        # enumeration. They ARE allocator decisions — so `decide`, not a pin.
+        rules.append(ClaimRule(
+            "decide",
+            "packed expert stack: priced through the packed-expert Fisher "
+            "path (install_packed_expert_hooks), not by per-Linear "
+            "enumeration",
+            predicate=lambda node: node.kind == "parameter"
+            and "expert" in node.module_class.lower(),
         ))
         rules.append(ClaimRule(
             "decide",

--- a/prismaquant/model_walk.py
+++ b/prismaquant/model_walk.py
@@ -95,14 +95,50 @@ Intake for a new architecture
    reason, or an exclusion to declare. Do not silence a failure without
    writing the reason down — the reasons land on the shipcard.
 
+The export gate
+---------------
+:func:`evaluate_walk_gate` projects a :class:`WalkResult` onto a STRUCTURED
+verdict (:class:`WalkGateVerdict`): ``refused``, a tuple of machine-readable
+``refusal_kinds``, and a provenance payload whose lists carry
+``(node, op, equation, module)`` as fields a gate can read. Prose — a
+:class:`WalkFailure` ``detail``, the ``refusal_reason`` — explains to humans;
+nothing branches on it. ``prismaquant/run-pipeline.sh`` invokes this module's
+CLI (``python3 -m prismaquant.model_walk``) immediately before every export
+lane, so an unclaimed matmul-fed parameter refuses the export instead of
+shipping by omission. Three properties are policy, not implementation
+accident:
+
+* An explicit override (:data:`WALK_GATE_OVERRIDE_ENV`, reason required and
+  stamped) excuses **trace incompleteness only — never a claim failure**.
+  Claims have a first-class mechanism (``pin(reason)`` in the profile's
+  rules); a bypass around it would be the silent-green this gate exists to
+  kill.
+* An UNKNOWN :class:`WalkFailure` ``kind`` refuses. Today the walk emits
+  ``unclaimed`` and ``unresolved``; a future category (for example the
+  Tensor-Parallel one — a quantization group boundary that does not align
+  with a shard boundary at TP degree N, which would land as
+  ``kind == "tp_group_boundary_misaligned"``) must make even an UNUPGRADED
+  gate refuse rather than pass silently.
+* The decision unit is the WHOLE LOGICAL tensor. Node names are module-tree
+  names of the unsharded model, so Tensor-Parallel degree cannot change the
+  walk's universe, and a disposition is a property of the logical tensor:
+  sharding never turns a ``pin`` into anything else. ``stored_bytes`` fields
+  are **total bytes of the logical tensor** (convention recorded in the
+  verdict as ``byte_accounting.convention``); per-device accounting arrives
+  with TP as an additive ``shard_policy`` annotation, never as node identity.
+
 This module imports only torch and the standard library, so it can wrap any
 torch model; the prismaquant-specific claim policy lives on the model profile.
 """
 from __future__ import annotations
 
 import dataclasses
+import hashlib
+import json
+import os
 import re
 from collections.abc import Callable, Iterable, Mapping, Sequence
+from pathlib import Path
 from typing import Any
 
 import torch
@@ -111,17 +147,32 @@ import torch.nn.functional as F
 from torch.overrides import TorchFunctionMode
 
 __all__ = [
+    "BYTE_POLICY_REPLICATED",
+    "BYTE_POLICY_SHARDED_EVENLY",
     "Claim",
     "ClaimRule",
     "EmbeddingUse",
+    "LoadedWalk",
+    "SCHEMA",
     "TraceCoverage",
     "UnresolvedOperand",
     "WalkEdge",
     "WalkError",
     "WalkFailure",
+    "WalkGateRefusal",
+    "WalkGateVerdict",
     "WalkNode",
+    "WalkProvenance",
     "WalkResult",
     "WeightUseInterceptor",
+    "WALK_GATE_OVERRIDE_ENV",
+    "WALK_GATE_SCHEMA",
+    "claim_rules_to_json",
+    "evaluate_walk_gate",
+    "load_walk",
+    "per_device_bytes",
+    "require_walk_coverage",
+    "save_walk",
     "walk_model",
 ]
 
@@ -180,6 +231,57 @@ _CONTAINER_CLASSES = (
     nn.ModuleList, nn.ModuleDict, nn.ParameterList, nn.ParameterDict,
 )
 
+# ---------------------------------------------------------------------------
+# Artifact identity + the TP byte seam
+# ---------------------------------------------------------------------------
+
+#: Identity of the serialized walk artifact written by :func:`save_walk`.
+#: ``load_walk`` refuses any other value (parse-time refusal, same pattern as
+#: ``decision_units.parse_payload``). The gate verdict carries its own
+#: sibling schema (:data:`WALK_GATE_SCHEMA`).
+SCHEMA = "prismaquant.model_walk.v1"
+
+#: Byte policies accepted by :func:`per_device_bytes`. They are the ONLY two
+#: honest readings of a logical-total under a Tensor-Parallel degree: a
+#: replicated tensor is read/held whole on every rank; an evenly sharded one
+#: divides exactly. There is deliberately no default policy and no inferred
+#: replication class yet — nothing in current code can populate one honestly,
+#: and a speculative enum invites silent defaulting.
+BYTE_POLICY_REPLICATED = "replicated"
+BYTE_POLICY_SHARDED_EVENLY = "sharded_evenly"
+BYTE_POLICIES = (BYTE_POLICY_REPLICATED, BYTE_POLICY_SHARDED_EVENLY)
+
+
+def per_device_bytes(total: int, tp_degree: int, policy: str) -> int:
+    """Device-local bytes for a logical total under a TP degree and policy.
+
+    This is THE seam the Tensor-Parallel campaign builds on. Every
+    ``stored_bytes`` field in this module is LOGICAL-TOTAL bytes of the whole
+    parameter; per-device accounting exists only through this explicit-policy
+    accessor, so a per-device reading can never be silently conflated with
+    the total. ``tp_degree=1`` is the identity for every policy. An evenly
+    sharded total that does not divide by the degree raises — a non-dividing
+    shard boundary is exactly the misalignment class that must be loud
+    (cf. the future ``tp_group_boundary_misaligned`` walk-failure kind).
+    """
+    if tp_degree < 1:
+        raise ValueError(f"tp_degree must be >= 1, got {tp_degree}")
+    if policy not in BYTE_POLICIES:
+        raise ValueError(
+            f"policy must be one of {list(BYTE_POLICIES)}, got {policy!r}; "
+            "there is deliberately no default — say which reading you want")
+    total = int(total)
+    if tp_degree == 1:
+        return total
+    if policy == BYTE_POLICY_REPLICATED:
+        return total
+    if total % tp_degree:
+        raise ValueError(
+            f"logical total {total} does not divide by tp_degree={tp_degree} "
+            f"under policy {policy!r}; a shard boundary would cross a tensor "
+            "granularity boundary — refuse rather than round")
+    return total // tp_degree
+
 
 def _storage_key(tensor: torch.Tensor) -> int | None:
     """Identity key of a tensor's underlying storage.
@@ -222,7 +324,9 @@ class WalkNode:
     persistent: bool                # False only for non-persistent buffers
     shape: tuple[int, ...]
     dtype: str
-    stored_bytes: int
+    stored_bytes: int               # LOGICAL-TOTAL bytes of the whole tensor;
+                                    # per-device readings go through
+                                    # per_device_bytes(total, degree, policy)
     owner_module: str               # qualified name of the owning module
     module_class: str               # class name of the owning module
     module_class_mro: tuple[str, ...]  # class names, most-derived first
@@ -250,7 +354,8 @@ class WalkEdge:
     operand_shape: tuple[int, ...]  # shape as consumed (view/slice shape)
     operand_dtype: str
     operand_shapes: tuple[tuple[int, ...], ...]  # every tensor operand's shape
-    stored_bytes: int               # bytes of the full parameter node
+    stored_bytes: int               # LOGICAL-TOTAL bytes of the full parameter
+                                    # node (see WalkNode.stored_bytes)
     module: str                     # module executing the op ("" = root)
     via: tuple[str, ...]            # alias/cast hops from parameter to operand
     calls: int = 1                  # identical consumptions in the trace
@@ -357,6 +462,11 @@ class WalkResult:
     failures: tuple[WalkFailure, ...]
     trace_coverage: TraceCoverage
     execution: str                  # "fake" | "real"
+    #: Captured at trace time by :func:`walk_model`. Deliberately NOT
+    #: serialized by :meth:`to_json_dict` — its timestamps would break the
+    #: run-to-run byte-determinism the conformance tests pin; it travels in
+    #: :func:`save_walk`'s envelope instead.
+    provenance: "WalkProvenance | None" = None
 
     @property
     def ok(self) -> bool:
@@ -391,6 +501,88 @@ class WalkResult:
             "failures": [f.to_json_dict() for f in self.failures],
             "trace_coverage": self.trace_coverage.to_json_dict(),
         }
+
+    @classmethod
+    def from_json_dict(cls, d: dict) -> "WalkResult":
+        """Rehydrate the inner result payload of a saved walk artifact.
+
+        Provenance is NOT part of this payload (see the field comment); it is
+        reloaded from the envelope by :func:`load_walk` and attached there.
+        """
+        nodes = tuple(
+            WalkNode(
+                name=n["name"], kind=n["kind"], persistent=n["persistent"],
+                shape=tuple(n["shape"]), dtype=n["dtype"],
+                stored_bytes=int(n["stored_bytes"]),
+                owner_module=n["owner_module"],
+                module_class=n["module_class"],
+                module_class_mro=tuple(n["module_class_mro"]),
+                aliases=tuple(n["aliases"]),
+            )
+            for n in d["nodes"]
+        )
+        edges = tuple(
+            WalkEdge(
+                param=e["param"], param_aliases=tuple(e["param_aliases"]),
+                op=e["op"], equation=e.get("equation"), role=e["role"],
+                operand_index=int(e["operand_index"]),
+                operand_shape=tuple(e["operand_shape"]),
+                operand_dtype=e["operand_dtype"],
+                operand_shapes=tuple(tuple(s) for s in e["operand_shapes"]),
+                stored_bytes=int(e["stored_bytes"]), module=e["module"],
+                via=tuple(e.get("via", ())), calls=int(e.get("calls", 1)),
+            )
+            for e in d["edges"]
+        )
+        claims = {
+            k: Claim(
+                disposition=v["disposition"], reason=v["reason"],
+                rule_index=int(v["rule_index"]),
+            )
+            for k, v in d["claims"].items()
+        }
+        embedding_uses = tuple(
+            EmbeddingUse(
+                param=u["param"],
+                param_aliases=tuple(u["param_aliases"]),
+                module=u["module"],
+            )
+            for u in d["embedding_uses"]
+        )
+        unresolved = tuple(
+            UnresolvedOperand(
+                op=u["op"], equation=u.get("equation"), module=u["module"],
+                operand_index=int(u["operand_index"]),
+                operand_shape=tuple(u["operand_shape"]),
+                operand_dtype=u["operand_dtype"], role=u["role"],
+                is_floating=bool(u["is_floating"]),
+            )
+            for u in d["unresolved_operands"]
+        )
+        failures = tuple(
+            WalkFailure(
+                kind=f["kind"], node=f.get("node"), op=f["op"],
+                equation=f.get("equation"), module=f["module"],
+                detail=f.get("detail", ""),
+            )
+            for f in d["failures"]
+        )
+        coverage = d["trace_coverage"]
+        return cls(
+            nodes=nodes,
+            edges=edges,
+            claims=claims,
+            unclaimed=tuple(d["unclaimed"]),
+            embedding_uses=embedding_uses,
+            unresolved_operands=unresolved,
+            failures=failures,
+            trace_coverage=TraceCoverage(
+                executed=tuple(coverage["executed"]),
+                not_executed=tuple(coverage["not_executed"]),
+                containers=tuple(coverage["containers"]),
+            ),
+            execution=str(d["execution"]),
+        )
 
 
 class WalkError(RuntimeError):
@@ -494,6 +686,318 @@ def apply_claim_rules(
                 )
                 break
     return claims
+
+
+# ---------------------------------------------------------------------------
+# Artifact provenance (captured at trace time) + applied-rule serialization
+#
+# `Claim.rule_index` points into the rule list that was applied, but only the
+# resolved claims used to survive serialization — so a reloaded artifact could
+# not audit WHY a node is pinned beyond its reason string. The envelope below
+# carries the rules themselves (matchers JSON-native; `predicate` recorded by
+# name/identity, never dropped silently) plus everything a cached walk must be
+# able to prove about what produced it. All of it is captured AT TRACE TIME;
+# none of it is reconstructible afterward.
+# ---------------------------------------------------------------------------
+
+
+def _callable_identity(fn: Callable | None) -> dict | None:
+    """Name/identity marker for a ClaimRule predicate.
+
+    Predicates are code, not data: the artifact records WHAT ran (name,
+    qualname, module, owner class, and for lambdas the defining source
+    line) so an auditor can find it — never a pickle. The digest over the
+    serialized list still changes if a different predicate object is swapped
+    in, because the identity strings change with it.
+    """
+    if fn is None:
+        return None
+    owner = getattr(fn, "__self__", None)
+    identity = {
+        "name": getattr(fn, "__name__", "") or repr(fn),
+        "qualname": getattr(fn, "__qualname__", "") or "",
+        "module": getattr(fn, "__module__", "") or "",
+        "owner": type(owner).__name__ if owner is not None else "",
+        "location": "",
+    }
+    code = getattr(fn, "__code__", None)
+    if code is not None and identity["name"] == "<lambda>":
+        identity["location"] = f"{code.co_filename}:{code.co_firstlineno}"
+    return identity
+
+
+def claim_rules_to_json(rules: Sequence[ClaimRule]) -> tuple[dict, ...]:
+    """Serialize an applied :class:`ClaimRule` list for the artifact.
+
+    ``predicate`` is the one non-JSON-native matcher field; it is recorded by
+    name/identity rather than dropped. The sha256 over this tuple's canonical
+    JSON is :attr:`WalkProvenance.claim_rules_digest`.
+    """
+    out: list[dict] = []
+    for index, rule in enumerate(rules):
+        out.append({
+            "index": index,
+            "disposition": rule.disposition,
+            "reason": rule.reason,
+            "name_regex": rule.name_regex,
+            "leaf": rule.leaf,
+            "module_class": rule.module_class,
+            "kind": rule.kind,
+            "persistent": rule.persistent,
+            "max_ndim": rule.max_ndim,
+            "min_ndim": rule.min_ndim,
+            "floating": rule.floating,
+            "predicate": _callable_identity(rule.predicate),
+        })
+    return tuple(out)
+
+
+def _canonical(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _claim_rules_digest(rules: Sequence[ClaimRule]) -> str:
+    return hashlib.sha256(
+        _canonical(list(claim_rules_to_json(rules))).encode("utf-8")
+    ).hexdigest()
+
+
+@dataclasses.dataclass(frozen=True)
+class WalkProvenance:
+    """Everything a reloaded walk artifact must prove about its origin.
+
+    Captured at trace time by :func:`walk_model`. Load-bearing, not
+    decoration: two walks of the same weights under different input contracts
+    can differ in ``trace_coverage`` when data-dependent control flow
+    executes shape-wise under fake tensors, so the example-input spec travels
+    with the result and ``load_walk`` refuses mismatches.
+    """
+
+    created_utc: str                    # ISO 8601, UTC
+    model_identity: str                 # architecture + config-content digest
+    torch_version: str
+    transformers_version: str | None
+    prismaquant_version: str            # "" when not installed as a dist
+    prismaquant_git: str                # git describe; "" when unavailable
+    execution: str                      # mirrors WalkResult.execution
+    example_inputs_spec: str
+    seq_len: int | None                 # set only for the synthesized default
+    claim_rules_digest: str             # sha256 over `claim_rules`
+    claim_rules: tuple[dict, ...]       # claim_rules_to_json() output
+
+    def to_json_dict(self) -> dict:
+        d = dataclasses.asdict(self)
+        d["claim_rules"] = list(self.claim_rules)
+        return d
+
+    @classmethod
+    def from_json_dict(cls, d: dict) -> "WalkProvenance":
+        return cls(
+            created_utc=str(d["created_utc"]),
+            model_identity=str(d["model_identity"]),
+            torch_version=str(d["torch_version"]),
+            transformers_version=(
+                None if d.get("transformers_version") is None
+                else str(d["transformers_version"])),
+            prismaquant_version=str(d.get("prismaquant_version", "")),
+            prismaquant_git=str(d.get("prismaquant_git", "")),
+            execution=str(d["execution"]),
+            example_inputs_spec=str(d["example_inputs_spec"]),
+            seq_len=(None if d.get("seq_len") is None else int(d["seq_len"])),
+            claim_rules_digest=str(d["claim_rules_digest"]),
+            claim_rules=tuple(dict(r) for r in d.get("claim_rules", ())),
+        )
+
+    def rules_digest_matches(self, rules: Sequence[ClaimRule]) -> bool:
+        return self.claim_rules_digest == _claim_rules_digest(rules)
+
+
+def _model_identity(model: nn.Module) -> str:
+    cfg = getattr(model, "config", None)
+    if cfg is not None:
+        try:
+            blob = _canonical(cfg.to_dict())
+            model_type = getattr(cfg, "model_type", "") or ""
+            digest = hashlib.sha256(blob.encode("utf-8")).hexdigest()
+            return (
+                f"{model_type or type(model).__name__}:sha256:{digest}"
+            )
+        except Exception:
+            pass
+    try:
+        n_params = sum(int(p.numel()) for p in model.parameters())
+    except Exception:
+        n_params = -1
+    return f"{type(model).__name__}:params:{n_params}"
+
+
+def _package_version(name: str) -> str:
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        return version(name)
+    except (PackageNotFoundError, Exception):  # noqa: BLE001 - best effort
+        return ""
+
+
+def _transformers_version() -> str | None:
+    try:
+        import transformers
+
+        return str(getattr(transformers, "__version__", "") or "")
+    except Exception:  # noqa: BLE001 - optional dependency of the walker
+        return None
+
+
+def _git_describe() -> str:
+    import subprocess
+
+    try:
+        out = subprocess.run(
+            ["git", "describe", "--always", "--dirty"],
+            cwd=Path(__file__).resolve().parents[1],
+            check=True, text=True, timeout=10,
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+        )
+        return out.stdout.strip()
+    except Exception:  # noqa: BLE001 - provenance degrades to "", never fails
+        return ""
+
+
+def _example_inputs_spec(example_inputs, seq_len: int,
+                         used_default: bool) -> str:
+    if used_default:
+        return f"default:input_ids(1,{seq_len})+use_cache_if_accepted"
+    parts: list[str] = []
+    if isinstance(example_inputs, Mapping):
+        items = sorted(example_inputs.items(), key=lambda kv: str(kv[0]))
+        for key, value in items:
+            for tensor in _iter_tensors(value):
+                parts.append(f"{key}:{list(tensor.shape)}@{tensor.dtype}")
+    elif isinstance(example_inputs, tuple):
+        for i, value in enumerate(example_inputs):
+            for tensor in _iter_tensors(value):
+                parts.append(f"[{i}]:{list(tensor.shape)}@{tensor.dtype}")
+    else:
+        for tensor in _iter_tensors(example_inputs):
+            parts.append(f"in:{list(tensor.shape)}@{tensor.dtype}")
+    blob = ";".join(parts)
+    digest = hashlib.sha256(blob.encode("utf-8")).hexdigest()[:12]
+    return f"provided:{digest}:{blob[:160]}"
+
+
+def capture_walk_provenance(
+    model: nn.Module,
+    *,
+    execution: str,
+    example_inputs,
+    seq_len: int | None,
+    claim_rules: Sequence[ClaimRule],
+    used_default_inputs: bool = False,
+) -> WalkProvenance:
+    """Snapshot at trace time what no later reader can reconstruct."""
+    import datetime
+
+    return WalkProvenance(
+        created_utc=datetime.datetime.now(datetime.timezone.utc).isoformat(
+            timespec="seconds"),
+        model_identity=_model_identity(model),
+        torch_version=str(torch.__version__),
+        transformers_version=_transformers_version(),
+        prismaquant_version=_package_version("prismaquant"),
+        prismaquant_git=_git_describe(),
+        execution=execution,
+        example_inputs_spec=_example_inputs_spec(
+            example_inputs, seq_len or 0, used_default_inputs),
+        seq_len=None if seq_len is None else int(seq_len),
+        claim_rules_digest=_claim_rules_digest(claim_rules),
+        claim_rules=claim_rules_to_json(claim_rules),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Artifact save/load (the cache: one walk per model/config/input-contract,
+# consumed many times). The envelope WRAPS today's payload — result bytes stay
+# exactly what the determinism ratchet pins; timestamps live only in
+# provenance.
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class LoadedWalk:
+    """One reloaded walk artifact: the result plus its trace-time proof."""
+
+    path: str
+    result: WalkResult
+    provenance: WalkProvenance
+
+
+def save_walk(
+    result: WalkResult,
+    path: str | os.PathLike,
+    *,
+    provenance: WalkProvenance,
+) -> Path:
+    """Atomically write ``{schema, provenance, result}`` as one JSON document.
+
+    Refuses a provenance that contradicts the one already attached to
+    ``result``. Plain JSON on purpose: size at DSv4 scale is unmeasured, so
+    no gzip claim is made here — measure before optimizing.
+    """
+    if result.provenance is not None and result.provenance != provenance:
+        raise ValueError(
+            "save_walk: provenance argument disagrees with the provenance "
+            "captured on this WalkResult")
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema": SCHEMA,
+        "provenance": provenance.to_json_dict(),
+        "result": result.to_json_dict(),
+    }
+    blob = (json.dumps(payload, indent=1, sort_keys=True) + "\n").encode(
+        "utf-8")
+    tmp = target.with_name(target.name + ".tmp")
+    tmp.write_bytes(blob)
+    os.replace(tmp, target)
+    return target
+
+
+def load_walk(
+    path: str | os.PathLike,
+    *,
+    expect_claim_rules: Sequence[ClaimRule] | None = None,
+) -> LoadedWalk:
+    """Load a saved walk artifact, refusing anything it cannot prove.
+
+    Fail-closed on: a foreign schema (parse-time refusal, same pattern as
+    ``decision_units.parse_payload``); a provenance whose ``execution``
+    disagrees with the result's own record; and — when the caller passes
+    ``expect_claim_rules`` — a claim-rules digest that does not match the
+    rules the caller is about to trust. A mismatch means the cached claims
+    were written by a different policy and must not be served silently.
+    """
+    artifact = Path(path)
+    payload = json.loads(artifact.read_text())
+    if not isinstance(payload, dict) or payload.get("schema") != SCHEMA:
+        found = payload.get("schema") if isinstance(payload, dict) else None
+        raise ValueError(
+            f"unsupported model-walk schema at {artifact}: {found!r} "
+            f"(expected {SCHEMA!r})")
+    provenance = WalkProvenance.from_json_dict(payload["provenance"])
+    result = WalkResult.from_json_dict(payload["result"])
+    result = dataclasses.replace(result, provenance=provenance)
+    if provenance.execution != result.execution:
+        raise ValueError(
+            f"{artifact}: provenance execution {provenance.execution!r} "
+            f"disagrees with the result's own {result.execution!r}")
+    if expect_claim_rules is not None and \
+            not provenance.rules_digest_matches(expect_claim_rules):
+        raise ValueError(
+            f"{artifact}: produced under different claim rules (digest "
+            f"{provenance.claim_rules_digest[:12]}); refusing to serve "
+            "claims this caller did not write")
+    return LoadedWalk(path=str(artifact), result=result, provenance=provenance)
 
 
 # ---------------------------------------------------------------------------
@@ -778,8 +1282,19 @@ def walk_model(
         raise ValueError(
             "execution='real' needs materialized weights; this model is on "
             "the meta device. Use execution='fake', or load real weights.")
-    if example_inputs is None:
+    default_inputs = example_inputs is None
+    if default_inputs:
         example_inputs = _default_example_inputs(model, seq_len, device)
+    # Trace-time provenance: captured before the forward, because none of it
+    # is reconstructible afterward (see WalkProvenance).
+    provenance = capture_walk_provenance(
+        model,
+        execution=execution,
+        example_inputs=example_inputs,
+        seq_len=seq_len if default_inputs else None,
+        claim_rules=claim_rules,
+        used_default_inputs=default_inputs,
+    )
 
     interceptor = WeightUseInterceptor(named_storages)
     input_tensors = list(_iter_tensors(
@@ -826,7 +1341,8 @@ def walk_model(
             handle.remove()
 
     result = _assemble(
-        nodes, interceptor, executed, module_names, claim_rules, execution)
+        nodes, interceptor, executed, module_names, claim_rules, execution,
+        provenance=provenance)
     interceptor.release()
     if strict:
         result.raise_if_failed()
@@ -840,6 +1356,7 @@ def _assemble(
     module_names: dict[str, nn.Module],
     claim_rules: Sequence[ClaimRule],
     execution: str,
+    provenance: WalkProvenance | None = None,
 ) -> WalkResult:
     node_by_name = {n.name: n for n in nodes}
 
@@ -963,4 +1480,577 @@ def _assemble(
             containers=containers,
         ),
         execution=execution,
+        provenance=provenance,
     )
+
+
+# ---------------------------------------------------------------------------
+# The export gate
+#
+# A STRUCTURED verdict over a WalkResult. The refusal branches on fields —
+# refusal_kinds, failure kind, node/op/equation/module lists — never on the
+# prose `detail` strings, which exist for the human reading the log.
+#
+# Tensor-Parallel stance (invariants, 2026-08-22): the decision unit is the
+# whole logical tensor, so node identity and dispositions are TP-degree
+# invariant by construction; `stored_bytes` everywhere here is TOTAL bytes of
+# the logical tensor with per-device accounting deferred to an additive
+# `shard_policy` annotation; and KNOWN_FAILURE_KINDS is a closed set whose
+# unknown members refuse, so a future TP category (e.g.
+# "tp_group_boundary_misaligned" — quantization group boundary vs shard
+# boundary at degree N) makes even an unupgraded gate fail closed.
+# ---------------------------------------------------------------------------
+
+WALK_GATE_SCHEMA = "prismaquant.model_walk_gate.v1"
+
+#: Per-run escape hatch for TRACE INCOMPLETENESS ONLY. Same doctrine as the CB
+#: route-status override: the value must be the REASON, and it is stamped into
+#: the verdict's provenance. It never excuses an unclaimed node or an
+#: unresolved multiplicand — claims have a first-class mechanism
+#: (`pin(reason)` / `exclude(reason)` in ModelProfile.walk_claim_rules()) and
+#: a side channel around it would be the silent-green this gate exists to kill.
+WALK_GATE_OVERRIDE_ENV = "PRISMAQUANT_WALK_GATE_OVERRIDE"
+
+TRACE_COMPLETE = "complete"
+TRACE_INCOMPLETE = "incomplete"
+
+#: The closed vocabulary of WalkFailure.kind this gate understands. Anything
+#: else refuses (fail-closed catch-all for future categories).
+KNOWN_FAILURE_KINDS = frozenset({"unclaimed", "unresolved"})
+
+_KIND_UNCLAIMED = "unclaimed_node"
+_KIND_UNRESOLVED = "unresolved_floating_multiplicand"
+_KIND_UNKNOWN_FAILURE = "unknown_walk_failure_kind"
+_KIND_TRACE_INCOMPLETE = "incomplete_trace"
+_KIND_DECIDED_UNPRICED = "decided_but_unpriced_node"
+
+
+class WalkGateRefusal(RuntimeError):
+    """Export refused by the discovery-walker coverage gate."""
+
+
+@dataclasses.dataclass(frozen=True)
+class WalkGateVerdict:
+    """The gate's result: structured provenance plus what it decided.
+
+    ``refusal_reason`` is prose for humans; every consumer (the CLI exit
+    code, run-pipeline.sh, a future shipcard stamp) branches only on
+    :attr:`refused` and the structured fields of :attr:`provenance`.
+    """
+
+    provenance: dict
+    refused: bool
+    refusal_kinds: tuple[str, ...]
+    refusal_reason: str = ""
+
+
+def evaluate_walk_gate(
+    result: WalkResult | None,
+    *,
+    trace_status: str = TRACE_COMPLETE,
+    trace_error_class: str = "",
+    override_reason: str | None = None,
+    unpriced_decides: Sequence[Mapping] = (),
+    scope: Mapping | None = None,
+) -> WalkGateVerdict:
+    """Project one walk onto the fail-closed export verdict.
+
+    Args:
+        result: the walk output; ``None`` means the traced forward itself
+            aborted (``trace_status`` is then forced to
+            ``TRACE_INCOMPLETE``) and no coverage claim is possible.
+        trace_status: ``"complete"`` or ``"incomplete"``. An incomplete trace
+            discovers only what executed before the abort, so gating on it
+            would under-discover exactly like the pipeline enumerations this
+            walker replaces: it refuses unless ``override_reason`` is given.
+        trace_error_class: exception class name when the trace aborted
+            (recorded, never branched on).
+        override_reason: explicit per-run reason excusing trace incompleteness
+            only. Defaults to :data:`WALK_GATE_OVERRIDE_ENV`. Claim failures
+            refuse regardless of any override.
+        unpriced_decides: structured entries for the contradiction class —
+            a node claimed ``decide`` that no pricing consumer can actually
+            reach (probe-skip class, probe-exclude regex). The gemma4 router
+            shipped exactly this way: decided by rule 9, excluded from probe
+            inventory by name. Each entry carries node/module_class/reason_code;
+            presence refuses, with no override.
+        scope: structured declaration of what this gate run asserts over
+            (profile name, rules source, rule-family census) — enabling is
+            provable per profile from the report itself, never prose.
+
+    Returns:
+        A :class:`WalkGateVerdict` whose ``provenance`` is JSON-serializable
+        and self-describing (decision unit, byte-accounting convention).
+    """
+    if result is None:
+        trace_status = TRACE_INCOMPLETE
+
+    unclaimed_nodes: list[dict] = []
+    unresolved_operands: list[dict] = []
+    kinds_seen: set[str] = set()
+    if result is not None:
+        kinds_seen.update(f.kind for f in result.failures)
+        seen: set[tuple] = set()
+        for f in result.failures:
+            if f.kind == "unclaimed":
+                entry = {
+                    "node": f.node,
+                    "op": f.op,
+                    "equation": f.equation,
+                    "module": f.module,
+                }
+                key = tuple(sorted(entry.items()))
+                if key not in seen:
+                    seen.add(key)
+                    unclaimed_nodes.append(entry)
+        unresolved_operands = [
+            {
+                "op": u.op,
+                "equation": u.equation,
+                "module": u.module,
+                "operand_index": u.operand_index,
+                "operand_shape": list(u.operand_shape),
+                "operand_dtype": u.operand_dtype,
+            }
+            for u in result.unresolved_operands
+            if u.is_floating and u.role == "multiplicand"
+        ]
+
+    disposition_counts = {"decide": 0, "pin": 0, "exclude": 0}
+    if result is not None:
+        for claim in result.claims.values():
+            disposition_counts[claim.disposition] += 1
+
+    fed_unclaimed = len(unclaimed_nodes)
+    unfed_unclaimed = (
+        len(result.unclaimed) - fed_unclaimed if result is not None else 0
+    )
+
+    base: dict = {
+        "schema": WALK_GATE_SCHEMA,
+        "policy": "fail_closed",
+        # TP invariant 1: identity is the logical tensor; sharding is a
+        # load-time concern and never renames or re-claims a node.
+        "decision_unit": "whole_logical_tensor",
+        # TP invariant 2: say which byte convention the schema carries.
+        "byte_accounting": {
+            "convention": "total_logical_tensor_bytes",
+            "shard_policy": None,  # reserved; additive when TP lands
+        },
+        "trace_status": trace_status,
+        "trace_error_class": trace_error_class,
+        "nodes_total": len(result.nodes) if result is not None else None,
+        "edges_total": len(result.edges) if result is not None else None,
+        "claims_by_disposition": disposition_counts,
+        "matmul_fed_unclaimed_total": fed_unclaimed,
+        "unclaimed_matmul_fed_nodes": sorted(
+            unclaimed_nodes,
+            key=lambda e: (e["node"] or "", e["op"], e["equation"] or ""),
+        ),
+        # Visible, non-fatal: nodes nothing consumed in the trace (a bias, a
+        # dormant module). Reported so silence can never masquerade as
+        # coverage, but they are not refusals.
+        "unclaimed_unfed_total": max(unfed_unclaimed, 0),
+        "unresolved_floating_multiplicands": unresolved_operands,
+        "failure_kinds_seen": sorted(kinds_seen),
+        "decided_but_unpriced_nodes": [dict(e) for e in unpriced_decides],
+        "scope": dict(scope or {}),
+        "override": _gate_override_record(override_reason),
+    }
+
+    kinds: list[str] = []
+    unknown = sorted(kinds_seen - KNOWN_FAILURE_KINDS)
+    if unknown:
+        kinds.append(_KIND_UNKNOWN_FAILURE)
+    if unclaimed_nodes:
+        kinds.append(_KIND_UNCLAIMED)
+    if unresolved_operands:
+        kinds.append(_KIND_UNRESOLVED)
+    if unpriced_decides:
+        kinds.append(_KIND_DECIDED_UNPRICED)
+    if trace_status != TRACE_COMPLETE:
+        kinds.append(_KIND_TRACE_INCOMPLETE)
+
+    base["refused"] = bool(kinds)
+    base["refusal_kinds"] = list(kinds)
+
+    if not kinds:
+        return WalkGateVerdict(
+            provenance=base, refused=False, refusal_kinds=())
+
+    claim_refusals = [
+        k for k in kinds
+        if k in (_KIND_UNKNOWN_FAILURE, _KIND_UNCLAIMED, _KIND_UNRESOLVED,
+                 _KIND_DECIDED_UNPRICED)
+    ]
+    if claim_refusals:
+        # No override reaches here, ever: claims are pinned/excluded/decided
+        # with reasons in the profile rules, not waived at export time.
+        refused = True
+    elif override_reason:
+        base["override_excused_trace_only"] = True
+        refused = False
+    else:
+        refused = True
+
+    return WalkGateVerdict(
+        provenance=base,
+        refused=refused,
+        refusal_kinds=tuple(kinds),
+        refusal_reason=_refusal_text(base, kinds, unknown, bool(override_reason)),
+    )
+
+
+def find_decided_but_unpriced(
+    result: WalkResult,
+    model: nn.Module,
+    profile,
+) -> tuple[dict, ...]:
+    """Surface the contradiction the gemma4 router shipped under: a node
+    claimed ``decide`` that no pricing consumer can reach.
+
+    A ``decide`` claim is a promise — "the allocator prices this tensor".
+    When the probe's own enumeration cannot see the node (owner class in
+    ``probe_skip_module_class_names``, or the node's name matches the
+    baseline/profile Linear-exclude regexes), and it is not priced through
+    the packed-expert path either, that promise is false and this returns a
+    structured entry for it. The gate refuses on any entry; the fix is to
+    correct the CLAIM (usually to a router-style pin), never to widen the
+    probe.
+
+    Imports prismaquant lazily so the walker core stays torch-only.
+    """
+    from prismaquant.incremental_probe import _BASE_LINEAR_EXCLUDE
+    from prismaquant.sensitivity_probe import _is_packed_experts_module
+
+    try:
+        extra = str(profile.probe_linear_exclude_extra() or "")
+    except AttributeError:
+        extra = ""
+    excludes = (_BASE_LINEAR_EXCLUDE,) if not extra else (
+        _BASE_LINEAR_EXCLUDE, extra)
+
+    entries: list[dict] = []
+    for node in result.nodes:
+        claim = result.claims.get(node.name)
+        if claim is None or claim.disposition != "decide":
+            continue
+        try:
+            module = model.get_submodule(node.owner_module)
+        except (AttributeError, KeyError):
+            entries.append({
+                "node": node.name,
+                "owner_module": node.owner_module,
+                "module_class": node.module_class,
+                "reason_code": "owner_module_missing",
+            })
+            continue
+        if profile.should_probe_linear(node.owner_module, module):
+            # The hook gate accepts the module; the NAME regexes are the
+            # remaining way pricing can silently skip it.
+            if not any(re.search(rx, node.name) for rx in excludes):
+                continue
+            reason_code = "probe_linear_excluded"
+        elif _is_packed_experts_module(module, profile):
+            # Priced through install_packed_expert_hooks instead.
+            continue
+        else:
+            reason_code = "owner_not_probe_priceable"
+        entries.append({
+            "node": node.name,
+            "owner_module": node.owner_module,
+            "module_class": node.module_class,
+            "reason_code": reason_code,
+        })
+    return tuple(sorted(entries, key=lambda e: e["node"]))
+
+
+def require_walk_coverage(
+    result: WalkResult | None,
+    **kwargs,
+) -> dict:
+    """Run the gate and raise :class:`WalkGateRefusal` on a refusal.
+
+    Returns the provenance payload for stamping next to the artifact's other
+    gate records.
+    """
+    verdict = evaluate_walk_gate(result, **kwargs)
+    if verdict.refused:
+        raise WalkGateRefusal(verdict.refusal_reason)
+    return verdict.provenance
+
+
+def _gate_override_record(reason: str | None) -> dict | None:
+    if not reason:
+        return None
+    return {"env": WALK_GATE_OVERRIDE_ENV, "reason": reason}
+
+
+def _refusal_text(base: dict, kinds: Sequence[str],
+                  unknown: Sequence[str], overridden: bool) -> str:
+    lines = [f"model-walk export gate refused [{', '.join(kinds)}]:"]
+    for entry in base["unclaimed_matmul_fed_nodes"]:
+        where = entry["op"] + (
+            f" '{entry['equation']}'" if entry["equation"] else "")
+        lines.append(
+            f"  [unclaimed] {entry['node']} fed to {where} "
+            f"in module '{entry['module'] or '<root>'}'"
+        )
+    for op in base["unresolved_floating_multiplicands"]:
+        where = op["op"] + (f" '{op['equation']}'" if op["equation"] else "")
+        lines.append(
+            f"  [unresolved] floating operand #{op['operand_index']} "
+            f"(shape {op['operand_shape']}) fed to {where} "
+            f"in module '{op['module'] or '<root>'}'"
+        )
+    for entry in base["decided_but_unpriced_nodes"]:
+        lines.append(
+            f"  [decided-but-unpriced] {entry.get('node')} "
+            f"(class {entry.get('module_class') or '?'}, "
+            f"reason_code {entry.get('reason_code')}) is claimed decide but "
+            "no pricing consumer can reach it"
+        )
+    if _KIND_UNKNOWN_FAILURE in kinds:
+        lines.append(
+            f"  [unknown-kind] walk emitted failure kinds outside the known "
+            f"vocabulary {sorted(KNOWN_FAILURE_KINDS)}: {list(unknown)} — "
+            "refusing without interpreting them"
+        )
+    if _KIND_TRACE_INCOMPLETE in kinds:
+        lines.append(
+            "  [incomplete-trace] the traced forward aborted, so coverage "
+            f"was evaluated over a partial discovery (last error class: "
+            f"{base['trace_error_class'] or 'n/a'})"
+        )
+    if overridden and not any(
+        k in (_KIND_UNCLAIMED, _KIND_UNRESOLVED, _KIND_UNKNOWN_FAILURE,
+              _KIND_DECIDED_UNPRICED)
+        for k in kinds
+    ):
+        lines.append(
+            f"  override {WALK_GATE_OVERRIDE_ENV} excuses trace "
+            "incompleteness ONLY; it is stamped into the report"
+        )
+    lines.append(
+        "Fixes, in order of preference: pin/exclude/decide the named node "
+        "with a reasoned ClaimRule in ModelProfile.walk_claim_rules(); make "
+        "the fake trace executable; or --execution real with materialized "
+        f"weights. Trace-incompleteness alone may ship via "
+        f"{WALK_GATE_OVERRIDE_ENV}=<reason> (stamped). Claim failures have "
+        "no override."
+    )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint (intake + export gate)
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Walk a checkpoint directory and apply the fail-closed export gate.
+
+    Exit codes follow the repo's guard convention: 0 passed, 2 refused.
+    """
+    import argparse
+    import json
+    import os
+    import pathlib
+    import sys
+
+    ap = argparse.ArgumentParser(
+        prog="python3 -m prismaquant.model_walk",
+        description=(
+            "Discovery walker (R5): enumerate every named tensor, trace one "
+            "forward, resolve matmul operands by storage identity, claim "
+            "every node, and refuse on any unclaimed matmul-fed parameter "
+            "or unresolved floating multiplicand."
+        ),
+    )
+    ap.add_argument("--model", required=True,
+                    help="Source HF checkpoint directory.")
+    ap.add_argument("--output", default=None,
+                    help="Write the walk + structured gate verdict JSON here.")
+    ap.add_argument("--seq-len", type=int, default=8,
+                    help="Length of the synthesized default input_ids.")
+    ap.add_argument("--execution", choices=("fake", "real"), default="fake",
+                    help="'fake' traces under FakeTensorMode (meta model, no "
+                         "weight I/O); 'real' runs a plain forward and "
+                         "requires --materialize.")
+    ap.add_argument("--materialize", action="store_true",
+                    help="Load real weights instead of meta-loading (needed "
+                         "for --execution real; sized like the checkpoint).")
+    ap.add_argument("--dtype", default="bf16",
+                    help="dtype for --materialize loads (default bf16).")
+    ap.add_argument("--rules", choices=("profile", "none"), default="profile",
+                    help="'profile' applies detect_profile().walk_claim_rules(); "
+                         "'none' applies no rules (every matmul-fed node "
+                         "refuses — useful as a self-test of the gate).")
+    ap.add_argument("--trust-remote-code", action="store_true")
+    ap.add_argument("--override-reason", default=None,
+                    help="Explicit reason excusing TRACE INCOMPLETENESS only "
+                         f"(same record as {WALK_GATE_OVERRIDE_ENV}). Never "
+                         "valid against claim failures.")
+    args = ap.parse_args(argv)
+
+    from prismaquant.model_profiles.registry import (
+        detect_profile_with_warning,
+    )
+
+    profile = detect_profile_with_warning(args.model, entrypoint="model_walk")
+
+    import torch
+    from transformers import AutoConfig, AutoModel
+
+    try:
+        from transformers import AutoModelForCausalLM
+        have_causal_lm = True
+    except Exception:  # pragma: no cover - transformers always ships it
+        have_causal_lm = False
+
+    cfg = AutoConfig.from_pretrained(
+        args.model, trust_remote_code=args.trust_remote_code)
+    load_kwargs: dict = {"trust_remote_code": args.trust_remote_code}
+    if args.materialize:
+        load_kwargs["dtype"] = getattr(torch, args.dtype)
+        load_kwargs["low_cpu_mem_usage"] = True
+        model_class_used = ""
+        if have_causal_lm:
+            try:
+                model = AutoModelForCausalLM.from_pretrained(
+                    args.model, **load_kwargs)
+                model_class_used = "causal_lm"
+            except Exception:
+                model = None
+        if not have_causal_lm or model is None:
+            model = AutoModel.from_pretrained(args.model, **load_kwargs)
+            model_class_used = model_class_used or "base"
+    else:
+        device_ctx = torch.device("meta")
+        model = None
+        model_class_used = ""
+        if have_causal_lm:
+            try:
+                with device_ctx:
+                    model = AutoModelForCausalLM.from_config(cfg, **load_kwargs)
+                model_class_used = "causal_lm"
+            except Exception:
+                model = None
+        if model is None:
+            with device_ctx:
+                model = AutoModel.from_config(cfg, **load_kwargs)
+            model_class_used = model_class_used or "base"
+    model.eval()
+
+    rules = profile.walk_claim_rules() if args.rules == "profile" else ()
+    print(f"[model-walk] profile={getattr(profile, 'name', type(profile).__name__)}"
+          f" model_class={model_class_used} rules={len(rules)}"
+          f" execution={args.execution}")
+
+    trace_status = TRACE_COMPLETE
+    trace_error_class = ""
+    result = None
+    try:
+        result = walk_model(
+            model,
+            claim_rules=rules,
+            execution=args.execution,
+            strict=False,
+            seq_len=args.seq_len,
+        )
+    except Exception as exc:  # noqa: BLE001 - the abort IS the finding
+        trace_status = TRACE_INCOMPLETE
+        trace_error_class = type(exc).__name__
+        print(f"[model-walk] trace aborted: {type(exc).__name__}: {exc}",
+              flush=True)
+
+    override_reason = args.override_reason or os.environ.get(
+        WALK_GATE_OVERRIDE_ENV) or None
+
+    # The gemma4-router contradiction class: a decide claim no pricing
+    # consumer can reach. Computed against the live profile + module tree,
+    # fed to the gate as structured entries.
+    unpriced_decides: tuple[dict, ...] = ()
+    scope: dict = {}
+    if result is not None:
+        try:
+            unpriced_decides = find_decided_but_unpriced(
+                result, model, profile)
+        except Exception as exc:  # noqa: BLE001 - checker failure is loud
+            print(f"[model-walk] WARNING: decided-but-unpriced check failed "
+                  f"({type(exc).__name__}: {exc}); treating as refusal input",
+                  file=sys.stderr)
+            unpriced_decides = ({
+                "node": "<checker>",
+                "module_class": "",
+                "reason_code": f"check_failed:{type(exc).__name__}",
+            },)
+        rules_json = result.provenance.claim_rules if \
+            result.provenance is not None else ()
+        scope = {
+            "profile": getattr(profile, "name", type(profile).__name__),
+            "rules_source": args.rules,
+            "claim_rule_count": len(rules),
+            "router_pin_rules": sum(
+                1 for r in rules_json
+                if r.get("disposition") == "pin"
+                and "router" in json.dumps(r).lower()),
+            "packed_expert_decide_rules": sum(
+                1 for r in rules_json
+                if r.get("disposition") == "decide"
+                and "expert" in json.dumps(r).lower()),
+        }
+
+    verdict = evaluate_walk_gate(
+        result,
+        trace_status=trace_status,
+        trace_error_class=trace_error_class,
+        override_reason=override_reason,
+        unpriced_decides=unpriced_decides,
+        scope=scope,
+    )
+
+    report = {
+        "schema": WALK_GATE_SCHEMA,
+        "walk_artifact_schema": SCHEMA,
+        "context": {
+            "model_path": args.model,
+            "profile": getattr(profile, "name", type(profile).__name__),
+            "auto_model_class": model_class_used,
+            "execution": args.execution,
+            "materialized": bool(args.materialize),
+            "rules_source": args.rules,
+        },
+        "gate": verdict.provenance,
+        "provenance": (
+            result.provenance.to_json_dict()
+            if result is not None and result.provenance is not None
+            else None
+        ),
+        "walk": result.to_json_dict() if result is not None else None,
+    }
+    if args.output:
+        out = pathlib.Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(report, indent=1, sort_keys=True) + "\n")
+        print(f"[model-walk] wrote {out}")
+
+    counts = verdict.provenance["claims_by_disposition"]
+    print(
+        "[model-walk] nodes="
+        f"{verdict.provenance['nodes_total']} "
+        f"claims={counts} "
+        f"unclaimed_matmul_fed={verdict.provenance['matmul_fed_unclaimed_total']} "
+        f"unresolved={len(verdict.provenance['unresolved_floating_multiplicands'])} "
+        f"trace={verdict.provenance['trace_status']}"
+    )
+    if verdict.refused:
+        print(verdict.refusal_reason, file=sys.stderr)
+        print("[model-walk] GATE: REFUSED", file=sys.stderr)
+        return 2
+    print("[model-walk] GATE: PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prismaquant/pipeline.py
+++ b/prismaquant/pipeline.py
@@ -1433,6 +1433,16 @@ def default_production_pipeline_spec(
             resident=True,
         ),
         ArtifactSpec("kl_metrics", "validation_metrics"),
+        # R5 discovery-walker export gate: the structured verdict the walk
+        # gate refuses on (prismaquant.model_walk.WALK_GATE_SCHEMA).
+        ArtifactSpec(
+            "walk_coverage_report",
+            "walk_coverage_report",
+            description=(
+                "Discovery-walker coverage ledger + fail-closed export-gate "
+                "verdict over the source model"
+            ),
+        ),
         ArtifactSpec("compressed_artifact", "hf_checkpoint"),
         ArtifactSpec("vllm_smoke", "validation_metrics"),
         ArtifactSpec("render.baseline_weight", "tensor", provided=True),
@@ -1552,6 +1562,40 @@ def default_production_pipeline_spec(
                 ),
             ),
             tags=("validation", "gpu_bound"),
+        ),
+        PipelineStageSpec(
+            name="export.walk_coverage_gate",
+            component="model_walk:walk_export_gate",
+            inputs=("source_model",),
+            outputs=("walk_coverage_report",),
+            tags=("walk", "gate", "fail_closed", "meta_intake_cpu"),
+            metadata={
+                "schema": "prismaquant.model_walk_gate.v1",
+                "policy": (
+                    "refuse on an unclaimed matmul-fed node, an unresolved "
+                    "floating multiplicand, or any unknown walk failure kind"
+                ),
+                # TP stance: identity and dispositions live on the whole
+                # logical tensor; byte fields are totals with a reserved
+                # additive shard_policy annotation.
+                "decision_unit": "whole_logical_tensor",
+                "byte_accounting": "total_logical_tensor_bytes",
+                "override_env": "PRISMAQUANT_WALK_GATE_OVERRIDE",
+                "override_scope": "trace_incompleteness_only_never_claims",
+                # Deliberately NOT a MetricGateSpec: the refusal is
+                # structural (a named node), not a metric comparison, and
+                # runtime enforcement lives in the stage code
+                # (run-pipeline.sh -> python3 -m prismaquant.model_walk).
+                "gate_kind": "structural_refusal",
+            },
+            description=(
+                "R5 discovery-walker export gate (§8.8): walks the source "
+                "model — module tree plus one FakeTensorMode forward — "
+                "against the profile's claim rules, immediately before every "
+                "export lane. An unclaimed matmul-fed parameter refuses the "
+                "export with the node named and the op cited. Meta-device "
+                "intake: no GPU, no weight I/O, no cache residency."
+            ),
         ),
         PipelineStageSpec(
             name="export.native_compressed",

--- a/prismaquant/run-pipeline.sh
+++ b/prismaquant/run-pipeline.sh
@@ -1119,6 +1119,7 @@ if [[ "$COST_MODE" == "aura" ]]; then
 fi
 echo "  EXPORT_GPTQ=$EXPORT_GPTQ EXPORT_SCALE_SWEEP=$EXPORT_SCALE_SWEEP"
 echo "  PIPELINE_SPEC_PATH=$PIPELINE_SPEC_PATH"
+echo "  WALK_GATE_EXECUTION=${WALK_GATE_EXECUTION:-auto->fake} WALK_GATE_SEQLEN=${WALK_GATE_SEQLEN:-8} PRISMAQUANT_WALK_GATE_OVERRIDE=${PRISMAQUANT_WALK_GATE_OVERRIDE:+<set>}"
 echo "  PRISMAQUANT_NVFP4_SCALE_RULE=${PRISMAQUANT_NVFP4_SCALE_RULE:-static_6}"
 echo "  PRODUCTION_CACHE_LRU_GB=$PRODUCTION_CACHE_LRU_GB PRODUCTION_CACHE_PREFETCH=$PRODUCTION_CACHE_PREFETCH"
 echo "  VALIDATED_FRONTIER_SKIP_CALIB=$VALIDATED_FRONTIER_SKIP_CALIB VALIDATED_FRONTIER_DATASET=$VALIDATED_FRONTIER_DATASET"
@@ -2550,6 +2551,46 @@ print(f"[pipeline] [3c] additivity stamped into {cost_path}: "
 PY
   fi
 fi
+
+# -----------------------------------------------------------------------
+# [3d] Discovery-walker export gate (R5; §8.8 +
+# docs/design/model_coverage_ledgers.md).
+#
+# The pipeline's decision universe used to be defined by the pipeline's own
+# enumeration — the exact hole `attn.wo_a` shipped through (17.9% of DSv4
+# decode read traffic, fed by a grouped einsum on a module class the probe
+# skips, never an allocator decision, every coverage stat still green). This
+# stage re-derives the universe from the object itself: module tree plus one
+# FakeTensorMode forward over a META load (no GPU, no weight I/O), every node
+# claimed decide/pin/exclude by the profile's walk_claim_rules().
+#
+# FAIL-CLOSED: exit 2 refuses the run before ANY export lane starts. A refusal
+# is decided from STRUCTURED fields only (failure kinds; per-node op/equation/
+# module lists in artifacts/model_walk.json) — never prose. An explicit
+# PRISMAQUANT_WALK_GATE_OVERRIDE=<reason> excuses TRACE INCOMPLETENESS ONLY
+# (e.g. DSv4's data-dependent scalar aborting the fake trace); it is stamped
+# into the report and NEVER excuses an unclaimed node — claims are pinned with
+# reasons in ModelProfile.walk_claim_rules(), not waived at export time.
+# -----------------------------------------------------------------------
+: "${WALK_GATE_SEQLEN:=8}"
+# auto->fake: the fake trace is the intended cheap path; an abort becomes a
+# structured incomplete-trace refusal (override env or --execution real via a
+# manual gate run), never a silent pass.
+: "${WALK_GATE_EXECUTION:=fake}"
+: "${PRISMAQUANT_WALK_GATE_OVERRIDE:=}"
+MODEL_WALK_REPORT="${WORK_DIR}/artifacts/model_walk.json"
+echo "[pipeline] [3d] discovery-walker export gate ..."
+WALK_GATE_ARGS=(
+  python3 -m prismaquant.model_walk
+  --model "$MODEL_PATH"
+  --execution "$WALK_GATE_EXECUTION"
+  --seq-len "$WALK_GATE_SEQLEN"
+  --output "$MODEL_WALK_REPORT"
+)
+[[ -n "$PRISMAQUANT_WALK_GATE_OVERRIDE" ]] && WALK_GATE_ARGS+=(
+  --override-reason "$PRISMAQUANT_WALK_GATE_OVERRIDE"
+)
+"${WALK_GATE_ARGS[@]}" 2>&1 | tee "${WORK_DIR}/logs/model_walk.log"
 
 if [[ "$EXPORT_CONTAINER" == "gguf" ]]; then
   # GGUF lane: one artifact serves llama.cpp natively and vLLM via the

--- a/tests/test_model_walk_export_gate.py
+++ b/tests/test_model_walk_export_gate.py
@@ -1,0 +1,557 @@
+"""The discovery-walker export gate + walk-artifact contract (R5).
+
+Proves the pieces `docs/design/model_coverage_ledgers.md` line 11-12 calls
+the open scope, minus the consumer migration:
+
+- the gate REFUSES on an unclaimed matmul-fed node (name + op cited,
+  structured fields only — never prose), on an unresolved floating
+  multiplicand, on an unknown future failure kind (the Tensor-Parallel
+  catch-all), and on a decided-but-unpriced contradiction (the gemma4
+  router polarity class);
+- the override excuses trace incompleteness ONLY — never a claim failure;
+- WalkResult round-trips through save_walk/load_walk fail-closed, with
+  trace-time provenance and the applied claim-rule list in the envelope;
+- every registered profile's claim rules carry the universal router-pin and
+  packed-expert-decide families the R5 sweep found missing;
+- pipeline.py declares the gate stage before export, run-pipeline.sh runs it
+  there, and both wirings are load-bearing (removal turns these red).
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+import pathlib
+
+import pytest
+import torch
+import torch.nn as nn
+
+from prismaquant.model_walk import (
+    BYTE_POLICIES,
+    SCHEMA,
+    WALK_GATE_OVERRIDE_ENV,
+    WALK_GATE_SCHEMA,
+    ClaimRule,
+    LoadedWalk,
+    WalkFailure,
+    WalkGateRefusal,
+    capture_walk_provenance,
+    claim_rules_to_json,
+    evaluate_walk_gate,
+    find_decided_but_unpriced,
+    load_walk,
+    per_device_bytes,
+    require_walk_coverage,
+    save_walk,
+    walk_model,
+)
+from prismaquant.model_walk import _default_example_inputs
+from test_model_walk import (
+    LINEAR_DECIDE,
+    GroupedEinsumToy,
+    WO_A_PIN_REASON,
+    _meta,
+    _toy_inputs,
+)
+
+FULLY_CLAIMED = [
+    ClaimRule("pin", WO_A_PIN_REASON, name_regex=r"^wo_a$"),
+    LINEAR_DECIDE,
+]
+
+
+def _run_pipeline_script() -> str:
+    root = pathlib.Path(__file__).resolve().parents[1]
+    return (root / "prismaquant" / "run-pipeline.sh").read_text()
+
+
+def _walked(**kwargs):
+    model = kwargs.pop("model", None) or _meta(GroupedEinsumToy)
+    return walk_model(
+        model, kwargs.pop("example_inputs", _toy_inputs()),
+        claim_rules=kwargs.pop("claim_rules", FULLY_CLAIMED),
+        strict=False, **kwargs)
+
+
+# ---------------------------------------------------------------- gate
+
+
+def test_gate_refuses_unclaimed_matmul_fed_node_with_name_and_op():
+    """THE acceptance test: no claim rule for wo_a -> the gate refuses, with
+    the node named and the op cited, as STRUCTURED fields. Removing the gate
+    function (or either wiring) turns this file red."""
+    result = _walked(claim_rules=[LINEAR_DECIDE])
+    assert result.failures, "walk must report the unclaimed einsum operand"
+    verdict = evaluate_walk_gate(result)
+    assert verdict.refused
+    assert "unclaimed_node" in verdict.refusal_kinds
+    entry = {
+        "node": "wo_a",
+        "op": "einsum",
+        "equation": "bsgd,grd->bsgr",
+        "module": "",
+    }
+    assert entry in verdict.provenance["unclaimed_matmul_fed_nodes"]
+    with pytest.raises(WalkGateRefusal) as excinfo:
+        require_walk_coverage(result)
+    # The human-facing message names what the structured fields already say.
+    assert "wo_a" in str(excinfo.value)
+    assert "einsum" in str(excinfo.value)
+
+
+def test_fully_claimed_model_passes_the_gate():
+    result = _walked()
+    assert result.ok
+    verdict = evaluate_walk_gate(result)
+    assert not verdict.refused
+    assert verdict.provenance["refusal_kinds"] == []
+    counts = verdict.provenance["claims_by_disposition"]
+    assert counts == {"decide": 1, "pin": 1, "exclude": 0}
+    require_walk_coverage(result)  # does not raise
+
+
+def test_unknown_failure_kind_refuses_fail_closed():
+    """The TP catch-all: a failure kind this gate version does not know must
+    refuse rather than pass. A future 'tp_group_boundary_misaligned' category
+    makes even an UNUPGRADED gate loud."""
+    result = dataclasses.replace(_walked(), failures=(
+        WalkFailure(
+            kind="tp_group_boundary_misaligned",
+            node="model.layers.0.mlp.experts.gate_up_proj",
+            op="linear", equation=None,
+            module="model.layers.0.mlp.experts",
+            detail="group 64 crosses shard boundary at tp_degree=4"),
+    ))
+    verdict = evaluate_walk_gate(result)
+    assert verdict.refused
+    assert "unknown_walk_failure_kind" in verdict.refusal_kinds
+    assert "tp_group_boundary_misaligned" in \
+        verdict.provenance["failure_kinds_seen"]
+    assert "tp_group_boundary_misaligned" in verdict.refusal_reason
+
+
+def test_override_excuses_trace_incompleteness_only():
+    aborted = evaluate_walk_gate(None, trace_status="incomplete")
+    assert aborted.refused
+    assert "incomplete_trace" in aborted.refusal_kinds
+
+    excused = evaluate_walk_gate(
+        None, trace_status="incomplete",
+        trace_error_class="DataDependentOutputException",
+        override_reason="DSA position scalar aborts the fake trace")
+    assert not excused.refused
+    assert excused.provenance["override"] == {
+        "env": WALK_GATE_OVERRIDE_ENV,
+        "reason": "DSA position scalar aborts the fake trace",
+    }
+
+    # ...but an override can NEVER excuse a claim failure.
+    unclaimed = _walked(claim_rules=[LINEAR_DECIDE])
+    still_refused = evaluate_walk_gate(unclaimed, override_reason="try me")
+    assert still_refused.refused
+    assert "unclaimed_node" in still_refused.refusal_kinds
+    assert still_refused.provenance.get("override_excused_trace_only") is None
+
+
+def test_verdict_is_independent_of_prose_detail_strings():
+    """House rule: the gate branches on structured fields, never prose."""
+    base = _walked(claim_rules=[LINEAR_DECIDE])
+    shouted = dataclasses.replace(base, failures=tuple(
+        dataclasses.replace(f, detail=f.detail.upper() + "!!!")
+        for f in base.failures))
+    assert evaluate_walk_gate(base).provenance == \
+        evaluate_walk_gate(shouted).provenance
+
+
+def test_byte_accounting_declares_total_logical_convention():
+    verdict = evaluate_walk_gate(_walked())
+    accounting = verdict.provenance["byte_accounting"]
+    assert accounting["convention"] == "total_logical_tensor_bytes"
+    assert "shard_policy" in accounting  # the named, reserved TP seam
+    assert verdict.provenance["decision_unit"] == "whole_logical_tensor"
+
+
+def test_scope_is_structured_and_stamped():
+    verdict = evaluate_walk_gate(_walked(), scope={
+        "profile": "qwen3", "rules_source": "profile"})
+    assert verdict.provenance["scope"]["profile"] == "qwen3"
+
+
+# ------------------------------------------------------------- byte seam
+
+
+def test_per_device_bytes_seam():
+    assert per_device_bytes(100, 1, "replicated") == 100   # identity at tp=1
+    assert per_device_bytes(100, 1, "sharded_evenly") == 100
+    assert per_device_bytes(100, 4, "replicated") == 100
+    assert per_device_bytes(100, 4, "sharded_evenly") == 25
+    with pytest.raises(ValueError):  # non-dividing shard boundary is loud
+        per_device_bytes(100, 3, "sharded_evenly")
+    for bad_call in (
+        lambda: per_device_bytes(100, 0, "sharded_evenly"),
+        lambda: per_device_bytes(100, 2, "row"),       # no silent policies
+        lambda: per_device_bytes(100, 2, ""),          # ...and no default
+    ):
+        with pytest.raises(ValueError):
+            bad_call()
+    assert set(BYTE_POLICIES) == {"replicated", "sharded_evenly"}
+
+
+# --------------------------------------------------- artifact extensions
+
+
+def test_save_load_roundtrip_preserves_the_result_payload(tmp_path):
+    result = _walked()
+    provenance = result.provenance
+    assert provenance is not None
+    path = save_walk(result, tmp_path / "walk.json", provenance=provenance)
+    loaded = load_walk(path, expect_claim_rules=FULLY_CLAIMED)
+    assert isinstance(loaded, LoadedWalk)
+    assert json.dumps(loaded.result.to_json_dict(), sort_keys=True) == \
+        json.dumps(result.to_json_dict(), sort_keys=True)
+    assert loaded.provenance.execution == result.execution
+    assert loaded.provenance.rules_digest_matches(FULLY_CLAIMED)
+
+
+def test_load_walk_refuses_foreign_schema(tmp_path):
+    path = save_walk(_walked(), tmp_path / "walk.json",
+                     provenance=_walked().provenance)
+    payload = json.loads(path.read_text())
+    payload["schema"] = "prismaquant.model_walk.v999"
+    path.write_text(json.dumps(payload))
+    with pytest.raises(ValueError, match="unsupported model-walk schema"):
+        load_walk(path)
+
+
+def test_load_walk_refuses_execution_mismatch(tmp_path):
+    result = _walked()
+    path = save_walk(result, tmp_path / "walk.json",
+                     provenance=result.provenance)
+    payload = json.loads(path.read_text())
+    payload["provenance"]["execution"] = "real"
+    path.write_text(json.dumps(payload))
+    with pytest.raises(ValueError, match="disagrees"):
+        load_walk(path)
+
+
+def test_load_walk_refuses_different_claim_rules_digest(tmp_path):
+    result = _walked()
+    path = save_walk(result, tmp_path / "walk.json",
+                     provenance=result.provenance)
+    other_rules = [ClaimRule("pin", "different policy", name_regex=".*")]
+    with pytest.raises(ValueError, match="different claim rules"):
+        load_walk(path, expect_claim_rules=other_rules)
+    # And the happy direction: matching rules load clean.
+    load_walk(path, expect_claim_rules=FULLY_CLAIMED)
+
+
+def test_provenance_is_captured_at_trace_time():
+    result = _walked()
+    prov = result.provenance
+    assert prov is not None
+    assert prov.execution == "fake"
+    # Explicit inputs are recorded by digest of their shapes/dtypes...
+    assert prov.example_inputs_spec.startswith("provided:")
+    assert prov.seq_len is None
+    # ...and the synthesized default records its contract verbatim (this is
+    # load-bearing: two walks under different input contracts can differ in
+    # trace_coverage when data-dependent control flow executes shape-wise).
+    default_prov = capture_walk_provenance(
+        _meta(GroupedEinsumToy), execution="fake",
+        example_inputs=_default_example_inputs(
+            _meta(GroupedEinsumToy), 8, __import__("torch").device("meta")),
+        seq_len=8, claim_rules=FULLY_CLAIMED, used_default_inputs=True)
+    assert default_prov.example_inputs_spec.startswith(
+        "default:input_ids(1,8)")
+    assert default_prov.seq_len == 8
+    assert prov.torch_version == torch.__version__
+    assert prov.model_identity  # architecture/config digest present
+    assert prov.claim_rules_digest
+    # The applied rule list survives serialization: index, reason, and
+    # predicates recorded by identity (None only where there is none).
+    serialized = claim_rules_to_json(FULLY_CLAIMED)
+    assert [r["index"] for r in serialized] == [0, 1]
+    assert serialized[0]["reason"] == WO_A_PIN_REASON
+    assert all(r["predicate"] is None for r in serialized)
+    with_predicate = claim_rules_to_json([ClaimRule(
+        "pin", "pinned by name predicate",
+        predicate=lambda node: node.name == "wo_a")])
+    identity = with_predicate[0]["predicate"]
+    assert identity["name"] == "<lambda>"
+    assert "test_model_walk_export_gate.py:" in identity["location"]
+
+
+def test_to_json_dict_stays_deterministic_with_provenance_attached():
+    first = _walked()
+    second = walk_model(
+        _meta(GroupedEinsumToy), _toy_inputs(),
+        claim_rules=FULLY_CLAIMED, strict=False)
+    assert first.provenance is not None
+    assert second.provenance is not None
+    assert json.dumps(first.to_json_dict(), sort_keys=True) == \
+        json.dumps(second.to_json_dict(), sort_keys=True)
+    # The envelope carries the timestamps; the payload above never does.
+    blob = json.dumps(first.to_json_dict())
+    assert first.provenance.created_utc[:4] not in blob
+
+
+# ------------------------------------------- R5 sweep: claim-rule families
+
+
+class SweepTopKRouter(nn.Module):
+    """The sweep's Finding 1 shape: a bare Parameter fed to F.linear."""
+
+    def __init__(self, experts=8, hidden=8):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(experts, hidden))
+
+    def forward(self, x):
+        return torch.nn.functional.linear(x.float(), self.weight.float())
+
+
+class SweepExperts(nn.Module):
+    """Finding 2: one 3-D packed stack consumed by an expert-slice matmul."""
+
+    def __init__(self, rows=8, hidden=8):
+        super().__init__()
+        self.gate_proj = nn.Parameter(torch.empty(rows, hidden, hidden))
+
+    def forward(self, x):
+        return x @ self.gate_proj[0]
+
+
+class SweepModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.router = SweepTopKRouter()
+        self.experts = SweepExperts()
+
+    def forward(self, x):
+        return self.router(x) + self.experts(x)
+
+
+def test_base_rules_claim_router_gates_and_packed_expert_stacks():
+    """End-to-end over the two universal families the R5 sweep found
+    unclaimed on six/seven profiles: with the base rules alone, the router
+    pin and the packed-expert decide cover them and the walk passes."""
+    from prismaquant.model_profiles.default import DefaultProfile
+
+    rules = DefaultProfile().walk_claim_rules()
+    model = _meta(SweepModel)
+    result = walk_model(model, _toy_inputs(features=8), claim_rules=rules)
+    assert result.ok
+    assert result.claims["router.weight"].disposition == "pin"
+    assert "never" in result.claims["router.weight"].reason
+    assert result.claims["experts.gate_proj"].disposition == "decide"
+    assert "packed-expert Fisher path" in \
+        result.claims["experts.gate_proj"].reason
+    # And the discovered edges exist for both (they are genuinely fed).
+    assert any(e.op == "linear" for e in result.edges_for("router.weight"))
+    assert any(e.param == "experts.gate_proj"
+               for e in result.edges_for("experts.gate_proj"))
+
+
+@pytest.mark.parametrize("profile_cls_name", [
+    "Qwen3_5DenseProfile", "Qwen3_5Profile", "Qwen3Profile", "Gemma4Profile",
+    "Lfm2MoeProfile", "MiniMaxM2Profile", "DeepseekV4Profile",
+    "HyV3Profile", "LagunaProfile",
+])
+def test_every_profile_carries_the_sweep_rule_families(profile_cls_name):
+    """Per-profile enablement, provable without instantiating topologies:
+    each profile's applied rule list contains a router pin and a packed-
+    expert decide (its own explicit rule or the base family rule)."""
+    import prismaquant.model_profiles.registry as registry
+
+    cls = getattr(registry, profile_cls_name)
+    profile = cls()
+    rules = claim_rules_to_json(profile.walk_claim_rules())
+    router_pins = [
+        r for r in rules
+        if r["disposition"] == "pin"
+        and "router" in json.dumps(r["reason"] + str(r)).lower()
+    ]
+    expert_decides = [
+        r for r in rules
+        if r["disposition"] == "decide"
+        and "expert" in json.dumps(r["reason"] + str(r)).lower()
+    ]
+    assert router_pins, f"{profile_cls_name} lost its router-pin rule"
+    assert expert_decides, f"{profile_cls_name} lost its expert-decide rule"
+
+
+# ------------------------------------- gemma4 polarity: decided-but-unpriced
+
+
+class RouterBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.router = nn.Linear(8, 8, bias=False)
+
+    def forward(self, x):
+        return self.router(x)
+
+
+class RouterLinearToy(nn.Module):
+    """gemma4's polarity bug shape: the router IS an nn.Linear (so a
+    Linear-decide rule claims it decide) while the probe's baseline name
+    exclusion (\\.router.) removes it from pricing inventory."""
+
+    def __init__(self):
+        super().__init__()
+        self.blk = RouterBlock()
+
+    def forward(self, x):
+        return self.blk(x)
+
+
+def test_decided_but_unpriced_contradiction_refuses():
+    from prismaquant.model_profiles.default import DefaultProfile
+
+    model = _meta(RouterLinearToy)
+    inputs = (_toy_inputs(features=8)[0],)
+    linear_rule = ClaimRule(
+        "decide", "nn.Linear weight", leaf="weight", module_class="Linear")
+    result = walk_model(model, inputs, claim_rules=[linear_rule],
+                        strict=False)
+    assert result.ok  # the CLAIM table alone sees no problem...
+    entries = find_decided_but_unpriced(result, model, DefaultProfile())
+    assert [e["reason_code"] for e in entries] == ["probe_linear_excluded"]
+    assert entries[0]["node"] == "blk.router.weight"
+
+    verdict = evaluate_walk_gate(result, unpriced_decides=entries)
+    assert verdict.refused
+    assert "decided_but_unpriced_node" in verdict.refusal_kinds
+    assert "blk.router.weight" in verdict.refusal_reason
+
+    # The fix is correcting the CLAIM to a pin (as the base router rule now
+    # does), which clears the contradiction without weakening anything:
+    pinned = walk_model(model, inputs, claim_rules=[
+        ClaimRule("pin", "routing logits; never priced",
+                  predicate=lambda n: "router" in n.name.lower()),
+        linear_rule,
+    ], strict=False)
+    assert pinned.ok
+    assert pinned.claims["blk.router.weight"].disposition == "pin"
+    assert find_decided_but_unpriced(pinned, model, DefaultProfile()) == ()
+    require_walk_coverage(pinned, unpriced_decides=())
+
+
+# ---------------------------------------------------------------- CLI
+
+
+@pytest.mark.slow
+def test_dsv4_real_topology_passes_the_gate_end_to_end():
+    """The motivating model, through the whole gate: shrunken real-DSv4
+    topology, real CPU forward, profile rules -> gate PASSES, wo_a's family
+    is pinned, and the decided-but-unpriced checker finds nothing (the sweep
+    verified DSv4's claim set complete; this holds it there)."""
+    import sys
+
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+    from test_model_walk import _shrunken_dsv4
+
+    profile, model = _shrunken_dsv4()
+    result = walk_model(
+        model, execution="real", seq_len=16,
+        claim_rules=profile.walk_claim_rules())
+    assert result.ok
+    assert all(
+        c.disposition == "pin" for n, c in result.claims.items()
+        if ".wo_a." in n)
+    verdict = evaluate_walk_gate(
+        result,
+        unpriced_decides=find_decided_but_unpriced(result, model, profile),
+        scope={"profile": "deepseek_v4", "rules_source": "profile"},
+    )
+    assert not verdict.refused
+    assert verdict.provenance["scope"]["profile"] == "deepseek_v4"
+    require_walk_coverage(result, unpriced_decides=find_decided_but_unpriced(
+        result, model, profile))
+
+
+# ---------------------------------------------------------------- CLI
+
+
+@pytest.fixture(scope="module")
+def tiny_qwen3_dir(tmp_path_factory):
+    from transformers import AutoConfig, AutoModelForCausalLM
+
+    cfg = AutoConfig.for_model(
+        "qwen3", vocab_size=128, hidden_size=64, intermediate_size=128,
+        num_hidden_layers=2, num_attention_heads=4, num_key_value_heads=2,
+        head_dim=16, max_position_embeddings=64, rope_theta=10000.0,
+        attention_dropout=0.0, tie_word_embeddings=False,
+        pad_token_id=0, bos_token_id=1, eos_token_id=2,
+    )
+    d = tmp_path_factory.mktemp("cli") / "tiny-qwen3"
+    AutoModelForCausalLM.from_config(cfg).save_pretrained(d)
+    return d
+
+
+def test_cli_passes_clean_checkpoint_and_writes_structured_report(
+        tiny_qwen3_dir):
+    from prismaquant.model_walk import main
+
+    out = tiny_qwen3_dir / "model_walk.json"
+    rc = main(["--model", str(tiny_qwen3_dir),
+               "--output", str(out), "--rules", "profile"])
+    assert rc == 0
+    report = json.loads(out.read_text())
+    assert report["schema"] == WALK_GATE_SCHEMA
+    assert report["walk_artifact_schema"] == SCHEMA
+    assert report["gate"]["refused"] is False
+    assert report["gate"]["scope"]["profile"] == "qwen3"
+    assert report["gate"]["scope"]["router_pin_rules"] >= 1
+    assert report["provenance"]["execution"] == "fake"
+    assert report["provenance"]["seq_len"] == 8
+    assert any(
+        r["predicate"] for r in report["provenance"]["claim_rules"])
+
+
+def test_cli_refuses_when_no_rules_claim_the_model(tiny_qwen3_dir):
+    from prismaquant.model_walk import main
+
+    out = tiny_qwen3_dir / "refuse.json"
+    rc = main(["--model", str(tiny_qwen3_dir),
+               "--output", str(out), "--rules", "none"])
+    assert rc == 2
+    report = json.loads(out.read_text())
+    assert report["gate"]["refused"] is True
+    assert "unclaimed_node" in report["gate"]["refusal_kinds"]
+    first = report["gate"]["unclaimed_matmul_fed_nodes"][0]
+    assert {"node", "op", "equation", "module"} <= set(first)
+
+
+# ------------------------------------------------------------ wiring
+
+
+def test_pipeline_contract_places_the_gate_before_export():
+    from prismaquant.pipeline import default_production_pipeline_spec
+
+    spec = default_production_pipeline_spec()
+    names = [stage.name for stage in spec.stages]
+    assert "export.walk_coverage_gate" in names
+    assert names.index("export.walk_coverage_gate") < \
+        names.index("export.native_compressed")
+    assert spec.validate().ok
+    stage = {s.name: s for s in spec.stages}["export.walk_coverage_gate"]
+    assert stage.metadata["schema"] == WALK_GATE_SCHEMA
+    assert stage.metadata["decision_unit"] == "whole_logical_tensor"
+    assert "never_claims" in stage.metadata["override_scope"]
+
+
+def test_run_pipeline_invokes_the_gate_before_every_export_lane():
+    script = _run_pipeline_script()
+    gate_pos = script.find('"${WALK_GATE_ARGS[@]}"')
+    assert gate_pos > 0, "run-pipeline.sh no longer executes the walk gate"
+    for exec_line in (
+        '"${GGUF_EXPORT_ARGS[@]}"',
+        '"${CB_EXPORT_ARGS[@]}"',
+        '"${EXPORT_ARGS[@]}"',
+    ):
+        pos = script.find(exec_line)
+        assert pos > 0, f"export invocation vanished: {exec_line}"
+        assert gate_pos < pos, \
+            f"the walk gate must precede the export lane ({exec_line})"
+    # Real wiring, not a comment:
+    assert "python3 -m prismaquant.model_walk" in script


### PR DESCRIPTION
Split 1 of 6 from `merge/proven-rescues` (#95). **This is the Walker.** Land this one first — three of the other five stack on it.

## What it does

Closes the remaining open half of the R5 design contract: the discovery walker is now wired as a **fail-closed export gate**, and the walk itself became a cacheable artifact.

`run-pipeline.sh` stage **[3d]** (`python3 -m prismaquant.model_walk`) runs before **every** export lane (GGUF, CB, compressed-tensors) and refuses with `exit 2` on:

- an unclaimed matmul-fed node,
- an unresolved floating multiplicand,
- an unknown walk-failure kind,
- a decided-but-unpriced contradiction.

It decides from **structured** fields only (`artifacts/model_walk.json`, gate schema `prismaquant.model_walk_gate.v1`). Prose `detail`/`refusal_reason` fields explain to humans; nothing branches on them (principle 14).

`PRISMAQUANT_WALK_GATE_OVERRIDE=<reason>` excuses **trace incompleteness only** — DSv4's data-dependent scalar aborts the fake trace — and is stamped into the verdict. Claim failures have no override: they are fixed by pinning with a reason in `ModelProfile.walk_claim_rules()`.

Same change: walks are persisted under `SCHEMA prismaquant.model_walk.v1` with an atomic write and a fail-closed reload (foreign schema, execution mismatch, or claim-rule digest mismatch all refuse), carrying trace-time provenance — model and config identity, package versions, input contract — plus the serialized applied rule list. Byte semantics are pinned as LOGICAL-TOTAL behind a `per_device_bytes(total, tp_degree, policy)` seam for tensor parallelism.

The R5 profile sweep's findings land in the universal base rules: MoE router gates are pinned and packed expert stacks are decided. Six or seven profiles had them unclaimed, and gemma4's router was **decided-but-never-priced** — the wrong polarity inside the claim table itself. The gate turns that contradiction class into a refusal so it cannot recur silently.

## Why it is worth landing

This is the piece that finds eligible tensors. Before it, a matmul-fed weight nobody claimed simply shipped at source precision and nobody was told. `find_decided_but_unpriced` is the part that matters most: it catches the class of bug where the claim table and the pricing path disagree, which is how `wo_a` stayed unpriced (see #103) and how gemma4's router was mis-polarised.

## What it touches that is live

`prismaquant/model_walk.py` is **not** a new module — `origin/main` already imports it from `model_profiles/base.py`, `deepseek_v4.py` and `glm5_next.py`. This is a `+1094/-4` extension of live code, so I checked the blast radius explicitly:

- The **only** symbol those three consumers import is `ClaimRule`. Its dataclass body and `apply_claim_rules` are **byte-identical to main** (verified by diffing the extracted definitions).
- The four removed lines are a field comment, a signature rewrap, and a guard hoist — no removed behaviour.
- `model_profiles/base.py` gains exactly two appended `ClaimRule`s (between the `ndim<=1` exclude and the final Linear-decide rule) plus a `9 -> 11` docstring renumber. Nothing else in the file moves.
- `pipeline.py` (+44) and `run-pipeline.sh` (+41) add the stage; no existing stage changes.

## Dependencies

- **None.** This is the base of the stack.
- Depended on by: `rescue/name-projection` (hard — three `test_name_projection.py` tests build a walk that only claims packed expert stacks after this PR's rule) and `rescue/grouped-woa` (hard — its tests extend `test_model_walk_export_gate.py`, and its frozen digest covers this PR's `base.py`).

## Tests

`origin/main` (`8461ae2`) baseline, **measured on that exact commit**: **5494 passed, 143 skipped, 3 xfailed, 179 subtests passed, 0 failed** — `EXIT=0`, fully green (14m22s).
Identical to the earlier `4cd8d39` baseline, as expected: the three commits `main` gained
mid-split (`1d35f70`, `22db4fb`, `8461ae2`) touch only `.github/`, `pyproject.toml` and
`docs/` — **zero delta under `prismaquant/`, `tests/`, `tools/` or `scripts/`**, verified by diff.
Note for the reviewer: the brief for this split warned of "4 pre-existing aarch64 failures".
They **do not reproduce** — #90 and #94 already fixed them — so every failure below is attributable. (Note for the record: the "4 pre-existing aarch64 failures" that were flagged to me do **not** reproduce on this commit — #90 and #94 fixed them. Any failure below is attributable.)

This branch: **2 failed, 5522 passed**, 143 skipped, 3 xfailed, 179 subtests passed (20m20s, `-p no:randomly`, `CUDA_VISIBLE_DEVICES=""`). Both failures are the DSv4 W8A16 freeze gate documented below; **everything else is green**, including `tests/test_run_pipeline_gates_execute.py` and both doc gates.

## ⚠️ Known red: the DSv4 W8A16 freeze gate

`tests/test_dsv4_w8a16_export_handoff.py` fails 2 tests, naming exactly one file:

```
frozen exporter/source closure changed (1 of 15 file(s)):
prismaquant/model_profiles/base.py;
observed=7cff3a4af253777d831094838a35ec56b9cd5e4c1022654431449163be8a848e,
expected=147699331599870a8ba153ae5132f5bda1f32f5ba4e0298a784c3084df05207a
```

**This is the gate working, not a defect in the split.** `base.py` is in the frozen export-source closure, so any change to it must be re-frozen *with review*. I did not re-stamp it: blind re-stamping is precisely what the gate exists to prevent, and the sandbox blocked me from editing that region anyway.

The review already exists. It was written on `merge/proven-rescues` (2026-08-22) and I **re-verified it against these rebased bytes**:

> `walk_claim_rules()` appended two ClaimRules between the `ndim<=1` exclude and the final Linear-decide rule (a router-class pin and an `*Experts` packed-stack decide; docstring renumbered 9→11). Nothing else in the file moved. The method's only consumer is the R5 discovery walker and its tests — a grep over this closure finds no other caller, so exporter, completeness, decode-source, and namespace behaviour cannot observe the change. On the DSv4 walk itself the rules are strictly shadowed or equivalent: `DeepseekV4Profile` prepends its own per-class router pins ahead of `super()`, first-match keeps the original disposition and reason for every node both rules match, and the R5 sweep verified every router-family node on the vendored topology was already pinned; the packed-expert decide matches owner classes containing "expert", but this lane swaps packed classes for per-expert `nn.Linear`s before instantiation, whose weights the Linear rule already claimed with the same disposition. Net: byte-identical claims on the shipped DSv4 topology; additional coverage only on architectures that previously had NO claim at all.

Re-verification on the rebase: `git diff origin/main -- prismaquant/model_profiles/base.py` on this branch is exactly the two appended ClaimRules plus the docstring renumber, and no other hunk.

**To clear it:** set `prismaquant/model_profiles/base.py` to `7cff3a4af253777d831094838a35ec56b9cd5e4c1022654431449163be8a848e` in `_FROZEN_EXPORT_SOURCE_SHA256` and add the review note above. One edit, reviewer's call.


## Merge-order note (applies to all six)

Every PR in this split adds its own stamp to the top of `docs/ARCHITECTURE.md`'s
provenance block (principle 13). Whichever merges second will therefore hit a
**textual conflict in that block and nowhere else** — resolution is to keep both
stamps, newest first. Verified by merging all six together: `docs/ARCHITECTURE.md`
is the *only* conflicting path across the entire split. **Zero code conflicts.**

---

Extracted from `merge/proven-rescues` commit `1dca4c2`. `merge/proven-rescues` is left in place as the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F46Tr8Az6t2Ky3sRExZ5y
