### PR TITLE
Install the exact Tessera development pin in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,33 @@ jobs:
           python-version: ${{ matrix.python }}
           cache: pip
 
+      # Resolve the compatibility pin without importing prismaquant: its
+      # package surface is exactly what this job has not installed yet.
+      - name: Resolve Tessera development pin
+        id: tessera-pin
+        run: echo "commit=$(python tools/resolve_tessera_dev_pin.py)" >> "$GITHUB_OUTPUT"
+
+      - name: Require Tessera repository token
+        env:
+          TESSERA_REPO_TOKEN: ${{ secrets.TESSERA_REPO_TOKEN }}
+        run: |
+          if [ -z "${TESSERA_REPO_TOKEN:-}" ]; then
+            echo "::error::TESSERA_REPO_TOKEN is required to check out pinned private Tessera"
+            exit 1
+          fi
+
+      - name: Check out pinned private Tessera
+        uses: actions/checkout@v7.0.1
+        with:
+          repository: RobTand/tessera
+          ref: ${{ steps.tessera-pin.outputs.commit }}
+          token: ${{ secrets.TESSERA_REPO_TOKEN }}
+          persist-credentials: false
+          path: .ci/tessera
+
+      - name: Install pinned Tessera
+        run: python -m pip install --no-deps .ci/tessera
+
       # CPU torch explicitly: the default PyPI wheel drags a full CUDA stack
       # (~2.5 GB of runner disk and minutes of download) that no test here can
       # use. Installed first so the project's own `torch>=2.6` is satisfied and
@@ -101,6 +128,27 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
+      - name: Resolve Tessera development pin
+        id: tessera-pin
+        run: echo "commit=$(python tools/resolve_tessera_dev_pin.py)" >> "$GITHUB_OUTPUT"
+      - name: Require Tessera repository token
+        env:
+          TESSERA_REPO_TOKEN: ${{ secrets.TESSERA_REPO_TOKEN }}
+        run: |
+          if [ -z "${TESSERA_REPO_TOKEN:-}" ]; then
+            echo "::error::TESSERA_REPO_TOKEN is required to check out pinned private Tessera"
+            exit 1
+          fi
+      - name: Check out pinned private Tessera
+        uses: actions/checkout@v7.0.1
+        with:
+          repository: RobTand/tessera
+          ref: ${{ steps.tessera-pin.outputs.commit }}
+          token: ${{ secrets.TESSERA_REPO_TOKEN }}
+          persist-credentials: false
+          path: .ci/tessera
+      - name: Install pinned Tessera
+        run: python -m pip install --no-deps .ci/tessera
       - name: Install CPU torch
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,9 @@ jobs:
       # package surface is exactly what this job has not installed yet.
       - name: Resolve Tessera development pin
         id: tessera-pin
-        run: echo "commit=$(python tools/resolve_tessera_dev_pin.py)" >> "$GITHUB_OUTPUT"
+        run: |
+          tessera_commit="$(python tools/resolve_tessera_dev_pin.py)"
+          printf 'commit=%s\n' "$tessera_commit" >> "$GITHUB_OUTPUT"
 
       - name: Require Tessera repository token
         env:
@@ -130,7 +132,9 @@ jobs:
           cache: pip
       - name: Resolve Tessera development pin
         id: tessera-pin
-        run: echo "commit=$(python tools/resolve_tessera_dev_pin.py)" >> "$GITHUB_OUTPUT"
+        run: |
+          tessera_commit="$(python tools/resolve_tessera_dev_pin.py)"
+          printf 'commit=%s\n' "$tessera_commit" >> "$GITHUB_OUTPUT"
       - name: Require Tessera repository token
         env:
           TESSERA_REPO_TOKEN: ${{ secrets.TESSERA_REPO_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,21 +75,14 @@ jobs:
           tessera_commit="$(python tools/resolve_tessera_dev_pin.py)"
           printf 'commit=%s\n' "$tessera_commit" >> "$GITHUB_OUTPUT"
 
-      - name: Require Tessera repository token
-        env:
-          TESSERA_REPO_TOKEN: ${{ secrets.TESSERA_REPO_TOKEN }}
-        run: |
-          if [ -z "${TESSERA_REPO_TOKEN:-}" ]; then
-            echo "::error::TESSERA_REPO_TOKEN is required to check out pinned private Tessera"
-            exit 1
-          fi
-
-      - name: Check out pinned private Tessera
+      # Tessera becomes public after its release fixes and audit. Until then,
+      # ordinary checkout access fails here; no private credential is required
+      # or exposed to contributor PRs by this workflow.
+      - name: Check out pinned Tessera
         uses: actions/checkout@v7.0.1
         with:
           repository: RobTand/tessera
           ref: ${{ steps.tessera-pin.outputs.commit }}
-          token: ${{ secrets.TESSERA_REPO_TOKEN }}
           persist-credentials: false
           path: .ci/tessera
 
@@ -135,20 +128,11 @@ jobs:
         run: |
           tessera_commit="$(python tools/resolve_tessera_dev_pin.py)"
           printf 'commit=%s\n' "$tessera_commit" >> "$GITHUB_OUTPUT"
-      - name: Require Tessera repository token
-        env:
-          TESSERA_REPO_TOKEN: ${{ secrets.TESSERA_REPO_TOKEN }}
-        run: |
-          if [ -z "${TESSERA_REPO_TOKEN:-}" ]; then
-            echo "::error::TESSERA_REPO_TOKEN is required to check out pinned private Tessera"
-            exit 1
-          fi
-      - name: Check out pinned private Tessera
+      - name: Check out pinned Tessera
         uses: actions/checkout@v7.0.1
         with:
           repository: RobTand/tessera
           ref: ${{ steps.tessera-pin.outputs.commit }}
-          token: ${{ secrets.TESSERA_REPO_TOKEN }}
           persist-credentials: false
           path: .ci/tessera
       - name: Install pinned Tessera

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,9 +6,11 @@ follow, newest first, each recording its own branch and date.
 Re-stamped (2026-09-04, `codex/pq-175-ci-tessera`) for the **pinned Tessera
 CI dependency** (§8.6; RobTand/prismaquant#175). Both CPU jobs resolve the
 single `TESSERA_DEV_PIN_COMMIT` literal with a stdlib-only source parser before
-PrismaQuant can be imported, fail closed with the named
-`TESSERA_REPO_TOKEN` prerequisite, check out that exact private commit without
-persisting credentials, and install its bytes before PrismaQuant. A failed
+PrismaQuant can be imported, check out that exact commit with ordinary checkout
+access without persisting credentials, and install its bytes before
+PrismaQuant. Tessera remains private until its fixes and audit are complete;
+checkout failure is expected until Rob publishes it. No private-repository
+secret is required by this workflow. A failed
 pin resolver stops the step before publishing any checkout output; its exit
 status is preserved by a separate shell assignment, so an empty ref cannot
 fall back to Tessera's default branch. Gate:
@@ -8358,10 +8360,11 @@ allocation.
 And there is CI to run it — `.github/workflows/ci.yml` (#18, `1cc7b90`) executes the suite on
 every push and PR, on Python 3.12 with CPU torch. Before PrismaQuant is
 installed, both jobs use the stdlib-only `tools/resolve_tessera_dev_pin.py` to
-derive the exact private Tessera checkout from `TESSERA_DEV_PIN_COMMIT`, stop
-without publishing a ref if that resolution fails, fail
-closed unless the explicitly named `TESSERA_REPO_TOKEN` secret is present, and
-install that checkout before exercising the package. §12 D11.
+derive the exact Tessera checkout from `TESSERA_DEV_PIN_COMMIT`, stop
+without publishing a ref if that resolution fails, and install that checkout
+before exercising the package. Ordinary checkout access is sufficient once
+Tessera is public; while it remains private pending fixes and audit, checkout
+failure is expected. §12 D11.
 
 ### 8.7 A fourth plug-in point: `FormatCostPlugin` (formats, not models)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,16 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-03 · `muse/pq-172-173-append`. Stamps
+As of: 2026-09-04 · `codex/pq-175-ci-tessera`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-04, `codex/pq-175-ci-tessera`) for the **pinned Tessera
+CI dependency** (§8.6; RobTand/prismaquant#175). Both CPU jobs resolve the
+single `TESSERA_DEV_PIN_COMMIT` literal with a stdlib-only source parser before
+PrismaQuant can be imported, fail closed with the named
+`TESSERA_REPO_TOKEN` prerequisite, check out that exact private commit without
+persisting credentials, and install its bytes before PrismaQuant. Gate:
+`tests/test_ci_tessera_install.py` (pre-fix: the workflow contained no pinned
+Tessera checkout).
 
 Re-stamped (2026-09-03, `muse/pq-172-173-append`) for the **append-identity
 follow-ups** (§5.4; RobTand/prismaquant#172, #173). Two configurations the
@@ -8344,7 +8353,11 @@ rather than uniform-format. Direct profile coverage asserts the spec stays
 empty so a native-lane assumption cannot silently constrain the Gridbook
 allocation.
 And there is CI to run it — `.github/workflows/ci.yml` (#18, `1cc7b90`) executes the suite on
-every push and PR, on py3.11 and 3.12 with CPU torch. §12 D11.
+every push and PR, on Python 3.12 with CPU torch. Before PrismaQuant is
+installed, both jobs use the stdlib-only `tools/resolve_tessera_dev_pin.py` to
+derive the exact private Tessera checkout from `TESSERA_DEV_PIN_COMMIT`, fail
+closed unless the explicitly named `TESSERA_REPO_TOKEN` secret is present, and
+install that checkout before exercising the package. §12 D11.
 
 ### 8.7 A fourth plug-in point: `FormatCostPlugin` (formats, not models)
 
@@ -9232,7 +9245,7 @@ unplumbed).
 | ~~D8~~ | **CLOSED 2026-07-30 (re-vet R24).** `_production_cache_prefetch_assignment` gained a `require` mode mirroring `production_weight_cache.prefetch_assignment(require=…)`, exposed as `--production-cache-prefetch {require,warn}`; `run-pipeline.sh` passes `require` on the native lane (matching `VALIDATED_SOURCE_PREFETCH=require`), and the CB/GGUF lanes read no production cache at all. A total miss is now a named failure instead of a silent NVMe-bound export. | `export_native_compressed._production_cache_prefetch_assignment` | ~~MED~~ | closed |
 | ~~D9~~ | **CLOSED 2026-07-30 (re-vet R24).** The guard is at `main()` entry (not import time) in all seven — `incremental_probe`, `incremental_measure_quant_cost`, `aura_cost`, `production_render_cost`, `export_nvfp4_cb[_streaming]`, `export_gguf`, `select_validated_frontier` — verified against every CPU-only test import first, and a parametrized test pins all twelve callers so a refactor cannot drop one. | `gpu_guard.py` | ~~MED~~ | closed |
 | ~~D10~~ | **CLOSED 2026-07-30 (re-vet R5).** `pipeline.py` now has one real job — settings-hash authority (§3.4) — and the bookkeeping is honest: the two owner names that existed nowhere in the tree are deleted, `streaming_model_weights` names `layer_streaming.LayerCache`, and a test asserts every approved owner has a class behind it. `QuantWeightCache` went to the archive wall with L3, so it is no longer an unmodelled holder. The *spec* half stays explicitly descriptive (§3.6); modelling the ten executed-but-unmodelled stages was refused as fiction-surface. | §3.6; `pipeline.py` | ~~MED~~ | closed |
-| D11 | **MOSTLY FIXED 2026-07-30.** `model_profiles/validate.py`'s 8 conformance checks had zero callers and there were no workflow files in the tree. Both halves closed: `.github/workflows/ci.yml` (#18, `1cc7b90`) runs the suite on every push and PR (py3.11/3.12, CPU torch), and `tests/test_model_profile_conformance.py` drives the CPU-safe checks (1, 6, 8 + four structural invariants) over every registered profile, with 2/3/4 behind `integration` and 6/7 behind `slow`, and known gaps encoded as ratchets rather than bare xfails. **Residual (2026-07-30, R12): the check-5 half is now covered** — `test_has_mtp_implies_a_buildable_mtp_module` asserts `build_mtp_module` is a real override (and `mtp_source_prefix()` non-empty) whenever `has_mtp()`, which is the declarative part of the check that would catch L2/D2; check 5 proper still materialises a decoder layer and stays out of CI. Remaining: nothing invokes the validator as a `run-pipeline.sh` preflight for the actual `MODEL_PATH`. | `.github/workflows/ci.yml`; `tests/test_model_profile_conformance.py:9-31,223-249` | LOW (was MED) | Add a preflight invocation for `MODEL_PATH`. |
+| D11 | **MOSTLY FIXED 2026-07-30.** `model_profiles/validate.py`'s 8 conformance checks had zero callers and there were no workflow files in the tree. Both halves closed: `.github/workflows/ci.yml` (#18, `1cc7b90`) runs the suite on every push and PR (Python 3.12, CPU torch), and `tests/test_model_profile_conformance.py` drives the CPU-safe checks (1, 6, 8 + four structural invariants) over every registered profile, with 2/3/4 behind `integration` and 6/7 behind `slow`, and known gaps encoded as ratchets rather than bare xfails. **Residual (2026-07-30, R12): the check-5 half is now covered** — `test_has_mtp_implies_a_buildable_mtp_module` asserts `build_mtp_module` is a real override (and `mtp_source_prefix()` non-empty) whenever `has_mtp()`, which is the declarative part of the check that would catch L2/D2; check 5 proper still materialises a decoder layer and stays out of CI. Remaining: nothing invokes the validator as a `run-pipeline.sh` preflight for the actual `MODEL_PATH`. | `.github/workflows/ci.yml`; `tests/test_model_profile_conformance.py:9-31,223-249` | LOW (was MED) | Add a preflight invocation for `MODEL_PATH`. |
 | ~~D12~~ | **CLOSED 2026-07-30 (re-vet R1).** `TARGET_DISK_GB` is plumbed through `run-pipeline.sh`: it overrides `TARGET_BITS`, narrows the Pareto sweep to the byte-feasible bracket, flips `SELECTION_MODE` to `validated-surrogate` and the frontier pick to `budget` = min measured KL among the rows that fit. Kneedle stays the default without a card and stays a diagnostic. See §4.6. | §4.6; `select_validated_frontier --mode budget` | ~~MED~~ | closed |
 | D13 | **FIXED 2026-07-30 (R22 + R27).** The two hardcoded MiniMax arch tests now route through `profile.bypass_hf_fp8_module_rewrite()` and `profile.packed_expert_module_class_names()`; `specs/minimax_m2.json` exists and declares all eight of that profile's overrides; `deepseek_v4.json` declares `default_serving_profile: vllm_packed_moe`. Core-stack arch literals in control flow: **0**. Residual (not debt, sequencing): the MiniMax Python overrides stay until the equivalence gate `tests/test_minimax_m2_spec.py` has held for a release. | §8.4, §8.5 L4 | closed | — |
 | ~~D14~~ | **CLOSED 2026-08-01.** Runtime documentation now lives with the sole canonical Gridbook package. PrismaQuant documents only its producer/export contract and points to the pinned package's machine-readable runtime contract; the former in-tree README was deleted with the vendored runtime. | external Gridbook `README.md`; `prismaquant/gridbook_runtime/gridbook_runtime_pin.json` | ~~MED~~ | closed |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,10 @@ CI dependency** (§8.6; RobTand/prismaquant#175). Both CPU jobs resolve the
 single `TESSERA_DEV_PIN_COMMIT` literal with a stdlib-only source parser before
 PrismaQuant can be imported, fail closed with the named
 `TESSERA_REPO_TOKEN` prerequisite, check out that exact private commit without
-persisting credentials, and install its bytes before PrismaQuant. Gate:
+persisting credentials, and install its bytes before PrismaQuant. A failed
+pin resolver stops the step before publishing any checkout output; its exit
+status is preserved by a separate shell assignment, so an empty ref cannot
+fall back to Tessera's default branch. Gate:
 `tests/test_ci_tessera_install.py` (pre-fix: the workflow contained no pinned
 Tessera checkout).
 
@@ -8355,7 +8358,8 @@ allocation.
 And there is CI to run it — `.github/workflows/ci.yml` (#18, `1cc7b90`) executes the suite on
 every push and PR, on Python 3.12 with CPU torch. Before PrismaQuant is
 installed, both jobs use the stdlib-only `tools/resolve_tessera_dev_pin.py` to
-derive the exact private Tessera checkout from `TESSERA_DEV_PIN_COMMIT`, fail
+derive the exact private Tessera checkout from `TESSERA_DEV_PIN_COMMIT`, stop
+without publishing a ref if that resolution fails, fail
 closed unless the explicitly named `TESSERA_REPO_TOKEN` secret is present, and
 install that checkout before exercising the package. §12 D11.
 

--- a/tests/test_ci_tessera_install.py
+++ b/tests/test_ci_tessera_install.py
@@ -2,10 +2,14 @@
 from __future__ import annotations
 
 import ast
+import os
 import re
 import subprocess
 import sys
+import textwrap
 from pathlib import Path
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -39,6 +43,53 @@ def _job(workflow: str, name: str) -> str:
     )
     assert match is not None, f"CI workflow has no {name!r} job"
     return match.group(0)
+
+
+@pytest.mark.parametrize("job_name", ["tests", "imports"])
+@pytest.mark.parametrize("valid_pin", [False, True])
+def test_ci_pin_step_propagates_resolver_status(tmp_path, job_name, valid_pin):
+    job = _job(WORKFLOW.read_text(encoding="utf-8"), job_name)
+    step = re.search(
+        r"(?ms)^      - name: Resolve Tessera development pin\n"
+        r"(.*?)(?=^      -|\Z)",
+        job,
+    )
+    assert step is not None
+    run = re.search(r"(?m)^        run: (.*)$", step.group(1))
+    assert run is not None
+    command = run.group(1)
+    if command == "|":
+        command = textwrap.dedent(step.group(1)[run.end():])
+
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "tools" / PIN_RESOLVER.name).write_text(
+        PIN_RESOLVER.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    (tmp_path / "prismaquant").mkdir()
+    pin = _dev_pin_literal() if valid_pin else "not-a-commit"
+    (tmp_path / "prismaquant" / PIN_SOURCE.name).write_text(
+        f"TESSERA_DEV_PIN_COMMIT = {pin!r}\n", encoding="utf-8"
+    )
+    output = tmp_path / "github-output"
+    completed = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", command],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "GITHUB_OUTPUT": str(output),
+            "PATH": f"{Path(sys.executable).parent}{os.pathsep}{os.environ['PATH']}",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if valid_pin:
+        assert completed.returncode == 0, completed.stderr
+        assert output.read_text(encoding="utf-8") == f"commit={pin}\n"
+    else:
+        assert completed.returncode != 0, "CI masked a failed pin resolver"
+        assert "must be a full lowercase Git SHA" in completed.stderr
+        assert not output.exists() or not output.read_text(encoding="utf-8")
 
 
 def test_stdlib_resolver_reads_the_authoritative_pin_without_package_imports():

--- a/tests/test_ci_tessera_install.py
+++ b/tests/test_ci_tessera_install.py
@@ -107,7 +107,7 @@ def test_stdlib_resolver_reads_the_authoritative_pin_without_package_imports():
     assert _dev_pin_literal() not in resolver
 
 
-def test_ci_installs_the_authoritative_private_tessera_pin_in_every_job():
+def test_ci_installs_the_authoritative_tessera_pin_without_private_credentials():
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
     # A copied SHA becomes a second pin and can drift from the admission rule.
@@ -119,19 +119,16 @@ def test_ci_installs_the_authoritative_private_tessera_pin_in_every_job():
         resolve = "python tools/resolve_tessera_dev_pin.py"
         assert resolve in job, name
         assert "id: tessera-pin" in job, name
-        assert "name: Require Tessera repository token" in job, name
-        assert "TESSERA_REPO_TOKEN is required" in job, name
-        assert 'if [ -z "${TESSERA_REPO_TOKEN:-}" ]' in job, name
+        assert "TESSERA_REPO_TOKEN" not in job, name
         assert "repository: RobTand/tessera" in job, name
         assert "ref: ${{ steps.tessera-pin.outputs.commit }}" in job, name
-        assert "token: ${{ secrets.TESSERA_REPO_TOKEN }}" in job, name
         assert "persist-credentials: false" in job, name
         assert "python -m pip install --no-deps .ci/tessera" in job, name
 
-        # Resolve and validate credentials before touching the private remote;
-        # install those bytes before importing/installing PrismaQuant itself.
-        assert job.index(resolve) < job.index("Require Tessera repository token")
-        assert job.index("Require Tessera repository token") < job.index(
+        # Resolve the pin before checkout; install those bytes before
+        # importing/installing PrismaQuant itself. Ordinary checkout access
+        # becomes sufficient when Tessera is published, including fork PRs.
+        assert job.index(resolve) < job.index(
             "repository: RobTand/tessera"
         )
         assert job.index("repository: RobTand/tessera") < job.index(

--- a/tests/test_ci_tessera_install.py
+++ b/tests/test_ci_tessera_install.py
@@ -1,0 +1,91 @@
+"""CI must install the exact Tessera checkout PrismaQuant was reviewed against."""
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+PIN_SOURCE = ROOT / "prismaquant" / "tessera_runtime_contract.py"
+PIN_RESOLVER = ROOT / "tools" / "resolve_tessera_dev_pin.py"
+
+
+def _dev_pin_literal() -> str:
+    tree = ast.parse(PIN_SOURCE.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if not any(
+            isinstance(target, ast.Name)
+            and target.id == "TESSERA_DEV_PIN_COMMIT"
+            for target in targets
+        ):
+            continue
+        value = ast.literal_eval(node.value)
+        assert isinstance(value, str)
+        return value
+    raise AssertionError("TESSERA_DEV_PIN_COMMIT is not a literal assignment")
+
+
+def _job(workflow: str, name: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(name)}:\n(.*?)(?=^  [a-zA-Z0-9_-]+:\n|\Z)",
+        workflow,
+    )
+    assert match is not None, f"CI workflow has no {name!r} job"
+    return match.group(0)
+
+
+def test_stdlib_resolver_reads_the_authoritative_pin_without_package_imports():
+    completed = subprocess.run(
+        [sys.executable, str(PIN_RESOLVER)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == _dev_pin_literal()
+    resolver = PIN_RESOLVER.read_text(encoding="utf-8")
+    assert "import prismaquant" not in resolver
+    assert _dev_pin_literal() not in resolver
+
+
+def test_ci_installs_the_authoritative_private_tessera_pin_in_every_job():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    # A copied SHA becomes a second pin and can drift from the admission rule.
+    # The workflow must run the stdlib-only source resolver from its checkout.
+    assert _dev_pin_literal() not in workflow
+
+    for name in ("tests", "imports"):
+        job = _job(workflow, name)
+        resolve = "python tools/resolve_tessera_dev_pin.py"
+        assert resolve in job, name
+        assert "id: tessera-pin" in job, name
+        assert "name: Require Tessera repository token" in job, name
+        assert "TESSERA_REPO_TOKEN is required" in job, name
+        assert 'if [ -z "${TESSERA_REPO_TOKEN:-}" ]' in job, name
+        assert "repository: RobTand/tessera" in job, name
+        assert "ref: ${{ steps.tessera-pin.outputs.commit }}" in job, name
+        assert "token: ${{ secrets.TESSERA_REPO_TOKEN }}" in job, name
+        assert "persist-credentials: false" in job, name
+        assert "python -m pip install --no-deps .ci/tessera" in job, name
+
+        # Resolve and validate credentials before touching the private remote;
+        # install those bytes before importing/installing PrismaQuant itself.
+        assert job.index(resolve) < job.index("Require Tessera repository token")
+        assert job.index("Require Tessera repository token") < job.index(
+            "repository: RobTand/tessera"
+        )
+        assert job.index("repository: RobTand/tessera") < job.index(
+            "python -m pip install --no-deps .ci/tessera"
+        )
+        assert job.index("python -m pip install --no-deps .ci/tessera") < job.index(
+            "name: Install prismaquant"
+        )

--- a/tools/resolve_tessera_dev_pin.py
+++ b/tools/resolve_tessera_dev_pin.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Print PrismaQuant's reviewed Tessera commit without importing PrismaQuant."""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+
+PIN_NAME = "TESSERA_DEV_PIN_COMMIT"
+PIN_SOURCE = (
+    Path(__file__).resolve().parents[1]
+    / "prismaquant"
+    / "tessera_runtime_contract.py"
+)
+
+
+def resolve_tessera_dev_pin(source: Path = PIN_SOURCE) -> str:
+    """Read the single literal development pin from its owning source file."""
+
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    values: list[object] = []
+    for node in tree.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if any(
+            isinstance(target, ast.Name) and target.id == PIN_NAME
+            for target in targets
+        ):
+            values.append(ast.literal_eval(node.value))
+    if len(values) != 1:
+        raise SystemExit(
+            f"{source}: expected exactly one literal {PIN_NAME} assignment"
+        )
+    value = values[0]
+    if not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{40}", value) is None:
+        raise SystemExit(
+            f"{source}: {PIN_NAME} must be a full lowercase Git SHA"
+        )
+    return value
+
+
+if __name__ == "__main__":
+    print(resolve_tessera_dev_pin())


### PR DESCRIPTION
Refs #175.

CI currently fails before collection because PrismaQuant imports Tessera's grammar but never installs Tessera. Both jobs now resolve the single `TESSERA_DEV_PIN_COMMIT` literal with a stdlib-only reader, check out that exact commit without persisting credentials, and install Tessera before PrismaQuant. Invalid pins stop the shell step before it can publish an empty ref and fall back to Tessera's default branch.

Tessera will become public after its remaining fixes and audit, as Rob has specified. This workflow uses ordinary checkout access and requires no private-repository secret, including for fork PRs. Checkout failure while Tessera remains private is expected; functional GitHub CI recovery is verified after publication. No repository visibility, serving eligibility, or PENDING release pin changes.

Validation through PrismaBuild on dl380g10, 1 CPU / 4 GiB, `CUDA_VISIBLE_DEVICES=''`:

- Original implementation: two regression failures before the fix (`469aa632bf3359c814255b9e0539f2845e8efb96f5b13feaca03c831b78c2b33`); both passed afterward.
- Shell-failure regression: `b6528206bd859a73121c59e27e7ccf8b5815e40a3c8ee03119f8ae0d497d1a97` produced `2 failed, 4 passed`, with `AssertionError: CI masked a failed pin resolver` in both jobs.
- Post-fix `ee2688b19208a673fe3c8cbb82930fe2d9fc08dd800ce890533d9f76eedeb6eb`: all six CI-contract cases passed; combined touched CI/doc files produced `22 passed, 3 failed`, no skips. Those three failures are the already-recorded missing `compressed_tensors` dependency, also present in the pristine-main comparison `742e6ff00bd859a58f422793c17a3c47b3a80b2db01b3cb31d36114e219f3c8f`.
- Publication-contract regression `cffe356189277b0d1a5c675aa815d2aad9870889f91470da735acda5b9402f5f`: `1 failed, 5 passed` because the former workflow still required `TESSERA_REPO_TOKEN`. Final `1f0f75fdaa8a21d449f51be67dfe43688f6aded9d3f892766dcfc91797473616`: all six CI cases passed, combined `22 passed, 3 failed`, no skips, with the same known dependency failures.

The latest CPU snapshots omit the three tracked external calibration symlinks because PrismaBuild correctly refuses to seal paths outside the repository. None of these static CI/doc tests reads those datasets; the source worktree's links are restored and unchanged. This is no CUDA acceptance claim and no full-suite run.
