### PR TITLE
Fix boundary gate HTTP response contract

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,18 +109,22 @@ fourth lane with a novel gate is one spec file plus one verifier, and neither
 roster exists to be forgotten.
 
 
-Re-stamped (2026-09-03, `muse/pq-87-shipgate`) for the **sampled
-boundary-behavior ship gate** (§7.2; issue #87). KL/PPL and greedy-smoke are
-argmax- and distribution-distance measures, structurally blind to
-boundary-token defects that only manifest under sampling (three DSV4-Flash
-quants within ~3% PPL spanning a 6x behavioral gap). `run_validation` now
-files a fifth check, `boundary_behavior`: 5 terse prompts × 6 reps sampled at
-temperature 1.0 under a 64-token cap, scored by the server-free
-`score_boundary_text` for `zero_tag` / `think_stutter` / `cap_truncation`
-with a zero bound. `verify` replays the ledger membership, the exact
-boundary thresholds, and the evidence (positive generation count, zero
-defects, sampling temperature). Gates:
-`tests/test_ship_boundary_behavior.py` (14).
+Re-stamped (2026-09-04, `codex/pq-87-boundary-chat`) for the **sampled
+boundary-behavior request contract** (§7.2; issue #87, still open). The first
+physical run showed that the original implementation posted bare prompts to
+`/v1/completions`; vLLM applies no chat template there, so healthy DSV4 and
+Qwen references both failed 30/30 before artifact behavior was exercised. The
+check now posts a user `messages` body to `/v1/chat/completions`, explicitly
+enables thinking and reasoning output, and recovers the raw boundary semantics
+from either unparsed `message.content` or vLLM's structured `reasoning` /
+`reasoning_content` split. The endpoint plus request/response schema are filed
+in the check metrics and replayed by `shipcard.verify`, so a copied zero count
+from the old route cannot certify an artifact. **This fixes only the request
+contract.** The same run disproved the universal 64-token/zero-defect policy
+(healthy DSV4: 7/30 at 64; stock Qwen3-8B: 10/15 even at 600), so those values
+remain fail-closed historical defaults pending a same-session control-derived
+cap and control-relative verdict; no artifact is promoted and #87 is not
+closed on this commit. Gate: `tests/test_ship_boundary_behavior.py`.
 
 Re-stamped (2026-09-03, `pq132-fused-licence`) for the **fused module's
 per-member rung licence, read from the contract** (§4.10; PrismaQuant #132
@@ -7214,9 +7218,9 @@ CLI-overridable:
 | `DEFAULT_MAX_MEAN_NLL` | 3.0 | mean NLL |
 | `DEFAULT_MIN_GEN_LEN` | 30 chars | per completion |
 | `DEFAULT_MIN_MTP_ACCEPT_P0` | 0.60 | position-0 draft acceptance |
-| `DEFAULT_MAX_BOUNDARY_DEFECTS` | 0 | any `</think>` stutter/zero-tag/cap-truncation on a terse prompt is a functional failure (the answer is never reached); the clean reference scores 0 on this stratum (official unquantized 0/60 terse) |
+| `DEFAULT_MAX_BOUNDARY_DEFECTS` | 0 | fail-closed historical value, **not a calibrated universal bound**: stock Qwen3-8B produced 10/15 at a 600-token cap. Replacement requires a same-session control-relative policy; #87 remains open |
 | `DEFAULT_BOUNDARY_TEMPERATURE` | 1.0 | the unmodified distribution — any temperature > 0 leaves the argmax path greedy-smoke takes; temp 0 is refused, not sampled |
-| `DEFAULT_BOUNDARY_MAX_TOKENS` | 64 | far above what these prompts need, so `length` means runaway/loop |
+| `DEFAULT_BOUNDARY_MAX_TOKENS` | 64 | fail-closed historical value, **known too short**: healthy DSV4 produced 7/30 cap truncations. It remains only until the paired control derives its finishing cap from the model/context contract |
 | `DEFAULT_BOUNDARY_REPS` | 6 | the published battery's own replication count (30 prompts × 6 reps): 5 prompts × 6 reps = 30 sampled generations |
 
 **Sampled boundary behavior (#87).** KL/PPL (distribution distance) and
@@ -7225,13 +7229,32 @@ distribution defects that only manifest under sampling: three DSV4-Flash
 quants within ~3% PPL spanned a 6x behavioral gap (14/180 to 83/180) on the
 frozen battery, because greedy takes the argmax path where the boundary token
 still wins and KL/PPL average a per-token near-tie at one boundary position
-into noise. `check_boundary_behavior` (`:388`) samples the terse
-boundary-stressing prompts (ultra-short numeric, terse QA, short recall —
-the first three verbatim from the report) at temperature > 0 under a small
-cap and scores every generation with the server-free `score_boundary_text`
-(`:360`) for the closed defect vocabulary `zero_tag` / `think_stutter` /
-`cap_truncation`. It runs alongside KL/PPL, not replacing them: a few dozen
-sampled generations, minutes of serve time, no reference model needed.
+into noise. `check_boundary_behavior` samples the terse boundary-stressing
+prompts (ultra-short numeric, terse QA, short recall — the first three
+verbatim from the report) at temperature > 0 and scores every generation with
+the server-free `score_boundary_text` for the closed defect vocabulary
+`zero_tag` / `think_stutter` / `cap_truncation`. The request contract is
+`prismaquant.boundary_chat_request/1`: POST `/v1/chat/completions`, one user
+`messages` row, thinking enabled in the chat-template kwargs, reasoning
+included, and special tokens retained. The response contract is
+`prismaquant.boundary_chat_response/1`: raw `message.content` is scored
+directly; when vLLM's reasoning parser has consumed the first close token and
+split the response into `reasoning` (or legacy `reasoning_content`) plus
+`content`, the client reconstructs exactly that one boundary only when both
+reasoning-side and answer-side content are non-empty. A later close remains
+visible as stutter, while either empty side remains zero-tag/cap-truncation.
+Both schema identities and the endpoint are filed in the shipcard and replayed
+offline.
+
+This endpoint fix is necessary and insufficient. Physical evidence invalidated
+the current 64-token cap and a universal zero roster: healthy DSV4 still filed
+7/30 cap truncations at 64, while stock Qwen3-8B filed 10/15 even at 600. The
+pending policy is a same-session BF16 control whose cap grows until the control
+reaches its own finishing fixed point, bounded by the declared model context
+and an explicit backstop; the quantized arm is then scored control-relative at
+that exact cap. Until that paired receipt is specified and replayed, the old
+64/zero values remain fail-closed, #87 remains `needs-decision`, and a boundary
+check cannot promote an artifact.
 
 **Spec-decode refusal.** `_spec_decode_on` scrapes `/metrics` for
 `vllm:spec_decode`; if present the perplexity check **refuses a verdict** rather than return
@@ -7241,7 +7264,7 @@ ship-ready requires both. The same refusal now also guards the gold lane (§7.3)
 exist only here.
 
 **The guard fails closed, and the URL it uses is not `--base-url` verbatim (2026-08-14).**
-`--base-url` is the **server** root: the module appends `/v1/completions` itself and reads
+`--base-url` is the **server** root: the module appends its `/v1/*` endpoints itself and reads
 `/health` and `/metrics` off the root. The `compressed_tensors` lane spec published the OpenAI
 root (`http://127.0.0.1:8000/v1`), so on the Qwen3.8-27B ship gate `wait_for_ready` polled
 `/v1/health` — 404 — for 11 minutes and would have burned its whole 900 s timeout without

--- a/prismaquant/shipcard.py
+++ b/prismaquant/shipcard.py
@@ -2874,9 +2874,34 @@ def _verify_ship_gate_record(
         problems.append(f"{slot}: missing structured perplexity evidence")
     boundary = metrics.get("boundary_behavior")
     if isinstance(boundary, Mapping):
-        # The behavioral replay: a sampled check with no generations, run at
-        # temp 0, or with defects over the zero-tolerance bound is not
-        # evidence — it is the old argmax-blind gate wearing the new name.
+        # The behavioral replay: raw `/v1/completions` never applies the chat
+        # template, so a clean-looking count from that endpoint is not
+        # boundary evidence.  Pin the producer's request and extraction
+        # schemas independently here, alongside the numerical replay below.
+        endpoint = boundary.get("endpoint")
+        if endpoint != "/v1/chat/completions":
+            problems.append(
+                f"{slot}: boundary endpoint={endpoint!r}, expected "
+                "'/v1/chat/completions'"
+            )
+        request_schema = boundary.get("request_schema")
+        if request_schema != "prismaquant.boundary_chat_request/1":
+            problems.append(
+                f"{slot}: boundary request schema={request_schema!r}, "
+                "expected 'prismaquant.boundary_chat_request/1'"
+            )
+        response_schema = boundary.get("response_schema")
+        if response_schema != "prismaquant.boundary_chat_response/1":
+            problems.append(
+                f"{slot}: boundary response schema={response_schema!r}, "
+                "expected 'prismaquant.boundary_chat_response/1'"
+            )
+
+        # A sampled check with no generations, run at temp 0, or with defects
+        # over the zero-tolerance bound is not evidence — it is the old
+        # argmax-blind gate wearing the new name.  The zero/64 values remain
+        # fail-closed historical defaults pending #87's paired-control policy;
+        # replaying them here does not claim they are calibrated universally.
         generations = boundary.get("n_generations")
         if (
             isinstance(generations, bool)

--- a/prismaquant/validate_quantized_model.py
+++ b/prismaquant/validate_quantized_model.py
@@ -19,7 +19,10 @@ Checks, in order:
    3. **Boundary behavior** — sampled (temperature > 0) generations over
       terse boundary-stressing prompts (`BOUNDARY_PROMPTS`), scored
       mechanically for `</think>` stutter/loop, zero-tag runaway, and
-      cap-truncation-before-answer. Zero defects allowed by default. This
+      cap-truncation-before-answer. The chat endpoint is mandatory: raw
+      completions do not apply the model's reasoning template. Zero defects
+      under 64 tokens remains a fail-closed historical default pending #87's
+      paired-control policy; it is not a calibrated universal claim. This
       is the axis KL/PPL (distribution distance) and greedy-smoke (argmax
       agreement) cannot see at any threshold: three DSV4-Flash quants
       within ~3% PPL spanned a 6x behavioral gap (14/180 to 83/180).
@@ -85,6 +88,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Mapping
 from dataclasses import dataclass, field, asdict
 
 
@@ -156,6 +160,19 @@ BOUNDARY_DEFECTS: tuple[str, ...] = (
 
 THINK_CLOSE_TAG = "</think>"
 
+# The boundary gate must exercise the model's chat template.  Raw
+# ``/v1/completions`` continues the literal user string and therefore never
+# enters a thinking model's reasoning scaffold.  These values are also filed
+# in the shipcard metrics so offline replay can reject a clean-looking count
+# produced under the old, structurally blind request.
+BOUNDARY_ENDPOINT = "/v1/chat/completions"
+BOUNDARY_REQUEST_SCHEMA = "prismaquant.boundary_chat_request/1"
+BOUNDARY_RESPONSE_SCHEMA = "prismaquant.boundary_chat_response/1"
+BOUNDARY_CHAT_TEMPLATE_KWARGS = {
+    "thinking": True,
+    "enable_thinking": True,
+}
+
 
 # -----------------------------------------------------------------
 # Default thresholds (tune via CLI if needed)
@@ -165,16 +182,14 @@ DEFAULT_MAX_P99_NLL = 6.0
 DEFAULT_MAX_MEAN_NLL = 3.0
 DEFAULT_MIN_GEN_LEN = 30               # chars in each generated completion
 DEFAULT_MIN_MTP_ACCEPT_P0 = 0.60       # position-0 accept fraction
-# Boundary-behavior gate (issue #87). `MAX_BOUNDARY_DEFECTS = 0` is not a
-# tuned knob: any stutter/zero-tag/cap-hit on a terse prompt is a functional
-# failure (the answer is never reached), and the clean reference scores 0 on
-# this stratum (official unquantized 0/60 terse, fixed quant 0/60). Sampling
-# temperature 1.0 is the unmodified distribution — any temperature > 0 leaves
-# the argmax path and exposes the near-tie; 1.0 adds no tuning. `MAX_TOKENS`
-# 64 is far above what these prompts need, so `length` means runaway/loop.
-# `REPS` 6 is the published battery's own replication count (30 prompts × 6
-# reps main + 24 reps × 5 numeric stackext): 5 prompts × 6 reps = 30 sampled
-# generations, minutes of serve time.
+# Boundary-behavior gate (issue #87).  Temperature 1.0 is the unmodified
+# distribution and `REPS` 6 is the published battery's own replication count.
+# The zero bound and 64-token cap are retained as fail-closed historical
+# defaults only while the paired-control policy is unresolved: a first real
+# endpoint audit found healthy DSV4 at 7/30 defects under 64 tokens and stock
+# Qwen3-8B at 10/15 even under 600.  They are not calibrated universal claims
+# and must not be used to close #87 or promote an artifact without the pending
+# same-session control decision.
 DEFAULT_MAX_BOUNDARY_DEFECTS = 0
 DEFAULT_BOUNDARY_TEMPERATURE = 1.0
 DEFAULT_BOUNDARY_MAX_TOKENS = 64
@@ -385,6 +400,59 @@ def score_boundary_text(
     return {"think_tag_count": count, "defects": defects}
 
 
+def _boundary_text_from_chat_choice(choice: Mapping) -> tuple[str, str]:
+    """Recover boundary semantics from one chat-completion choice.
+
+    vLLM without a reasoning parser returns the raw generated text in
+    ``message.content``.  With a parser, it consumes the first ``</think>`` and
+    returns the two sides as ``message.reasoning`` (current spelling) or
+    ``message.reasoning_content`` (older OpenAI-compatible spelling).  In the
+    structured case we synthesize exactly that one consumed delimiter only
+    when both reasoning-side and answer-side content are non-empty.  A second
+    delimiter remains in content and is still scored as stutter; an empty
+    side remains zero-tag/cap-truncation rather than receiving an invented
+    close token.
+
+    The accepted shapes are deliberately closed.  An ambiguous pair of
+    non-null reasoning fields or a non-string field is a malformed response,
+    not a clean generation.
+    """
+    if not isinstance(choice, Mapping):
+        raise TypeError("chat choice is not an object")
+    message = choice.get("message")
+    if not isinstance(message, Mapping):
+        raise TypeError("chat choice is missing message object")
+
+    content = message.get("content")
+    if content is not None and not isinstance(content, str):
+        raise TypeError("chat message.content is not a string or null")
+
+    structured: list[tuple[str, str]] = []
+    for field_name in ("reasoning", "reasoning_content"):
+        value = message.get(field_name)
+        if value is None:
+            continue
+        if not isinstance(value, str):
+            raise TypeError(
+                f"chat message.{field_name} is not a string or null")
+        structured.append((field_name, value))
+    if len(structured) > 1:
+        raise ValueError(
+            "chat message carries both reasoning and reasoning_content")
+
+    if structured:
+        field_name, reasoning = structured[0]
+        if reasoning and content:
+            return reasoning + THINK_CLOSE_TAG + content, field_name
+        if not reasoning:
+            return reasoning, f"{field_name}_empty"
+        return reasoning, f"{field_name}_without_content"
+    if content is None:
+        raise TypeError(
+            "chat message has neither content nor structured reasoning")
+    return content, "content"
+
+
 def check_boundary_behavior(
     base_url: str,
     model_name: str,
@@ -395,11 +463,15 @@ def check_boundary_behavior(
     reps: int = DEFAULT_BOUNDARY_REPS,
     prompts: tuple[str, ...] | list[str] = BOUNDARY_PROMPTS,
 ) -> CheckResult:
-    """Sample boundary-stressing prompts and score `</think>` behavior.
+    """Sample chat-templated prompts and score `</think>` behavior.
 
     Each prompt is sampled `reps` times at `temperature > 0` (sampling, not
     the argmax path greedy-smoke takes) with a small `max_tokens` cap, and
-    every generation is scored by :func:`score_boundary_text`. Fails when
+    every generation is scored by :func:`score_boundary_text`.  The request
+    uses ``/v1/chat/completions`` with a ``messages`` body; raw completions do
+    not apply the model's chat template and cannot exercise this boundary.
+    Reasoning-parser responses are recovered through
+    :func:`_boundary_text_from_chat_choice` before scoring. Fails when
     total defects exceed `max_defects` (default 0: any stutter, zero-tag
     runaway, or cap-truncation on these terse prompts is a functional
     failure). Runs alongside KL/PPL, not replacing them.
@@ -413,23 +485,33 @@ def check_boundary_behavior(
         )
     n_defects = 0
     by_kind: dict[str, int] = {kind: 0 for kind in BOUNDARY_DEFECTS}
+    response_modes: dict[str, int] = {}
     failing_examples: list[dict] = []
     n_generations = 0
     for prompt in prompts:
         for _rep in range(reps):
             try:
                 r = _post_json(
-                    f"{base_url}/v1/completions",
+                    f"{_server_root(base_url)}{BOUNDARY_ENDPOINT}",
                     {
                         "model": model_name,
-                        "prompt": prompt,
+                        "messages": [{"role": "user", "content": prompt}],
                         "max_tokens": max_tokens,
                         "temperature": temperature,
+                        "include_reasoning": True,
+                        "skip_special_tokens": False,
+                        "chat_template_kwargs": dict(
+                            BOUNDARY_CHAT_TEMPLATE_KWARGS),
                     },
                 )
                 choice = r["choices"][0]
-                text = choice.get("text") or ""
+                text, response_mode = _boundary_text_from_chat_choice(choice)
+                response_modes[response_mode] = (
+                    response_modes.get(response_mode, 0) + 1)
                 finish = choice.get("finish_reason")
+                if finish is not None and not isinstance(finish, str):
+                    raise TypeError(
+                        "chat choice.finish_reason is not a string or null")
             except Exception as e:
                 return CheckResult(
                     name="boundary_behavior",
@@ -452,6 +534,10 @@ def check_boundary_behavior(
                         "excerpt": text[:200],
                     })
     metrics = {
+        "endpoint": BOUNDARY_ENDPOINT,
+        "request_schema": BOUNDARY_REQUEST_SCHEMA,
+        "response_schema": BOUNDARY_RESPONSE_SCHEMA,
+        "response_modes": response_modes,
         "n_prompts": len(list(prompts)),
         "reps": reps,
         "n_generations": n_generations,

--- a/tests/test_publish_artifact.py
+++ b/tests/test_publish_artifact.py
@@ -35,6 +35,9 @@ from prismaquant.shipcard import (
 import tools.publish_artifact as publisher
 from tools.publish_artifact import main as publish_cli
 from prismaquant.validate_quantized_model import (
+    BOUNDARY_ENDPOINT,
+    BOUNDARY_REQUEST_SCHEMA,
+    BOUNDARY_RESPONSE_SCHEMA,
     DEFAULT_BOUNDARY_MAX_TOKENS,
     DEFAULT_BOUNDARY_REPS,
     DEFAULT_BOUNDARY_TEMPERATURE,
@@ -122,6 +125,9 @@ def _ship_gate_record(model_sha, *, source, passed=True):
     if "boundary_behavior" in ledger:
         ledger["boundary_behavior"] = {
             "passed": True,
+            "endpoint": BOUNDARY_ENDPOINT,
+            "request_schema": BOUNDARY_REQUEST_SCHEMA,
+            "response_schema": BOUNDARY_RESPONSE_SCHEMA,
             "n_prompts": 5,
             "reps": DEFAULT_BOUNDARY_REPS,
             "n_generations": 5 * DEFAULT_BOUNDARY_REPS,
@@ -854,5 +860,4 @@ def test_ship_gate_ledger_follows_the_producer_not_a_roster(monkeypatch):
     ledger = _ship_gate_record("0" * 64, source="test")["metrics"]
     assert "mtp_acceptance_v2" in ledger
     assert "mtp_acceptance" not in ledger
-
 

--- a/tests/test_ship_boundary_behavior.py
+++ b/tests/test_ship_boundary_behavior.py
@@ -106,7 +106,8 @@ def test_length_sanity_is_blind_to_stutter_the_boundary_scorer_catches():
 # ---------------------------------------------------------------------------
 
 class _BoundaryHandler(BaseHTTPRequestHandler):
-    mode: str = "clean"  # "clean" | "broken"
+    mode: str = "clean"
+    requests: list[dict] = []
 
     def log_message(self, *a, **kw):
         pass
@@ -128,14 +129,63 @@ class _BoundaryHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         n = int(self.headers.get("Content-Length", "0"))
         req = json.loads(self.rfile.read(n))
+        self.requests.append({"path": self.path, "body": req})
+        if self.path != "/v1/chat/completions":
+            self.send_response(404)
+            self.end_headers()
+            return
         if self.mode == "clean":
-            body = {"choices": [{"text": "<think>12</think> 12",
-                                 "finish_reason": "stop"}]}
+            # Current vLLM's reasoning parser removes the delimiter and files
+            # the two sides separately.  The client must reconstruct boundary
+            # semantics before passing text to the frozen scorer.
+            body = {"choices": [{
+                "message": {"reasoning": "12", "content": " 12"},
+                "finish_reason": "stop",
+            }]}
+        elif self.mode == "legacy":
+            # Older OpenAI-compatible vLLM stacks used this field spelling.
+            body = {"choices": [{
+                "message": {"reasoning_content": "12", "content": " 12"},
+                "finish_reason": "stop",
+            }]}
+        elif self.mode == "raw":
+            # With no reasoning parser, chat content retains the raw delimiter
+            # and is scored without synthesis.
+            body = {"choices": [{
+                "message": {"content": "<think>12</think> 12"},
+                "finish_reason": "stop",
+            }]}
+        elif self.mode == "stutter":
+            # A parser consumes the first close token only; any repeated close
+            # remains in content and must still be visible to the scorer.
+            body = {"choices": [{
+                "message": {
+                    "reasoning": "first trace",
+                    "content": "</think> second trace 12",
+                },
+                "finish_reason": "stop",
+            }]}
+        elif self.mode == "empty_reasoning":
+            body = {"choices": [{
+                "message": {"reasoning": "", "content": "12"},
+                "finish_reason": "stop",
+            }]}
+        elif self.mode == "malformed_finish":
+            body = {"choices": [{
+                "message": {"reasoning": "12", "content": " 12"},
+                "finish_reason": ["length"],
+            }]}
         else:
-            # The broken shape from the issue: no clean </think> under
-            # sampling (T10 failing 6/6 on the broken artifact).
-            body = {"choices": [{"text": "12 12 12 12 12 12",
-                                 "finish_reason": "stop"}]}
+            # No answer-side content means the parser never observed a usable
+            # reasoning boundary.  The client must retain zero-tag and cap
+            # defects rather than inventing a close token from this shape.
+            body = {"choices": [{
+                "message": {
+                    "reasoning": "12 12 12 12 12 12",
+                    "content": None,
+                },
+                "finish_reason": "length",
+            }]}
         out = json.dumps(body).encode("utf-8")
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
@@ -146,6 +196,7 @@ class _BoundaryHandler(BaseHTTPRequestHandler):
 @pytest.fixture
 def boundary_server():
     _BoundaryHandler.mode = "clean"
+    _BoundaryHandler.requests = []
     srv = HTTPServer(("127.0.0.1", 0), _BoundaryHandler)
     port = srv.server_address[1]
     t = threading.Thread(target=srv.serve_forever, daemon=True)
@@ -161,6 +212,62 @@ def test_boundary_check_passes_a_clean_serve(boundary_server):
     assert r.passed, r.detail
     assert r.metrics["n_generations"] == 2
     assert r.metrics["n_defects"] == 0
+    assert r.metrics["endpoint"] == "/v1/chat/completions"
+    assert r.metrics["request_schema"] == \
+        "prismaquant.boundary_chat_request/1"
+    assert r.metrics["response_schema"] == \
+        "prismaquant.boundary_chat_response/1"
+    assert len(_BoundaryHandler.requests) == 2
+    for observed in _BoundaryHandler.requests:
+        assert observed["path"] == "/v1/chat/completions"
+        body = observed["body"]
+        assert body["messages"] == [{"role": "user", "content": "9²"}]
+        assert "prompt" not in body
+        assert body["include_reasoning"] is True
+        assert body["skip_special_tokens"] is False
+        assert body["chat_template_kwargs"] == {
+            "thinking": True,
+            "enable_thinking": True,
+        }
+
+
+@pytest.mark.parametrize("mode", ["legacy", "raw"])
+def test_boundary_check_accepts_both_declared_chat_response_shapes(
+    boundary_server, mode,
+):
+    _BoundaryHandler.mode = mode
+    r = vqm.check_boundary_behavior(
+        boundary_server, "any", prompts=("9²",), reps=1)
+    assert r.passed, r.detail
+    assert r.metrics["n_defects"] == 0
+
+
+def test_boundary_check_preserves_stutter_after_reasoning_parser_split(
+    boundary_server,
+):
+    _BoundaryHandler.mode = "stutter"
+    r = vqm.check_boundary_behavior(
+        boundary_server, "any", prompts=("9²",), reps=1)
+    assert not r.passed
+    assert r.metrics["defects_by_kind"]["think_stutter"] == 1
+
+
+def test_boundary_check_does_not_invent_a_close_for_empty_reasoning(
+    boundary_server,
+):
+    _BoundaryHandler.mode = "empty_reasoning"
+    r = vqm.check_boundary_behavior(
+        boundary_server, "any", prompts=("9²",), reps=1)
+    assert not r.passed
+    assert r.metrics["defects_by_kind"]["zero_tag"] == 1
+
+
+def test_boundary_check_refuses_a_malformed_finish_reason(boundary_server):
+    _BoundaryHandler.mode = "malformed_finish"
+    r = vqm.check_boundary_behavior(
+        boundary_server, "any", prompts=("9²",), reps=1)
+    assert not r.passed
+    assert "finish_reason" in r.detail
 
 
 def test_boundary_check_fails_a_broken_serve(boundary_server):
@@ -170,6 +277,7 @@ def test_boundary_check_fails_a_broken_serve(boundary_server):
     assert not r.passed
     assert r.metrics["n_defects"] == 2
     assert r.metrics["defects_by_kind"]["zero_tag"] == 2
+    assert r.metrics["defects_by_kind"]["cap_truncation"] == 2
 
 
 def test_boundary_check_refuses_a_greedy_temperature():
@@ -221,8 +329,17 @@ def _artifact(tmp_path, *, name="exported"):
     return model_dir, compute_model_sha(model_dir)
 
 
-def _ship_gate_record(model_sha, *, source, boundary_defects=0,
-                      boundary_passed=True, drop_boundary=False):
+def _ship_gate_record(
+    model_sha,
+    *,
+    source,
+    boundary_defects=0,
+    boundary_passed=True,
+    boundary_endpoint="/v1/chat/completions",
+    boundary_request_schema="prismaquant.boundary_chat_request/1",
+    boundary_response_schema="prismaquant.boundary_chat_response/1",
+    drop_boundary=False,
+):
     from prismaquant.shipcard import make_record
 
     ledger = {name: {"passed": True} for name in _producer_check_names()}
@@ -236,6 +353,9 @@ def _ship_gate_record(model_sha, *, source, boundary_defects=0,
     }
     ledger["boundary_behavior"] = {
         "passed": boundary_passed,
+        "endpoint": boundary_endpoint,
+        "request_schema": boundary_request_schema,
+        "response_schema": boundary_response_schema,
         "n_prompts": len(vqm.BOUNDARY_PROMPTS),
         "reps": vqm.DEFAULT_BOUNDARY_REPS,
         "n_generations": len(vqm.BOUNDARY_PROMPTS)
@@ -338,3 +458,27 @@ def test_verify_accepts_a_clean_boundary_receipt(tmp_path):
 
     path, model_dir = _full_card(tmp_path)
     assert verify(load_shipcard(path), model_dir=model_dir) == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "needle"),
+    [
+        ("boundary_endpoint", "/v1/completions", "endpoint"),
+        ("boundary_request_schema", "prompt-string-v0", "request schema"),
+        ("boundary_response_schema", "text-choice-v0", "response schema"),
+    ],
+)
+def test_verify_refuses_boundary_receipt_from_the_wrong_http_contract(
+    tmp_path, field, value, needle,
+):
+    """A clean count from the raw endpoint is not boundary evidence.
+
+    Even if a caller copies zeros into the metrics, replay must reject the
+    endpoint/schema that never applied a chat template or exposed the
+    reasoning boundary.
+    """
+    from prismaquant.shipcard import load_shipcard, verify
+
+    path, model_dir = _full_card(tmp_path, **{field: value})
+    problems = verify(load_shipcard(path), model_dir=model_dir)
+    assert any(needle in problem for problem in problems), problems

--- a/tests/test_shipcard.py
+++ b/tests/test_shipcard.py
@@ -37,6 +37,9 @@ from prismaquant.shipcard import (
 )
 from prismaquant.shipcard_cli import main as shipcard_cli
 from prismaquant.validate_quantized_model import (
+    BOUNDARY_ENDPOINT,
+    BOUNDARY_REQUEST_SCHEMA,
+    BOUNDARY_RESPONSE_SCHEMA,
     DEFAULT_BOUNDARY_MAX_TOKENS,
     DEFAULT_BOUNDARY_REPS,
     DEFAULT_BOUNDARY_TEMPERATURE,
@@ -177,6 +180,9 @@ def _ship_gate_record(model_sha, *, passed=True, source="artifact",
         # zero defects, so the fixture must look like a real measurement.
         ledger["boundary_behavior"] = {
             "passed": True,
+            "endpoint": BOUNDARY_ENDPOINT,
+            "request_schema": BOUNDARY_REQUEST_SCHEMA,
+            "response_schema": BOUNDARY_RESPONSE_SCHEMA,
             "n_prompts": 5,
             "reps": 6,
             "n_generations": 30,
@@ -1482,5 +1488,4 @@ def test_build_without_forensics_is_left_alone():
     legacy = {"build": {"achieved_bpp": {"value": 4.3065, "source": "x"}}}
     assert verify(legacy, model_dir=None, required=[]) == []
     assert verify(_forensic_build(), model_dir=None, required=[]) == []
-
 

--- a/tests/test_shipcard_uniform_control.py
+++ b/tests/test_shipcard_uniform_control.py
@@ -40,6 +40,9 @@ from prismaquant.shipcard import (
 )
 from prismaquant.shipcard_cli import main as shipcard_cli
 from prismaquant.validate_quantized_model import (
+    BOUNDARY_ENDPOINT,
+    BOUNDARY_REQUEST_SCHEMA,
+    BOUNDARY_RESPONSE_SCHEMA,
     DEFAULT_BOUNDARY_MAX_TOKENS,
     DEFAULT_BOUNDARY_REPS,
     DEFAULT_BOUNDARY_TEMPERATURE,
@@ -213,6 +216,9 @@ def _ship_gate_record(model_sha, *, source):
     if "boundary_behavior" in ledger:
         ledger["boundary_behavior"] = {
             "passed": True,
+            "endpoint": BOUNDARY_ENDPOINT,
+            "request_schema": BOUNDARY_REQUEST_SCHEMA,
+            "response_schema": BOUNDARY_RESPONSE_SCHEMA,
             "n_prompts": 5,
             "reps": DEFAULT_BOUNDARY_REPS,
             "n_generations": 5 * DEFAULT_BOUNDARY_REPS,

--- a/tests/test_validate_quantized_model.py
+++ b/tests/test_validate_quantized_model.py
@@ -58,6 +58,20 @@ class _FakeVLLMHandler(BaseHTTPRequestHandler):
         self.requests.append(req)
         prompt = req.get("prompt", "")
 
+        if self.path == "/v1/chat/completions":
+            messages = req.get("messages") or []
+            prompt = messages[-1].get("content", "") if messages else ""
+            body = {"choices": [{
+                "message": {"reasoning": "brief trace", "content": " 12"},
+                "finish_reason": "stop",
+            }]}
+            out = json.dumps(body).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(out)
+            return
+
         if self.path == "/v1/completions":
             mt = int(req.get("max_tokens") or 1)
             echo = bool(req.get("echo", False))
@@ -89,16 +103,9 @@ class _FakeVLLMHandler(BaseHTTPRequestHandler):
                 }
             else:
                 # Plain generation request: return a short stub completion.
-                # Boundary-stressing prompts get a clean boundary shape
-                # (exactly one </think>, finish stop) so the healthy arm is
-                # healthy on every check; anything else gets generic prose.
-                if prompt in vqm.BOUNDARY_PROMPTS:
-                    body = {"choices": [{"text": "<think>12</think> 12",
-                                         "finish_reason": "stop"}]}
-                else:
-                    txt = ("Pretend this is a coherent completion about the topic "
-                           "that goes on for enough characters.")
-                    body = {"choices": [{"text": txt}]}
+                txt = ("Pretend this is a coherent completion about the topic "
+                       "that goes on for enough characters.")
+                body = {"choices": [{"text": txt}]}
 
             out = json.dumps(body).encode("utf-8")
             self.send_response(200)


### PR DESCRIPTION
## Outcome

This is the narrow fail-closed request/response-contract fix for #87. It makes the sampled boundary probe exercise the model's chat template and makes offline shipcard replay reject receipts produced under the old raw-completion contract.

It intentionally leaves #87 open: the known-invalid universal 64-token cap and zero-defect threshold remain fail-closed historical defaults until the separately versioned same-session BF16-control policy is decided and measured.

## Changes

- POST `/v1/chat/completions` with an exact user `messages` body and explicit thinking/reasoning settings.
- Pin and file versioned boundary request/response schema identities.
- Support raw chat content and the current/legacy structured reasoning-parser shapes without hiding stutter.
- Treat empty structured reasoning/content as zero-tag and refuse malformed fields, including non-string/non-null `finish_reason`.
- Replay endpoint and schema identity from the shipcard.
- Update the normative architecture contract and correct the unsupported 64/zero claims.

## PrismaBuild evidence

All actions ran CPU-only on Sparky with `CUDA_VISIBLE_DEVICES=''`; no GPU capacity was consumed.

- Pre-fix strict endpoint/replay failure: `41900b50415d6025f66124df64c9b7ced170ad8122412896df921dcc77191c1f` — 9 failed, 11 passed. The fake rejected raw `/v1/completions` with HTTP 404, and replay accepted wrong endpoint/schema receipts.
- Pre-fix response-shape failure: `3630211e3d70f0b34c7f8c982c80336ed24a668fc914d641181516b3e33e980d` — 2 failed. Empty reasoning was falsely clean and list-valued `finish_reason` evaded validation.
- Focused post-fix: action `fa70c258d5c839a8f32f1c960dfd1c5429d9e41f36bfc4a4cf63e242687a6d1c`, receipt `9ea6a93d3a2c5343c57e67bf0395639be6307d2a2e91df4c2403a5771b857489` — 22 passed.
- Touched behavior/shipcard population: action `8de0124b10d7dedf980aa7a8a7913847a468e2519660ef1b6d3d469fbb708118`, receipt `530f55599ec764c1570731baaf5fd89cef3c79641344be2b3f9e6da933397be9` — 160 passed.
- Architecture/doc checks: action `c7ac20eefb4a50cce5de5f43c937fb796fd5eabff2a2a3ca68629125b8e8ae34`, receipt `985b28389e5afe793c03d6f432909ed52d1bb07eb7e424a0c137aa798aba112a` — 19 passed.
- Changed-module compile check: action `827a52270f83fca81cdc7205d47ddd5fd3db7b985b5b34471a3f2e8a8e7bcfc6`, receipt `7d00f061e869d92362a551108e5a3c30a429004289002da092c226a4c1860dd1` — rc 0.

Refs #87; does not close it.
