### PR TITLE
refactor(names): one shared name-projection layer, and all four consumers on it

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,72 @@
 # PrismaQuant Architecture
 
-As of: 2026-08-29 · `rescue/walker-export-gate` — stamps follow, newest
+As of: 2026-08-29 · `rescue/name-projection` — stamps follow, newest
 first, each recording its own branch and date. Re-stamped (2026-08-29,
-`rescue/walker-export-gate`) for
+`rescue/name-projection`) for
+**the cost consumer migrating onto the shared name-projection layer** (§8.8.1):
+`_scan_source_dtype_manifest` lost its private checkpoint→live→recipe builders
+(`_strip_weight_suffix`, `_to_recipe_name`, `_packed_to_recipe_name`,
+`_per_expert_packed_recipe_name`) and now projects every source-kind row
+through `NameProjection.checkpoint_to_live` / `recipe_unit` /
+`packed_parent_of_expert_param` (`prismaquant/allocator_candidates.py`);
+`decision_units._recipe_name` is retired for
+`name_projection.strip_weight_leaf`, as is the inline leaf surgery in
+`production_render_cost.canonical_cost_name` (whose umbrella-infix half stays
+a total normalizer — render/cost payloads key costed MTP rows physically,
+which a declining projection must never drop) and `measure_quant_cost`'s
+act-cache candidate builder. Emitted values are UNCHANGED for existing
+profiles and artifacts — the manifest's profile=None convention now builds
+over the repo's declared generic baseline (`DefaultProfile`, the substitution
+`resolve_cost_target_name` always made) instead of inlined string surgery.
+One deliberate behavior change, fail-closed only: a profile accessor that
+RAISES now propagates `NameProjectionError` instead of silently skipping the
+row (the wo_a shape); MTP rows stay recipe-native verbatim by an explicit,
+commented short-circuit pending a profile declaration of recipe-native
+checkpoint prefixes. Probe, footprint, and read-traffic remain unmigrated.
+Previously re-stamped (2026-08-22, `walker/consumer-probe`) for **the probe
+consumer migrating onto the shared name-projection layer** (§8.8.1): `FisherAccumulator`
+now builds one `NameProjection`, and the probe holds no private name mapping — the
+packed-expert shard-scope filter reads its block id through `NameProjection.block_id`
+(previously a positional `[:3]` qname slice of its own; value-identical on every qname
+shape reachable at that site, pinned by `tests/test_consumer_probe_name_projection.py`),
+and the Fisher skip set keys its embedding clause on the profile's declared
+`ModelProfile.embedding_name()` (previously a hardcoded `"model.embed_tokens"` substring
+test). Probe stats keys, inventories, and shard regexes are untouched, and the regression
+baseline is byte-identical; the walk-edge-list migration itself stays open for all four
+consumers.
+Previously re-stamped (2026-08-22, `walker/consumer-footprint`) for **the
+second R5 consumer migration**: `footprint.py` holds no private name mapping anymore — its
+private `.weight` strips and its packed-expert parser (`packed_expert_alias` + the legacy
+parent fallback, now defined in `name_projection.py` and re-exported) are the shared
+layer's; `source_tensor_bytes_manifest` / `floor_bytes_for_model` accept a prebuilt
+`NameProjection` (keyword-only, mutually exclusive with the raw accessor kwargs), map
+checkpoint keys through `checkpoint_to_live`, keep the profile's DECLARED drops as raw-key
+floor entries (data, not exceptions), and propagate layer refusals instead of swallowing
+them. Emitted bytes are unchanged — projection/accessor parity is pinned test-side.
+Previously re-stamped (2026-08-22, `walker/consumer-readtraffic`) for
+**the first name-projection consumer migration: read-traffic**
+(`prismaquant/read_traffic.py`). Both entry points build one
+`NameProjection(profile)` and route every checkpoint→live question through
+it: the classifier's decline-to-map rule branches on
+`ProjectedName.outcome == declared_out_of_graph` (`excluded_non_text_graph`),
+the private `_strip_weight` leaf helper is deleted in favor of
+`strip_weight_leaf`, and a profile accessor that fails now refuses as
+`NameProjectionError` instead of silently passing the raw key through
+(previously it would have re-priced unmappable tensors at p=1). No emitted
+number moves; the class table, byte authorities, and refusals are pinned
+byte-identical by `tests/test_read_traffic.py`. Previously re-stamped
+(2026-08-22, `walker/name-projection`) for
+**the shared name-projection layer** (§8.8.1, `prismaquant/name_projection.py`):
+one profile-routed projection between the live/recipe/checkpoint/export/vLLM
+namespaces, fail-closed with structured refusal codes, explicit
+many→one/one→many shapes for fused siblings and packed experts, round-trip
+identity pinned where the profile's rules are total (Qwen3, Qwen3.5
+multimodal, DSv4 — including the surfaced `hc_head` inverse gap), and no
+rank/shard/degree anywhere in the API (the TP seam stays in
+`model_walk.per_device_bytes`). Consumers are not migrated; the module ships
+with its conformance tests only.
+
+Earlier stamp (2026-08-29, `rescue/walker-export-gate`) for
 **the discovery walker as a fail-closed export gate** (§8.8,
 `prismaquant/model_walk.py`): the R5 design contract's remaining open half —
 wiring the walk as an export gate — is closed; the probe/cost/footprint/
@@ -4663,7 +4727,9 @@ embedding (one row is gathered per token, not the table), **indexed lookup table
 the MTP/draft sidecar (read every token under spec-decode and never without it — the honest
 default is excluded, and `excluded.mtp_bytes` lets a spec-decode serve add it back exactly),
 and anything the model profile's own `checkpoint_to_live_name` declines to map into the live
-text graph (vision/audio towers). `ModelProfile.embedding_name()` (`model_profiles/base.py`, spec key
+text graph (vision/audio towers) — read through the shared name-projection
+layer (§8.8.1), whose `declared_out_of_graph` outcome is what that rule
+branches on. `ModelProfile.embedding_name()` (`model_profiles/base.py`, spec key
 `shard_regexes.embedding_name`) is the twin of `lm_head_name()` and exists so "which
 tensor is the embedding" is a declaration rather than a substring test.
 
@@ -6269,9 +6335,84 @@ inside the claim table — is pinned like every other router; the gate's
 `find_decided_but_unpriced` checker turns that contradiction class into a
 refusal so it cannot recur silently.
 
-Still open per the design doc: migrating probe/cost/footprint/read-traffic
-onto the walker's edge list — separate, deliberate work (the consumption-API
-design lives in the R5 reports).
+Two distinct migrations are in play here, and only one has landed. The
+first wave is the shared **name-projection layer** (below), and as of
+2026-08-29 **all four consumers route their private NAME mappings through
+it**: read-traffic (`walker/consumer-readtraffic`), footprint
+(`walker/consumer-footprint`), probe (`walker/consumer-probe`) and cost
+(`walker/consumer-cost`). No consumer holds its own checkpoint→live→recipe
+string surgery any more. One deliberate exception remains and is not a
+projection: `production_render_cost.canonical_cost_name`'s umbrella-infix half
+stays a **total** normalizer, because render/cost payloads key costed MTP rows
+physically and a projection that may decline must never drop them.
+
+The **edge-list migration proper is still open for all four**, and is the
+larger of the two: every consumer's INVENTORY remains its own enumeration —
+the probe still builds its tracked set from `named_modules()` plus shard
+regexes — so the walker's edge list is not yet the single enumeration the
+stages derive from. Sharing a name projection is not the same as sharing a
+requirement set; the first makes the four agree on what a unit is *called*,
+the second would make them agree on which units *exist*.
+
+#### 8.8.1 The shared name-projection layer
+
+`prismaquant/name_projection.py` (2026-08-22, `walker/name-projection`)
+lands the ONE projection between the pipeline's parameter-name namespaces
+that the R5 consumer analyses each said they were re-deriving ad hoc: a
+Linear's live name (`WalkNode.name`), its allocator/probe recipe name,
+its source-checkpoint key, its exported-artifact key, and its vLLM
+scheme-dispatch qname (`NameProjection`, five `LIVE/RECIPE/CHECKPOINT/
+EXPORT/VLLM` constants). The contract, pinned by
+`tests/test_name_projection.py`:
+
+- **The profile owns the knowledge; the layer owns the discipline.**
+  Every mapping routes through existing `ModelProfile` accessors
+  (`checkpoint_to_live_name`, `live_to_recipe_name`,
+  `to_vllm_internal_name`, `source_tensor_name`, `export_tensor_name`,
+  `fused_sibling_group`, `packed_expert_format_group`) — no second
+  mapping lives anywhere, and consumers keep no private
+  `_recipe_name`/`_strip_weight` helpers (the leaf rule itself is
+  `strip_weight_leaf` here).
+- **Fail closed and loud.** An unmappable or ambiguous name raises
+  `NameProjectionError` with structured fields — `code`
+  (`unmapped_in_universe`, `ambiguous`, `no_universe_supplied`,
+  `malformed_profile_result`, `profile_accessor_failed`,
+  `unknown_namespace`, `unsupported_pair`, `uncovered_unit`),
+  source/target namespace, and what was tried. Unlike
+  `decision_units.fused_group_key`, nothing swallows a profile failure
+  into an identity fallback. The profile's DECLARED drops (visual/MTP/
+  scale keys) are data instead: `project()` returns a `ProjectedName`
+  whose `outcome == declared_out_of_graph`, so read-traffic can classify
+  `excluded_non_text_graph` by branching on a field.
+- **Non-totality is in the type.** Fused siblings and packed experts
+  surface as `ServingGroup(kind, key, members)` with packed precedence
+  over fused for expert stacks; reverse lookups refuse group KEYS rather
+  than returning an arbitrary member; the coverage index mirrors
+  footprint's dual-entry manifest convention so one logical tensor
+  covered by many split checkpoint spellings answers under either
+  naming (`checkpoint_keys_for` / `require_checkpoint_span`, the
+  coverage assertion footprint.md asked for).
+- **Round-trip property tested where the profile's rules are total**:
+  Qwen3 dense (identity), Qwen3.5 multimodal (umbrella-infix rewrite),
+  DSv4 flat naming — plus the recorded gap the round trip SURFACED:
+  DSv4's spec generates `hc_head.hc_*` source spellings while the real
+  checkpoint stores flat `hc_head_*`, so that family's inverse declines;
+  the layer reports it, it does not guess.
+- **TP seam held**: names are logical, whole-tensor facts; no rank,
+  shard index, or degree exists in any signature (a constructor-kwarg
+  refusal test pins this). Byte accounting stays in
+  `model_walk.per_device_bytes`.
+
+Still open per the design doc: migrating the consumers onto the walker's
+EDGE LIST. The first wave of that migration is the shared
+**name-projection layer** (below), and as of 2026-08-29 all four
+consumers route their NAME derivations through it — cost
+(`walker/consumer-cost`), probe (`walker/consumer-probe`), footprint
+(`walker/consumer-footprint`) and read-traffic
+(`walker/consumer-readtraffic`). Their INVENTORIES are still their own
+enumerations — the probe still builds its tracked set from
+`named_modules()` plus shard regexes — so the edge-list migration
+proper remains open for all four.
 
 ## 9. Serving lanes
 

--- a/prismaquant/allocator_candidates.py
+++ b/prismaquant/allocator_candidates.py
@@ -39,6 +39,10 @@ from .footprint import (
     plain_source_dtype_tensor_payload_breakdown,
 )
 from . import trellis_menu
+from .name_projection import (
+    MAPPED,
+    NameProjection,
+)
 from .serving_profiles import (
     SERVING_LANE_SCHEMA,
     check_serving_format,
@@ -2991,95 +2995,19 @@ def _scan_source_dtype_manifest(
         except Exception:
             continue
 
-    def _strip_weight_suffix(name: str) -> str:
-        return name[:-7] if name.endswith(".weight") else name
+    # R5: every namespace mapping below routes through the ONE shared
+    # projection (`name_projection.NameProjection`); this consumer keeps no
+    # private checkpoint->live->recipe builder. A caller with no profile
+    # gets the repo's declared generic baseline — the same substitution
+    # `measure_quant_cost.resolve_cost_target_name` has always made — whose
+    # default `checkpoint_to_live_name` reproduces exactly the hardcoded
+    # visual/audio/MTP-decline + language_model-infix rules this function
+    # used to inline. Unlike those inlined fallbacks, a profile accessor
+    # that now FAILS raises `NameProjectionError` instead of silently
+    # skipping the row (fail-closed; a silent skip here is the wo_a shape).
+    from .model_profiles import DefaultProfile
 
-    def _to_recipe_name(ck_base: str) -> str:
-        if ck_base.startswith("mtp."):
-            # MTP tensors are REAL source tensors stored under the recipe
-            # namespace itself (transformers v5 drops the module; prismaquant
-            # synthesizes it back under the same names, and probe/cost rows
-            # use them verbatim). The historical skip left MTP names with no
-            # source kind, so the BF16 passthrough was dropped
-            # (source_dtype_mismatch) and --mtp-format=BF16 hard-failed the
-            # moment MTP rows were actually costed (35B frontier, 2026-07-02).
-            return ck_base
-        weight_key = f"{ck_base}.weight"
-        if profile is not None:
-            mapper = getattr(profile, "checkpoint_to_live_name", None)
-            if callable(mapper):
-                try:
-                    live_param = mapper(weight_key, multimodal=False)
-                except TypeError:
-                    live_param = mapper(weight_key)
-                except Exception:
-                    live_param = None
-                if live_param is None:
-                    return ""
-                live_qname = _strip_weight_suffix(str(live_param))
-                recipe_mapper = getattr(profile, "live_to_recipe_name", None)
-                if callable(recipe_mapper):
-                    try:
-                        return str(recipe_mapper(live_qname))
-                    except Exception:
-                        return live_qname
-                return live_qname
-        if (ck_base.startswith("model.visual.")
-                or ck_base.startswith("model.audio_tower.")
-                or ck_base.startswith("model.vision_tower.")
-                or ck_base.startswith("model.embed_vision.")
-                or ck_base.startswith("model.embed_audio.")):
-            return ""
-        if ck_base.startswith("model.language_model."):
-            return "model." + ck_base[len("model.language_model."):]
-        return ck_base
-
-    def _packed_to_recipe_name(ck_key: str) -> str:
-        # Packed expert params have no ``.weight`` to fabricate for
-        # checkpoint_to_live_name; checkpoint name == live name modulo the
-        # language_model prefix, then the profile's live->recipe mapping.
-        name = ck_key
-        if name.startswith("model.language_model."):
-            name = "model." + name[len("model.language_model."):]
-        if profile is not None:
-            recipe_mapper = getattr(profile, "live_to_recipe_name", None)
-            if callable(recipe_mapper):
-                try:
-                    return str(recipe_mapper(name))
-                except Exception:
-                    return name
-        return name
-
-    def _per_expert_packed_recipe_name(recipe_name: str) -> str | None:
-        """Map ``experts.E.proj`` source names to the packed recipe unit.
-
-        A per-expert checkpoint and a packed live Transformers module name
-        the same weights at different granularities.  Source-passthrough
-        legality is checked against the live probe/cost key, so recording
-        only the indexed source names makes its source kind look unknown and
-        incorrectly removes BF16 from the expert menu.  The profile owns the
-        projection-to-parent mapping; mixed source kinds fold to ``other`` so
-        no byte-copy format can be admitted for a heterogeneous stack.
-        """
-        if profile is None:
-            return None
-        parent_for = getattr(
-            profile, "packed_expert_parent_for_projection", None)
-        if not callable(parent_for):
-            return None
-        parts = str(recipe_name).split(".")
-        try:
-            experts_idx = len(parts) - 1 - list(reversed(parts)).index(
-                "experts")
-        except ValueError:
-            return None
-        tail = parts[experts_idx + 1:]
-        if len(tail) != 2 or not tail[0].isdigit():
-            return None
-        packed_leaf = parent_for(tail[1])
-        if packed_leaf is None:
-            return None
-        return ".".join(parts[:experts_idx + 1] + [str(packed_leaf)])
+    proj = NameProjection(profile if profile is not None else DefaultProfile())
 
     def _record_source_kind(name: str, source_kind: str) -> None:
         previous = manifest.get(name)
@@ -3124,16 +3052,44 @@ def _scan_source_dtype_manifest(
             source_kind = "unknown"
         else:
             source_kind = dtype.lower()
-        recipe_name = (
-            _packed_to_recipe_name(base) if base in packed_bases
-            else _to_recipe_name(base)
-        )
-        if not recipe_name:
-            continue
+        # MTP tensors are REAL source tensors stored under the recipe
+        # namespace itself (transformers v5 drops the module; prismaquant
+        # synthesizes it back under the same names, and probe/cost rows use
+        # them verbatim — physical key IS the recipe key, the same retention
+        # DSv4's fp8_scale_pairs applies). The historical skip left MTP names
+        # with no source kind, so the BF16 passthrough was dropped
+        # (source_dtype_mismatch) and --mtp-format=BF16 hard-failed the
+        # moment MTP rows were actually costed (35B frontier, 2026-07-02).
+        # This short-circuit is universe-membership policy, not name
+        # projection: no profile accessor declares "which checkpoint
+        # prefixes are recipe-native rows" yet (`source_passthrough_prefixes`
+        # is an EXPORT contract and admits visual prefixes this manifest must
+        # keep declining), so the narrow literal stays until that declaration
+        # exists. Packed expert keys are the suffix-less 3-D spellings
+        # (LFM2.5, Qwen3.6-35B) with no ``.weight`` leaf to fabricate.
+        if base.startswith("mtp."):
+            recipe_name = base
+        else:
+            projected = proj.checkpoint_to_live(
+                base if base in packed_bases else f"{base}.weight")
+            if projected.outcome != MAPPED:
+                continue  # declared out-of-graph: no recipe row exists
+            recipe_name = proj.recipe_unit(projected.target)
         _record_source_kind(recipe_name, source_kind)
-        packed_recipe_name = _per_expert_packed_recipe_name(recipe_name)
-        if packed_recipe_name is not None:
-            _record_source_kind(packed_recipe_name, source_kind)
+        # Fold a per-expert source name's kind onto its packed parent: a
+        # per-expert checkpoint and a packed live module name the same
+        # weights at different granularities, and source-passthrough legality
+        # is checked against the live probe/cost key. The layer reuses
+        # `footprint.packed_expert_alias` with the profile's own mapping;
+        # mixed kinds fold to ``other`` so no byte-copy format can be
+        # admitted for a heterogeneous stack. With NO caller-supplied
+        # profile there is no declared mapping and nothing folds
+        # (historical behavior).
+        packed_parent = (
+            None if profile is None
+            else proj.packed_parent_of_expert_param(recipe_name))
+        if packed_parent is not None:
+            _record_source_kind(packed_parent, source_kind)
     fp8_pairs = None
     if profile is not None:
         pairs_fn = getattr(profile, "fp8_scale_pairs", None)
@@ -3143,14 +3099,8 @@ def _scan_source_dtype_manifest(
             except Exception:
                 fp8_pairs = None
     if fp8_pairs:
-        recipe_mapper = getattr(profile, "live_to_recipe_name", None)
         for live_param in fp8_pairs:
-            live_qname = _strip_weight_suffix(str(live_param))
-            if callable(recipe_mapper):
-                try:
-                    live_qname = str(recipe_mapper(live_qname))
-                except Exception:
-                    pass
+            live_qname = proj.recipe_unit(str(live_param))
             # A profile's ``fp8_scale_pairs`` answers "does this weight have a
             # serialized scale sibling the dequant pass must read", which is
             # true of EVERY block-scaled format — DSv4's MXFP4 experts and its

--- a/prismaquant/decision_units.py
+++ b/prismaquant/decision_units.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from . import format_registry as fr
 from .allocator_candidates import check_format_applicability
+from .name_projection import strip_weight_leaf
 from .serving_profiles import resolve_target_profile
 
 
@@ -118,16 +119,12 @@ def incomplete_fused_group_members(names: Iterable[str], profile) -> set[str]:
     return pinned
 
 
-def _recipe_name(full_name: str) -> str:
-    return full_name[:-7] if full_name.endswith(".weight") else full_name
-
-
 def _enumerate_quantizable_linears(model, profile=None) -> list[str]:
     from .build_rtn_cache import iter_quantizable_tensors
 
     names: list[str] = []
     for full_name, _module, _attr in iter_quantizable_tensors(model, profile):
-        names.append(_recipe_name(full_name))
+        names.append(strip_weight_leaf(full_name))
     return sorted(set(names))
 
 
@@ -136,7 +133,7 @@ def _shape_of_param(model, qname: str, profile=None) -> tuple[int, ...] | None:
 
     target = qname
     for full_name, module, attr in iter_quantizable_tensors(model, profile):
-        if _recipe_name(full_name) == target:
+        if strip_weight_leaf(full_name) == target:
             param = getattr(module, attr, None)
             if param is None:
                 return None
@@ -270,7 +267,7 @@ def _discover_units_from_model_graph(
         return None
 
     shapes_by_name = {
-        _recipe_name(tensor.recipe_name): tensor.shape
+        strip_weight_leaf(tensor.recipe_name): tensor.shape
         for tensor in graph.quantizable_tensors()
     }
     if not shapes_by_name:
@@ -283,9 +280,9 @@ def _discover_units_from_model_graph(
     for opt_unit in graph.optimization_units():
         unit_name = _decision_unit_name_from_graph_unit(opt_unit.id)
         members = tuple(
-            _recipe_name(member)
+            strip_weight_leaf(member)
             for member in opt_unit.members
-            if _recipe_name(member) in shapes_by_name
+            if strip_weight_leaf(member) in shapes_by_name
         )
         if not members:
             continue
@@ -351,8 +348,8 @@ def _target_profile_id(profile, target_profile: str | None) -> str:
 def _decision_unit_name_from_graph_unit(unit_id: str) -> str:
     for prefix in ("fused:", "packed_expert:", "tensor:"):
         if unit_id.startswith(prefix):
-            return _recipe_name(unit_id[len(prefix):])
-    return _recipe_name(unit_id)
+            return strip_weight_leaf(unit_id[len(prefix):])
+    return strip_weight_leaf(unit_id)
 
 
 def _parse_pair_key(key: str) -> tuple[str, str]:

--- a/prismaquant/footprint.py
+++ b/prismaquant/footprint.py
@@ -41,6 +41,16 @@ weight-only W4A16 and ship only the weight scalar.
 :func:`nvfp4_global_sidecar_bytes` adds the exact one- or two-scalar payload
 (per expert × on-disk projection for packed 3-D tensors).
 
+Name derivation is NOT done here. Every mapping between checkpoint keys,
+live allocator qnames, and packed aggregates routes through
+:mod:`prismaquant.name_projection` (the shared R5 layer): the leaf rule is
+its ``strip_weight_leaf``, the per-expert→packed alias is its
+``packed_expert_alias`` (re-exported below for the historic import path),
+and :func:`source_tensor_bytes_manifest` / :func:`floor_bytes_for_model`
+accept a prebuilt ``NameProjection`` so a caller holding a profile gets the
+layer's fail-closed refusals and declared-drop outcomes instead of this
+module re-deriving any of it.
+
 There is exactly ONE way to run that identity: :func:`assignment_artifact_bytes`
 (and :func:`floor_bytes_for_model` for the model-path convenience form, which
 shares the same resolve/check helpers). Every consumer — the byte-budget ship
@@ -65,6 +75,12 @@ from typing import Iterable, Mapping
 
 from . import format_registry as fr
 from .allocator_solver import _shape_from_stats
+from .name_projection import (
+    MAPPED,
+    NameProjection,
+    packed_expert_alias,
+    strip_weight_leaf,
+)
 from .nvfp4_cb_footprint import (
     CBSerializationContext,
     cb_assignment_payload_breakdown,
@@ -267,46 +283,6 @@ def source_regime(by_dtype: Mapping[str, int]) -> str:
 _SIDECAR_SUFFIXES = (".scale", ".weight_scale_inv", ".weight_scale")
 
 
-def _default_expert_parent_for_projection(projection_name: str) -> str | None:
-    """No-profile fallback for the per-expert -> packed projection mapping.
-
-    Mirrors ``ModelProfile.packed_expert_parent_for_projection``'s legacy
-    fallback: per-expert ``gate_proj``/``up_proj`` fuse into the packed
-    ``gate_up_proj`` (output-axis cat, the transformers packed-FusedMoE
-    convention); ``down_proj`` packs 1:1. Anything else (e.g. MiniMax's
-    per-expert ``w1``/``w2``/``w3`` modules, which stay per-expert live)
-    has no packed parent here — callers with a profile should pass its
-    ``packed_expert_parent_for_projection`` instead.
-    """
-    if projection_name in ("gate_proj", "up_proj"):
-        return "gate_up_proj"
-    if projection_name == "down_proj":
-        return "down_proj"
-    return None
-
-
-def packed_expert_alias(qname: str, parent_for_projection=None) -> str | None:
-    """Packed live qname a per-expert Linear aggregates into, or None.
-
-    ``...experts.{i}.{proj}`` -> ``...experts.{parent}`` when
-    ``parent_for_projection(proj)`` names a packed parent
-    (``ModelProfile.packed_expert_parent_for_projection``; the legacy
-    gate/up/down fallback when None). Non-expert names and unrecognized
-    projections return None. This is the same structural
-    ``experts.{idx}.{leaf}`` detection the profile layer uses for
-    packed-format grouping (``packed_expert_format_group``).
-    """
-    parts = str(qname).split(".")
-    if len(parts) < 3 or parts[-3] != "experts" or not parts[-2].isdigit():
-        return None
-    fn = (parent_for_projection if parent_for_projection is not None
-          else _default_expert_parent_for_projection)
-    parent = fn(parts[-1])
-    if not parent:
-        return None
-    return ".".join(parts[:-2] + [str(parent)])
-
-
 class SourceByteManifest(dict):
     """``{live_qname: source_bytes}`` that remembers WHICH spans it summed.
 
@@ -344,15 +320,15 @@ class SourceByteManifest(dict):
 def source_span_identity(checkpoint_key: str) -> str:
     """The SOURCE identity of a checkpoint key: the key without ``.weight``.
 
-    Unique per checkpoint tensor and shared by every live name that covers it
-    (the per-expert entry and the packed aggregate both resolve to it), which
-    is what makes a double charge structurally detectable in
+    The leaf rule is the name-projection layer's (``strip_weight_leaf``,
+    imported above); this historic name is kept as a thin alias because
+    callers outside this module (``read_traffic``) resolve spans by it.
+    Unique per checkpoint tensor and shared by every live name that covers
+    it (the per-expert entry and the packed aggregate both resolve to it),
+    which is what makes a double charge structurally detectable in
     :class:`SourceByteManifest.spans`.
     """
-    return (
-        checkpoint_key[: -len(".weight")]
-        if checkpoint_key.endswith(".weight") else checkpoint_key
-    )
+    return strip_weight_leaf(checkpoint_key)
 
 
 def source_tensor_span_bytes(model_path: str) -> dict[str, int]:
@@ -417,6 +393,8 @@ def source_tensor_bytes_manifest(
     model_path: str,
     name_map=None,
     expert_parent_for_projection=None,
+    *,
+    projection: NameProjection | None = None,
 ) -> SourceByteManifest:
     """Exact on-disk source bytes per weight tensor, keyed by live qname base.
 
@@ -424,10 +402,31 @@ def source_tensor_bytes_manifest(
     byte span with its quantization sidecars (``<base>.scale``,
     ``<base>.weight_scale_inv``, ``<base>.weight_scale``) — exactly the
     bytes the export removes from the checkpoint when it re-encodes that
-    Linear. ``name_map`` maps a checkpoint key to the live transformers
-    parameter name (``ModelProfile.checkpoint_to_live_name``); identity
-    when None. Keys are stored without the ``.weight`` suffix to match
+    Linear. Keys are stored without the ``.weight`` suffix to match
     allocator qnames.
+
+    The name mapping is the shared projection layer's, in one of two
+    mutually exclusive forms:
+
+    - **``projection=NameProjection(...)``** (preferred): every key goes
+      through :meth:`NameProjection.checkpoint_to_live`. A mapped key uses
+      the projected live unit; a DECLARED drop (the profile declines the
+      key by contract — MTP sidecars, visual towers, fp8 scale siblings)
+      keeps its RAW checkpoint spelling, because a live-graph mapper
+      declining a key does NOT mean the tensor has no source bytes. A
+      profile accessor that raises or returns garbage propagates as a
+      structured :class:`NameProjectionError` — never a silent skip.
+      Per-expert spans are aliased into their packed aggregate via
+      :meth:`NameProjection.packed_parent_of_expert_param`.
+    - **``name_map`` / ``expert_parent_for_projection``** (legacy form):
+      the raw ``ModelProfile.checkpoint_to_live_name`` /
+      ``packed_expert_parent_for_projection`` accessors; identity when
+      None. Same semantics, but accessor failures surface as raw
+      exceptions and an empty-string mapper result falls back to the raw
+      key instead of refusing.
+
+    Passing both forms is refused: two name authorities for one manifest
+    is exactly the second-enumeration drift this module must not host.
 
     Both packed-MoE on-disk layouts resolve to the packed allocator names
     (``...experts.gate_up_proj`` / ``...experts.down_proj``):
@@ -438,8 +437,8 @@ def source_tensor_bytes_manifest(
       lands in the manifest under its own name.
     - **Per-expert 2-D on disk** (``...experts.{i}.{proj}.weight``): each
       per-expert span is ALSO accumulated into the packed parent name via
-      :func:`packed_expert_alias` (gate+up fuse into gate_up), driven by
-      ``expert_parent_for_projection``
+      the shared alias primitive (gate+up fuse into gate_up), driven by the
+      projection or by ``expert_parent_for_projection``
       (``ModelProfile.packed_expert_parent_for_projection``; legacy
       gate/up/down fallback when None). The per-expert entries are kept
       alongside the packed aggregate so per-expert-named allocations
@@ -463,6 +462,38 @@ def source_tensor_bytes_manifest(
     manifest is >= 0 by construction (a negative floor is always an
     accounting bug — rejected at the consumers).
     """
+    if projection is not None and (
+            name_map is not None or expert_parent_for_projection is not None):
+        raise ValueError(
+            "[footprint] source_tensor_bytes_manifest: pass EITHER a "
+            "name-projection layer object (projection=NameProjection(...)) "
+            "OR the raw profile accessors (name_map / "
+            "expert_parent_for_projection), never both — one manifest must "
+            "not carry two disagreeing name authorities")
+
+    def _live_and_packed(name: str) -> tuple[str, str | None]:
+        # THE one name mapping, owned by prismaquant.name_projection:
+        # checkpoint key -> live allocator unit qname, with the profile's
+        # DECLARED drops kept under their raw checkpoint spelling and each
+        # per-expert span aliased into its packed aggregate.
+        if projection is not None:
+            projected = projection.checkpoint_to_live(name)
+            live = (projected.target if projected.outcome == MAPPED
+                    else strip_weight_leaf(name))
+            return live, projection.packed_parent_of_expert_param(live)
+        # Legacy accessor form: `or name` keeps a DECLINED key's bytes in
+        # the manifest under the raw checkpoint spelling (the MTP case:
+        # transformers v5 dropped the module, so the Qwen profiles decline
+        # `mtp.*`, while the exporter still re-encodes them from exactly
+        # these bytes and the allocator assigns them under raw names).
+        # Inert for tensors nothing re-encodes: the floor is
+        # `checkpoint_total - sum(resolved re-encoded spans)`, so a
+        # manifest entry no `reencoded_names` member references never
+        # moves it.
+        live = strip_weight_leaf(
+            (name_map(name) if name_map is not None else name) or name)
+        return live, packed_expert_alias(live, expert_parent_for_projection)
+
     out = SourceByteManifest()
     provenance: dict[str, set[str]] = {}
 
@@ -478,25 +509,12 @@ def source_tensor_bytes_manifest(
         # Packed 3-D expert params have no ".weight" suffix; the key IS the
         # base (and its sidecars still hang off `<base>.scale` etc.).
         base = source_span_identity(name)
-        # A live-graph mapper declining a key does NOT mean the tensor has no
-        # source bytes, so it must not drop out of the manifest: MTP sidecars
-        # are the live case (transformers v5 removed the module, so
-        # `checkpoint_to_live_name("mtp.fc.weight")` is None on the Qwen
-        # profiles) while the exporter still re-encodes `mtp.*` from exactly
-        # these bytes, and the allocator assigns them under their raw names.
-        # Fall back to the checkpoint key so such a name resolves. This is
-        # inert for tensors nothing re-encodes: the floor is
-        # `checkpoint_total - sum(resolved re-encoded spans)`, so a manifest
-        # entry no `reencoded_names` member references never moves it.
-        live = (name_map(name) if name_map is not None else name) or name
-        if live.endswith(".weight"):
-            live = live[: -len(".weight")]
-        # `base` (the checkpoint key without .weight) is the SOURCE identity:
-        # unique per checkpoint tensor, and shared by the per-expert entry and
-        # the packed aggregate that both cover it. That shared key is what
-        # makes the double-charge structurally detectable.
+        # `base` is the SOURCE identity: unique per checkpoint tensor, and
+        # shared by the per-expert entry and the packed aggregate that both
+        # cover it. That shared key is what makes the double charge
+        # structurally detectable.
+        live, packed = _live_and_packed(name)
         _add(live, total, base)
-        packed = packed_expert_alias(live, expert_parent_for_projection)
         if packed is not None:
             _add(packed, total, base)
     out.spans = {k: frozenset(v) for k, v in provenance.items()}
@@ -681,8 +699,8 @@ def resolve_reencoded_source_bytes(
     for qname in reencoded_names:
         key = qname
         nb = manifest.get(key)
-        if nb is None and qname.endswith(".weight"):
-            key = qname[: -len(".weight")]
+        if nb is None:
+            key = strip_weight_leaf(qname)
             nb = manifest.get(key)
         if nb is None:
             missing.append(qname)
@@ -1146,8 +1164,8 @@ def assignment_artifact_bytes(
                 source_manifest, passthrough_names, context=context)
     for qname, fmt in assignment.items():
         entry = stats.get(qname)
-        if entry is None and qname.endswith(".weight"):
-            entry = stats.get(qname[: -len(".weight")])
+        if entry is None:
+            entry = stats.get(strip_weight_leaf(qname))
         if not isinstance(entry, dict):
             missing_stats.append(qname)
             continue
@@ -1279,6 +1297,7 @@ def floor_bytes_for_model(
     regime: str | None = None,
     name_map=None,
     expert_parent_for_projection=None,
+    projection: NameProjection | None = None,
 ) -> dict:
     """Compute the non-quantizable floor (and the scalars to reuse) from a model.
 
@@ -1294,19 +1313,23 @@ def floor_bytes_for_model(
     so it never needs the regime-wide per-param rate); a name the manifest
     cannot resolve is a hard error (:func:`resolve_reencoded_source_bytes`) —
     an unresolved name would silently over-count the artifact.
-    ``name_map`` / ``expert_parent_for_projection`` are the profile's
-    ``checkpoint_to_live_name`` / ``packed_expert_parent_for_projection``
-    (pass them for any packed-MoE architecture; defaults handle the
-    identity naming and the legacy gate/up/down packing). ``regime``
-    defaults to :func:`source_regime` (robust fp8/bf16 detection) and is
-    returned for reporting. ``stats`` is retained for call compatibility
-    (shapes are no longer needed to price source bytes).
+    The name mapping goes to the shared projection layer: pass
+    ``projection=NameProjection(...)`` (fail-closed refusals, declared-drop
+    outcomes) OR the legacy ``name_map`` /
+    ``expert_parent_for_projection`` accessor pair — never both (see
+    :func:`source_tensor_bytes_manifest`). Pass the profile's accessors for
+    any packed-MoE architecture; defaults handle identity naming and the
+    legacy gate/up/down packing. ``regime`` defaults to
+    :func:`source_regime` (robust fp8/bf16 detection) and is returned for
+    reporting. ``stats`` is retained for call compatibility (shapes are no
+    longer needed to price source bytes).
     """
     total, by_dtype = source_checkpoint_bytes(model_path)
     reg = regime if regime is not None else source_regime(by_dtype)
     manifest = source_tensor_bytes_manifest(
         model_path, name_map=name_map,
-        expert_parent_for_projection=expert_parent_for_projection)
+        expert_parent_for_projection=expert_parent_for_projection,
+        projection=projection)
     reenc_by_name = resolve_reencoded_source_bytes(
         manifest, reencoded_names, context="floor_bytes_for_model")
     reenc_src = sum(reenc_by_name.values())

--- a/prismaquant/measure_quant_cost.py
+++ b/prismaquant/measure_quant_cost.py
@@ -41,6 +41,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from . import format_registry as fr
+from .name_projection import strip_weight_leaf
 from .nvfp4_cb_footprint import (
     cb_fields_for_context,
     cb_cost_provenance,
@@ -320,8 +321,9 @@ def cb_render_provenance_for_results(
     source_weights: dict[str, torch.Tensor] = {}
     for param_name, param in model.named_parameters():
         candidates = [str(param_name)]
-        if str(param_name).endswith(".weight"):
-            candidates.append(str(param_name)[:-7])
+        module_spelling = strip_weight_leaf(str(param_name))
+        if module_spelling != str(param_name):
+            candidates.append(module_spelling)
         for candidate in candidates:
             resolved = resolve_cost_target_name(candidate, targets, profile)
             if resolved in targets and resolved not in source_weights:

--- a/prismaquant/name_projection.py
+++ b/prismaquant/name_projection.py
@@ -1,0 +1,869 @@
+"""One shared projection between PrismaQuant's parameter-name namespaces.
+
+A Linear in this pipeline has four names, and until this module every
+consumer re-derived the mapping between them ad hoc — which is how a
+weight consumed through a skipped module class (DSv4's ``attn.wo_a``)
+could stay invisible to the allocator while its bytes shipped. This
+module is the ONE projection layer: after it lands, no consumer keeps a
+private name mapping.
+
+The namespaces (all names are LOGICAL — whole-tensor, device- and
+rank-independent; see "Tensor Parallelism" below):
+
+* ``live``      — loaded-transformers parameter names, exactly what
+  :attr:`prismaquant.model_walk.WalkNode.name` carries
+  (``model.layers.0.self_attn.q_proj.weight``). Tensor spelling: the
+  parameter leaf is part of the name.
+* ``recipe``    — allocator/probe/stats/assignment qnames
+  (``model.layers.0.self_attn.q_proj``, module spelling without the
+  leaf). This is the namespace probe stats rows, format plans,
+  assignment dicts and cost tables key on.
+* ``checkpoint``— SOURCE safetensors tensor keys (the floor's byte
+  authority). Tensor spelling.
+* ``export``    — exported-artifact safetensors keys written by an
+  export lane. Tensor spelling. May intentionally differ from
+  ``checkpoint`` (packed-expert splitting, multimodal conventions).
+* ``vllm``      — vLLM-internal module qnames that scheme dispatch
+  compares against at load time. Module spelling.
+
+Every mapping routes through :class:`prismaquant.model_profiles.base.ModelProfile`
+accessors — the profile owns the knowledge, this module owns the
+discipline:
+
+* **Fail closed and loud.** A name with no mapping raises
+  :class:`NameProjectionError` carrying structured fields (name,
+  source and target namespace, a machine-readable ``code``, and what
+  was tried). No silent ``None``, no best-effort guess.
+* **Declared drops are data, not failures.**
+  ``checkpoint_to_live_name`` returns ``None`` BY CONTRACT for keys
+  outside the live graph (visual towers, MTP sidecars, FP8 scale
+  siblings). That outcome is surfaced as
+  :data:`DECLARED_OUT_OF_GRAPH` on a :class:`ProjectedName` so callers
+  branch on a field, never on prose.
+* **Non-totality lives in the type.** Where one logical tensor spans
+  several spellings or several tensors collapse into one serving unit,
+  the API says so: reverse lookups return/require unique members via
+  explicit errors, packed-expert aggregates expose their member lists
+  as tuples, and fused sibling groups report kind + members on
+  :class:`ServingGroup`. Nothing collapses silently.
+
+Round-trip property (pinned by tests): where the profile's rules are
+prefix rewrites — the normal case — ``recipe -> checkpoint -> recipe``
+is the identity, and ``recipe_to_live`` inverts ``live_to_recipe``
+exactly over the supplied universe. Where the rules are NOT invertible
+(DSv4's flat checkpoint naming has no ``source_tensor_name`` override,
+so the live→checkpoint direction is declared identity while the real
+mapping is not invertible from a single name), the layer reports the
+declared answer and the asymmetry stays visible instead of being papered
+over with a guessed inverse.
+
+Tensor Parallelism
+------------------
+Names here are properties of the LOGICAL tensor. No method accepts or
+returns a rank, shard index, or TP degree, and node identity never
+changes with TP degree — a per-rank spelling is a SEPARATE decoration
+over a logical name, deliberately absent until the serving lane
+publishes a machine-readable shard contract. Byte accounting does not
+live here at all: totals stay on
+:class:`prismaquant.model_walk.WalkNode` and per-device readings go
+through :func:`prismaquant.model_walk.per_device_bytes`.
+
+This module imports only the standard library at module scope; torch
+and model_walk types enter lazily through :meth:`NameProjection.for_walk`.
+"""
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Iterable, Sequence
+
+__all__ = [
+    "CHECKPOINT",
+    "DECLARED_OUT_OF_GRAPH",
+    "EXPORT",
+    "GROUP_FUSED_SIBLINGS",
+    "GROUP_PACKED_EXPERTS",
+    "GROUP_SINGLETON",
+    "LIVE",
+    "MAPPED",
+    "NAMESPACES",
+    "NameProjection",
+    "NameProjectionError",
+    "packed_expert_alias",
+    "PROJECTABLE_PAIRS",
+    "ProjectedName",
+    "RECIPE",
+    "ServingGroup",
+    "VLLM",
+    "strip_weight_leaf",
+]
+
+# ---------------------------------------------------------------------------
+# Namespaces and outcomes
+# ---------------------------------------------------------------------------
+
+#: Loaded-transformers parameter names (what WalkNode.name carries).
+LIVE = "live"
+#: Allocator/probe/stats/assignment qnames (module spelling).
+RECIPE = "recipe"
+#: Source safetensors tensor keys.
+CHECKPOINT = "checkpoint"
+#: Exported-artifact safetensors tensor keys.
+EXPORT = "export"
+#: vLLM-internal scheme-dispatch module qnames.
+VLLM = "vllm"
+
+NAMESPACES = (LIVE, RECIPE, CHECKPOINT, EXPORT, VLLM)
+
+#: Outcome of a projection that the profile DECLINES by contract (a key
+#: outside the live graph). Data for callers to branch on — never an
+#: exception, never a silent None.
+DECLARED_OUT_OF_GRAPH = "declared_out_of_graph"
+#: Outcome of a successful projection.
+MAPPED = "mapped"
+
+_PROJECTABLE_PAIRS = {
+    (LIVE, RECIPE),
+    (RECIPE, LIVE),
+    (RECIPE, VLLM),
+    (CHECKPOINT, LIVE),
+    (LIVE, CHECKPOINT),
+    (RECIPE, EXPORT),
+}
+#: The (source, target) pairs :meth:`NameProjection.project` serves.
+PROJECTABLE_PAIRS = tuple(sorted(_PROJECTABLE_PAIRS))
+
+
+def strip_weight_leaf(tensor_name: str) -> str:
+    """Drop a trailing ``.weight``; leave any other name unchanged.
+
+    The recipe namespace spells units WITHOUT the parameter leaf (stats
+    rows, assignment dicts, hook targets), while live/checkpoint/export
+    spellings carry it. This module owns that conversion so consumers
+    stop re-deriving it with private ``_recipe_name`` helpers.
+    """
+    name = str(tensor_name)
+    return name[: -len(".weight")] if name.endswith(".weight") else name
+
+
+def _default_expert_parent_for_projection(projection_name: str) -> str | None:
+    """No-profile fallback for the per-expert -> packed projection mapping.
+
+    Mirrors ``ModelProfile.packed_expert_parent_for_projection``'s legacy
+    fallback: per-expert ``gate_proj``/``up_proj`` fuse into the packed
+    ``gate_up_proj`` (output-axis cat, the transformers packed-FusedMoE
+    convention); ``down_proj`` packs 1:1. Anything else (e.g. MiniMax's
+    per-expert ``w1``/``w2``/``w3`` modules, which stay per-expert live)
+    has no packed parent here — callers with a profile should pass its
+    ``packed_expert_parent_for_projection`` instead.
+    """
+    if projection_name in ("gate_proj", "up_proj"):
+        return "gate_up_proj"
+    if projection_name == "down_proj":
+        return "down_proj"
+    return None
+
+
+def packed_expert_alias(qname: str, parent_for_projection=None) -> str | None:
+    """Packed live qname a per-expert Linear aggregates into, or None.
+
+    ``...experts.{i}.{proj}`` -> ``...experts.{parent}`` when
+    ``parent_for_projection(proj)`` names a packed parent
+    (``ModelProfile.packed_expert_parent_for_projection``; the legacy
+    gate/up/down fallback when None). Non-expert names and unrecognized
+    projections return None.
+
+    Lives HERE because it is name derivation, not byte accounting: it is
+    the one structural ``experts.{idx}.{leaf}`` parser, shared by
+    :meth:`NameProjection.packed_parent_of_expert_param` and by
+    ``footprint.source_tensor_bytes_manifest``'s dual-entry convention
+    (a per-expert span is covered under BOTH spellings), and it mirrors
+    the profile layer's own packed-format grouping detection
+    (``packed_expert_format_group``).
+    """
+    parts = str(qname).split(".")
+    if len(parts) < 3 or parts[-3] != "experts" or not parts[-2].isdigit():
+        return None
+    fn = (parent_for_projection if parent_for_projection is not None
+          else _default_expert_parent_for_projection)
+    parent = fn(parts[-1])
+    if not parent:
+        return None
+    return ".".join(parts[:-2] + [str(parent)])
+
+
+@dataclasses.dataclass(frozen=True)
+class ProjectedName:
+    """One resolved projection. Callers branch on :attr:`outcome`."""
+
+    source: str
+    source_namespace: str
+    target: str                  # None iff outcome == DECLARED_OUT_OF_GRAPH
+    target_namespace: str
+    outcome: str                 # MAPPED | DECLARED_OUT_OF_GRAPH
+    via: str                     # the profile accessor that produced it
+
+
+@dataclasses.dataclass(frozen=True)
+class ServingGroup:
+    """The profile-declared serving group of one unit.
+
+    ``kind`` distinguishes the three shapes a unit can take; ``key`` is
+    the group identity in the queried namespace and is ``""`` only when
+    ``kind == GROUP_SINGLETON``. For grouped kinds, ``members`` lists
+    the member names PRESENT IN THE SUPPLIED LIVE UNIVERSE (empty when
+    no universe was given — use :meth:`NameProjection.require_serving_group`
+    when absence would be a defect); for singletons it is the unit
+    itself.
+    """
+
+    kind: str                    # GROUP_SINGLETON | GROUP_FUSED_SIBLINGS | GROUP_PACKED_EXPERTS
+    key: str
+    namespace: str               # namespace of `key` and `members` (mirrors the query)
+    members: tuple[str, ...]
+
+
+GROUP_SINGLETON = "singleton"
+GROUP_FUSED_SIBLINGS = "fused_siblings"
+GROUP_PACKED_EXPERTS = "packed_experts"
+
+
+class NameProjectionError(KeyError):
+    """A projection failed closed.
+
+    Every field is structured so callers branch on fields, never on
+    message text: ``code`` discriminates the failure class
+    (``unknown_namespace``, ``unmapped_in_universe``, ``ambiguous``,
+    ``no_universe_supplied``, ``malformed_profile_result``,
+    ``profile_accessor_failed``, ``unsupported_pair``); ``tried`` names
+    each mechanism that was attempted; the message exists for humans.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        source_namespace: str,
+        target_namespace: str,
+        code: str,
+        tried: Iterable[str] = (),
+        detail: str = "",
+    ) -> None:
+        self.name = str(name)
+        self.source_namespace = str(source_namespace)
+        self.target_namespace = str(target_namespace)
+        self.code = str(code)
+        self.tried = tuple(str(t) for t in tried)
+        self.detail = str(detail)
+        message = (
+            f"name_projection: cannot map {self.name!r} from "
+            f"{self.source_namespace!r} to {self.target_namespace!r} "
+            f"[{self.code}]"
+        )
+        if self.detail:
+            message += f": {self.detail}"
+        if self.tried:
+            message += "; tried: " + "; ".join(self.tried)
+        super().__init__(message)
+
+    def __str__(self) -> str:  # KeyError.__str__ reprs its argument
+        return self.args[0]
+
+
+# ---------------------------------------------------------------------------
+# The projection
+# ---------------------------------------------------------------------------
+
+
+class NameProjection:
+    """All name projections for one model family, derived from one profile.
+
+    Build once per process and pass to every consumer::
+
+        proj = NameProjection.for_walk(load_walk(path).result, profile)
+        stats_key = proj.recipe_unit(node.name)          # probe/cost join
+        live = proj.checkpoint_to_live(ckpt_key)         # footprint/read-traffic join
+
+    ``live_names`` seeds the universe the reverse directions need: the
+    walk supplies it naturally (:meth:`for_walk`), and a consumer may
+    supply any comparable enumeration instead. Reverse queries without a
+    universe raise ``code="no_universe_supplied"`` rather than guessing;
+    forward queries never need one. ``checkpoint_keys`` (a source span
+    scan, e.g. ``footprint.source_tensor_span_bytes``) additionally
+    enables the coverage queries (:meth:`checkpoint_keys_for`,
+    :meth:`require_checkpoint_span`) whose empty answer is the loud gate
+    the footprint migration needs.
+    """
+
+    def __init__(
+        self,
+        profile,
+        *,
+        live_names: Sequence[str] = (),
+        checkpoint_keys: Sequence[str] | None = None,
+    ) -> None:
+        if profile is None:
+            raise ValueError(
+                "NameProjection requires a ModelProfile; a None profile "
+                "would silently degrade every mapping to identity")
+        self._profile = profile
+        self._live_names = tuple(dict.fromkeys(str(n) for n in live_names))
+        # Forward index once, O(universe): recipe spellings of every live
+        # name, keyed both ways. Tied weights keep distinct recipes, so a
+        # collision here means the PROFILE collapses distinct tensors and
+        # the reverse direction is genuinely ambiguous — recorded, then
+        # raised at query time with both candidates named.
+        self._recipe_param_by_live: dict[str, str] = {}
+        self._live_by_recipe_param: dict[str, list[str]] = {}
+        self._live_by_unit: dict[str, list[str]] = {}
+        for live in self._live_names:
+            recipe_param = self.live_to_recipe(live)
+            self._recipe_param_by_live[live] = recipe_param
+            self._live_by_recipe_param.setdefault(recipe_param, []).append(live)
+            self._live_by_unit.setdefault(
+                strip_weight_leaf(recipe_param), []).append(live)
+        self._ckpt_supplied = checkpoint_keys is not None
+        self._ckpt_keys_by_target = self._build_checkpoint_index(
+            checkpoint_keys or ())
+        # Group membership among the universe, keyed by canonical group
+        # key (module spelling): the present-in-universe view that makes
+        # many->one groups inspectable without a second enumeration.
+        self._members_by_group: dict[tuple[str, str], list[str]] = {}
+        for live in self._live_names:
+            group = self.serving_group(live)
+            if group.kind != GROUP_SINGLETON:
+                self._members_by_group.setdefault(
+                    (group.namespace, group.key), []).append(live)
+
+    @classmethod
+    def for_walk(
+        cls,
+        result,
+        profile,
+        *,
+        checkpoint_keys: Sequence[str] | None = None,
+    ) -> "NameProjection":
+        """Build the projection over a walked model's node universe."""
+        from .model_walk import WalkResult  # noqa: F401  (type guard only)
+
+        if not isinstance(result, WalkResult):
+            raise TypeError(
+                "for_walk expects a prismaquant.model_walk.WalkResult, "
+                f"got {type(result).__name__}")
+        return cls(
+            profile,
+            live_names=[node.name for node in result.nodes],
+            checkpoint_keys=checkpoint_keys,
+        )
+
+    # ------------------------------------------------------------ basics --
+
+    @property
+    def profile(self):
+        return self._profile
+
+    def live_names(self) -> tuple[str, ...]:
+        """The live universe backing the reverse directions."""
+        return self._live_names
+
+    # ---------------------------------------------------- forward paths --
+    # Each wrapper validates the accessor's RESULT type and wraps accessors
+    # failures; none swallows exceptions into a fallback (that best-effort
+    # shape is decision_units.fused_group_key's, and it is precisely what
+    # this layer must not repeat).
+
+    def live_to_recipe(self, live_name: str) -> str:
+        """Live parameter/module name -> recipe spelling (leaf preserved).
+
+        Total over the live graph: profiles declare it identity unless a
+        multimodal staging splits the namespaces.
+        """
+        return self._map_module_form(
+            live_name, LIVE, RECIPE, "live_to_recipe_name")
+
+    def recipe_unit(self, live_name: str) -> str:
+        """Live name -> the recipe UNIT key (module spelling).
+
+        This is THE join for probe stats rows, format plans, assignment
+        dicts, cost tables, and hook targets. It is ``strip_weight_leaf``
+        composed with :meth:`live_to_recipe`, owned here so no consumer
+        keeps a private ``_recipe_name``.
+        """
+        return strip_weight_leaf(self.live_to_recipe(live_name))
+
+    def to_vllm_internal(self, name: str) -> str:
+        """Recipe/checkpoint spelling -> vLLM scheme-dispatch qname.
+
+        Accepts module or parameter spelling; the leaf survives (the
+        exact-match rules some specs declare operate on module qnames,
+        so the accessor is applied to the module form and the leaf
+        reattached — the same composition
+        ``structure.build_model_graph`` uses).
+        """
+        module_form = strip_weight_leaf(name)
+        vllm_module = self._call_accessor(
+            "to_vllm_internal_name", module_form, source=RECIPE, target=VLLM)
+        leaf = name[len(module_form):] if name != module_form else ""
+        if leaf and not vllm_module.endswith(leaf):
+            return f"{vllm_module}{leaf}"
+        return vllm_module
+
+    def checkpoint_to_live(
+        self, ckpt_key: str, *, multimodal: bool = False,
+    ) -> ProjectedName:
+        """Source checkpoint key -> live name, or the DECLARED drop.
+
+        Never raises for a key the profile declines by contract (visual
+        towers, MTP sidecars, scale siblings): that is
+        :data:`DECLARED_OUT_OF_GRAPH`, the field read-traffic classifies
+        ``excluded_non_text_graph`` from. Raises only when the accessor
+        itself misbehaves.
+        """
+        try:
+            mapped = self._profile.checkpoint_to_live_name(
+                str(ckpt_key), multimodal=multimodal)
+        except Exception as exc:
+            raise NameProjectionError(
+                name=str(ckpt_key), source_namespace=CHECKPOINT,
+                target_namespace=LIVE, code="profile_accessor_failed",
+                tried=("ModelProfile.checkpoint_to_live_name",),
+                detail=f"{type(exc).__name__}: {exc}",
+            ) from exc
+        if mapped is None:
+            return ProjectedName(
+                source=str(ckpt_key), source_namespace=CHECKPOINT,
+                target=None, target_namespace=LIVE,
+                outcome=DECLARED_OUT_OF_GRAPH,
+                via="ModelProfile.checkpoint_to_live_name",
+            )
+        if not isinstance(mapped, str) or not mapped:
+            raise NameProjectionError(
+                name=str(ckpt_key), source_namespace=CHECKPOINT,
+                target_namespace=LIVE, code="malformed_profile_result",
+                tried=("ModelProfile.checkpoint_to_live_name",),
+                detail=f"expected a non-empty str or None, got {mapped!r}",
+            )
+        # The accessor returns a PARAMETER spelling; normalize a trailing
+        # .weight off exactly as footprint's manifest does, so the target
+        # matches allocator unit qnames.
+        return ProjectedName(
+            source=str(ckpt_key), source_namespace=CHECKPOINT,
+            target=strip_weight_leaf(mapped), target_namespace=LIVE,
+            outcome=MAPPED, via="ModelProfile.checkpoint_to_live_name",
+        )
+
+    def live_to_source(self, live_param: str) -> str:
+        """Live parameter name -> the profile's declared SOURCE spelling.
+
+        HONEST LIMIT: ``source_tensor_name`` documents export/source
+        naming and is NOT guaranteed to invert
+        ``checkpoint_to_live_name`` (DSv4 overrides the latter with its
+        flat naming but leaves the former identity — its docstring's
+        inverse claim has no code behind it). Treat this as the DECLARED
+        spelling; the authoritative live->checkpoint direction is the
+        universe-backed :meth:`checkpoint_keys_for` once a span scan is
+        supplied.
+        """
+        try:
+            mapped = self._profile.source_tensor_name(str(live_param))
+        except Exception as exc:
+            raise NameProjectionError(
+                name=str(live_param), source_namespace=LIVE,
+                target_namespace=CHECKPOINT, code="profile_accessor_failed",
+                tried=("ModelProfile.source_tensor_name",),
+                detail=f"{type(exc).__name__}: {exc}",
+            ) from exc
+        if not isinstance(mapped, str) or not mapped:
+            raise NameProjectionError(
+                name=str(live_param), source_namespace=LIVE,
+                target_namespace=CHECKPOINT, code="malformed_profile_result",
+                tried=("ModelProfile.source_tensor_name",),
+                detail=f"expected a non-empty str, got {mapped!r}",
+            )
+        return mapped
+
+    def recipe_to_export(self, recipe_param: str) -> str:
+        """Recipe parameter name -> exported-artifact tensor key."""
+        try:
+            mapped = self._profile.export_tensor_name(str(recipe_param))
+        except Exception as exc:
+            raise NameProjectionError(
+                name=str(recipe_param), source_namespace=RECIPE,
+                target_namespace=EXPORT, code="profile_accessor_failed",
+                tried=("ModelProfile.export_tensor_name",),
+                detail=f"{type(exc).__name__}: {exc}",
+            ) from exc
+        if not isinstance(mapped, str) or not mapped:
+            raise NameProjectionError(
+                name=str(recipe_param), source_namespace=RECIPE,
+                target_namespace=EXPORT, code="malformed_profile_result",
+                tried=("ModelProfile.export_tensor_name",),
+                detail=f"expected a non-empty str, got {mapped!r}",
+            )
+        return mapped
+
+    # ----------------------------------------------------- reverse paths --
+    # Index-backed over the live universe; they refuse loudly rather than
+    # guess when the universe is missing or the inverse is ambiguous.
+
+    def _unique_inverse(
+        self, recipe_name: str, tables: Sequence[tuple[dict[str, list[str]], str]],
+    ) -> str:
+        wanted = str(recipe_name)
+        tried: list[str] = []
+        found: list[str] = []
+        for table, label in tables:
+            tried.append(f"{label} over the live universe "
+                         f"({len(self._live_names)} name(s))")
+            candidates = table.get(wanted)
+            if candidates:
+                found = candidates
+                break
+        if not found:
+            raise NameProjectionError(
+                name=wanted, source_namespace=RECIPE,
+                target_namespace=LIVE, code="unmapped_in_universe",
+                tried=tuple(tried),
+                detail="no live name maps to this recipe spelling under "
+                       "this profile; a fused-group or packed-aggregate "
+                       "KEY is not itself a live tensor — ask for a member",
+            )
+        if len(found) > 1:
+            raise NameProjectionError(
+                name=wanted, source_namespace=RECIPE,
+                target_namespace=LIVE, code="ambiguous",
+                tried=tuple(tried),
+                detail=f"{len(found)} live names map to this recipe "
+                       f"spelling ({', '.join(sorted(found))}); the "
+                       "inverse is not unique, resolve via serving_group()",
+            )
+        return found[0]
+
+    def recipe_to_live(self, recipe_name: str) -> str:
+        """Unique live parameter behind a recipe spelling (inverse of
+        :meth:`live_to_recipe`). Accepts unit or parameter spelling."""
+        return self._unique_inverse(recipe_name, (
+            (self._live_by_recipe_param, "live_to_recipe"),
+            (self._live_by_unit, "recipe_unit"),
+        ))
+
+    def unit_to_live(self, unit_qname: str) -> str:
+        """Unique live parameter behind a recipe UNIT key (module spelling)."""
+        return self._unique_inverse(unit_qname, (
+            (self._live_by_unit, "recipe_unit"),
+        ))
+
+    # --------------------------------------------------- coverage joins --
+
+    def _build_checkpoint_index(self, checkpoint_keys: Sequence[str]) -> dict[str, tuple[str, ...]]:
+        """Map live/recipe/packed-aggregate targets -> covering ckpt keys.
+
+        Mirrors footprint's dual-entry manifest convention: a per-expert
+        checkpoint key covers BOTH its own name and its packed-parent
+        aggregate, so a coverage query succeeds under either naming
+        scheme and an uncovered unit is genuinely uncovered.
+        """
+        covered: dict[str, set[str]] = {}
+
+        def _cover(target: str, key: str) -> None:
+            covered.setdefault(strip_weight_leaf(target), set()).add(key)
+
+        for raw in checkpoint_keys:
+            key = str(raw)
+            projected = self.checkpoint_to_live(key)
+            if projected.outcome != MAPPED:
+                continue  # declared out-of-graph: covers nothing live
+            live_base = projected.target
+            _cover(live_base, key)
+            packed = self.packed_parent_of_expert_param(live_base)
+            if packed is not None:
+                _cover(packed, key)
+        return {target: tuple(sorted(keys)) for target, keys in covered.items()}
+
+    def checkpoint_keys_for(self, target: str) -> tuple[str, ...]:
+        """Checkpoint keys whose bytes cover this live/unit name.
+
+        Empty means genuinely uncovered — combine with
+        :meth:`require_checkpoint_span` where emptiness is a refusal.
+        """
+        if not self._ckpt_supplied:
+            raise NameProjectionError(
+                name=str(target), source_namespace=LIVE,
+                target_namespace=CHECKPOINT, code="no_universe_supplied",
+                tried=("checkpoint-key index",),
+                detail="constructed without checkpoint_keys; pass a source "
+                       "span scan (footprint.source_tensor_span_bytes) to "
+                       "enable coverage queries",
+            )
+        return self._ckpt_keys_by_target.get(strip_weight_leaf(str(target)), ())
+
+    def require_checkpoint_span(self, target: str) -> tuple[str, ...]:
+        """:meth:`checkpoint_keys_for`, refusing an uncovered unit.
+
+        This is the coverage assertion footprint.md asked for: a decided
+        unit with no source span is an accounting bug, and this call is
+        where it becomes loud instead of a silent floor term.
+        """
+        keys = self.checkpoint_keys_for(target)
+        if not keys:
+            raise NameProjectionError(
+                name=str(target), source_namespace=LIVE,
+                target_namespace=CHECKPOINT, code="uncovered_unit",
+                tried=(f"checkpoint-key index over "
+                       f"{len(self._ckpt_keys_by_target)} covered target(s)",),
+                detail="no supplied checkpoint key maps to this unit (or to "
+                       "its packed aggregate)",
+            )
+        return keys
+
+    # --------------------------------------------------------- grouping --
+
+    def fused_sibling_group(self, qname: str) -> str | None:
+        """Profile-declared fused-sibling group key, or None.
+
+        Unlike ``decision_units.fused_group_key`` this does NOT swallow
+        profile exceptions into an identity fallback: an accessor that
+        fails is a declaration bug and refuses here.
+        """
+        try:
+            group = self._profile.fused_sibling_group(strip_weight_leaf(qname))
+        except Exception as exc:
+            raise NameProjectionError(
+                name=str(qname), source_namespace=RECIPE, target_namespace=RECIPE,
+                code="profile_accessor_failed",
+                tried=("ModelProfile.fused_sibling_group",),
+                detail=f"{type(exc).__name__}: {exc}",
+            ) from exc
+        if group is None:
+            return None
+        if not isinstance(group, str) or not group:
+            raise NameProjectionError(
+                name=str(qname), source_namespace=RECIPE, target_namespace=RECIPE,
+                code="malformed_profile_result",
+                tried=("ModelProfile.fused_sibling_group",),
+                detail=f"expected a non-empty str or None, got {group!r}",
+            )
+        return group
+
+    def packed_format_group(self, qname: str) -> str | None:
+        """Profile-declared packed-expert serving-format group, or None."""
+        try:
+            group = self._profile.packed_expert_format_group(
+                strip_weight_leaf(qname))
+        except Exception as exc:
+            raise NameProjectionError(
+                name=str(qname), source_namespace=RECIPE, target_namespace=RECIPE,
+                code="profile_accessor_failed",
+                tried=("ModelProfile.packed_expert_format_group",),
+                detail=f"{type(exc).__name__}: {exc}",
+            ) from exc
+        if group is None:
+            return None
+        if not isinstance(group, str) or not group:
+            raise NameProjectionError(
+                name=str(qname), source_namespace=RECIPE, target_namespace=RECIPE,
+                code="malformed_profile_result",
+                tried=("ModelProfile.packed_expert_format_group",),
+                detail=f"expected a non-empty str or None, got {group!r}",
+            )
+        return group
+
+    def serving_group(self, qname: str) -> ServingGroup:
+        """The one serving group of a unit: packed experts first, then
+        fused siblings, else singleton.
+
+        Precedence matters where both match (an unpacked expert
+        projection's leaf can carry a fused-sibling name too): routed
+        experts must group by their STACK, so packed wins. The key
+        inherits the queried namespace; members are the group's names
+        present in the live universe.
+        """
+        base = strip_weight_leaf(qname)
+        packed = self.packed_format_group(base)
+        if packed is not None:
+            return ServingGroup(
+                kind=GROUP_PACKED_EXPERTS, key=packed, namespace=RECIPE,
+                members=tuple(sorted(
+                    self._members_by_group.get((RECIPE, packed), ())),
+                ),
+            )
+        fused = self.fused_sibling_group(base)
+        if fused is not None:
+            return ServingGroup(
+                kind=GROUP_FUSED_SIBLINGS, key=fused, namespace=RECIPE,
+                members=tuple(sorted(
+                    self._members_by_group.get((RECIPE, fused), ()))),
+            )
+        return ServingGroup(
+            kind=GROUP_SINGLETON, key="", namespace=RECIPE,
+            members=(base,),
+        )
+
+    def require_serving_group(self, qname: str, *, kinds: Sequence[str]) -> ServingGroup:
+        """Refuse unless the unit's serving group is of a required kind.
+
+        Cost declarations branch on group kind (CB stacks need packed
+        groups; dense fusion needs fused ones). Passing an empty
+        ``kinds`` asserts the unit is grouped at all.
+        """
+        group = self.serving_group(qname)
+        allowed = tuple(kinds)
+        if not allowed:
+            if group.kind == GROUP_SINGLETON:
+                raise NameProjectionError(
+                    name=str(qname), source_namespace=RECIPE,
+                    target_namespace=RECIPE, code="ungrouped_unit",
+                    tried=("serving_group",),
+                    detail="unit carries no profile-declared group",
+                )
+            return group
+        if group.kind not in allowed:
+            raise NameProjectionError(
+                name=str(qname), source_namespace=RECIPE,
+                target_namespace=RECIPE, code="wrong_group_kind",
+                tried=("serving_group",),
+                detail=f"group kind is {group.kind!r}, required one of "
+                       f"{list(allowed)}",
+            )
+        return group
+
+    def block_id(self, qname: str) -> str:
+        """Architectural block id of a unit (shared helper, not a copy)."""
+        from .decision_units import block_id_from_qname
+
+        return block_id_from_qname(strip_weight_leaf(str(qname)))
+
+    # -------------------------------------------------- packed experts --
+
+    def packed_parent_of_expert_param(self, qname: str) -> str | None:
+        """Packed aggregate a per-expert parameter folds into, or None.
+
+        None means "not a per-expert parameter" — the same declared
+        meaning :func:`packed_expert_alias` gives (defined in this
+        module, shared with footprint's manifest), applied with the
+        profile's own parent mapping.
+        """
+        base = strip_weight_leaf(str(qname))
+        try:
+            return packed_expert_alias(
+                base, self._profile.packed_expert_parent_for_projection)
+        except Exception as exc:
+            raise NameProjectionError(
+                name=base, source_namespace=RECIPE, target_namespace=RECIPE,
+                code="profile_accessor_failed",
+                tried=("packed_expert_alias("
+                       "ModelProfile.packed_expert_parent_for_projection)",),
+                detail=f"{type(exc).__name__}: {exc}",
+            ) from exc
+
+    # -------------------------------------------------------- dispatch --
+
+    def project(
+        self, name: str, source_namespace: str, target_namespace: str,
+        *, multimodal: bool = False,
+    ) -> ProjectedName:
+        """Namespace-generic entry point; always returns a
+        :class:`ProjectedName` (branch on ``outcome``) or raises a
+        :class:`NameProjectionError`.
+
+        Serves exactly the pairs with a declared accessor or a built
+        index — see :data:`PROJECTABLE_PAIRS`. Composing chains (live ->
+        recipe -> vllm) is the CALLER'S decision; this method never
+        invents a hop the profile did not declare.
+        """
+        pair = (str(source_namespace), str(target_namespace))
+        for ns in pair:
+            if ns not in NAMESPACES:
+                raise NameProjectionError(
+                    name=str(name), source_namespace=pair[0],
+                    target_namespace=pair[1], code="unknown_namespace",
+                    tried=(),
+                    detail=f"{ns!r} is not one of {list(NAMESPACES)}",
+                )
+        if pair not in _PROJECTABLE_PAIRS:
+            raise NameProjectionError(
+                name=str(name), source_namespace=pair[0],
+                target_namespace=pair[1], code="unsupported_pair",
+                tried=(),
+                detail=f"projectable pairs: {PROJECTABLE_PAIRS}",
+            )
+        source_ns, target_ns = pair
+        if (source_ns, target_ns) == (CHECKPOINT, LIVE):
+            return self.checkpoint_to_live(name, multimodal=multimodal)
+        if (source_ns, target_ns) == (RECIPE, EXPORT):
+            return ProjectedName(
+                source=str(name), source_namespace=source_ns,
+                target=self.recipe_to_export(name), target_namespace=target_ns,
+                outcome=MAPPED, via="ModelProfile.export_tensor_name",
+            )
+        if (source_ns, target_ns) == (LIVE, CHECKPOINT):
+            return ProjectedName(
+                source=str(name), source_namespace=source_ns,
+                target=self.live_to_source(name), target_namespace=target_ns,
+                outcome=MAPPED, via="ModelProfile.source_tensor_name",
+            )
+        if (source_ns, target_ns) == (RECIPE, VLLM):
+            return ProjectedName(
+                source=str(name), source_namespace=source_ns,
+                target=self.to_vllm_internal(name), target_namespace=target_ns,
+                outcome=MAPPED, via="ModelProfile.to_vllm_internal_name",
+            )
+        if (source_ns, target_ns) == (LIVE, RECIPE):
+            return ProjectedName(
+                source=str(name), source_namespace=source_ns,
+                target=self.live_to_recipe(name), target_namespace=target_ns,
+                outcome=MAPPED, via="ModelProfile.live_to_recipe_name",
+            )
+        # (RECIPE, LIVE) — the one index-backed pair.
+        return ProjectedName(
+            source=str(name), source_namespace=source_ns,
+            target=self.recipe_to_live(name), target_namespace=target_ns,
+            outcome=MAPPED,
+            via="reverse index over the live universe",
+        )
+
+    # ------------------------------------------------------- internals --
+
+    def _map_module_form(
+        self, name: str, source_ns: str, target_ns: str, accessor: str,
+    ) -> str:
+        """Apply a MODULE-form profile accessor with leaf preservation.
+
+        Prefix rewrites survive the leaf either way, but specs also
+        declare EXACT rules against bare module qnames (qwen3_5's
+        ``lm_head``), so the accessor runs on the module form and the
+        leaf is reattached — mirroring structure.build_model_graph.
+        """
+        module_form = strip_weight_leaf(name)
+        mapped_module = self._call_accessor(
+            accessor, module_form, source=source_ns, target=target_ns)
+        leaf = name[len(module_form):] if name != module_form else ""
+        if leaf:
+            return f"{mapped_module}{leaf}"
+        return mapped_module
+
+    def _call_accessor(
+        self, accessor: str, arg: str, *, source: str, target: str,
+    ) -> str:
+        method = getattr(self._profile, accessor, None)
+        if not callable(method):
+            raise NameProjectionError(
+                name=arg, source_namespace=source, target_namespace=target,
+                code="profile_accessor_failed", tried=(accessor,),
+                detail=f"profile {type(self._profile).__name__} has no "
+                       f"callable {accessor}()",
+            )
+        try:
+            mapped = method(arg)
+        except Exception as exc:
+            raise NameProjectionError(
+                name=arg, source_namespace=source, target_namespace=target,
+                code="profile_accessor_failed", tried=(accessor,),
+                detail=f"{type(exc).__name__}: {exc}",
+            ) from exc
+        if not isinstance(mapped, str) or not mapped:
+            raise NameProjectionError(
+                name=arg, source_namespace=source, target_namespace=target,
+                code="malformed_profile_result", tried=(accessor,),
+                detail=f"expected a non-empty str, got {mapped!r}",
+            )
+        return mapped

--- a/prismaquant/production_render_cost.py
+++ b/prismaquant/production_render_cost.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from prismaquant import format_registry as fr
+from prismaquant.name_projection import strip_weight_leaf
 
 if TYPE_CHECKING:
     from prismaquant.source_class_format_plan import SourceClassFormatPlan
@@ -32,9 +33,20 @@ SCHEMA = "prismaquant.production_render_score_cost.v1"
 
 
 def canonical_cost_name(qname: str) -> str:
-    name = str(qname)
-    if name.endswith(".weight"):
-        name = name[:-len(".weight")]
+    """Normalize a producer-recorded qname to the recipe-unit spelling.
+
+    The leaf half is the shared layer's one leaf function
+    (`name_projection.strip_weight_leaf`). The umbrella-infix half mirrors
+    the base profile's checkpoint→live rule (`model.language_model.` →
+    `model.`, `model_profiles/base.py` `checkpoint_to_live_name`) and is
+    deliberately NOT routed through a projection: this module never sees a
+    profile, and a checkpoint/live projection may DECLINE a key (visual,
+    scale siblings) while cost/render payloads legitimately carry rows this
+    normalizer must keep — DSv4's MTP units are costed and keyed under their
+    physical spelling (deepseek_v4 fp8_scale_pairs retains it for the same
+    reason). Total by contract: every input comes back, spelled one way.
+    """
+    name = strip_weight_leaf(str(qname))
     prefix = "model.language_model."
     if name.startswith(prefix):
         name = "model." + name[len(prefix):]

--- a/prismaquant/read_traffic.py
+++ b/prismaquant/read_traffic.py
@@ -148,6 +148,12 @@ from . import format_registry as fr
 from . import footprint as fp
 from .allocator_solver import _shape_from_stats
 from .cb_export_config import CODEBOOK_TENSOR_PREFIX
+from .name_projection import (
+    DECLARED_OUT_OF_GRAPH,
+    MAPPED,
+    NameProjection,
+    strip_weight_leaf,
+)
 from .nvfp4_cb_footprint import is_cb_format
 
 SCHEMA = "prismaquant.read_traffic.v1"
@@ -327,10 +333,6 @@ def read_model_config(model_path: str | os.PathLike) -> dict:
 # Classification
 # ---------------------------------------------------------------------------
 
-def _strip_weight(name: str) -> str:
-    return name[: -len(".weight")] if name.endswith(".weight") else name
-
-
 def _has_experts_segment(name: str) -> bool:
     """True when a qname structurally sits under a routed-expert container.
 
@@ -385,7 +387,7 @@ def resolve_vocab_size(config: Mapping[str, Any] | None) -> int | None:
 
 def _module_stem(name: str) -> str:
     """The module a tensor hangs off: its name minus the final leaf."""
-    base = _strip_weight(str(name))
+    base = strip_weight_leaf(str(name))
     for suffix in fp._SIDECAR_SUFFIXES:
         if base.endswith(suffix):
             base = base[: -len(suffix)]
@@ -554,7 +556,7 @@ class EmbeddingDisposition:
 
 def _matches_declared(base: str, declared: str) -> bool:
     """``base`` is the tensor the profile means by ``declared``."""
-    declared = _strip_weight(str(declared))
+    declared = strip_weight_leaf(str(declared))
     return base == declared or base.endswith("." + declared)
 
 
@@ -600,12 +602,12 @@ def resolve_embedding_disposition(
     says ``head``) while ``embedding_name()`` is the live one (``model.
     embed_tokens``, where the checkpoint says ``embed``).
     """
-    lm_head = _strip_weight(str(profile.lm_head_name()))
-    embedding = _strip_weight(str(profile.embedding_name()))
+    lm_head = strip_weight_leaf(str(profile.lm_head_name()))
+    embedding = strip_weight_leaf(str(profile.embedding_name()))
     lm_head_present = False
     embedding_present = False
     for raw in names:
-        base = _strip_weight(str(raw))
+        base = strip_weight_leaf(str(raw))
         if _matches_declared(base, lm_head):
             lm_head_present = True
         elif _matches_declared(base, embedding):
@@ -666,6 +668,7 @@ def classify_read_class(
     scaled_stems: frozenset[str] | None = None,
     quant_targets: tuple[str, ...] = (),
     context: str = "read_traffic",
+    projection: NameProjection | None = None,
 ) -> str:
     """The read class of one tensor.  See :data:`READ_CLASS_TABLE`.
 
@@ -674,7 +677,10 @@ def classify_read_class(
     profile's ``checkpoint_to_live_name`` declines it, so the manifest falls
     back to the raw key).  Both spellings are tested against every rule, so a
     class is never missed on naming alone (project memory: a Linear has three
-    names).
+    names).  The checkpoint→live bridge is the shared
+    :class:`~prismaquant.name_projection.NameProjection`, not a private
+    mapping here; pass the caller's instance (``projection=``) so every span
+    shares one projection.
 
     ``embedding_streamed`` answers the one question a single tensor's name
     cannot: a tied embedding IS the output projection and is read in full
@@ -690,7 +696,7 @@ def classify_read_class(
     spellings = {str(name)}
     if checkpoint_key:
         spellings.add(str(checkpoint_key))
-    bases = {_strip_weight(s) for s in spellings}
+    bases = {strip_weight_leaf(s) for s in spellings}
 
     if any(base.startswith(CODEBOOK_TENSOR_PREFIX) for base in bases):
         return "resident_codebooks"
@@ -730,7 +736,7 @@ def classify_read_class(
             )
         return "routed_experts"
 
-    embedding = _strip_weight(str(profile.embedding_name()))
+    embedding = strip_weight_leaf(str(profile.embedding_name()))
     if any(_matches_declared(base, embedding) for base in bases):
         if embedding_streamed is None:
             raise ReadTrafficError(
@@ -749,12 +755,14 @@ def classify_read_class(
     # the architecture's OWN declaration that the tensor is not part of the
     # text decode path (vision/audio towers).  It is a declaration, not a
     # name test, which is why it is the rule rather than a prefix list.
+    # Routed through the shared name-projection layer: the DECLARED drop is
+    # data (DECLARED_OUT_OF_GRAPH), and an accessor that fails raises
+    # NameProjectionError instead of silently passing the key through.
     if checkpoint_key is not None:
-        try:
-            mapped = profile.checkpoint_to_live_name(str(checkpoint_key))
-        except Exception:
-            mapped = str(checkpoint_key)
-        if mapped is None:
+        if projection is None:
+            projection = NameProjection(profile)
+        projected = projection.checkpoint_to_live(str(checkpoint_key))
+        if projected.outcome == DECLARED_OUT_OF_GRAPH:
             return "excluded_non_text_graph"
 
     return "dense" if in_assignment else "held_fixed"
@@ -1005,6 +1013,11 @@ def assignment_read_traffic(
         if passthrough_names else {}
     )
 
+    # One shared name-projection for every checkpoint→live question below.
+    # Built from the same profile the byte authorities take, so the ledger
+    # cannot describe a different model than the footprint does.
+    projection = NameProjection(profile)
+
     # The embedding's read probability is a whole-checkpoint fact (is there a
     # separate output projection?), so it is resolved once, over every name in
     # the artifact, before any tensor is classified.
@@ -1012,11 +1025,15 @@ def assignment_read_traffic(
     live_names: list[str] = list(merged)
 
     def _live(ckpt_key: str) -> str:
-        try:
-            mapped = profile.checkpoint_to_live_name(ckpt_key)
-        except Exception:
-            mapped = ckpt_key
-        return _strip_weight(mapped or ckpt_key)
+        # The layer's declared drop (vision/audio/MTP/scale keys) keeps the
+        # raw checkpoint spelling in play as a NAME for rule matching -- which
+        # is what the pre-projection code did with a ``None`` mapping too --
+        # while a failing profile accessor now refuses loudly through
+        # NameProjectionError instead of silently passing the key through.
+        projected = projection.checkpoint_to_live(ckpt_key)
+        if projected.outcome == MAPPED:
+            return projected.target
+        return strip_weight_leaf(ckpt_key)
 
     for key in span_bytes:
         live_names.append(key)        # the checkpoint spelling (`head`)
@@ -1043,7 +1060,7 @@ def assignment_read_traffic(
     for qname, raw_format in merged.items():
         entry = stats.get(qname)
         if entry is None and qname.endswith(".weight"):
-            entry = stats.get(_strip_weight(qname))
+            entry = stats.get(strip_weight_leaf(qname))
         if not isinstance(entry, dict):
             continue  # unpriced: its source bytes stay in the floor half
         # `priced` in footprint's own loop: these are the names whose SOURCE
@@ -1110,7 +1127,7 @@ def assignment_read_traffic(
     covered_spans: set[str] = set()
     span_map = getattr(source_manifest, "spans", {}) or {}
     for qname in priced_names:
-        key = qname if qname in source_manifest else _strip_weight(qname)
+        key = qname if qname in source_manifest else strip_weight_leaf(qname)
         covered_spans.update(span_map.get(key, ()))
 
     for ckpt_key, nbytes in sorted(span_bytes.items()):
@@ -1122,7 +1139,7 @@ def assignment_read_traffic(
             in_assignment=False, embedding_streamed=embedding.streamed,
             dtype=dtype, shape=shape, vocab_size=vocab_size,
             scaled_stems=scaled_stems, quant_targets=quant_targets,
-            context=context)
+            context=context, projection=projection)
         saw_routed |= klass == "routed_experts"
         integer_tally.note(dtype, shape, nbytes, klass)
         _charge(int(nbytes), klass)
@@ -1257,18 +1274,21 @@ def exported_checkpoint_read_traffic(
     if config is None:
         config = read_model_config(export_dir)
 
+    projection = NameProjection(profile)
     spans = fp.source_tensor_span_bytes(export_dir)
 
     # Classify on the LIVE spelling with the on-disk one alongside: a
     # multimodal checkpoint stores the embedding as
     # `model.language_model.embed_tokens.weight`, and only the profile's own
-    # mapping turns that into the name the profile declares.
+    # mapping turns that into the name the profile declares.  The mapping is
+    # the shared name-projection layer: a declared drop keeps the raw key as a
+    # rule-matching name (as the pre-projection code did with `None`), while
+    # a failing profile accessor refuses instead of passing through.
     def _live(ckpt_key: str) -> str:
-        try:
-            mapped = profile.checkpoint_to_live_name(ckpt_key)
-        except Exception:
-            mapped = ckpt_key
-        return _strip_weight(mapped or ckpt_key)
+        projected = projection.checkpoint_to_live(ckpt_key)
+        if projected.outcome == MAPPED:
+            return projected.target
+        return strip_weight_leaf(ckpt_key)
 
     embedding = resolve_embedding_disposition(
         [name for key in spans for name in (key, _live(key))],
@@ -1291,7 +1311,7 @@ def exported_checkpoint_read_traffic(
             in_assignment=False, embedding_streamed=embedding.streamed,
             dtype=dtype, shape=shape, vocab_size=vocab_size,
             scaled_stems=scaled_stems, quant_targets=quant_targets,
-            context=context)
+            context=context, projection=projection)
         integer_tally.note(dtype, shape, nbytes, klass)
         # An exported artifact has no allocator/floor distinction on disk, so
         # every always-active tensor lands in `held_fixed`; the recipe-side
@@ -1301,7 +1321,7 @@ def exported_checkpoint_read_traffic(
         class_totals[klass]["n_tensors"] += 1
 
     for name, (_dtype, shape) in header_meta.items():
-        if len(shape) == 3 and _has_experts_segment(_strip_weight(name)):
+        if len(shape) == 3 and _has_experts_segment(strip_weight_leaf(name)):
             observed_expert_counts[name] = shape[0]
 
     ledger_total = sum(
@@ -1338,7 +1358,14 @@ def exported_checkpoint_read_traffic(
         },
         embedding=embedding,
         integer_tally=integer_tally,
-        measured_from=f"exported safetensors headers under {export_dir}",
+        # Deliberately NOT f"...under {export_dir}": during a staged export
+        # this function runs against the ATOMIC STAGING directory, which the
+        # publishing rename then destroys -- so an embedded absolute path is
+        # provenance naming a directory that no longer exists by the time
+        # anyone reads the card. The card already records the final location
+        # in `model_dir`. Describe WHAT was measured, matching the sibling
+        # claim at :1165 ("allocator assignment + source checkpoint spans").
+        measured_from="exported safetensors headers",
     )
 
 

--- a/prismaquant/sensitivity_probe.py
+++ b/prismaquant/sensitivity_probe.py
@@ -81,6 +81,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from .name_projection import NameProjection
+
 
 _STAGED_TEMP_DIRS: list[Path] = []
 
@@ -1809,6 +1811,18 @@ class FisherAccumulator:
             except Exception:
                 model_profile = None
         self.model_profile = model_profile
+        # One shared name projection (R5 consumer migration). Block
+        # identity and the declared structural spellings are read through
+        # prismaquant.name_projection, never re-derived here from string
+        # surgery. When the model's own profile is unavailable, fall back
+        # to DefaultProfile exactly like `_packed_expert_param_name_set`
+        # above; NameProjection itself refuses a None profile by contract,
+        # so the fallback is an explicit declaration, not a silent degrade.
+        if self.model_profile is not None:
+            self._name_projection = NameProjection(self.model_profile)
+        else:
+            from .model_profiles import DefaultProfile
+            self._name_projection = NameProjection(DefaultProfile())
 
         # Per-layer accumulator for full per-weight Fisher diagonal.
         # Keyed by Linear qname -> CPU fp64 tensor of shape [out, in]
@@ -1866,13 +1880,27 @@ class FisherAccumulator:
         self._h_packed_channel: dict[str, torch.Tensor] = {}
         # Pre-compute the BF16-skip set: profile-pinned Linears end up BF16
         # in serving, so accumulating their full per-weight Fisher matrix is
-        # dead work. Keep the embedding fallback for older profiles; embeddings
-        # are normally not nn.Linear and therefore never enter this loop.
+        # dead work. The embedding spelling is the profile's DECLARATION
+        # (ModelProfile.embedding_name), not a probe substring test; the
+        # embedding fallback only fires for profiles that implement the
+        # table as an nn.Linear (embeddings are normally not nn.Linear and
+        # therefore never enter this loop).
+        #
+        # Both accessors are read defensively, for the same reason: skipping
+        # here is an OPTIMIZATION, never a correctness gate, so a profile that
+        # declares neither simply does the extra work. `model_profile` is a
+        # loosely-typed optional kwarg that duck-typed objects reach (see
+        # tests/test_incremental_measure_quant_cost.py), and a probe must not
+        # start refusing profiles over a field that only saves it work.
+        _embedding_decl = getattr(
+            self._name_projection.profile, "embedding_name", None)
+        _declared_embedding = (
+            str(_embedding_decl()) if _embedding_decl is not None else None)
         def _skip_fisher_name(qname: str) -> bool:
             checker = getattr(self.model_profile, "is_pinned_name", None)
             if checker is not None and checker(qname):
                 return True
-            return qname == "model.embed_tokens" or qname.endswith(".embed_tokens")
+            return qname == _declared_embedding
 
         # Detect MoE expert blocks for batched Fisher accumulation. A block
         # qualifies if its immediate children all expose w1/w2/w3 nn.Linear
@@ -2010,10 +2038,14 @@ class FisherAccumulator:
                 # by layer).
                 experts_qname = meta.pop("_packed_experts_module")
                 meta.pop("_packed_param", None)
-                # Heuristic: include packed entry if any of its conjugate
-                # "in this same parent layer" Linears are tracked. This
-                # makes shard regexes (`model.layers.X.`) work cleanly.
-                parent_layer = ".".join(experts_qname.split(".")[:3])  # e.g. model.layers.7
+                # Include the packed entry iff its BLOCK has tracked
+                # Linears, so shard regexes (`model.layers.X.`) work
+                # cleanly. The block id comes from the shared name
+                # projection (decision_units.block_id_from_qname via
+                # NameProjection.block_id) — not a positional slice of
+                # the qname, which is only correct by accident when the
+                # layer prefix happens to be two components wide.
+                parent_layer = self._name_projection.block_id(experts_qname)
                 if any(t.startswith(parent_layer + ".") for t in self.tracked):
                     self.stats[full_name] = meta
                     # Register a forward hook on the experts module to

--- a/tests/test_consumer_cost_name_projection.py
+++ b/tests/test_consumer_cost_name_projection.py
@@ -1,0 +1,151 @@
+"""The cost consumer routes every name mapping through name_projection.
+
+R5 consumer-cost migration: `_scan_source_dtype_manifest` lost its private
+checkpoint->live->recipe builders (`_strip_weight_suffix`,
+`_to_recipe_name`, `_packed_to_recipe_name`,
+`_per_expert_packed_recipe_name`) and `decision_units` lost `_recipe_name`.
+These tests pin the migrated contract:
+
+- values are UNCHANGED versus the private spellings (same manifest keys,
+  same kinds, MTP rows retained verbatim, visual keys declined);
+- a profile accessor failure REFUSES (`NameProjectionError`) instead of
+  silently skipping rows — the fail-closed direction requirement 3 demands;
+- the packed-parent fold goes through the layer's
+  `packed_parent_of_expert_param` (footprint.packed_expert_alias + the
+  profile's own mapping), and does not exist without a caller-supplied
+  profile.
+"""
+from __future__ import annotations
+
+import torch
+
+from prismaquant.allocator_candidates import _scan_source_dtype_manifest
+from prismaquant.name_projection import NameProjectionError
+from prismaquant.model_profiles import DefaultProfile
+
+
+def _write_checkpoint(tmp_path, tensors: dict[str, torch.Tensor]) -> str:
+    from safetensors.torch import save_file
+
+    save_file(tensors, str(tmp_path / "model.safetensors"))
+    return str(tmp_path)
+
+
+def test_manifest_with_real_profile_matches_the_old_hardcoded_fallbacks(
+    tmp_path,
+) -> None:
+    # With a real profile the old code consulted
+    # checkpoint_to_live_name/live_to_recipe_name; with profile=None it
+    # inlined the SAME rules as string surgery. The migrated scan builds the
+    # projection over the supplied profile (or DefaultProfile when none), so
+    # both call conventions must agree value-for-value.
+    model_path = _write_checkpoint(tmp_path, {
+        "model.layers.0.self_attn.q_proj.weight":
+            torch.randn(4, 4, dtype=torch.bfloat16),
+        # Umbrella-infix spelling must land on the stripped recipe key.
+        "model.language_model.layers.1.self_attn.o_proj.weight":
+            torch.randn(4, 4, dtype=torch.float32),
+        # Visual towers are DECLARED out-of-graph: no row, not identity.
+        "model.visual.encoder.patch_embed.weight":
+            torch.randn(2, 2, dtype=torch.bfloat16),
+    })
+    expected = {
+        "model.layers.0.self_attn.q_proj": "bf16",
+        "model.layers.1.self_attn.o_proj": "f32",
+    }
+    assert _scan_source_dtype_manifest(model_path, profile=None) == expected
+    assert (
+        _scan_source_dtype_manifest(model_path, profile=DefaultProfile())
+        == expected
+    )
+
+
+def test_manifest_keeps_mtp_rows_verbatim_under_a_real_profile(
+    tmp_path,
+) -> None:
+    # MTP tensors are REAL source tensors stored under the recipe namespace
+    # itself; profiles DECLINE mtp.* in checkpoint_to_live_name (DSv4 drops
+    # them from the body map), but the manifest must keep them or the BF16
+    # passthrough disappears again (--mtp-format=BF16 hard-failed before).
+    model_path = _write_checkpoint(tmp_path, {
+        "mtp.fc.weight": torch.randn(4, 8, dtype=torch.bfloat16),
+        "mtp.layers.0.self_attn.q_proj.weight":
+            torch.randn(4, 4, dtype=torch.bfloat16),
+    })
+    expected = {
+        "mtp.fc": "bf16",
+        "mtp.layers.0.self_attn.q_proj": "bf16",
+    }
+    assert _scan_source_dtype_manifest(model_path, profile=None) == expected
+    assert (
+        _scan_source_dtype_manifest(model_path, profile=DefaultProfile())
+        == expected
+    )
+
+
+def test_packed_parent_fold_routes_through_the_layer(tmp_path) -> None:
+    # Per-expert INDEXED source keys fold their kind onto the packed recipe
+    # parent the probe/cost actually enumerate — via the layer's
+    # packed_parent_of_expert_param (footprint.packed_expert_alias + the
+    # profile's declared mapping), not a local structural re-parse.
+    model_path = _write_checkpoint(tmp_path, {
+        "model.layers.0.mlp.experts.0.gate_proj.weight":
+            torch.randn(8, 4, dtype=torch.bfloat16),
+        "model.layers.0.mlp.experts.0.up_proj.weight":
+            torch.randn(8, 4, dtype=torch.float32),
+    })
+    manifest = _scan_source_dtype_manifest(
+        model_path, profile=DefaultProfile())
+    # Own rows keep their names...
+    assert manifest["model.layers.0.mlp.experts.0.gate_proj"] == "bf16"
+    assert manifest["model.layers.0.mlp.experts.0.up_proj"] == "f32"
+    # ...and the mixed kinds fold onto the shared packed parent as
+    # heterogeneous (no byte-copy format may be admitted for it).
+    assert manifest["model.layers.0.mlp.experts.gate_up_proj"] == (
+        "heterogeneous"
+    )
+    # Without a caller-supplied profile there is NO declared mapping and
+    # nothing folds (historical behavior).
+    unfolded = _scan_source_dtype_manifest(model_path, profile=None)
+    assert "model.layers.0.mlp.experts.gate_up_proj" not in unfolded
+
+
+def test_profile_accessor_failure_refuses_instead_of_silently_skipping(
+    tmp_path,
+) -> None:
+    # The old private mapper swallowed every accessor exception into an
+    # empty recipe name and dropped the row — the wo_a shape. The layer
+    # refuses; the refusal must propagate out of the scan.
+    class BrokenProfile(DefaultProfile):
+        def checkpoint_to_live_name(self, ckpt_key: str, *,
+                                    multimodal: bool = False):
+            raise RuntimeError("boom")
+
+    model_path = _write_checkpoint(tmp_path, {
+        "model.layers.0.self_attn.q_proj.weight":
+            torch.randn(4, 4, dtype=torch.bfloat16),
+    })
+    try:
+        _scan_source_dtype_manifest(model_path, profile=BrokenProfile())
+    except NameProjectionError as exc:
+        assert exc.code == "profile_accessor_failed"
+        assert exc.source_namespace == "checkpoint"
+        assert exc.target_namespace == "live"
+    else:
+        raise AssertionError(
+            "a failing profile accessor was swallowed into a skipped row")
+
+
+def test_decision_units_uses_the_shared_leaf_function() -> None:
+    # decision_units._recipe_name is gone; the leaf rule lives once, in
+    # name_projection. Pin the migrated call sites' values.
+    from prismaquant.decision_units import (
+        _decision_unit_name_from_graph_unit,
+    )
+
+    assert _decision_unit_name_from_graph_unit(
+        "fused:model.layers.0.self_attn.qkv_proj.weight"
+    ) == "model.layers.0.self_attn.qkv_proj"
+    assert _decision_unit_name_from_graph_unit(
+        "tensor:model.layers.1.mlp.down_proj.weight"
+    ) == "model.layers.1.mlp.down_proj"

--- a/tests/test_consumer_probe_name_projection.py
+++ b/tests/test_consumer_probe_name_projection.py
@@ -1,0 +1,186 @@
+"""R5 consumer migration: the probe's name derivation routes through the
+shared name-projection layer.
+
+Pins what changed when ``prismaquant/sensitivity_probe.py`` stopped
+holding private name mappings (2026-08-22, ``walker/consumer-probe``):
+
+1. The packed-expert shard-scope filter derives its block id from
+   :meth:`NameProjection.block_id` (the shared
+   ``decision_units.block_id_from_qname`` rule), not a positional
+   ``[:3]`` slice of the qname. On every qname shape reachable in this
+   repo today the two agree exactly — pinned here so the refactor is
+   provably value-preserving on shipped families.
+2. The Fisher skip set's embedding clause keys on the profile's DECLARED
+   embedding name (:meth:`ModelProfile.embedding_name`), not a hardcoded
+   ``"model.embed_tokens"`` spelling: rename the declaration and the
+   skip follows it.
+3. The accumulator builds its ``NameProjection`` once and refuses to run
+   without a profile: the layer's constructor rejects ``None`` rather
+   than degrading every mapping to identity, so the probe can never
+   silently fall back to an ungoverned mapping.
+
+No GPU, no checkpoint weights, no network.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from prismaquant.decision_units import block_id_from_qname
+from prismaquant.model_profiles.qwen3 import Qwen3Profile
+from prismaquant.name_projection import NameProjection
+from prismaquant.sensitivity_probe import FisherAccumulator
+
+
+class _ToyPackedExperts(nn.Module):
+    """Qwen3.5-style packed experts container: 3-D params named like the
+    default profile declaration. The probe only needs install-time
+    metadata to observe the block filter; nothing calls forward."""
+
+    def __init__(self, num_experts: int = 2, hidden: int = 4, inter: int = 3):
+        super().__init__()
+        self.gate_up_proj = nn.Parameter(
+            torch.zeros(num_experts, 2 * inter, hidden))
+        self.down_proj = nn.Parameter(torch.zeros(num_experts, hidden, inter))
+
+
+class _Mlp(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.up = nn.Linear(4, 4)
+        self.experts = _ToyPackedExperts()
+
+
+class _Block(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.mlp = _Mlp()
+
+
+def _tiny_model() -> nn.Module:
+    """`model.{embed_tokens,layers.{7,9}.mlp.*,lm_head}` — Linear-typed
+    embedding/head stand-ins at the conventional live spellings, with
+    packed-experts containers under two blocks so inclusion scoping is
+    observable."""
+
+    class _Inner(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embed_tokens = nn.Linear(4, 4)
+            self.layers = nn.ModuleDict({"7": _Block(), "9": _Block()})
+            self.lm_head = nn.Linear(4, 4)
+
+    class _Root(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = _Inner()
+
+    return _Root()
+
+
+def _tracked_names(model: nn.Module) -> list[str]:
+    return [
+        n for n, m in model.named_modules() if isinstance(m, nn.Linear)
+    ]
+
+
+# --------------------------------------------------------------- block id
+
+
+def test_packed_block_filter_matches_the_legacy_slice_on_reachable_shapes():
+    """Value preservation: for every packed-experts qname this repo can
+    produce today, NameProjection.block_id returns exactly what the old
+    private `".".join(qname.split(".")[:3])` returned, so no stats row
+    can gain or lose inclusion."""
+    proj = NameProjection(Qwen3Profile())
+    # NOTE: every live tree the accumulator can be handed today starts
+    # with a two-component layer prefix (`model.layers`, `mtp.layers`),
+    # so the `layers.<int>` pair sits at component depth 1 and the two
+    # derivations coincide exactly. Deeper wrappers diverge (pinned as a
+    # divergence below); a relative `layers.N...` root is a CHECKPOINT
+    # spelling that never reaches this filter.
+    for qname in (
+        "model.layers.7.mlp.experts",          # body MoE block
+        "model.layers.0.mlp.experts",          # first block
+        "mtp.layers.0.ffn.experts",            # MTP shard wrapper
+    ):
+        assert proj.block_id(qname) == ".".join(qname.split(".")[:3])
+
+
+def test_block_id_is_the_shared_rule_not_a_private_slice():
+    """The accumulator's projection delegates to the one shared block-id
+    rule, and diverges from the legacy slice exactly where the slice was
+    only correct by accident (a layer prefix deeper than two components).
+    The divergence is the layer's explicit rule winning over a heuristic;
+    it is documented in the migration report, not smuggled in."""
+    acc_proj = NameProjection(Qwen3Profile())
+    assert acc_proj.block_id("model.layers.2.self_attn.q_proj") == (
+        block_id_from_qname("model.layers.2.self_attn.q_proj"))
+    deep = "model.language_model.layers.7.mlp.experts"
+    assert acc_proj.block_id(deep) == "model.language_model.layers.7"
+    assert ".".join(deep.split(".")[:3]) != acc_proj.block_id(deep)
+
+
+def test_packed_entry_included_only_when_its_block_is_tracked():
+    model = _tiny_model()
+    # Only block 7 has a tracked dense Linear; block 9's experts container
+    # must stay out of stats under both the old slice and the shared rule.
+    tracked = ["model.layers.7.mlp.up"]
+    acc = FisherAccumulator(model, tracked, {}, model_profile=Qwen3Profile())
+    assert "model.layers.7.mlp.experts.gate_up_proj" in acc.stats
+    assert "model.layers.7.mlp.experts.down_proj" in acc.stats
+    assert "model.layers.9.mlp.experts.gate_up_proj" not in acc.stats
+    assert "model.layers.9.mlp.experts.down_proj" not in acc.stats
+
+
+# ------------------------------------------------------------ fisher skip
+
+
+def test_fisher_skip_keys_on_pinned_and_declared_embedding_names():
+    model = _tiny_model()
+    acc = FisherAccumulator(
+        model, _tracked_names(model), {}, model_profile=Qwen3Profile())
+    # lm_head is skipped through the profile's pins (unchanged behavior);
+    # the embedding is skipped because the profile DECLARES that name.
+    assert "model.lm_head" in acc._fisher_skip
+    assert "model.embed_tokens" in acc._fisher_skip
+    assert "model.layers.7.mlp.up" not in acc._fisher_skip
+    assert "model.layers.9.mlp.up" not in acc._fisher_skip
+
+
+def test_embedding_skip_follows_a_renamed_declaration():
+    class _RenamedEmbedProfile(Qwen3Profile):
+        def embedding_name(self) -> str:
+            return "model.model.embed_tokens"
+
+    model = _tiny_model()
+    acc = FisherAccumulator(
+        model, _tracked_names(model), {},
+        model_profile=_RenamedEmbedProfile())
+    # Only the DECLARED spelling and the pins are skipped. In particular
+    # `model.embed_tokens` stays measurable: the old private clause would
+    # have substring-matched it regardless of any declaration.
+    assert acc._fisher_skip == {"model.lm_head"}
+
+
+# ------------------------------------------------- construction refusal
+
+
+def test_projection_seam_refuses_a_none_profile():
+    """Requirement: a refusal propagates instead of degrading. The probe
+    builds its projection from a resolved profile; if it ever handed the
+    layer a None profile, construction itself must fail loudly."""
+    with pytest.raises(ValueError):
+        NameProjection(None)
+
+
+def test_accumulator_seam_carries_no_tp_degree():
+    """TP invariant 1: names are logical whole-tensor facts; nothing in
+    the migrated seam accepts a rank/shard/degree."""
+    model = _tiny_model()
+    acc = FisherAccumulator(model, _tracked_names(model), {},
+                            model_profile=Qwen3Profile())
+    assert not hasattr(acc._name_projection, "tp_degree")
+    with pytest.raises(TypeError):
+        NameProjection(Qwen3Profile(), tp_degree=8)  # type: ignore[call-arg]

--- a/tests/test_footprint.py
+++ b/tests/test_footprint.py
@@ -14,11 +14,12 @@ import struct
 
 import pytest
 
+import prismaquant.name_projection as npx
 from prismaquant import footprint as fp
 from prismaquant import format_registry as fr
+from prismaquant.model_profiles.base import ModelProfile
+from prismaquant.model_profiles.qwen3 import Qwen3Profile
 from prismaquant.nvfp4_cb_footprint import CBSerializationContext
-
-
 def _write_safetensors(path, tensors):
     """Write a minimal valid .safetensors file. tensors: {name: (dtype, shape)}.
 
@@ -951,3 +952,145 @@ def test_partition_allows_the_shipping_shape(tmp_path):
     # Unchanged from the no-universe call: the guard refuses, it never reprices.
     assert part == fp.partitioned_source_total_bytes(
         m, total, ["mtp."], context="unit")
+
+
+# ---------------------------------------------------------------------------
+# Name derivation routes through the shared projection layer (R5,
+# walker/consumer-footprint): footprint keeps no private name mapping.
+# The leaf rule and the packed-expert alias ARE
+# prismaquant.name_projection's; these pins hold the projection-object
+# path byte-identical to the raw-accessor path and hold refusals loud.
+# ---------------------------------------------------------------------------
+
+
+class _ExplodingCheckpointProfile(ModelProfile):
+    """A profile whose checkpoint_to_live_name is a declaration bug."""
+
+    name = "exploding-checkpoint-stub"
+
+    @classmethod
+    def matches(cls, model_type, architectures):
+        return False
+
+    def structure_spec(self):
+        return None
+
+    def checkpoint_to_live_name(self, ckpt_key, *, multimodal=False):
+        raise RuntimeError("spec exploded")
+
+
+def test_footprint_holds_no_private_name_mapping():
+    """The leaf rule and the packed-expert parser are THE layer's.
+
+    ``footprint`` re-exports them for the historic import paths; it does
+    not reimplement them."""
+    assert fp.strip_weight_leaf is npx.strip_weight_leaf
+    assert fp.packed_expert_alias is npx.packed_expert_alias
+    # The span-identity helper is a thin alias over the layer's leaf rule.
+    assert fp.source_span_identity("a.b.weight") == npx.strip_weight_leaf(
+        "a.b.weight")
+    assert fp.source_span_identity("a.b") == "a.b"
+
+
+def _projection_parity_checkpoint(tmp_path):
+    """Per-expert-on-disk MoE spans, an fp8 scale sibling with no base
+    tensor, a declined MTP tensor, and the BF16 floor — everything the
+    manifest's name mapping has to survive identically under both forms."""
+    _write_safetensors(tmp_path / "m.safetensors", {
+        "model.layers.0.mlp.experts.0.gate_proj.weight": ("BF16", (16, 32)),
+        "model.layers.0.mlp.experts.0.up_proj.weight": ("BF16", (16, 32)),
+        "model.layers.0.mlp.experts.0.down_proj.weight": ("BF16", (32, 16)),
+        "model.layers.0.mlp.experts.1.gate_proj.weight": ("BF16", (16, 32)),
+        "model.layers.0.mlp.experts.1.up_proj.weight": ("BF16", (16, 32)),
+        "model.layers.0.mlp.experts.1.down_proj.weight": ("BF16", (32, 16)),
+        "model.layers.0.self_attn.q_proj.weight_scale_inv": ("F32", (1, 1)),
+        "mtp.fc.weight": ("BF16", (8, 8)),                          # 128
+        "embed.weight": ("BF16", (100, 8)),                         # 1600
+    })
+
+
+def test_manifest_via_projection_matches_the_raw_accessor_path(tmp_path):
+    _projection_parity_checkpoint(tmp_path)
+    profile = Qwen3Profile()
+    legacy = fp.source_tensor_bytes_manifest(
+        str(tmp_path),
+        name_map=profile.checkpoint_to_live_name,
+        expert_parent_for_projection=(
+            profile.packed_expert_parent_for_projection),
+    )
+    via_layer = fp.source_tensor_bytes_manifest(
+        str(tmp_path), projection=npx.NameProjection(profile))
+
+    # Byte-for-byte identical manifest, provenance included.
+    assert dict(via_layer) == dict(legacy)
+    assert via_layer.spans == legacy.spans
+
+    # The interesting branches really fired on this fixture:
+    # per-expert spans aggregate into the packed allocator names ...
+    assert via_layer["model.layers.0.mlp.experts.gate_up_proj"] == 4 * 1024
+    assert via_layer["model.layers.0.mlp.experts.down_proj"] == 2 * 1024
+    # ... a DECLARED drop keeps its raw checkpoint spelling (MTP) ...
+    assert via_layer["mtp.fc"] == 128
+    # ... and a standalone sidecar gets no entry of its own.
+    assert "model.layers.0.self_attn.q_proj.weight_scale_inv" not in via_layer
+
+
+def test_floor_bytes_for_model_accepts_a_projection(tmp_path):
+    _case_a_per_expert_disk(tmp_path)
+    profile = Qwen3Profile()
+    via_layer = fp.floor_bytes_for_model(
+        str(tmp_path), _PACKED_NAMES, _PACKED_STATS,
+        projection=npx.NameProjection(profile))
+    legacy = fp.floor_bytes_for_model(
+        str(tmp_path), _PACKED_NAMES, _PACKED_STATS,
+        name_map=profile.checkpoint_to_live_name,
+        expert_parent_for_projection=profile.packed_expert_parent_for_projection)
+    assert via_layer["floor_bytes"] == legacy["floor_bytes"] == 1600
+    assert via_layer["reencoded_source_bytes"] == \
+        legacy["reencoded_source_bytes"] == 6 * 1024
+    assert dict(via_layer["source_manifest"]) == dict(legacy["source_manifest"])
+    assert via_layer["source_manifest"].spans == legacy["source_manifest"].spans
+
+
+def test_projection_and_raw_accessors_are_mutually_exclusive(tmp_path):
+    _partitioned_disk(tmp_path)
+    proj = npx.NameProjection(Qwen3Profile())
+    with pytest.raises(ValueError, match="never both"):
+        fp.source_tensor_bytes_manifest(
+            str(tmp_path), name_map=lambda k: k, projection=proj)
+    with pytest.raises(ValueError, match="never both"):
+        fp.floor_bytes_for_model(
+            str(tmp_path), ["layers.0.mlp.gate_proj"], {},
+            name_map=lambda k: k, projection=proj)
+
+
+def test_layer_refusals_propagate_out_of_the_manifest(tmp_path):
+    """Requirement: a refused name propagates as a refusal — it must not be
+    swallowed into a skip/None/zero (silent-zero is how wo_a stayed
+    invisible). A raising or malformed profile accessor is a structured
+    NameProjectionError out of source_tensor_bytes_manifest."""
+    _write_safetensors(tmp_path / "m.safetensors",
+                       {"a.weight": ("BF16", (2, 2))})
+    proj = npx.NameProjection(_ExplodingCheckpointProfile())
+    with pytest.raises(npx.NameProjectionError) as raising:
+        fp.source_tensor_bytes_manifest(str(tmp_path), projection=proj)
+    assert raising.value.code == "profile_accessor_failed"
+    assert raising.value.name == "a.weight"
+
+    class _Malformed(ModelProfile):
+        name = "malformed-checkpoint-stub"
+
+        @classmethod
+        def matches(cls, model_type, architectures):
+            return False
+
+        def structure_spec(self):
+            return None
+
+        def checkpoint_to_live_name(self, ckpt_key, *, multimodal=False):
+            return 42
+
+    with pytest.raises(npx.NameProjectionError) as malformed:
+        fp.source_tensor_bytes_manifest(
+            str(tmp_path), projection=npx.NameProjection(_Malformed()))
+    assert malformed.value.code == "malformed_profile_result"

--- a/tests/test_name_projection.py
+++ b/tests/test_name_projection.py
@@ -1,0 +1,598 @@
+"""The shared name-projection layer (``prismaquant/name_projection.py``).
+
+These tests pin the contract the four R5 consumer migrations depend on:
+one projection between the live/recipe/checkpoint/export/vLLM namespaces,
+routed entirely through the model profile; fail-closed refusals with
+structured fields; explicit many->one and one->many shapes for fused
+siblings and packed experts; and round-trip identity wherever the
+profile's mapping is total.
+
+Fixtures use real profiles against real (toy) transformers models where a
+forward can execute offline, and real profile declarations from their
+shipped structure specs everywhere else. No checkpoint weights are used.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+import prismaquant.name_projection as npx
+from prismaquant.model_profiles.base import ModelProfile
+from prismaquant.model_profiles.deepseek_v4 import DeepseekV4Profile
+from prismaquant.model_profiles.qwen3 import Qwen3Profile
+from prismaquant.model_walk import WalkResult, walk_model
+
+
+# ---------------------------------------------------------------- fixtures
+
+
+def _meta(build):
+    prev = torch.get_default_dtype()
+    torch.set_default_dtype(torch.bfloat16)
+    try:
+        with torch.device("meta"):
+            return build().eval()
+    finally:
+        torch.set_default_dtype(prev)
+
+
+def _tiny_qwen3():
+    from transformers import AutoConfig, AutoModelForCausalLM
+
+    def build():
+        cfg = AutoConfig.for_model(
+            "qwen3",
+            vocab_size=128, hidden_size=64, intermediate_size=128,
+            num_hidden_layers=2, num_attention_heads=4, num_key_value_heads=2,
+            head_dim=16, max_position_embeddings=64, rope_theta=10000.0,
+            attention_dropout=0.0, tie_word_embeddings=False,
+            pad_token_id=0, bos_token_id=1, eos_token_id=2,
+        )
+        return AutoModelForCausalLM.from_config(cfg)
+
+    return _meta(build)
+
+
+def _tiny_qwen3_moe():
+    # transformers 5.x builds the PACKED expert tree (`mlp.experts.
+    # gate_up_proj` / `.down_proj`, 3-D parameters) and its grouped-mm
+    # forward only has a BF16 meta kernel, so this fixture constructs in
+    # bfloat16. Root A (the node universe) is what these tests consume.
+    from transformers import AutoConfig, AutoModelForCausalLM
+
+    def build():
+        cfg = AutoConfig.for_model(
+            "qwen3_moe",
+            vocab_size=64, hidden_size=32, intermediate_size=64,
+            moe_intermediate_size=32, num_hidden_layers=2,
+            num_attention_heads=4, num_key_value_heads=2, head_dim=8,
+            num_experts=4, num_experts_per_tok=2,
+            max_position_embeddings=64, tie_word_embeddings=False,
+        )
+        return AutoModelForCausalLM.from_config(cfg)
+
+    return _meta(build)
+
+
+def _walked(model, profile):
+    rules = profile.walk_claim_rules()
+    result = walk_model(model, claim_rules=rules)
+    result.raise_if_failed()
+    return result
+
+
+@pytest.fixture(scope="module")
+def qwen3_result():
+    return _walked(_tiny_qwen3(), Qwen3Profile())
+
+
+@pytest.fixture(scope="module")
+def qwen3_proj(qwen3_result):
+    return npx.NameProjection.for_walk(qwen3_result, Qwen3Profile())
+
+
+@pytest.fixture(scope="module")
+def moe_result():
+    return _walked(_tiny_qwen3_moe(), Qwen3Profile())
+
+
+# ------------------------------------------------------- the probe/cost join
+
+
+def test_recipe_unit_is_the_stats_assignment_key(qwen3_proj):
+    unit = qwen3_proj.recipe_unit(
+        "model.layers.0.self_attn.q_proj.weight")
+    assert unit == "model.layers.0.self_attn.q_proj"
+    # The leaf handling belongs to the layer, not to each consumer.
+    assert not unit.endswith(".weight")
+
+
+def test_live_to_recipe_is_total_over_the_walk_universe(
+        qwen3_result, qwen3_proj):
+    decided = [n for n, c in qwen3_result.claims.items()
+               if c.disposition == "decide"]
+    assert decided  # the fixture really walked a quantizable model
+    for name in decided:
+        recipe = qwen3_proj.live_to_recipe(name)
+        assert isinstance(recipe, str) and recipe
+        # Round trip over a total mapping is the identity.
+        assert qwen3_proj.recipe_to_live(recipe) == name
+
+
+def test_block_id_and_dispatch_agree_with_shared_helpers(qwen3_proj):
+    assert qwen3_proj.block_id(
+        "model.layers.1.self_attn.o_proj.weight") == "model.layers.1"
+
+
+def test_project_dispatch_serves_declared_pairs_only(qwen3_proj):
+    projected = qwen3_proj.project(
+        "model.layers.0.self_attn.q_proj.weight", npx.LIVE, npx.RECIPE)
+    assert isinstance(projected, npx.ProjectedName)
+    assert projected.outcome == npx.MAPPED
+    assert projected.target == "model.layers.0.self_attn.q_proj.weight"
+
+    with pytest.raises(npx.NameProjectionError) as unknown_ns:
+        qwen3_proj.project("x", "tensor_parallel_shard", npx.LIVE)
+    assert unknown_ns.value.code == "unknown_namespace"
+
+    with pytest.raises(npx.NameProjectionError) as bad_pair:
+        qwen3_proj.project("x", npx.LIVE, npx.VLLM)
+    assert bad_pair.value.code == "unsupported_pair"
+
+
+# ------------------------------------------- fused siblings: many -> one
+
+
+def test_fused_sibling_group_collapses_explicitly(qwen3_proj):
+    qkv = {
+        proj: qwen3_proj.fused_sibling_group(
+            f"model.layers.0.self_attn.{proj}")
+        for proj in ("q_proj", "k_proj", "v_proj")
+    }
+    assert len(set(qkv.values())) == 1
+    group_key = next(iter(qkv.values()))
+    assert group_key == "model.layers.0.self_attn.qkv_proj"
+    # o_proj and down_proj are NOT fused siblings.
+    assert qwen3_proj.fused_sibling_group(
+        "model.layers.0.self_attn.o_proj") is None
+    assert qwen3_proj.fused_sibling_group(
+        "model.layers.0.mlp.down_proj") is None
+
+
+def test_serving_group_reports_kind_members_namespace(qwen3_proj):
+    group = qwen3_proj.serving_group("model.layers.1.mlp.gate_proj.weight")
+    assert group.kind == npx.GROUP_FUSED_SIBLINGS
+    assert group.key == "model.layers.1.mlp.gate_up_proj"
+    assert group.members == (
+        "model.layers.1.mlp.gate_proj.weight",
+        "model.layers.1.mlp.up_proj.weight",
+    )
+    singleton = qwen3_proj.serving_group(
+        "model.layers.1.self_attn.o_proj.weight")
+    assert singleton.kind == npx.GROUP_SINGLETON
+    assert singleton.key == ""
+    assert singleton.members == ("model.layers.1.self_attn.o_proj",)
+
+
+def test_reverse_of_a_group_key_refuses_instead_of_guessing(qwen3_proj):
+    # A fused-group KEY names a serving unit, not a parameter. Handing it
+    # to a reverse lookup must refuse loudly — silently returning one of
+    # the siblings would be exactly the ad hoc guessing this layer kills.
+    with pytest.raises(npx.NameProjectionError) as err:
+        qwen3_proj.unit_to_live("model.layers.0.self_attn.qkv_proj")
+    assert err.value.code == "unmapped_in_universe"
+    assert err.value.source_namespace == npx.RECIPE
+    assert err.value.target_namespace == npx.LIVE
+    assert err.value.tried  # what was attempted is part of the record
+
+
+def test_require_serving_group_refuses_the_wrong_shape(qwen3_proj):
+    with pytest.raises(npx.NameProjectionError) as wrong:
+        qwen3_proj.require_serving_group(
+            "model.layers.0.mlp.down_proj.weight",
+            kinds=(npx.GROUP_PACKED_EXPERTS,))
+    assert wrong.value.code == "wrong_group_kind"
+    with pytest.raises(npx.NameProjectionError) as ungrouped:
+        qwen3_proj.require_serving_group(
+            "model.layers.0.mlp.down_proj.weight", kinds=())
+    assert ungrouped.value.code == "ungrouped_unit"
+    grouped = qwen3_proj.require_serving_group(
+        "model.layers.0.mlp.gate_proj.weight",
+        kinds=(npx.GROUP_FUSED_SIBLINGS, npx.GROUP_PACKED_EXPERTS))
+    assert grouped.kind == npx.GROUP_FUSED_SIBLINGS
+
+
+# ------------------------------------------------- packed experts (MoE tree)
+
+
+def test_packed_expert_stack_groups_by_role(moe_result):
+    profile = Qwen3Profile()
+    proj = npx.NameProjection.for_walk(moe_result, profile)
+    packed_node = "model.layers.1.mlp.experts.gate_up_proj"
+    assert any(node.name == packed_node for node in moe_result.nodes), (
+        "fixture expected the packed 3-D expert parameters of the "
+        "transformers 5.x tree")
+    key = proj.packed_format_group(packed_node)
+    assert key == (
+        "model.layers.1.mlp.experts::__packed_format__:gate_up_proj,down_proj"
+    )
+    group = proj.serving_group(packed_node)
+    assert group.kind == npx.GROUP_PACKED_EXPERTS
+    assert set(group.members) >= {packed_node,
+                                  "model.layers.1.mlp.experts.down_proj"}
+
+
+def test_split_checkpoint_spells_cover_the_packed_aggregate(moe_result):
+    """One logical tensor, many export spellings: the coverage index must
+    answer under EITHER naming scheme (footprint's dual-entry manifest
+    convention), which is the one->many case made explicit."""
+    profile = Qwen3Profile()
+    split_keys = [
+        f"model.layers.1.mlp.experts.{expert}.{projection}.weight"
+        for expert in range(4)
+        for projection in ("gate_proj", "up_proj", "down_proj")
+    ]
+    proj = npx.NameProjection.for_walk(
+        moe_result, profile, checkpoint_keys=split_keys)
+    gate_up = proj.checkpoint_keys_for(
+        "model.layers.1.mlp.experts.gate_up_proj")
+    assert gate_up == tuple(sorted(
+        f"model.layers.1.mlp.experts.{e}.{p}.weight"
+        for e in range(4) for p in ("gate_proj", "up_proj")))
+    down = proj.checkpoint_keys_for("model.layers.1.mlp.experts.down_proj")
+    assert down == tuple(sorted(
+        f"model.layers.1.mlp.experts.{e}.down_proj.weight"
+        for e in range(4)))
+    # A per-expert spelling resolves too, to its own single span.
+    own = proj.checkpoint_keys_for("model.layers.1.mlp.experts.2.gate_proj")
+    assert own == ("model.layers.1.mlp.experts.2.gate_proj.weight",)
+
+
+def test_coverage_queries_fail_closed(moe_result):
+    profile = Qwen3Profile()
+    # No checkpoint universe supplied: the query refuses rather than
+    # answering an empty tuple that could be read as "uncovered".
+    bare = npx.NameProjection.for_walk(moe_result, profile)
+    with pytest.raises(npx.NameProjectionError) as missing:
+        bare.checkpoint_keys_for("lm_head")
+    assert missing.value.code == "no_universe_supplied"
+
+    covered = npx.NameProjection.for_walk(
+        moe_result, profile,
+        checkpoint_keys=["model.layers.1.mlp.experts.gate_up_proj"])
+    with pytest.raises(npx.NameProjectionError) as uncovered:
+        covered.require_checkpoint_span("lm_head.weight")
+    assert uncovered.value.code == "uncovered_unit"
+    assert covered.require_checkpoint_span(
+        "model.layers.1.mlp.experts.gate_up_proj") == (
+        "model.layers.1.mlp.experts.gate_up_proj",)
+
+
+def test_packed_precedence_over_fused_is_explicit():
+    """An unpacked expert projection's LEAF can carry a fused-sibling
+    name; routed experts must group by their stack. Packed wins."""
+
+    class _BothGroupsProfile(ModelProfile):
+        name = "both-groups-stub"
+
+        @classmethod
+        def matches(cls, model_type, architectures):
+            return False
+
+        def structure_spec(self):
+            return None
+
+        def packed_expert_param_names(self):
+            return frozenset({"gate_up_proj", "down_proj"})
+
+        def fused_sibling_group(self, linear_qname):
+            # Aggressive stand-in for a vLLM-derived leaf matcher: fires
+            # on every gate/up leaf anywhere in the tree.
+            if linear_qname.rsplit(".", 1)[-1] in {"gate_proj", "up_proj"}:
+                parent, _, _ = linear_qname.rpartition(".")
+                return f"{parent}.gate_up_proj"
+            return None
+
+        def packed_expert_format_group(self, qname):
+            if ".experts." in f"{qname}.":
+                return f"{qname.split('.experts.')[0]}.experts::__stack__"
+            return None
+
+    profile = _BothGroupsProfile()
+    proj = npx.NameProjection(profile, live_names=[
+        "model.layers.0.mlp.experts.3.gate_proj.weight",
+        "model.layers.0.mlp.gate_proj.weight",
+    ])
+    expert_group = proj.serving_group(
+        "model.layers.0.mlp.experts.3.gate_proj.weight")
+    assert expert_group.kind == npx.GROUP_PACKED_EXPERTS
+    assert expert_group.key.endswith("experts::__stack__")
+    dense_group = proj.serving_group("model.layers.0.mlp.gate_proj.weight")
+    assert dense_group.kind == npx.GROUP_FUSED_SIBLINGS
+    assert dense_group.key == "model.layers.0.mlp.gate_up_proj"
+
+
+# --------------------------------------------------- multimodal namespaces
+#
+# Qwen3.5's shipped spec declares non-identity rewrites in all three
+# directions (specs/qwen3_5.json `naming`): live strips the
+# `language_model.` infix into recipes, recipes re-add it for source
+# spellings, and vLLM dispatch uses `language_model.model.`.
+
+
+@pytest.fixture(scope="module")
+def qwen35_multimodal_profile():
+    from prismaquant.model_profiles.registry import profile_from_config
+
+    return profile_from_config({
+        "model_type": "qwen3_5_moe",
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+    })
+
+
+def test_multimodal_live_to_recipe_strips_the_umbrella_infix(
+        qwen35_multimodal_profile):
+    proj = npx.NameProjection(qwen35_multimodal_profile, live_names=[
+        "model.language_model.layers.0.self_attn.q_proj.weight",
+        "model.language_model.layers.0.mlp.experts.gate_up_proj",
+        "lm_head.weight",
+    ])
+    live = "model.language_model.layers.0.self_attn.q_proj.weight"
+    assert proj.live_to_recipe(live) == \
+        "model.layers.0.self_attn.q_proj.weight"
+    assert proj.recipe_unit(live) == "model.layers.0.self_attn.q_proj"
+    # Round trip over a total mapping is the identity.
+    assert proj.recipe_to_live("model.layers.0.self_attn.q_proj.weight") == \
+        live
+
+
+def test_multimodal_recipe_to_checkpoint_round_trip_identity(
+        qwen35_multimodal_profile):
+    proj = npx.NameProjection(qwen35_multimodal_profile)
+    # recipe -> checkpoint -> recipe, requirement 4 verbatim: identity
+    # wherever the profile's rules are total.
+    for recipe in (
+        "model.layers.0.self_attn.q_proj.weight",
+        "model.layers.0.mlp.experts.gate_up_proj.weight",
+        "model.layers.7.mlp.shared_expert.down_proj.weight",
+    ):
+        source = proj.live_to_source(recipe)  # live==recipe prefix here
+        back = proj.project(source, npx.CHECKPOINT, npx.LIVE)
+        assert back.outcome == npx.MAPPED
+        # Live targets are UNIT spellings (module qnames), the form
+        # allocator/assignment dicts key on.
+        assert back.target == npx.strip_weight_leaf(recipe)
+
+
+def test_vllm_internal_names_use_exact_rules_and_preserve_leaves(
+        qwen35_multimodal_profile):
+    proj = npx.NameProjection(qwen35_multimodal_profile)
+    assert proj.to_vllm_internal(
+        "model.layers.0.mlp.experts.gate_up_proj") == (
+        "language_model.model.layers.0.mlp.experts.gate_up_proj")
+    # The spec's EXACT rule targets the bare module qname `lm_head`;
+    # applying the accessor at module granularity keeps the leaf intact.
+    assert proj.to_vllm_internal("lm_head.weight") == \
+        "language_model.lm_head.weight"
+    assert proj.to_vllm_internal("lm_head") == "language_model.lm_head"
+
+
+# ------------------------------------------------------------- DSv4 joins
+
+
+DSV4_SAMPLES = [
+    # (live parameter, flat checkpoint key) pairs attested by the
+    # profile's own mapping (deepseek_v4.py checkpoint_to_live_name).
+    ("model.embed_tokens.weight", "embed.weight"),
+    ("lm_head.weight", "head.weight"),
+    ("model.norm.weight", "norm.weight"),
+    ("model.layers.0.self_attn.wo_a.weight", "layers.0.attn.wo_a.weight"),
+    ("model.layers.2.mlp.gate_proj.weight", "layers.2.ffn.gate_proj.weight"),
+    ("model.layers.2.mlp.experts.3.gate_proj.weight",
+     "layers.2.ffn.experts.3.w1.weight"),
+    ("model.layers.1.mlp.shared_experts.down_proj.weight",
+     "layers.1.ffn.shared_experts.w2.weight"),
+]
+
+
+def test_dsv4_flat_checkpoint_join():
+    proj = npx.NameProjection(DeepseekV4Profile())
+    for live, ckpt in DSV4_SAMPLES:
+        mapped = proj.checkpoint_to_live(ckpt)
+        assert mapped.outcome == npx.MAPPED, ckpt
+        assert mapped.target == live[:-len(".weight")] or \
+            mapped.target == live
+        assert mapped.via == "ModelProfile.checkpoint_to_live_name"
+
+
+def test_dsv4_recipe_checkpoint_round_trip_is_identity_on_the_body():
+    proj = npx.NameProjection(DeepseekV4Profile())
+    for live, _ckpt in DSV4_SAMPLES:
+        source = proj.live_to_source(live)
+        back = proj.project(source, npx.CHECKPOINT, npx.LIVE)
+        assert back.outcome == npx.MAPPED, (live, source)
+        assert back.target == npx.strip_weight_leaf(live), (live, source)
+
+
+def test_dsv4_declared_drops_are_data_not_errors():
+    proj = npx.NameProjection(DeepseekV4Profile())
+    # FP8 scale sibling, standalone scale, MTP sidecar: the profile
+    # declines these BY CONTRACT and the projection reports it as an
+    # outcome, never a silent None and never an exception.
+    for declined in (
+        "layers.2.attn.wkv.scale",
+        "layers.2.ffn.experts.3.w1.scale",
+        "mtp.2.hc_head_fn",
+        "mtp.fc.weight",
+    ):
+        projected = proj.checkpoint_to_live(declined)
+        assert projected.outcome == npx.DECLARED_OUT_OF_GRAPH, declined
+        assert projected.target is None
+    # The generic entry point carries the same structured outcome.
+    via_project = proj.project("head.scale", npx.CHECKPOINT, npx.LIVE)
+    assert via_project.outcome == npx.DECLARED_OUT_OF_GRAPH
+
+
+def test_dsv4_hyperhead_inverse_gap_is_surfaced_not_guessed():
+    """Recorded debt: DSv4's declared recipe->source rules generate
+    `hc_head.hc_fn` while its checkpoint stores the flat `hc_head_fn`
+    (real checkpoint keys verified 2026-08-22). The layer must surface
+    the asymmetry — the generated spelling DECLINES on the way back —
+    instead of papering over it with a guessed inverse. Fixing the spec
+    is profile-side work; this test pins the honest behavior either way
+    the fix lands (mapped-after-fix would need this test updated in the
+    same commit)."""
+    proj = npx.NameProjection(DeepseekV4Profile())
+    forward = proj.live_to_source("model.hc_head.hc_fn.weight")
+    assert forward == "hc_head.hc_fn.weight"
+    back = proj.project(forward, npx.CHECKPOINT, npx.LIVE)
+    assert back.outcome == npx.DECLARED_OUT_OF_GRAPH
+    # The REAL flat key still maps, so the gap is one-sided.
+    real = proj.checkpoint_to_live("hc_head_fn")
+    assert real.outcome == npx.MAPPED
+    assert real.target == "model.hc_head.hc_fn"
+
+
+# ------------------------------------------------------------ refusals
+
+
+class _CollapsingProfile(ModelProfile):
+    """A profile whose live_to_recipe is genuinely many->one: two live
+    tensors land on one recipe name. The inverse is ambiguous by
+    construction and must be reported as such."""
+
+    name = "collapsing-stub"
+
+    @classmethod
+    def matches(cls, model_type, architectures):
+        return False
+
+    def structure_spec(self):
+        return None
+
+    def live_to_recipe_name(self, live_qname):
+        return "model.shared.unit.weight"
+
+
+class _MalformedRecipeProfile(ModelProfile):
+    name = "malformed-recipe-stub"
+
+    @classmethod
+    def matches(cls, model_type, architectures):
+        return False
+
+    def structure_spec(self):
+        return None
+
+    def live_to_recipe_name(self, live_qname):
+        return None
+
+
+class _RaisingFusedProfile(ModelProfile):
+    name = "raising-fused-stub"
+
+    @classmethod
+    def matches(cls, model_type, architectures):
+        return False
+
+    def structure_spec(self):
+        return None
+
+    def fused_sibling_group(self, linear_qname):
+        raise RuntimeError("spec exploded")
+
+    def packed_expert_format_group(self, qname):
+        return None
+
+
+class _BadCheckpointProfile(ModelProfile):
+    name = "bad-checkpoint-stub"
+
+    @classmethod
+    def matches(cls, model_type, architectures):
+        return False
+
+    def structure_spec(self):
+        return None
+
+    def checkpoint_to_live_name(self, k, *, multimodal=False):
+        return 42
+
+
+def test_ambiguous_inverse_raises_listing_both_candidates():
+    proj = npx.NameProjection(_CollapsingProfile(), live_names=[
+        "model.a.weight", "model.b.weight"])
+    with pytest.raises(npx.NameProjectionError) as err:
+        proj.recipe_to_live("model.shared.unit.weight")
+    assert err.value.code == "ambiguous"
+    assert "model.a.weight" in err.value.detail
+    assert "model.b.weight" in err.value.detail
+
+
+def test_malformed_accessor_results_are_structured_refusals():
+    with pytest.raises(npx.NameProjectionError) as built:
+        npx.NameProjection(
+            _MalformedRecipeProfile(), live_names=["model.a.weight"])
+    assert built.value.code == "malformed_profile_result"
+
+    proj = npx.NameProjection(_BadCheckpointProfile())
+    with pytest.raises(npx.NameProjectionError) as ckpt:
+        proj.checkpoint_to_live("anything.weight")
+    assert ckpt.value.code == "malformed_profile_result"
+    assert ckpt.value.source_namespace == npx.CHECKPOINT
+    assert ckpt.value.target_namespace == npx.LIVE
+
+    # Construction eagerly validates the profile's group declarations
+    # over the whole universe: an accessor that explodes is a declaration
+    # bug and refuses at build time, not mid-query.
+    with pytest.raises(npx.NameProjectionError) as fused:
+        npx.NameProjection(
+            _RaisingFusedProfile(),
+            live_names=["model.layers.0.mlp.gate_proj"])
+    assert fused.value.code == "profile_accessor_failed"
+    assert any("fused_sibling_group" in t for t in fused.value.tried)
+
+
+def test_construction_requires_a_profile():
+    with pytest.raises(ValueError):
+        npx.NameProjection(None)
+
+
+def test_projection_carries_no_tp_degree():
+    """TP seam guard: names are logical, degree-independent facts. No
+    constructor kwarg, method argument, or field exposes a rank/shard/
+    degree anywhere in this API — a future per-rank spelling is a
+    SEPARATE decoration over these logical names."""
+    proj = npx.NameProjection(Qwen3Profile(), live_names=["lm_head.weight"])
+    with pytest.raises(TypeError):
+        npx.NameProjection(Qwen3Profile(), tp_degree=8)
+    with pytest.raises(TypeError):
+        proj.recipe_unit("lm_head.weight", rank=0)  # type: ignore[call-arg]
+    assert proj.recipe_unit("lm_head.weight") == "lm_head"
+
+
+def test_strip_weight_leaf_is_the_one_leaf_rule():
+    assert npx.strip_weight_leaf("a.b.weight") == "a.b"
+    # Packed 3-D parameters carry NO leaf; they pass through unchanged.
+    assert npx.strip_weight_leaf("model.layers.0.mlp.experts.gate_up_proj") \
+        == "model.layers.0.mlp.experts.gate_up_proj"
+    # Only the WEIGHT leaf is special; sidecars are footprint's business.
+    assert npx.strip_weight_leaf("a.b.weight_scale") == "a.b.weight_scale"
+
+
+def test_for_walk_rejects_non_results(qwen3_result):
+    with pytest.raises(TypeError):
+        npx.NameProjection.for_walk(["not", "a", "result"], Qwen3Profile())
+    assert isinstance(qwen3_result, WalkResult)
+
+
+def test_error_str_is_readable_but_fields_are_authoritative():
+    proj = npx.NameProjection(Qwen3Profile(), live_names=["lm_head.weight"])
+    with pytest.raises(npx.NameProjectionError) as err:
+        proj.unit_to_live("nope")
+    message = str(err.value)
+    assert "nope" in message and "recipe" in message and "live" in message
+    exc = err.value
+    assert (exc.name, exc.code, exc.tried) == (
+        "nope", "unmapped_in_universe", exc.tried)

--- a/tests/test_read_traffic.py
+++ b/tests/test_read_traffic.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from prismaquant import footprint as fp
+from prismaquant import name_projection as npx
 from prismaquant import read_traffic as rt
 from prismaquant.model_profiles import detect_profile_with_warning
 
@@ -497,3 +498,86 @@ def test_untied_declaration_without_an_lm_head_refuses(tmp_path: Path):
     with pytest.raises(rt.ReadTrafficError, match="tie_word_embeddings=false"):
         rt.assignment_read_traffic(
             ASSIGNMENT, STATS, model_path=str(root), profile=profile)
+
+
+# ---------------------------------------------------------------------------
+# The checkpoint->live bridge is the shared name-projection layer.
+# ---------------------------------------------------------------------------
+
+def test_the_private_leaf_helper_is_gone():
+    """The `.weight` leaf rule lives in the name-projection layer only.
+
+    A second copy here is how namespace mappings drift apart between
+    consumers; the mechanical pin keeps it deleted (R5: one mechanism).
+    """
+    assert not hasattr(rt, "_strip_weight")
+
+
+def test_declared_out_of_graph_keys_route_through_the_layer(tmp_path: Path):
+    """A key the profile DECLINES to map lands `excluded_non_text_graph`.
+
+    The layer surfaces the profile's declared drop as
+    ``ProjectedName.outcome == declared_out_of_graph`` -- data the classifier
+    branches on -- so vision/audio bytes are itemized at p=0 rather than
+    silently skipped or priced as always-active.
+    """
+    root = tmp_path / "with-visual"
+    root.mkdir()
+    tensors = dict(_TENSORS)
+    tensors["model.visual.blocks.0.attn.q.weight"] = (HIDDEN, HIDDEN)  # 128 B
+    _write_safetensors(root / "model.safetensors", tensors)
+    (root / "config.json").write_text(json.dumps({
+        "model_type": "qwen3_moe",
+        "architectures": ["Qwen3MoeForCausalLM"],
+        "hidden_size": HIDDEN,
+        "num_hidden_layers": 1,
+        "num_experts": N_EXPERTS,
+        "num_experts_per_tok": TOPK,
+    }))
+    profile = detect_profile_with_warning(str(root), entrypoint="test")
+
+    projected = npx.NameProjection(profile).checkpoint_to_live(
+        "model.visual.blocks.0.attn.q.weight")
+    assert projected.outcome == npx.DECLARED_OUT_OF_GRAPH
+
+    # The classifier consumes exactly that outcome -- with and without a
+    # caller-supplied projection instance.
+    for kwargs in ({}, {"projection": npx.NameProjection(profile)}):
+        assert rt.classify_read_class(
+            "model.visual.blocks.0.attn.q", profile=profile,
+            checkpoint_key="model.visual.blocks.0.attn.q.weight",
+            **kwargs) == "excluded_non_text_graph"
+
+    report = rt.exported_checkpoint_read_traffic(str(root), profile=profile)
+    assert report["classes"]["excluded_non_text_graph"]["stored_bytes"] == 128
+    # The ledger still partitions every shipped byte, visual keys included.
+    assert report["reconciliation"]["ledger_stored_bytes"] == (
+        SOURCE_TOTAL_BYTES + 128)
+
+
+def test_a_failing_profile_mapping_refuses_rather_than_passing_through(
+        model_dir: Path, profile):
+    """A broken mapping accessor is a refusal, not a raw-key passthrough.
+
+    The pre-projection code caught every accessor exception and fell back to
+    the checkpoint key itself, so a misbehaving profile would have re-priced
+    every unmappable tensor as an always-active operand instead of failing.
+    Through the shared layer the refusal propagates; the advisory claim form
+    reports it as a reason, never as a value.
+    """
+    class _BrokenMapping:
+        def __getattr__(self, item):
+            return getattr(profile, item)
+
+        def checkpoint_to_live_name(self, ckpt_key, *, multimodal=False):
+            raise RuntimeError("broken mapping")
+
+    broken = _BrokenMapping()
+    with pytest.raises(npx.NameProjectionError) as err:
+        rt.exported_checkpoint_read_traffic(str(model_dir), profile=broken)
+    assert err.value.code == "profile_accessor_failed"
+
+    claim = rt.read_traffic_claim(str(model_dir), profile=broken)
+    assert claim["value"] is None
+    assert claim["source"] is None
+    assert "profile_accessor_failed" in claim["reason"]


### PR DESCRIPTION
Split 2 of 6 from `merge/proven-rescues` (#95).

> **Merge order: this stacks on #99 (`rescue/walker-export-gate`), and the dependency is hard, not cosmetic.** Base is set to that branch; GitHub will retarget to `main` when it merges.

## What it does

The R5 consumer analyses each independently found the same thing: probe, cost, footprint and read-traffic were re-deriving the mapping between the pipeline's parameter-name namespaces ad hoc, with private string surgery in four places that could — and did — disagree.

`prismaquant/name_projection.py` is the one projection between a Linear's **live** name (`WalkNode.name`), its allocator/probe **recipe** name, its source-**checkpoint** key, its **exported**-artifact key, and its **vLLM** scheme-dispatch qname. The contract:

- **The profile owns the knowledge; the layer owns the discipline.** Every mapping routes through existing `ModelProfile` accessors. No second mapping lives anywhere, and consumers keep no private `_recipe_name` / `_strip_weight` helpers.
- **Fail closed and loud.** An unmappable or ambiguous name raises `NameProjectionError` with structured fields — `code`, source/target namespace, and what was tried. Unlike `decision_units.fused_group_key`, nothing swallows a profile failure into an identity fallback. The profile's *declared* drops are data instead: `project()` returns a `ProjectedName` whose `outcome == declared_out_of_graph`, so read-traffic classifies `excluded_non_text_graph` by branching on a field.
- **Non-totality is in the type.** Fused siblings and packed experts surface as `ServingGroup(kind, key, members)`; reverse lookups refuse group KEYS rather than returning an arbitrary member.
- **Round-trip property tested where the profile's rules are total** — Qwen3 dense, Qwen3.5 multimodal, DSv4 — plus the gap the round trip *surfaced*: DSv4's spec generates `hc_head.hc_*` source spellings while the real checkpoint stores flat `hc_head_*`, so that family's inverse declines. The layer reports it; it does not guess.
- **TP seam held.** No rank, shard index or degree exists in any signature (pinned by a constructor-kwarg refusal test). Byte accounting stays in `model_walk.per_device_bytes`.

All four consumers are migrated in this PR, because a shared layer with no consumers is not a refactor, it is a second mapping.

## Why it is worth landing

The migrations are not cosmetic. Two of them close silent-wrong-answer paths:

- **read-traffic**: a failing profile accessor used to pass the raw key through, which **re-priced unmappable tensors at p=1**. It now refuses.
- **probe**: the packed-expert shard-scope filter read its block id from a positional `[:3]` qname slice, and the Fisher skip set keyed its embedding clause on a hardcoded `"model.embed_tokens"` substring test. Both now go through the profile's declared accessors.

## What it touches that is live

All four are live pipeline stages: `read_traffic.py`, `footprint.py`, `sensitivity_probe.py`, and the cost path (`allocator_candidates.py`, `decision_units.py`, `measure_quant_cost.py`, `production_render_cost.py`).

**Emitted values are unchanged.** Bytes, class tables, byte authorities, refusals, probe stats keys, inventories and shard regexes are pinned byte-identical test-side. The manifest's `profile=None` convention now builds over the repo's declared generic baseline (`DefaultProfile` — the substitution `resolve_cost_target_name` always made) instead of inlined string surgery.

One deliberate behaviour change, **fail-closed only**: a profile accessor that raises now propagates `NameProjectionError` instead of silently skipping the row.

One exception stays and is **not** a projection: `production_render_cost.canonical_cost_name`'s umbrella-infix half remains a **total** normalizer, because render/cost payloads key costed MTP rows physically and a projection that may decline must never drop them.

Sharing a name projection is not sharing a requirement set. Every consumer's INVENTORY is still its own enumeration, so the edge-list migration proper stays open for all four.

## Dependencies

- **Hard dependency on #99.** I initially built this off `main` and the tests found it: three `test_name_projection.py` tests (`test_packed_expert_stack_groups_by_role`, `test_split_checkpoint_spells_cover_the_packed_aggregate`, `test_coverage_queries_fail_closed`) build a walk over a packed-expert fixture and raise `WalkError` on `main`, because `walk_claim_rules()` does not claim packed expert stacks until #99 adds that rule. `name_projection.py` also cites `load_walk` and `per_device_bytes` in its module docstring, both of which #99 introduces.
- No other PR in this split depends on this one.

## Tests

`origin/main` (`8461ae2`) baseline, **measured on that exact commit**: **5494 passed, 143 skipped, 3 xfailed, 179 subtests passed, 0 failed** — `EXIT=0`, fully green (14m22s).
Identical to the earlier `4cd8d39` baseline, as expected: the three commits `main` gained
mid-split (`1d35f70`, `22db4fb`, `8461ae2`) touch only `.github/`, `pyproject.toml` and
`docs/` — **zero delta under `prismaquant/`, `tests/`, `tools/` or `scripts/`**, verified by diff.
Note for the reviewer: the brief for this split warned of "4 pre-existing aarch64 failures".
They **do not reproduce** — #90 and #94 already fixed them — so every failure below is attributable.

This branch: **2 failed, 5568 passed**, 143 skipped, 3 xfailed, 179 subtests passed (20m27s). Both failures are #99's inherited freeze gate, documented below; **everything else is green**.



## ⚠️ Known red: the DSv4 W8A16 freeze gate (inherited, not this PR's)

`tests/test_dsv4_w8a16_export_handoff.py` fails the same 2 tests as #99, naming the
same single file, `prismaquant/model_profiles/base.py`, at the same owed digest
`7cff3a4af253777d831094838a35ec56b9cd5e4c1022654431449163be8a848e`.

**This PR's own commit does not touch the frozen closure at all** — verified: the diff
between #99's tip and this branch's tip contains no file under
`prismaquant/model_profiles/`, and this branch's `base.py` is byte-identical to
#99's. The red is inherited by stacking and **clears the moment #99's
re-freeze lands**; nothing extra is owed here.

## Merge-order note (applies to all six)

Every PR in this split adds its own stamp to the top of `docs/ARCHITECTURE.md`'s
provenance block (principle 13). Whichever merges second will therefore hit a
**textual conflict in that block and nowhere else** — resolution is to keep both
stamps, newest first. Verified by merging all six together: `docs/ARCHITECTURE.md`
is the *only* conflicting path across the entire split. **Zero code conflicts.**

---

Extracted from `merge/proven-rescues` commits `7fee52b`, `28b9822`, `f64b861`, `25b82c0`, `2a49363`, `ef4455b`, `db8d3ae`, `41d3333`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F46Tr8Az6t2Ky3sRExZ5y
