### PR TITLE
fix(pqwork): attribute evictions and age work into protection

### DIFF
--- a/docs/design/work_queue.md
+++ b/docs/design/work_queue.md
@@ -58,7 +58,7 @@ python3 $Q requeue <id>    # failed -> ready
 python3 $Q cancel <id>     # ready/claimed -> failed
 ```
 
-## The five properties that make it safe
+## The seven properties that make it safe
 
 1. **Claiming is `rename()`.** Atomic on NFSv4; the loser gets `ENOENT` and
    moves on. `flock` over NFS is version-dependent and was not used.
@@ -142,6 +142,54 @@ python3 $Q cancel <id>     # ready/claimed -> failed
    job goes through `systemctl --user stop` instead; that path is tested to
    terminate in well under a second and leave no orphaned children.
 
+7. **Eviction measures the trend, attributes the event, and ages work into
+   protection.** The box-wide trigger is the median of every consecutive
+   `MemAvailable` slope in the 30-second window, with at least three valid
+   intervals required. A single endpoint step therefore cannot trigger an
+   eviction. The median is deliberate: one interior outlier creates one steep
+   fall and one steep recovery, while an endpoint outlier creates one bad
+   interval; neither can dominate a sustained majority trend. A genuine fast
+   fall across the window still projects through the reserve and fires. lina
+   had swap free during the incident, so its configured 60-second horizon was
+   the branch in force; the earlier 120-second reconstruction was wrong.
+
+   Victim selection is still lowest-priority-first, but newest-first is gone.
+   Within a priority it chooses the least cumulative **measured sunk runtime**,
+   including runtime discarded by prior evictions. Restarting an item no
+   longer makes it newest and therefore the next victim of the policy that just
+   restarted it.
+
+   At each box sample the worker also records every running job's own footprint
+   from its cgroup `memory.current` (or the direct process tree's RSS when the
+   job is uncapped). The record distinguishes `evicted_for_own_memory_growth`,
+   `evicted_as_collateral`, and `evicted_without_attribution`; exact box and
+   victim slopes, footprint endpoints, source, sample count, and window travel
+   with the item. Missing measurement is never converted into blame.
+
+   `evictions` is now explicitly a **policy-aging count**, not an impossibility
+   budget. Every eviction earns age and a fixed 60-second cooldown. After two
+   losses, the next attempt is non-evictable and holds admission for its
+   declared footprint, falling back to its observed peak. If neither exists,
+   the queue drains current work and gives it an exclusive attempt. New
+   arrivals cannot consume the reservation while it waits. Thus a fitting item
+   loses at most two attempts before the queue guarantees one; it never ages
+   into a permanent bench. The old exponential cooldown and
+   `evicted_Nx_does_not_fit` terminal outcome no longer exist.
+
+   The only memory-fit terminal is
+   `measured_footprint_exceeds_box_capacity`, reached when a declared or
+   observed footprint is larger than `MemTotal - mem_reserve_gb`. Its record
+   carries the source footprint, total memory, reserve, capacity, and timestamp.
+   Ordinary command/receipt failures retain their separate attempt contract.
+
+   Optimistic admission is unchanged for new work: the queue still starts it
+   whenever headroom is positive and measures what happens. The 2026-08-30
+   `pq-currency-4b-v2` log is the incident behind this split: its application
+   samples stayed near 81 GB with a 24 GB reserve, so it demonstrably fit, but
+   those sparse four-minute samples cannot reconstruct the governor's unlogged
+   two-second series. They establish that the repeated fit verdict was false;
+   they do not establish which individual endpoint sample caused each trigger.
+
 ## Adding a box that is not a Spark
 
 Eligibility is opt-in by declaration: `is_runnable` filters on the item's
@@ -200,6 +248,35 @@ journalctl --user -u pqwork -f          # what it is pulling
 python3 $Q reserve --slots 1 --why "…"  # hold the GPU for a hand-launched job
 python3 $Q reserve --release            # give it back
 ```
+
+### Deploying a worker change
+
+Merging the repo file does not change either live worker. From the merged
+checkout, one command propagates the exact source through both deployment
+layers and restarts the services:
+
+```bash
+python3 tools/deploy_pqwork.py
+```
+
+It atomically installs `tools/pqwork.py` to
+`/mnt/shared/pq-queue/bin/pqwork.py`, copies that shared artifact atomically to
+`/home/rob/.local/bin/pqwork.py` on sparky and sparklina, verifies one SHA-256
+across all three deployed copies, and restarts both `pqwork` user services.
+
+**This command is safe only between claims, never mid-claim.** A runner may
+reread the script at a claim boundary; swapping it while a claim is active can
+split one execution across two contracts. The deployer creates the shared
+`.deploying` admission hold first and refuses to change any file while
+`claimed/*.json` is non-empty. Workers carrying this version admit no new
+claims while the hold exists. For the first rollout from an older worker that
+does not yet understand the hold, choose a verified idle window immediately
+after the board shows no claimed items; the refusal check remains a second
+guard, but cannot close a race in code not deployed yet. An ordinary failed
+deployment removes its hold and reports the incomplete step; a process killed
+before its `finally` block can leave the hold behind, and that marker must be
+cleared only after confirming no deployment is active and no item is claimed.
+Rerun only after the board is idle again.
 
 Restarting the unit kills any job it is running. That is intentional: the
 lease then goes stale, the reaper requeues, and receipt-gating makes the

--- a/tests/test_pqwork.py
+++ b/tests/test_pqwork.py
@@ -24,6 +24,8 @@ if not (Path(__file__).resolve().parents[1] / "tools").is_dir():
                 allow_module_level=True)
 
 _TOOL_PATH = Path(__file__).resolve().parents[1] / "tools" / "pqwork.py"
+_DEPLOY_TOOL_PATH = (Path(__file__).resolve().parents[1]
+                     / "tools" / "deploy_pqwork.py")
 
 
 def _load_tool():
@@ -34,6 +36,17 @@ def _load_tool():
 
 
 pqwork = _load_tool()
+
+
+def _load_deploy_tool():
+    spec = importlib.util.spec_from_file_location("deploy_pqwork",
+                                                  _DEPLOY_TOOL_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+pqdeploy = _load_deploy_tool()
 
 
 @pytest.fixture()
@@ -486,3 +499,271 @@ def test_only_declared_refuses_work_that_did_not_ask_for_this_box(queue):
     assert not pqwork.is_runnable({"id": "gb10only", "cmd": "true",
                                    "requires": ["gb10"]},
                                   "wslgpu", tags, False)
+
+
+# --------------------------------------------------------------------------
+# 10. memory-governor trends and eviction attribution
+
+
+def _governor(*, total_gb=128.0):
+    return pqwork.MemoryGovernor(reserve_gb=24.0, horizon_s=60.0,
+                                 settle_s=0.0, total_gb=total_gb)
+
+
+def _drive_sample(monkeypatch, governor, sampled_at, available_gb):
+    monkeypatch.setattr(pqwork.time, "time", lambda: sampled_at)
+    monkeypatch.setattr(pqwork, "mem_available_gb", lambda: available_gb)
+    return governor.sample()
+
+
+def _drive_pressure(monkeypatch, *, start=0.0):
+    governor = _governor()
+    monkeypatch.setattr(pqwork, "swap_free_gb", lambda: 16.0)
+    for offset, available in [(0, 90.0), (2, 87.5),
+                              (4, 85.0), (6, 82.5)]:
+        _drive_sample(monkeypatch, governor, start + offset, available)
+    return governor
+
+
+def test_currency_log_trace_is_flat_and_does_not_evict(monkeypatch):
+    """The sparse application log proves a plateau, not a falling box."""
+    monkeypatch.setattr(pqwork, "swap_free_gb", lambda: 16.0)
+    # Seconds and MemAvailable GB transcribed from pq-currency-4b-v2's fifth
+    # run, 01:40:45--02:27:45.  The job moved only 1 GB in 47 minutes and
+    # remained 56.9 GB above the worker's 24 GB reserve.
+    governor = _governor()
+    for sample in [
+        (0, 81.9), (234, 81.4), (468, 81.4), (703, 81.3),
+        (937, 81.3), (1172, 81.3), (1406, 81.3), (1642, 81.3),
+        (1877, 81.3), (2115, 81.3), (2351, 81.3), (2585, 81.3),
+        (2820, 80.9),
+    ]:
+        _drive_sample(monkeypatch, governor, *sample)
+        assert not governor.must_evict([object()])
+
+
+def test_one_endpoint_step_cannot_override_a_flat_trace(monkeypatch):
+    """One alarming pair cannot become a 60-second trajectory."""
+    monkeypatch.setattr(pqwork, "swap_free_gb", lambda: 16.0)
+    governor = _governor()
+    # lina's swap leaves the configured horizon at 60 seconds.  The old
+    # endpoint estimator turns this isolated 1 GB/s step into a projected
+    # 60 GB fall and fires immediately; subsequent samples show a plateau.
+    for sample in [(0, 82.9), (2, 80.9), (4, 80.9),
+                   (6, 80.9), (8, 80.9)]:
+        _drive_sample(monkeypatch, governor, *sample)
+        assert not governor.must_evict([object()])
+
+
+def test_sustained_fast_drop_still_evicts(monkeypatch):
+    governor = _drive_pressure(monkeypatch)
+    assert governor.must_evict([object()])
+
+
+def test_single_memory_blip_then_recovery_does_not_evict(monkeypatch):
+    monkeypatch.setattr(pqwork, "swap_free_gb", lambda: 16.0)
+    governor = _governor()
+    for sample in [(0, 81.3), (2, 81.3), (4, 30.0),
+                   (6, 81.3), (8, 81.3)]:
+        _drive_sample(monkeypatch, governor, *sample)
+    assert not governor.must_evict([object()])
+
+
+def _claimed_job(item_id, **fields):
+    enqueue(item_id, attempts=0, max_attempts=3, **fields)
+    item = pqwork.try_claim(item_id, "mine")
+    assert item is not None
+    return pqwork.Job(item, "mine")
+
+
+def test_declared_job_samples_its_cgroup_memory_current(queue, tmp_path):
+    job = _claimed_job("measured", mem_gb=55.0)
+    job.unit = pqwork.unit_name(job.id)
+    memory_current = tmp_path / "memory.current"
+    job._memory_current_path = memory_current
+
+    for sampled_at, footprint_gb in [
+        (0, 20.0), (2, 21.0), (4, 22.0), (6, 23.0),
+    ]:
+        memory_current.write_text(str(int(footprint_gb * 1024 ** 3)))
+        assert job.sample_footprint(sampled_at) == footprint_gb
+
+    assert list(job.footprint_samples) == [
+        (0, 20.0), (2, 21.0), (4, 22.0), (6, 23.0),
+    ]
+    assert job.footprint_source == f"cgroup:{memory_current}"
+
+
+def test_collateral_eviction_records_policy_age_without_fit_blame(queue):
+    """Victim policy is not evidence that the selected job caused pressure."""
+    collateral = _claimed_job("collateral", evictions=1)
+    collateral.footprint_samples.extend([
+        (0, 20.0), (2, 20.0), (4, 20.0), (6, 20.0),
+    ])
+    attribution = collateral.classify_eviction(box_drop_rate_gb_s=1.0)
+    assert attribution["classification"] == "collateral"
+    collateral.evicted = True
+    collateral.eviction_attribution = attribution
+    assert collateral._finish_eviction()
+
+    record = read_state(pqwork.READY, "collateral")
+    assert record["outcome"] == "evicted_as_collateral"
+    assert record["evictions"] == 2
+    assert record.get("attributed_evictions", 0) == 0
+    assert record["collateral_evictions"] == 1
+    assert record["protection_earned"] is True
+    assert (record["not_before"] - record["last_evicted_at"]
+            == pytest.approx(pqwork.EVICT_BACKOFF_S))
+    assert record["eviction_attribution"]["victim_growth_gb_s"] == 0.0
+    assert state_of("collateral") != pqwork.FAILED
+
+    growing = _claimed_job("growing", evictions=0)
+    growing.footprint_samples.extend([
+        (0, 20.0), (2, 22.0), (4, 24.0), (6, 26.0),
+    ])
+    attribution = growing.classify_eviction(box_drop_rate_gb_s=1.0)
+    assert attribution["classification"] == "victim_growth"
+    growing.evicted = True
+    growing.eviction_attribution = attribution
+    assert growing._finish_eviction()
+
+    measured = read_state(pqwork.READY, "growing")
+    assert measured["outcome"] == "evicted_for_own_memory_growth"
+    assert measured["attributed_evictions"] == 1
+    assert measured["evictions"] == 1
+    assert state_of("growing") != pqwork.FAILED
+
+
+def _live_job(item_id, *, priority, evictions, started,
+              evicted_runtime_s=0.0, mem_gb=55.0):
+    item = {
+        "id": item_id,
+        "cmd": "true",
+        "priority": priority,
+        "evictions": evictions,
+        "evicted_runtime_s": evicted_runtime_s,
+        "evictable": True,
+        "mem_gb": mem_gb,
+    }
+    job = pqwork.Job(item, "mine")
+    job.started = started
+    job.alive = lambda: True
+    return job
+
+
+def test_restart_does_not_make_the_evicted_item_the_next_victim(monkeypatch):
+    governor = _drive_pressure(monkeypatch, start=1000.0)
+    incumbent = _live_job("incumbent", priority=50, evictions=0,
+                          started=900.0)
+    restarted = _live_job("restarted", priority=50, evictions=1,
+                          evicted_runtime_s=200.0, started=1005.0)
+
+    jobs = [incumbent, restarted]
+    assert governor.must_evict(jobs)
+    assert pqwork.choose_victim(jobs) is incumbent
+
+
+def test_fitting_item_ages_into_protection_and_completes(
+        queue, tmp_path, monkeypatch):
+    """A low-priority fit survives an unbounded stream within two losses."""
+    receipt = tmp_path / "target.receipt"
+    enqueue("target", cmd=f"echo complete > {receipt}", cwd=tmp_path,
+            receipt=str(receipt), mem_gb=55.0, priority=10)
+    target_item = read_state(pqwork.READY, "target")
+    protection_after = getattr(pqwork, "EVICTIONS_BEFORE_PROTECTION", 2)
+    survived = False
+
+    for attempt in range(protection_after + 1):
+        now = 2000.0 + attempt * 20.0
+        governor = _drive_pressure(monkeypatch, start=now - 6.0)
+        item_evictions = int(target_item.get("evictions", 0))
+        target = _live_job(
+            "target", priority=10,
+            evictions=item_evictions,
+            evicted_runtime_s=float(target_item.get("evicted_runtime_s", 0.0)),
+            started=now - 1.0)
+        arrival = _live_job(f"arrival-{attempt}", priority=50, evictions=0,
+                            started=now - 10.0)
+        assert governor.must_evict([target, arrival])
+        victim = pqwork.choose_victim([target, arrival])
+        if victim is arrival:
+            survived = True
+            break
+        assert victim is target
+        target_item["evictions"] = item_evictions + 1
+        target_item["evicted_runtime_s"] = (
+            float(target_item.get("evicted_runtime_s", 0.0)) + 1.0)
+
+    assert survived, "the fitting target kept losing to newer arrivals"
+    assert target_item["evictions"] == protection_after
+
+    # Aging also reserves admission: no newcomer can consume the target's
+    # 55 GB while it waits, and its running attempt is non-evictable.
+    newcomer = {"id": "newcomer", "priority": 99, "evictions": 0,
+                "enqueued_at": 0.0, "mem_gb": 1.0}
+    target_item["enqueued_at"] = 1.0
+    assert governor.admission_candidates([newcomer, target_item]) == [target_item]
+    assert not target.evictable
+    _drive_sample(monkeypatch, governor, now + 2.0, 50.0)
+    assert not governor.may_admit(target_item, [arrival])
+    _drive_sample(monkeypatch, governor, now + 4.0, 100.0)
+    assert governor.may_admit(target_item, [])
+
+    pqwork.write_json_atomic(pqwork.item_path(pqwork.READY, "target"),
+                             target_item)
+    monkeypatch.setattr(pqwork, "capping_supported", lambda: False)
+    claimed = pqwork.try_claim("target", "mine")
+    assert claimed is not None
+    assert _run_sync(claimed) == "done"
+    assert receipt.read_text().strip() == "complete"
+
+
+def test_only_measured_absolute_impossibility_is_terminal(queue):
+    enqueue("oversized", mem_gb=80.0)
+    item = read_state(pqwork.READY, "oversized")
+    governor = _governor(total_gb=100.0)
+
+    assert pqwork.fail_measured_impossibility(item, governor)
+    terminal = read_state(pqwork.FAILED, "oversized")
+    assert terminal["outcome"] == "measured_footprint_exceeds_box_capacity"
+    measurement = terminal["fit_measurement"]
+    assert measurement["source"] == "declared"
+    assert measurement["footprint_gb"] == pytest.approx(80.0)
+    assert measurement["box_total_gb"] == pytest.approx(100.0)
+    assert measurement["reserve_gb"] == pytest.approx(24.0)
+    assert measurement["capacity_gb"] == pytest.approx(76.0)
+    assert measurement["measured_at"] > 0
+
+
+def test_deployment_propagates_identical_copies_only_between_claims(
+        queue, tmp_path, monkeypatch):
+    source = tmp_path / "repo-pqwork.py"
+    source.write_text("#!/usr/bin/env python3\nprint('new')\n")
+    shared = queue / "bin" / "pqwork.py"
+    shared.parent.mkdir()
+    shared.write_text("old shared copy\n")
+    local = tmp_path / "local" / "pqwork.py"
+    monkeypatch.setattr(pqdeploy, "LOCAL_TARGET", local)
+
+    digest = pqdeploy.deploy(source, queue, ["localhost"], restart=False)
+    assert pqdeploy.sha256(shared) == digest
+    assert pqdeploy.sha256(local) == digest
+    assert not (queue / pqdeploy.DEPLOY_HOLD).exists()
+
+    pqwork.write_json_atomic(queue / pqwork.CLAIMED / "busy.json",
+                             {"id": "busy"})
+    source.write_text("#!/usr/bin/env python3\nprint('must not land')\n")
+    before = shared.read_bytes()
+    with pytest.raises(RuntimeError, match="safe only between claims"):
+        pqdeploy.deploy(source, queue, ["localhost"], restart=False)
+    assert shared.read_bytes() == before
+    assert local.read_bytes() == before
+    assert not (queue / pqdeploy.DEPLOY_HOLD).exists()
+
+
+def test_deployment_hold_blocks_new_claim_candidates(queue):
+    enqueue("waiting")
+    assert [item["id"] for item in
+            pqwork.ready_candidates("mine", set(), True)] == ["waiting"]
+    pqwork.deployment_hold_path().write_text("deployment in progress\n")
+    assert pqwork.ready_candidates("mine", set(), True) == []

--- a/tools/deploy_pqwork.py
+++ b/tools/deploy_pqwork.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Atomically deploy pqwork from this checkout to the two live workers.
+
+Run only between claims.  The command holds new admissions, refuses to replace
+any copy while ``claimed/*.json`` is non-empty, verifies identical hashes, and
+restarts the user services before releasing the hold.  The first deployment of
+a worker that predates the hold mechanism still relies on the operator choosing
+an actually idle window; later deployments close the admission race themselves.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import shlex
+import shutil
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+
+DEFAULT_QUEUE_ROOT = Path("/mnt/shared/pq-queue")
+DEFAULT_HOSTS = ("sparky", "sparklina")
+LOCAL_TARGET = Path("/home/rob/.local/bin/pqwork.py")
+DEPLOY_HOLD = ".deploying"
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def atomic_install(source: Path, target: Path) -> None:
+    """Replace ``target`` atomically without using ``/tmp``."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    staged = target.parent / f".{target.name}.deploy-{os.getpid()}"
+    try:
+        shutil.copyfile(source, staged)
+        staged.chmod(0o755)
+        os.replace(staged, target)
+    finally:
+        staged.unlink(missing_ok=True)
+
+
+def claimed_items(queue_root: Path) -> list[str]:
+    return sorted(path.stem for path in (queue_root / "claimed").glob("*.json"))
+
+
+def acquire_hold(queue_root: Path) -> Path:
+    hold = queue_root / DEPLOY_HOLD
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    fd = os.open(hold, flags, 0o644)
+    with os.fdopen(fd, "w") as fh:
+        fh.write(f"host={socket.gethostname()} pid={os.getpid()}\n")
+    return hold
+
+
+def is_local_host(host: str) -> bool:
+    local = socket.gethostname().split(".")[0]
+    return host in (local, "localhost")
+
+
+def validate_host(host: str) -> None:
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+", host):
+        raise ValueError(f"invalid host name: {host!r}")
+
+
+def run_remote(host: str, command: str) -> str:
+    result = subprocess.run(["ssh", host, command], check=True,
+                            capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def remote_install(host: str, shared_source: Path) -> None:
+    source = shlex.quote(str(shared_source))
+    target = shlex.quote(str(LOCAL_TARGET))
+    # $$ must expand remotely, so quote the fixed directory and construct the
+    # basename in the remote shell rather than interpolating user input.
+    command = (
+        "set -eu; "
+        f"src={source}; dst={target}; "
+        "stage=/home/rob/.local/bin/.pqwork.py.deploy-$$; "
+        "trap 'rm -f \"$stage\"' EXIT; "
+        "install -m 0755 \"$src\" \"$stage\"; "
+        "mv -f \"$stage\" \"$dst\"; trap - EXIT"
+    )
+    run_remote(host, command)
+
+
+def restart_worker(host: str) -> None:
+    command = ["systemctl", "--user", "restart", "pqwork"]
+    if is_local_host(host):
+        subprocess.run(command, check=True)
+    else:
+        run_remote(host, "systemctl --user restart pqwork")
+
+
+def installed_hash(host: str) -> str:
+    if is_local_host(host):
+        return sha256(LOCAL_TARGET)
+    output = run_remote(host, f"sha256sum {shlex.quote(str(LOCAL_TARGET))}")
+    return output.split()[0] if output else ""
+
+
+def deploy(source: Path, queue_root: Path, hosts: list[str],
+           *, restart: bool = True) -> str:
+    source = source.resolve()
+    if not source.is_file():
+        raise FileNotFoundError(f"repo source does not exist: {source}")
+    if not (queue_root / "claimed").is_dir():
+        raise FileNotFoundError(
+            f"queue root has no claimed/ directory: {queue_root}")
+    for host in hosts:
+        validate_host(host)
+        if not is_local_host(host):
+            run_remote(host, "true")
+
+    hold = acquire_hold(queue_root)
+    try:
+        running = claimed_items(queue_root)
+        if running:
+            raise RuntimeError(
+                "deployment is safe only between claims; currently claimed: "
+                + ", ".join(running))
+
+        shared_target = queue_root / "bin" / "pqwork.py"
+        atomic_install(source, shared_target)
+        expected = sha256(shared_target)
+
+        for host in hosts:
+            if is_local_host(host):
+                atomic_install(shared_target, LOCAL_TARGET)
+            else:
+                remote_install(host, shared_target)
+
+        actual = {host: installed_hash(host) for host in hosts}
+        wrong = {host: digest for host, digest in actual.items()
+                 if digest != expected}
+        if wrong:
+            raise RuntimeError(f"installed hashes differ from {expected}: {wrong}")
+
+        if restart:
+            for host in hosts:
+                restart_worker(host)
+        return expected
+    finally:
+        hold.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--source", type=Path,
+        default=Path(__file__).resolve().with_name("pqwork.py"),
+        help="repo pqwork.py to deploy (default: sibling of this script)")
+    parser.add_argument("--queue-root", type=Path, default=DEFAULT_QUEUE_ROOT)
+    parser.add_argument("--host", action="append", dest="hosts",
+                        help="target worker; repeatable (default: both GB10s)")
+    args = parser.parse_args(argv)
+    hosts = args.hosts or list(DEFAULT_HOSTS)
+    try:
+        digest = deploy(args.source, args.queue_root, hosts)
+    except (OSError, RuntimeError, subprocess.SubprocessError, ValueError) as exc:
+        print(f"pqwork deployment refused: {exc}", file=sys.stderr)
+        return 1
+    print(f"deployed pqwork sha256={digest} via shared storage to "
+          f"{', '.join(hosts)}; workers restarted")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/pqwork.py
+++ b/tools/pqwork.py
@@ -51,6 +51,7 @@ import json
 import os
 import signal
 import socket
+import statistics
 import subprocess
 import sys
 import threading
@@ -65,6 +66,7 @@ DONE = "done"
 FAILED = "failed"
 LOGS = "logs"
 RESERVED = "reserved"
+DEPLOY_HOLD = ".deploying"
 STATE_DIRS = (READY, CLAIMED, DONE, FAILED, LOGS, RESERVED)
 
 # A lease is refreshed this often and considered abandoned after this long.
@@ -83,18 +85,20 @@ POLL_S = 10
 # means the kernel OOM killer picks a victim immediately, with no cushion and
 # by its own heuristic.  It has picked wrong here before.  Evicting early is
 # how we choose the victim ourselves.
-# An evicted item must not be re-admitted immediately.  Aggressive
-# admission and zero backoff together are a livelock: the box evicts, sees
-# headroom, re-admits the same job, and evicts it again, forever, making no
-# progress while looking busy.  Backoff is the necessary complement to
-# "start it and find out" -- observed doing exactly this on 2026-08-29
-# before the cooldown existed.
-EVICT_BACKOFF_BASE_S = 60.0
-EVICT_BACKOFF_CAP_S = 1800.0
-MAX_EVICTIONS = 5
+# An evicted item must not be re-admitted immediately.  Aggressive admission
+# and zero cooldown together are a livelock, but exponential backoff merely
+# makes the same losing race take longer.  Every policy eviction therefore
+# earns scheduler age; after two, the next attempt reserves its footprint and
+# is non-evictable.  The fixed cooldown damps immediate churn without turning
+# lost races into an ever-longer bench.
+EVICT_BACKOFF_S = 60.0
+EVICTIONS_BEFORE_PROTECTION = 2
 
 MEM_SAMPLE_S = 2.0
 MEM_RATE_WINDOW_S = 30.0
+MIN_TREND_INTERVALS = 3
+ATTRIBUTION_MIN_FRACTION = 0.5
+CGROUP_LOOKUP_RETRY_S = 5.0
 EVICT_GRACE_S = 10.0
 
 
@@ -104,6 +108,10 @@ EVICT_GRACE_S = 10.0
 
 def qdir(name: str) -> Path:
     return QUEUE_ROOT / name
+
+
+def deployment_hold_path() -> Path:
+    return QUEUE_ROOT / DEPLOY_HOLD
 
 
 def queue_reachable() -> bool:
@@ -285,6 +293,20 @@ def sort_key(item: dict) -> tuple:
     return (-int(item.get("priority", 50)), float(item.get("enqueued_at", 0)))
 
 
+def ready_candidates(host: str, tags: set, has_gpu: bool,
+                     only_declared: bool = False) -> list[dict]:
+    """Runnable items, or none while a deployment holds claim boundaries."""
+    if deployment_hold_path().exists():
+        return []
+    candidates = []
+    for path in qdir(READY).glob("*.json"):
+        item = read_item(path)
+        if item and is_runnable(item, host, tags, has_gpu, only_declared):
+            candidates.append(item)
+    candidates.sort(key=sort_key)
+    return candidates
+
+
 # --------------------------------------------------------------------------
 # lease bookkeeping
 
@@ -443,6 +465,94 @@ def mem_available_gb() -> float:
     return float("inf")
 
 
+def mem_total_gb() -> float:
+    """Physical memory governed by this worker, in GB."""
+    try:
+        with open("/proc/meminfo") as fh:
+            for line in fh:
+                if line.startswith("MemTotal:"):
+                    return int(line.split()[1]) / (1024.0 * 1024.0)
+    except OSError:
+        pass
+    return float("inf")
+
+
+def _positive_item_gb(item: dict, key: str) -> float | None:
+    try:
+        value = float(item.get(key) or 0.0)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def item_eviction_count(item: dict) -> int:
+    """Policy evictions earned by an item; never a fit verdict."""
+    try:
+        return max(0, int(item.get("evictions", 0)))
+    except (TypeError, ValueError):
+        return 0
+
+
+def item_is_protected(item: dict) -> bool:
+    """Whether scheduler aging guarantees this item's next attempt."""
+    return item_eviction_count(item) >= EVICTIONS_BEFORE_PROTECTION
+
+
+def _median_consecutive_slope(samples) -> float | None:
+    """Return the median value-growth slope, or ``None`` without a trend.
+
+    Consecutive-pair slopes are used instead of an endpoint difference so
+    every sample in the window participates.  Their median was chosen over a
+    least-squares fit because a single interior outlier contributes one steep
+    rise and one steep fall, while an endpoint outlier contributes only one
+    bad interval; neither can dominate the median.  Requiring at least three
+    valid intervals also means one sample pair can never constitute a trend.
+    """
+    ordered = list(samples)
+    slopes = []
+    for (t0, value0), (t1, value1) in zip(ordered, ordered[1:]):
+        dt = t1 - t0
+        if dt > 0:
+            slopes.append((value1 - value0) / dt)
+    if len(slopes) < MIN_TREND_INTERVALS:
+        return None
+    return float(statistics.median(slopes))
+
+
+def _process_tree_rss_gb(root_pid: int) -> float | None:
+    """Resident bytes for a direct child and its descendants.
+
+    An uncapped job is launched as a process group, but Linux exposes RSS per
+    process rather than per group.  Walking ``children`` captures the shell
+    and the workload it launched without charging unrelated processes to the
+    victim.  Races with process exit are expected and simply omit that sample.
+    """
+    pending = [root_pid]
+    seen = set()
+    resident_pages = 0
+    observed = False
+    while pending:
+        pid = pending.pop()
+        if pid in seen:
+            continue
+        seen.add(pid)
+        proc_root = Path("/proc") / str(pid)
+        try:
+            children = (proc_root / "task" / str(pid) / "children").read_text()
+            pending.extend(int(child) for child in children.split())
+        except (OSError, ValueError):
+            pass
+        try:
+            fields = (proc_root / "statm").read_text().split()
+            resident_pages += int(fields[1])
+            observed = True
+        except (IndexError, OSError, ValueError):
+            pass
+    if not observed:
+        return None
+    return resident_pages * os.sysconf("SC_PAGE_SIZE") / (1024.0 ** 3)
+
+
 def unit_name(item_id: str) -> str:
     """systemd unit name for a job. Only [A-Za-z0-9:_.\\-] survive."""
     safe = "".join(c if (c.isalnum() or c in ":_.-") else "-" for c in item_id)
@@ -479,6 +589,11 @@ class Job:
         self.started = time.time()
         self.avail_at_start = mem_available_gb()
         self.evicted = False
+        self.eviction_attribution: dict | None = None
+        self.footprint_samples: collections.deque = collections.deque()
+        self.footprint_source: str | None = None
+        self._memory_current_path: Path | None = None
+        self._next_cgroup_lookup_at = 0.0
         self.state: str | None = None
         self.thread = threading.Thread(target=self._run, daemon=True)
 
@@ -491,7 +606,130 @@ class Job:
 
     @property
     def evictable(self) -> bool:
-        return bool(self.item.get("evictable", True))
+        return (bool(self.item.get("evictable", True))
+                and not item_is_protected(self.item))
+
+    def sunk_runtime_s(self, now: float | None = None) -> float:
+        """Measured runtime discarded across this and earlier attempts."""
+        try:
+            earlier = max(0.0, float(self.item.get("evicted_runtime_s") or 0.0))
+        except (TypeError, ValueError):
+            earlier = 0.0
+        current = max(0.0, (time.time() if now is None else now) - self.started)
+        return earlier + current
+
+    def _cgroup_footprint_gb(self) -> float | None:
+        """Read this transient service's ``memory.current`` when available."""
+        path = self._memory_current_path
+        if path is None:
+            now = time.monotonic()
+            if now < self._next_cgroup_lookup_at:
+                return None
+            self._next_cgroup_lookup_at = now + CGROUP_LOOKUP_RETRY_S
+            try:
+                out = subprocess.run(
+                    ["systemctl", "--user", "show", self.unit,
+                     "-p", "ControlGroup", "--value"],
+                    capture_output=True, text=True, timeout=5)
+                control_group = (out.stdout or "").strip()
+                relative = Path(control_group.lstrip("/"))
+                if (out.returncode == 0 and control_group not in ("", "/")
+                        and control_group.startswith("/")
+                        and ".." not in relative.parts):
+                    path = Path("/sys/fs/cgroup") / relative / "memory.current"
+                    self._memory_current_path = path
+            except (OSError, subprocess.SubprocessError):
+                return None
+        if path is None:
+            return None
+        try:
+            return int(path.read_text().strip()) / (1024.0 ** 3)
+        except (OSError, ValueError):
+            # A unit may disappear between ``systemctl show`` and the read.
+            self._memory_current_path = None
+            return None
+
+    def _read_footprint_gb(self) -> tuple[float, str] | None:
+        if self.unit is not None:
+            value = self._cgroup_footprint_gb()
+            if value is None:
+                return None
+            return value, f"cgroup:{self._memory_current_path}"
+        proc = self.proc
+        if proc is None or proc.poll() is not None:
+            return None
+        value = _process_tree_rss_gb(proc.pid)
+        if value is None:
+            return None
+        return value, f"rss_tree:{proc.pid}"
+
+    def sample_footprint(self, now: float | None = None) -> float | None:
+        """Sample this job's own resident footprint for later attribution."""
+        reading = self._read_footprint_gb()
+        if reading is None:
+            return None
+        value, source = reading
+        if self.footprint_source is not None and source != self.footprint_source:
+            # A source change is a different accounting boundary; joining the
+            # values would manufacture a slope at the seam.
+            self.footprint_samples.clear()
+        self.footprint_source = source
+        sampled_at = time.time() if now is None else now
+        self.footprint_samples.append((sampled_at, value))
+        while (self.footprint_samples
+               and sampled_at - self.footprint_samples[0][0]
+               > MEM_RATE_WINDOW_S):
+            self.footprint_samples.popleft()
+        return value
+
+    def classify_eviction(self, box_drop_rate_gb_s: float) -> dict:
+        """Attribute pressure only when this victim measurably drove it.
+
+        A growing victim is not automatically the cause: unrelated work can
+        consume most of the box while the selected job grows slowly.  A
+        ``victim_growth`` classification therefore requires a sustained own-
+        footprint slope that explains at least half of the sustained box-wide
+        MemAvailable fall.  Flat, recovering, or minority growth is recorded
+        as collateral.  Missing samples are recorded as unknown, never turned
+        into a factual fit verdict.
+        """
+        growth = _median_consecutive_slope(self.footprint_samples)
+        sample_count = len(self.footprint_samples)
+        window_s = (self.footprint_samples[-1][0]
+                    - self.footprint_samples[0][0]) if sample_count >= 2 else 0.0
+        record = {
+            "classification": "unknown",
+            "box_drop_gb_s": round(float(box_drop_rate_gb_s), 6),
+            "victim_growth_gb_s": (None if growth is None
+                                     else round(float(growth), 6)),
+            "victim_growth_share": None,
+            "victim_footprint_start_gb": (
+                round(float(self.footprint_samples[0][1]), 3)
+                if sample_count else None),
+            "victim_footprint_gb": (
+                round(float(self.footprint_samples[-1][1]), 3)
+                if sample_count else None),
+            "sample_count": sample_count,
+            "window_s": round(window_s, 3),
+            "source": self.footprint_source,
+            "measured_at": time.time(),
+        }
+        if growth is None:
+            record["reason"] = "insufficient_footprint_samples"
+            return record
+        if box_drop_rate_gb_s <= 0:
+            record.update(classification="collateral",
+                          reason="box_not_falling")
+            return record
+        share = max(0.0, growth) / box_drop_rate_gb_s
+        record["victim_growth_share"] = round(share, 6)
+        if growth > 0 and share >= ATTRIBUTION_MIN_FRACTION:
+            record.update(classification="victim_growth",
+                          reason="victim_growth_explains_box_drop")
+        else:
+            record.update(classification="collateral",
+                          reason="victim_not_growing_enough_to_explain_drop")
+        return record
 
     def _run(self) -> None:
         item, host = self.item, self.host
@@ -576,29 +814,13 @@ class Job:
                 rc = self.proc.wait()
             elapsed = time.time() - self.started
             if self.evicted:
-                fh.write(f"\n[pqwork] evicted to avoid OOM after {elapsed:.0f}s\n")
+                classification = (self.eviction_attribution or {}).get(
+                    "classification", "unknown")
+                fh.write(f"\n[pqwork] evicted to avoid OOM after {elapsed:.0f}s "
+                         f"(attribution={classification})\n")
 
         if self.evicted:
-            # An eviction is not a failure of the work, so it does not spend
-            # an attempt -- a box under memory pressure would otherwise burn
-            # through max_attempts on items that never got to run. It does
-            # spend an *eviction*, which backs the item off and eventually
-            # concludes it does not fit here.
-            evictions = int(item.get("evictions", 0)) + 1
-            if evictions >= MAX_EVICTIONS:
-                move_item(self.id, CLAIMED, FAILED,
-                          {"outcome": f"evicted_{evictions}x_does_not_fit",
-                           "evictions": evictions, "finished_at": time.time()})
-                self.state = "does_not_fit"
-                return
-            backoff = min(EVICT_BACKOFF_BASE_S * (2 ** (evictions - 1)),
-                          EVICT_BACKOFF_CAP_S)
-            move_item(self.id, CLAIMED, READY,
-                      {"outcome": "evicted_for_memory",
-                       "evictions": evictions,
-                       "not_before": time.time() + backoff,
-                       "attempts": max(0, int(item.get("attempts", 1)) - 1)})
-            self.state = f"evicted (backoff {backoff:.0f}s)"
+            self._finish_eviction()
             return
 
         if self.oomed and not receipt_satisfied(item.get("receipt") or ""):
@@ -632,13 +854,72 @@ class Job:
             move_item(self.id, CLAIMED, FAILED, patch)
             self.state = "failed"
 
+    def _finish_eviction(self) -> bool:
+        """Requeue with more scheduler protection, never a fit verdict."""
+        if not self.evicted:
+            return False
+        item = self.item
+        attribution = self.eviction_attribution or {
+            "classification": "unknown",
+            "reason": "eviction_without_attribution_measurement",
+            "box_drop_gb_s": None,
+            "victim_growth_gb_s": None,
+            "victim_growth_share": None,
+            "victim_footprint_start_gb": None,
+            "victim_footprint_gb": None,
+            "sample_count": len(self.footprint_samples),
+            "window_s": 0.0,
+            "source": self.footprint_source,
+            "measured_at": time.time(),
+        }
+        now = time.time()
+        evictions = item_eviction_count(item) + 1
+        observed = [value for _, value in self.footprint_samples]
+        prior_peak = _positive_item_gb(item, "observed_peak_gb")
+        if prior_peak is not None:
+            observed.append(prior_peak)
+        common = {
+            "eviction_attribution": attribution,
+            "last_evicted_at": now,
+            "attempts": max(0, int(item.get("attempts", 1)) - 1),
+            "evictions": evictions,
+            "evicted_runtime_s": round(self.sunk_runtime_s(now), 3),
+            "protection_earned": (
+                evictions >= EVICTIONS_BEFORE_PROTECTION),
+        }
+        if observed:
+            common["observed_peak_gb"] = round(max(observed), 3)
+
+        classification = attribution.get("classification")
+        if classification == "victim_growth":
+            field = "attributed_evictions"
+            outcome = "evicted_for_own_memory_growth"
+            state = "evicted for own growth"
+        elif classification == "collateral":
+            field = "collateral_evictions"
+            outcome = "evicted_as_collateral"
+            state = "evicted as collateral"
+        else:
+            field = "unattributed_evictions"
+            outcome = "evicted_without_attribution"
+            state = "evicted without attribution"
+        common[field] = int(item.get(field, 0)) + 1
+        moved = move_item(
+            self.id, CLAIMED, READY,
+            {**common, "outcome": outcome,
+             "not_before": now + EVICT_BACKOFF_S})
+        if common["protection_earned"]:
+            state += "; next attempt protected"
+        self.state = f"{state} (cooldown {EVICT_BACKOFF_S:.0f}s)"
+        return moved
+
     def start(self) -> None:
         self.thread.start()
 
     def alive(self) -> bool:
         return self.thread.is_alive()
 
-    def evict(self) -> None:
+    def evict(self, attribution: dict | None = None) -> None:
         """Stop this job so its memory comes back, and requeue it.
 
         SIGTERM to the process group first so a job with a cleanup handler
@@ -646,6 +927,7 @@ class Job:
         rather than the shell matters: the shell is not the process holding
         the tens of gigabytes.
         """
+        self.eviction_attribution = attribution
         self.evicted = True
         if self.unit:
             # A capped job lives in its own unit, not in our process group.
@@ -731,13 +1013,19 @@ class MemoryGovernor:
     """
 
     def __init__(self, reserve_gb: float, horizon_s: float, settle_s: float,
-                 admission: str = "optimistic"):
+                 admission: str = "optimistic", total_gb: float | None = None):
         self.reserve_gb = reserve_gb
         self.horizon_s = horizon_s
         self.settle_s = settle_s
         self.admission = admission
+        self.total_gb = mem_total_gb() if total_gb is None else total_gb
         self.external_hold_gb = 0.0
         self.samples: collections.deque = collections.deque()
+
+    @property
+    def capacity_gb(self) -> float:
+        """Absolute job capacity after the worker's operating reserve."""
+        return max(0.0, self.total_gb - self.reserve_gb)
 
     def sample(self) -> float:
         now, avail = time.time(), mem_available_gb()
@@ -747,15 +1035,70 @@ class MemoryGovernor:
         return avail
 
     def drop_rate_gb_s(self) -> float:
-        """GB/s at which MemAvailable is falling; negative means recovering."""
-        if len(self.samples) < 2:
-            return 0.0
-        (t0, a0), (t1, a1) = self.samples[0], self.samples[-1]
-        dt = t1 - t0
-        return (a0 - a1) / dt if dt > 0 else 0.0
+        """Sustained GB/s fall; negative means sustained recovery.
+
+        This is the negative median consecutive-pair slope.  See
+        :func:`_median_consecutive_slope` for the outlier and minimum-interval
+        contract.
+        """
+        slope = _median_consecutive_slope(self.samples)
+        return -slope if slope is not None else 0.0
+
+    def projection_horizon_s(self) -> float:
+        horizon = self.horizon_s
+        if swap_free_gb() <= 0.5:
+            horizon *= 2.0
+        return horizon
+
+    def projected_available_gb(self) -> float:
+        if not self.samples:
+            return float("inf")
+        return (self.samples[-1][1]
+                - self.drop_rate_gb_s() * self.projection_horizon_s())
 
     def set_external_hold(self, gb: float) -> None:
         self.external_hold_gb = gb
+
+    def reservation_gb(self, item: dict) -> float | None:
+        """Measured/declarative reservation, or ``None`` for exclusive run."""
+        return (_positive_item_gb(item, "mem_gb")
+                or _positive_item_gb(item, "observed_peak_gb"))
+
+    def measured_impossibility(self, item: dict) -> dict | None:
+        """Evidence that this item exceeds absolute capacity on this box."""
+        if item.get("receipt") and receipt_satisfied(item["receipt"]):
+            return None
+        for source, key in (("declared", "mem_gb"),
+                            ("observed", "observed_peak_gb")):
+            footprint = _positive_item_gb(item, key)
+            if footprint is not None and footprint > self.capacity_gb:
+                return {
+                    "source": source,
+                    "footprint_gb": round(footprint, 3),
+                    "box_total_gb": round(self.total_gb, 3),
+                    "reserve_gb": round(self.reserve_gb, 3),
+                    "capacity_gb": round(self.capacity_gb, 3),
+                    "measured_at": time.time(),
+                }
+        return None
+
+    def admission_candidates(self, candidates: list[dict]) -> list[dict]:
+        """Let the most-aged protected item hold admission until it can start.
+
+        Once an item has earned protection, admitting another arrival ahead of
+        it would recreate starvation one layer earlier.  Returning only the
+        most-aged reservation drains existing work without letting a stream of
+        newcomers consume the memory or slot it is waiting for.
+        """
+        protected = [item for item in candidates if item_is_protected(item)]
+        if not protected:
+            return candidates
+        reserved = min(
+            protected,
+            key=lambda item: (-item_eviction_count(item),
+                              -int(item.get("priority", 50)),
+                              float(item.get("enqueued_at", 0))))
+        return [reserved]
 
     def headroom(self, jobs: list) -> float:
         """Memory we may still commit, after unrealized declarations.
@@ -792,11 +1135,16 @@ class MemoryGovernor:
         work is genuinely expensive.
         """
         headroom = self.headroom(jobs)
+        if item_is_protected(item):
+            reservation = self.reservation_gb(item)
+            if reservation is None:
+                # No declared or observed size: drain the box and give the
+                # protected item an exclusive attempt rather than inventing a
+                # number that MemAvailable cannot support.
+                return not jobs and headroom > 0
+            return headroom >= reservation
         if self.admission == "strict":
-            try:
-                want = float(item.get("mem_gb") or 0.0)
-            except (TypeError, ValueError):
-                want = 0.0
+            want = _positive_item_gb(item, "mem_gb") or 0.0
             return headroom >= want
         return headroom > 0
 
@@ -814,26 +1162,38 @@ class MemoryGovernor:
         avail = self.samples[-1][1]
         if avail <= self.reserve_gb:
             return True
-        horizon = self.horizon_s
-        if swap_free_gb() <= 0.5:
-            horizon *= 2.0
-        projected = avail - self.drop_rate_gb_s() * horizon
-        return projected < self.reserve_gb
+        return self.projected_available_gb() < self.reserve_gb
+
+
+def fail_measured_impossibility(item: dict, governor: MemoryGovernor) -> bool:
+    """Fail a ready item only from an explicit absolute-capacity measurement."""
+    measurement = governor.measured_impossibility(item)
+    if measurement is None:
+        return False
+    return move_item(
+        item["id"], READY, FAILED,
+        {"outcome": "measured_footprint_exceeds_box_capacity",
+         "fit_measurement": measurement,
+         "finished_at": time.time()})
 
 
 def choose_victim(jobs: list):
-    """The newest, lowest-priority evictable job.
+    """The lowest-priority job with the least measured sunk runtime.
 
-    Newest because it is the one that pushed the box over and has the least
-    sunk compute to lose; lowest priority first so gold-path work outlives
-    speculative work. A job marked non-evictable is never chosen -- which
-    means a box can still OOM if everything running is pinned, and that is
-    the operator's declared choice rather than a surprise.
+    ``started`` is not a sunk-work measurement: a restarted victim is newest
+    by construction, so newest-first selects the output of its own eviction
+    again.  ``sunk_runtime_s`` carries discarded runtime across attempts and
+    makes restart history protective.  After the bounded aging threshold the
+    job is non-evictable altogether. A user-pinned item remains non-evictable
+    independently of scheduler protection.
     """
     victims = [j for j in jobs if j.evictable and j.alive()]
     if not victims:
         return None
-    return sorted(victims, key=lambda j: (int(j.item.get("priority", 50)), -j.started))[0]
+    now = time.time()
+    return min(victims,
+               key=lambda job: (int(job.item.get("priority", 50)),
+                                job.sunk_runtime_s(now), job.id))
 
 
 def wait_for_queue(once: bool) -> None:
@@ -884,6 +1244,8 @@ def worker_loop(host: str, tags: set, gpu_slots: int, cpu_slots: int,
           f"queue={QUEUE_ROOT}", flush=True)
     last_held = None
     last_mem_hold = 0.0
+    last_reservation = None
+    last_deploy_hold = False
     last_beat = 0.0
     while True:
         if not queue_reachable():
@@ -893,6 +1255,9 @@ def worker_loop(host: str, tags: set, gpu_slots: int, cpu_slots: int,
             ensure_layout()
         avail = gov.sample()
         jobs = [j for j in jobs if j.alive()]
+        sampled_at = gov.samples[-1][0]
+        for job in jobs:
+            job.sample_footprint(sampled_at)
 
         # Memory policing comes before admission: give the box back its
         # headroom before considering whether to take on more.
@@ -900,11 +1265,17 @@ def worker_loop(host: str, tags: set, gpu_slots: int, cpu_slots: int,
             victim = choose_victim(jobs)
             if victim is not None:
                 rate = gov.drop_rate_gb_s()
+                attribution = victim.classify_eviction(rate)
+                growth = attribution["victim_growth_gb_s"]
+                growth_text = ("unmeasured" if growth is None
+                               else f"{growth:.2f}GB/s")
                 print(f"[pqwork] EVICT {victim.id}: MemAvailable {avail:.1f}GB "
                       f"falling {rate:.2f}GB/s -> projected "
-                      f"{avail - rate * horizon_s:.1f}GB below the "
-                      f"{reserve_gb:.0f}GB reserve", flush=True)
-                victim.evict()
+                      f"{gov.projected_available_gb():.1f}GB below the "
+                      f"{reserve_gb:.0f}GB reserve; victim growth "
+                      f"{growth_text} ({attribution['classification']})",
+                      flush=True)
+                victim.evict(attribution)
 
         now = time.time()
         if now - last_beat >= HEARTBEAT_S:
@@ -933,13 +1304,42 @@ def worker_loop(host: str, tags: set, gpu_slots: int, cpu_slots: int,
                       f" -> gpu capacity {gpu_capacity}", flush=True)
             last_held = held
 
-        candidates = []
-        for p in qdir(READY).glob("*.json"):
-            item = read_item(p)
-            if item and is_runnable(item, host, tags, has_gpu,
-                                    only_declared):
-                candidates.append(item)
-        candidates.sort(key=sort_key)
+        deploy_held = deployment_hold_path().exists()
+        if deploy_held != last_deploy_hold:
+            if deploy_held:
+                print("[pqwork] deployment hold active; admitting no new claims",
+                      flush=True)
+            else:
+                print("[pqwork] deployment hold released", flush=True)
+            last_deploy_hold = deploy_held
+
+        candidates = ready_candidates(host, tags, has_gpu, only_declared)
+
+        possible = []
+        for item in candidates:
+            impossibility = gov.measured_impossibility(item)
+            if impossibility is None:
+                possible.append(item)
+                continue
+            if fail_measured_impossibility(item, gov):
+                print(f"[pqwork] FAIL {item['id']}: "
+                      f"{impossibility['source']} footprint "
+                      f"{impossibility['footprint_gb']:.1f}GB exceeds "
+                      f"box capacity {impossibility['capacity_gb']:.1f}GB",
+                      flush=True)
+        candidates = gov.admission_candidates(possible)
+        reservation = (candidates[0] if len(candidates) == 1
+                       and item_is_protected(candidates[0]) else None)
+        reservation_id = reservation["id"] if reservation else None
+        if reservation_id != last_reservation:
+            if reservation is not None:
+                want = gov.reservation_gb(reservation)
+                requirement = (f"{want:.1f}GB" if want is not None
+                               else "an exclusive slot")
+                print(f"[pqwork] protecting {reservation_id} after "
+                      f"{item_eviction_count(reservation)} policy evictions; "
+                      f"reserving {requirement}", flush=True)
+            last_reservation = reservation_id
 
         started_any = False
         for item in candidates:
@@ -1020,6 +1420,11 @@ def cmd_enqueue(a: argparse.Namespace) -> int:
         "enqueued_at": time.time(),
         "attempts": 0,
         "evictions": 0,
+        "attributed_evictions": 0,
+        "collateral_evictions": 0,
+        "unattributed_evictions": 0,
+        "evicted_runtime_s": 0.0,
+        "protection_earned": False,
         "not_before": 0,
     }
     write_json_atomic(item_path(READY, a.id), item)
@@ -1068,14 +1473,18 @@ def cmd_status(a: argparse.Namespace) -> int:
                 where = lease.get("host") if lease else "?"
                 stale = " STALE" if lease_is_stale(i["id"]) else ""
                 bits.append(f"on {where} {_fmt_age(i.get('claimed_at'))}{stale}")
+                if item_is_protected(i):
+                    bits.append("protected")
             elif state == READY:
                 pending = [p for p in (i.get("after") or []) if not receipt_satisfied(p)]
                 if pending:
                     bits.append(f"blocked on {len(pending)} receipt(s)")
+                if item_is_protected(i):
+                    bits.append("protected reservation")
                 cool = float(i.get("not_before") or 0) - time.time()
                 if cool > 0:
-                    bits.append(f"cooling {int(cool)}s after "
-                                f"{i.get('evictions')} eviction(s)")
+                    cause = str(i.get("outcome") or "eviction").replace("_", " ")
+                    bits.append(f"cooling {int(cool)}s after {cause}")
                 bits.append(f"waiting {_fmt_age(i.get('enqueued_at'))}")
             elif state in (DONE, FAILED):
                 bits.append(str(i.get("outcome")))
@@ -1116,7 +1525,13 @@ def cmd_requeue(a: argparse.Namespace) -> int:
     for state in (FAILED, DONE):
         if item_path(state, a.id).exists():
             move_item(a.id, state, READY, {"outcome": None, "attempts": 0,
-                                           "evictions": 0, "not_before": 0})
+                                           "evictions": 0,
+                                           "attributed_evictions": 0,
+                                           "collateral_evictions": 0,
+                                           "unattributed_evictions": 0,
+                                           "evicted_runtime_s": 0.0,
+                                           "protection_earned": False,
+                                           "not_before": 0})
             print(f"requeued {a.id} (was {state})")
             return 0
     print(f"error: no failed/done item '{a.id}'", file=sys.stderr)


### PR DESCRIPTION
## Stack

Depends on #112 and intentionally targets `claude/pqwork-memory-caps`, where `tools/pqwork.py` exists. This branch is one commit ahead of that head.

## What changed

- Replace the endpoint-only MemAvailable rate with the median of consecutive-pair slopes over the retained window. At least three valid intervals are required, so one pair cannot become a trend. Median pair slopes were chosen because one interior outlier creates one steep fall and one steep recovery, while one endpoint outlier corrupts only one interval; neither can dominate the median.
- Sample each running job from its cgroup `memory.current`, with direct process-tree RSS as the uncapped fallback. Persist victim and box rates, footprint endpoints, source, sample count, window, and attribution.
- Separate `evicted_for_own_memory_growth`, `evicted_as_collateral`, and `evicted_without_attribution`. Collateral events do not increment `attributed_evictions`.
- Remove the eviction-count fit verdict entirely. `evicted_Nx_does_not_fit` and exponential backoff are gone. `evictions` is now explicitly scheduler age, with a fixed 60-second cooldown.
- Rank same-priority victims by cumulative measured sunk runtime instead of newest start time. After two policy evictions, the next attempt is non-evictable and holds admission for its declared/observed footprint; an unknown-size item gets an exclusive attempt.
- Add the only memory-fit terminal outcome, `measured_footprint_exceeds_box_capacity`, gated by declared or observed footprint exceeding `MemTotal - reserve` and carrying the measurements in the record.
- Add `python3 tools/deploy_pqwork.py`: repo -> shared queue binary -> both box-local installs, identical SHA-256 verification, service restarts, and a shared no-new-claims hold. It refuses to deploy with any claimed item.

Optimistic admission for new work is unchanged.

## Diagnosis correction

The code defects are confirmed, but the sparse application log cannot by itself reproduce the false projection: its samples are about four minutes apart while the governor retains 30 seconds. Replaying those timestamps through `MemoryGovernor.sample()` is flat on both old and new code. It proves `pq-currency-4b-v2` fit; it does not reveal the unlogged two-second endpoint pair that triggered each eviction.

Also, lina had swap free, so the code used the configured 60-second horizon, not the previously stated 120 seconds. The current-code-failing regression therefore drives `sample()` at the real two-second cadence with one 1 GB/s endpoint step followed by a plateau. The old endpoint implementation evicts on the second sample; this implementation waits for sustained evidence and never evicts that trace.

## Current-code regressions and mutation checks

Exact old-policy mutations were applied temporarily and reverted after each run:

- endpoint slope `(a0 - a1) / dt` -> `test_one_endpoint_step_cannot_override_a_flat_trace` failed;
- victim key `(priority, -started)` -> `test_restart_does_not_make_the_evicted_item_the_next_victim` failed by selecting the restarted item;
- protection forced false -> bounded-arrival simulation failed because the fitting target never survived;
- attribution forced true -> collateral attribution test failed;
- footprint sampler disabled -> cgroup sampling test failed;
- median replaced by the most alarming pair -> blip/recovery test failed;
- sustained rate forced to zero -> genuine-fast-drop positive control failed;
- exponential cooldown restored -> fixed-cooldown assertion failed (120 s observed vs 60 s required);
- measured-impossibility check disabled -> oversized-item converse failed;
- claimed-item check disabled -> deployment refusal test failed;
- worker deployment-hold check disabled -> ready-candidate hold test failed.

The literal sparse-log replay survives the endpoint mutation. That is expected and is the evidence correction above, not a claim that it discriminates the estimator. The two-second endpoint/plateau regression is the test that kills the old implementation.

## Tests

- `tests/test_pqwork.py`: 33 passed
- architecture/doc gates: 20 passed
- required full suite:
  `TMPDIR=/home/rob/pqwork-governor-attribution-scratch PYTHONPATH=. /home/rob/dq-runs/venvs/prismaquant-cu130/bin/python -m pytest tests/ -q -p no:cacheprovider`
  -> **5602 passed, 108 skipped, 3 xfailed, 179 subtests passed; 0 failed** in 19m41s.

Failure-set comparison, not count comparison:

- supplied current-main baseline: `∅`
- this stacked branch: `∅`
- delta: `∅`

The pass total is higher than the approximately 5568 current-main baseline because this PR is stacked on #112 and includes its pqwork coverage plus the new regressions.

## Deployment safety

After merge, run exactly:

```bash
python3 tools/deploy_pqwork.py
```

Run only between claims, never mid-claim. The first rollout must start in a verified idle window because the currently deployed worker does not yet honor the new `.deploying` hold; subsequent rollouts close the admission race themselves. The live queue was not touched and the command was not run during this PR because `pq-currency-4b-v2` is actively claimed and the user explicitly prohibited queue mutation.

No subagent or Fable consultation was used.
