### PR TITLE
feat(probe): price the grouped operand wo_a with an exact grouped Fisher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 
+### Added
+
+- **Grouped-BMM Fisher: DSv4's `attn.wo_a` is now an allocator decision**
+  (`sensitivity_probe.py`, `incremental_probe.py`, `measure_quant_cost.py`,
+  `model_profiles/*`). The grouped operand — 33.5M params × 43 layers, 17.9%
+  of decode read traffic — had never been priced: the probe skipped
+  `DeepseekV4GroupedLinear` because the dense accumulator cannot represent a
+  `[G,R,D]` consumption (its `chunk_h` comes out `[R,D]` against a `[G*R,D]`
+  plane), and the walk held the weight as a named pin. The new accumulator is
+  EXACT (the grouped Fisher is block-diagonal in `g`; one batched matmul per
+  hook), shares the dense rows' one global-token normalization and wiring
+  identity (`sum(fisher_row) == sum(fisher_col) == h_trace_raw` by
+  construction), reports flat-plane dims plus `num_groups` (never
+  `num_experts`, so packed-expert scoping cannot ride along), and dispatches
+  only on the new spec field `probe.grouped_module_class_names` — declared
+  classes lacking `n_groups` fail fast. The cost stage prices grouped units
+  from probe keys with no new plumbing and stamps their joint-output-MSE
+  screen honestly unmeasured (`output_mse_measured=False`): its dense
+  `y = X @ W.T` model would inflate the output term ~G-fold with cross-group
+  error no token sees. The walk claim for `wo_a` moves from
+  `pin(probe skips...)` to `decide`; no shipped artifact changes (the DSpark
+  sidecar keeps all three `wo_a` bases on source-FP8 W8A16, and CB export
+  still refuses grouped operands). Boundary: the W8A16 handoff's frozen
+  source closure pins `model_profiles/base.py`, `model_profiles/deepseek_v4.py`
+  and `specs/deepseek_v4.json` byte-for-byte, so the next handoff
+  verification refuses until those three files are re-frozen with review.
+  (`docs/ARCHITECTURE.md` §8.9; tests `tests/test_grouped_linear_fisher.py`.)
+
 ### Fixed
 
 - **FP8-source MoE checkpoints now build end to end** — first wrapped-VLM

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,27 @@
 # PrismaQuant Architecture
 
-As of: 2026-08-29 · `rescue/walker-export-gate` — stamps follow, newest
+As of: 2026-08-29 · `rescue/grouped-woa` — stamps follow, newest
 first, each recording its own branch and date. Re-stamped (2026-08-29,
-`rescue/walker-export-gate`) for
+`rescue/grouped-woa`) for
+**pricing the grouped operand `wo_a`** (§8.9): DSv4's grouped-BMM attention
+output projection — 17.9% of decode read traffic — was never an allocator
+decision because the probe skipped its class. The grouped Fisher accumulator
+(`prismaquant/sensitivity_probe.py`: exact per-group bmm reductions, flat-plane
+marginals, the ONE global-token normalization) landed FIRST; then
+`DeepseekV4GroupedLinear` moved from the spec's `probe_skip_module_class_names`
+to the new `probe.grouped_module_class_names`, which routes the probe to the
+grouped accumulator and lets the walk claim `wo_a` as an ordinary `decide`.
+Cost cells flow from probe keys with no new plumbing; the joint-output-MSE
+screen ships honestly unmeasured (`output_mse_measured=False`) for grouped
+units because the dense screen mis-models the contraction. No shipped artifact
+changes: the DSpark sidecar contract keeps all three `wo_a` bases on
+source-FP8 W8A16 (`dspark_cb_expected_physical_targets`), CB export still
+refuses grouped operands, and the W8A16 handoff's frozen source closure now
+names three drifted files (`model_profiles/base.py`,
+`model_profiles/deepseek_v4.py`, `specs/deepseek_v4.json`) that require a
+reviewed re-freeze before the next handoff verification passes.
+
+Earlier stamp (2026-08-29, `rescue/walker-export-gate`) for
 **the discovery walker as a fail-closed export gate** (§8.8,
 `prismaquant/model_walk.py`): the R5 design contract's remaining open half —
 wiring the walk as an export gate — is closed; the probe/cost/footprint/
@@ -4652,8 +4671,9 @@ routed-expert stacks get `num_experts_per_tok / n_routed_experts` (exact as an
 expectation under the per-layer-uniform expert invariant §6.4 — routing skew changes
 *which* experts are read, not how many bytes); allocator-assigned always-active units
 (`dense`) and always-active tensors the allocator never decided (`held_fixed` — norms,
-biases, routers, a pinned `lm_head`, and grouped operands the probe skips such as DSv4's
-`attn.wo_a`) get `1.0`. Both `topk` and `E` are read from the architecture's own config
+biases, routers, a pinned `lm_head`; DSv4's grouped `attn.wo_a`, which the probe prices
+since the grouped Fisher accumulator landed and which sits here only while no
+assignment covers it) get `1.0`. Both `topk` and `E` are read from the architecture's own config
 declarations and **cross-checked against the tensors' measured stack depth**; an MoE
 model that declares neither is refused rather than defaulted (principle 2 — the
 `moe_imatrix` "assume 8" fallback would mis-price the largest term in the ledger).
@@ -6209,9 +6229,12 @@ purpose), or `exclude(reason)` (outside the artifact's scope). Claims come
 from ordered `ClaimRule` lists supplied by the profile:
 `ModelProfile.walk_claim_rules()` (`model_profiles/base.py`) derives the base
 set from the profile's own declarations — spec
-`probe_skip_module_class_names` → pin (this is the `wo_a` rule: the spec
-already said the probe skips `DeepseekV4GroupedLinear`, so the walker turns
-that declaration into a named debt), `pinned_names` → pin, MTP/visual
+`probe_skip_module_class_names` → pin (the mechanism that held DSv4's
+grouped-BMM `attn.wo_a` as a named debt until it could be priced;
+2026-08-22 the grouped Fisher accumulator landed, `DeepseekV4GroupedLinear`
+moved to the spec's `probe_grouped_module_class_names`, and its weight
+became an ordinary `decide` — see §8.9),
+`pinned_names` → pin, MTP/visual
 prefixes and `nn.Embedding` weights and non-persistent buffers and
 non-floating or ≤1-D tensors → exclude with reasons, remaining `nn.Linear`
 weights → decide. **A matmul-fed node no rule matches fails the walk** with
@@ -6272,6 +6295,58 @@ refusal so it cannot recur silently.
 Still open per the design doc: migrating probe/cost/footprint/read-traffic
 onto the walker's edge list — separate, deliberate work (the consumption-API
 design lives in the R5 reports).
+
+### 8.9 Pricing a grouped operand: the `wo_a` accumulator (2026-08-22)
+
+DSv4's `attn.wo_a` — 33,554,432 parameters × 43 layers, 1.443 GB/token,
+17.9% of decode read traffic — is consumed by a view + per-group
+`torch.bmm` inside `DeepseekV4GroupedLinear` (`y[...,g,r] = Σ_d x[...,g,d]·W[g,r,d]`).
+The class sat in the probe's skip list because the dense accumulator cannot
+represent that consumption: its chunk_h comes out `[R, D]` against a `[G*R, D]`
+plane (the `chunk_h * w.pow(2)` broadcast), and flattening groups into the
+token axis destroys the per-channel marginals. The walker then held the weight
+as a named pin — correct polarity, real debt.
+
+The debt is closed by ONE grouped mechanism (`prismaquant/sensitivity_probe.py`,
+shared by both probe backends):
+
+- **Math.** The elementwise Fisher of a grouped operand is block-diagonal in
+  `g`, so the exact per-token-summed empirical Fisher (audit M3's estimator,
+  never sum-then-square) reduces over one batched matmul:
+  `chunk_h[g,r,d] = Σ_t gy²[t,g,r]·x²[t,g,d]`. Every scalar and marginal —
+  `h_trace`, `fisher_row[g*R+r]`, `fisher_col[d]`, `g_sq_sum`, `act_sq_sum`,
+  `act_absmax`, `h_trace_per_group_raw[g]` — reduces the SAME fp32
+  `chunk_h`, so `sum(fisher_row) == sum(fisher_col) == h_trace_raw` holds by
+  construction, which is the card's wiring check.
+- **Schema.** The unit stays the whole logical tensor in FLAT-PLANE
+  coordinates: `out_features = G*R`, `in_features = D`, `n_params` counts all
+  groups, and `num_groups` distinguishes it from a same-shape dense Linear —
+  deliberately NOT `num_experts`, which `_shape_from_stats` and
+  `_stats_indicates_packed_expert` read as a packed expert stack. TP note:
+  identity/dispositions/byte totals are logical; a future rowwise shard cuts
+  the plane's row axis and must not straddle a group boundary.
+- **Normalization.** Unchanged and global: rows stay raw token sums until
+  `finalize_fisher_stats` divides every row by the GLOBAL calibration token
+  count. Grouped operands are attention output projections — every group sees
+  every token — so the shared denominator is exact, not merely consistent;
+  `n_tokens_seen` counts tokens, not token-group pairs.
+- **Dispatch.** Explicit declaration only: spec field
+  `probe.grouped_module_class_names` (conformance-tested like every other
+  spec field). A declared class whose instance lacks `n_groups` fails fast;
+  nothing heuristic falls through to the dense accumulator.
+- **Cost cells.** They flow from probe keys with no new plumbing; the weight
+  render is exact on the flat plane for every menu format because row-wise
+  quantization never mixes rows. The joint-output-MSE screen ships honestly
+  UNMEASURED (`output_mse_measured=False`) for grouped units in both cost
+  paths: its `y = X @ W.T` model would score each group slice against all
+  `G*R` outputs, inflating the output term ~G-fold with cross-group error no
+  token sees.
+- **Serving unchanged.** Candidacy is not assignment: the DSpark sidecar
+  contract keeps all three `wo_a` bases on source-FP8 W8A16
+  (`dspark_source_metadata.dspark_cb_expected_physical_targets`), CB export
+  still refuses grouped-BMM semantics, and Gridbook's pinned contract declares
+  no grouped structure lane. "Priced, kept on FP8_SOURCE" is now an honest
+  allocator decision where silence used to be.
 
 ## 9. Serving lanes
 

--- a/docs/design/model_coverage_ledgers.md
+++ b/docs/design/model_coverage_ledgers.md
@@ -11,6 +11,17 @@ like a tree traversal.").**
 walks are usable now; wiring the walk as an export gate and migrating
 probe/cost/footprint/read-traffic onto its edge list is still open.**
 
+**Update 2026-08-22 (`walker/woa-grouped-fisher`): the motivating instance is
+priced.** The grouped Fisher accumulator landed (`ARCHITECTURE.md` §8.9) —
+exact per-group reductions on the same estimator, flat-plane marginals, the
+one global-token normalization — and `DeepseekV4GroupedLinear` left the
+probe's skip list for the new `probe.grouped_module_class_names`. DSv4's
+`wo_a` walk claim moved from `pin(probe cannot price grouped operands yet)`
+to `decide`, and cost cells flow from probe keys with an honestly unmeasured
+output-MSE screen. The edge-list migration above remains open: this change
+prices `wo_a` through the EXISTING module-boundary hook mechanism; it does not
+yet derive the probe's inventory from the walk's edge list.
+
 ## The failure class this exists to kill
 
 On DeepSeek-V4, `attn.wo_a` — 17.9% of all decode read traffic — was never an
@@ -75,7 +86,10 @@ profile-plugin time, before any campaign spends GPU hours — and again at
 export as a gate. Dispositions with reasons are first-class output: they land
 on the shipcard and the model card, so the honest state is visible instead of
 silent. `wo_a` claimed as `pin(probe cannot price grouped operands yet)` on
-day one is a known debt with a name; `wo_a` absent is what bit us.
+day one is a known debt with a name; `wo_a` absent is what bit us. (That
+particular debt retired 2026-08-22 when the accumulator landed — see the
+update note above — but the pin mechanism stays for the next class no
+accumulator covers.)
 
 ## One enumeration, every consumer derives
 

--- a/prismaquant/incremental_probe.py
+++ b/prismaquant/incremental_probe.py
@@ -235,6 +235,9 @@ from .sensitivity_probe import (
     discover_moe_structure,
     discover_moe_routers,
     finalize_fisher_stats,
+    grouped_linear_fisher_chunk,
+    grouped_linear_groups,
+    grouped_linear_stats_entry,
     h_detail_blob,
     install_packed_expert_hooks,
     kv_cotangent_path_enabled,
@@ -2144,12 +2147,59 @@ def _compute_global_precompute(
             resident_stats[name]["n_tokens_seen"] += x2.size(0)
         return hook
 
+    def _make_resident_grouped_bwd(name: str, mod_ref: nn.Linear,
+                                   num_groups: int):
+        """Resident-path grouped fold (wo_a shape). Immediate like the
+        dense resident hook; reductions via `grouped_linear_fisher_chunk`
+        so both backends share one mechanism. Marginals land in the same
+        five-key slot and index the flat [G*R, D] plane."""
+        def hook(module, grad_input, grad_output):
+            gy = grad_output[0]
+            x = resident_saved_inputs.pop(name, None)
+            if x is None or gy is None:
+                return
+            pieces = grouped_linear_fisher_chunk(x, gy, num_groups,
+                                                 mod_ref.weight)
+            resident_stats[name]["h_trace_raw"] += float(
+                pieces["h_trace"].item())
+            if _emit_marginals:
+                _marginal_accumulate(
+                    resident_marginals, name,
+                    [pieces["fisher_row"], pieces["fisher_col"],
+                     pieces["g_sq_sum"], pieces["act_sq_sum"],
+                     pieces["act_absmax"]])
+            w = mod_ref.weight
+            if w is not None and not w.is_meta:
+                if pieces["h_w2"] is not None:
+                    resident_stats[name]["h_w2_sum_raw"] += float(
+                        pieces["h_w2"].item())
+            # TOKENS, not token-group pairs (metadata parity with dense).
+            tokens = int(x.numel()) // (num_groups * int(x.shape[-1]))
+            resident_stats[name]["n_tokens_seen"] += tokens
+        return hook
+
     for fqn in resident_tracked:
         mod = model.get_submodule(fqn)
         if not isinstance(mod, nn.Linear):
             continue
         w = mod.weight
         if w.is_meta:
+            continue
+        num_groups_res = grouped_linear_groups(mod, _profile)
+        if num_groups_res is not None:
+            resident_stats[fqn] = grouped_linear_stats_entry(
+                mod, num_groups_res,
+                w_max_abs=float(w.detach().abs().max().item()),
+                w_norm_sq=float(w.detach().pow(2).sum().item()))
+            if _emit_marginals:
+                resident_stats[fqn].update(
+                    _marginal_zeros(mod.out_features, mod.in_features))
+            for p in mod.parameters():
+                p.requires_grad_(True)
+            resident_handles.append(
+                mod.register_forward_hook(_make_resident_fwd(fqn)))
+            resident_handles.append(mod.register_full_backward_hook(
+                _make_resident_grouped_bwd(fqn, mod, num_groups_res)))
             continue
         resident_stats[fqn] = {
             "h_trace_raw": 0.0,
@@ -3291,6 +3341,71 @@ def _run_body_streaming_shard(
                 # Flag so the per-Linear hook short-circuits to deferred path.
                 pass  # (no-op, used as documentation; lookup happens per-call)
 
+            def _fold_grouped_layer_stat(name: str, x, gy, mod_ref,
+                                         num_groups: int):
+                """Grouped-BMM Fisher fold for ONE (x, gy) pair on the
+                body-shard path. Shares the dense path's storage exactly —
+                device_accums scalar slots, device_marginals five-vector
+                slot, acc_h_full, acc_g2_per_token — so every flush and
+                merge below this line is unchanged. The math comes from
+                `grouped_linear_fisher_chunk` (one mechanism with the
+                non-streaming backend); only the folding differs because
+                this site honors deferred_sync."""
+                pieces = grouped_linear_fisher_chunk(x, gy, num_groups,
+                                                     mod_ref.weight)
+                per_group_slot = grouped_per_group_acc.get(name)
+                if per_group_slot is None:
+                    grouped_per_group_acc[name] = pieces["trace_per_group"]
+                else:
+                    per_group_slot.add_(pieces["trace_per_group"])
+                if emit_marginals:
+                    _marginal_accumulate(
+                        device_marginals, name,
+                        [pieces["fisher_row"], pieces["fisher_col"],
+                         pieces["g_sq_sum"], pieces["act_sq_sum"],
+                         pieces["act_absmax"]])
+                if collect_h_full:
+                    # Per-(token, group) rows: the plane-coordinate
+                    # analog of the dense per-token vector.
+                    gy_sq = gy.detach().reshape(
+                        -1, num_groups, gy.shape[-1]).pow(2)
+                    x_sq = x.detach().reshape(
+                        -1, num_groups, x.shape[-1]).pow(2)
+                    pt = (gy_sq.sum(dim=-1) * x_sq.sum(dim=-1)).reshape(-1)
+                    acc_g2_per_token[name].append(
+                        pt.detach().to("cpu", dtype=torch.float32))
+                    acc = acc_h_full.get(name)
+                    if acc is None:
+                        acc = torch.zeros(
+                            int(pieces["chunk_flat"].shape[0]),
+                            int(pieces["chunk_flat"].shape[1]),
+                            dtype=torch.float32, device="cpu")
+                        acc_h_full[name] = acc
+                    acc.add_(pieces["chunk_flat"].to(acc.device).to(acc.dtype))
+                h_trace_dev = pieces["h_trace"]
+                if deferred_sync:
+                    slot = device_accums.get(name)
+                    if slot is None:
+                        slot = (
+                            torch.zeros((), device=h_trace_dev.device,
+                                        dtype=torch.float32),
+                            torch.zeros((), device=h_trace_dev.device,
+                                        dtype=torch.float32),
+                        )
+                        device_accums[name] = slot
+                    slot[0].add_(h_trace_dev)
+                    if pieces["h_w2"] is not None:
+                        slot[1].add_(pieces["h_w2"])
+                else:
+                    acc_stats[name]["h_trace_raw"] += float(
+                        h_trace_dev.item())
+                    if pieces["h_w2"] is not None:
+                        acc_stats[name]["h_w2_sum_raw"] += float(
+                            pieces["h_w2"].item())
+                tokens = int(x.numel()) // (
+                    num_groups * int(x.shape[-1]))
+                acc_stats[name]["n_tokens_seen"] += tokens
+
             def make_fwd(name: str):
                 def hook(module, inp, out):
                     x = inp[0] if isinstance(inp, tuple) else inp
@@ -3460,6 +3575,14 @@ def _run_body_streaming_shard(
                     x = saved_inputs.pop(name, None)
                     if x is None or gy is None:
                         return
+                    # Grouped-BMM operand: same immediate path, grouped
+                    # reductions (never the dense flatten below — it would
+                    # broadcast-fail against the [G*R, D] plane anyway).
+                    g_count = grouped_map.get(name)
+                    if g_count is not None:
+                        _fold_grouped_layer_stat(
+                            name, x.detach(), gy.detach(), mod_ref, g_count)
+                        return
                     gy2 = gy.reshape(-1, gy.size(-1))
                     x2 = x.reshape(-1, x.size(-1))
                     T = x2.size(0)
@@ -3547,6 +3670,18 @@ def _run_body_streaming_shard(
                     acc_stats[name]["n_tokens_seen"] += T
                 return hook
 
+            # Grouped-BMM operands in this shard's scope (wo_a shape):
+            # dispatched to `_fold_grouped_layer_stat` at backward time.
+            grouped_map: dict[str, int] = {}
+            for fqn in tracked_here:
+                try:
+                    g_mod = model.get_submodule(fqn)
+                except AttributeError:
+                    continue
+                g_count = grouped_linear_groups(g_mod, _shard_profile)
+                if g_count is not None:
+                    grouped_map[fqn] = g_count
+
             for fqn in tracked_here:
                 mod = model.get_submodule(fqn)
                 if not isinstance(mod, nn.Linear):
@@ -3558,6 +3693,19 @@ def _run_body_streaming_shard(
                 # batched .stack().cpu() and memoizes; subsequent shards
                 # / chunks return instantly with no device sync.
                 w_max_abs, w_norm_sq = _get_or_compute_w_stats(fqn, w)
+                if fqn in grouped_map:
+                    acc_stats[fqn] = grouped_linear_stats_entry(
+                        mod, grouped_map[fqn],
+                        w_max_abs=w_max_abs, w_norm_sq=w_norm_sq)
+                    if emit_marginals:
+                        acc_stats[fqn].update(
+                            _marginal_zeros(mod.out_features, mod.in_features))
+                    for p in mod.parameters():
+                        p.requires_grad_(True)
+                    handles.append(mod.register_forward_hook(make_fwd(fqn)))
+                    handles.append(mod.register_full_backward_hook(
+                        make_bwd(fqn, mod)))
+                    continue
                 acc_stats[fqn] = {
                     "h_trace_raw": 0.0,
                     "h_w2_sum_raw": 0.0,
@@ -3589,6 +3737,11 @@ def _run_body_streaming_shard(
             # Values are device-resident 0-dim fp32 tensors (flushed via
             # float() below — one sync per packed param per layer).
             packed_grad_acc: dict[str, torch.Tensor] = {}
+            # Per-GROUP Fisher trace [G] for grouped-BMM operands (wo_a
+            # shape) in this layer. Same device-resident discipline; the
+            # flush below lands it on the stats entry as a plain float
+            # list (pickle/merge-safe, like `h_trace_per_expert_raw`).
+            grouped_per_group_acc: dict[str, torch.Tensor] = {}
             # Per-expert per-channel Fisher [E, M] — enables per-expert
             # h_trace decomposition for the allocator's packed-3D prune
             # cost without re-measuring cost per expert. Always enabled
@@ -3730,6 +3883,15 @@ def _run_body_streaming_shard(
             # h_trace / h_w2_sum stay device-resident here too.
             if deferred_compute and deferred_queue:
                 for name, x, gy, mod_ref in deferred_queue:
+                    # Grouped-BMM operand: fold through the grouped
+                    # reductions; the dense flatten below would compute
+                    # the wrong-shaped marginals against the [G*R, D]
+                    # plane.
+                    g_count = grouped_map.get(name)
+                    if g_count is not None:
+                        _fold_grouped_layer_stat(name, x, gy, mod_ref,
+                                                 g_count)
+                        continue
                     gy2 = gy.reshape(-1, gy.size(-1))
                     x2 = x.reshape(-1, x.size(-1))
                     T = x2.size(0)
@@ -3838,6 +4000,25 @@ def _run_body_streaming_shard(
                     acc_stats[full_key]["h_trace_per_expert_raw"] = summed
             packed_channel_acc.clear()
 
+            # Per-group Fisher trace flush (grouped-BMM operands). One
+            # .cpu() per grouped param — same honesty as the packed
+            # per-expert list: plain floats, elementwise-merged across
+            # shard splits, normalized by the global token count in
+            # `finalize_fisher_stats`.
+            for local_key, per_group in grouped_per_group_acc.items():
+                full_key = f"{layer_prefix}{local_key}"
+                entry = acc_stats.get(full_key)
+                if entry is None:
+                    continue
+                vals = per_group.detach().to(torch.float64).tolist()
+                prev = entry.get("h_trace_per_group_raw")
+                if prev is None:
+                    entry["h_trace_per_group_raw"] = vals
+                else:
+                    entry["h_trace_per_group_raw"] = [
+                        p + float(v) for p, v in zip(prev, vals)]
+            grouped_per_group_acc.clear()
+
             # Per-expert AQUA marginals. One .cpu() per array (four per
             # packed param per layer -- the arrays are [E, M] / [E, N] /
             # [E], so ~8 MB per MoE layer at E=256; the dense marginals'
@@ -3889,6 +4070,18 @@ def _run_body_streaming_shard(
                         else:
                             prev["h_trace_per_expert_raw"] = [
                                 a + b for a, b in zip(per_prev, per_new)
+                            ]
+                    # Per-group Fisher (grouped-BMM operands): identical
+                    # elementwise-sum rule, same reason — it is a [G]
+                    # decomposition of the one h_trace across shard splits.
+                    grp_prev = prev.get("h_trace_per_group_raw")
+                    grp_new = s.get("h_trace_per_group_raw")
+                    if grp_new is not None:
+                        if grp_prev is None:
+                            prev["h_trace_per_group_raw"] = list(grp_new)
+                        else:
+                            prev["h_trace_per_group_raw"] = [
+                                a + b for a, b in zip(grp_prev, grp_new)
                             ]
                     # Per-expert AQUA marginals follow the SAME merge
                     # rules as the dense ones: sums add, an absmax bound

--- a/prismaquant/measure_quant_cost.py
+++ b/prismaquant/measure_quant_cost.py
@@ -46,6 +46,7 @@ from .nvfp4_cb_footprint import (
     cb_cost_provenance,
     cb_serialization_context_from_env,
 )
+from .sensitivity_probe import grouped_linear_groups
 
 
 def _cb_cost_quantize_dequantize(
@@ -1313,8 +1314,19 @@ def measure_unbatched(model: nn.Module, act_cache: "ActivationIndex",
         W = mod.weight.detach()
         X_cpu, row_indices = act_cache.load_with_row_indices(canonical_name)
         X = X_cpu.to(W.dtype).to(W.device)
-        y_ref = X @ W.T
-        ref_energy = float(y_ref.float().pow(2).mean().item())
+        # Grouped-BMM operand (wo_a shape): the joint-output screen below
+        # models consumption as y = X @ W.T over the whole stored plane,
+        # which is not how a grouped operand is contracted (row (g,r) only
+        # ever meets group g's input slice). Scoring it dense would inflate
+        # the output term ~G-fold with cross-group error that no token ever
+        # sees — a fake measurement. Ship weight_mse + predicted_dloss and
+        # stamp the output side honestly unmeasured instead.
+        num_groups = grouped_linear_groups(mod, profile)
+        y_ref = None
+        ref_energy = 0.0
+        if num_groups is None:
+            y_ref = X @ W.T
+            ref_energy = float(y_ref.float().pow(2).mean().item())
         # Per-weight H diagonal and per-token g² weights if available.
         # Shape of H matches W; g² aligns with rows of X.
         h_full = None
@@ -1378,14 +1390,20 @@ def measure_unbatched(model: nn.Module, act_cache: "ActivationIndex",
                 X_hat = spec.activation_quantize_dequantize(X.clone())
                 err = (W - W_hat).float()
                 weight_mse = float(err.pow(2).mean().item())
-                y_q = X_hat @ W_hat.T
-                y_err_sq = (y_ref - y_q).float().pow(2)
-                output_mse = float(y_err_sq.mean().item())
+                output_mse = 0.0
+                rel_mse = 0.0
+                output_mse_measured = False
                 fisher_output_mse = None
-                if gq_rows is not None:
-                    fisher_output_mse = float(
-                        (y_err_sq * gq_rows.unsqueeze(1)).mean().item()
-                    )
+                if y_ref is not None:
+                    y_q = X_hat @ W_hat.T
+                    y_err_sq = (y_ref - y_q).float().pow(2)
+                    output_mse = float(y_err_sq.mean().item())
+                    rel_mse = output_mse / max(ref_energy, 1e-12)
+                    output_mse_measured = True
+                    if gq_rows is not None:
+                        fisher_output_mse = float(
+                            (y_err_sq * gq_rows.unsqueeze(1)).mean().item()
+                        )
                 predicted_dloss = None
                 if h_full is not None:
                     predicted_dloss = float(0.5 * (h_full * err.pow(2)).sum().item())
@@ -1397,6 +1415,7 @@ def measure_unbatched(model: nn.Module, act_cache: "ActivationIndex",
                     output_mse,
                     output_mse / max(ref_energy, 1e-12),
                     predicted_dloss=predicted_dloss,
+                    output_mse_measured=output_mse_measured,
                     fisher_output_mse=fisher_output_mse,
                     raw_render=_cb_raw_sidecar_metrics(
                         W, raw_out, h_full=h_full,
@@ -2835,6 +2854,16 @@ def measure_batched_gpu(model: nn.Module, act_cache: "ActivationIndex",
         for chunk_i, chunk in enumerate(chunks_list):
             names = [n for n, _ in chunk]
             N = len(chunk)
+            # Grouped-BMM operands (wo_a shape): the joint-output screen
+            # models y = X @ W.T over the whole plane, which is not how a
+            # grouped operand is contracted (row (g,r) only ever meets
+            # group g's input slice). Scoring it dense would inflate the
+            # output term ~G-fold with cross-group error no token sees —
+            # a fake measurement. Weight-side metrics stay exact; the
+            # output side ships stamped unmeasured.
+            grouped_flags = [
+                grouped_linear_groups(m, profile) is not None for _, m in chunk
+            ]
             # Lazy load activations for this chunk only. With prefetch
             # enabled, the future is already in flight from the prior
             # iteration (or kicked off above for the first chunk).
@@ -3015,14 +3044,17 @@ def measure_batched_gpu(model: nn.Module, act_cache: "ActivationIndex",
                     err = (Ws - W_hat).float()
                     weight_mse = err.pow(2).mean(dim=(1, 2))  # (n_sub,)
                     # Output side, one BMM per row bucket: every Linear is
-                    # scored on ALL of its own cached rows.
-                    output_mse = torch.empty(n_sub, dtype=torch.float32,
+                    # scored on ALL of its own cached rows. Grouped-BMM
+                    # members are skipped (see grouped_flags above) and
+                    # their output slots ship zeroed + stamped unmeasured.
+                    output_mse = torch.zeros(n_sub, dtype=torch.float32,
                                              device=dev)
                     fisher_output_mse = (
-                        torch.empty(n_sub, dtype=torch.float32, device=dev)
+                        torch.zeros(n_sub, dtype=torch.float32, device=dev)
                         if gq_per_item is not None else None)
                     for r, members in row_buckets.items():
-                        cs = [c for c in members if c in slot_of]
+                        cs = [c for c in members
+                              if c in slot_of and not grouped_flags[c]]
                         if not cs:
                             continue
                         bslots = [slot_in_bucket[c] for c in cs]
@@ -3080,9 +3112,11 @@ def measure_batched_gpu(model: nn.Module, act_cache: "ActivationIndex",
                                 if dloss_val is not None
                                 else None
                             ),
+                            output_mse_measured=not grouped_flags[item_i],
                             fisher_output_mse=(
                                 float(fisher_val)
-                                if fisher_val is not None
+                                if (fisher_val is not None
+                                    and not grouped_flags[item_i])
                                 else None
                             ),
                             n_activation_rows=rows_used[cpos],

--- a/prismaquant/model_profiles/base.py
+++ b/prismaquant/model_profiles/base.py
@@ -1359,10 +1359,13 @@ class ModelProfile(ABC):
 
     def should_probe_linear(self, name: str, mod) -> bool:
         """Whether to register Fisher hooks on this Linear module.
-        DSv4 returns False for `DeepseekV4GroupedLinear` (its weight
-        shape doesn't match the per-token Hessian-trace effective
-        output dim, so the chunk_h * w.pow(2) accumulator can't
-        broadcast). Default: True for any nn.Linear instance.
+        DSv4's `DeepseekV4GroupedLinear` used to be skipped here (its
+        grouped consumption broke the dense chunk_h * w.pow(2)
+        accumulator); since the grouped Fisher accumulator landed it is
+        probed through the grouped path instead, driven by the spec's
+        `probe_grouped_module_class_names`. The skip list itself remains
+        for classes with no accumulator at all. Default: True for any
+        nn.Linear instance.
 
         Profiles may also use this to skip e.g. router gates that
         shouldn't carry Fisher info."""
@@ -1375,6 +1378,27 @@ class ModelProfile(ABC):
             if type(mod).__name__ in skipped:
                 return False
         return True
+
+    def probe_grouped_module_class_names(self) -> tuple[str, ...]:
+        """Module classes whose forward consumes their weight through a
+        grouped/batched contraction over a leading GROUP axis (the
+        `wo_a` shape: `y[..., g, r] = sum_d x[..., g, d] * W[g, r, d]`,
+        stored as one `[G*R, D]` plane on an `nn.Linear` subclass).
+
+        Declared per family in the structure spec under
+        ``probe.grouped_module_class_names`` — the same one-declaration
+        discipline as ``probe_skip_module_class_names``, which these
+        classes previously lived in. The probe routes a declared class
+        to the grouped Fisher accumulator (`prismaquant.sensitivity_probe.
+        grouped_linear_groups`) instead of the dense one; an empty
+        declaration means the family has no such classes.
+
+        A declared class must expose its group count as `n_groups`;
+        anything else fails fast rather than silently dense-hooking."""
+        spec = self.structure_spec()
+        if spec is None:
+            return ()
+        return tuple(spec.probe_grouped_module_class_names)
 
     def walk_claim_rules(self):
         """Claim rules for the discovery walker (`prismaquant.model_walk`).
@@ -1392,8 +1416,13 @@ class ModelProfile(ABC):
 
         1. **pin** — weights of module classes the profile's spec declares in
            ``probe_skip_module_class_names``. The probe cannot price them, so
-           they are held at source precision as a *named* debt (this is
-           exactly the ``wo_a`` case: matmul-fed, discovered, unpriced).
+           they are held at source precision as a *named* debt. (This was
+           the ``wo_a`` rule until the grouped Fisher accumulator landed:
+           DSv4 declared ``DeepseekV4GroupedLinear`` here, and the walk
+           turned that declaration into a named pin. Grouped classes now
+           live under ``probe_grouped_module_class_names`` and are decided
+           like any other Linear; the mechanism stays for the next class
+           no accumulator covers.)
         2. **pin** — ``pinned_names()`` (``lm_head`` and friends).
         3. **exclude** — the MTP sidecar (``mtp_source_prefix()``), read only
            under spec decode; dispositioned by the MTP lane.

--- a/prismaquant/model_profiles/deepseek_v4.py
+++ b/prismaquant/model_profiles/deepseek_v4.py
@@ -438,12 +438,17 @@ class DeepseekV4Profile(ModelProfile):
 
     def walk_claim_rules(self):
         """DSv4 has four matmul-fed families the base rules cannot claim —
-        every one a bare Parameter (or an out-of-inventory Linear) on a
-        module class the probe's enumeration skips, which is the exact
-        `wo_a` failure class the walker exists to surface. Each is pinned
-        with the reason it ships at source precision; the GroupedLinear
-        (`wo_a`) pin itself comes from the base rules via the spec's
-        `probe_skip_module_class_names`."""
+        every one a bare Parameter on a module class the probe's dense
+        enumeration cannot hook, each pinned with the reason it ships at
+        source precision.
+
+        The fifth former member of that set — the grouped-BMM `wo_a` —
+        is NOT here any more: since the grouped Fisher accumulator landed,
+        `DeepseekV4GroupedLinear` is declared under the spec's
+        `probe_grouped_module_class_names` (it left
+        `probe_skip_module_class_names`), so the base rules claim its
+        weight as an ordinary `decide` and the allocator prices it like
+        any other Linear."""
         from prismaquant.model_walk import ClaimRule
 
         rules = [

--- a/prismaquant/model_profiles/specs/deepseek_v4.json
+++ b/prismaquant/model_profiles/specs/deepseek_v4.json
@@ -129,7 +129,8 @@
     "per_expert_mtp_regex": "re:^model[.]mtp[.][0-9]+[.]mlp[.]experts[.][0-9]+[.](gate|up|down)_proj$"
   },
   "probe": {
-    "skip_module_class_names": [
+    "skip_module_class_names": [],
+    "grouped_module_class_names": [
       "DeepseekV4GroupedLinear"
     ]
   },

--- a/prismaquant/model_profiles/structure.py
+++ b/prismaquant/model_profiles/structure.py
@@ -384,6 +384,7 @@ class ModelStructureSpec:
     bypass_hf_fp8_module_rewrite: bool = False
     fast_kernel_requirements: tuple[PackageRequirement, ...] = ()
     probe_skip_module_class_names: tuple[str, ...] = ()
+    probe_grouped_module_class_names: tuple[str, ...] = ()
     passthrough_prefixes: tuple[str, ...] = ()
     pinned_names: tuple[str, ...] = ("lm_head",)
     stage_text_only_strip_keys: tuple[str, ...] | None = None
@@ -461,6 +462,9 @@ class ModelStructureSpec:
             ),
             probe_skip_module_class_names=tuple(
                 str(v) for v in probe.get("skip_module_class_names", ())
+            ),
+            probe_grouped_module_class_names=tuple(
+                str(v) for v in probe.get("grouped_module_class_names", ())
             ),
             passthrough_prefixes=tuple(
                 str(v) for v in payload.get("passthrough_prefixes", ())

--- a/prismaquant/read_traffic.py
+++ b/prismaquant/read_traffic.py
@@ -34,9 +34,16 @@ class                        read probability       what lands here
 ``held_fixed``               ``1.0``                always-active tensors the
                                                     allocator never decided —
                                                     norms, biases, routers,
-                                                    a pinned ``lm_head``,
-                                                    grouped operands the probe
-                                                    skips (DSv4 ``attn.wo_a``)
+                                                    a pinned ``lm_head``.
+                                                    (DSv4's grouped ``wo_a``
+                                                    used to be named here as
+                                                    "probe-skipped"; since the
+                                                    grouped Fisher accumulator
+                                                    landed it is priced and
+                                                    moves to ``dense`` exactly
+                                                    when an assignment covers
+                                                    it — same p=1.0 either
+                                                    way.)
 ``excluded_embedding``       ``0.0`` (excluded)     the input embedding table
                                                     of an UNTIED model: one row
                                                     is gathered per token, not

--- a/prismaquant/sensitivity_probe.py
+++ b/prismaquant/sensitivity_probe.py
@@ -533,7 +533,203 @@ def finalize_fisher_stats(merged_stats: dict, global_tokens: int) -> None:
         per = s.get("h_trace_per_expert_raw")
         if per is not None:
             s["h_trace_per_expert"] = [float(v) / global_tokens for v in per]
+        # Per-GROUP Fisher trace (grouped-BMM operands like DSv4's wo_a).
+        # Same rule, same denominator: the group axis is a contraction
+        # structure ON one logical tensor, and every group sees every
+        # calibration token (attention output projection — nothing is
+        # routed), so the global count is exact for it, not just
+        # consistent.
+        per_group = s.get("h_trace_per_group_raw")
+        if per_group is not None:
+            s["h_trace_per_group"] = [
+                float(v) / global_tokens for v in per_group]
         s["h_trace_norm_tokens"] = global_tokens
+
+
+# ---------------------------------------------------------------------------
+# Grouped-BMM Linear Fisher (`wo_a` shape)
+#
+# A declared grouped module (spec `probe.grouped_module_class_names`) is an
+# nn.Linear subclass whose forward consumes its `[G*R, D]` weight plane as
+# `W[g, r, d]`: `y[..., g, r] = sum_d x[..., g, d] * W[g, r, d]`
+# (view + bmm in `DeepseekV4GroupedLinear.forward`). The dense accumulator's
+# flatten-to-2D cannot represent this consumption: its chunk_h comes out
+# [R, D] against an [G*R, D] weight (the `chunk_h * w.pow(2)` broadcast that
+# motivated the original probe skip), and pooling groups into the token axis
+# destroys the per-(g,r) channel marginals. The functions below are the ONE
+# grouped accumulation mechanism; both backends fold its outputs into the
+# same stats keys the dense rows use.
+#
+# TP note (walker campaign addendum, 2026-08-22): identity, dispositions,
+# and every field below are properties of the WHOLE logical tensor. A future
+# Tensor-Parallel shard of `wo_a` would cut the stored plane's ROW axis
+# (axis 0 = G*R; the profile's `base_model_tp_plan` declares `rowwise`),
+# so a shard boundary must not straddle a group (a cut inside g's R rows
+# would make any future group-aware format illegal at that TP degree).
+# Nothing here bakes rank/shard identity into keys or sizes; byte totals
+# are TOTAL-of-logical, per-device splits are a serving-runtime concern.
+
+
+def grouped_linear_groups(mod, profile=None) -> int | None:
+    """Group count `G` for a profile-declared grouped-BMM Linear, else None.
+
+    Dispatch is EXPLICIT: only classes the profile declares under
+    ``probe.grouped_module_class_names`` are grouped — never a shape
+    heuristic. A declared class whose instance lacks a usable ``n_groups``
+    fails fast: silently falling through to the dense accumulator would
+    produce the inflated, mis-shaped numbers the old probe skip existed to
+    prevent.
+    """
+    import torch.nn as _nn
+    if not isinstance(mod, _nn.Linear) or profile is None:
+        return None
+    try:
+        declared = tuple(profile.probe_grouped_module_class_names())
+    except AttributeError:
+        declared = ()
+    if type(mod).__name__ not in declared:
+        return None
+    n_groups = getattr(mod, "n_groups", None)
+    if n_groups is None:
+        raise ValueError(
+            f"{type(mod).__name__} is declared under "
+            "probe.grouped_module_class_names but carries no n_groups "
+            "attribute; refusing to fall through to the dense Fisher "
+            "accumulator (its numbers would be wrong-shaped)")
+    g = int(n_groups)
+    out_features = int(mod.out_features)
+    if g <= 0 or out_features % g != 0:
+        raise ValueError(
+            f"{type(mod).__name__}: n_groups={g} does not divide "
+            f"out_features={out_features}")
+    return g
+
+
+def grouped_linear_stats_entry(mod, num_groups: int,
+                               w_max_abs: float | None = None,
+                               w_norm_sq: float | None = None) -> dict:
+    """Stats-schema entry for a grouped operand, mirroring the dense row.
+
+    Shape convention follows the serialized truth, NOT a slice fiction:
+    `out_features`=G*R and `in_features`=D name the flat `[G*R, D]` plane
+    the exporter quantizes, and the 1-D marginals index that same plane
+    (`fisher_row[g*R + r]`). `num_groups` is the distinguishing field —
+    deliberately NOT `num_experts`, which downstream code
+    (`_shape_from_stats`, `_stats_indicates_packed_expert`) reads as a
+    packed expert stack. Per-group structure rides on
+    `h_trace_per_group_raw`; the unit stays the whole logical tensor."""
+    w = mod.weight
+    return {
+        "h_trace_raw": 0.0,
+        "h_w2_sum_raw": 0.0,
+        "w_max_abs": w_max_abs,
+        "w_norm_sq": w_norm_sq,
+        "n_params": int(w.numel()),
+        "in_features": int(mod.in_features),
+        "out_features": int(mod.out_features),
+        "num_groups": int(num_groups),
+        "n_tokens_seen": 0,
+        # Grouped attention output projections are not routed: route
+        # metadata exists for schema parity with dense rows, always None.
+        "route_prob": None,
+        "router_path": None,
+        "expert_id": None,
+    }
+
+
+def grouped_linear_fisher_chunk(
+    x: torch.Tensor,
+    gy: torch.Tensor,
+    num_groups: int,
+    weight: torch.Tensor | None = None,
+) -> dict[str, torch.Tensor]:
+    """One backward hook's worth of grouped empirical-Fisher pieces.
+
+    Input contract (validated): `x` is the module input `[..., G, D]`,
+    `gy = dL/dy` is `[..., G, R]`, `weight` is the `[G*R, D]` plane. The
+    per-token gradient of the weight is `grad_t W[g,r,d] =
+    gy[t,g,r] * x[t,g,d]`, so the per-token-summed empirical Fisher —
+    the SAME estimator as every dense row (`Σ_t ‖∇_t‖²_F`, audit M3;
+    never `‖Σ_t ∇_t‖²`) factorizes exactly:
+
+        h_trace = Σ_t Σ_g ‖gy[t,g,:]‖² · ‖x[t,g,:]‖²
+                = Σ_g Σ_{r,d} chunk_h[g,r,d],
+        chunk_h[g,r,d] = Σ_t gy[t,g,r]² · x[t,g,d]²
+
+    The true elementwise Fisher is block-diagonal in `g`
+    (`H[(g,r),(g',d)] = 0` for `g' ≠ g`), so the per-group bmm is EXACT,
+    not an approximation. Everything downstream reduces the ONE fp32
+    `chunk_h`, which makes `sum(fisher_row) == sum(fisher_col) ==
+    h_trace` hold BY CONSTRUCTION — the wiring discipline the dense
+    sites document at their own accumulation points.
+
+    Returns device-resident fp32 tensors:
+      h_trace         0-dim, raw (pre-`finalize_fisher_stats`)
+      h_w2            0-dim ⟨chunk_h, W²⟩ proxy (None when weight absent/meta)
+      fisher_row     [G*R] flat-plane output-channel marginal
+      fisher_col     [D]    input-channel marginal (pools groups: column d
+                      of the plane serves every group's contraction)
+      g_sq_sum       [G*R] flat gy² marginal
+      act_sq_sum     [D]    imatrix second moment (pools groups)
+      act_absmax     [D]    max |x| bound (pools groups; merge rule MAX)
+      trace_per_group [G]  decomposition of h_trace across the group axis
+      chunk_flat     [G*R, D] chunk_h reshaped onto the stored plane, for
+                      `h_full` collection
+
+    Normalization is NOT applied here: rows keep raw token-SUMMED values
+    and `finalize_fisher_stats` divides every row by the GLOBAL calibration
+    token count. Callers bump `n_tokens_seen` by TOKENS (= x rows before
+    the group dim), never T*G — group slices of one token are one token's
+    evidence, and the shared global denominator is what keeps grouped rows
+    commensurable with dense ones.
+    """
+    g = int(num_groups)
+    if x.dim() < 2 or gy.dim() < 2 or x.shape[-2] != g or gy.shape[-2] != g:
+        raise ValueError(
+            f"grouped Fisher expects x [..., {g}, D] and gy [..., {g}, R]; "
+            f"got x {tuple(x.shape)}, gy {tuple(gy.shape)}")
+    d_in = int(x.shape[-1])
+    r_out = int(gy.shape[-1])
+    if weight is not None and tuple(weight.shape) != (g * r_out, d_in):
+        raise ValueError(
+            f"grouped weight plane expected {(g * r_out, d_in)}, "
+            f"got {tuple(weight.shape)}")
+
+    xf = x.detach().reshape(-1, g, d_in)     # [T, G, D]
+    gyf = gy.detach().reshape(-1, g, r_out)  # [T, G, R]
+    tokens = int(xf.size(0))
+    gy_sq = gyf.pow(2)                       # input dtype, like the dense path
+    x_sq = xf.pow(2)
+    # One batched matmul over the group axis: [G,R,T] @ [G,T,D] -> [G,R,D].
+    # Same cost class as the dense chunk_h matmul; the [T*G, ...] flattening
+    # the dense path would apply instead pools groups into the token axis
+    # and loses exactly the structure this function exists to keep.
+    chunk_h = torch.bmm(
+        gy_sq.permute(1, 2, 0), x_sq.permute(1, 0, 2)).float()
+    if tokens == 0:
+        # An empty reduction would make amax/amin raise (same guard as
+        # _marginal_chunk); every sum here is already zero.
+        act_absmax = torch.zeros(d_in, dtype=torch.float32, device=xf.device)
+    else:
+        hi = torch.maximum(xf.amax(dim=0).abs(), xf.amin(dim=0).abs())
+        act_absmax = hi.amax(dim=0).to(torch.float32)
+
+    out = {
+        "h_trace": chunk_h.sum(),
+        "fisher_row": chunk_h.sum(dim=-1).reshape(-1),
+        "fisher_col": chunk_h.sum(dim=(0, 1)),
+        "g_sq_sum": gy_sq.sum(dim=0).reshape(-1).to(torch.float32),
+        "act_sq_sum": x_sq.sum(dim=(0, 1)).to(torch.float32),
+        "act_absmax": act_absmax,
+        "trace_per_group": chunk_h.sum(dim=(1, 2)),
+        "chunk_flat": chunk_h.reshape(g * r_out, d_in),
+    }
+    if weight is not None and not weight.is_meta:
+        w_view = weight.detach().view(g, r_out, d_in)
+        out["h_w2"] = (chunk_h * w_view.float().pow(2)).sum()
+    else:
+        out["h_w2"] = None
+    return out
 
 
 def _scalar_acc_add(acc: dict, name: str, value: torch.Tensor) -> None:
@@ -1956,6 +2152,29 @@ class FisherAccumulator:
             if _skip_fisher_name(name):
                 self._fisher_skip.add(name)
             w = mod.weight
+            # Grouped-BMM operand (wo_a shape): route to the grouped
+            # accumulator BEFORE the dense registration below. Its stats
+            # entry carries `num_groups`; the flat-plane dims let every
+            # dense consumer (byte math, card validate, shape gates) read
+            # it unchanged.
+            num_groups = grouped_linear_groups(mod, self.model_profile)
+            if num_groups is not None:
+                self.stats[name] = grouped_linear_stats_entry(
+                    mod, num_groups,
+                    w_max_abs=None if w.is_meta else float(
+                        w.detach().abs().max().item()),
+                    w_norm_sq=None if w.is_meta else float(
+                        w.detach().pow(2).sum().item()),
+                )
+                self._h_full[name] = (
+                    None if w.is_meta
+                    else torch.zeros(int(w.shape[0]), int(w.shape[1]),
+                                     dtype=torch.float32, device=w.device))
+                self._fwd_handles.append(
+                    mod.register_forward_hook(self._make_fwd(name)))
+                self._bwd_handles.append(mod.register_full_backward_hook(
+                    self._make_grouped_bwd(name, num_groups)))
+                continue
             router_qname, eid = expert_info.get(name, (None, None))
             # Weights loaded under accelerate disk offload start on the
             # meta device and materialize lazily during forward. Defer
@@ -2164,6 +2383,66 @@ class FisherAccumulator:
                         (idx.detach().to("cpu", dtype=torch.long) + base)
                     )
                     self._rows_got[name] += flat.size(0)
+        return hook
+
+    def _make_grouped_bwd(self, name: str, num_groups: int):
+        """Backward hook for a grouped-BMM operand (wo_a shape).
+
+        Same accumulators and same flush discipline as the dense
+        `_make_bwd` (device-resident 0-dim fp32 scalars, `h_full`,
+        per-token grad norms), but the reductions run through
+        `grouped_linear_fisher_chunk`, which keeps the group axis
+        explicit instead of flattening it into the token axis. Scalars
+        land in `self._gpu_h_trace` / `self._gpu_h_w2_sum`, so the
+        existing finalize() flush and the ONE global-token normalization
+        in `finalize_fisher_stats` apply unchanged."""
+        def hook(module, grad_input, grad_output):
+            # Fast skip: same contract as the dense hook.
+            if name in self._fisher_skip:
+                self._saved_inputs.pop(name, None)
+                return
+            gy = grad_output[0]
+            x = self._saved_inputs.pop(name, None)
+            if x is None or gy is None:
+                return
+            pieces = grouped_linear_fisher_chunk(
+                x, gy, num_groups, module.weight)
+            gpu_trace = self._gpu_h_trace.get(name)
+            if gpu_trace is None:
+                gpu_trace = torch.zeros(
+                    (), dtype=torch.float32, device=pieces["h_trace"].device)
+                self._gpu_h_trace[name] = gpu_trace
+            gpu_trace.add_(pieces["h_trace"])
+            w2 = pieces.get("h_w2")
+            if w2 is not None:
+                gpu_w2 = self._gpu_h_w2_sum.get(name)
+                if gpu_w2 is None:
+                    gpu_w2 = torch.zeros(
+                        (), dtype=torch.float32, device=w2.device)
+                    self._gpu_h_w2_sum[name] = gpu_w2
+                gpu_w2.add_(w2)
+            acc = self._h_full.get(name)
+            if acc is None:
+                acc = torch.zeros(
+                    int(pieces["chunk_flat"].shape[0]),
+                    int(pieces["chunk_flat"].shape[1]),
+                    dtype=torch.float32, device="cpu")
+                self._h_full[name] = acc
+            acc.add_(pieces["chunk_flat"].to(acc.device))
+            # Per-(token, group) grad-norm² rows: ‖gy_t,g‖²·‖x_t,g‖² —
+            # the plane-coordinate analog of the dense per-token vector,
+            # so h_detail reconstruction tooling reads it unchanged.
+            gy_sq = gy.detach().reshape(-1, num_groups, gy.shape[-1]).pow(2)
+            x_sq = x.detach().reshape(-1, num_groups, x.shape[-1]).pow(2)
+            pt = (gy_sq.sum(dim=-1) * x_sq.sum(dim=-1)).reshape(-1)
+            self._per_token_grad_norm.setdefault(name, []).append(
+                pt.detach().to("cpu", dtype=torch.float32))
+            # TOKENS, not token-group pairs: one token's group slices are
+            # one token's evidence. The normalization denominator is the
+            # global calibration count either way (`finalize_fisher_stats`);
+            # this field is metadata and must count what a dense row counts.
+            tokens = int(x.detach().numel()) // (num_groups * int(x.shape[-1]))
+            self.stats[name]["n_tokens_seen"] += tokens
         return hook
 
     def _make_moe_block_flush(self, block_name: str):

--- a/tests/test_deepseek_v4_profile.py
+++ b/tests/test_deepseek_v4_profile.py
@@ -60,18 +60,24 @@ def test_source_passthrough_prefixes_are_spec_backed(profile):
     )
 
 
-def test_probe_skip_linear_class_names_are_spec_backed(profile):
+def test_probe_skip_and_grouped_class_declarations_are_spec_backed(profile):
     DeepseekV4GroupedLinear = type(
         "DeepseekV4GroupedLinear",
         (nn.Linear,),
         {},
     )
 
-    assert profile.structure_spec().probe_skip_module_class_names == (
+    # The grouped-BMM class LEFT the skip list when the grouped Fisher
+    # accumulator landed: it is priced now, so holding it at source
+    # precision would be a choice, not a debt. The declaration moved to
+    # `grouped_module_class_names`, which routes the probe to the grouped
+    # accumulator instead of the dense one.
+    assert profile.structure_spec().probe_skip_module_class_names == ()
+    assert profile.structure_spec().probe_grouped_module_class_names == (
         "DeepseekV4GroupedLinear",
     )
     assert profile.should_probe_linear("model.layers.0.self_attn.wq_a", nn.Linear(4, 4))
-    assert not profile.should_probe_linear(
+    assert profile.should_probe_linear(
         "model.layers.0.self_attn.wo_a",
         DeepseekV4GroupedLinear(4, 4),
     )

--- a/tests/test_grouped_linear_fisher.py
+++ b/tests/test_grouped_linear_fisher.py
@@ -1,0 +1,292 @@
+"""Grouped-BMM Fisher: the `wo_a` shape gets a real, correctly-priced row.
+
+DSv4's `attn.wo_a` is an `nn.Linear` subclass whose forward consumes its
+`[G*R, D]` weight plane as `W[g, r, d]` through a view + bmm. The dense
+accumulator cannot price it (its chunk_h comes out [R, D] against a
+[G*R, D] plane), which is why the class used to live in the probe's skip
+list and the walk pinned it as unpriced debt. These tests pin the
+replacement:
+
+  - the grouped chunk math is EXACT (the elementwise Fisher is
+    block-diagonal in g) and hand-checkable on all-ones inputs;
+  - the marginals satisfy sum(fisher_row) == sum(fisher_col) == h_trace_raw
+    BY CONSTRUCTION — the wiring identity the card validates;
+  - normalization matches the dense convention exactly: rows stay RAW
+    token sums until `finalize_fisher_stats` divides by the GLOBAL
+    calibration token count — never per-routed-token, never /G, never
+    /route_prob (that convention was deliberately removed);
+  - `n_tokens_seen` counts TOKENS, not token-group pairs;
+  - dispatch is explicit (profile-declared classes only) and fails fast
+    when a declared class lacks its group count.
+
+The synthetic `GroupedBMMLinear` mirrors the vendored
+`DeepseekV4GroupedLinear.forward` line for line; the slow test at the
+bottom runs the REAL vendored class end to end.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+from prismaquant.sensitivity_probe import (
+    FisherAccumulator,
+    finalize_fisher_stats,
+    grouped_linear_fisher_chunk,
+    grouped_linear_groups,
+    grouped_linear_stats_entry,
+)
+
+# Tiny but non-trivial: G does not divide R or D, so a mis-shapen
+# accumulator cannot pass by symmetry.
+G, R, D, T = 2, 3, 4, 4
+
+
+class GroupedBMMLinear(nn.Linear):
+    """Mirror of DeepseekV4GroupedLinear: standard [out, in] storage,
+    per-group bmm consumption."""
+
+    def __init__(self, in_features_per_group: int, out_features: int,
+                 n_groups: int):
+        super().__init__(in_features_per_group, out_features, bias=False)
+        self.n_groups = n_groups
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        batch_shape = x.shape[:-2]
+        d_in = x.shape[-1]
+        out_per_group = self.out_features // self.n_groups
+        w = self.weight.view(self.n_groups, out_per_group, d_in)
+        xx = x.reshape(-1, self.n_groups, d_in).permute(1, 0, 2)
+        y = torch.bmm(xx, w.transpose(-1, -2)).permute(1, 0, 2)
+        return y.reshape(*batch_shape, self.n_groups, out_per_group)
+
+
+class _DeclaringProfile:
+    """Minimal profile stand-in: declares GroupedBMMLinear, nothing else."""
+
+    def probe_grouped_module_class_names(self):
+        return ("GroupedBMMLinear",)
+
+
+class _SilentProfile:
+    def probe_grouped_module_class_names(self):
+        return ()
+
+
+def test_grouped_chunk_matches_the_hand_computed_fisher():
+    """All-ones inputs make every term countable by hand.
+
+    grad_t W[g,r,d] = gy[t,g,r]·x[t,g,d], so with ones:
+      h_trace_raw   = Σ_{t,g,r,d} 1 = T*G*R*D          = 4*2*3*4 = 96
+      fisher_row[g*R+r] = Σ_{t,d} 1 = T*D              = 16   (6 entries)
+      fisher_col[d]     = Σ_{t,g,r} 1 = T*G*R          = 24   (4 entries)
+      g_sq_sum[g*R+r]   = Σ_t gy² = T                  = 4
+      act_sq_sum[d]     = Σ_{t,g} x² = T*G             = 8
+      trace_per_group[g] = T*R*D                       = 48
+      h_w2 with W = w0 everywhere: w0² · T*G*R*D        = 0.25·96 = 24
+    """
+    x = torch.ones(T, G, D)
+    gy = torch.ones(T, G, R)
+    weight = torch.full((G * R, D), 0.5)
+
+    pieces = grouped_linear_fisher_chunk(x, gy, G, weight)
+
+    assert float(pieces["h_trace"]) == pytest.approx(T * G * R * D)
+    assert pieces["fisher_row"].shape == (G * R,)
+    assert torch.allclose(
+        pieces["fisher_row"], torch.full((G * R,), float(T * D)))
+    assert pieces["fisher_col"].shape == (D,)
+    assert torch.allclose(pieces["fisher_col"], torch.full((D,), float(T * G * R)))
+    assert torch.allclose(pieces["g_sq_sum"], torch.full((G * R,), float(T)))
+    assert torch.allclose(pieces["act_sq_sum"], torch.full((D,), float(T * G)))
+    assert torch.allclose(pieces["act_absmax"], torch.ones(D))
+    assert pieces["trace_per_group"].shape == (G,)
+    assert torch.allclose(
+        pieces["trace_per_group"],
+        torch.full((G,), float(T * R * D)))
+    assert float(pieces["h_w2"]) == pytest.approx(0.25 * T * G * R * D)
+
+
+def test_grouped_chunk_marginals_satisfy_the_wiring_identity():
+    """sum(fisher_row) == sum(fisher_col) == h_trace, on random inputs,
+    because every marginal reduces the SAME fp32 chunk_h. This is the
+    identity SensitivityCard.validate() enforces downstream."""
+    torch.manual_seed(7)
+    x = torch.randn(6, G, D)
+    gy = torch.randn(6, G, R)
+    pieces = grouped_linear_fisher_chunk(x, gy, G, None)
+    total = float(pieces["h_trace"])
+    assert float(pieces["fisher_row"].sum()) == pytest.approx(total, rel=1e-5)
+    assert float(pieces["fisher_col"].sum()) == pytest.approx(total, rel=1e-5)
+
+
+def test_grouped_chunk_is_exact_vs_brute_force_per_group():
+    """The per-group bmm reproduces the brute-force per-token gradient
+    norm sum exactly (block-diagonal in g — no approximation)."""
+    torch.manual_seed(11)
+    x = torch.randn(5, G, D)
+    gy = torch.randn(5, G, R)
+    xf = x.double()
+    gyf = gy.double()
+
+    # Brute force: materialize each token's full [G,R,D] gradient.
+    expected = 0.0
+    for t in range(5):
+        grad_t = gyf[t].unsqueeze(-1) * xf[t].unsqueeze(-2)  # [G,R,D]
+        expected += float(grad_t.pow(2).sum())
+
+    pieces = grouped_linear_fisher_chunk(x, gy, G, None)
+    assert float(pieces["h_trace"].double()) == pytest.approx(expected, rel=1e-6)
+
+
+def test_grouped_row_normalizes_like_a_dense_row_end_to_end():
+    """THE normalization test. A dense row and a grouped row measured in
+    the same run must share ONE denominator: the GLOBAL calibration token
+    count passed to finalize(). With ones everywhere:
+
+      dense   raw = T * R * D       = 48 -> h_trace = 48 / 4 = 12
+      grouped raw = T * G * R * D   = 96 -> h_trace = 96 / 4 = 24
+
+    Any other denominator on the grouped side (per-routed-token, /G,
+    /route_prob) would break the equality with this arithmetic — that is
+    the inverted-importance failure mode `finalize_fisher_stats` exists
+    to prevent. `n_tokens_seen` stays RAW metadata and counts TOKENS:
+    the grouped row saw T tokens through G slices each, NOT T*G."""
+    model = nn.Module()
+    model.dense = nn.Linear(D, R, bias=False)
+    model.grouped = GroupedBMMLinear(D, G * R, G)
+    with torch.no_grad():
+        model.dense.weight.fill_(1.0)
+        model.grouped.weight.fill_(0.5)
+    for p in model.parameters():
+        p.requires_grad_(False)
+
+    acc = FisherAccumulator(model, ["dense", "grouped"], {},
+                            model_profile=_DeclaringProfile())
+    x_g = torch.ones(T, G, D, requires_grad=True)
+    x_d = torch.ones(T, D, requires_grad=True)
+    loss = (model.grouped(x_g) * 1.0).sum() + (model.dense(x_d) * 1.0).sum()
+    loss.backward()
+    acc.finalize(None, global_tokens=T)
+    acc.remove_hooks()
+
+    drow, grow = acc.stats["dense"], acc.stats["grouped"]
+
+    # Same denominator, each against its own hand value.
+    assert drow["h_trace"] == pytest.approx(float(R * D))          # 48/4
+    assert grow["h_trace"] == pytest.approx(float(G * R * D))      # 96/4
+    assert drow["h_trace_norm_tokens"] == T
+    assert grow["h_trace_norm_tokens"] == T
+
+    # Raw accumulators were token-SUMMED (pre-normalization values).
+    assert grow["h_trace_raw"] == pytest.approx(float(T * G * R * D))
+
+    # Token accounting: TOKENS, not token-group pairs.
+    assert grow["n_tokens_seen"] == T
+    assert drow["n_tokens_seen"] == T
+
+    # The unit is the whole logical tensor, in flat-plane coordinates.
+    assert grow["num_groups"] == G
+    assert grow["out_features"] == G * R
+    assert grow["in_features"] == D
+    assert grow["n_params"] == G * R * D
+
+    # Weight-aware proxy shares the raw/global convention.
+    assert grow["h_w2_sum"] == pytest.approx(0.25 * float(G * R * D))
+
+
+def test_finalize_normalizes_the_per_group_decomposition():
+    """`h_trace_per_group_raw` is a [G] decomposition of h_trace_raw; it
+    must divide by the same global count as its scalar."""
+    stats = {"grouped": {
+        "h_trace_raw": 96.0, "h_w2_sum_raw": 24.0,
+        "h_trace_per_group_raw": [40.0, 56.0],
+        "n_tokens_seen": 4,
+    }}
+    finalize_fisher_stats(stats, global_tokens=4)
+    s = stats["grouped"]
+    assert s["h_trace"] == pytest.approx(24.0)
+    assert s["h_trace_norm_tokens"] == 4
+    assert s["h_trace_per_group"] == pytest.approx([10.0, 14.0])
+    assert sum(s["h_trace_per_group"]) == pytest.approx(s["h_trace"])
+
+
+def test_stats_entry_schema_distinguishes_groups_from_experts():
+    """`num_groups` — never `num_experts`, which downstream reads as a
+    packed expert stack (`_shape_from_stats`,
+    `_stats_indicates_packed_expert`)."""
+    mod = GroupedBMMLinear(D, G * R, G)
+    entry = grouped_linear_stats_entry(mod, G, w_max_abs=0.1, w_norm_sq=2.0)
+    assert entry["num_groups"] == G
+    assert "num_experts" not in entry
+    assert entry["in_features"] == D
+    assert entry["out_features"] == G * R
+    assert entry["n_params"] == G * R * D
+
+
+def test_dispatch_is_explicit_and_fails_fast():
+    mod = GroupedBMMLinear(D, G * R, G)
+    plain = nn.Linear(D, R)
+    assert grouped_linear_groups(mod, _DeclaringProfile()) == G
+    # Undeclared class -> dense path (explicit declaration only).
+    assert grouped_linear_groups(mod, _SilentProfile()) is None
+    assert grouped_linear_groups(mod, None) is None
+    assert grouped_linear_groups(plain, _DeclaringProfile()) is None
+    # Declared class without its group count must fail LOUD, not fall
+    # through to numbers the dense flatten would get wrong.
+    bare = type("GroupedBMMLinear", (nn.Linear,), {})(D, G * R)
+    with pytest.raises(ValueError, match="n_groups"):
+        grouped_linear_groups(bare, _DeclaringProfile())
+
+
+@pytest.mark.slow
+def test_real_dsv4_wo_a_gets_a_priced_probe_row():
+    """End to end on the REAL vendored DSv4 modeling code (toy dims): the
+    probe tracks `DeepseekV4GroupedLinear` now, and a backward through it
+    lands a priced stats row with the right group structure."""
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from test_model_walk import _shrunken_dsv4
+
+    profile, model = _shrunken_dsv4()
+    tracked = sorted(
+        n for n, m in model.named_modules()
+        if type(m).__name__ == "DeepseekV4GroupedLinear")
+    assert tracked, "shrunken DSv4 must contain wo_a modules"
+    for name in tracked:
+        assert profile.should_probe_linear(name, model.get_submodule(name))
+
+    o_groups, o_lora_rank = 4, 32
+    heads_x_head_dim = 8 * 32
+    d_in = heads_x_head_dim // o_groups
+    acc = FisherAccumulator(model, tracked, {}, model_profile=profile)
+    # Drive each tracked module DIRECTLY rather than backward through the
+    # whole toy stack: the shrunken random-init model's compressed-attention
+    # backward produces NaN cotangents on some draws/processes (its own
+    # masking paths, not the accumulator), which would make this plumbing
+    # test flaky. The dispatch and accumulation under test are identical.
+    torch.manual_seed(0)
+    x = torch.randn(2, o_groups, d_in)
+    for name in tracked:
+        out = model.get_submodule(name)(x)
+        assert out.shape == (2, o_groups, o_lora_rank)
+        out.float().pow(2).sum().backward()
+        model.zero_grad(set_to_none=True)
+    acc.finalize(None, global_tokens=2)
+    acc.remove_hooks()
+
+    for name in tracked:
+        row = acc.stats[name]
+        assert row["num_groups"] == o_groups
+        assert row["out_features"] == o_groups * o_lora_rank
+        assert row["in_features"] == d_in
+        assert row["n_params"] == o_groups * o_lora_rank * d_in
+        assert row["h_trace"] > 0.0
+        assert row["n_tokens_seen"] == 2
+        h_full = acc._h_full[name]
+        assert tuple(h_full.shape) == (o_groups * o_lora_rank, d_in)
+        # Wiring identity holds on the collected plane too.
+        assert float(h_full.sum()) == pytest.approx(row["h_trace_raw"],
+                                                    rel=1e-4)

--- a/tests/test_model_walk.py
+++ b/tests/test_model_walk.py
@@ -373,10 +373,14 @@ def test_qwen3_walk_is_stable_across_two_runs(qwen3_walk):
 DSV4_CONFIG = "/home/rob/dq-runs/dsv4-flash-0731/source/config.json"
 
 
-def test_dsv4_profile_rules_pin_the_grouped_linear_weight():
-    """The wo_a claim does not need the 284B model: the DSv4 spec declares
-    `DeepseekV4GroupedLinear` in `probe_skip_module_class_names`, and the
-    base rules translate that declaration into a pin with a reason."""
+def test_dsv4_profile_rules_decide_the_grouped_linear_weight():
+    """The wo_a claim after the grouped Fisher accumulator landed: the
+    DSv4 spec no longer declares `DeepseekV4GroupedLinear` in
+    `probe_skip_module_class_names` (it moved to
+    `probe_grouped_module_class_names`, and the probe prices it through
+    the grouped accumulator), so the base rules claim its weight as an
+    ordinary allocator decision. The pin mechanism itself stays covered
+    by the generic base-rule tests below."""
     from prismaquant.model_profiles.deepseek_v4 import DeepseekV4Profile
     from prismaquant.model_walk import WalkNode, apply_claim_rules
 
@@ -391,8 +395,7 @@ def test_dsv4_profile_rules_pin_the_grouped_linear_weight():
         aliases=(),
     )
     claim = apply_claim_rules([wo_a], rules)[wo_a.name]
-    assert claim.disposition == "pin"
-    assert "probe" in claim.reason and "unpriced" in claim.reason
+    assert claim.disposition == "decide"
 
 
 def _shrunken_dsv4():
@@ -422,11 +425,12 @@ def _shrunken_dsv4():
 
 
 @pytest.mark.slow
-def test_dsv4_real_cpu_walk_discovers_and_pins_wo_a():
+def test_dsv4_real_cpu_walk_discovers_and_decides_wo_a():
     """Acceptance c on the contract's root-B fallback: the real DSv4
-    modeling code, real tiny tensors, CPU. Discovers the `wo_a` bmm edge
-    plus the OTHER matmul-fed bare-Parameter families the walk surfaced
-    (router gates, mHC mixers), all pinned by the profile's rules."""
+    modeling code, real tiny tensors, CPU. Discovers the `wo_a` bmm edge;
+    since the grouped Fisher accumulator landed, its claim is `decide` —
+    priced, not pinned-with-debt. The OTHER matmul-fed bare-Parameter
+    families (router gates, mHC mixers) stay pinned."""
     profile, model = _shrunken_dsv4()
     result = walk_model(
         model, execution="real", seq_len=16,
@@ -437,8 +441,7 @@ def test_dsv4_real_cpu_walk_discovers_and_pins_wo_a():
     assert len(wo_a_edges) == 4  # one per layer
     for edge in wo_a_edges:
         assert edge.op == "bmm"
-        assert result.claims[edge.param].disposition == "pin"
-        assert "unpriced" in result.claims[edge.param].reason
+        assert result.claims[edge.param].disposition == "decide"
 
     # The families the walk discovered beyond wo_a — each was a silent
     # omission candidate until claimed.

--- a/tests/test_model_walk_export_gate.py
+++ b/tests/test_model_walk_export_gate.py
@@ -442,9 +442,10 @@ def test_decided_but_unpriced_contradiction_refuses():
 @pytest.mark.slow
 def test_dsv4_real_topology_passes_the_gate_end_to_end():
     """The motivating model, through the whole gate: shrunken real-DSv4
-    topology, real CPU forward, profile rules -> gate PASSES, wo_a's family
-    is pinned, and the decided-but-unpriced checker finds nothing (the sweep
-    verified DSv4's claim set complete; this holds it there)."""
+    topology, real CPU forward, profile rules -> gate PASSES with wo_a a
+    REAL DECISION (the grouped accumulator prices it, so the
+    decided-but-unpriced checker accepts it), and the other pinned
+    families stay out of its way."""
     import sys
 
     sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
@@ -456,11 +457,13 @@ def test_dsv4_real_topology_passes_the_gate_end_to_end():
         claim_rules=profile.walk_claim_rules())
     assert result.ok
     assert all(
-        c.disposition == "pin" for n, c in result.claims.items()
+        c.disposition == "decide" for n, c in result.claims.items()
         if ".wo_a." in n)
+    unpriced = find_decided_but_unpriced(result, model, profile)
+    assert unpriced == ()
     verdict = evaluate_walk_gate(
         result,
-        unpriced_decides=find_decided_but_unpriced(result, model, profile),
+        unpriced_decides=unpriced,
         scope={"profile": "deepseek_v4", "rules_source": "profile"},
     )
     assert not verdict.refused


### PR DESCRIPTION
Split 4 of 6 from `merge/proven-rescues` (#95).

> **Merge order: this stacks on #99 (`rescue/walker-export-gate`).** Base is set to that branch; GitHub will retarget to `main` when it merges.

## What it does

DSv4's grouped-BMM attention output projection `attn.wo_a` — **33.5M params across 43 layers, 17.9% of decode read traffic** — had never been an allocator decision. Two things held it out:

1. The probe skipped `DeepseekV4GroupedLinear`, because the dense accumulator cannot represent a `[G,R,D]` consumption (its `chunk_h` comes out `[R,D]` against a `[G*R,D]` plane).
2. The walk held the weight as a named pin.

It was **unpriced, not cheap**. This is exactly the class of gap #99's `find_decided_but_unpriced` checker exists to surface.

**The grouped Fisher accumulator lands first** (`sensitivity_probe.py`, `incremental_probe.py`). It is EXACT rather than approximate: the grouped Fisher is block-diagonal in `g`, so one batched matmul per hook computes it outright. It shares the dense rows' single global-token normalization and their wiring identity — `sum(fisher_row) == sum(fisher_col) == h_trace_raw` **by construction** — and reports flat-plane dims plus `num_groups`, never `num_experts`, so packed-expert scoping cannot ride along.

**Dispatch is declarative.** `DeepseekV4GroupedLinear` moves from the spec's `probe.skip_module_class_names` to the new `probe.grouped_module_class_names`, and a declared class lacking `n_groups` fails fast. The walk claim for `wo_a` moves from `pin(probe skips...)` to an ordinary `decide`.

**The cost stage is honest about what it did not measure.** Cost cells flow from probe keys with no new plumbing, and the joint-output-MSE screen is stamped `output_mse_measured=False` for grouped units: the dense `y = X @ W.T` model would inflate the output term roughly G-fold with cross-group error no token ever sees. Recording that as a number would be selling a screen as a result.

## Why it is worth landing

17.9% of decode read traffic that the allocator was structurally unable to consider. Not because it was measured and found not worth quantizing — because the measurement did not exist.

## What it touches that is live

`sensitivity_probe.py` (+279), `incremental_probe.py` (+193), `measure_quant_cost.py`, `model_profiles/{base,deepseek_v4,structure}.py`, `specs/deepseek_v4.json`, `read_traffic.py`.

**No shipped artifact changes.** The DSpark sidecar contract keeps all three `wo_a` bases on source-FP8 W8A16 (`dspark_source_metadata.dspark_cb_expected_physical_targets`) for a structural reason this branch does not touch — Gridbook's generic CB Linear method does not implement the grouped-BMM algebra — so the hybrid sidecar CB surface stays nine physical bases per stage. CB export still refuses grouped operands.

What **is** now true and was not before: a future DSv4 export may let the allocator choose a format for `wo_a` instead of inheriting source precision. **That means the 92 GB budget split (87.403 body + 4.597 draft) must be re-checked on the next export rather than inherited.**

## Dependencies

- **Hard dependency on #99**: this PR's test hunks extend `tests/test_model_walk_export_gate.py`, which only exists after that PR, and its frozen digest for `base.py` covers that PR's ClaimRule additions.
- Independent of #100 (name projection) — they were parallel branches off the same point and touch disjoint hunks of `sensitivity_probe.py`, `measure_quant_cost.py` and `read_traffic.py`.

## Tests

`origin/main` (`8461ae2`) baseline, **measured on that exact commit**: **5494 passed, 143 skipped, 3 xfailed, 179 subtests passed, 0 failed** — `EXIT=0`, fully green (14m22s).
Identical to the earlier `4cd8d39` baseline, as expected: the three commits `main` gained
mid-split (`1d35f70`, `22db4fb`, `8461ae2`) touch only `.github/`, `pyproject.toml` and
`docs/` — **zero delta under `prismaquant/`, `tests/`, `tools/` or `scripts/`**, verified by diff.
Note for the reviewer: the brief for this split warned of "4 pre-existing aarch64 failures".
They **do not reproduce** — #90 and #94 already fixed them — so every failure below is attributable.

This branch: **2 failed, 5532 passed**, 143 skipped, 3 xfailed, 179 subtests passed (19m49s). Both failures are the DSv4 W8A16 freeze gate documented below, and the gate names exactly the three files listed there, at exactly those digests; **everything else is green**.

New coverage: `tests/test_grouped_linear_fisher.py` (292 lines).

## ⚠️ Known red: the DSv4 W8A16 freeze gate

`tests/test_dsv4_w8a16_export_handoff.py` fails 2 tests. Three files in this PR are inside the frozen export-source closure, so the gate refuses until they are re-frozen **with review**. I did not re-stamp them: blind re-stamping is what the gate exists to prevent.

Digests owed (recomputed on this rebase):

| file | new digest |
|---|---|
| `prismaquant/model_profiles/base.py` | `0f7ff9245a03e5b937223f3143efd2aafccbd5d797561c32cbeb8821c0fc3b64` |
| `prismaquant/model_profiles/deepseek_v4.py` | `06cf8a5ed7bc0a11cca415147110465ffa9030e65fa5cb6fa65cfe28085d562f` |
| `prismaquant/model_profiles/specs/deepseek_v4.json` | `cbfaeb815f3b51d23a29d943a0bb57deff87ed1ae4f61ce560f74feee5b13a7b` |

(`base.py`'s digest supersedes the one owed by #99, since this branch contains both changes.)

**The review already exists and Rob signed it off** on `merge/proven-rescues` (`d635677`, 2026-08-23). It reads:

> The change is deliberately consequential for the ALLOCATOR (it is the point of the branch) and inert for THIS lane:
> - `specs/deepseek_v4.json` — data only: `DeepseekV4GroupedLinear` moves from `probe.skip_module_class_names` (now `[]`) to the new `probe.grouped_module_class_names`. No other key moves.
> - `model_profiles/deepseek_v4.py` — DOCSTRING ONLY. `walk_claim_rules()` re-describes `wo_a` as decided rather than pinned; not one statement changed. Verified by AST comparison with docstrings elided: identical.
> - `model_profiles/base.py` — two docstrings plus ONE new method, `probe_grouped_module_class_names()`, which returns the spec tuple and nothing else. Verified by per-method AST comparison with docstrings elided: 72 methods → 73, ZERO existing bodies changed, none removed.
>
> Why this lane cannot observe it: the changed declarations are read at exactly four sites — `model_profiles/structure.py`, `base.py` itself, `sensitivity_probe.py`, and `model_walk.py`. A grep over the whole closure finds NO exporter, completeness, decode-source, footprint, output-safety, or namespace consumer.

**I re-ran that verification against these rebased bytes rather than quoting it**, because a stale verification quoted as current is the forgery the gate exists to catch:

```
=== prismaquant/model_profiles/base.py   (rescue/walker-export-gate -> rescue/grouped-woa)
  methods: 77 -> 78
  added   (1): ['ModelProfile.probe_grouped_module_class_names']
  removed (0): []
  bodies changed (0): []

=== prismaquant/model_profiles/deepseek_v4.py
  methods: 17 -> 17
  added (0) / removed (0) / bodies changed (0)
  whole-module AST identical with docstrings elided: True
```

The absolute method count is 77→78 rather than 72→73 because `main` and #99 have added methods since; the **claim** — exactly one added, zero changed, none removed, and `deepseek_v4.py` docstring-only — holds exactly.


## Merge-order note (applies to all six)

Every PR in this split adds its own stamp to the top of `docs/ARCHITECTURE.md`'s
provenance block (principle 13). Whichever merges second will therefore hit a
**textual conflict in that block and nowhere else** — resolution is to keep both
stamps, newest first. Verified by merging all six together: `docs/ARCHITECTURE.md`
is the *only* conflicting path across the entire split. **Zero code conflicts.**

---

Extracted from `merge/proven-rescues` commits `a2e1ae1` and the re-freeze rationale from merge `d635677`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F46Tr8Az6t2Ky3sRExZ5y
