### PR TITLE
feat(cluster): unit-sharded production-cache renders, with a byte-faithful merge

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,24 @@
 # PrismaQuant Architecture
 
-As of: 2026-08-29 · `docs/architecture-currency-20260829` — stamps follow, newest
+As of: 2026-08-29 · `rescue/parallel-producer` — stamps follow, newest
 first, each recording its own branch and date. Re-stamped (2026-08-29,
+`rescue/parallel-producer`) for
+**unit-sharded production-cache renders** (§5.4, D33): `PRISMAQUANT_UNIT_SHARD=i/N` splits a
+dense render across boxes on a deterministic layer-contiguous, exact-byte-balanced partition
+(`prismaquant/unit_sharding.py`), and `tools/merge_unit_shards.py` reassembles the shards into
+the same `ProductionWeightCache` under a fail-closed completeness gate. No default changes and
+`run-pipeline.sh` is untouched; unset is a byte-identical no-op, verified on Qwen3-0.6B. The
+substantive behaviour change is inside `_LinearActivationCollector`: row-priority reservoir
+values are now drawn for every hooked Linear rather than only for the ones a run stores, which
+also fixes resumed builds that did not reproduce a fresh build's sampled rows.
+(`--include-qnames-file` shrinks the hooked set itself, upstream of this fix, and still
+changes sampled rows — D33.) Each shard stamps the `(unit, format)` entries it owed, so the
+merge gate reads the shard's own debt instead of an operator-supplied layer config, and the
+merged `cache_dir` is byte-identical to an unsharded one. `production_render_cost`,
+`production_recache`, and packed-expert renders refuse the variable rather than pretending to
+shard.
+
+Earlier stamp (2026-08-29,
 `docs/architecture-currency-20260829`) for a **§8.4 conformance-matrix
 correction on `glm5_next`**, found by a principle-13 sweep of `origin/main`
 rather than by a test — the two doc gates were green across both drifts. (i) The
@@ -19,8 +36,9 @@ quantized formats outside the three module families PR #53906 wires a
 `b4a8846` refresh, so it is the § P13 "currency is not truth" case: this file
 was re-stamped in lockstep while carrying a false statement about a serving
 default. Nothing else in the window crossed the trigger; the reasoning is in the
-commit message. Re-stamped (2026-08-29,
-`claude/trellis-continuous-surface`) for the **trellis seam correction**
+commit message.
+
+Earlier stamp (2026-08-29, `claude/trellis-continuous-surface`) for the **trellis seam correction**
 (§4.9): the seam that landed earlier the same day is now **fail-closed** when
 enabled, and this document's claim that it made trellis rungs "pass the same
 legality, aggregation and byte accounting every other candidate does" is
@@ -3772,6 +3790,51 @@ at phase 50 with `before=("gptq",)` and no relation to each other, and
 (matching `pipeline.py`'s own stage list); `fisher_gptq` (50, archived); `scale_sweep` (60,
 after gptq). The production lever set is §3.3.
 
+**A unit shard is a lifetime mode of that same store too** (`prismaquant/unit_sharding.py`,
+2026-08-23). `PRISMAQUANT_UNIT_SHARD=i/N` makes `build_production_cache` render only shard `i`
+of a deterministic layer-contiguous partition of the units it already enumerates, balanced by
+exact source-tensor bytes with a min-max partition DP. Unset is a byte-identical no-op, and
+`run-pipeline.sh` does not set it. `tools/merge_unit_shards.py` puts the shards back into one
+`ProductionWeightCache` with the same layout — not a second store — and refuses unless every
+unit of the recomputed partition appears exactly once, under its owning shard. There is no
+force flag; missing, duplicate, and out-of-shard units all name the units and stop.
+
+The gate reads what each shard says it owed, not what an operator says it should have. Every
+shard stamps `owed_pairs` — the exact `(unit, format)` entries fixed at the moment its render
+map was built, from the same structure the render loop consumes — so a `--render-layer-config`
+that disagreed with the config a shard actually ran under can no longer under-expect a dropped
+unit into a clean merge. That flag survives only for stamps predating the field. The merged
+artifact is the unsharded artifact: `.pt` files, `render_scores.json` (through the stage's own
+`_write_render_score_sidecar`, whose `{"records": …}` envelope the resume loader requires) and
+`activation_max_abs.json` are written in the same order and shape, the render-gate summary is
+re-derived over every shard's records rather than inherited from shard 0, and the merged pickle
+differs from an unsharded one only by its `cache_dir` path and the `unit_shard_merge` block.
+
+Three properties make a shard's rendered bytes the unsharded run's bytes, and each is enforced
+rather than assumed. Layer atomicity keeps every fused-sibling group in one shard, so the joint
+NVFP4 global (`_compute_nvfp4_joint_global`, a max over the members present in the run) is
+computed over the same members; the stage asserts the grouping against the model profile and
+refuses a straddling group. The hooked activation set, the fused-sibling joint globals, and
+`activation_max_abs` are all computed over the FULL enumeration — only the render narrows. And
+`_LinearActivationCollector` now draws its row-priority reservoir values for **every** hooked
+Linear, not only for the ones this run stores (`production_weight_cache.py`). One generator
+feeds every Linear's reservoir, so drawing only for stored Linears made the surviving rows a
+function of which other Linears happened to be in the run — which also means a **resumed** build
+did not reproduce a fresh build's rows. That is a defect fix, not only shard plumbing; a fresh
+full build is unaffected byte-for-byte. `--include-qnames-file` is a different and still-open
+case: it filters the `qnames` list before the fill, so it shrinks the hooked set itself and the
+fix does not reach it (§12, D33).
+
+`production_render_cost` renders nothing, so it does not shard: it runs once on the merged
+cache and refuses a cache still carrying an unmerged shard stamp. `production_recache` and
+`--recache-layer-config` refuse the variable outright — the recache is a whole-model
+calibration replay, not a per-unit render. Packed-MoE expert renders refuse it too: their
+reservoir has the same shared-generator coupling and their enumeration is separate, so v1
+shards dense units only. `tools/cluster_render_sentinel.py` is the cross-box preflight: it
+renders K deterministically chosen units through this same fill path and byte-compares the
+manifests, refusing a match that was produced without `PRISMAQUANT_DETERMINISTIC=1`. Cross-box
+execution and the 4B repeat of the bit-identity acceptance remain open (§12).
+
 ### 5.5 Named invariants
 
 | Name | One line | Detail |
@@ -7382,6 +7445,7 @@ New with the 2026-07-30 merge:
 | D30 | **The Sensitivity Card's non-scalar tiers are screening surrogates, and its probe wiring has two soft spots** (added 2026-08-14, §4.8). Four honest gaps, none of them closed: (1) **No served A/B.** The `MARGINAL` tier and AQUA-AURA have never been measured on exact full-vocab vLLM KL-vs-BF16 or direct WikiText PPL. `SCALAR` is a byte-identical reproduction of today's model and carries no such debt; the other two must not be cited as results (§2.5). (2) **The rank-1 reconstruction's error is unquantified on real layers.** `H = Σ_t outer(g_t², x_t²)` is exactly rank-1 only when one token dominates; `outer(row, col)/h_trace_raw` is provably exact in that case (`rtol=1e-10`) and an approximation of unknown magnitude everywhere else. Nothing has compared it against a materialized `H` on a real Linear. (3) **The marginal identity is exact only at the two streaming sites.** `sum(fisher_row) == sum(fisher_col) == h_trace_raw` holds by construction where `h_trace_raw` is literally `chunk_h.sum()` in fp32 (`incremental_probe.py:2520`, `:2751`). On the **resident** path `h_trace_raw` comes from the bf16 outer-product-norm identity `(gy2_sq.sum(1) · x2_sq.sum(1)).sum()` (`:1667-1668`) while the marginals reduce the fp32 `chunk_h`, so the two agree mathematically but not bitwise; `SensitivityUnit.validate`'s `rtol=1e-3` is what absorbs that, and nothing measures the actual spread. (4) **One accumulation site is dead on the shipping path and therefore untested.** The batched MoE block-flush hook (`:2276-2362`) fires only for blocks whose immediate children are per-expert containers exposing the profile's projection names as `nn.Linear` — the *unpacked*-expert layout. The shipping recipe's MoE models do not take it, and `tests/test_probe_marginals.py` covers the helpers and the two streaming sites but not that branch, so its marginal emission has never executed. A transposed axis or a wrong merge rule there would surface first on a new unpacked-expert architecture, which is exactly the class of silent-garbage failure §8.5 L3 is about. | §4.8; `prismaquant/sensitivity_card.py`, `format_cost_protocol.py`, `sensitivity_card_allocate.py`; `incremental_probe.py:97-199,1667-1672,2276-2360,2501-2520,2735-2751`; `tests/test_sensitivity_card.py`, `tests/test_probe_marginals.py`; `docs/design/sensitivity_card_contract.md` §8 | MED | (1)-(2) run the rank-agreement check against measured `output_mse` on Qwen3-0.6B and an allocation-churn check against a shipped `cost.pkl` before any tier but `SCALAR` is proposed for a default; (3) record the resident-vs-streaming identity spread on one real probe, or tighten the resident path to reduce `chunk_h` for both; (4) cover the MoE block flush with a synthetic unpacked-expert fixture, or state that the branch is retired. |
 | D31 | **Shipcard replay binds recorded evidence to the serving pin at HEAD** (added 2026-08-18). Every gate slot records the runtime that actually gated it (serve-manifest `gridbook_distribution`, endpoint-contract stack), but the replay compares those records against `load_gridbook_serving_runtime_pin()` at HEAD — so the 0.8.9 pin bump made the already-published DSv4 flagship unpublishable for a docs-only README update: six slot refusals, all "is not the tracked pin", on evidence that exactly matches the pin that was tracked when it was measured. Worked around honestly for the 0.8.9 card update by running the publisher from a worktree at `0266662` (the pre-bump commit; publisher and verifier code there are byte-identical to HEAD — the bump commit `6a883bc` touched pin data and docs only — so this verifies the card against the pin that gated it, with zero tool divergence). Recurs on every serving-pin bump for every historical artifact. | `prismaquant/shipcard.py:1225,2374,2521`; `tools/publish_artifact.py` dry-run refusal 2026-08-18 | MED | Decision for Robert: accept a declarative superseded-pins record in `gridbook_serving_runtime_pin.py` (version/commit/wheel of prior released pins; replay accepts recorded == current OR recorded ∈ superseded, and the verdict names which) — keeps fail-closed against unreviewed runtimes without rotting history — or rule that docs updates to historical artifacts always re-run the publisher at the artifact's pin era. |
 | D32 | **The Fisher probe is not bit-reproducible, and nothing in the tree said so** (added 2026-08-20). Two runs of `incremental_probe` with byte-identical calibration, the same commit and the same `--layers-per-shard` differ on **379/402 units**, median `|Δh_trace|/h_trace` **2.5e-4** (max 1.1e-2); `n_tokens_seen` and the per-expert Fisher *support* are bit-identical on every unit, so the forward and the routing are exactly deterministic and only the backward moves. Mechanism: 30 of Ornith-1.5-35B-A3B's 40 layers are Gated DeltaNet, whose `fla` Triton kernels reduce over chunks in a non-deterministic order. **Why it is debt rather than a bug:** the jitter is unbiased (signed mean +6.5e-5 against its own sd 5.7e-4) and three orders below the 23% cost CV that §9 records as producing 3% assignment churn and 0σ served — but a probe-side change gated on bit-identity refuses for reasons that have nothing to do with the change, and `--layers-per-shard auto` (sized from free RAM at launch) adds a second, *avoidable* source on top. **Consequence for provenance:** probe-derived artifacts (`cost_baseline.pkl`, `cost_aura.pkl`, `cost.pkl`, the sensitivity card) must be rebuilt together from one probe run rather than half-reused, or `cost.pkl`'s stamped provenance names a probe that produced only some of its numbers. | `incremental_probe.py`; `sensitivity_probe.py` `_accumulate_packed_per_token_fisher`; measured Ornith-1.5-35B-A3B 2026-08-20 | LOW | Gate probe changes on what is invariant (`n_tokens_seen`, per-expert support, an unbiased signed mean within a *measured* floor), never on bit-identity; pin `--layers-per-shard` for any A/B. |
+| D33 | **Unit-sharded renders are proven on 0.6B dense only, and the packed-expert half is unbuilt** (added 2026-08-23, §5.4). `PRISMAQUANT_UNIT_SHARD` splits a dense production-cache render across boxes and `tools/merge_unit_shards.py` gates completeness fail-closed, but four gaps are open. (1) **No cross-box run.** `tools/cluster_render_sentinel.py` exists and is unit-tested; it has never been executed on a second Spark, so the cross-box bit-identity the design assumes is untested. (2) **Packed-MoE experts do not shard.** `fill_packed_expert_cache_entries` enumerates its own modules and reservoir-samples them off a second shared `torch.Generator`, so every shard would render every expert; the stage refuses instead. The spec's motivating wall is an MoE cost stage, so v1 does not speed up the case that prompted it. (3) **`--include-qnames-file` still perturbs sampled rows.** It filters the `qnames` list before the fill, so it shrinks the hooked activation set itself, upstream of the reservoir fix; a partial render selected that way is not a slice of the full render. (4) **Bit-identity is measured at 0.6B, one calibration.** The A1 merge-versus-unsharded comparison ran on Qwen3-0.6B at 8x256 under `PRISMAQUANT_DETERMINISTIC=1`; the 4B repeat the spec asks for has not run, and nothing has measured whether the render is bit-identical with the determinism flag OFF. | `prismaquant/unit_sharding.py`; `prismaquant/production_weight_cache.py` `_LinearActivationCollector`; `tools/merge_unit_shards.py`; `tools/cluster_render_sentinel.py`; `tests/test_unit_sharding.py` | MED | Run the sentinel across both Sparks before any distributed campaign; repeat A1 at 4B; either give the packed-expert reservoir a per-module generator and shard it, or record that experts are permanently unsharded. |
 
 **Open items carried from session handovers.** Of the 41 items the handover census could not
 map to a verified closure, the prior FP4-CB fast-expander/Triton item is now closed by the

--- a/docs/design/runtime_flags.md
+++ b/docs/design/runtime_flags.md
@@ -190,6 +190,74 @@ levers or cost modes are requested.
 | `EXPORT_PRODUCTION_CACHE_PREFETCH` | `require` (native lane) | Export-side assignment prefetch policy (re-vet R24, closes D8) → `export_native_compressed --production-cache-prefetch {require,warn}`. `require` fails the export when the cache cannot supply a layer's assignment instead of silently degrading to per-tensor NVMe reads; the bare-CLI default stays `warn`. The CB/GGUF lanes read no production cache. |
 | `PRODUCTION_CACHE_PREFETCH_WORKERS` | `4` | Thread count for eager production-cache prefetch. |
 | `EXPORT_CONTAINER` | `compressed-tensors` | `gguf` and `nvfp4_cb` switch stage 4 to their own exporters and impose gates (see §5, §8). |
+| `PRISMAQUANT_UNIT_SHARD` | unset | Split one production-cache render across boxes by unit: `i/N` renders only shard `i` of the deterministic layer-contiguous partition (§3.1). Unset is a byte-identical no-op. `run-pipeline.sh` does not set it; a cluster driver exports it around the `build_production_cache` invocation. |
+
+### 3.1 `PRISMAQUANT_UNIT_SHARD` — render one shard of the units
+
+`PRISMAQUANT_UNIT_SHARD=i/N` makes `build_production_cache` render only shard
+`i` of the units it would otherwise render. The stage enumerates its unit list
+exactly as it does today, then splits it with `prismaquant/unit_sharding.py`:
+layer-contiguous atoms, balanced by exact source-tensor bytes with a min-max
+partition DP, a pure function of the ordered unit list and `N`. Unset is a
+byte-identical no-op.
+
+Layer atomicity is the invariant that makes a shard's bytes the unsharded
+run's bytes. Fused siblings share one NVFP4 global scale computed as a max
+over the group members present in the run, so a partition that split a fused
+group would change those members' rendered weights. The stage also asserts the
+grouping against the model profile and refuses rather than rendering a split
+group.
+
+Everything that establishes cross-unit identity stays at the full enumeration:
+the hooked activation set and its shared row-priority stream,
+`activation_max_abs`, and the fused-sibling joint globals. Only the render
+narrows. The collector draws its row priorities for every hooked Linear rather
+than only for the ones a run stores, which is what keeps a shard's sampled rows
+equal to the full run's. `--include-qnames-file` still shrinks the hooked set
+itself and therefore still changes sampled rows; use the shard variable, not the
+include file, to split a render.
+
+Each shard cache carries `metadata['unit_shard']` — the shard label, the
+`partition_hash`, its own unit names, the complete ordered enumeration, the
+host that rendered it, and `owed_pairs`: the exact `(unit, format)` entries
+that shard set out to render, recorded from the same format map its render
+loop consumes. `tools/merge_unit_shards.py` recomputes the partition from that
+stamp and refuses to merge unless every unit appears exactly once, under the
+shard the partition assigns it to, and every owed entry is present. There is
+no force flag.
+
+The shard states its own debt because the alternative puts an operator file in
+the trust path: a `--render-layer-config` that disagrees with the config the
+shard actually rendered under would under-expect, and a dropped unit would
+merge clean. That flag now only serves stamps written before `owed_pairs`
+existed.
+
+A merged cache is the unsharded artifact, not a lookalike. The merge writes
+its `.pt` files, `render_scores.json`, and `activation_max_abs.json` through
+the same writers and in the same order the unsharded stage uses, so a merged
+`cache_dir` resumes and re-reads identically; it re-derives the render-gate
+summary over every shard's records rather than inheriting shard 0's counters;
+and the merged pickle differs from an unsharded one only by its `cache_dir`
+path and the added `unit_shard_merge` provenance block.
+
+Three paths refuse the variable outright, because a unit shard has no meaning
+for them:
+
+- `production_render_cost` renders nothing. It reads the render scores the
+  cache already recorded, so it runs once, unsharded, on the merged cache. It
+  also refuses a cache that still carries an unmerged shard stamp.
+- `production_recache`, and `build_production_cache --recache-layer-config`,
+  replay calibration through the whole model with the selected weights
+  installed. A shard holding a subset of the assignment would measure a
+  different activation distribution.
+- Packed-MoE expert renders. `fill_packed_expert_cache_entries` enumerates its
+  own modules off a second shared reservoir generator, so every shard would
+  render every expert. Dense units shard; experts do not, in v1.
+
+Run both shards under `PRISMAQUANT_DETERMINISTIC=1`. Without it the GPTQ
+Cholesky and U-update reduction order is not reproducible, and neither the
+merge nor `tools/cluster_render_sentinel.py` can certify that two boxes
+produced the same bytes.
 
 ## 4. CUDA / system flags
 

--- a/prismaquant/activation_sampling.py
+++ b/prismaquant/activation_sampling.py
@@ -17,13 +17,21 @@ def update_priority_reservoir(
     new_rows: torch.Tensor,
     *,
     max_rows: int,
-    generator: torch.Generator,
+    generator: torch.Generator | None = None,
+    new_priorities: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
     """Return an updated uniform row sample.
 
     ``current_priorities`` must contain the random priorities for
     ``current_rows`` and is kept on CPU. ``new_rows`` may live on CPU or CUDA;
     returned rows stay on the same device/dtype as the candidate row tensor.
+
+    ``new_priorities`` lets the caller draw the incoming rows' priorities
+    itself. A caller that hooks many tensors off one generator must draw for
+    *every* hooked tensor, or a run that stores a subset consumes a different
+    slice of the stream and the surviving rows stop being the rows the full
+    run would have kept — see ``_LinearActivationCollector``. Exactly one of
+    ``generator`` / ``new_priorities`` is required.
     """
     limit = int(max_rows)
     if limit <= 0 or new_rows.numel() == 0:
@@ -32,12 +40,26 @@ def update_priority_reservoir(
         raise ValueError("priority reservoir expects 2D row tensors")
 
     incoming = new_rows.detach()
-    new_priorities = torch.rand(
-        int(incoming.shape[0]),
-        generator=generator,
-        dtype=torch.float32,
-        device="cpu",
-    )
+    if (generator is None) == (new_priorities is None):
+        raise ValueError(
+            "priority reservoir requires exactly one of generator / "
+            "new_priorities"
+        )
+    if new_priorities is None:
+        new_priorities = torch.rand(
+            int(incoming.shape[0]),
+            generator=generator,
+            dtype=torch.float32,
+            device="cpu",
+        )
+    else:
+        new_priorities = new_priorities.detach().to(
+            device="cpu", dtype=torch.float32
+        )
+        if int(new_priorities.shape[0]) != int(incoming.shape[0]):
+            raise ValueError(
+                "new_priorities length must match the incoming row count"
+            )
     if current_rows is None:
         candidates = incoming
         priorities = new_priorities

--- a/prismaquant/build_production_cache.py
+++ b/prismaquant/build_production_cache.py
@@ -136,6 +136,47 @@ def _explicit_cb_render_context(formats):
         raise SystemExit(f"[build-prod-cache] ERROR: {exc}") from exc
 
 
+def _resolve_unit_shard(args):
+    """Resolve PRISMAQUANT_UNIT_SHARD once, at the CLI boundary.
+
+    Unset is a byte-identical no-op: nothing downstream changes shape. When
+    set, refuse the paths a unit shard cannot mean:
+
+    * packed-MoE experts — ``fill_packed_expert_cache_entries`` enumerates
+      and reservoir-samples its own modules off a second shared generator, so
+      every shard would render every expert (duplicates the merge would
+      reject) with rows that are not the full run's rows;
+    * the recache replay (``--recache-layer-config``) — it is a whole-model
+      calibration forward with the production weights installed, not a
+      per-unit render, and a shard holding a subset of the weights would
+      measure a different activation distribution.
+    """
+    from prismaquant.unit_sharding import SHARD_ENV, resolve_shard_spec
+
+    try:
+        spec = resolve_shard_spec()
+    except ValueError as exc:
+        raise SystemExit(f"[build-prod-cache] ERROR: {exc}") from exc
+    if spec is None:
+        return None
+    if args.recache_layer_config:
+        raise SystemExit(
+            f"[build-prod-cache] ERROR: {SHARD_ENV}={spec.label} with "
+            "--recache-layer-config. The production recache is a whole-model "
+            "calibration replay with the selected weights installed, not a "
+            "per-unit render; a shard would replay with a subset of the "
+            "assignment installed. Shard the render, merge, then recache."
+        )
+    if args.render_packed_experts:
+        raise SystemExit(
+            f"[build-prod-cache] ERROR: {SHARD_ENV}={spec.label} with "
+            "--render-packed-experts. Packed-MoE expert renders are not "
+            "unit-sharded in v1 (see prismaquant/unit_sharding.py); every "
+            "shard would render every expert."
+        )
+    return spec
+
+
 def _model_has_packed_experts(model: nn.Module, profile) -> bool:
     from prismaquant.sensitivity_probe import _is_packed_experts_module
     return any(
@@ -269,7 +310,7 @@ def _load_cache_calibration(tokenizer, args) -> torch.Tensor:
     )
 
 
-def _run_streaming(args, formats, levers, dtype) -> int:
+def _run_streaming(args, formats, levers, dtype, unit_shard=None) -> int:
     """Streaming per-layer render path for models too large to load whole.
 
     No whole-model from_pretrained and no calibration forward: dense + packed
@@ -404,6 +445,7 @@ def _run_streaming(args, formats, levers, dtype) -> int:
             format_plan.identity_sha256
             if format_plan is not None else None
         ),
+        unit_shard=unit_shard,
     )
     if render_assignment is not None:
         profile = detect_profile_with_warning(
@@ -428,6 +470,11 @@ def _run_streaming(args, formats, levers, dtype) -> int:
         )
     elapsed = time.monotonic() - t0
 
+    if unit_shard is not None and render_assignment is not None:
+        shard_units = set((cache.metadata or {})["unit_shard"]["unit_names"])
+        render_assignment = {
+            q: fmt for q, fmt in render_assignment.items() if q in shard_units
+        }
     try:
         if render_assignment is not None:
             coverage_assignment = _filter_assignment_to_include_qnames(
@@ -717,6 +764,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = p.parse_args(argv)
     if args.format_plan and not args.streaming:
         p.error("--format-plan requires --streaming")
+    unit_shard = _resolve_unit_shard(args)
 
     # Opt-in deterministic CUDA path. The default lever ablations on small
     # models show ~2-4% per-Linear weight variance across re-runs of the
@@ -761,7 +809,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     dtype = _dtype_from_name(args.dtype)
 
     if args.streaming:
-        return _run_streaming(args, formats, levers, dtype)
+        return _run_streaming(args, formats, levers, dtype, unit_shard)
 
     staged, cleanup = stage_multimodal(args.model)
     device = require_cuda_hot_path("build_production_cache")
@@ -895,6 +943,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             h_detail_dir=args.h_detail_dir,
             col_weights=col_weights,
             cb_serialization_context=cb_serialization_context,
+            unit_shard=unit_shard,
         )
         # R14: stamp the calibration identity onto the cache so every artifact
         # derived from it (production_render_cost's cost table) can be checked
@@ -932,6 +981,18 @@ def main(argv: Sequence[str] | None = None) -> int:
         # assignment (which format each expert gets).
         expert_assignment = render_assignment or recache_assignment
         expert_coverage: dict = {}
+        if (
+            unit_shard is not None
+            and expert_assignment is not None
+            and _model_has_packed_experts(model, profile)
+        ):
+            from prismaquant.unit_sharding import SHARD_ENV
+            raise SystemExit(
+                f"[build-prod-cache] ERROR: {SHARD_ENV}={unit_shard.label} on "
+                "a model with packed-MoE experts. Packed-expert renders are "
+                "not unit-sharded in v1: every shard would render every "
+                "expert. Render this model unsharded."
+            )
         if expert_assignment is not None:
             from prismaquant.production_weight_cache import (
                 fill_packed_expert_cache_entries,
@@ -987,14 +1048,31 @@ def main(argv: Sequence[str] | None = None) -> int:
         # failures, and any other silent gaps that would otherwise fall
         # through to RTN at hook time.
         try:
-            if render_assignment is not None:
+            # A shard is complete when ITS units are complete; the merge
+            # tool is what gates the full enumeration.  Narrow by shard
+            # first, then by --include-qnames-file, in the same order the
+            # streaming path applies them.
+            coverage_qnames = qnames
+            coverage_assignment = render_assignment
+            if unit_shard is not None:
+                shard_units = set(
+                    (cache.metadata or {})["unit_shard"]["unit_names"]
+                )
+                coverage_qnames = [q for q in qnames if q in shard_units]
+                if coverage_assignment is not None:
+                    coverage_assignment = {
+                        q: fmt
+                        for q, fmt in coverage_assignment.items()
+                        if q in shard_units
+                    }
+            if coverage_assignment is not None:
                 coverage_assignment = _filter_assignment_to_include_qnames(
-                    render_assignment, include_qnames,
+                    coverage_assignment, include_qnames,
                 )
                 validate_render_assignment_cache_coverage(
                     cache, coverage_assignment)
             else:
-                cache.validate_coverage(qnames, formats)
+                cache.validate_coverage(coverage_qnames, formats)
             print("[build-prod-cache] coverage check passed", flush=True)
         except RuntimeError as e:
             if args.allow_incomplete:

--- a/prismaquant/production_recache.py
+++ b/prismaquant/production_recache.py
@@ -491,6 +491,19 @@ def main(argv: list[str] | None = None) -> int:
              "an ablation or smoke run.",
     )
     args = parser.parse_args(argv)
+    from prismaquant.unit_sharding import SHARD_ENV, resolve_shard_spec
+
+    shard = resolve_shard_spec()
+    if shard is not None:
+        raise SystemExit(
+            f"[production-recache] ERROR: {SHARD_ENV}={shard.label} is set, "
+            "but the recache is a whole-model calibration replay with the "
+            "selected production weights installed — not a per-unit render. "
+            "A shard holding a subset of the assignment would measure a "
+            "different activation distribution, so its activation_max_abs "
+            "would not be the full run's. Run this stage unsharded on the "
+            "merged cache."
+        )
 
     from transformers import AutoTokenizer
 

--- a/prismaquant/production_render_cost.py
+++ b/prismaquant/production_render_cost.py
@@ -208,6 +208,31 @@ def _calibration_hashes(*sources: object) -> list[str]:
     return sorted(found)
 
 
+def _refuse_unmerged_shard_cache(production_cache: object) -> None:
+    """Refuse a cache that is one unit shard rather than the whole render.
+
+    This stage does no rendering: it reads the render scores the production
+    cache already recorded. A single shard's cache carries scores for only
+    its own units, and every other unit would silently fall back to the
+    baseline table — a cost payload that is part production-render and part
+    something else, with nothing in it saying so. Merge the shards first
+    (``tools/merge_unit_shards.py``).
+    """
+    metadata = getattr(production_cache, "metadata", None)
+    if not isinstance(metadata, Mapping):
+        return
+    stamp = metadata.get("unit_shard")
+    if not isinstance(stamp, Mapping):
+        return
+    raise ValueError(
+        f"production cache is unit shard {stamp.get('shard')} of "
+        f"{stamp.get('shard_count')} "
+        f"(partition_hash={stamp.get('partition_hash')}), not a complete "
+        "render. Merge every shard with tools/merge_unit_shards.py and run "
+        "this stage on the merged cache."
+    )
+
+
 def _lookup_record(
     records: Mapping[tuple[str, str], Mapping],
     qname: str,
@@ -496,6 +521,7 @@ def synthesize_production_render_cost_payload(
             cache_pairs | transient_pairs
         )
 
+    _refuse_unmerged_shard_cache(production_cache)
     records = _cache_render_score_records(production_cache)
 
     output_costs: dict[str, dict[str, dict]] = {}
@@ -637,6 +663,13 @@ def synthesize_production_render_cost_payload(
         inherited_provenance["source_format_plan_identity_sha256"] = (
             format_plan.identity_sha256
         )
+    cache_metadata = getattr(production_cache, "metadata", None)
+    if isinstance(cache_metadata, Mapping):
+        merge_stamp = cache_metadata.get("unit_shard_merge")
+        if isinstance(merge_stamp, Mapping):
+            # Which boxes rendered these bytes travels with the cost table,
+            # not only with the cache it came from.
+            inherited_provenance["unit_shard_merge"] = dict(merge_stamp)
     return {
         "schema": SCHEMA,
         "costs": output_costs,
@@ -719,6 +752,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         "instead of output_mse/fisher_output_mse.",
     )
     args = parser.parse_args(argv)
+    from prismaquant.unit_sharding import SHARD_ENV, resolve_shard_spec
+
+    shard = resolve_shard_spec()
+    if shard is not None:
+        raise SystemExit(
+            f"[production-render-cost] ERROR: {SHARD_ENV}={shard.label} is "
+            "set, but this stage renders nothing — it synthesizes allocator "
+            "cost from the render scores the production cache already "
+            "recorded. Shard the CACHE BUILD "
+            "(python -m prismaquant.build_production_cache), merge the "
+            "shards with tools/merge_unit_shards.py, then run this stage "
+            "once on the merged cache with the variable unset."
+        )
     from prismaquant.gpu_guard import require_cuda_hot_path
     require_cuda_hot_path("production_render_cost")
 

--- a/prismaquant/production_weight_cache.py
+++ b/prismaquant/production_weight_cache.py
@@ -964,6 +964,28 @@ class _LinearActivationCollector:
                 if prev is None
                 else torch.maximum(prev, x_abs_max.detach())
             )
+            # Draw this call's row priorities for EVERY hooked Linear,
+            # stored or not. One generator feeds every Linear's reservoir, so
+            # the slice of the stream a Linear receives is a function of how
+            # many rows every earlier hook consumed. Drawing only for stored
+            # Linears would make a run that stores a subset — a unit shard,
+            # or a resume that skips already-rendered units — keep DIFFERENT
+            # rows than the full run, and the rendered bytes follow the rows.
+            # (`--include-qnames-file` shrinks the hooked set itself, upstream
+            # of this hook, so it is a separate and still-open case.) Draws are
+            # CPU floats; the cost is noise next to the D2H copy below.
+            last_dim = int(x.shape[-1]) if x.dim() >= 1 else 0
+            n_rows = (x.numel() // last_dim) if last_dim > 0 else 0
+            new_priorities = (
+                torch.rand(
+                    int(n_rows),
+                    generator=self._activation_generator,
+                    dtype=torch.float32,
+                    device="cpu",
+                )
+                if n_rows > 0 and self.max_rows > 0
+                else None
+            )
             # Only store the full activation tensor if this Linear is in
             # the store set.  Memory bound: store_qnames × max_rows × in.
             if key not in self.store_qnames:
@@ -986,7 +1008,7 @@ class _LinearActivationCollector:
                 self._activation_priorities.get(key),
                 flat,
                 max_rows=self.max_rows,
-                generator=self._activation_generator,
+                new_priorities=new_priorities,
             )
             self.activations[key] = [] if sampled is None else [sampled]
             if priorities is None:
@@ -4737,6 +4759,8 @@ def fill_production_weight_cache(
     h_detail_dir: str | Path | None = None,
     col_weights: Mapping[str, torch.Tensor] | None = None,
     cb_serialization_context=None,
+    unit_shard=None,
+    render_qnames: Sequence[str] | None = None,
 ) -> ProductionWeightCache:
     """End-to-end fill: collect activations, render production δw per
     (qname, fmt), return a `ProductionWeightCache`.
@@ -4772,6 +4796,21 @@ def fill_production_weight_cache(
       cb_serialization_context: explicit artifact serialization identity for
         every CB render. Required when the scope contains a CB format; never
         inferred from the current environment.
+      unit_shard: optional ``unit_sharding.ShardSpec``. When given, this run
+        RENDERS only its shard of the deterministic layer-contiguous
+        partition of the full unit enumeration, and stamps the shard identity
+        into ``metadata['unit_shard']`` for ``tools/merge_unit_shards.py``.
+        Everything that establishes cross-unit identity — the hooked
+        activation set and its priority stream, the fused-sibling NVFP4 joint
+        globals, and ``activation_max_abs`` — is still computed over the FULL
+        enumeration, so a shard's rendered bytes are the unsharded run's
+        bytes. Resolved at the CLI boundary and passed explicitly; this
+        function never reads the environment.
+      render_qnames: optional subset of ``qnames`` to RENDER. Same contract
+        as ``unit_shard`` (hook / joint-global / max_abs scope stays full);
+        used by ``tools/cluster_render_sentinel.py`` to render a handful of
+        units with production-identical inputs. Intersected with the shard
+        when both are given.
     """
     if recache_pass and not recache_assignment:
         raise ValueError(
@@ -4862,6 +4901,97 @@ def fill_production_weight_cache(
             model_profile = profile_from_model(model)
         except Exception:
             model_profile = None
+
+    render_only: set[str] | None = None
+    if render_qnames is not None:
+        render_only = {str(name) for name in render_qnames}
+        unknown = sorted(render_only - qname_set)
+        if unknown:
+            raise ValueError(
+                "render_qnames contains units outside the render scope; "
+                f"sample={unknown[:8]}"
+            )
+
+    unit_shard_stamp: dict[str, object] | None = None
+    if unit_shard is not None:
+        from prismaquant import unit_sharding as _unit_sharding
+        from prismaquant.decision_units import fused_group_key
+
+        if any(
+            _is_cb_format_name(fmt)
+            for fmts in render_formats_by_qname.values()
+            for fmt in fmts
+        ):
+            raise ValueError(
+                "unit sharding refuses a CB render scope: CB pairs carry "
+                "per-pair identity/resume sidecars and a set-level artifact "
+                "digest that a v1 shard merge would relabel. Render CB "
+                "unsharded."
+            )
+        ordered = [str(q) for q in qnames if str(q) in qname_set]
+        if len(ordered) != len(qname_set):
+            raise ValueError(
+                "unit sharding requires the caller's qname enumeration to "
+                "cover every rendered unit in a deterministic order; "
+                f"enumeration={len(ordered)} render_scope_units="
+                f"{len(qname_set)}"
+            )
+        named_modules_for_bytes = dict(model.named_modules())
+        unit_records: list[tuple[str, int]] = []
+        for name in ordered:
+            mod = named_modules_for_bytes.get(name)
+            weight = getattr(mod, "weight", None)
+            if weight is None:
+                raise ValueError(
+                    f"unit sharding cannot size unit {name!r}: no source "
+                    "weight on the live module"
+                )
+            unit_records.append(
+                (name, int(weight.numel()) * int(weight.element_size()))
+            )
+        # Layer atomicity is what keeps a fused-sibling group whole; assert it
+        # against the profile's real grouping rather than trusting the name.
+        _unit_sharding.assert_groups_within_atoms(
+            ordered,
+            lambda name: (
+                fused_group_key(model_profile, name)
+                if model_profile is not None else None
+            ),
+            where="production weight cache unit shard",
+        )
+        partition = _unit_sharding.partition_units(
+            unit_records, unit_shard.count
+        )
+        shard_units = set(partition.units_for(unit_shard))
+        unit_shard_stamp = {
+            **_unit_sharding.shard_stamp(partition, unit_shard),
+            "host": _unit_sharding.host_identity(),
+        }
+        render_only = (
+            shard_units if render_only is None
+            else (render_only & shard_units)
+        )
+        if progress:
+            print(
+                f"[prod-cache] unit shard {unit_shard.label}: rendering "
+                f"{len(shard_units)}/{len(ordered)} units "
+                f"({partition.shard_bytes[unit_shard.index]:,} of "
+                f"{sum(b for _, b in unit_records):,} source bytes); "
+                f"partition_hash={partition.partition_hash[:16]}",
+                flush=True,
+            )
+
+    if render_only is not None:
+        # Restrict only what gets RENDERED. `qname_set` (the hooked
+        # activation set and its shared priority stream), `qname_to_module`,
+        # the fused-sibling NVFP4 joint globals and `activation_max_abs` all
+        # stay at the full enumeration — that is what makes a restricted
+        # run's bytes the full run's bytes.
+        render_formats_by_qname = {
+            qname: fmts
+            for qname, fmts in render_formats_by_qname.items()
+            if qname in render_only
+        }
 
     if progress:
         requested_entries = sum(
@@ -5012,6 +5142,10 @@ def fill_production_weight_cache(
         # A qname is FULLY done if every requested format has a shard.
         prerendered = 0
         for q in list(qname_set):
+            if not render_formats_by_qname.get(q):
+                # Out of this unit shard's render scope: leave its (empty)
+                # missing set alone instead of counting it as pre-rendered.
+                continue
             missing = {
                 f for f in render_formats_by_qname.get(q, ())
                 if not (cache_dir_path / _cache_weight_filename(q, f)).is_file()
@@ -5291,6 +5425,18 @@ def fill_production_weight_cache(
     import gc as _gc
     activations_local = dict(activations)  # shallow copy; we'll pop entries
     n = sum(len(render_formats_by_qname.get(q, ())) for q in qname_to_module)
+    if unit_shard_stamp is not None:
+        # Stamp the shard's debt from the same structure the loop below
+        # consumes, so the merge gate never has to infer it.
+        from prismaquant import unit_sharding as _unit_sharding_stamp
+
+        unit_shard_stamp.update(
+            _unit_sharding_stamp.owed_pairs_stamp(
+                (qname, fmt)
+                for qname in qname_to_module
+                for fmt in render_formats_by_qname.get(qname, ())
+            )
+        )
     done = 0
     skipped_resumed = 0
     skipped_prewritten = 0
@@ -5674,6 +5820,9 @@ def fill_production_weight_cache(
             "render_scope": render_scope,
             "requested_formats": list(requested_formats),
             "requested_entries": int(n),
+            **({
+                "unit_shard": unit_shard_stamp,
+            } if unit_shard_stamp is not None else {}),
             **({
                 "calib_hash": cb_pair_calibration_hash,
             } if cb_pair_calibration_hash is not None else {}),

--- a/prismaquant/streaming_production_cache.py
+++ b/prismaquant/streaming_production_cache.py
@@ -1361,6 +1361,7 @@ def run_streaming_render(
     include_qnames: Sequence[str] | None = None,
     format_plan: Mapping[str, Sequence[str]] | None = None,
     format_plan_identity: str | None = None,
+    unit_shard=None,
     install=None,
     unload=None,
     set_priority=None,
@@ -1446,6 +1447,57 @@ def run_streaming_render(
         skip_tokens,
         include_qname_set,
     )
+    unit_shard_stamp: dict[str, object] | None = None
+    if unit_shard is not None:
+        from prismaquant import unit_sharding as _unit_sharding
+        from prismaquant.decision_units import fused_group_key
+
+        if any(_is_cb_format_name(fmt) for fmt in requested_formats):
+            raise ValueError(
+                "unit sharding refuses a CB render scope: CB pairs carry "
+                "per-pair identity/resume sidecars and a set-level artifact "
+                "digest that a v1 shard merge would relabel. Render CB "
+                "unsharded."
+            )
+        ordered = list(dense_modules)
+        unit_records = [
+            (
+                qname,
+                int(mod.weight.numel()) * int(mod.weight.element_size()),
+            )
+            for qname, mod in dense_modules.items()
+        ]
+        # Layer atomicity keeps each fused-sibling group inside one shard.
+        # The streamed joint NVFP4 global is already computed per layer over
+        # co-resident siblings, so an intact layer renders identical bytes.
+        _unit_sharding.assert_groups_within_atoms(
+            ordered,
+            lambda name: (
+                fused_group_key(profile, name) if profile is not None else None
+            ),
+            where="streaming production cache unit shard",
+        )
+        partition = _unit_sharding.partition_units(
+            unit_records, unit_shard.count
+        )
+        shard_units = set(partition.units_for(unit_shard))
+        unit_shard_stamp = {
+            **_unit_sharding.shard_stamp(partition, unit_shard),
+            "host": _unit_sharding.host_identity(),
+        }
+        cache.metadata["unit_shard"] = unit_shard_stamp
+        dense_modules = {
+            qname: mod
+            for qname, mod in dense_modules.items()
+            if qname in shard_units
+        }
+        if progress:
+            print(
+                f"[stream-prod-cache] unit shard {unit_shard.label}: "
+                f"rendering {len(dense_modules)}/{len(ordered)} dense units; "
+                f"partition_hash={partition.partition_hash[:16]}",
+                flush=True,
+            )
     if render_scope == "assignment":
         render_formats_by_qname = {
             qname: (fmt,)
@@ -1499,12 +1551,30 @@ def run_streaming_render(
                 for qname, formats in render_formats_by_qname.items()
                 if formats
             }
+    if unit_shard_stamp is not None:
+        # The shard states its own debt, from the format map the render loop
+        # consumes, so the merge gate never infers it from an operator file.
+        from prismaquant import unit_sharding as _unit_sharding_stamp
+
+        unit_shard_stamp.update(
+            _unit_sharding_stamp.owed_pairs_stamp(
+                (qname, fmt)
+                for qname, formats in render_formats_by_qname.items()
+                for fmt in formats
+            )
+        )
     per_layer_dense: dict[int | None, dict[str, nn.Module]] = defaultdict(dict)
     for qname, mod in dense_modules.items():
         per_layer_dense[_layer_index_of(qname, layers_prefix)][qname] = mod
     per_layer_experts = _experts_qnames_by_layer(
         model, profile, layers_prefix, num_layers,
     )
+    if unit_shard is not None and any(per_layer_experts.values()):
+        raise ValueError(
+            f"unit shard {unit_shard.label} on a model with packed-MoE "
+            "experts: packed-expert renders are not unit-sharded in v1 "
+            "(every shard would render every expert). Render unsharded."
+        )
 
     cb_scope = _streaming_cb_render_scope(
         model,
@@ -1746,6 +1816,7 @@ def fill_production_weight_cache_streaming(
     include_qnames: Sequence[str] | None = None,
     format_plan: Mapping[str, Sequence[str]] | None = None,
     format_plan_identity: str | None = None,
+    unit_shard=None,
     offload_folder: str | Path | None = None,
     progress: bool = True,
 ) -> ProductionWeightCache:
@@ -1812,6 +1883,7 @@ def fill_production_weight_cache_streaming(
             include_qnames=include_qnames,
             format_plan=format_plan,
             format_plan_identity=format_plan_identity,
+            unit_shard=unit_shard,
             install=ctx.install,
             unload=ctx.unload,
             set_priority=_priority_setter(ctx),

--- a/prismaquant/unit_sharding.py
+++ b/prismaquant/unit_sharding.py
@@ -1,0 +1,445 @@
+"""Deterministic unit sharding for the render-bound production stages.
+
+One render-bound stage run may be split across boxes by *unit* (parallel
+producer v1). The split must be a pure function of the stage's own ordered
+unit enumeration so that every shard, on every box, agrees on who renders
+what without a coordinator handing out work items.
+
+Three properties are load-bearing and are why this module exists instead of
+an inline ``units[i::n]`` in each stage:
+
+1. **Layer-contiguous.** Units are grouped into *atoms* by decoder-layer
+   index and an atom is never split. Fused-sibling groups (q/k/v, gate/up)
+   live inside one layer, and the NVFP4 joint fused-sibling global scale is
+   computed as a max over the group members present in the run
+   (``export_native_compressed._compute_nvfp4_joint_global``). A partition
+   that split a fused group would hand its members different scales and the
+   shard's rendered bytes would stop being the unsharded run's bytes. Layer
+   atomicity is the invariant that keeps a sharded render bit-identical.
+   Callers that know the real fused grouping should additionally assert it
+   with :func:`assert_groups_within_atoms`.
+2. **Balanced by exact source bytes.** The balance objective is the exact
+   ``numel * element_size`` of each unit's source tensor, minimized over the
+   worst shard by an exact contiguous-partition DP — not a unit count, not
+   an estimate.
+3. **Pure.** No RNG, no clock, no host state. ``(ordered units, N)`` in,
+   partition + ``partition_hash`` out, so a merge tool can recompute the
+   same partition from the stamp and gate completeness fail-closed.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+SCHEMA = "prismaquant.unit_sharding.v1"
+SHARD_ENV = "PRISMAQUANT_UNIT_SHARD"
+
+_SHARD_RE = re.compile(r"^(\d+)/(\d+)$")
+
+# A decoder-layer atom is the qname prefix through the layer index. The
+# container names are the explicit set the model profiles in this repo use;
+# a unit that matches none of them becomes its own singleton atom, which is
+# always a safe partition (it can only be over-split, never under-grouped)
+# but gives the caller no fused-group guarantee — hence
+# `assert_groups_within_atoms`.
+_LAYER_CONTAINERS = ("layers", "blocks", "h")
+_LAYER_RE = re.compile(
+    r"^(?P<prefix>.*?\b(?:" + "|".join(_LAYER_CONTAINERS) + r")\.\d+)(?:\.|$)"
+)
+
+
+@dataclass(frozen=True)
+class ShardSpec:
+    """One shard of an ``index/count`` split."""
+
+    index: int
+    count: int
+
+    @property
+    def label(self) -> str:
+        return f"{self.index}/{self.count}"
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.label
+
+
+@dataclass(frozen=True)
+class UnitPartition:
+    """The full deterministic partition of one ordered unit enumeration."""
+
+    units: tuple[tuple[str, int], ...]
+    count: int
+    shards: tuple[tuple[str, ...], ...]
+    shard_bytes: tuple[int, ...]
+    atom_keys: tuple[str, ...]
+    partition_hash: str
+
+    def units_for(self, spec: ShardSpec) -> tuple[str, ...]:
+        if spec.count != self.count:
+            raise ValueError(
+                f"shard spec count {spec.count} does not match partition "
+                f"count {self.count}"
+            )
+        return self.shards[spec.index]
+
+
+def parse_shard_spec(value: str | None) -> ShardSpec | None:
+    """Parse ``"i/N"``. ``None``/empty means "no shard" (the whole run).
+
+    Malformed input is fatal, never a silent whole-run fallback: a driver
+    that typos the split would otherwise render everything on every box and
+    the merge would only find out afterwards.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    match = _SHARD_RE.match(text)
+    if match is None:
+        raise ValueError(
+            f"malformed {SHARD_ENV}={value!r}; expected 'i/N' with "
+            "0 <= i < N (for example '0/2')"
+        )
+    index = int(match.group(1))
+    count = int(match.group(2))
+    if count < 1:
+        raise ValueError(
+            f"malformed {SHARD_ENV}={value!r}; shard count must be >= 1"
+        )
+    if index >= count:
+        raise ValueError(
+            f"malformed {SHARD_ENV}={value!r}; shard index must be < count"
+        )
+    return ShardSpec(index=index, count=count)
+
+
+def resolve_shard_spec(
+    env: Mapping[str, str] | None = None,
+) -> ShardSpec | None:
+    """Read :data:`SHARD_ENV` from ``env`` (default ``os.environ``)."""
+    source = os.environ if env is None else env
+    return parse_shard_spec(source.get(SHARD_ENV))
+
+
+def atom_key(name: str) -> str:
+    """Return the layer-atom key for a unit qname.
+
+    ``model.layers.7.self_attn.q_proj`` -> ``model.layers.7``. A unit with no
+    recognizable layer index is its own atom.
+    """
+    match = _LAYER_RE.match(str(name))
+    if match is None:
+        return str(name)
+    return match.group("prefix")
+
+
+def _normalize_units(
+    units: Sequence[tuple[str, int]] | Sequence[Sequence],
+) -> tuple[tuple[str, int], ...]:
+    out: list[tuple[str, int]] = []
+    seen: set[str] = set()
+    for item in units:
+        name, nbytes = str(item[0]), int(item[1])
+        if nbytes < 0:
+            raise ValueError(f"unit {name!r} has negative byte size {nbytes}")
+        if name in seen:
+            raise ValueError(f"duplicate unit in enumeration: {name!r}")
+        seen.add(name)
+        out.append((name, nbytes))
+    return tuple(out)
+
+
+def partition_hash(
+    units: Sequence[tuple[str, int]],
+    count: int,
+) -> str:
+    """SHA-256 over the exact partition inputs.
+
+    The hash covers the FULL ordered enumeration (name + exact bytes) and the
+    shard count, so any shard's stamp proves which enumeration it split and
+    the merge tool can recompute the partition without the model.
+    """
+    normalized = _normalize_units(units)
+    payload = json.dumps(
+        {
+            "schema": SCHEMA,
+            "count": int(count),
+            "units": [[name, nbytes] for name, nbytes in normalized],
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _contiguous_min_max_partition(
+    weights: Sequence[int],
+    count: int,
+) -> list[int]:
+    """Exact contiguous partition minimizing the heaviest part.
+
+    Returns the ``count + 1`` boundary offsets. Deterministic tie-break: the
+    smallest feasible split index wins, so the same inputs always yield the
+    same boundaries on any host.
+    """
+    n = len(weights)
+    prefix = [0] * (n + 1)
+    for i, weight in enumerate(weights):
+        prefix[i + 1] = prefix[i] + int(weight)
+
+    # dp[k][i]: min possible heaviest part when the first i atoms are split
+    # into k parts. Empty parts are legal (count may exceed atom count).
+    inf = float("inf")
+    dp = [[inf] * (n + 1) for _ in range(count + 1)]
+    choice = [[0] * (n + 1) for _ in range(count + 1)]
+    dp[0][0] = 0.0
+    for k in range(1, count + 1):
+        for i in range(0, n + 1):
+            best = inf
+            best_j = 0
+            for j in range(0, i + 1):
+                if dp[k - 1][j] == inf:
+                    continue
+                part = prefix[i] - prefix[j]
+                candidate = dp[k - 1][j] if dp[k - 1][j] > part else float(part)
+                if candidate < best:
+                    best = candidate
+                    best_j = j
+            dp[k][i] = best
+            choice[k][i] = best_j
+
+    if dp[count][n] == inf:  # pragma: no cover - unreachable for count >= 1
+        raise ValueError("no feasible contiguous partition")
+
+    bounds = [0] * (count + 1)
+    bounds[count] = n
+    i = n
+    for k in range(count, 0, -1):
+        j = choice[k][i]
+        bounds[k - 1] = j
+        i = j
+    return bounds
+
+
+def partition_units(
+    units: Sequence[tuple[str, int]],
+    count: int,
+) -> UnitPartition:
+    """Split an ordered unit enumeration into ``count`` contiguous shards."""
+    if int(count) < 1:
+        raise ValueError(f"shard count must be >= 1, got {count}")
+    normalized = _normalize_units(units)
+    count = int(count)
+
+    atom_order: list[str] = []
+    atom_units: dict[str, list[str]] = {}
+    atom_bytes: dict[str, int] = {}
+    for name, nbytes in normalized:
+        key = atom_key(name)
+        if key not in atom_units:
+            atom_order.append(key)
+            atom_units[key] = []
+            atom_bytes[key] = 0
+        elif atom_order[-1] != key:
+            raise ValueError(
+                "unit enumeration is not layer-contiguous: atom "
+                f"{key!r} reappears after {atom_order[-1]!r} at unit {name!r}"
+            )
+        atom_units[key].append(name)
+        atom_bytes[key] += nbytes
+
+    weights = [atom_bytes[key] for key in atom_order]
+    bounds = _contiguous_min_max_partition(weights, count)
+
+    shards: list[tuple[str, ...]] = []
+    shard_bytes: list[int] = []
+    for k in range(count):
+        keys = atom_order[bounds[k]:bounds[k + 1]]
+        names: list[str] = []
+        total = 0
+        for key in keys:
+            names.extend(atom_units[key])
+            total += atom_bytes[key]
+        shards.append(tuple(names))
+        shard_bytes.append(total)
+
+    return UnitPartition(
+        units=normalized,
+        count=count,
+        shards=tuple(shards),
+        shard_bytes=tuple(shard_bytes),
+        atom_keys=tuple(atom_order),
+        partition_hash=partition_hash(normalized, count),
+    )
+
+
+def assert_groups_within_atoms(
+    units: Sequence[str],
+    group_key,
+    *,
+    where: str,
+) -> None:
+    """Refuse an enumeration whose co-rendering groups straddle atoms.
+
+    ``group_key(name)`` returns the caller's real grouping identity (the
+    fused-sibling group for the dense render path). A group split across two
+    atoms could land on two boxes, and the members' shared NVFP4 global scale
+    would be computed over different member sets — the shard's bytes would
+    stop being the unsharded run's bytes. Fail closed instead.
+    """
+    atoms_by_group: dict[str, set[str]] = {}
+    for name in units:
+        key = group_key(name)
+        if key is None:
+            continue
+        atoms_by_group.setdefault(str(key), set()).add(atom_key(name))
+    straddling = sorted(
+        group for group, atoms in atoms_by_group.items() if len(atoms) > 1
+    )
+    if straddling:
+        raise ValueError(
+            f"{where}: {len(straddling)} co-rendered group(s) straddle "
+            f"layer atoms and cannot be unit-sharded; sample={straddling[:5]}"
+        )
+
+
+def shard_stamp(
+    partition: UnitPartition,
+    spec: ShardSpec,
+) -> dict:
+    """The provenance block every shard artifact carries."""
+    if spec.count != partition.count:
+        raise ValueError(
+            f"shard spec {spec.label} does not match partition count "
+            f"{partition.count}"
+        )
+    names = partition.shards[spec.index]
+    return {
+        "schema": SCHEMA,
+        "shard": spec.label,
+        "shard_index": int(spec.index),
+        "shard_count": int(spec.count),
+        "partition_hash": partition.partition_hash,
+        "unit_names": list(names),
+        "unit_count": len(names),
+        "shard_bytes": int(partition.shard_bytes[spec.index]),
+        "total_units": len(partition.units),
+        "total_bytes": int(sum(nbytes for _, nbytes in partition.units)),
+        # The complete ordered enumeration travels with every shard so the
+        # merge tool can recompute the partition and gate completeness
+        # without loading the model.
+        "all_units": [[name, nbytes] for name, nbytes in partition.units],
+    }
+
+
+def owed_pairs_stamp(pairs) -> dict:
+    """Record the exact ``(qname, format)`` entries this shard set out to render.
+
+    The merge gate needs to know what each shard *owed* before it can call a
+    missing entry missing. Reconstructing that downstream from an
+    operator-supplied layer config would put the operator's file in the trust
+    path: a config that disagrees with the one the shard actually rendered
+    under would under-expect, and a unit dropped by the render would merge
+    clean. So the shard states its own debt, at the moment it is fixed and
+    from the same structure the render loop consumes.
+    """
+    canonical = sorted(
+        {(str(qname), str(fmt).upper()) for qname, fmt in pairs}
+    )
+    payload = json.dumps(canonical, separators=(",", ":")).encode("utf-8")
+    return {
+        "owed_pairs": [[qname, fmt] for qname, fmt in canonical],
+        "owed_pair_count": len(canonical),
+        "owed_pairs_sha256": hashlib.sha256(payload).hexdigest(),
+    }
+
+
+def owed_pairs_from_stamp(stamp: Mapping) -> set[tuple[str, str]] | None:
+    """Read back an ``owed_pairs_stamp``, verifying its own digest.
+
+    Returns ``None`` when the stamp predates the field, so a caller can fall
+    back to reconstruction and say so.
+    """
+    raw = stamp.get("owed_pairs")
+    if raw is None:
+        return None
+    pairs = sorted(
+        {(str(item[0]), str(item[1]).upper()) for item in raw}
+    )
+    payload = json.dumps(
+        [[qname, fmt] for qname, fmt in pairs], separators=(",", ":")
+    ).encode("utf-8")
+    digest = hashlib.sha256(payload).hexdigest()
+    recorded = str(stamp.get("owed_pairs_sha256", ""))
+    if recorded and digest != recorded:
+        raise ValueError(
+            f"unit-shard stamp {stamp.get('shard')!r} owed_pairs do not match "
+            f"owed_pairs_sha256 ({digest} != {recorded}); the stamp was "
+            "edited after the render."
+        )
+    if int(stamp.get("owed_pair_count", len(pairs))) != len(pairs):
+        raise ValueError(
+            f"unit-shard stamp {stamp.get('shard')!r} owed_pair_count "
+            f"{stamp.get('owed_pair_count')!r} disagrees with the "
+            f"{len(pairs)} pairs it lists."
+        )
+    return set(pairs)
+
+
+def host_identity() -> dict:
+    """Who rendered this shard. Impure by design; provenance only.
+
+    A distributed render is only as trustworthy as the claim that both boxes
+    ran the same wheel on the same architecture, so the merged artifact has
+    to be able to name what actually produced each shard's bytes.
+    """
+    import platform
+    import socket
+
+    identity: dict[str, object] = {
+        "hostname": socket.gethostname(),
+        "platform": platform.platform(),
+        "python_version": platform.python_version(),
+    }
+    try:
+        import torch
+
+        identity["torch_version"] = str(torch.__version__)
+        identity["torch_cuda_version"] = str(
+            getattr(torch.version, "cuda", None)
+        )
+        if torch.cuda.is_available():
+            identity["cuda_device_name"] = torch.cuda.get_device_name(0)
+            identity["cuda_capability"] = ".".join(
+                str(part) for part in torch.cuda.get_device_capability(0)
+            )
+    except Exception:  # pragma: no cover - torch is always present in prod
+        identity["torch_version"] = None
+    return identity
+
+
+def partition_from_stamp(stamp: Mapping) -> UnitPartition:
+    """Rebuild the partition a shard stamp describes."""
+    if str(stamp.get("schema")) != SCHEMA:
+        raise ValueError(
+            f"unexpected unit-shard stamp schema {stamp.get('schema')!r}"
+        )
+    all_units = stamp.get("all_units")
+    if not isinstance(all_units, Sequence) or isinstance(all_units, (str, bytes)):
+        raise ValueError("unit-shard stamp is missing its all_units enumeration")
+    partition = partition_units(
+        [(str(item[0]), int(item[1])) for item in all_units],
+        int(stamp["shard_count"]),
+    )
+    if partition.partition_hash != str(stamp.get("partition_hash")):
+        raise ValueError(
+            "unit-shard stamp partition_hash does not match its own "
+            "enumeration; the stamp is inconsistent"
+        )
+    return partition

--- a/tests/test_unit_sharding.py
+++ b/tests/test_unit_sharding.py
@@ -1,0 +1,825 @@
+"""Unit sharding: partition, env parsing, merge gate, sentinel compare."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import pickle
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn as nn
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from prismaquant import unit_sharding as us  # noqa: E402
+from prismaquant.production_weight_cache import ProductionWeightCache  # noqa: E402
+
+
+def _load_tool(name: str):
+    path = REPO_ROOT / "tools" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"_tool_{name}", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+merge_tool = _load_tool("merge_unit_shards")
+sentinel_tool = _load_tool("cluster_render_sentinel")
+
+
+LEAVES = (
+    "self_attn.q_proj",
+    "self_attn.k_proj",
+    "self_attn.v_proj",
+    "self_attn.o_proj",
+    "mlp.gate_proj",
+    "mlp.up_proj",
+    "mlp.down_proj",
+)
+
+
+def make_units(n_layers: int = 8, base: int = 1_000_000):
+    units = [("model.embed_projection", 4096)]
+    for layer in range(n_layers):
+        for leaf in LEAVES:
+            units.append((f"model.layers.{layer}.{leaf}", base + layer * 1000))
+    return units
+
+
+# --------------------------------------------------------------------------
+# env parsing
+# --------------------------------------------------------------------------
+def test_parse_shard_spec_accepts_well_formed():
+    spec = us.parse_shard_spec("0/2")
+    assert (spec.index, spec.count, spec.label) == (0, 2, "0/2")
+    assert us.parse_shard_spec(" 3/4 ").index == 3
+    assert us.parse_shard_spec("0/1").count == 1
+
+
+def test_parse_shard_spec_unset_is_no_shard():
+    assert us.parse_shard_spec(None) is None
+    assert us.parse_shard_spec("") is None
+    assert us.parse_shard_spec("   ") is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["2/2", "3/2", "1", "a/b", "1/0", "-1/2", "1/2/3", "1 / 2", "0/-2", "0.5/2"],
+)
+def test_parse_shard_spec_rejects_malformed(value):
+    with pytest.raises(ValueError):
+        us.parse_shard_spec(value)
+
+
+def test_resolve_shard_spec_reads_the_env(monkeypatch):
+    monkeypatch.delenv(us.SHARD_ENV, raising=False)
+    assert us.resolve_shard_spec() is None
+    monkeypatch.setenv(us.SHARD_ENV, "1/3")
+    assert us.resolve_shard_spec().label == "1/3"
+
+
+# --------------------------------------------------------------------------
+# partition
+# --------------------------------------------------------------------------
+def test_partition_is_total_and_disjoint():
+    units = make_units()
+    partition = us.partition_units(units, 3)
+    flat = [name for shard in partition.shards for name in shard]
+    assert sorted(flat) == sorted(name for name, _ in units)
+    assert len(flat) == len(set(flat))
+
+
+def test_partition_is_deterministic_and_pure():
+    units = make_units()
+    first = us.partition_units(units, 4)
+    second = us.partition_units(list(units), 4)
+    assert first.shards == second.shards
+    assert first.partition_hash == second.partition_hash
+
+
+def test_partition_hash_tracks_inputs():
+    units = make_units()
+    baseline = us.partition_units(units, 2).partition_hash
+    assert us.partition_units(units, 3).partition_hash != baseline
+    perturbed = list(units)
+    perturbed[5] = (perturbed[5][0], perturbed[5][1] + 1)
+    assert us.partition_units(perturbed, 2).partition_hash != baseline
+
+
+def test_partition_keeps_layers_contiguous_and_whole():
+    units = make_units(n_layers=9)
+    partition = us.partition_units(units, 3)
+    for shard in partition.shards:
+        atoms = [us.atom_key(name) for name in shard]
+        # each atom appears as one contiguous run
+        assert atoms == sorted(atoms, key=lambda a: atoms.index(a))
+    seen: dict[str, int] = {}
+    for index, shard in enumerate(partition.shards):
+        for name in shard:
+            key = us.atom_key(name)
+            assert seen.setdefault(key, index) == index, (
+                f"atom {key} straddles shards"
+            )
+
+
+def test_partition_balances_by_exact_bytes():
+    units = make_units(n_layers=8)
+    partition = us.partition_units(units, 2)
+    total = sum(nbytes for _, nbytes in units)
+    assert sum(partition.shard_bytes) == total
+    # Layer atoms are equal-ish, so a two-way split lands within one atom.
+    atom_bytes = max(
+        sum(n for name, n in units if us.atom_key(name) == key)
+        for key in {us.atom_key(name) for name, _ in units}
+    )
+    assert abs(partition.shard_bytes[0] - partition.shard_bytes[1]) <= atom_bytes
+
+
+def test_partition_minimizes_the_heaviest_shard():
+    # Deliberately lopsided: an exact DP must not just cut in the middle.
+    units = [
+        ("model.layers.0.mlp.down_proj", 10),
+        ("model.layers.1.mlp.down_proj", 10),
+        ("model.layers.2.mlp.down_proj", 100),
+        ("model.layers.3.mlp.down_proj", 10),
+    ]
+    partition = us.partition_units(units, 2)
+    assert max(partition.shard_bytes) == 110
+    assert partition.shards[0] == (
+        "model.layers.0.mlp.down_proj",
+        "model.layers.1.mlp.down_proj",
+    )
+
+
+def test_partition_allows_more_shards_than_atoms():
+    units = [("model.layers.0.mlp.down_proj", 10)]
+    partition = us.partition_units(units, 3)
+    assert sum(len(shard) for shard in partition.shards) == 1
+
+
+def test_partition_rejects_non_contiguous_enumeration():
+    units = [
+        ("model.layers.0.mlp.down_proj", 10),
+        ("model.layers.1.mlp.down_proj", 10),
+        ("model.layers.0.mlp.up_proj", 10),
+    ]
+    with pytest.raises(ValueError, match="not layer-contiguous"):
+        us.partition_units(units, 2)
+
+
+def test_partition_rejects_duplicate_units():
+    units = [("model.layers.0.mlp.down_proj", 10)] * 2
+    with pytest.raises(ValueError, match="duplicate unit"):
+        us.partition_units(units, 2)
+
+
+def test_partition_rejects_bad_count():
+    with pytest.raises(ValueError):
+        us.partition_units(make_units(), 0)
+
+
+def test_atom_key_groups_experts_into_their_layer():
+    assert us.atom_key("model.layers.3.mlp.experts.5.w1") == "model.layers.3"
+    assert us.atom_key("model.language_model.layers.2.mlp.up_proj") == (
+        "model.language_model.layers.2"
+    )
+    assert us.atom_key("lm_head") == "lm_head"
+
+
+def test_assert_groups_within_atoms_accepts_fused_siblings():
+    units = [name for name, _ in make_units(n_layers=3)]
+    us.assert_groups_within_atoms(
+        units,
+        lambda name: name.rsplit(".", 1)[0],
+        where="test",
+    )
+
+
+def test_assert_groups_within_atoms_refuses_a_straddling_group():
+    units = [name for name, _ in make_units(n_layers=3)]
+    with pytest.raises(ValueError, match="straddle layer atoms"):
+        us.assert_groups_within_atoms(
+            units,
+            lambda name: name.rsplit(".", 1)[-1],  # groups q_proj across layers
+            where="test",
+        )
+
+
+def test_shard_stamp_round_trips_through_partition_from_stamp():
+    units = make_units()
+    partition = us.partition_units(units, 3)
+    stamp = us.shard_stamp(partition, us.ShardSpec(1, 3))
+    assert stamp["shard"] == "1/3"
+    assert list(stamp["unit_names"]) == list(partition.shards[1])
+    rebuilt = us.partition_from_stamp(stamp)
+    assert rebuilt.shards == partition.shards
+    assert rebuilt.partition_hash == partition.partition_hash
+
+
+def test_partition_from_stamp_refuses_a_tampered_stamp():
+    partition = us.partition_units(make_units(), 2)
+    stamp = us.shard_stamp(partition, us.ShardSpec(0, 2))
+    stamp["all_units"][3][1] += 1
+    with pytest.raises(ValueError, match="partition_hash does not match"):
+        us.partition_from_stamp(stamp)
+
+
+# --------------------------------------------------------------------------
+# merge completeness gate (A3)
+# --------------------------------------------------------------------------
+def _shard_cache(tmp_path, partition, index, *, formats=("NVFP4",), drop=(),
+                 extra=(), duplicate_of=None, stamp_owed=True, gates=None):
+    spec = us.ShardSpec(index, partition.count)
+    stamp = {**us.shard_stamp(partition, spec), "host": {"hostname": "test"}}
+    if stamp_owed:
+        # A real shard stamps the debt it set out to render, before the loop
+        # runs — so `drop` below leaves the stamp intact and the gate sees it.
+        stamp.update(us.owed_pairs_stamp(
+            (name, fmt)
+            for name in partition.shards[index]
+            for fmt in formats
+        ))
+    names = list(partition.shards[index])
+    if duplicate_of is not None:
+        names = names + list(partition.shards[duplicate_of])
+    weights = {}
+    scores = {}
+    for name in names:
+        if name in drop:
+            continue
+        for fmt in formats:
+            weights[(name, fmt)] = torch.zeros(2, 2, dtype=torch.bfloat16)
+            scores[f"{name}|{fmt}"] = {"qname": name, "format": fmt}
+    for name in extra:
+        for fmt in formats:
+            weights[(name, fmt)] = torch.zeros(2, 2, dtype=torch.bfloat16)
+    cache = ProductionWeightCache(
+        weights=weights,
+        levers={"gptq": True},
+        activation_max_abs={name: 1.0 for name, _ in partition.units},
+        failed={},
+        cache_dir=None,
+        metadata={
+            "unit_shard": stamp,
+            "render_scope": "format-menu",
+            "requested_formats": list(formats),
+            "render_scores": {
+                "schema": "prismaquant.production_render_scores.v1",
+                "entries": len(scores),
+                "records": scores,
+            },
+            **({"render_gates": gates} if gates is not None else {}),
+        },
+    )
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    path = tmp_path / f"shard{index}.pkl"
+    with open(path, "wb") as fh:
+        pickle.dump(cache, fh)
+    return path
+
+
+def _merge(tmp_path, shard_paths):
+    return merge_tool.main([
+        "merge",
+        *[arg for path in shard_paths for arg in ("--shard", str(path))],
+        "--output", str(tmp_path / "merged.pkl"),
+    ])
+
+
+def test_merge_accepts_a_complete_partition(tmp_path):
+    partition = us.partition_units(make_units(n_layers=4), 2)
+    paths = [_shard_cache(tmp_path, partition, i) for i in range(2)]
+    assert _merge(tmp_path, paths) == 0
+    with open(tmp_path / "merged.pkl", "rb") as fh:
+        merged = pickle.load(fh)
+    assert len(merged.weights) == len(partition.units)
+    stamp = merged.metadata["unit_shard_merge"]
+    assert stamp["shard_count"] == 2
+    assert [entry["shard"] for entry in stamp["shards"]] == ["0/2", "1/2"]
+    assert "unit_shard" not in merged.metadata
+    # canonical order: full-enumeration unit order, not shard-append order
+    assert [key[0] for key in merged.weights] == [
+        name for name, _ in partition.units
+    ]
+
+
+def test_merge_refuses_a_missing_unit(tmp_path):
+    partition = us.partition_units(make_units(n_layers=4), 2)
+    victim = partition.shards[1][2]
+    paths = [
+        _shard_cache(tmp_path, partition, 0),
+        _shard_cache(tmp_path, partition, 1, drop=(victim,)),
+    ]
+    with pytest.raises(SystemExit) as excinfo:
+        _merge(tmp_path, paths)
+    assert "missing entries" in str(excinfo.value)
+    assert victim in str(excinfo.value)
+
+
+def test_merge_refuses_a_duplicate_unit(tmp_path):
+    partition = us.partition_units(make_units(n_layers=4), 2)
+    paths = [
+        _shard_cache(tmp_path, partition, 0),
+        _shard_cache(tmp_path, partition, 1, duplicate_of=0),
+    ]
+    with pytest.raises(SystemExit) as excinfo:
+        _merge(tmp_path, paths)
+    assert "outside their shard" in str(excinfo.value)
+
+
+def test_merge_refuses_an_extra_unit(tmp_path):
+    partition = us.partition_units(make_units(n_layers=4), 2)
+    paths = [
+        _shard_cache(tmp_path, partition, 0, extra=("model.layers.99.mlp.up_proj",)),
+        _shard_cache(tmp_path, partition, 1),
+    ]
+    with pytest.raises(SystemExit) as excinfo:
+        _merge(tmp_path, paths)
+    assert "outside their shard" in str(excinfo.value)
+
+
+def test_merge_refuses_a_missing_shard(tmp_path):
+    partition = us.partition_units(make_units(n_layers=4), 3)
+    paths = [_shard_cache(tmp_path, partition, i) for i in (0, 1)]
+    with pytest.raises(SystemExit) as excinfo:
+        _merge(tmp_path, paths)
+    assert "declares 3 shards" in str(excinfo.value)
+
+
+def test_merge_refuses_shards_of_different_partitions(tmp_path):
+    partition_a = us.partition_units(make_units(n_layers=4), 2)
+    partition_b = us.partition_units(make_units(n_layers=5), 2)
+    paths = [
+        _shard_cache(tmp_path, partition_a, 0),
+        _shard_cache(tmp_path / "b", partition_b, 1),
+    ]
+    with pytest.raises(SystemExit) as excinfo:
+        _merge(tmp_path, paths)
+    assert "partition_hash differs" in str(excinfo.value)
+
+
+def test_merge_refuses_activation_max_abs_disagreement(tmp_path):
+    partition = us.partition_units(make_units(n_layers=4), 2)
+    paths = [_shard_cache(tmp_path, partition, i) for i in range(2)]
+    with open(paths[1], "rb") as fh:
+        cache = pickle.load(fh)
+    victim = partition.units[0][0]
+    cache.activation_max_abs[victim] = 2.0
+    with open(paths[1], "wb") as fh:
+        pickle.dump(cache, fh)
+    with pytest.raises(SystemExit) as excinfo:
+        _merge(tmp_path, paths)
+    assert "activation_max_abs disagreements" in str(excinfo.value)
+
+
+def test_merge_refuses_an_unsharded_cache(tmp_path):
+    cache = ProductionWeightCache(weights={}, levers={}, metadata={})
+    path = tmp_path / "plain.pkl"
+    with open(path, "wb") as fh:
+        pickle.dump(cache, fh)
+    with pytest.raises(SystemExit) as excinfo:
+        _merge(tmp_path, [path, path])
+    assert "no 'unit_shard' stamp" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------
+# the shard states its own debt
+# --------------------------------------------------------------------------
+def test_owed_pairs_stamp_round_trips_and_is_order_insensitive():
+    pairs = [("a", "NVFP4"), ("b", "fp8_e4m3"), ("a", "FP8_E4M3")]
+    stamp = us.owed_pairs_stamp(pairs)
+    assert stamp["owed_pair_count"] == 3
+    assert us.owed_pairs_from_stamp(stamp) == {
+        ("a", "NVFP4"), ("a", "FP8_E4M3"), ("b", "FP8_E4M3"),
+    }
+    assert us.owed_pairs_stamp(reversed(pairs)) == stamp
+
+
+def test_owed_pairs_from_stamp_refuses_a_tampered_stamp():
+    stamp = us.owed_pairs_stamp([("a", "NVFP4"), ("b", "NVFP4")])
+    stamp["owed_pairs"] = [["a", "NVFP4"]]
+    with pytest.raises(ValueError, match="owed_pairs_sha256"):
+        us.owed_pairs_from_stamp(stamp)
+
+
+def test_owed_pairs_from_stamp_is_none_when_the_field_is_absent():
+    assert us.owed_pairs_from_stamp({"shard": "0/2"}) is None
+
+
+def test_merge_gate_trusts_the_stamped_debt_over_an_operator_config(tmp_path):
+    """A layer config that under-declares must not excuse a dropped unit.
+
+    The operator supplies `--render-layer-config`; the shard supplies its own
+    owed list. If the config wins, a config that calls the dropped unit BF16
+    makes a silently incomplete merge pass — the exact failure the gate exists
+    to prevent.
+    """
+    partition = us.partition_units(make_units(n_layers=4), 2)
+    victim = partition.shards[1][2]
+    paths = [
+        _shard_cache(tmp_path, partition, 0),
+        _shard_cache(tmp_path, partition, 1, drop=(victim,)),
+    ]
+    config = tmp_path / "layer_config.json"
+    config.write_text(json.dumps(
+        {name: ("BF16" if name == victim else "NVFP4")
+         for name, _ in partition.units}
+    ))
+    with pytest.raises(SystemExit) as excinfo:
+        merge_tool.main([
+            "merge",
+            *[arg for path in paths for arg in ("--shard", str(path))],
+            "--output", str(tmp_path / "merged.pkl"),
+            "--render-layer-config", str(config),
+        ])
+    assert "missing entries" in str(excinfo.value)
+    assert victim in str(excinfo.value)
+
+
+def test_merge_falls_back_to_reconstruction_for_a_legacy_stamp(tmp_path):
+    partition = us.partition_units(make_units(n_layers=4), 2)
+    victim = partition.shards[0][1]
+    paths = [
+        _shard_cache(tmp_path, partition, 0, drop=(victim,), stamp_owed=False),
+        _shard_cache(tmp_path, partition, 1, stamp_owed=False),
+    ]
+    with pytest.raises(SystemExit) as excinfo:
+        _merge(tmp_path, paths)
+    assert "missing entries" in str(excinfo.value)
+    assert victim in str(excinfo.value)
+
+
+def test_merge_orders_keys_like_an_unsharded_run(tmp_path):
+    """Unit order, then REQUESTED-format order — not alphabetical."""
+    partition = us.partition_units(make_units(n_layers=4), 2)
+    formats = ("NVFP4", "FP8_E4M3")
+    paths = [
+        _shard_cache(tmp_path, partition, i, formats=formats)
+        for i in range(2)
+    ]
+    assert _merge(tmp_path, paths) == 0
+    with open(tmp_path / "merged.pkl", "rb") as fh:
+        merged = pickle.load(fh)
+    expected = [
+        (name, fmt) for name, _ in partition.units for fmt in formats
+    ]
+    assert list(merged.weights) == expected
+
+
+def test_merged_sidecars_are_readable_by_the_production_loader(tmp_path):
+    """A merged cache_dir must resume exactly like an unsharded one."""
+    from prismaquant.production_weight_cache import _load_render_score_sidecar
+
+    partition = us.partition_units(make_units(n_layers=4), 2)
+    paths = [_shard_cache(tmp_path, partition, i) for i in range(2)]
+    out_dir = tmp_path / "merged_cache_dir"
+    assert merge_tool.main([
+        "merge",
+        *[arg for path in paths for arg in ("--shard", str(path))],
+        "--output", str(tmp_path / "merged.pkl"),
+        "--output-cache-dir", str(out_dir),
+    ]) == 0
+    records = _load_render_score_sidecar(out_dir / "render_scores.json")
+    assert len(records) == len(partition.units)
+    assert all(
+        f"{name}|NVFP4" in records for name, _ in partition.units
+    )
+    max_abs = json.loads((out_dir / "activation_max_abs.json").read_text())
+    # enumeration order, as the unsharded stage writes it
+    assert list(max_abs) == [name for name, _ in partition.units]
+
+
+def test_merge_unions_the_render_gate_summary(tmp_path):
+    """Merged counters cover every shard, not shard 0's tally relabelled."""
+    def gates_for(index):
+        records = [
+            {
+                "qname": name,
+                "format": "NVFP4",
+                "trace": [{
+                    "mechanism": "gptq",
+                    "accepted": True,
+                    "reason": "improved",
+                    "package": ["gptq"],
+                }],
+            }
+            for name in partition.shards[index]
+        ]
+        return {"enabled": True, "entries": len(records),
+                "mechanisms": {"gptq": {
+                    "accepted": len(records), "rejected": 0,
+                    "reasons": {"improved": len(records)},
+                    "package_accepted": len(records),
+                }},
+                "records": records}
+
+    partition = us.partition_units(make_units(n_layers=4), 2)
+    paths = [
+        _shard_cache(tmp_path, partition, i, gates=gates_for(i))
+        for i in range(2)
+    ]
+    assert _merge(tmp_path, paths) == 0
+    with open(tmp_path / "merged.pkl", "rb") as fh:
+        merged = pickle.load(fh)
+    total = len(partition.units)
+    gates = merged.metadata["render_gates"]
+    assert gates["entries"] == total
+    assert len(gates["records"]) == total
+    assert gates["mechanisms"]["gptq"]["accepted"] == total
+    assert gates["mechanisms"]["gptq"]["reasons"]["improved"] == total
+    # records land in canonical enumeration order, not shard-append order
+    assert [rec["qname"] for rec in gates["records"]] == [
+        name for name, _ in partition.units
+    ]
+
+
+# --------------------------------------------------------------------------
+# sentinel
+# --------------------------------------------------------------------------
+def test_select_sentinel_units_is_deterministic_and_spread():
+    names = [f"model.layers.{i}.mlp.down_proj" for i in range(40)]
+    picked = sentinel_tool.select_sentinel_units(names, 5)
+    assert picked == sentinel_tool.select_sentinel_units(names, 5)
+    assert len(picked) == 5
+    assert picked[0] == names[0]
+    assert picked[-1] != names[-1]  # evenly spaced, not the tail
+    assert len(set(picked)) == len(picked)
+
+
+def test_select_sentinel_units_clamps_to_the_enumeration():
+    names = ["a", "b"]
+    assert sentinel_tool.select_sentinel_units(names, 10) == names
+
+
+def _manifest(entries, deterministic="1", host="boxA"):
+    return {
+        "schema": sentinel_tool.SCHEMA,
+        "formats": ["NVFP4"],
+        "levers": ["gptq"],
+        "units": sorted({key.split("|")[0] for key in entries}),
+        "k": 2,
+        "calibration": {"calib_hash": "abc"},
+        "deterministic_mode": deterministic,
+        "host": {"hostname": host},
+        "entries": entries,
+    }
+
+
+def test_sentinel_compare_accepts_matching_manifests(tmp_path):
+    entries = {"a|NVFP4": {"sha256": "aa", "dtype": "torch.bfloat16",
+                           "shape": [2, 2]}}
+    paths = []
+    for name, host in (("a.json", "boxA"), ("b.json", "boxB")):
+        path = tmp_path / name
+        path.write_text(json.dumps(_manifest(entries, host=host)))
+        paths.append(str(path))
+    assert sentinel_tool.main(
+        ["compare", "--manifest", paths[0], "--manifest", paths[1]]
+    ) == 0
+
+
+def test_sentinel_compare_flags_a_differing_unit(tmp_path):
+    a = _manifest({"a|NVFP4": {"sha256": "aa"}})
+    b = _manifest({"a|NVFP4": {"sha256": "bb"}}, host="boxB")
+    problems = sentinel_tool.compare_manifests([a, b])
+    assert any("rendered units differ" in p for p in problems)
+
+
+def test_sentinel_compare_flags_a_missing_unit():
+    a = _manifest({"a|NVFP4": {"sha256": "aa"}, "b|NVFP4": {"sha256": "bb"}})
+    b = _manifest({"a|NVFP4": {"sha256": "aa"}}, host="boxB")
+    problems = sentinel_tool.compare_manifests([a, b])
+    assert any("only in the first manifest" in p for p in problems)
+
+
+def test_sentinel_compare_flags_an_incomplete_manifest():
+    # A box that could not render a format at all (2026-08-23: no python3-dev
+    # on sparklina → Triton build failure → every NVFP4 entry absent) must be
+    # named as incomplete, not just "missing units".
+    complete = _manifest({"a|NVFP4": {"sha256": "aa"}, "b|NVFP4": {"sha256": "bb"}})
+    partial = dict(complete, host={"hostname": "boxB"},
+                   entries={"a|NVFP4": {"sha256": "aa"}})
+    assert sentinel_tool.missing_entries(partial) == ["b|NVFP4"]
+    assert sentinel_tool.missing_entries(complete) == []
+    # The CLI alias is promised; the cache keys by the canonical name.
+    aliased = dict(complete, formats=["FP8_DYNAMIC"],
+                   entries={"a|FP8_E4M3": {"sha256": "aa"},
+                            "b|FP8_E4M3": {"sha256": "bb"}})
+    assert sentinel_tool.missing_entries(aliased) == []
+    problems = sentinel_tool.compare_manifests([complete, partial])
+    assert any("boxB is incomplete" in p and "b|NVFP4" in p for p in problems)
+
+
+def test_sentinel_compare_refuses_a_nondeterministic_match(tmp_path):
+    entries = {"a|NVFP4": {"sha256": "aa"}}
+    paths = []
+    for name, host in (("a.json", "boxA"), ("b.json", "boxB")):
+        path = tmp_path / name
+        path.write_text(
+            json.dumps(_manifest(entries, deterministic="0", host=host))
+        )
+        paths.append(str(path))
+    assert sentinel_tool.main(
+        ["compare", "--manifest", paths[0], "--manifest", paths[1]]
+    ) == 1
+
+
+def test_sentinel_compare_flags_a_deterministic_mode_disagreement():
+    a = _manifest({"a|NVFP4": {"sha256": "aa"}}, deterministic="1")
+    b = _manifest({"a|NVFP4": {"sha256": "aa"}}, deterministic="0")
+    problems = sentinel_tool.compare_manifests([a, b])
+    assert any("PRISMAQUANT_DETERMINISTIC differs" in p for p in problems)
+
+
+# --------------------------------------------------------------------------
+# streaming render path: shard filter at the dense-module enumeration seam
+# --------------------------------------------------------------------------
+class _StreamAttn(nn.Module):
+    def __init__(self, hidden):
+        super().__init__()
+        self.q_proj = nn.Linear(hidden, hidden, bias=False)
+        self.k_proj = nn.Linear(hidden, hidden, bias=False)
+        self.v_proj = nn.Linear(hidden, hidden, bias=False)
+        self.o_proj = nn.Linear(hidden, hidden, bias=False)
+
+    def forward(self, h):
+        return self.o_proj(self.q_proj(h) + self.k_proj(h) + self.v_proj(h))
+
+
+class _StreamLayer(nn.Module):
+    def __init__(self, hidden):
+        super().__init__()
+        self.self_attn = _StreamAttn(hidden)
+
+    def forward(self, h):
+        self.self_attn(h)
+        return h
+
+
+class _StreamInner(nn.Module):
+    def __init__(self, hidden, layers):
+        super().__init__()
+        self.layers = nn.ModuleList([_StreamLayer(hidden) for _ in range(layers)])
+
+    def forward(self, h):
+        for layer in self.layers:
+            h = layer(h)
+        return h
+
+
+class _StreamModel(nn.Module):
+    def __init__(self, hidden=16, layers=4):
+        super().__init__()
+        self.model = _StreamInner(hidden, layers)
+
+    def forward(self, h, **kw):
+        return self.model(h)
+
+
+def _stream_render(tmp_path, model, act_dir, tag, unit_shard=None):
+    from prismaquant.measure_quant_cost import ActivationIndex
+    from prismaquant.streaming_production_cache import run_streaming_render
+
+    out_dir = tmp_path / tag
+    out_dir.mkdir(parents=True, exist_ok=True)
+    dense = [
+        name for name, mod in model.named_modules()
+        if isinstance(mod, torch.nn.Linear)
+    ]
+    assignment = {name: "NVFP4" for name in dense}
+    return run_streaming_render(
+        model,
+        layers_prefix="model.layers.",
+        num_layers=4,
+        render_assignment=assignment,
+        act_index=ActivationIndex(act_dir, []),
+        formats=["NVFP4"],
+        levers={"gptq": False, "static_act_order": False,
+                "joint_scale_opt": False},
+        cache_dir_path=out_dir,
+        profile=None,
+        skip_tokens=[],
+        device=torch.device("cpu"),
+        expert_render_mode="batched",
+        progress=False,
+        unit_shard=unit_shard,
+    ), out_dir
+
+
+def test_streaming_shards_merge_to_the_unsharded_render(tmp_path):
+    import re
+
+    torch.manual_seed(0)
+    model = _StreamModel().to(dtype=torch.bfloat16).eval()
+    act_dir = tmp_path / "act"
+    act_dir.mkdir()
+    rows = torch.randn(32, 16, dtype=torch.bfloat16)
+    for name, mod in model.named_modules():
+        if not isinstance(mod, torch.nn.Linear):
+            continue
+        fname = re.sub(r"[^A-Za-z0-9_-]", "__", name) + ".pt"
+        torch.save({"inputs": rows.float(), "name": name}, act_dir / fname)
+
+    full, full_dir = _stream_render(tmp_path, model, act_dir, "full")
+    shard0, dir0 = _stream_render(
+        tmp_path, model, act_dir, "s0", us.ShardSpec(0, 2)
+    )
+    shard1, dir1 = _stream_render(
+        tmp_path, model, act_dir, "s1", us.ShardSpec(1, 2)
+    )
+
+    assert set(shard0.weights) | set(shard1.weights) == set(full.weights)
+    assert not (set(shard0.weights) & set(shard1.weights))
+    assert shard0.metadata["unit_shard"]["shard"] == "0/2"
+    assert (
+        shard0.metadata["unit_shard"]["partition_hash"]
+        == shard1.metadata["unit_shard"]["partition_hash"]
+    )
+    # layer atomicity: no layer appears in both shards
+    atoms0 = {us.atom_key(q) for q, _ in shard0.weights}
+    atoms1 = {us.atom_key(q) for q, _ in shard1.weights}
+    assert not (atoms0 & atoms1)
+
+    from prismaquant.production_weight_cache import _cache_weight_filename
+
+    for cache, cache_dir in ((shard0, dir0), (shard1, dir1)):
+        for key in cache.weights:
+            got = torch.load(
+                cache_dir / _cache_weight_filename(*key),
+                map_location="cpu", weights_only=True,
+            )
+            want = torch.load(
+                full_dir / _cache_weight_filename(*key),
+                map_location="cpu", weights_only=True,
+            )
+            assert torch.equal(got, want), f"{key} differs from the full render"
+
+
+# --------------------------------------------------------------------------
+# the reservoir coupling a unit shard depends on
+# --------------------------------------------------------------------------
+class _ResAttn(nn.Module):
+    def __init__(self, hidden):
+        super().__init__()
+        self.q_proj = nn.Linear(hidden, hidden, bias=False)
+        self.o_proj = nn.Linear(hidden, hidden, bias=False)
+
+    def forward(self, x):
+        return self.o_proj(self.q_proj(x))
+
+
+class _ResModel(nn.Module):
+    def __init__(self, hidden=64, layers=4):
+        super().__init__()
+        self.layers = nn.ModuleList([_ResAttn(hidden) for _ in range(layers)])
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+def test_stored_subset_keeps_the_full_runs_rows():
+    """A run that STORES a subset must sample the same rows as the full run.
+
+    One `torch.Generator` feeds every hooked Linear's priority reservoir, so
+    drawing only for stored Linears makes the surviving rows a function of
+    which other Linears the run happened to store. That is exactly what a
+    unit shard changes, and the rendered bytes follow the rows.
+    """
+    from prismaquant.production_weight_cache import _LinearActivationCollector
+
+    torch.manual_seed(0)
+    model = _ResModel().eval()
+    names = [
+        name for name, mod in model.named_modules()
+        if isinstance(mod, nn.Linear)
+    ]
+    assert len(names) == 8
+    subset = set(names[4:])
+    batches = [torch.randn(1, 40, 64) for _ in range(3)]  # 120 rows > max_rows
+
+    def collect(store):
+        collector = _LinearActivationCollector(
+            model, set(names), max_rows=16, store_qnames=store
+        )
+        collector.install()
+        try:
+            with torch.no_grad():
+                for batch in batches:
+                    model(batch)
+        finally:
+            collector.remove()
+        return collector.collected()
+
+    full = collect(set(names))
+    partial = collect(subset)
+    assert set(partial) == subset
+    for name in sorted(subset):
+        assert torch.equal(full[name], partial[name]), (
+            f"{name} sampled different rows when only a subset was stored"
+        )

--- a/tools/cluster_render_sentinel.py
+++ b/tools/cluster_render_sentinel.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Cross-box determinism preflight for a unit-sharded distributed render.
+
+A distributed render is only correct if both boxes turn the same source
+weight into the same bytes. Same GB10, same wheel, same levers — expected
+bit-identical; but "expected" is not measured, and a render that differs
+across boxes turns a merged cache into two half-artifacts wearing one name.
+So the campaign runs this first, on both boxes, and refuses to launch unless
+the manifests match exactly.
+
+    # on each box
+    python tools/cluster_render_sentinel.py render \\
+        --model /home/rob/models/Qwen3-0.6B \\
+        --k 8 --formats NVFP4,FP8_DYNAMIC \\
+        --output /work/sentinel-$(hostname).json
+
+    # on the coordinator
+    python tools/cluster_render_sentinel.py compare \\
+        --manifest /work/sentinel-boxA.json \\
+        --manifest /work/sentinel-boxB.json
+
+``compare`` exits non-zero on ANY mismatch and names the first differing
+units. The unit pick is deterministic (evenly spaced over the model's own
+enumeration order), so both boxes render the same K units without
+coordination.
+
+Determinism note: ``PRISMAQUANT_DETERMINISTIC=1`` is what makes the GPTQ
+Cholesky/U-update reduction order reproducible (see
+``build_production_cache.py``). The sentinel records whether it was set and
+``compare`` refuses to certify two manifests that disagree about it — a
+cross-box match under nondeterministic reductions is luck, and a mismatch
+under them is uninformative.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import torch  # noqa: E402
+import torch.nn as nn  # noqa: E402
+
+SCHEMA = "prismaquant.cluster_render_sentinel.v1"
+
+
+def select_sentinel_units(qnames, k: int) -> list[str]:
+    """Deterministically pick K units, evenly spaced over the enumeration.
+
+    Even spacing (rather than the first K) makes the pick span the depth of
+    the model, so a divergence confined to late layers is still caught.
+    """
+    names = [str(name) for name in qnames]
+    if k < 1:
+        raise ValueError("k must be >= 1")
+    if k >= len(names):
+        return names
+    step = len(names) / float(k)
+    picked: list[str] = []
+    for i in range(k):
+        index = int(i * step)
+        if names[index] not in picked:
+            picked.append(names[index])
+    return picked
+
+
+def _tensor_digest(tensor: torch.Tensor) -> dict:
+    contiguous = tensor.detach().cpu().contiguous()
+    payload = contiguous.reshape(-1).view(torch.uint8).numpy().tobytes()
+    return {
+        "dtype": str(contiguous.dtype),
+        "shape": list(contiguous.shape),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+    }
+
+
+def _render(args) -> int:
+    from prismaquant.build_rtn_cache import iter_quantizable_tensors
+    from prismaquant.calibration_data import (
+        _dtype_from_name,
+        load_wikitext_calibration_windowed,
+    )
+    from prismaquant.gpu_guard import require_cuda_hot_path
+    from prismaquant.model_profiles import detect_profile_with_warning
+    from prismaquant.perturbed_x_cache import calibration_data_hash
+    from prismaquant.production_weight_cache import (
+        fill_production_weight_cache,
+    )
+    from prismaquant.unit_sharding import host_identity
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    device = require_cuda_hot_path("cluster_render_sentinel")
+    formats = [f.strip().upper() for f in args.formats.split(",") if f.strip()]
+    levers = {
+        name: True
+        for name in (x.strip() for x in args.enable.split(","))
+        if name
+    }
+    dtype = _dtype_from_name(args.dtype)
+
+    local_only = Path(args.model).exists()
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.model, trust_remote_code=True, local_files_only=local_only
+    )
+    calib_ids = load_wikitext_calibration_windowed(
+        tokenizer,
+        args.n_calib_samples,
+        args.calib_seqlen,
+        split=args.calib_split,
+        seed=args.calib_seed,
+    )
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model,
+        torch_dtype=dtype,
+        trust_remote_code=True,
+        local_files_only=local_only,
+        device_map="cuda" if device.type == "cuda" else None,
+    )
+    model.eval()
+    profile = detect_profile_with_warning(
+        args.model, entrypoint="cluster-render-sentinel"
+    )
+    skip_tokens = list(profile.pinned_names())
+    qnames: list[str] = []
+    for full_name, mod, attr in iter_quantizable_tensors(model, profile):
+        if attr != "weight" or not isinstance(mod, nn.Linear):
+            continue
+        qname = (
+            full_name[:-7] if full_name.endswith(".weight") else full_name
+        )
+        if any(s in qname.split(".") for s in skip_tokens):
+            continue
+        qnames.append(qname)
+
+    picked = select_sentinel_units(qnames, args.k)
+    print(
+        f"[sentinel] rendering {len(picked)} of {len(qnames)} units x "
+        f"{formats}",
+        flush=True,
+    )
+    # Pass the FULL enumeration and render only the picked units. The
+    # activation reservoir is shared across hooked Linears, so a run that
+    # hooked only K units would sample different rows and the sentinel would
+    # be certifying bytes the real build never produces. `render_qnames`
+    # narrows the render and nothing else.
+    cache = fill_production_weight_cache(
+        model,
+        calib_ids,
+        qnames,
+        formats=formats,
+        levers=levers,
+        max_act_rows=args.max_act_rows,
+        progress=False,
+        render_qnames=picked,
+    )
+    entries = {
+        f"{qname}|{fmt}": _tensor_digest(cache.get(qname, fmt))
+        for (qname, fmt) in sorted(cache.weights)
+    }
+    # Fail closed on a partial render. The cache fill can drop a (unit,
+    # format) it could not render (2026-08-23: sparklina lacked python3-dev,
+    # Triton could not build, every NVFP4 entry was silently absent while
+    # the FP8 entries matched); a manifest that omits them would certify a
+    # box that cannot render the format at all.
+    missing = missing_entries({"units": picked, "formats": formats,
+                               "entries": entries})
+    if missing:
+        print(
+            "[sentinel] ERROR: incomplete render — refusing to write a "
+            f"manifest. {len(missing)} of {len(picked) * len(formats)} "
+            f"(unit, format) pairs did not render on this box: "
+            f"{missing[:8]}. Look for build/toolchain errors above.",
+            flush=True,
+        )
+        return 2
+    records = (cache.metadata or {}).get("render_scores") or {}
+    payload = {
+        "schema": SCHEMA,
+        "model": str(args.model),
+        "formats": formats,
+        "levers": sorted(k for k, v in levers.items() if v),
+        "k": int(args.k),
+        "units": picked,
+        "calibration": {
+            "n_calib_samples": int(args.n_calib_samples),
+            "calib_seqlen": int(args.calib_seqlen),
+            "calib_split": str(args.calib_split),
+            "calib_seed": int(args.calib_seed),
+            "max_act_rows": int(args.max_act_rows),
+            "calib_hash": calibration_data_hash(calib_ids),
+        },
+        "deterministic_mode": os.environ.get(
+            "PRISMAQUANT_DETERMINISTIC", "0"
+        ),
+        "host": host_identity(),
+        "entries": entries,
+        "render_scores": dict(sorted((records.get("records") or {}).items())),
+    }
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    print(
+        f"[sentinel] wrote {output} entries={len(entries)} "
+        f"digest={_manifest_digest(payload)[:16]}",
+        flush=True,
+    )
+    return 0
+
+
+def _manifest_digest(payload) -> str:
+    comparable = {
+        key: payload[key]
+        for key in ("schema", "formats", "levers", "units", "entries")
+    }
+    return hashlib.sha256(
+        json.dumps(comparable, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def missing_entries(manifest) -> list[str]:
+    """(unit, format) keys a manifest promises but did not render.
+
+    Entries are keyed by the cache's canonical format name (the CLI alias
+    FP8_DYNAMIC renders as FP8_E4M3), so requested formats are canonicalized
+    before they are looked up.
+    """
+    try:
+        from prismaquant.format_registry import canonical_format_name
+    except ImportError:  # compare-only hosts without the package
+        def canonical_format_name(name):
+            return name
+    expected = {
+        f"{unit}|{canonical_format_name(fmt)}"
+        for unit in manifest.get("units") or []
+        for fmt in manifest.get("formats") or []
+    }
+    return sorted(expected - set(manifest.get("entries") or {}))
+
+
+def compare_manifests(manifests) -> list[str]:
+    """Return the list of problems; empty means the boxes agree."""
+    problems: list[str] = []
+    for index, manifest in enumerate(manifests):
+        missing = missing_entries(manifest)
+        if missing:
+            host = (manifest.get("host") or {}).get("hostname", f"#{index}")
+            problems.append(
+                f"manifest {host} is incomplete: {len(missing)} of its "
+                f"promised (unit, format) pairs are absent: {missing[:8]}"
+            )
+    first = manifests[0]
+    for other in manifests[1:]:
+        for field in ("schema", "formats", "levers", "units", "k"):
+            if first.get(field) != other.get(field):
+                problems.append(
+                    f"{field} differs: {first.get(field)!r} vs "
+                    f"{other.get(field)!r}"
+                )
+        if first.get("calibration") != other.get("calibration"):
+            problems.append(
+                "calibration contract differs: "
+                f"{first.get('calibration')!r} vs {other.get('calibration')!r}"
+            )
+        if str(first.get("deterministic_mode")) != str(
+            other.get("deterministic_mode")
+        ):
+            problems.append(
+                "PRISMAQUANT_DETERMINISTIC differs across boxes: "
+                f"{first.get('deterministic_mode')!r} vs "
+                f"{other.get('deterministic_mode')!r}"
+            )
+        a_entries = first.get("entries") or {}
+        b_entries = other.get("entries") or {}
+        only_a = sorted(set(a_entries) - set(b_entries))
+        only_b = sorted(set(b_entries) - set(a_entries))
+        if only_a:
+            problems.append(f"entries only in the first manifest: {only_a[:8]}")
+        if only_b:
+            problems.append(f"entries only in a later manifest: {only_b[:8]}")
+        differing = sorted(
+            key
+            for key in set(a_entries) & set(b_entries)
+            if a_entries[key] != b_entries[key]
+        )
+        if differing:
+            sample = ", ".join(
+                f"{key} {a_entries[key].get('sha256', '')[:12]} != "
+                f"{b_entries[key].get('sha256', '')[:12]}"
+                for key in differing[:5]
+            )
+            problems.append(
+                f"{len(differing)} of {len(a_entries)} rendered units differ: "
+                f"{sample}"
+            )
+    return problems
+
+
+def _compare(args) -> int:
+    manifests = [json.loads(Path(p).read_text()) for p in args.manifest]
+    if len(manifests) < 2:
+        raise SystemExit(
+            "[sentinel] ERROR: --manifest must be given at least twice."
+        )
+    problems = compare_manifests(manifests)
+    if problems:
+        print("[sentinel] CROSS-BOX RENDER MISMATCH — refuse the run:")
+        for problem in problems:
+            print(f"  - {problem}")
+        return 1
+    if str(manifests[0].get("deterministic_mode", "0")).lower() not in {
+        "1",
+        "true",
+        "yes",
+    }:
+        print(
+            "[sentinel] CROSS-BOX RENDER MISMATCH — refuse the run:\n"
+            "  - manifests match but were rendered with "
+            "PRISMAQUANT_DETERMINISTIC unset; the GPTQ reduction order is "
+            "not reproducible, so the match does not certify anything. "
+            "Re-run both boxes with PRISMAQUANT_DETERMINISTIC=1."
+        )
+        return 1
+    hosts = [m.get("host", {}).get("hostname") for m in manifests]
+    print(
+        f"[sentinel] OK: {len(manifests)} manifests agree on "
+        f"{len(manifests[0].get('entries') or {})} rendered units "
+        f"(hosts={hosts}, "
+        f"digest={_manifest_digest(manifests[0])[:16]})"
+    )
+    return 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    render = sub.add_parser("render", help="Render K fixed units, emit a manifest.")
+    render.add_argument("--model", required=True)
+    render.add_argument("--output", required=True)
+    render.add_argument("--k", type=int, default=8)
+    render.add_argument("--formats", default="NVFP4,FP8_DYNAMIC")
+    render.add_argument(
+        "--enable", default="gptq,static_act_order,joint_scale_opt"
+    )
+    render.add_argument("--n-calib-samples", type=int, default=8)
+    render.add_argument("--calib-seqlen", type=int, default=256)
+    render.add_argument("--calib-split", default="train")
+    render.add_argument("--calib-seed", type=int, default=42)
+    render.add_argument("--max-act-rows", type=int, default=512)
+    render.add_argument("--dtype", default="bf16")
+    render.set_defaults(func=_render)
+
+    compare = sub.add_parser("compare", help="Diff two or more manifests.")
+    compare.add_argument("--manifest", action="append", required=True)
+    compare.set_defaults(func=_compare)
+
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/merge_unit_shards.py
+++ b/tools/merge_unit_shards.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+"""Merge unit-sharded ProductionWeightCache renders into one canonical cache.
+
+Parallel producer v1 splits a render-bound cache build across boxes by unit
+(``PRISMAQUANT_UNIT_SHARD=i/N``, see ``prismaquant/unit_sharding.py``). This
+tool puts the pieces back together into the SAME ``ProductionWeightCache``
+layout the unsharded stage writes — no parallel store, no new consumer.
+
+The completeness gate is fail-closed and is the whole point of the tool. A
+distributed render that quietly dropped a unit would produce a cost table
+where that unit falls back to a different estimator, or an export that RTNs a
+Linear by omission — both are silent-quality failures that no downstream gate
+would name. So: every unit of the full enumeration must be accounted for
+exactly once, by the shard the deterministic partition says owns it. Missing,
+duplicated, or out-of-shard units are hard errors that name the units. There
+is no ``--force``, no zero-fill, and no "merge what we have".
+
+Usage:
+
+    python tools/merge_unit_shards.py merge \\
+        --shard /work/shard0/production_cache.pkl \\
+        --shard /work/shard1/production_cache.pkl \\
+        --output /work/artifacts/production_cache.pkl \\
+        --output-cache-dir /work/artifacts/production_cache_dir
+
+    python tools/merge_unit_shards.py digest \\
+        --cache /work/artifacts/production_cache.pkl \\
+        --output /work/artifacts/production_cache.digest.json
+
+``digest`` writes the content manifest used to byte-compare a merged cache
+against the unsharded reference: per ``(qname, format)`` SHA-256 over the
+rendered tensor's exact bytes plus dtype/shape, the render-score records, and
+``activation_max_abs``. It deliberately does NOT hash the pickle container —
+a merged cache carries provenance an unsharded one cannot (which boxes
+rendered what), and container bytes are not a stable equality test anyway.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pickle
+import shutil
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import torch  # noqa: E402
+
+from prismaquant import format_registry as fr  # noqa: E402
+from prismaquant.unit_sharding import (  # noqa: E402
+    SCHEMA as SHARD_SCHEMA,
+    owed_pairs_from_stamp,
+    partition_from_stamp,
+)
+
+MERGE_SCHEMA = "prismaquant.unit_shard_merge.v1"
+DIGEST_SCHEMA = "prismaquant.production_cache_digest.v1"
+
+
+def _load_cache(path: Path):
+    with open(path, "rb") as fh:
+        return pickle.load(fh)
+
+
+def _metadata(cache) -> Mapping:
+    meta = getattr(cache, "metadata", None)
+    return meta if isinstance(meta, Mapping) else {}
+
+
+def _shard_stamp(cache, path: Path) -> Mapping:
+    stamp = _metadata(cache).get("unit_shard")
+    if not isinstance(stamp, Mapping):
+        raise SystemExit(
+            f"[merge-unit-shards] ERROR: {path} carries no 'unit_shard' "
+            "stamp. It was not produced with PRISMAQUANT_UNIT_SHARD set, so "
+            "there is nothing to merge — use it directly."
+        )
+    if str(stamp.get("schema")) != SHARD_SCHEMA:
+        raise SystemExit(
+            f"[merge-unit-shards] ERROR: {path} has unit-shard schema "
+            f"{stamp.get('schema')!r}, expected {SHARD_SCHEMA!r}."
+        )
+    return stamp
+
+
+def _resolve_weight_bytes(cache, key, base_dir: Path | None):
+    """Return (tensor, on_disk_filename_or_None) for one cache entry."""
+    value = cache.weights[key]
+    if isinstance(value, str):
+        if base_dir is None:
+            raise SystemExit(
+                f"[merge-unit-shards] ERROR: entry {key} is a path reference "
+                f"({value!r}) but its cache has no cache_dir."
+            )
+        path = base_dir / value
+        if not path.is_file():
+            raise SystemExit(
+                f"[merge-unit-shards] ERROR: entry {key} references missing "
+                f"shard file {path}"
+            )
+        return None, value
+    return value, None
+
+
+def _tensor_digest(tensor: torch.Tensor) -> dict:
+    contiguous = tensor.detach().cpu().contiguous()
+    # Reinterpret as bytes: numpy has no bfloat16, and the comparison this
+    # feeds is about exact rendered bytes, not about a float view of them.
+    payload = contiguous.reshape(-1).view(torch.uint8).numpy().tobytes()
+    return {
+        "dtype": str(contiguous.dtype),
+        "shape": list(contiguous.shape),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+    }
+
+
+def _entry_digest(cache, key, base_dir: Path | None) -> dict:
+    value = cache.weights[key]
+    if isinstance(value, str):
+        tensor = torch.load(
+            base_dir / value, map_location="cpu", weights_only=True
+        )
+    else:
+        tensor = value
+    return _tensor_digest(tensor)
+
+
+def _canonical_unit_order(stamps) -> list[str]:
+    partition = partition_from_stamp(stamps[0])
+    return [name for name, _ in partition.units]
+
+
+def _gate_shards(stamps, paths) -> None:
+    """Fail closed unless the shards are exactly one complete partition."""
+    hashes = {str(stamp["partition_hash"]) for stamp in stamps}
+    if len(hashes) != 1:
+        detail = ", ".join(
+            f"{path.name}={stamp['partition_hash'][:16]}"
+            for stamp, path in zip(stamps, paths)
+        )
+        raise SystemExit(
+            "[merge-unit-shards] ERROR: shards do not share one partition; "
+            f"partition_hash differs ({detail}). They split different unit "
+            "enumerations and cannot be merged."
+        )
+    counts = {int(stamp["shard_count"]) for stamp in stamps}
+    if len(counts) != 1:
+        raise SystemExit(
+            f"[merge-unit-shards] ERROR: shards disagree on shard_count: "
+            f"{sorted(counts)}"
+        )
+    count = counts.pop()
+    if len(stamps) != count:
+        raise SystemExit(
+            f"[merge-unit-shards] ERROR: partition declares {count} shards "
+            f"but {len(stamps)} were supplied."
+        )
+    indices = [int(stamp["shard_index"]) for stamp in stamps]
+    if sorted(indices) != list(range(count)):
+        raise SystemExit(
+            f"[merge-unit-shards] ERROR: shard indices {sorted(indices)} are "
+            f"not exactly 0..{count - 1}; missing or duplicated shards."
+        )
+
+    partition = partition_from_stamp(stamps[0])
+    for stamp in stamps:
+        index = int(stamp["shard_index"])
+        expected = list(partition.shards[index])
+        observed = [str(name) for name in stamp["unit_names"]]
+        if observed != expected:
+            missing = sorted(set(expected) - set(observed))
+            extra = sorted(set(observed) - set(expected))
+            raise SystemExit(
+                f"[merge-unit-shards] ERROR: shard {stamp['shard']} unit list "
+                "does not match the recomputed partition slice; "
+                f"missing={missing[:8]} extra={extra[:8]}"
+            )
+
+
+def _expected_pairs(cache, stamp, assignment) -> set[tuple[str, str]]:
+    """The (qname, format) entries this shard was supposed to produce.
+
+    A shard produced by a current build states its own debt in the stamp
+    (``owed_pairs``), recorded from the same format map its render loop
+    consumed. That is authoritative and keeps the operator's layer config out
+    of the trust path. The reconstruction below is the fallback for stamps
+    that predate the field.
+    """
+    stamped = owed_pairs_from_stamp(stamp)
+    if stamped is not None:
+        return stamped
+    owned = [str(name) for name in stamp["unit_names"]]
+    meta = _metadata(cache)
+    scope = str(meta.get("render_scope", ""))
+    if scope == "assignment":
+        if assignment is None:
+            raise SystemExit(
+                "[merge-unit-shards] ERROR: assignment-scope shards require "
+                "--render-layer-config so the merge knows which (unit, "
+                "format) entries were owed."
+            )
+        pairs = set()
+        for qname in owned:
+            fmt = assignment.get(qname)
+            if fmt is None:
+                continue
+            fmt_canon = fr.canonical_format_name(str(fmt))
+            if fmt_canon == "BF16":
+                continue
+            pairs.add((qname, fmt_canon))
+        return pairs
+    formats = [
+        fr.canonical_format_name(str(fmt))
+        for fmt in (meta.get("requested_formats") or [])
+    ]
+    formats = [fmt for fmt in formats if fmt != "BF16"]
+    if not formats:
+        raise SystemExit(
+            "[merge-unit-shards] ERROR: shard "
+            f"{stamp['shard']} records no requested_formats; cannot decide "
+            "what it owed."
+        )
+    return {(qname, fmt) for qname in owned for fmt in formats}
+
+
+def _merge(args) -> int:
+    paths = [Path(p) for p in args.shard]
+    if len(paths) < 2:
+        raise SystemExit(
+            "[merge-unit-shards] ERROR: --shard must be given at least twice."
+        )
+    caches = [_load_cache(path) for path in paths]
+    stamps = [_shard_stamp(cache, path) for cache, path in zip(caches, paths)]
+    _gate_shards(stamps, paths)
+
+    assignment = None
+    if args.render_layer_config:
+        from prismaquant.layer_config import load_assignment
+
+        assignment = load_assignment(args.render_layer_config)
+
+    order = {name: i for i, name in enumerate(_canonical_unit_order(stamps))}
+    owner_by_unit: dict[str, int] = {}
+    for stamp in stamps:
+        for name in stamp["unit_names"]:
+            owner_by_unit[str(name)] = int(stamp["shard_index"])
+
+    merged_weights: dict[tuple[str, str], object] = {}
+    seen_from: dict[tuple[str, str], str] = {}
+    duplicates: list[str] = []
+    out_of_shard: list[str] = []
+    missing: list[str] = []
+    failed: dict[tuple[str, str], str] = {}
+    render_scores: dict[str, dict] = {}
+    gate_records: list[dict] = []
+    activation_max_abs: dict[str, float] = {}
+    max_abs_conflicts: list[str] = []
+
+    output_dir = Path(args.output_cache_dir) if args.output_cache_dir else None
+    if output_dir is not None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    for cache, stamp, path in zip(caches, stamps, paths):
+        label = str(stamp["shard"])
+        owned = set(str(name) for name in stamp["unit_names"])
+        base_dir = Path(cache.cache_dir) if cache.cache_dir else path.parent
+        expected = _expected_pairs(cache, stamp, assignment)
+        observed = set(cache.weights)
+        for key in sorted(observed, key=lambda k: (order.get(k[0], 1 << 30), k)):
+            qname, fmt = str(key[0]), str(key[1])
+            if qname not in owned:
+                out_of_shard.append(f"{qname}@{fmt} in shard {label}")
+                continue
+            if key in seen_from:
+                duplicates.append(
+                    f"{qname}@{fmt} in shards {seen_from[key]} and {label}"
+                )
+                continue
+            seen_from[key] = label
+            tensor, filename = _resolve_weight_bytes(cache, key, base_dir)
+            if filename is not None:
+                if output_dir is None:
+                    raise SystemExit(
+                        "[merge-unit-shards] ERROR: shards are disk-streamed "
+                        "(cache_dir set); --output-cache-dir is required."
+                    )
+                destination = output_dir / filename
+                source = base_dir / filename
+                if destination.resolve() != source.resolve():
+                    if destination.exists():
+                        destination.unlink()
+                    try:
+                        os.link(source, destination)
+                    except OSError:
+                        shutil.copy2(source, destination)
+                merged_weights[key] = filename
+            else:
+                merged_weights[key] = tensor
+        for owed in sorted(expected - observed):
+            missing.append(f"{owed[0]}@{owed[1]} owed by shard {label}")
+        for key, error in (cache.failed or {}).items():
+            failed[(str(key[0]), str(key[1]))] = str(error)
+        records = _metadata(cache).get("render_scores")
+        if isinstance(records, Mapping):
+            for record_key, record in (records.get("records") or {}).items():
+                if record_key in render_scores:
+                    duplicates.append(f"render score {record_key} in {label}")
+                    continue
+                render_scores[str(record_key)] = dict(record)
+        gates = _metadata(cache).get("render_gates")
+        if isinstance(gates, Mapping):
+            for record in gates.get("records") or []:
+                if isinstance(record, Mapping):
+                    gate_records.append(dict(record))
+        for qname, value in (cache.activation_max_abs or {}).items():
+            previous = activation_max_abs.get(str(qname))
+            if previous is not None and float(previous) != float(value):
+                max_abs_conflicts.append(
+                    f"{qname}: {previous!r} vs {value!r}"
+                )
+            activation_max_abs[str(qname)] = float(value)
+
+    problems: list[str] = []
+    if missing:
+        problems.append(
+            f"{len(missing)} missing entries: {missing[:8]}"
+        )
+    if duplicates:
+        problems.append(
+            f"{len(duplicates)} duplicate entries: {duplicates[:8]}"
+        )
+    if out_of_shard:
+        problems.append(
+            f"{len(out_of_shard)} entries outside their shard: "
+            f"{out_of_shard[:8]}"
+        )
+    if failed:
+        problems.append(
+            f"{len(failed)} failed renders: {sorted(failed)[:8]}"
+        )
+    if max_abs_conflicts:
+        # Every shard computes activation_max_abs over the FULL enumeration,
+        # so disagreement means the shards did not see the same calibration
+        # forward — the render bytes cannot be assumed comparable either.
+        problems.append(
+            f"{len(max_abs_conflicts)} activation_max_abs disagreements "
+            f"across shards: {max_abs_conflicts[:8]}"
+        )
+    if problems:
+        raise SystemExit(
+            "[merge-unit-shards] ERROR: completeness gate failed.\n  "
+            + "\n  ".join(problems)
+        )
+
+    # Canonical insertion order: full-enumeration unit order, then the
+    # requested-format order — which is exactly the order an unsharded run
+    # inserts its keys in. A merge that appended shard-by-shard, or that
+    # sorted formats alphabetically, would produce a different pickle for the
+    # same content and defeat any container-level comparison downstream.
+    format_rank = {
+        fr.canonical_format_name(str(fmt)): i
+        for i, fmt in enumerate(_metadata(caches[0]).get("requested_formats") or [])
+    }
+    ordered_weights = {
+        key: merged_weights[key]
+        for key in sorted(
+            merged_weights,
+            key=lambda k: (
+                order.get(k[0], 1 << 30),
+                format_rank.get(k[1], 1 << 30),
+                k[1],
+            ),
+        )
+    }
+
+    from prismaquant.production_weight_cache import (
+        ProductionWeightCache,
+        _summarize_render_gate_records,
+        _write_render_score_sidecar,
+    )
+
+    reference_meta = dict(_metadata(caches[0]))
+    reference_meta.pop("unit_shard", None)
+    # Re-derive the render-gate summary over EVERY shard's records. Inheriting
+    # shard 0's counters would label one shard's tally as the whole run's.
+    gate_records.sort(
+        key=lambda rec: (
+            order.get(str(rec.get("qname", "")), 1 << 30),
+            format_rank.get(str(rec.get("format", "")), 1 << 30),
+            str(rec.get("format", "")),
+        )
+    )
+    gate_summary = _summarize_render_gate_records(gate_records)
+    reference_meta["render_gates"] = {**gate_summary, "records": gate_records}
+    mechanisms = gate_summary.get("mechanisms") or {}
+    reference_meta["four_over_six"] = dict(
+        mechanisms.get("four_over_six")
+        or {"accepted": 0, "rejected": 0, "package_accepted": 0, "reasons": {}}
+    )
+    reference_meta["render_scores"] = {
+        "schema": "prismaquant.production_render_scores.v1",
+        "entries": int(len(render_scores)),
+        "records": dict(sorted(render_scores.items())),
+        "cost_semantics": (
+            (_metadata(caches[0]).get("render_scores") or {}).get(
+                "cost_semantics", ""
+            )
+        ),
+    }
+    reference_meta["requested_entries"] = int(len(ordered_weights))
+    reference_meta["render_failures"] = {}
+    reference_meta["unit_shard_merge"] = {
+        "schema": MERGE_SCHEMA,
+        "partition_hash": str(stamps[0]["partition_hash"]),
+        "shard_count": int(stamps[0]["shard_count"]),
+        "total_units": int(stamps[0]["total_units"]),
+        "merged_entries": int(len(ordered_weights)),
+        "shards": [
+            {
+                "shard": str(stamp["shard"]),
+                "unit_count": int(stamp["unit_count"]),
+                "shard_bytes": int(stamp["shard_bytes"]),
+                "source": str(path),
+                "host": dict(stamp.get("host") or {}),
+                "calib_hash": _metadata(cache).get("calib_hash"),
+            }
+            for stamp, path, cache in sorted(
+                zip(stamps, paths, caches),
+                key=lambda item: int(item[0]["shard_index"]),
+            )
+        ],
+    }
+
+    merged = ProductionWeightCache(
+        weights=ordered_weights,
+        levers=dict(caches[0].levers),
+        activation_max_abs=activation_max_abs or None,
+        failed={},
+        cache_dir=str(output_dir) if output_dir is not None else None,
+        metadata=reference_meta,
+    )
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "wb") as fh:
+        pickle.dump(merged, fh, protocol=pickle.HIGHEST_PROTOCOL)
+    if output_dir is not None:
+        # Write the sidecars through the SAME writer the unsharded stage uses.
+        # A merged cache_dir has to be resumable and re-readable exactly like
+        # an unsharded one; a bare records dict here is silently discarded by
+        # `_load_render_score_sidecar`, which reads `payload["records"]`.
+        _write_render_score_sidecar(
+            output_dir / "render_scores.json", render_scores
+        )
+        (output_dir / "activation_max_abs.json").write_text(
+            json.dumps(
+                {
+                    name: activation_max_abs[name]
+                    for name in sorted(
+                        activation_max_abs, key=lambda n: order.get(n, 1 << 30)
+                    )
+                },
+                indent=2,
+            )
+        )
+    print(
+        f"[merge-unit-shards] merged {len(stamps)} shards -> {output_path} "
+        f"({len(ordered_weights)} entries, {len(render_scores)} render "
+        f"scores, partition_hash={str(stamps[0]['partition_hash'])[:16]})",
+        flush=True,
+    )
+    if args.digest_json:
+        _write_digest(merged, Path(args.digest_json))
+    return 0
+
+
+def _write_digest(cache, output_path: Path) -> dict:
+    base_dir = Path(cache.cache_dir) if cache.cache_dir else None
+    entries = {
+        f"{qname}|{fmt}": _entry_digest(cache, (qname, fmt), base_dir)
+        for (qname, fmt) in sorted(cache.weights)
+    }
+    records = _metadata(cache).get("render_scores")
+    scores = dict(sorted((records or {}).get("records", {}).items()))
+    payload = {
+        "schema": DIGEST_SCHEMA,
+        "entries": entries,
+        "entry_count": len(entries),
+        "render_scores": scores,
+        "activation_max_abs": dict(
+            sorted((cache.activation_max_abs or {}).items())
+        ),
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    print(
+        f"[merge-unit-shards] digest {output_path} entries={len(entries)} "
+        f"manifest_sha256={digest}",
+        flush=True,
+    )
+    return payload
+
+
+def _digest(args) -> int:
+    cache = _load_cache(Path(args.cache))
+    _write_digest(cache, Path(args.output))
+    return 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    merge = sub.add_parser(
+        "merge", help="Merge N unit-shard caches into one canonical cache."
+    )
+    merge.add_argument("--shard", action="append", required=True)
+    merge.add_argument("--output", required=True)
+    merge.add_argument("--output-cache-dir", default=None)
+    merge.add_argument(
+        "--render-layer-config",
+        default=None,
+        help="Required for assignment-scope shards: the concrete assignment "
+        "that says which (unit, format) entries each shard owed.",
+    )
+    merge.add_argument("--digest-json", default=None)
+    merge.set_defaults(func=_merge)
+
+    digest = sub.add_parser(
+        "digest", help="Write a content digest manifest for one cache."
+    )
+    digest.add_argument("--cache", required=True)
+    digest.add_argument("--output", required=True)
+    digest.set_defaults(func=_digest)
+
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
> ## 🚧 BLOCKED — draft, do not merge
>
> This PR changes `prismaquant/production_weight_cache.py` (+150/-1), which is inside the **DSv4 W8A16 frozen export-source closure**. It needs Rob's **reviewed** re-freeze. `tests/test_dsv4_w8a16_export_handoff.py` is red on this branch **by design** — that is the gate firing, not a defect in the split.
>
> The change to review:
> ```
> git diff 90cd143 9cd25af -- prismaquant/production_weight_cache.py
> ```
> Three things in it: the `unit_shard` / `render_qnames` parameters, the shard stamp, and the `_LinearActivationCollector` reservoir-draw change (from `5a8303b`).
>
> A reviewed re-freeze to `03bb1aa4c71b59f2cc92c830b561b3911d19120600c18052c95c5c7607ea0894` closes it. **I did not attempt the re-freeze** — blind re-stamping is exactly the band-aid that gate exists to prevent.
>
> Verified on the rebase: the file's digest on this branch is byte-identical to the digest recorded as owed on `merge/proven-rescues`, so rebasing onto current `main` did **not** move the review target.

Split 5 of 6 from `merge/proven-rescues` (#95).

## What it does

Splits a dense production-cache render across boxes. `PRISMAQUANT_UNIT_SHARD=i/N` partitions the render on a deterministic, layer-contiguous, exact-byte-balanced split (`prismaquant/unit_sharding.py`), and `tools/merge_unit_shards.py` reassembles the shards into the same `ProductionWeightCache` under a fail-closed completeness gate. The merged `cache_dir` is byte-identical to an unsharded one.

**Each shard stamps the `(unit, format)` entries it owed**, so the merge gate reads the shard's own debt rather than an operator-supplied layer config. That is the difference between a gate and a hope: an operator-supplied enumeration can be wrong in the same direction as the mistake it is meant to catch.

`tools/cluster_render_sentinel.py` certifies a shard's render before it is merged, refusing a partial render instead of certifying it, and keys its completeness check by the **canonical** format name. It ships here rather than with the other cluster tools (#102) because it imports `prismaquant.unit_sharding` and was born in the same commit.

`production_render_cost`, `production_recache` and packed-expert renders **refuse** the variable rather than pretending to shard.

The merge tool re-derives the render-gate summary over **every** shard's records; inheriting shard 0's counters would label one shard's tally as the whole run's.

## Why it is worth landing

It is the mechanism that makes the second Spark useful for producing rather than only for serving. It also fixes a real reproducibility bug on the way (below).

## What it touches that is live

This is the only PR in the split that touches the render hot path: `production_weight_cache.py`, `build_production_cache.py`, `production_recache.py`, `production_render_cost.py`, `activation_sampling.py`, `streaming_production_cache.py`.

No default changes and `run-pipeline.sh` is untouched. **Unset is a byte-identical no-op**, verified on Qwen3-0.6B.

The substantive behaviour change is inside `_LinearActivationCollector`: row-priority reservoir values are now drawn for **every** hooked Linear rather than only for the ones a run stores. That also fixes resumed builds which did not reproduce a fresh build's sampled rows. (`--include-qnames-file` shrinks the hooked set itself, upstream of this fix, and still changes sampled rows.)

That reservoir change is one of the two pieces the freeze review has to look at, because it is **not** gated behind an unset parameter.

## Dependencies

- **None on the other five.** It can rebase onto `main` alone once unblocked.
- #102 mentions this PR because the third cluster tool lives here.
- One conflict with `main` was resolved: `build_production_cache.py`'s coverage narrowing now applies shard filtering **first**, then `--include-qnames-file`, in the same order the streaming path applies them. This matches the resolution the earlier worker made in `d53bf4c` on the original branch.

## Tests

`origin/main` (`8461ae2`) baseline, **measured on that exact commit**: **5494 passed, 143 skipped, 3 xfailed, 179 subtests passed, 0 failed** — `EXIT=0`, fully green (14m22s).
Identical to the earlier `4cd8d39` baseline, as expected: the three commits `main` gained
mid-split (`1d35f70`, `22db4fb`, `8461ae2`) touch only `.github/`, `pyproject.toml` and
`docs/` — **zero delta under `prismaquant/`, `tests/`, `tools/` or `scripts/`**, verified by diff.
Note for the reviewer: the brief for this split warned of "4 pre-existing aarch64 failures".
They **do not reproduce** — #90 and #94 already fixed them — so every failure below is attributable.

This branch: **2 failed, 5546 passed**, 143 skipped, 3 xfailed, 179 subtests passed (19m22s). Both failures are the declared blocker at the top of this PR — the freeze gate naming exactly `prismaquant/production_weight_cache.py` at exactly `03bb1aa4c71b59f2cc92c830b561b3911d19120600c18052c95c5c7607ea0894`, the digest recorded as owed. **Everything else is green.**

New coverage: `tests/test_unit_sharding.py` (825 lines).


## Merge-order note (applies to all six)

Every PR in this split adds its own stamp to the top of `docs/ARCHITECTURE.md`'s
provenance block (principle 13). Whichever merges second will therefore hit a
**textual conflict in that block and nowhere else** — resolution is to keep both
stamps, newest first. Verified by merging all six together: `docs/ARCHITECTURE.md`
is the *only* conflicting path across the entire split. **Zero code conflicts.**

---

Extracted from `merge/proven-rescues` commits `5a8303b`, `eb06a72`, `6a66cf7`, `fee7a7f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F46Tr8Az6t2Ky3sRExZ5y
