### PR TITLE
tools(cluster): TP=2 decode feasibility harness and residency budget planner

### DIFF
--- a/tests/test_tp2_budget_plan.py
+++ b/tests/test_tp2_budget_plan.py
@@ -1,0 +1,484 @@
+"""CPU-only tests for tools/tp2_budget_plan.py.
+
+Every fixture is a synthetic safetensors file written into a worktree-local
+temp dir: no artifact, no GPU, no network, and nothing written under /tmp.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import struct
+import tempfile
+
+import pytest
+
+from tools import tp2_budget_plan as T
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture()
+def workdir():
+    """A scratch dir INSIDE the worktree (project rule: never write to /tmp)."""
+    root = REPO_ROOT / "tests" / "_tmp_tp2"
+    root.mkdir(parents=True, exist_ok=True)
+    path = Path(tempfile.mkdtemp(dir=root))
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+        try:
+            root.rmdir()
+        except OSError:
+            pass
+
+
+def write_safetensors(path: Path, tensors, *, corrupt_offsets_for=None) -> None:
+    """tensors: {name: (dtype, shape)}.  Writes a real (tiny) safetensors file."""
+    header = {}
+    offset = 0
+    blobs = []
+    for name, (dtype, shape) in tensors.items():
+        nbytes = T.tensor_bytes(dtype, shape) if dtype in T.DTYPE_BYTES else 0
+        span = nbytes
+        if corrupt_offsets_for == name:
+            span = nbytes + 1
+        header[name] = {"dtype": dtype, "shape": list(shape),
+                        "data_offsets": [offset, offset + span]}
+        offset += span
+        blobs.append(b"\0" * span)
+    blob = json.dumps(header).encode("utf-8")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as fh:
+        fh.write(struct.pack("<Q", len(blob)))
+        fh.write(blob)
+        for b in blobs:
+            fh.write(b)
+
+
+def simple_model(num_layers: int, per_layer_elems, *, prefix="model.") -> dict:
+    """A minimal well-formed checkpoint: embed + N layers + norm + lm_head."""
+    tensors = {
+        f"{prefix}embed_tokens.weight": ("BF16", [8, 4]),
+        f"{prefix}norm.weight": ("F32", [4]),
+        "lm_head.weight": ("BF16", [8, 4]),
+    }
+    for i in range(num_layers):
+        elems = per_layer_elems[i] if isinstance(per_layer_elems, (list, tuple)) \
+            else per_layer_elems
+        tensors[f"{prefix}layers.{i}.mlp.weight"] = ("U8", [elems])
+    return tensors
+
+
+# ---------------------------------------------------------------------------
+# 1. Exact byte math across dtypes.
+
+
+@pytest.mark.parametrize("dtype,width", [
+    ("F32", 4), ("BF16", 2), ("F16", 2), ("F8_E4M3", 1), ("F8_E5M2", 1),
+    ("F8_E8M0", 1), ("U8", 1), ("I8", 1), ("I64", 8), ("I32", 4), ("BOOL", 1),
+])
+def test_tensor_bytes_exact_per_dtype(dtype, width):
+    assert T.tensor_bytes(dtype, [7, 3]) == 21 * width
+    assert T.tensor_bytes(dtype, []) == width  # 0-d tensor is one element
+
+
+def test_unknown_dtype_is_a_hard_error():
+    with pytest.raises(T.HeaderError, match="unknown safetensors dtype"):
+        T.tensor_bytes("F4_E2M1", [16])
+
+
+def test_artifact_byte_totals_are_exact_across_dtypes(workdir):
+    tensors = {
+        "model.embed_tokens.weight": ("BF16", [10, 4]),      # 80
+        "model.layers.0.a.cb_qweight": ("U8", [100]),        # 100
+        "model.layers.0.a.weight_scale": ("F32", [10]),      # 40
+        "model.layers.0.a.act_scale": ("F8_E4M3", [10]),     # 10
+        "model.layers.0.a.idx": ("I8", [10]),                # 10
+        "model.norm.weight": ("F32", [4]),                   # 16
+        "lm_head.weight": ("BF16", [10, 4]),                 # 80
+    }
+    write_safetensors(workdir / "model.safetensors", tensors)
+    collected = T.collect_artifact_tensors(workdir)
+    classified = T.classify_entries(collected["entries"])
+    total = sum(e["bytes"] for e in classified)
+    assert total == 80 + 100 + 40 + 10 + 10 + 16 + 80
+    assert T.bucket_bytes(classified, T.BUCKET_EMBED) == 80
+    assert T.bucket_bytes(classified, T.BUCKET_HEAD) == 80
+    assert T.bucket_bytes(classified, T.BUCKET_NORM) == 16
+    assert T.layer_byte_table(classified) == [160]
+
+
+def test_offset_mismatch_is_a_hard_error(workdir):
+    write_safetensors(workdir / "model.safetensors",
+                      {"model.layers.0.a.weight": ("BF16", [4, 4])},
+                      corrupt_offsets_for="model.layers.0.a.weight")
+    with pytest.raises(T.HeaderError, match="data_offsets span"):
+        T.collect_artifact_tensors(workdir)
+
+
+def test_tensor_data_is_never_read(workdir, monkeypatch):
+    """The header parse must not depend on the data region existing."""
+    path = workdir / "model.safetensors"
+    header = {"model.layers.0.a.weight": {"dtype": "BF16", "shape": [1024, 1024],
+                                          "data_offsets": [0, 2 * 1024 * 1024]}}
+    blob = json.dumps(header).encode("utf-8")
+    with open(path, "wb") as fh:          # header only; no tensor bytes at all
+        fh.write(struct.pack("<Q", len(blob)))
+        fh.write(blob)
+    entries = T.collect_artifact_tensors(workdir)["entries"]
+    assert entries[0]["bytes"] == 2 * 1024 * 1024
+    assert path.stat().st_size < 4096     # proof no data region was needed
+
+
+# ---------------------------------------------------------------------------
+# 2. Classification rules.
+
+
+def test_layer_regex_matches_dsv4_unprefixed_names():
+    """DSv4 ships `layers.0.attn...`; a bare `\\.layers\\.` matches none of it."""
+    assert T.classify("layers.0.attn.wo_b.cb_qweight")["layer"] == 0
+    assert T.classify("model.language_model.layers.63.mlp.w")["layer"] == 63
+
+
+def test_endcap_placement():
+    assert T.classify("model.language_model.embed_tokens.weight")["bucket"] == T.BUCKET_EMBED
+    assert T.classify("embed.weight")["bucket"] == T.BUCKET_EMBED
+    assert T.classify("lm_head.weight")["bucket"] == T.BUCKET_HEAD
+    assert T.classify("head.weight")["bucket"] == T.BUCKET_HEAD
+    assert T.classify("model.norm.weight")["bucket"] == T.BUCKET_NORM
+    assert T.classify("model.language_model.norm.weight")["bucket"] == T.BUCKET_NORM
+
+
+def test_head_like_name_is_labelled_assumed_placement():
+    cls = T.classify("hc_head_base")
+    assert cls["bucket"] == T.BUCKET_HEAD
+    assert cls["assumed_placement"] is True
+    assert T.classify("head.weight")["assumed_placement"] is False
+
+
+def test_sidecar_rule_fires_before_the_layer_and_norm_rules():
+    """mtp.layers.N.* must NOT become a body layer; mtp.norm the final norm."""
+    assert T.classify("mtp.layers.0.mlp.down_proj.weight")["bucket"] == T.BUCKET_SIDECAR
+    assert T.classify("mtp.norm.weight")["bucket"] == T.BUCKET_SIDECAR
+    assert T.classify("mtp.pre_fc_norm_embedding.weight")["bucket"] == T.BUCKET_SIDECAR
+    assert T.classify("model.nextn.layers.0.w")["bucket"] == T.BUCKET_SIDECAR
+    assert T.classify("draft_model.layers.0.w")["bucket"] == T.BUCKET_SIDECAR
+
+
+def test_unmatched_names_are_a_hard_error_listing_all_of_them():
+    entries = [
+        {"name": "model.layers.0.a.weight", "bytes": 4},
+        {"name": "mystery.tensor.one", "bytes": 4},
+        {"name": "another.unknown.thing", "bytes": 4},
+    ]
+    with pytest.raises(T.ClassificationError) as exc:
+        T.classify_entries(entries)
+    msg = str(exc.value)
+    assert "2 tensor name(s) matched no pipeline-stage rule" in msg
+    assert "mystery.tensor.one" in msg
+    assert "another.unknown.thing" in msg
+
+
+def test_non_contiguous_layer_ids_are_a_hard_error():
+    classified = [
+        {"name": "layers.0.a", "bytes": 4, "bucket": T.BUCKET_LAYER, "layer": 0},
+        {"name": "layers.2.a", "bytes": 4, "bucket": T.BUCKET_LAYER, "layer": 2},
+    ]
+    with pytest.raises(T.ClassificationError, match="not contiguous"):
+        T.layer_byte_table(classified)
+
+
+# ---------------------------------------------------------------------------
+# 3. Splits.
+
+
+def test_vllm_even_split_remainder_goes_to_partitions_minus_two():
+    assert T.vllm_even_split(64, 2) == [32, 32]
+    assert T.vllm_even_split(43, 2) == [22, 21]     # DSv4: extra on rank 0
+    assert T.vllm_even_split(10, 4) == [2, 3, 3, 2]  # skips first and last
+    assert sum(T.vllm_even_split(61, 4)) == 61
+
+
+def test_even_split_refuses_more_stages_than_layers():
+    with pytest.raises(ValueError, match="cannot fill"):
+        T.vllm_even_split(3, 4)
+    with pytest.raises(ValueError, match="cannot fill"):
+        T.optimal_split([1, 1, 1], 4)
+
+
+def test_optimal_split_beats_even_on_an_imbalanced_model():
+    # Front-loaded body: the even 3/3 split is far worse than 4/2.
+    layer_bytes = [10, 10, 10, 10, 40, 40]
+    even = T.vllm_even_split(len(layer_bytes), 2)
+    opt = T.optimal_split(layer_bytes, 2)
+    assert even == [3, 3]
+    assert opt == [4, 2]
+    even_ranks = T.rank_weight_bytes(even, layer_bytes, 0, 0)
+    opt_ranks = T.rank_weight_bytes(opt, layer_bytes, 0, 0)
+    assert even_ranks == [30, 90]
+    assert opt_ranks == [40, 80]
+    assert max(opt_ranks) <= max(even_ranks)
+
+
+def test_optimal_split_accounts_for_the_endcaps():
+    layer_bytes = [10] * 4
+    # A fat last-stage endcap pulls layers off the last rank.
+    assert T.optimal_split(layer_bytes, 2, first_extra=0, last_extra=20) == [3, 1]
+    assert T.optimal_split(layer_bytes, 2, first_extra=20, last_extra=0) == [1, 3]
+    assert T.optimal_split(layer_bytes, 2, 0, 0) == [2, 2]
+
+
+def test_optimal_split_is_deterministic_under_ties():
+    layer_bytes = [10] * 6
+    assert T.optimal_split(layer_bytes, 3) == [2, 2, 2]
+    # Earliest-boundary tie-break: every rank must still hold >= 1 layer.
+    assert min(T.optimal_split([1, 1, 1, 100], 3)) >= 1
+
+
+def test_rank_weight_bytes_places_endcaps_on_first_and_last(workdir):
+    tensors = simple_model(4, [100, 100, 100, 100])
+    tensors["mtp.fc.weight"] = ("BF16", [50])   # 100 B sidecar -> last stage
+    write_safetensors(workdir / "model.safetensors", tensors)
+    plan = T.build_plan(workdir, "pp", 2, 121.0, None, "optimal")
+    inv = plan["inventory"]
+    assert inv["embed_bytes"] == 64 and inv["head_bytes"] == 64
+    assert inv["final_norm_bytes"] == 16
+    assert inv["sidecar_bytes"] == 100
+    endcaps = plan["pp"]["endcaps"]
+    assert endcaps["first_stage_bytes"] == 64            # embed only
+    assert endcaps["last_stage_bytes"] == 64 + 16 + 100  # head + norm + sidecar
+    rows = plan["residency_rows"]
+    assert rows[0]["weight_bytes"] - sum(inv["layer_bytes"][:rows[0]["layer_count"]]) == 64
+    assert plan["sidecar_line_items"][0]["name"] == "mtp.fc.weight"
+
+
+# ---------------------------------------------------------------------------
+# 4. Feasibility arithmetic (hand-computed fixture).
+
+
+def test_max_feasible_matches_the_hand_computed_fixture():
+    layer_bytes = [10, 10, 10, 10]
+    counts = T.optimal_split(layer_bytes, 2, first_extra=5, last_extra=7)
+    assert counts == [2, 2]
+    mf = T.max_feasible_artifact_bytes(
+        counts, layer_bytes, first_extra=5, last_extra=7,
+        budget_bytes=100, overhead_bytes=20)
+    # rank0: (100-20-5)/(40*0.5) = 3.75 ; rank1: (100-20-7)/20 = 3.65 -> binding
+    assert mf["feasible"] is True
+    assert mf["binding_rank"] == 1
+    assert mf["s_max"] == pytest.approx(3.65)
+    assert mf["max_body_bytes"] == pytest.approx(146.0)
+    assert mf["fixed_endcap_bytes"] == 12
+    assert mf["max_artifact_bytes"] == pytest.approx(158.0)
+
+
+def test_max_feasible_is_infeasible_when_endcaps_alone_bust_the_budget():
+    mf = T.max_feasible_artifact_bytes([1, 1], [10, 10], first_extra=0,
+                                       last_extra=200, budget_bytes=100,
+                                       overhead_bytes=20)
+    assert mf["feasible"] is False
+    assert mf["binding_rank"] == 1
+
+
+def test_missing_overhead_prints_unknown_not_a_number(workdir):
+    write_safetensors(workdir / "model.safetensors", simple_model(4, 100))
+    plan = T.build_plan(workdir, "pp", 2, 121.0, None, "optimal")
+    assert plan["max_feasible"]["label"] == T.UNKNOWN_OVERHEAD
+    for row in plan["residency_rows"]:
+        assert row["headroom_bytes"] is None
+        assert row["headroom_label"] == T.UNKNOWN_OVERHEAD
+    text = T.render(plan)
+    assert text.count(T.UNKNOWN_OVERHEAD) >= 3
+    assert "MAX-FEASIBLE-ARTIFACT: UNKNOWN-NEEDS-OVERHEAD" in text
+
+
+def test_max_feasible_render_is_labelled_assumed_linear(workdir):
+    write_safetensors(workdir / "model.safetensors", simple_model(4, 100))
+    plan = T.build_plan(workdir, "pp", 2, 121.0, 1.0, "optimal")
+    text = T.render(plan)
+    assert T.LABEL_ASSUMED_LINEAR in text
+    assert "body bytes scale linearly" in text
+
+
+def test_pp_partition_flag_selects_which_split_drives_the_table(workdir):
+    tensors = simple_model(6, [10, 10, 10, 10, 400, 400])
+    write_safetensors(workdir / "model.safetensors", tensors)
+    even = T.build_plan(workdir, "pp", 2, 121.0, 1.0, "even")
+    opt = T.build_plan(workdir, "pp", 2, 121.0, 1.0, "optimal")
+    # Both splits are always reported, whichever one is selected.
+    assert set(even["pp"]["splits"]) == {"even", "optimal"}
+    assert even["pp"]["selected"] == "even"
+    assert opt["pp"]["selected"] == "optimal"
+    assert even["pp"]["splits"]["even"]["counts"] == [3, 3]
+    assert opt["pp"]["splits"]["optimal"]["counts"] != [3, 3]
+    assert (opt["pp"]["splits"]["optimal"]["max_rank_bytes"]
+            < even["pp"]["splits"]["even"]["max_rank_bytes"])
+    assert opt["residency_rows"][0]["layer_count"] == \
+        opt["pp"]["splits"]["optimal"]["counts"][0]
+    assert "VLLM_PP_LAYER_PARTITION=" in T.render(opt)
+
+
+# ---------------------------------------------------------------------------
+# 5. TP mode: everything ASSUMED.
+
+
+def test_tp_mode_labels_every_line_assumed(workdir):
+    write_safetensors(workdir / "model.safetensors", simple_model(4, 100))
+    plan = T.build_plan(workdir, "tp", 2, 121.0, 4.0, "optimal")
+    assert plan["tp"]["label"] == T.LABEL_ASSUMED_TP
+    for row in plan["residency_rows"]:
+        assert row["label"] == T.LABEL_ASSUMED_TP
+        assert row["headroom_label"] == T.LABEL_ASSUMED_TP
+    text = T.render(plan)
+    # Every printed residency row carries the label, not just the section.
+    table = text.split("PER-RANK RESIDENCY")[1].split("TP DECOMPOSITION")[0]
+    row_lines = [ln for ln in table.splitlines()
+                 if ln.strip() and ln.split()[0].isdigit()]
+    assert len(row_lines) == 2
+    assert all("ASSUMED" in ln for ln in row_lines)
+    assert "TP DECOMPOSITION" in text
+    assert "ASSUMED sharded" in text and "ASSUMED replicated" in text
+    assert "Every TP row above is ASSUMED" in text
+    # A max-feasible number is refused, not guessed, in TP mode.
+    assert plan["max_feasible"]["label"] == "NOT-COMPUTED-FOR-TP"
+
+
+def test_tp_assumed_shard_classification():
+    assert T.tp_assumed_replicated("model.layers.0.input_layernorm.weight",
+                                   T.BUCKET_LAYER) is True
+    assert T.tp_assumed_replicated("model.layers.0.mlp.up_proj.bias",
+                                   T.BUCKET_LAYER) is True
+    assert T.tp_assumed_replicated("model.layers.0.mlp.up_proj.weight",
+                                   T.BUCKET_LAYER) is False
+    assert T.tp_assumed_replicated("model.embed_tokens.weight",
+                                   T.BUCKET_EMBED) is True
+    assert T.tp_assumed_replicated("lm_head.weight", T.BUCKET_HEAD) is True
+
+
+def test_tp_per_rank_arithmetic(workdir):
+    tensors = {
+        "model.embed_tokens.weight": ("U8", [64]),            # 64 replicated
+        "model.layers.0.mlp.up_proj.weight": ("U8", [400]),   # 400 sharded
+        "model.layers.0.input_layernorm.weight": ("U8", [8]),  # 8 replicated
+        "model.norm.weight": ("U8", [8]),                      # 8 replicated
+        "lm_head.weight": ("U8", [64]),                        # 64 replicated
+    }
+    write_safetensors(workdir / "model.safetensors", tensors)
+    plan = T.build_plan(workdir, "tp", 2, 121.0, None, "optimal")
+    tp = plan["tp"]
+    assert tp["assumed_sharded_bytes"] == 400
+    assert tp["assumed_replicated_bytes"] == 64 + 8 + 8 + 64
+    assert tp["assumed_per_rank_bytes"] == pytest.approx(400 / 2 + 144)
+
+
+# ---------------------------------------------------------------------------
+# 6. Sharded-index path.
+
+
+def test_sharded_index_path_sums_across_shards(workdir):
+    a = {"model.embed_tokens.weight": ("BF16", [8, 4]),
+         "model.layers.0.mlp.weight": ("U8", [100])}
+    b = {"model.layers.1.mlp.weight": ("U8", [100]),
+         "model.norm.weight": ("F32", [4]),
+         "lm_head.weight": ("BF16", [8, 4])}
+    write_safetensors(workdir / "model-00001-of-00002.safetensors", a)
+    write_safetensors(workdir / "model-00002-of-00002.safetensors", b)
+    weight_map = {k: "model-00001-of-00002.safetensors" for k in a}
+    weight_map.update({k: "model-00002-of-00002.safetensors" for k in b})
+    total = 64 + 100 + 100 + 16 + 64
+    (workdir / "model.safetensors.index.json").write_text(json.dumps(
+        {"metadata": {"total_size": total}, "weight_map": weight_map}))
+    plan = T.build_plan(workdir, "pp", 2, 121.0, None, "optimal")
+    assert plan["inventory"]["total_classified_bytes"] == total
+    assert plan["inventory"]["num_layers"] == 2
+    assert len(plan["inventory"]["index"]["shards"]) == 2
+
+
+def test_index_total_size_mismatch_is_a_hard_error(workdir):
+    tensors = {"model.embed_tokens.weight": ("BF16", [8, 4]),
+               "model.layers.0.mlp.weight": ("U8", [100]),
+               "model.norm.weight": ("F32", [4]),
+               "lm_head.weight": ("BF16", [8, 4])}
+    write_safetensors(workdir / "model-00001-of-00001.safetensors", tensors)
+    (workdir / "model.safetensors.index.json").write_text(json.dumps(
+        {"metadata": {"total_size": 999999},
+         "weight_map": {k: "model-00001-of-00001.safetensors" for k in tensors}}))
+    with pytest.raises(T.HeaderError, match="metadata.total_size"):
+        T.collect_artifact_tensors(workdir)
+
+
+def test_index_and_shard_header_disagreement_is_a_hard_error(workdir):
+    tensors = {"model.layers.0.mlp.weight": ("U8", [100])}
+    write_safetensors(workdir / "model-00001-of-00001.safetensors", tensors)
+    weight_map = {"model.layers.0.mlp.weight": "model-00001-of-00001.safetensors",
+                  "model.layers.9.ghost.weight": "model-00001-of-00001.safetensors"}
+    (workdir / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": weight_map}))
+    with pytest.raises(T.HeaderError, match="weight_map and shard headers disagree"):
+        T.collect_artifact_tensors(workdir)
+
+
+def test_missing_checkpoint_is_a_hard_error(workdir):
+    with pytest.raises(T.HeaderError, match="neither model.safetensors.index.json"):
+        T.collect_artifact_tensors(workdir)
+
+
+# ---------------------------------------------------------------------------
+# 7. Non-safetensors payload reporting + CLI plumbing.
+
+
+def test_non_safetensors_files_are_reported_not_classified(workdir):
+    write_safetensors(workdir / "model.safetensors", simple_model(2, 100))
+    (workdir / "cb_codebooks.pqcb").write_bytes(b"\0" * 4096)
+    (workdir / "config.json").write_text("{}")
+    plan = T.build_plan(workdir, "pp", 2, 121.0, None, "optimal")
+    names = {r["file"]: r for r in plan["reported_not_classified"]}
+    assert names["cb_codebooks.pqcb"]["bytes"] == 4096
+    assert names["cb_codebooks.pqcb"]["kind"] == "payload"
+    assert names["config.json"]["kind"] == "metadata-extension"
+    # Excluded from residency: totals must not move.
+    assert plan["inventory"]["total_classified_bytes"] == 64 + 200 + 16 + 64
+    text = T.render(plan)
+    assert "REPORTED-NOT-CLASSIFIED" in text
+    assert "cb_codebooks.pqcb" in text
+
+
+def test_parse_parallelism():
+    assert T.parse_parallelism("pp:2") == ("pp", 2)
+    assert T.parse_parallelism("TP:4") == ("tp", 4)
+    for bad in ("pp", "dp:2", "pp:1", "pp:x"):
+        with pytest.raises(SystemExit):
+            T.parse_parallelism(bad)
+
+
+def test_json_out_refuses_tmp():
+    with pytest.raises(SystemExit, match="refusing to write under /tmp"):
+        T.check_out_path(Path("/tmp/plan.json"))
+    with pytest.raises(SystemExit):
+        T.check_out_path(Path("/tmp/nested/dir/plan.json"))
+
+
+def test_cli_end_to_end_writes_json(workdir, capsys):
+    write_safetensors(workdir / "model.safetensors", simple_model(4, 100))
+    out = workdir / "plan.json"
+    rc = T.main(["--artifact", str(workdir), "--parallelism", "pp:2",
+                 "--overhead-gb-per-rank", "2", "--json-out", str(out)])
+    assert rc == 0
+    payload = json.loads(out.read_text())
+    assert payload["schema"] == T.SCHEMA
+    assert payload["parallelism"] == {"mode": "pp", "world_size": 2}
+    assert payload["max_feasible"]["label"] == T.LABEL_ASSUMED_LINEAR
+    text = capsys.readouterr().out
+    assert "PER-RANK RESIDENCY" in text and "GiB = 1024**3" in text
+
+
+def test_cli_rejects_an_unclassifiable_artifact(workdir, capsys):
+    tensors = simple_model(2, 100)
+    tensors["some.unknown.tensor"] = ("BF16", [4])
+    write_safetensors(workdir / "model.safetensors", tensors)
+    rc = T.main(["--artifact", str(workdir), "--parallelism", "pp:2"])
+    assert rc == 2
+    assert "some.unknown.tensor" in capsys.readouterr().err

--- a/tests/test_tp_decode_feasibility.py
+++ b/tests/test_tp_decode_feasibility.py
@@ -1,0 +1,153 @@
+"""CPU-only contract tests for tools/tp_decode_feasibility.py.
+
+These cover the decide-mode arithmetic against hand-checked fixtures: the
+all-reduce counts and byte counts are 2*L and H x bf16 per token, and the
+Qwen3.8-27B-CB numbers in the task spec (128 collectives/token,
+1.31 MB/token, ~1.1 ms wire) are the anchors.  No ranks, no network, no GPU.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tools.tp_decode_feasibility import (
+    BF16_BYTES,
+    DEFAULT_SIZES_BYTES,
+    MODEL_SPECS,
+    VERDICT_LOSE,
+    VERDICT_UNKNOWN,
+    VERDICT_WIN,
+    _resolve_sizes,
+    build_decision_rows,
+    check_scratch_path,
+    collective_math,
+    percentile,
+    verdict_for,
+)
+
+
+# ---------------------------------------------------------------------------
+# Seeded model specs are the task's fixtures; drift here is a bug.
+
+
+def test_model_specs_seeded_values():
+    assert MODEL_SPECS["Qwen3.8-27B-CB"] == {
+        "hidden_size": 5120, "layers": 64, "tpot_ms_single": 64.4, "moe": False}
+    for name in ("Qwen3.5-122B-A10B", "Mistral-Medium-3.5-128B", "DSv4-Flash"):
+        assert MODEL_SPECS[name]["tpot_ms_single"] is None, name
+    # MoE flag matters because routing adds collectives beyond 2*L.
+    assert MODEL_SPECS["Qwen3.5-122B-A10B"]["moe"] is True
+    assert MODEL_SPECS["Mistral-Medium-3.5-128B"]["moe"] is False
+    assert MODEL_SPECS["DSv4-Flash"]["moe"] is False
+
+
+def test_default_sweep_sizes_are_hidden_sizes_times_bf16():
+    assert DEFAULT_SIZES_BYTES == (8192, 10240, 12288, 16384)
+    hidden = [b // BF16_BYTES for b in DEFAULT_SIZES_BYTES]
+    assert hidden == [4096, 5120, 6144, 8192]
+
+
+def test_resolve_sizes_parses_and_sorts():
+    assert _resolve_sizes(type("A", (), {"sizes_bytes": "16384,8192,12288"})) == \
+        (8192, 12288, 16384)
+    with pytest.raises(SystemExit):
+        _resolve_sizes(type("A", (), {"sizes_bytes": "8191"}))  # not bf16-even
+
+
+# ---------------------------------------------------------------------------
+# Hand-checked collective arithmetic.
+
+
+@pytest.mark.parametrize(
+    "hidden,layers,ar_per_tok,bytes_per_tok,wire_ms",
+    [
+        # Qwen3.8-27B-CB: 128 AR/tok, 1310720 B/tok = 1.31 MB, ~1.05 ms @10GbE
+        (5120, 64, 128, 1310720, 1.048576),
+        (6144, 80, 160, 1966080, 1.572864),
+        (6144, 88, 176, 2162688, 1.7301504),
+        (4096, 43, 86, 704512, 0.5636096),
+    ],
+)
+def test_collective_math_hand_checked(hidden, layers, ar_per_tok, bytes_per_tok, wire_ms):
+    m = collective_math(hidden, layers, latency_us=30.0)
+    assert m["all_reduces_per_token"] == ar_per_tok == 2 * layers
+    assert m["bytes_per_allreduce"] == hidden * 2
+    assert m["bytes_per_token"] == bytes_per_tok
+    assert m["wire_ms_at_link"] == pytest.approx(wire_ms, abs=1e-9)
+    assert m["added_ms"] == pytest.approx(ar_per_tok * 30.0 / 1000.0)
+
+
+def test_added_latency_matches_spec_examples():
+    # Spec: Qwen3.8-27B at 30/100/200 us/collective => 3.8/12.8/25.6 ms/token.
+    for us, expected_ms in ((30.0, 3.84), (100.0, 12.8), (200.0, 25.6)):
+        m = collective_math(5120, 64, latency_us=us)
+        assert m["added_ms"] == pytest.approx(expected_ms, rel=1e-12)
+
+
+def test_qwen_cb_budget_and_crossover_threshold():
+    # TPOT 64.4 ms => budget 32.2 ms over 128 collectives => <251.5625 us each.
+    tpot = MODEL_SPECS["Qwen3.8-27B-CB"]["tpot_ms_single"]
+    budget_ms = tpot / 2.0
+    assert budget_ms == pytest.approx(32.2)
+    threshold_us = budget_ms * 1000.0 / 128.0
+    assert threshold_us == pytest.approx(251.5625)
+    # Just under the threshold wins; just over loses.
+    assert verdict_for(tpot, 128 * (threshold_us - 1.0) / 1000.0) == VERDICT_WIN
+    assert verdict_for(tpot, 128 * (threshold_us + 1.0) / 1000.0) == VERDICT_LOSE
+
+
+def test_verdict_boundary_is_strict_inequality():
+    # Exactly at budget counts as LOSE (no free lunch).
+    assert verdict_for(64.4, 32.2) == VERDICT_LOSE
+    assert verdict_for(64.4, 32.199999) == VERDICT_WIN
+
+
+@pytest.mark.parametrize("latency_us", [0.001, 30.0, 250.0, 10_000.0])
+def test_unknown_tpot_never_prints_a_verdict(latency_us):
+    # The hard rule: no WIN/LOSE without a measured single-box TPOT.
+    for name in ("Qwen3.5-122B-A10B", "Mistral-Medium-3.5-128B", "DSv4-Flash"):
+        spec = MODEL_SPECS[name]
+        m = collective_math(spec["hidden_size"], spec["layers"], latency_us)
+        assert verdict_for(None, m["added_ms"]) == VERDICT_UNKNOWN
+
+
+def test_build_decision_rows_flat_latency():
+    rows = {r["model"]: r for r in build_decision_rows(latency_us=30.0)}
+    assert len(rows) == 4
+    qwen = rows["Qwen3.8-27B-CB"]
+    assert qwen["verdict"] == VERDICT_WIN
+    assert qwen["budget_us_per_allreduce"] == pytest.approx(251.5625)
+    assert rows["DSv4-Flash"]["verdict"] == VERDICT_UNKNOWN
+    # Rows with latency_us=None defer the verdict to size-matched percentiles.
+    deferred = {r["model"]: r for r in build_decision_rows()}
+    assert all(r["verdict"] is None for r in deferred.values())
+
+
+# ---------------------------------------------------------------------------
+# Percentile semantics (numpy 'linear' interpolation), hand-checked.
+
+
+def test_percentile_linear_interpolation():
+    vals = [10.0, 20.0, 30.0, 40.0]          # pos = (n-1)*q/100
+    assert percentile(vals, 50) == pytest.approx(25.0)   # idx 1.5
+    assert percentile(vals, 90) == pytest.approx(37.0)   # idx 2.7
+    assert percentile(vals, 99) == pytest.approx(39.7)   # idx 2.97
+    assert percentile([7.0], 99) == 7.0
+    assert percentile(list(range(1, 101)), 50) == pytest.approx(50.5)
+    with pytest.raises(ValueError):
+        percentile([], 50)
+
+
+# ---------------------------------------------------------------------------
+# Scratch-path discipline: host /tmp is never written.
+
+
+def test_check_scratch_path_rejects_tmp():
+    with pytest.raises(ValueError, match="dq-runs"):
+        check_scratch_path("/tmp/opencode/whatever.json")
+    with pytest.raises(ValueError):
+        check_scratch_path("/tmp")
+
+
+def test_check_scratch_path_accepts_dq_runs():
+    p = check_scratch_path("/home/rob/dq-runs/ox-wave3-2026-08-23/tpbench/x.json")
+    assert str(p).startswith("/home/rob/dq-runs/")

--- a/tools/tp2_budget_plan.py
+++ b/tools/tp2_budget_plan.py
@@ -1,0 +1,1006 @@
+#!/usr/bin/env python3
+"""Two-box (DGX Spark cluster) residency budget planner for a shipped artifact.
+
+The question this tool settles: given an artifact and a parallelism spec,
+what actually RESIDES on each rank, and how large an artifact still fits?
+
+It is a *residency* planner, not a speed model.  It never loads a tensor: it
+reads safetensors headers only (the 8-byte length prefix plus the JSON header)
+and computes per-tensor bytes from dtype x shape, cross-checked against the
+header's own data_offsets.  That cross-check is what earns the EXACT label.
+
+Honesty contract (ported from tools/tp_decode_feasibility.py):
+  * Every number carries a provenance label.  EXACT means byte math off the
+    checkpoint.  DERIVED means computed from a rule read out of another
+    codebase (vLLM's layer split).  ASSUMED means a modelling choice this
+    tool made and could be wrong about.  MEASURED is reserved for numbers
+    that came from an instrument.
+  * Nothing is silently bucketed.  A tensor matching no classification rule
+    is a hard error that lists the offending names (the silent-zero lesson:
+    silent buckets rank broken arms first).
+  * TP mode does not pretend to know the shard policy.  It prints an ASSUMED
+    all-body-sharded model, labels every line of that table ASSUMED, and says
+    what would have to be attested to remove the label.
+  * Missing overhead is printed as UNKNOWN-NEEDS-OVERHEAD, never defaulted to
+    a number (same discipline as UNKNOWN-NEEDS-TPOT in tp_decode_feasibility).
+
+Checkpoint-name classification (checkpoint namespace ONLY -- never the recipe
+or vLLM-internal namespace):
+
+  1. sidecar   any dot-segment that is or starts with mtp/nextn/draft.
+               Checked FIRST, so an MTP block that carries its own
+               ``.layers.N.`` names cannot be mistaken for a body layer and
+               ``mtp.norm.weight`` cannot be mistaken for the final norm.
+  2. layer     ``(?:^|\\.)layers\\.(\\d+)\\.``  -- note the ``^|`` extension
+               over a bare ``\\.layers\\.``: DSv4 checkpoints name their body
+               ``layers.0.attn...`` with no ``model.`` prefix, and the bare
+               form matches none of them.
+  3. embed     first segment (after stripping model./language_model./
+               transformer. wrappers) in {embed_tokens, embed, wte,
+               tok_embeddings}  -> FIRST stage.
+  4. head      that first segment == lm_head or head (EXACT rule), or merely
+               CONTAINS "head" (e.g. DSv4's ``hc_head_base``) -- the latter is
+               line-itemed ASSUMED-PLACEMENT because this tool does not know
+               that such a head is last-stage-resident only.  -> LAST stage.
+  5. norm      that first segment in {norm, final_norm, final_layernorm,
+               ln_f}  -> LAST stage.
+
+Anything else: hard error.
+
+Non-safetensors payload files (codebooks, quant_config.json, ...) are
+line-itemed under REPORTED-NOT-CLASSIFIED with their on-disk size and are
+EXCLUDED from every rank-residency number.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import math
+import os
+from pathlib import Path
+import re
+import struct
+import subprocess
+import sys
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+SCHEMA = "prismaquant.tp2_budget_plan.v1"
+
+GIB = 1024 ** 3
+GB_UNIT_NOTE = "all *GB columns are GiB = 1024**3 bytes"
+
+# Provenance labels.  EXACT / DERIVED / ASSUMED / MEASURED is load-bearing.
+LABEL_EXACT = "EXACT / safetensors header (dtype x shape, offset-verified)"
+LABEL_DERIVED_VLLM = "DERIVED / vllm get_pp_indices default split"
+LABEL_EXACT_DP = "EXACT / balanced contiguous split (DP over exact bytes)"
+LABEL_ASSUMED_TP = "ASSUMED / no shard-policy source; see TP CAVEAT"
+LABEL_ASSUMED_LINEAR = "ASSUMED-LINEAR-SCALING"
+LABEL_ASSUMED_PLACEMENT = "ASSUMED-PLACEMENT"
+UNKNOWN_OVERHEAD = "UNKNOWN-NEEDS-OVERHEAD"
+
+# The default is the operator's rule of thumb for a 128 GB DGX Spark
+# (MemTotal on sparky is 121.6 GiB); it is NOT a measurement made here.
+PER_DEVICE_GB_DEFAULT = 121.0
+LABEL_PER_DEVICE_DEFAULT = (
+    "ASSUMED / default 121 GiB usable of a 128 GB unified pool (not measured "
+    "by this tool; pass --per-device-gb to override)")
+
+# Measured cross-box link facts, printed for context only.  This planner does
+# not model bandwidth or latency -- tools/tp_decode_feasibility.py does.
+LINK_JSON_DEFAULT = Path("/home/rob/dq-runs/tp2-2026-08-23/nccl_allreduce.json")
+
+# safetensors dtype -> bytes per element.  An unknown dtype is a hard error,
+# never a guess: sub-byte dtypes would silently halve the artifact.
+DTYPE_BYTES: Dict[str, int] = {
+    "BOOL": 1,
+    "U8": 1, "I8": 1,
+    "F8_E4M3": 1, "F8_E5M2": 1, "F8_E8M0": 1,
+    "U16": 2, "I16": 2, "F16": 2, "BF16": 2,
+    "U32": 4, "I32": 4, "F32": 4,
+    "U64": 8, "I64": 8, "F64": 8,
+}
+
+LAYER_RE = re.compile(r"(?:^|\.)layers\.(\d+)\.")
+SIDECAR_SEGMENT_RE = re.compile(r"^(mtp|nextn|draft)([_.\-].*)?$")
+WRAPPER_PREFIXES = ("model.language_model.", "language_model.", "model.",
+                    "transformer.")
+EMBED_SEGMENTS = {"embed_tokens", "embed", "wte", "tok_embeddings"}
+HEAD_SEGMENTS = {"lm_head", "head"}
+NORM_SEGMENTS = {"norm", "final_norm", "final_layernorm", "ln_f"}
+
+BUCKET_LAYER = "layer"
+BUCKET_EMBED = "embed"
+BUCKET_HEAD = "head"
+BUCKET_NORM = "final_norm"
+BUCKET_SIDECAR = "sidecar"
+
+METADATA_EXTENSIONS = {".json", ".txt", ".md", ".jinja", ".png", ".model",
+                       ".py", ".yaml", ".yml"}
+
+
+class ClassificationError(RuntimeError):
+    """A tensor matched no classification rule (fail closed, never bucket it)."""
+
+
+class HeaderError(RuntimeError):
+    """The safetensors header is unreadable or internally inconsistent."""
+
+
+# ---------------------------------------------------------------------------
+# Pure byte math and classification (unit-tested; no artifact needed).
+
+
+def dtype_bytes(dtype: str) -> int:
+    try:
+        return DTYPE_BYTES[dtype]
+    except KeyError:
+        raise HeaderError(
+            f"unknown safetensors dtype {dtype!r}; refusing to guess its width "
+            f"(known: {', '.join(sorted(DTYPE_BYTES))})") from None
+
+
+def tensor_bytes(dtype: str, shape: Sequence[int]) -> int:
+    """Exact byte size from dtype x shape.  A 0-d tensor is one element."""
+    n = 1
+    for dim in shape:
+        if int(dim) < 0:
+            raise HeaderError(f"negative dimension in shape {list(shape)}")
+        n *= int(dim)
+    return n * dtype_bytes(dtype)
+
+
+def read_safetensors_header(path: Path) -> Dict[str, Any]:
+    """Parse the 8-byte-length JSON header only.  Tensor data is never read."""
+    with open(path, "rb") as fh:
+        raw = fh.read(8)
+        if len(raw) != 8:
+            raise HeaderError(f"{path}: file shorter than the 8-byte header length")
+        (hlen,) = struct.unpack("<Q", raw)
+        if hlen <= 0 or hlen > 512 * 1024 * 1024:
+            raise HeaderError(f"{path}: implausible safetensors header length {hlen}")
+        blob = fh.read(hlen)
+        if len(blob) != hlen:
+            raise HeaderError(f"{path}: truncated safetensors header")
+    try:
+        header = json.loads(blob)
+    except json.JSONDecodeError as exc:
+        raise HeaderError(f"{path}: safetensors header is not JSON ({exc})") from exc
+    if not isinstance(header, dict):
+        raise HeaderError(f"{path}: safetensors header is not a JSON object")
+    return header
+
+
+def entries_from_header(header: Dict[str, Any], source: str) -> List[Dict[str, Any]]:
+    """Header dict -> per-tensor entries, with the offset cross-check applied.
+
+    The cross-check (dtype x shape == data_offsets delta) is what makes the
+    EXACT label honest; a mismatch means the dtype table is wrong for this
+    checkpoint and the whole plan would be wrong with it.
+    """
+    out: List[Dict[str, Any]] = []
+    for name, meta in header.items():
+        if name == "__metadata__":
+            continue
+        if not isinstance(meta, dict) or "dtype" not in meta or "shape" not in meta:
+            raise HeaderError(f"{source}: tensor {name!r} has no dtype/shape metadata")
+        nbytes = tensor_bytes(meta["dtype"], meta["shape"])
+        offsets = meta.get("data_offsets")
+        if isinstance(offsets, (list, tuple)) and len(offsets) == 2:
+            span = int(offsets[1]) - int(offsets[0])
+            if span != nbytes:
+                raise HeaderError(
+                    f"{source}: tensor {name!r} dtype x shape = {nbytes} B but "
+                    f"data_offsets span {span} B; the dtype width table does "
+                    f"not describe this checkpoint")
+        out.append({
+            "name": name,
+            "dtype": meta["dtype"],
+            "shape": [int(d) for d in meta["shape"]],
+            "bytes": nbytes,
+            "file": source,
+        })
+    return out
+
+
+def _endcap_segment(name: str) -> str:
+    """First segment after stripping model./language_model./transformer."""
+    stripped = name
+    changed = True
+    while changed:
+        changed = False
+        for prefix in WRAPPER_PREFIXES:
+            if stripped.startswith(prefix):
+                stripped = stripped[len(prefix):]
+                changed = True
+    return stripped.split(".", 1)[0]
+
+
+def classify(name: str) -> Dict[str, Any]:
+    """Classify one checkpoint tensor name.  Raises ClassificationError."""
+    segments = name.split(".")
+    if any(SIDECAR_SEGMENT_RE.match(seg) for seg in segments):
+        return {"bucket": BUCKET_SIDECAR, "layer": None, "rule": "sidecar segment",
+                "assumed_placement": False}
+    m = LAYER_RE.search(name)
+    if m:
+        return {"bucket": BUCKET_LAYER, "layer": int(m.group(1)),
+                "rule": "layers.<n>", "assumed_placement": False}
+    seg = _endcap_segment(name)
+    if seg in EMBED_SEGMENTS:
+        return {"bucket": BUCKET_EMBED, "layer": None, "rule": f"embed segment {seg!r}",
+                "assumed_placement": False}
+    if seg in HEAD_SEGMENTS:
+        return {"bucket": BUCKET_HEAD, "layer": None, "rule": f"head segment {seg!r}",
+                "assumed_placement": False}
+    if seg in NORM_SEGMENTS:
+        return {"bucket": BUCKET_NORM, "layer": None, "rule": f"norm segment {seg!r}",
+                "assumed_placement": False}
+    if "head" in seg:
+        return {"bucket": BUCKET_HEAD, "layer": None,
+                "rule": f"segment {seg!r} contains 'head'", "assumed_placement": True}
+    raise ClassificationError(name)
+
+
+def classify_entries(entries: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Classify every entry; one hard error listing ALL unmatched names."""
+    out: List[Dict[str, Any]] = []
+    unmatched: List[str] = []
+    for e in entries:
+        try:
+            cls = classify(e["name"])
+        except ClassificationError:
+            unmatched.append(e["name"])
+            continue
+        out.append({**e, **cls})
+    if unmatched:
+        listed = "\n  ".join(sorted(unmatched))
+        raise ClassificationError(
+            f"{len(unmatched)} tensor name(s) matched no pipeline-stage rule; "
+            f"refusing to plan with a silent bucket:\n  {listed}")
+    return out
+
+
+def layer_byte_table(classified: Sequence[Dict[str, Any]]) -> List[int]:
+    """Per-layer byte totals indexed 0..L-1.  Layer ids must be contiguous."""
+    per: Dict[int, int] = {}
+    for e in classified:
+        if e["bucket"] == BUCKET_LAYER:
+            per[e["layer"]] = per.get(e["layer"], 0) + e["bytes"]
+    if not per:
+        raise ClassificationError("no decoder-layer tensors found in this artifact")
+    ids = sorted(per)
+    if ids != list(range(len(ids))):
+        raise ClassificationError(
+            f"decoder layer ids are not contiguous 0..L-1: found {ids}")
+    return [per[i] for i in ids]
+
+
+def bucket_bytes(classified: Sequence[Dict[str, Any]], bucket: str) -> int:
+    return sum(e["bytes"] for e in classified if e["bucket"] == bucket)
+
+
+# ---------------------------------------------------------------------------
+# Splits.
+
+
+def vllm_even_split(num_layers: int, pp_size: int) -> List[int]:
+    """vLLM's default layer partition (get_pp_indices, no VLLM_PP_LAYER_PARTITION).
+
+    Transcribed from vllm/distributed/utils.py::get_pp_indices: the remainder
+    is added to partitions[-2], [-3], ... -- the LAST rank is skipped because
+    it carries the output endcaps.  43 layers at pp:2 -> [22, 21].
+    """
+    if pp_size < 1:
+        raise ValueError("pp_size must be >= 1")
+    if num_layers < pp_size:
+        raise ValueError(
+            f"{num_layers} decoder layers cannot fill {pp_size} pipeline stages")
+    base = num_layers // pp_size
+    partitions = [base] * pp_size
+    remaining = num_layers % pp_size
+    for i in range(2, remaining + 2):
+        partitions[-i] += 1
+    return partitions
+
+
+def split_to_ranges(counts: Sequence[int]) -> List[Tuple[int, int]]:
+    ranges: List[Tuple[int, int]] = []
+    start = 0
+    for c in counts:
+        ranges.append((start, start + c))
+        start += c
+    return ranges
+
+
+def rank_weight_bytes(
+    counts: Sequence[int],
+    layer_bytes: Sequence[int],
+    first_extra: int,
+    last_extra: int,
+) -> List[int]:
+    """Resident weight bytes per rank for a contiguous layer split."""
+    out: List[int] = []
+    for r, (lo, hi) in enumerate(split_to_ranges(counts)):
+        total = sum(layer_bytes[lo:hi])
+        if r == 0:
+            total += first_extra
+        if r == len(counts) - 1:
+            total += last_extra
+        out.append(total)
+    return out
+
+
+def optimal_split(
+    layer_bytes: Sequence[int],
+    pp_size: int,
+    first_extra: int = 0,
+    last_extra: int = 0,
+) -> List[int]:
+    """Contiguous split minimising the maximum per-rank resident bytes.
+
+    Exact DP (layer counts are small): dp[r][i] = the best achievable maximum
+    when the first r ranks cover layers [0, i).  Ties are broken toward the
+    EARLIEST boundary, so the answer is deterministic.
+    """
+    n = len(layer_bytes)
+    if pp_size < 1:
+        raise ValueError("pp_size must be >= 1")
+    if n < pp_size:
+        raise ValueError(
+            f"{n} decoder layers cannot fill {pp_size} pipeline stages")
+    prefix = [0] * (n + 1)
+    for i, b in enumerate(layer_bytes):
+        prefix[i + 1] = prefix[i] + b
+
+    def span(lo: int, hi: int, rank: int) -> int:
+        total = prefix[hi] - prefix[lo]
+        if rank == 0:
+            total += first_extra
+        if rank == pp_size - 1:
+            total += last_extra
+        return total
+
+    inf = math.inf
+    # dp[r][i]: r ranks used, covering layers [0, i)
+    dp: List[List[float]] = [[inf] * (n + 1) for _ in range(pp_size + 1)]
+    choice: List[List[int]] = [[-1] * (n + 1) for _ in range(pp_size + 1)]
+    dp[0][0] = 0.0
+    for r in range(1, pp_size + 1):
+        for i in range(r, n - (pp_size - r) + 1):
+            best = inf
+            best_j = -1
+            for j in range(r - 1, i):
+                if dp[r - 1][j] == inf:
+                    continue
+                cand = max(dp[r - 1][j], float(span(j, i, r - 1)))
+                if cand < best:
+                    best = cand
+                    best_j = j
+            dp[r][i] = best
+            choice[r][i] = best_j
+    if dp[pp_size][n] == inf:  # pragma: no cover - guarded by the n < pp_size check
+        raise ValueError("no feasible contiguous split")
+    counts: List[int] = []
+    i = n
+    for r in range(pp_size, 0, -1):
+        j = choice[r][i]
+        counts.append(i - j)
+        i = j
+    counts.reverse()
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Feasibility arithmetic.
+
+
+def max_feasible_artifact_bytes(
+    counts: Sequence[int],
+    layer_bytes: Sequence[int],
+    first_extra: int,
+    last_extra: int,
+    budget_bytes: float,
+    overhead_bytes: float,
+) -> Dict[str, Any]:
+    """Largest artifact that still fits, under ASSUMED-LINEAR-SCALING.
+
+    Two assumptions, both printed by the caller:
+      (1) body bytes scale linearly with artifact size,
+      (2) each rank keeps the body SHARE it holds under the chosen split at
+          today's size (shares frozen; the split is not re-solved),
+      and the endcaps (embed / head / final norm / sidecar) stay fixed.
+
+    Then rank r holds  s * body_total * f_r + endcap_r + overhead, and
+    s_max = min_r (budget - overhead - endcap_r) / (body_total * f_r).
+    """
+    body_total = sum(layer_bytes)
+    endcaps = [0] * len(counts)
+    endcaps[0] += first_extra
+    endcaps[-1] += last_extra
+    shares: List[float] = []
+    for lo, hi in split_to_ranges(counts):
+        shares.append((sum(layer_bytes[lo:hi]) / body_total) if body_total else 0.0)
+    limits: List[Optional[float]] = []
+    binding = None
+    s_max = math.inf
+    for r, share in enumerate(shares):
+        avail = budget_bytes - overhead_bytes - endcaps[r]
+        if avail <= 0:
+            return {
+                "feasible": False,
+                "reason": (f"rank {r} endcaps ({endcaps[r]} B) plus overhead "
+                           f"already exceed the per-device budget"),
+                "s_max": 0.0,
+                "max_artifact_bytes": 0,
+                "binding_rank": r,
+                "rank_limits": limits,
+            }
+        if share <= 0:
+            limits.append(None)
+            continue
+        limit = avail / (body_total * share)
+        limits.append(limit)
+        if limit < s_max:
+            s_max = limit
+            binding = r
+    fixed = first_extra + last_extra
+    return {
+        "feasible": True,
+        "reason": None,
+        "s_max": s_max,
+        "body_total_bytes": body_total,
+        "fixed_endcap_bytes": fixed,
+        "max_body_bytes": s_max * body_total,
+        "max_artifact_bytes": s_max * body_total + fixed,
+        "binding_rank": binding,
+        "rank_limits": limits,
+    }
+
+
+# ---------------------------------------------------------------------------
+# TP (assumed) model.
+
+
+def tp_assumed_replicated(name: str, bucket: str) -> bool:
+    """ASSUMED shard policy: norms, biases and the embed/head endcaps replicate.
+
+    This is a modelling choice, not knowledge.  The real replicated set is a
+    property of the serving runtime's parallel-Linear registration, which this
+    producer-side tool has no attested source for.
+    """
+    if bucket in (BUCKET_EMBED, BUCKET_HEAD, BUCKET_NORM):
+        return True
+    segments = name.split(".")
+    if any("norm" in seg for seg in segments):
+        return True
+    if segments[-1] == "bias" or any(seg == "bias" for seg in segments):
+        return True
+    return False
+
+
+def tp_plan(classified: Sequence[Dict[str, Any]], tp_size: int) -> Dict[str, Any]:
+    replicated = 0
+    sharded = 0
+    for e in classified:
+        if tp_assumed_replicated(e["name"], e["bucket"]):
+            replicated += e["bytes"]
+        else:
+            sharded += e["bytes"]
+    per_rank = sharded / tp_size + replicated
+    return {
+        "tp_size": tp_size,
+        "assumed_replicated_bytes": replicated,
+        "assumed_sharded_bytes": sharded,
+        "assumed_per_rank_bytes": per_rank,
+        "label": LABEL_ASSUMED_TP,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Artifact IO.
+
+
+def parse_parallelism(spec: str) -> Tuple[str, int]:
+    if ":" not in spec:
+        raise SystemExit(f"--parallelism must look like pp:2 or tp:2 (got {spec!r})")
+    mode, _, count = spec.partition(":")
+    mode = mode.strip().lower()
+    if mode not in ("pp", "tp"):
+        raise SystemExit(f"--parallelism mode must be pp or tp (got {mode!r})")
+    try:
+        n = int(count)
+    except ValueError:
+        raise SystemExit(f"--parallelism size must be an integer (got {count!r})") from None
+    if n < 2:
+        raise SystemExit(f"--parallelism size must be >= 2 (got {n})")
+    return mode, n
+
+
+def collect_artifact_tensors(artifact_dir: Path) -> Dict[str, Any]:
+    """Read every safetensors header in the artifact (index-aware)."""
+    index_path = artifact_dir / "model.safetensors.index.json"
+    single = artifact_dir / "model.safetensors"
+    entries: List[Dict[str, Any]] = []
+    index_meta: Optional[Dict[str, Any]] = None
+    if index_path.exists():
+        index = json.loads(index_path.read_text())
+        weight_map = index.get("weight_map")
+        if not isinstance(weight_map, dict) or not weight_map:
+            raise HeaderError(f"{index_path}: no usable weight_map")
+        shard_files = sorted(set(weight_map.values()))
+        for shard in shard_files:
+            shard_path = artifact_dir / shard
+            if not shard_path.exists():
+                raise HeaderError(f"{index_path}: shard {shard} referenced but missing")
+            entries.extend(entries_from_header(
+                read_safetensors_header(shard_path), shard))
+        header_names = {e["name"] for e in entries}
+        map_names = set(weight_map)
+        missing = sorted(map_names - header_names)
+        extra = sorted(header_names - map_names)
+        if missing or extra:
+            raise HeaderError(
+                f"{index_path}: weight_map and shard headers disagree; "
+                f"{len(missing)} in index only (e.g. {missing[:5]}), "
+                f"{len(extra)} in shards only (e.g. {extra[:5]})")
+        index_meta = {
+            "shards": shard_files,
+            "declared_total_size": index.get("metadata", {}).get("total_size"),
+        }
+        declared = index_meta["declared_total_size"]
+        computed = sum(e["bytes"] for e in entries)
+        if declared is not None and int(declared) != computed:
+            raise HeaderError(
+                f"{index_path}: metadata.total_size {declared} != computed "
+                f"tensor bytes {computed}")
+        source = "sharded index"
+    elif single.exists():
+        entries = entries_from_header(read_safetensors_header(single),
+                                      "model.safetensors")
+        source = "single model.safetensors (no index)"
+    else:
+        raise HeaderError(
+            f"{artifact_dir}: neither model.safetensors.index.json nor "
+            f"model.safetensors is present")
+    names = [e["name"] for e in entries]
+    if len(names) != len(set(names)):
+        dupes = sorted({n for n in names if names.count(n) > 1})
+        raise HeaderError(f"{artifact_dir}: duplicate tensor names {dupes[:5]}")
+    return {"entries": entries, "source": source, "index": index_meta}
+
+
+def unclassified_payload_files(artifact_dir: Path) -> List[Dict[str, Any]]:
+    """Every non-safetensors file, by size.  No threshold, no bucketing."""
+    rows: List[Dict[str, Any]] = []
+    for path in sorted(artifact_dir.iterdir()):
+        if not path.is_file():
+            continue
+        if path.suffix == ".safetensors":
+            continue
+        if path.name == "model.safetensors.index.json":
+            continue
+        rows.append({
+            "file": path.name,
+            "bytes": path.stat().st_size,
+            "kind": "metadata-extension" if path.suffix in METADATA_EXTENSIONS
+                    else "payload",
+        })
+    rows.sort(key=lambda r: -r["bytes"])
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Rendering.
+
+
+def gib(nbytes: float) -> str:
+    return f"{nbytes / GIB:.3f}"
+
+
+def check_out_path(path: Path) -> Path:
+    """Refuse host /tmp for outputs (standing project rule: /tmp gets cleared)."""
+    resolved = Path(path).expanduser().resolve()
+    if resolved == Path("/tmp") or Path("/tmp") in resolved.parents:
+        raise SystemExit(
+            f"refusing to write under /tmp ({resolved}); /tmp was cleared by an "
+            f"OOM once already and took artifacts with it")
+    return resolved
+
+
+def _git_sha() -> Optional[str]:
+    try:
+        out = subprocess.run(["git", "rev-parse", "--short", "HEAD"],
+                             capture_output=True, text=True, timeout=10, check=True)
+        return out.stdout.strip()
+    except Exception:
+        return None
+
+
+def _link_facts(path: Path) -> Optional[Dict[str, Any]]:
+    try:
+        blob = json.loads(Path(path).read_text())
+    except Exception:
+        return None
+    rows = blob.get("rows") or []
+    if not rows:
+        return None
+    small = min(rows, key=lambda r: r["bytes"])
+    fastest = max(rows, key=lambda r: r.get("busbw_GBps", 0.0))
+    return {
+        "source": str(path),
+        "provenance": blob.get("provenance"),
+        "small_msg_bytes": small["bytes"],
+        "small_msg_p50_us": small["p50_us"],
+        "peak_busbw_GBps": fastest.get("busbw_GBps"),
+        "peak_busbw_bytes": fastest["bytes"],
+    }
+
+
+def build_plan(
+    artifact_dir: Path,
+    mode: str,
+    world: int,
+    per_device_gb: float,
+    overhead_gb: Optional[float],
+    pp_partition: str,
+) -> Dict[str, Any]:
+    collected = collect_artifact_tensors(artifact_dir)
+    classified = classify_entries(collected["entries"])
+    layer_bytes = layer_byte_table(classified)
+
+    embed_b = bucket_bytes(classified, BUCKET_EMBED)
+    head_b = bucket_bytes(classified, BUCKET_HEAD)
+    norm_b = bucket_bytes(classified, BUCKET_NORM)
+    sidecar_b = bucket_bytes(classified, BUCKET_SIDECAR)
+    body_b = sum(layer_bytes)
+    total_b = body_b + embed_b + head_b + norm_b + sidecar_b
+
+    first_extra = embed_b
+    last_extra = head_b + norm_b + sidecar_b
+
+    budget_bytes = per_device_gb * GIB
+    overhead_bytes = None if overhead_gb is None else overhead_gb * GIB
+
+    plan: Dict[str, Any] = {
+        "schema": SCHEMA,
+        "utc": datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds"),
+        "git_sha": _git_sha(),
+        "argv": sys.argv,
+        "artifact": str(artifact_dir),
+        "unit_note": GB_UNIT_NOTE,
+        "parallelism": {"mode": mode, "world_size": world},
+        "per_device_gb": per_device_gb,
+        "per_device_gb_label": LABEL_PER_DEVICE_DEFAULT,
+        "overhead_gb_per_rank": overhead_gb,
+        "inventory": {
+            "label": LABEL_EXACT,
+            "index_source": collected["source"],
+            "index": collected["index"],
+            "tensor_count": len(classified),
+            "num_layers": len(layer_bytes),
+            "body_bytes": body_b,
+            "embed_bytes": embed_b,
+            "head_bytes": head_b,
+            "final_norm_bytes": norm_b,
+            "sidecar_bytes": sidecar_b,
+            "total_classified_bytes": total_b,
+            "layer_bytes": layer_bytes,
+        },
+        "endcap_line_items": [
+            {"name": e["name"], "bucket": e["bucket"], "bytes": e["bytes"],
+             "rule": e["rule"],
+             "label": LABEL_ASSUMED_PLACEMENT if e["assumed_placement"] else LABEL_EXACT}
+            for e in sorted(classified, key=lambda x: (-x["bytes"], x["name"]))
+            if e["bucket"] in (BUCKET_EMBED, BUCKET_HEAD, BUCKET_NORM)
+        ],
+        "sidecar_line_items": [
+            {"name": e["name"], "bytes": e["bytes"], "label": LABEL_EXACT}
+            for e in sorted(classified, key=lambda x: (-x["bytes"], x["name"]))
+            if e["bucket"] == BUCKET_SIDECAR
+        ],
+        "reported_not_classified": unclassified_payload_files(artifact_dir),
+        "link_facts": _link_facts(LINK_JSON_DEFAULT),
+    }
+
+    if mode == "pp":
+        even = vllm_even_split(len(layer_bytes), world)
+        opt = optimal_split(layer_bytes, world, first_extra, last_extra)
+        splits = {}
+        for name, counts, label in (("even", even, LABEL_DERIVED_VLLM),
+                                    ("optimal", opt, LABEL_EXACT_DP)):
+            ranks = rank_weight_bytes(counts, layer_bytes, first_extra, last_extra)
+            splits[name] = {
+                "counts": list(counts),
+                "ranges": [list(r) for r in split_to_ranges(counts)],
+                "rank_weight_bytes": ranks,
+                "max_rank_bytes": max(ranks),
+                "imbalance_bytes": max(ranks) - min(ranks),
+                "label": label,
+                "vllm_pp_layer_partition": ",".join(str(c) for c in counts),
+            }
+        plan["pp"] = {
+            "splits": splits,
+            "selected": pp_partition,
+            "endcaps": {"first_stage_bytes": first_extra,
+                        "last_stage_bytes": last_extra},
+        }
+        sel = splits[pp_partition]
+        rows = []
+        for r, nbytes in enumerate(sel["rank_weight_bytes"]):
+            lo, hi = sel["ranges"][r]
+            row = {
+                "rank": r,
+                "layers": f"{lo}..{hi - 1}",
+                "layer_count": hi - lo,
+                "weight_bytes": nbytes,
+                "overhead_bytes": overhead_bytes,
+                "total_bytes": None if overhead_bytes is None else nbytes + overhead_bytes,
+                "headroom_bytes": None if overhead_bytes is None
+                                  else budget_bytes - nbytes - overhead_bytes,
+                "headroom_label": UNKNOWN_OVERHEAD if overhead_bytes is None else LABEL_EXACT,
+            }
+            rows.append(row)
+        plan["residency_rows"] = rows
+        if overhead_bytes is None:
+            plan["max_feasible"] = {"label": UNKNOWN_OVERHEAD, "feasible": None}
+        else:
+            mf = max_feasible_artifact_bytes(
+                sel["counts"], layer_bytes, first_extra, last_extra,
+                budget_bytes, overhead_bytes)
+            mf["label"] = LABEL_ASSUMED_LINEAR
+            mf["current_artifact_bytes"] = total_b
+            plan["max_feasible"] = mf
+    else:
+        tp = tp_plan(classified, world)
+        plan["tp"] = tp
+        per_rank = tp["assumed_per_rank_bytes"]
+        rows = []
+        for r in range(world):
+            rows.append({
+                "rank": r,
+                "weight_bytes": per_rank,
+                "overhead_bytes": overhead_bytes,
+                "total_bytes": None if overhead_bytes is None else per_rank + overhead_bytes,
+                "headroom_bytes": None if overhead_bytes is None
+                                  else budget_bytes - per_rank - overhead_bytes,
+                "headroom_label": UNKNOWN_OVERHEAD if overhead_bytes is None
+                                  else LABEL_ASSUMED_TP,
+                "label": LABEL_ASSUMED_TP,
+            })
+        plan["residency_rows"] = rows
+        plan["max_feasible"] = {
+            "label": "NOT-COMPUTED-FOR-TP",
+            "reason": ("a max-feasible size needs a shard policy this tool has no "
+                       "attested source for; run --parallelism pp:N for that number"),
+        }
+    return plan
+
+
+TP_CAVEAT = [
+    "Every TP row above is ASSUMED.  The per-rank number models the body as",
+    "fully sharded across N ranks with norms, biases, embeddings and the head",
+    "replicated in full -- classified BY NAME, not by any shard policy this",
+    "tool can read.  Removing the ASSUMED label needs an attested source for",
+    "the serving runtime's parallel-Linear registration (which Linears are",
+    "Column/RowParallel, which stay replicated, and how quantized scale",
+    "tensors shard alongside their weights).  Until then, do not plan a",
+    "deployment on these numbers.",
+]
+
+PP_ASSUMPTIONS = [
+    "(1) body bytes scale linearly with artifact size;",
+    "(2) every rank keeps the body SHARE it holds under the selected split at",
+    "    today's size (shares frozen -- the split is NOT re-solved as the",
+    "    artifact grows), and the endcaps (embed / head / final norm /",
+    "    sidecar) stay at today's fixed size;",
+    "(3) 'artifact size' means total CLASSIFIED TENSOR bytes: it excludes the",
+    "    REPORTED-NOT-CLASSIFIED files and every runtime allocation (KV cache,",
+    "    activations, CUDA context, graph pools) -- those live in --overhead-gb-per-rank.",
+]
+
+
+def render(plan: Dict[str, Any]) -> str:
+    L: List[str] = []
+    inv = plan["inventory"]
+    mode = plan["parallelism"]["mode"]
+    world = plan["parallelism"]["world_size"]
+    budget_gb = plan["per_device_gb"]
+
+    L.append("=" * 78)
+    L.append("TP2 CLUSTER BUDGET PLAN -- per-rank residency and max feasible artifact")
+    L.append(f"artifact     : {plan['artifact']}")
+    L.append(f"parallelism  : {mode}:{world}")
+    L.append(f"per-device   : {budget_gb:g} GiB  [{plan['per_device_gb_label']}]")
+    ovh = plan["overhead_gb_per_rank"]
+    L.append(f"overhead/rank: " + (f"{ovh:g} GiB  [ASSUMED / operator-supplied]"
+                                   if ovh is not None
+                                   else f"{UNKNOWN_OVERHEAD} (pass --overhead-gb-per-rank)"))
+    L.append(f"units        : {plan['unit_note']}")
+    L.append("=" * 78)
+
+    L.append("")
+    L.append(f"TENSOR INVENTORY  [{inv['label']}]")
+    L.append(f"  source              : {inv['index_source']}")
+    if inv["index"]:
+        L.append(f"  shards              : {len(inv['index']['shards'])} "
+                 f"(index total_size {inv['index']['declared_total_size']})")
+    L.append(f"  tensors             : {inv['tensor_count']}")
+    L.append(f"  decoder layers      : {inv['num_layers']} (ids 0..{inv['num_layers'] - 1})")
+    L.append(f"  body (layers)       : {gib(inv['body_bytes']):>10} GiB  "
+             f"({inv['body_bytes']:,} B)")
+    L.append(f"  embed  -> stage 0   : {gib(inv['embed_bytes']):>10} GiB  "
+             f"({inv['embed_bytes']:,} B)")
+    L.append(f"  final norm -> last  : {gib(inv['final_norm_bytes']):>10} GiB  "
+             f"({inv['final_norm_bytes']:,} B)")
+    L.append(f"  head   -> last      : {gib(inv['head_bytes']):>10} GiB  "
+             f"({inv['head_bytes']:,} B)")
+    L.append(f"  sidecar-> last      : {gib(inv['sidecar_bytes']):>10} GiB  "
+             f"({inv['sidecar_bytes']:,} B)")
+    L.append(f"  TOTAL classified    : {gib(inv['total_classified_bytes']):>10} GiB  "
+             f"({inv['total_classified_bytes']:,} B)")
+
+    L.append("")
+    L.append("ENDCAP LINE ITEMS (embed / final norm / head)")
+    if not plan["endcap_line_items"]:
+        L.append("  (none)")
+    for item in plan["endcap_line_items"]:
+        tag = " <-- ASSUMED-PLACEMENT" if item["label"] == LABEL_ASSUMED_PLACEMENT else ""
+        L.append(f"  {item['bucket']:<10} {gib(item['bytes']):>9} GiB  {item['name']}"
+                 f"   [{item['rule']}]{tag}")
+
+    L.append("")
+    L.append("SIDECAR LINE ITEMS (mtp / nextn / draft -- resident on the LAST stage)")
+    if not plan["sidecar_line_items"]:
+        L.append("  (none: this artifact ships no MTP/nextn/draft tensors)")
+    for item in plan["sidecar_line_items"]:
+        L.append(f"  {gib(item['bytes']):>9} GiB  {item['name']}")
+
+    L.append("")
+    L.append("REPORTED-NOT-CLASSIFIED (non-safetensors files; EXCLUDED from every "
+             "residency number above and below)")
+    if not plan["reported_not_classified"]:
+        L.append("  (none)")
+    for row in plan["reported_not_classified"]:
+        L.append(f"  {row['bytes']:>14,} B  {row['file']}  [{row['kind']}]")
+
+    if mode == "pp":
+        pp = plan["pp"]
+        L.append("")
+        L.append("PP LAYER SPLITS")
+        for name in ("even", "optimal"):
+            s = pp["splits"][name]
+            marker = " *SELECTED*" if name == pp["selected"] else ""
+            L.append(f"  {name:<8} counts={s['vllm_pp_layer_partition']:<24} "
+                     f"max-rank {gib(s['max_rank_bytes'])} GiB  "
+                     f"imbalance {gib(s['imbalance_bytes'])} GiB{marker}")
+            L.append(f"           [{s['label']}]")
+        opt = pp["splits"]["optimal"]
+        L.append(f"  VLLM_PP_LAYER_PARTITION={opt['vllm_pp_layer_partition']}"
+                 f"   (realizes the optimal split)")
+        L.append(f"  endcaps: stage-0 +{gib(pp['endcaps']['first_stage_bytes'])} GiB, "
+                 f"last-stage +{gib(pp['endcaps']['last_stage_bytes'])} GiB")
+        L.append("  NOTE: the 'even' split is DERIVED by transcribing vLLM's")
+        L.append("  get_pp_indices (remainder to partitions[-2], [-3], ... so the last")
+        L.append("  rank, which carries the endcaps, is skipped).  It is read from a")
+        L.append("  vLLM source tree on this box, NOT attested from the pinned serving")
+        L.append("  image -- re-read get_pp_indices there before trusting it in prod.")
+
+    L.append("")
+    L.append(f"PER-RANK RESIDENCY ({mode}:{world}"
+             + (f", split={plan['pp']['selected']})" if mode == "pp"
+                else ")  -- EVERY ROW IS ASSUMED, see TP CAVEAT"))
+    hdr = (f"  {'rank':>4} {'layers':>9} {'weight GiB':>11} {'overhead GiB':>13} "
+           f"{'total GiB':>10} {'headroom GiB':>26}")
+    L.append(hdr)
+    L.append("  " + "-" * (len(hdr) - 2))
+    for row in plan["residency_rows"]:
+        layers = row.get("layers", "-")
+        ovh_s = "-" if row["overhead_bytes"] is None else gib(row["overhead_bytes"])
+        tot_s = "-" if row["total_bytes"] is None else gib(row["total_bytes"])
+        if row["headroom_bytes"] is None:
+            head_s = UNKNOWN_OVERHEAD
+        else:
+            head_s = gib(row["headroom_bytes"])
+            if row["headroom_bytes"] < 0:
+                head_s += " OVER-BUDGET"
+        suffix = "  ASSUMED" if mode == "tp" else ""
+        L.append(f"  {row['rank']:>4} {layers:>9} {gib(row['weight_bytes']):>11} "
+                 f"{ovh_s:>13} {tot_s:>10} {head_s:>26}{suffix}")
+    if mode == "tp":
+        tp = plan["tp"]
+        L.append("")
+        L.append(f"TP DECOMPOSITION  [{tp['label']}]")
+        L.append(f"  ASSUMED sharded (body, split /{tp['tp_size']}): "
+                 f"{gib(tp['assumed_sharded_bytes'])} GiB total -> "
+                 f"{gib(tp['assumed_sharded_bytes'] / tp['tp_size'])} GiB/rank")
+        L.append(f"  ASSUMED replicated (norm/bias/embed/head, full on each rank): "
+                 f"{gib(tp['assumed_replicated_bytes'])} GiB/rank")
+        L.append("")
+        L.append("TP CAVEAT")
+        for line in TP_CAVEAT:
+            L.append("  " + line)
+
+    L.append("")
+    mf = plan["max_feasible"]
+    if mode != "pp":
+        L.append(f"MAX-FEASIBLE-ARTIFACT: {mf['label']}")
+        L.append(f"  {mf['reason']}")
+    elif mf.get("label") == UNKNOWN_OVERHEAD:
+        L.append(f"MAX-FEASIBLE-ARTIFACT: {UNKNOWN_OVERHEAD}")
+        L.append("  A max-feasible size is meaningless without the per-rank runtime")
+        L.append("  overhead (KV cache + activations + CUDA context + graph pools).")
+        L.append("  Pass --overhead-gb-per-rank to get the number.")
+    elif not mf["feasible"]:
+        L.append(f"MAX-FEASIBLE-ARTIFACT: INFEASIBLE  [{mf['label']}]")
+        L.append(f"  {mf['reason']}")
+    else:
+        L.append(f"MAX-FEASIBLE-ARTIFACT  [{mf['label']}]")
+        L.append(f"  body scale factor s_max : {mf['s_max']:.4f}x "
+                 f"(binding rank {mf['binding_rank']})")
+        L.append(f"  max body                : {gib(mf['max_body_bytes'])} GiB")
+        L.append(f"  fixed endcaps           : {gib(mf['fixed_endcap_bytes'])} GiB")
+        L.append(f"  MAX ARTIFACT            : {gib(mf['max_artifact_bytes'])} GiB "
+                 f"({mf['max_artifact_bytes'] / mf['current_artifact_bytes']:.4f}x "
+                 f"today's {gib(mf['current_artifact_bytes'])} GiB)")
+        L.append("  assumptions behind that number:")
+        for line in PP_ASSUMPTIONS:
+            L.append("    " + line)
+
+    if plan.get("link_facts"):
+        lf = plan["link_facts"]
+        L.append("")
+        L.append("CROSS-BOX LINK CONTEXT (not used in any number above)")
+        L.append(f"  {lf['provenance']}")
+        L.append(f"    p50 {lf['small_msg_p50_us']:.1f} us at {lf['small_msg_bytes']} B; "
+                 f"peak busbw {lf['peak_busbw_GBps']:.1f} GB/s at "
+                 f"{lf['peak_busbw_bytes']} B")
+        L.append(f"    source: {lf['source']}")
+        L.append("  This planner models RESIDENCY only.  For the latency/bandwidth")
+        L.append("  arithmetic of TP=2 decode, use tools/tp_decode_feasibility.py.")
+    L.append("")
+    return "\n".join(L)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Per-rank residency and max-feasible-artifact planner for the "
+                    "two-DGX-Spark cluster.")
+    ap.add_argument("--artifact", required=True, type=Path,
+                    help="artifact directory (safetensors + index)")
+    ap.add_argument("--parallelism", required=True,
+                    help="pp:N or tp:N (N >= 2)")
+    ap.add_argument("--per-device-gb", type=float, default=PER_DEVICE_GB_DEFAULT,
+                    help=f"usable GiB per rank (default {PER_DEVICE_GB_DEFAULT:g}, ASSUMED)")
+    ap.add_argument("--overhead-gb-per-rank", type=float, default=None,
+                    help="runtime overhead GiB per rank; omitted -> "
+                         f"{UNKNOWN_OVERHEAD} instead of an invented number")
+    ap.add_argument("--pp-partition", choices=("even", "optimal"), default="optimal",
+                    help="which split drives the residency table and the "
+                         "max-feasible inversion (both are always reported)")
+    ap.add_argument("--json-out", type=Path, default=None,
+                    help="write the full plan as JSON here (never under /tmp)")
+    args = ap.parse_args(argv)
+
+    mode, world = parse_parallelism(args.parallelism)
+    artifact = args.artifact.expanduser().resolve()
+    if not artifact.is_dir():
+        print(f"error: --artifact {artifact} is not a directory", file=sys.stderr)
+        return 2
+    try:
+        plan = build_plan(artifact, mode, world, args.per_device_gb,
+                          args.overhead_gb_per_rank, args.pp_partition)
+    except (ClassificationError, HeaderError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(render(plan))
+    if args.json_out is not None:
+        out = check_out_path(args.json_out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(plan, indent=2) + "\n", encoding="utf-8")
+        print(f"wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/tp_decode_feasibility.py
+++ b/tools/tp_decode_feasibility.py
@@ -1,0 +1,747 @@
+#!/usr/bin/env python3
+"""TP=2 decode feasibility harness for the 10 GbE two-DGX-Spark cluster.
+
+The open question this tool settles: is tensor-parallel (TP=2) decode across
+two DGX Spark boxes joined by plain 10 GbE TCP (no RDMA, no ConnectX) faster
+or slower than single-box decode?
+
+Decode is memory-bandwidth bound, so TP=2 roughly halves per-GPU weight reads.
+The cost is 2*L all-reduces per token of hidden_size bf16 elements each.  Wire
+time at those sizes is negligible on 10 GbE; LATENCY dominates because every
+one of the 128 sync points (Qwen3.8-27B) stalls the token.  Crossover rule:
+
+    TP=2 wins iff   net_overhead_per_token < TPOT_single / 2
+
+The decisive unknown is per-all-reduce latency AT OUR MESSAGE SIZES ON THIS
+LINK.  Three modes turn that into a one-command measurement:
+
+  loopback   Two ranks on localhost.  Measures the SOFTWARE FLOOR (gloo +
+             TCP stack + sync overhead) with zero wire time.  Every number it
+             produces is a LOWER BOUND on the real two-box number, never an
+             estimate of it.  Runs today on one box.
+  netbench   Two ranks over the real link (run the same command on both boxes;
+             see the banner it prints).  Small-message all-reduce latency at
+             the exact sizes our models need, plus an iperf3 bandwidth leg
+             when iperf3 exists on both boxes.
+  decide     Apply a measured (or assumed) per-collective latency to the model
+             specs below and print the WIN/LOSE/UNKNOWN verdict table.
+
+Honesty contract (standing rule: never sell a screen as a result):
+  * Output distinguishes MEASURED from ASSUMED everywhere latency enters.
+  * Loopback numbers are labelled LOWER BOUND on every line they influence.
+  * The caveats that can invalidate the arithmetic are printed by this tool,
+    not left in a side document.
+
+CPU/TCP only: gloo needs no GPU, so this harness is safe to run while another
+job holds /home/rob/dq-runs/gpu.lock.  Scratch stays under /home/rob/dq-runs/;
+paths under host /tmp are refused.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import math
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import time
+from typing import Any, Dict, List, Optional, Sequence, Set
+
+BF16_BYTES = 2
+LINK_BPS_DEFAULT = 10e9  # 10 GbE TCP, no RDMA (verified: enP7s7 at 10000 Mb/s)
+
+# Decode all-reduce payload sizes: bytes = hidden_size x bf16 for the models
+# in MODEL_SPECS.  Swept exactly; do not pad or round these.
+DEFAULT_SIZES_BYTES: tuple[int, ...] = (8192, 10240, 12288, 16384)
+
+WARMUP_MIN = 200      # spec: >= 200 warmup iterations
+ITERS_MIN = 2000      # spec: >= 2000 measured iterations
+SYNC_EVERY_DEFAULT = 200   # re-barrier this often so skew cannot accumulate
+PORT_DEFAULT = 29517       # rendezvous port; iperf3 leg uses port+1
+
+SCHEMA = "prismaquant.tp_feasibility_result.v1"
+SCRATCH_ROOT = Path("/home/rob/dq-runs")
+DEFAULT_OUT_DIR = SCRATCH_ROOT / "ox-wave3-2026-08-23" / "tpbench"
+
+# Verdict labels.  A verdict is NEVER printed when TPOT is unknown.
+VERDICT_WIN = "WIN"
+VERDICT_LOSE = "LOSE"
+VERDICT_UNKNOWN = "UNKNOWN-NEEDS-TPOT"
+
+# Provenance labels.  MEASURED vs ASSUMED is the load-bearing distinction.
+LABEL_NETBENCH = "MEASURED / REAL-LINK (gloo over TCP)"
+LABEL_LOOPBACK = "MEASURED / LOOPBACK LOWER BOUND (software floor only)"
+LABEL_ASSUMED = "ASSUMED / user-supplied number"
+
+# ---------------------------------------------------------------------------
+# Model specs (the fixtures for the decide-mode arithmetic).
+#
+# hidden_size / layers are architectural constants.  tpot_ms_single is the
+# MEASURED single-box TPOT of the shipped artifact on THIS box; None means no
+# trusted measurement exists yet, and any model with None gets
+# UNKNOWN-NEEDS-TPOT, never a WIN/LOSE.
+#
+# moe=True models route tokens through extra collectives beyond the 2*L
+# all-reduces counted here (see CAVEATS).
+MODEL_SPECS: dict[str, dict[str, Any]] = {
+    # measured 2026-08 CB artifact, single DGX Spark (see tpbench report)
+    "Qwen3.8-27B-CB":         {"hidden_size": 5120, "layers": 64, "tpot_ms_single": 64.4, "moe": False},
+    "Qwen3.5-122B-A10B":      {"hidden_size": 6144, "layers": 80, "tpot_ms_single": None, "moe": True},
+    "Mistral-Medium-3.5-128B": {"hidden_size": 6144, "layers": 88, "tpot_ms_single": None, "moe": False},
+    "DSv4-Flash":             {"hidden_size": 4096, "layers": 43, "tpot_ms_single": None, "moe": False},
+}
+
+CAVEATS = [
+    "(a) CB GEMV kernel time may NOT halve cleanly under TP=2: the codebook "
+    "GEMV kernels are not purely bandwidth-bound, so per-GPU decode time can "
+    "fall by less than 2x.",
+    "(b) MoE routing adds collectives beyond the 2*L all-reduces counted "
+    "here; the true sync count for MoE models is higher than tabulated.",
+    "(c) Latency was measured with the gloo backend over TCP.  gloo is "
+    "slower than NCCL, so a gloo number is PESSIMISTIC for a future "
+    "NCCL-over-TCP deployment.",
+    "(d) The crossover rule TPOT/2 assumes the memory-bound part of decode "
+    "scales ideally across boxes; wire-time assumes exclusive use of the "
+    "10 GbE link.",
+]
+
+
+# ---------------------------------------------------------------------------
+# Pure arithmetic (unit-tested; no torch.distributed needed).
+
+
+def percentile(values: Sequence[float], q: float) -> float:
+    """Linear-interpolated percentile (numpy 'linear' semantics) of q in [0,100]."""
+    if not values:
+        raise ValueError("percentile() of an empty sample")
+    vs = sorted(float(v) for v in values)
+    if len(vs) == 1:
+        return vs[0]
+    pos = (len(vs) - 1) * (q / 100.0)
+    lo = math.floor(pos)
+    hi = math.ceil(pos)
+    return vs[lo] + (vs[hi] - vs[lo]) * (pos - lo)
+
+
+def collective_math(
+    hidden_size: int,
+    layers: int,
+    latency_us: float,
+    link_bps: float = LINK_BPS_DEFAULT,
+) -> Dict[str, Optional[float]]:
+    """Per-token TP=2 collectives arithmetic for one model.
+
+    Returns all-reduce count, byte counts, wire time at link_bps, and the
+    added per-token latency implied by latency_us per collective.
+    """
+    all_reduces_per_token = 2 * layers
+    bytes_per_allreduce = hidden_size * BF16_BYTES
+    bytes_per_token = all_reduces_per_token * bytes_per_allreduce
+    wire_ms = bytes_per_token * 8.0 / link_bps * 1000.0
+    added_ms = all_reduces_per_token * latency_us / 1000.0
+    return {
+        "all_reduces_per_token": all_reduces_per_token,
+        "bytes_per_allreduce": bytes_per_allreduce,
+        "bytes_per_token": bytes_per_token,
+        "wire_ms_at_link": wire_ms,
+        "added_ms": added_ms,
+        "latency_us": latency_us,
+    }
+
+
+def verdict_for(tpot_ms_single: Optional[float], added_ms: float) -> str:
+    """WIN iff added per-token network latency beats the TPOT/2 budget.
+
+    Strict inequality: equal-to-budget counts as LOSE (no free lunch).  A
+    model without a measured single-box TPOT gets VERDICT_UNKNOWN, never a
+    WIN/LOSE, regardless of the numbers.
+    """
+    if tpot_ms_single is None:
+        return VERDICT_UNKNOWN
+    return VERDICT_WIN if added_ms < tpot_ms_single / 2.0 else VERDICT_LOSE
+
+
+def build_decision_rows(
+    latency_us: Optional[float] = None,
+    link_bps: float = LINK_BPS_DEFAULT,
+) -> List[Dict[str, Any]]:
+    """Decision rows for every model in MODEL_SPECS, stable order.
+
+    When latency_us is given it prices every row identically (flat assumed
+    number); when None the 'verdict' key is left None for the caller to fill
+    from size-matched measured percentiles.
+    """
+    rows: List[Dict[str, Any]] = []
+    for name, spec in MODEL_SPECS.items():
+        m = collective_math(spec["hidden_size"], spec["layers"],
+                            latency_us if latency_us is not None else 0.0, link_bps)
+        tpot = spec["tpot_ms_single"]
+        budget_ms = None if tpot is None else tpot / 2.0
+        verdict = None
+        if latency_us is not None:
+            verdict = verdict_for(tpot, float(m["added_ms"]))
+        rows.append({
+            "model": name,
+            "hidden_size": spec["hidden_size"],
+            "layers": spec["layers"],
+            "moe": spec["moe"],
+            "tpot_ms_single": tpot,
+            "budget_ms": budget_ms,
+            "budget_us_per_allreduce": None if budget_ms is None
+            else budget_ms * 1000.0 / m["all_reduces_per_token"],
+            "verdict": verdict,
+            **m,
+        })
+    return rows
+
+
+def check_scratch_path(path: Path) -> Path:
+    """Refuse host /tmp; everything scratch lives under /home/rob/dq-runs."""
+    resolved = Path(path).expanduser().resolve()
+    if resolved.is_relative_to(Path("/tmp")):
+        raise ValueError(f"refusing /tmp path ({resolved}); scratch belongs under {SCRATCH_ROOT}")
+    return resolved
+
+
+def _git_sha() -> Optional[str]:
+    try:
+        out = subprocess.run(["git", "rev-parse", "--short", "HEAD"],
+                             capture_output=True, text=True, timeout=10, check=True)
+        return out.stdout.strip()
+    except Exception:
+        return None
+
+
+def _primary_ip(peer: Optional[str]) -> str:
+    """Best-effort IPv4 this box would use to reach peer (UDP connect trick)."""
+    target = peer or (socket.gethostbyname(socket.gethostname()))
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect((target, 9))  # no packet is sent for UDP
+        return s.getsockname()[0]
+    except OSError:
+        return socket.gethostbyname(socket.gethostname())
+    finally:
+        s.close()
+
+
+def _parse_cpu_pin(spec: Optional[str]) -> Optional[List[Set[int]]]:
+    """'16-17,18-19' -> [{16,17}, {18,19}] (one core-set per rank).
+
+    Ranges matter: each rank runs a main thread plus gloo device thread(s);
+    forcing both onto one core serialises them against each other.
+    """
+    if not spec:
+        return None
+    ranks: List[Set[int]] = []
+    for part in spec.split(","):
+        if "-" in part:
+            lo, hi = part.split("-")
+            cores = set(range(int(lo), int(hi) + 1))
+        else:
+            cores = {int(part)}
+        if not cores:
+            raise SystemExit(f"--cpu-pin: empty core range '{part}'")
+        ranks.append(cores)
+    flat = [c for cs in ranks for c in cs]
+    if len(flat) != len(set(flat)):
+        raise SystemExit("--cpu-pin: a core appears in two ranks' sets")
+    return ranks
+
+
+def _load_snapshot() -> Dict[str, float]:
+    """1/5/15-minute load averages, recorded so contention is provable later."""
+    try:
+        l1, l5, l15 = os.getloadavg()
+        ncpu = os.cpu_count() or 1
+        return {"load1": round(l1, 2), "load5": round(l5, 2),
+                "load15": round(l15, 2), "cpus": ncpu}
+    except OSError:  # pragma: no cover - getloadavg is universal on linux
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Benchmark core.
+
+
+def _init_pg(rank: int, world_size: int, init_method: str):
+    os.environ.setdefault("CUDA_VISIBLE_DEVICES", "")  # CPU/TCP only, ever
+    import torch
+    torch.set_num_threads(1)
+    import torch.distributed as dist
+    dist.init_process_group(
+        backend="gloo",
+        init_method=init_method,
+        rank=rank,
+        world_size=world_size,
+        timeout=datetime.timedelta(seconds=120),
+    )
+    return torch, dist
+
+
+def _rank_bench(
+    rank: int,
+    world_size: int,
+    init_method: str,
+    sizes_bytes: Sequence[int],
+    warmup: int,
+    iters: int,
+    sync_every: int,
+    result_q=None,
+    cpu_pin: Optional[Sequence[Set[int]]] = None,
+) -> None:
+    """One rank of the latency sweep.  Rank 0 pushes per-size stats to result_q."""
+    if cpu_pin is not None:
+        os.sched_setaffinity(0, set(cpu_pin[rank]))
+    torch, dist = _init_pg(rank, world_size, init_method)
+    try:
+        for nbytes in sizes_bytes:
+            numel = nbytes // BF16_BYTES
+            t = torch.empty(numel, dtype=torch.bfloat16)
+            t.normal_()
+            for _ in range(warmup):
+                dist.all_reduce(t)
+            dist.barrier()
+            lat_us: List[float] = []
+            for i in range(iters):
+                if sync_every > 0 and i % sync_every == 0:
+                    dist.barrier()
+                t0 = time.perf_counter_ns()
+                dist.all_reduce(t)
+                lat_us.append((time.perf_counter_ns() - t0) / 1000.0)
+            dist.barrier()
+            if rank == 0 and result_q is not None:
+                result_q.put({
+                    "bytes": nbytes,
+                    "hidden_size": numel,
+                    "p50_us": percentile(lat_us, 50),
+                    "p90_us": percentile(lat_us, 90),
+                    "p99_us": percentile(lat_us, 99),
+                    "mean_us": sum(lat_us) / len(lat_us),
+                    "min_us": min(lat_us),
+                    "max_us": max(lat_us),
+                    "n": len(lat_us),
+                })
+    finally:
+        dist.destroy_process_group()
+
+
+def _spawn_loopback(args: argparse.Namespace, sizes_bytes: Sequence[int],
+                    warmup: int, iters: int, sync_every: int) -> List[Dict[str, Any]]:
+    """Two ranks on localhost; returns rank-0's per-size stat dicts."""
+    import multiprocessing as mp
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+    ctx = mp.get_context("spawn")
+    result_q = ctx.Queue()
+    cpu_pin = _parse_cpu_pin(getattr(args, "cpu_pin", None))
+    if cpu_pin is not None and len(cpu_pin) != 2:
+        raise SystemExit("--cpu-pin takes one core or range per rank, e.g. '16-17,18-19'")
+    procs = [
+        ctx.Process(
+            target=_rank_bench,
+            args=(rank, 2, f"tcp://127.0.0.1:{port}",
+                  sizes_bytes, warmup, iters, sync_every, result_q, cpu_pin),
+        )
+        for rank in (0, 1)
+    ]
+    for p in procs:
+        p.start()
+    results = [result_q.get(timeout=max(60, (warmup + iters) // 50)) for _ in sizes_bytes]
+    for p in procs:
+        p.join(timeout=120)
+        if p.exitcode not in (0, None):
+            raise RuntimeError(f"loopback rank exited with {p.exitcode}")
+    return sorted(results, key=lambda r: r["bytes"])
+
+
+def _iperf3_leg(rank: int, dist: Any, peer: Optional[str], port: int, seconds: int) -> Optional[Dict[str, Any]]:
+    """Cross-box iperf3 bandwidth leg, orchestrated over the live process group.
+
+    Rank 0 serves, rank 1 clients.  Skips (returns None) when either box lacks
+    the binary or anything goes wrong; never raises into the latency results.
+    """
+    import torch
+
+    def _which() -> bool:
+        return subprocess.run(["which", "iperf3"], capture_output=True).returncode == 0
+
+    have = torch.tensor([1.0 if _which() else 0.0])
+    dist.all_reduce(have, op=dist.ReduceOp.MIN)
+    if int(have.item()) != 1:
+        if rank == 0:
+            print("iperf3 bandwidth leg: SKIPPED (iperf3 not present on both boxes)")
+        return None
+    iport = port + 1
+    server = None
+    try:
+        if rank == 0:
+            server = subprocess.Popen(
+                ["iperf3", "-s", "-1", "-p", str(iport)],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            time.sleep(0.7)
+        go = torch.zeros(1, dtype=torch.int64)
+        dist.broadcast(go, src=0)  # go signal after server is listening
+        if rank == 1:
+            assert peer, "--peer (the rank-0 box) is required for the iperf3 leg"
+            proc = subprocess.run(
+                ["iperf3", "-c", peer, "-p", str(iport), "-t", str(seconds), "-J"],
+                capture_output=True, text=True, timeout=seconds + 60)
+            report = json.loads(proc.stdout)
+            gbps = report["end"]["sum_received"]["bits_per_second"] / 1e9
+            dist.broadcast(torch.tensor([gbps]), src=1)
+        else:
+            gbps = float(dist.broadcast(torch.zeros(1), src=1).item())
+        if rank == 0:
+            print(f"iperf3 bandwidth leg: MEASURED {gbps:.2f} Gbit/s "
+                  f"(tcp, {seconds}s, rank1->rank0 receive)")
+        return {"ran": True, "gbits_s": round(gbps, 3), "seconds": seconds}
+    except Exception as exc:  # noqa: BLE001 - this leg is strictly optional
+        if rank == 0:
+            print(f"iperf3 bandwidth leg: SKIPPED ({exc})")
+        return None
+    finally:
+        if server is not None and server.poll() is None:
+            server.terminate()
+
+
+def _write_json(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="ascii")
+    print(f"wrote {path}")
+
+
+def _bench_provenance(mode: str, label: str, args: argparse.Namespace) -> Dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "mode": mode,
+        "label": label,
+        "utc": datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds"),
+        "host": socket.gethostname(),
+        "peer": getattr(args, "peer", None),
+        "git_sha": _git_sha(),
+        "argv": sys.argv,
+        "backend": "gloo",
+        "transport": "TCP",
+        "load": _load_snapshot(),
+        "cpu_pin": getattr(args, "cpu_pin", None),
+        "note": ("loopback numbers are a LOWER BOUND on the real two-box link, "
+                 "not an estimate of it") if mode == "loopback" else None,
+    }
+
+
+def _print_latency_table(results: List[Dict[str, Any]], label: str, lower_bound: bool) -> None:
+    tag = " [LOOPBACK LOWER BOUND]" if lower_bound else ""
+    print(f"\nper-collective latency ({label}){tag}:")
+    print(f"{'bytes':>7} {'H':>6} {'p50 us':>10} {'p90 us':>10} {'p99 us':>10} "
+          f"{'mean us':>10} {'min us':>10} {'n':>6}")
+    for r in results:
+        print(f"{r['bytes']:7d} {r['hidden_size']:6d} {r['p50_us']:10.1f} "
+              f"{r['p90_us']:10.1f} {r['p99_us']:10.1f} {r['mean_us']:10.1f} "
+              f"{r['min_us']:10.1f} {r['n']:6d}")
+    if lower_bound:
+        print("NOTE: every number above is a software-floor LOWER BOUND with zero "
+              "wire time; the real 10 GbE cross-box number will be higher.")
+
+
+# ---------------------------------------------------------------------------
+# Modes.
+
+
+def mode_loopback(args: argparse.Namespace) -> int:
+    sizes = _resolve_sizes(args)
+    warmup, iters, sync_every = _resolve_iters(args)
+    print("=" * 78)
+    print("MODE: loopback -- two ranks on LOCALHOST (127.0.0.1)")
+    print("This measures the SOFTWARE FLOOR: gloo + TCP loopback + Python sync")
+    print("overhead, with ZERO wire time.  It is a LOWER BOUND on the real")
+    print("two-box number over 10 GbE -- NOT an estimate of that number.")
+    print("=" * 78)
+    results = _spawn_loopback(args, sizes, warmup, iters, sync_every)
+    _print_latency_table(results, LABEL_LOOPBACK, lower_bound=True)
+    load = _load_snapshot()
+    if load:
+        print(f"system context at measurement time: load {load['load1']}/{load['load5']} "
+              f"on {load['cpus']} cpus (contention inflates these numbers)")
+        print(f"cpu pin: {args.cpu_pin or 'none'}")
+    print("iperf3 bandwidth leg: N/A in loopback mode (there is no wire)")
+    payload = _bench_provenance("loopback", LABEL_LOOPBACK, args)
+    payload.update({
+        "config": {"world_size": 2, "warmup": warmup, "iters": iters,
+                   "sync_every": sync_every, "sizes_bytes": list(sizes)},
+        "results": results,
+        "iperf3": None,
+    })
+    _write_json(check_scratch_path(args.json_out), payload)
+    _print_caveats()
+    return 0
+
+
+def mode_netbench(args: argparse.Namespace) -> int:
+    if not args.peer:
+        print("error: --mode netbench requires --peer HOST (the other box)\n",
+              file=sys.stderr)
+        return 2
+    sizes = _resolve_sizes(args)
+    warmup, iters, sync_every = _resolve_iters(args)
+    print("=" * 78)
+    print("MODE: netbench -- REAL LINK, one process per box (gloo over TCP)")
+    print("Protocol: run this EXACT command on BOTH boxes, differing only in")
+    print(f"  --rank : this invocation is rank {args.rank}.")
+    print(f"  Rendezvous: tcp://{args.peer}:{args.port} "
+          f"(iperf3 leg, if present, uses port {args.port + 1}).")
+    print("=" * 78)
+    if args.rank == 0:
+        store_host = _primary_ip(args.peer)
+        init_method = f"tcp://{store_host}:{args.port}"
+        print(f"rank 0 hosting rendezvous on {store_host}:{args.port}, waiting for rank 1 ...")
+    else:
+        init_method = f"tcp://{args.peer}:{args.port}"
+
+    cpu_pin = _parse_cpu_pin(args.cpu_pin)
+    if cpu_pin is not None:
+        if len(cpu_pin) != 2:
+            raise SystemExit("--cpu-pin takes one core or range per rank, e.g. '16-17,18-19'")
+        os.sched_setaffinity(0, cpu_pin[args.rank])
+    _, dist = _init_pg(args.rank, 2, init_method)
+    results: List[Dict[str, Any]] = []
+    try:
+        for nbytes in sizes:
+            numel = nbytes // BF16_BYTES
+            t = torch.empty(numel, dtype=torch.bfloat16)
+            t.normal_()
+            for _ in range(warmup):
+                dist.all_reduce(t)
+            dist.barrier()
+            lat_us: List[float] = []
+            for i in range(iters):
+                if sync_every > 0 and i % sync_every == 0:
+                    dist.barrier()
+                t0 = time.perf_counter_ns()
+                dist.all_reduce(t)
+                lat_us.append((time.perf_counter_ns() - t0) / 1000.0)
+            dist.barrier()
+            if args.rank == 0:
+                results.append({
+                    "bytes": nbytes,
+                    "hidden_size": numel,
+                    "p50_us": percentile(lat_us, 50),
+                    "p90_us": percentile(lat_us, 90),
+                    "p99_us": percentile(lat_us, 99),
+                    "mean_us": sum(lat_us) / len(lat_us),
+                    "min_us": min(lat_us),
+                    "max_us": max(lat_us),
+                    "n": len(lat_us),
+                })
+        iperf = None
+        if args.rank == 0:
+            print("\nlatency sweep done; running optional bandwidth leg ...")
+        iperf = _iperf3_leg(args.rank, dist, args.peer, args.port, args.iperf3_time)
+    finally:
+        dist.destroy_process_group()
+
+    if args.rank == 0:
+        _print_latency_table(results, LABEL_NETBENCH, lower_bound=False)
+        payload = _bench_provenance("netbench", LABEL_NETBENCH, args)
+        payload.update({
+            "config": {"world_size": 2, "warmup": warmup, "iters": iters,
+                       "sync_every": sync_every, "sizes_bytes": list(sizes)},
+            "results": results,
+            "iperf3": iperf,
+        })
+        _write_json(check_scratch_path(args.json_out), payload)
+        _print_caveats()
+    return 0
+
+
+def _print_caveats() -> None:
+    print("\nCAVEATS that can invalidate the WIN/LOSE arithmetic:")
+    for c in CAVEATS:
+        print(f"  {c}")
+
+
+def mode_decide(args: argparse.Namespace) -> int:
+    per_size, flat, label = _resolve_decide_latency(args)
+    lower_bound = label is LABEL_LOOPBACK
+    print("=" * 78)
+    print("DECIDE: TP=2-vs-single-box decode crossover (rule: TP=2 wins iff")
+    print("        net overhead per token < TPOT_single / 2)")
+    print(f"latency source: {label}")
+    if lower_bound:
+        print("WARNING: loopback latency is a LOWER BOUND.  Verdicts below can only")
+        print("be upgraded to final by --mode netbench across the two real boxes.")
+    print("=" * 78)
+
+    rows = build_decision_rows(link_bps=args.link_gbps * 1e9)
+    hdr = (f"{'model':<26} {'AR/tok':>7} {'KB/tok':>9} {'wire ms':>8} "
+           f"{'add p50 ms':>11} {'add p99 ms':>11} {'TPOT ms':>9} "
+           f"{'budget ms':>10} {'us/AR':>8} {'verdict':>18}")
+    print(hdr)
+    print("-" * len(hdr))
+    unknown_settle: List[str] = []
+    for r in rows:
+        p50_us, p99_us, note = _latency_for_row(r, per_size, flat)
+        ar = int(r["all_reduces_per_token"])
+        add_p50_ms = ar * p50_us / 1000.0
+        add_p99_ms = ar * p99_us / 1000.0
+        verdict = verdict_for(r["tpot_ms_single"], add_p50_ms)
+        tpot = "unknown" if r["tpot_ms_single"] is None else f"{r['tpot_ms_single']:.1f}"
+        budget = "-" if r["budget_ms"] is None else f"{r['budget_ms']:.1f}"
+        us_ar = "-" if r["budget_us_per_allreduce"] is None \
+            else f"<{r['budget_us_per_allreduce']:.0f}"
+        flag = ""
+        if verdict == VERDICT_WIN and r["budget_ms"] is not None \
+                and add_p99_ms >= r["budget_ms"]:
+            flag = " (marginal at p99)"
+        print(f"{r['model']:<26} {ar:>7d} {r['bytes_per_token'] / 1024.0:>9.1f} "
+              f"{r['wire_ms_at_link']:>8.3f} "
+              f"{add_p50_ms:>11.2f} {add_p99_ms:>11.2f} "
+              f"{tpot:>9} {budget:>10} {us_ar:>8} {verdict:>18}{flag}")
+        print(f"{'':26} latency {p50_us:.1f}/{p99_us:.1f} us p50/p99 -- {note}")
+        if r["moe"]:
+            print(f"{'':26} note: MoE -- routing adds collectives beyond "
+                  f"{ar}/token (caveat b)")
+        if verdict == VERDICT_UNKNOWN:
+            unknown_settle.append(r["model"])
+        elif lower_bound:
+            print(f"{'':26} NOTE: this verdict rides on a LOOPBACK LOWER BOUND")
+
+    if unknown_settle:
+        print(f"\nUNKNOWN-NEEDS-TPOT ({len(unknown_settle)}): {', '.join(unknown_settle)}")
+        print("What settles them: a measured single-box TPOT (ms/token) for each model")
+        print("on THIS box, on the same calibration contract as the Qwen3.8-27B-CB")
+        print("measurement; budget is then TPOT/2 spread over the tabulated AR count.")
+    _print_caveats()
+    if lower_bound:
+        print("\nReminder: loopback = software floor, a LOWER BOUND only.  The cluster")
+        print("decision is settled solely by netbench p50/p99 across the two boxes.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing.
+
+
+def _resolve_sizes(args: argparse.Namespace) -> tuple[int, ...]:
+    sizes = tuple(sorted(set(int(b) for b in args.sizes_bytes.split(","))))
+    bad = [b for b in sizes if b % BF16_BYTES]
+    if bad:
+        raise SystemExit(f"--sizes-bytes entries must be bf16-even multiples: {bad}")
+    return sizes
+
+
+def _resolve_iters(args: argparse.Namespace) -> tuple[int, int, int]:
+    warmup = max(WARMUP_MIN, args.warmup)
+    iters = max(ITERS_MIN, args.iters)
+    if (warmup, iters) != (args.warmup, args.iters):
+        print(f"note: raised to spec minimums (warmup>={WARMUP_MIN}, iters>={ITERS_MIN})")
+    return warmup, iters, max(0, args.sync_every)
+
+
+def _resolve_decide_latency(
+    args: argparse.Namespace,
+) -> tuple[Optional[Dict[int, Dict[str, float]]], Optional[float], str]:
+    """Resolve decide-mode latency inputs.
+
+    Returns (per_size, flat, label):
+      per_size  maps all-reduce payload bytes -> {"p50_us", "p99_us"} taken
+                from a bench-mode JSON (MEASURED), or None.
+      flat      a single user-supplied microseconds figure used for both the
+                p50 and p99 columns (ASSUMED), or None.
+    """
+    if args.latency_json:
+        payload = json.loads(Path(args.latency_json).read_text(encoding="ascii"))
+        per_size = {
+            int(r["bytes"]): {"p50_us": float(r["p50_us"]), "p99_us": float(r["p99_us"])}
+            for r in payload["results"]
+        }
+        raw = str(payload.get("label", ""))
+        label = LABEL_LOOPBACK if "LOOPBACK" in raw else (
+            LABEL_NETBENCH if raw.startswith("MEASURED") else LABEL_ASSUMED)
+        return per_size, None, label
+    if args.latency_us is not None:
+        return None, float(args.latency_us), LABEL_ASSUMED
+    raise SystemExit("decide needs --latency-us N (assumed) or --latency-json FILE (measured)")
+
+
+def _latency_for_row(
+    row: Dict[str, Any],
+    per_size: Optional[Dict[int, Dict[str, float]]],
+    flat: Optional[float],
+) -> tuple[float, float, str]:
+    """(p50_us, p99_us, provenance-note) for one decision row.
+
+    MEASURED beats ASSUMED: when a bench JSON is present, each model is priced
+    at its OWN all-reduce size (bytes = hidden_size x bf16); models whose exact
+    size was not swept fall back to the largest swept size, flagged as such.
+    """
+    want = row["hidden_size"] * BF16_BYTES
+    if per_size:
+        if want in per_size:
+            s = per_size[want]
+            return s["p50_us"], s["p99_us"], "matched size"
+        biggest = max(per_size)
+        s = per_size[biggest]
+        return s["p50_us"], s["p99_us"], f"fallback: largest swept size ({biggest}B)"
+    assert flat is not None
+    return flat, flat, "single assumed number (used for both p50 and p99)"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        prog="tp_decode_feasibility.py",
+        description="TP=2 decode feasibility across a 10 GbE two-DGX-Spark cluster "
+                    "(gloo/CPU/TCP only -- safe while gpu.lock is held).")
+    ap.add_argument("--mode", required=True, choices=["netbench", "loopback", "decide"])
+    ap.add_argument("--peer", help="other box's address (netbench: rank 1 connects here; "
+                                   "used to pick rank 0's interface)")
+    ap.add_argument("--rank", type=int, default=0, choices=[0, 1],
+                    help="netbench only: this process's rank (default 0)")
+    ap.add_argument("--port", type=int, default=PORT_DEFAULT,
+                    help=f"rendezvous port (default {PORT_DEFAULT}; iperf3 leg uses port+1)")
+    ap.add_argument("--warmup", type=int, default=WARMUP_MIN,
+                    help=f"warmup iterations per size (spec floor {WARMUP_MIN})")
+    ap.add_argument("--iters", type=int, default=ITERS_MIN,
+                    help=f"measured iterations per size (spec floor {ITERS_MIN})")
+    ap.add_argument("--sync-every", type=int, default=SYNC_EVERY_DEFAULT,
+                    help="re-barrier this often during measurement (0 disables; "
+                         f"default {SYNC_EVERY_DEFAULT})")
+    ap.add_argument("--sizes-bytes", default=",".join(str(b) for b in DEFAULT_SIZES_BYTES),
+                    help="comma-separated all-reduce payload sizes in bf16 bytes "
+                         f"(default: {','.join(map(str, DEFAULT_SIZES_BYTES))} "
+                         "= H x 2 for H in 4096/5120/6144/8192)")
+    ap.add_argument("--cpu-pin", default=None,
+                    help="pin ranks to cores to cut scheduler noise, one core or "
+                         "range per rank, e.g. '16-17,18-19' (loopback: rank0 cores, "
+                         "rank1 cores; netbench: this rank's set)")
+    ap.add_argument("--json-out", type=Path, default=DEFAULT_OUT_DIR / "last_bench.json",
+                    help=f"where bench modes write their result JSON (default under {DEFAULT_OUT_DIR})")
+    # decide-mode inputs
+    ap.add_argument("--latency-us", type=float, default=None,
+                    help="ASSUMED per-all-reduce latency in microseconds")
+    ap.add_argument("--latency-json", default=None,
+                    help="MEASURED latency: JSON written by a bench mode")
+    ap.add_argument("--latency-stat", choices=["p50_us", "p90_us", "p99_us"], default="p50_us",
+                    help="which percentile to take from --latency-json (default p50_us)")
+    ap.add_argument("--link-gbps", type=float, default=10.0,
+                    help="link rate for wire-time accounting (default 10)")
+    ap.add_argument("--iperf3-time", type=int, default=5,
+                    help="seconds for the optional iperf3 leg (netbench only)")
+    return ap
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.mode == "loopback":
+        return mode_loopback(args)
+    if args.mode == "netbench":
+        return mode_netbench(args)
+    return mode_decide(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Split 3 of 6 from `merge/proven-rescues` (#95). The cheapest one to review: two files under `tools/`, two test files, nothing else.

## What it does

Two CPU-only planning tools for the two-DGX-Spark cluster.

**`tools/tp_decode_feasibility.py`** settles whether TP=2 decode across two Sparks on plain 10 GbE TCP beats single-box decode. Decode is memory-bandwidth bound, so TP=2 roughly halves per-GPU weight reads; the cost is `2*L` all-reduces per token, and **latency, not wire time, dominates** because every one of the 128 sync points (Qwen3.8-27B) stalls the token. The crossover rule is:

```
TP=2 wins iff   net_overhead_per_token < TPOT_single / 2
```

The decisive unknown is per-all-reduce latency **at our message sizes on this link**. Three modes turn that into a one-command measurement:

- `loopback` — two ranks on localhost. Measures the software floor (gloo + TCP stack + sync overhead) with zero wire time. Every number it produces is labelled a **LOWER BOUND** on the real two-box number, never an estimate of it.
- `netbench` — two ranks over the real link, plus an iperf3 bandwidth leg when iperf3 exists on both boxes.
- `decide` — apply a measured (or assumed) latency to the model specs and print the WIN/LOSE/UNKNOWN verdict table.

gloo needs no GPU, so this is safe to run beside a job holding `/home/rob/dq-runs/gpu.lock`.

**`tools/tp2_budget_plan.py`** answers the residency question: given an artifact and a parallelism spec, what actually resides on each rank, and how large an artifact still fits? It is a **residency** planner, not a speed model, and it never loads a tensor — it reads safetensors headers only (the 8-byte length prefix plus the JSON header) and computes per-tensor bytes from dtype × shape, cross-checked against the header's own `data_offsets`. That cross-check is what earns the EXACT label.

## Why it is worth landing

The honesty contract is the reason these are worth having rather than a spreadsheet:

- Every number is labelled **EXACT / DERIVED / ASSUMED / MEASURED**, and MEASURED is reserved for numbers that came from an instrument.
- **Nothing is silently bucketed.** A checkpoint tensor matching no classification rule is a hard error that lists the offending names — the silent-zero lesson: silent buckets rank broken arms first.
- TP mode does not pretend to know the shard policy. It prints an ASSUMED all-body-sharded model, labels every line ASSUMED, and says what would have to be attested to remove the label.
- Missing overhead prints as `UNKNOWN-NEEDS-OVERHEAD`, never defaulted to a number, matching `UNKNOWN-NEEDS-TPOT` in the feasibility harness.

Classification runs in the **checkpoint namespace only**, and the layer rule is anchored `(?:^|\.)layers\.(\d+)\.` because DSv4 checkpoints name their body `layers.0.attn...` with no `model.` prefix, which a bare `\.layers\.` misses entirely. Sidecars are checked **first**, so an MTP block carrying its own `.layers.N.` names cannot be mistaken for a body layer and `mtp.norm.weight` cannot be mistaken for the final norm.

Context for a future reader: this is groundwork adjacent to what `docs/design/prismabuild.md` sketches. That spec is already on `main`, marked SPEC / NOT BUILT, and **nothing here builds it** — these two tools stand on their own merits.

The third cluster tool, `tools/cluster_render_sentinel.py`, is deliberately **not** in this PR: it imports `prismaquant.unit_sharding` and therefore ships with #104.

## What it touches that is live

**Nothing.** Pure additions under `tools/`; no file in `prismaquant/` imports either module, and no pipeline stage changes.

## Dependencies

**None**, in either direction. This can merge at any time, independently of the other five.

## Tests

`origin/main` (`8461ae2`) baseline, **measured on that exact commit**: **5494 passed, 143 skipped, 3 xfailed, 179 subtests passed, 0 failed** — `EXIT=0`, fully green (14m22s).
Identical to the earlier `4cd8d39` baseline, as expected: the three commits `main` gained
mid-split (`1d35f70`, `22db4fb`, `8461ae2`) touch only `.github/`, `pyproject.toml` and
`docs/` — **zero delta under `prismaquant/`, `tests/`, `tools/` or `scripts/`**, verified by diff.
Note for the reviewer: the brief for this split warned of "4 pre-existing aarch64 failures".
They **do not reproduce** — #90 and #94 already fixed them — so every failure below is attributable.

This branch: **0 failed, 5556 passed**, 143 skipped, 3 xfailed, 179 subtests passed (19m44s). **Fully green** — `EXIT=0`.

New coverage: `tests/test_tp2_budget_plan.py` (484 lines) and `tests/test_tp_decode_feasibility.py` (153 lines) — 62 tests, all passing.


## Merge-order note (applies to all six)

Every PR in this split adds its own stamp to the top of `docs/ARCHITECTURE.md`'s
provenance block (principle 13). Whichever merges second will therefore hit a
**textual conflict in that block and nowhere else** — resolution is to keep both
stamps, newest first. Verified by merging all six together: `docs/ARCHITECTURE.md`
is the *only* conflicting path across the entire split. **Zero code conflicts.**

---

Extracted from `merge/proven-rescues` commits `7e5f888`, `3a9061d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F46Tr8Az6t2Ky3sRExZ5y
