### PR TITLE
fix(cache): fail closed on activation sidecar corruption

### DIFF
--- a/prismaquant/dsv4_w8a16_export_handoff.py
+++ b/prismaquant/dsv4_w8a16_export_handoff.py
@@ -577,7 +577,7 @@ _FROZEN_EXPORT_SOURCE_SHA256 = {
         "e2d947fe9ba98c612e13a9abe66dbb70aaadde83b0b0db394d100cbff82378c1"
     ),
     "prismaquant/production_weight_cache.py": (
-        "c0c2aa9c322e2c5aa264d786d8df26166908fc47290ab14ae996c207370d7263"
+        "69e29daf21ec8fcfb6ee86375dc6a9792750f38e32337c931b26be64bb0c9fc7"
     ),
     "prismaquant/nvfp4_cb_footprint.py": (
         "96bc38a7ab18c6d2401ed2b66141eef9809409c78468f8ceb16c0891b9701547"

--- a/prismaquant/production_recache.py
+++ b/prismaquant/production_recache.py
@@ -21,6 +21,7 @@ import torch
 import torch.nn as nn
 
 from prismaquant import format_registry as fr
+from prismaquant.cost_stage_checkpoint import atomic_write_bytes
 from prismaquant.decision_units import fused_group_key
 from prismaquant.layer_config import load_assignment as _load_assignment
 from prismaquant.memory_management import model_device as _model_device
@@ -427,7 +428,10 @@ def recache_production_weight_cache(
         # re-open the exact resurrection path the apply step closes.
         applied = dict(
             getattr(production_weight_cache, "activation_max_abs", {}) or {})
-        sidecar.write_text(json.dumps(applied, indent=2))
+        atomic_write_bytes(
+            sidecar,
+            json.dumps(applied, indent=2).encode("utf-8"),
+        )
         delta = (
             getattr(production_weight_cache, "metadata", {}) or {}
         ).get("activation_recache", {}).get("activation_max_abs_delta")

--- a/prismaquant/production_weight_cache.py
+++ b/prismaquant/production_weight_cache.py
@@ -83,6 +83,7 @@ import torch.nn as nn
 
 from prismaquant.activation_sampling import update_priority_reservoir
 from prismaquant.build_rtn_cache import iter_quantizable_tensors
+from prismaquant.cost_stage_checkpoint import atomic_write_bytes
 from prismaquant.render_score import (
     gate_render_candidate,
     normalize_row_weights,
@@ -1531,19 +1532,28 @@ def _local_forward_render_score(
 def _load_render_score_sidecar(path: Path | None) -> dict[str, dict[str, object]]:
     if path is None or not path.is_file():
         return {}
-    import json as _json
 
     try:
-        raw = _json.loads(path.read_text())
-    except Exception:
-        return {}
+        raw = json.loads(path.read_text())
+    except Exception as exc:
+        raise RuntimeError(
+            f"failed to load render-score sidecar {path}: {exc}; "
+            "refusing resume"
+        ) from exc
     records = raw.get("records") if isinstance(raw, Mapping) else None
     if not isinstance(records, Mapping):
-        return {}
+        raise RuntimeError(
+            f"render-score sidecar {path} does not contain a records object; "
+            "refusing resume"
+        )
     out: dict[str, dict[str, object]] = {}
     for key, value in records.items():
-        if isinstance(value, Mapping):
-            out[str(key)] = dict(value)
+        if not isinstance(value, Mapping):
+            raise RuntimeError(
+                f"render-score sidecar {path} has a non-object record for "
+                f"{key!r}; refusing resume"
+            )
+        out[str(key)] = dict(value)
     return out
 
 
@@ -1562,6 +1572,37 @@ def _write_render_score_sidecar(
     tmp = path.with_name(path.name + ".tmp")
     tmp.write_text(_json.dumps(payload, indent=2, sort_keys=True))
     os.replace(tmp, path)
+
+
+def _load_activation_max_abs_sidecar(path: Path) -> dict[str, float]:
+    try:
+        raw = json.loads(path.read_text())
+    except Exception as exc:
+        raise RuntimeError(
+            f"failed to load activation max-abs sidecar {path}: {exc}; "
+            "refusing resume"
+        ) from exc
+    if not isinstance(raw, Mapping):
+        raise RuntimeError(
+            f"activation max-abs sidecar {path} is not a JSON object; "
+            "refusing resume"
+        )
+
+    values: dict[str, float] = {}
+    for qname, value in raw.items():
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise RuntimeError(
+                f"activation max-abs sidecar {path} has a non-numeric value "
+                f"for {qname!r}; refusing resume"
+            )
+        numeric = float(value)
+        if not math.isfinite(numeric) or numeric <= 0.0:
+            raise RuntimeError(
+                f"activation max-abs sidecar {path} has an invalid value "
+                f"for {qname!r}: {value!r}; refusing resume"
+            )
+        values[str(qname)] = numeric
+    return values
 
 
 def _format_supports_render_mechanism(fmt: str, mechanism: str) -> bool:
@@ -5213,21 +5254,15 @@ def fill_production_weight_cache(
     # rendered qnames.  ``sidecar_path`` was defined earlier (before the
     # forward-skip decision); re-using it here.
     if sidecar_path is not None and sidecar_path.is_file():
-        import json as _json
-        try:
-            activation_max_abs.update(_json.loads(sidecar_path.read_text()))
-            if progress:
-                print(
-                    f"[prod-cache] resume: loaded {len(activation_max_abs)} "
-                    f"max_abs entries from sidecar",
-                    flush=True,
-                )
-        except Exception as e:
-            if progress:
-                print(
-                    f"[prod-cache] sidecar load failed ({e}); recomputing",
-                    flush=True,
-                )
+        activation_max_abs.update(
+            _load_activation_max_abs_sidecar(sidecar_path)
+        )
+        if progress:
+            print(
+                f"[prod-cache] resume: loaded {len(activation_max_abs)} "
+                f"max_abs entries from sidecar",
+                flush=True,
+            )
 
     if "NVFP4" in render_base_fmt_set:
         # Group by fused sibling key for max-across-siblings unification.
@@ -5281,8 +5316,10 @@ def fill_production_weight_cache(
         # Persist max_abs to sidecar so future resume runs can skip
         # activation collection entirely for completed qnames.
         if sidecar_path is not None and activation_max_abs:
-            import json as _json
-            sidecar_path.write_text(_json.dumps(activation_max_abs, indent=2))
+            atomic_write_bytes(
+                sidecar_path,
+                json.dumps(activation_max_abs, indent=2).encode("utf-8"),
+            )
 
     # MEM: free per-Linear activation tensors after each render so peak
     # memory stays bounded.  On 27B, 497 Linears × ~10K in_features × 512

--- a/tests/test_production_weight_cache.py
+++ b/tests/test_production_weight_cache.py
@@ -1483,6 +1483,12 @@ def test_production_cache_records_render_scores(monkeypatch, tmp_path):
 
     model = _TinyChain()
     calib_ids = torch.tensor([[0, 1]], dtype=torch.long)
+    atomic_paths: list[Path] = []
+    real_atomic_write = pwc.atomic_write_bytes
+
+    def record_atomic_write(path, payload):
+        atomic_paths.append(Path(path))
+        real_atomic_write(path, payload)
 
     monkeypatch.setattr(
         enc,
@@ -1494,6 +1500,7 @@ def test_production_cache_records_render_scores(monkeypatch, tmp_path):
         "render_production_weight",
         lambda weight, fmt, **_kwargs: weight.detach().to(torch.float32),
     )
+    monkeypatch.setattr(pwc, "atomic_write_bytes", record_atomic_write)
 
     cache = fill_production_weight_cache(
         model,
@@ -1513,6 +1520,7 @@ def test_production_cache_records_render_scores(monkeypatch, tmp_path):
     assert record["normalizer"] == 64.0
     assert record["score"] == pytest.approx(0.0)
     assert (tmp_path / "render_scores.json").is_file()
+    assert tmp_path / "activation_max_abs.json" in atomic_paths
 
 
 def test_resume_collects_activations_when_render_scores_missing(tmp_path):
@@ -1591,6 +1599,86 @@ class _TinyChain(nn.Module):
         return self.l2(x)
 
 
+def test_resume_refuses_truncated_activation_max_abs_sidecar(tmp_path):
+    import json
+    import prismaquant.production_weight_cache as pwc
+
+    model = _TinyChain()
+    torch.save(
+        model.l1.weight.detach().to(torch.float32),
+        tmp_path / pwc._cache_weight_filename("l1", "NVFP4"),
+    )
+    (tmp_path / "render_scores.json").write_text(json.dumps({
+        "schema": "prismaquant.production_render_scores.v1",
+        "records": {"l1|NVFP4": {}},
+    }))
+    sidecar = tmp_path / "activation_max_abs.json"
+    sidecar.write_text('{"l1":')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        fill_production_weight_cache(
+            model,
+            torch.tensor([[0, 1]], dtype=torch.long),
+            qnames=["l1"],
+            formats=["NVFP4"],
+            levers={"gptq": False, "scale_sweep": False},
+            cache_dir=tmp_path,
+            max_act_rows=8,
+            progress=False,
+        )
+
+    assert str(sidecar) in str(exc_info.value)
+
+
+def test_resume_loads_existing_activation_max_abs_sidecar(tmp_path):
+    import json
+    import prismaquant.production_weight_cache as pwc
+
+    model = _TinyChain()
+    torch.save(
+        model.l1.weight.detach().to(torch.float32),
+        tmp_path / pwc._cache_weight_filename("l1", "NVFP4"),
+    )
+    (tmp_path / "render_scores.json").write_text(json.dumps({
+        "schema": "prismaquant.production_render_scores.v1",
+        "records": {"l1|NVFP4": {}},
+    }))
+    sidecar = tmp_path / "activation_max_abs.json"
+    sidecar.write_text(json.dumps({"l1": 2.5}, indent=2))
+
+    cache = fill_production_weight_cache(
+        model,
+        torch.tensor([[0, 1]], dtype=torch.long),
+        qnames=["l1"],
+        formats=["NVFP4"],
+        levers={"gptq": False, "scale_sweep": False},
+        cache_dir=tmp_path,
+        max_act_rows=8,
+        progress=False,
+    )
+
+    assert cache.activation_max_abs == {"l1": 2.5}
+
+
+def test_resume_refuses_truncated_render_score_sidecar(tmp_path):
+    sidecar = tmp_path / "render_scores.json"
+    sidecar.write_text('{"records":')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        fill_production_weight_cache(
+            _TinyChain(),
+            torch.tensor([[0, 1]], dtype=torch.long),
+            qnames=["l1"],
+            formats=["NVFP4"],
+            levers={"gptq": False, "scale_sweep": False},
+            cache_dir=tmp_path,
+            max_act_rows=8,
+            progress=False,
+        )
+
+    assert str(sidecar) in str(exc_info.value)
+
+
 def test_production_recache_measures_quantized_upstream_activation_range():
     model = _TinyChain()
     cache = ProductionWeightCache(
@@ -1621,6 +1709,50 @@ def test_production_recache_measures_quantized_upstream_activation_range():
     assert delta["n_common"] == 2
     assert delta["changed_gt_5pct"] == 1
     assert delta["ratio_p50"] == pytest.approx(2.0)
+
+
+def test_production_recache_atomically_publishes_activation_sidecar(
+    monkeypatch,
+    tmp_path,
+):
+    import json
+    import prismaquant.production_recache as production_recache
+
+    cache = ProductionWeightCache(
+        weights={},
+        levers={},
+        cache_dir=str(tmp_path),
+        activation_max_abs={"l1": 1.0},
+    )
+    monkeypatch.setattr(
+        production_recache,
+        "measure_production_activation_max_abs",
+        lambda *_args, **_kwargs: {"l1": 2.0},
+    )
+    atomic_paths: list[Path] = []
+    real_atomic_write = production_recache.atomic_write_bytes
+
+    def record_atomic_write(path, payload):
+        atomic_paths.append(Path(path))
+        real_atomic_write(path, payload)
+
+    monkeypatch.setattr(
+        production_recache,
+        "atomic_write_bytes",
+        record_atomic_write,
+    )
+
+    recache_production_weight_cache(
+        nn.Linear(1, 1),
+        torch.ones((1, 1), dtype=torch.long),
+        {"l1": "BF16"},
+        cache,
+        progress=False,
+    )
+
+    sidecar = tmp_path / "activation_max_abs.json"
+    assert atomic_paths == [sidecar]
+    assert json.loads(sidecar.read_text()) == {"l1": 2.0}
 
 
 def test_production_recache_tempdir_uses_requested_parent(monkeypatch, tmp_path):


### PR DESCRIPTION
## Verified pre-fix behavior

Against base commit 8461ae2:

- Weight shards already used a same-directory temporary file and os.replace at production_weight_cache.py lines 1231-1246.
- activation_max_abs.json parse/read failures were swallowed at production_weight_cache.py lines 5215-5230; loaded values then won over measurement at lines 5238-5242.
- The two activation sidecar writes were in-place at production_weight_cache.py lines 5283-5285 and production_recache.py lines 421-430.
- render_scores.json was already atomically replaced at production_weight_cache.py lines 1562-1564, but the snapshot was loaded once at lines 4961-4967 and rewritten wholesale at lines 5508-5511 and 5531. That can lose updates only with concurrent writers sharing a cache directory, which is an invalid topology under the architecture contract, so this PR does not add locking or merge machinery.

## Fix

- Publish activation_max_abs.json through the existing durable atomic byte writer at both call sites: same-directory .tmp, fsync, os.replace, then directory fsync.
- Fail closed with the sidecar path in the exception on read/JSON/schema/value corruption. Valid existing numeric mappings keep the same on-disk format and keys.
- Make malformed render_scores.json reads fail closed while preserving its existing lightweight atomic writer.
- Add resume corruption, valid-cache compatibility, and both-writer atomic-publication coverage.

## Validation

- Exact requested selection: PYTHONPATH=. /home/rob/dq-runs/venvs/prismaquant-cu130/bin/python -m pytest tests/ -q -k "cache or recache or production" -p no:cacheprovider
  - 406 passed, 1 skipped, 5275 deselected, 1 xfailed, 14 warnings in 52.10s.
- Targeted sidecar/atomic tests: 5 passed, 50 deselected.
- py_compile passed for both touched modules and the touched test module.

Mutation proof for the load-bearing activation regression:

1. Fixed implementation: 1 passed, 52 deselected.
2. Temporarily restored catch-and-continue around the loader: 1 failed, 52 deselected with DID NOT RAISE RuntimeError.
3. Restored fail-closed implementation: 1 passed, 52 deselected.