### PR TITLE
Refuse empty boundary samples and add paired BF16 measurement

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,19 @@
 # PrismaQuant Architecture
 
+Re-stamped (2026-09-04, `codex/pq-87-control-relative`) for the **opt-in
+paired boundary instrument** (§7.2). `prismaquant/boundary_control.py`
+records a frozen prompt/seed schedule and replays every raw scored outcome.
+The BF16 budget grows until no sampled completion is censored, bounded by
+the live model context minus chat-tokenized input lengths; exhausting that
+bound or the explicit iteration backstop is inconclusive. A candidate uses
+the identical final cap and schedule, with common campaign/host/stack and
+tokenization bindings. `tools/measure_boundary_control.py` captures live
+process/residency manifests before and after, and can also run the historical
+raw-request arm in the same control session. Per-stratum defect deltas are
+**advisory only**: this adds no pass threshold, fills no shipcard slot, and
+does not replace the historical mandatory 64/zero policy. No physical served
+result is claimed by implementation or CPU tests.
+
 Re-stamped (2026-09-04, `codex/pq-87-control-relative`) for the boundary
 probe's input refusal (§7.2). Empty prompt/repetition populations, non-finite
 or nonpositive sampling temperatures, nonpositive token caps and malformed
@@ -7264,9 +7278,19 @@ the current 64-token cap and a universal zero roster: healthy DSV4 still filed
 pending policy is a same-session BF16 control whose cap grows until the control
 reaches its own finishing fixed point, bounded by the declared model context
 and an explicit backstop; the quantized arm is then scored control-relative at
-that exact cap. Until that paired receipt is specified and replayed, the old
-64/zero values remain fail-closed, #87 remains `needs-decision`, and a boundary
-check cannot promote an artifact.
+that exact cap. The opt-in `boundary_control.py` instrument now specifies and
+replays that paired receipt: every prompt/seed outcome, cap-growth step, score
+and aggregate is checked, and the candidate names the exact control digest.
+The CLI `tools/measure_boundary_control.py` reads the context from the live
+`/v1/models` identity and input lengths from chat `/tokenize`; it retains
+pre/post process/residency manifests and refuses a changed serve. It can
+record raw-request A versus chat-request B at the historical initial cap,
+followed by the uncensored control budget. Relative counts are per stratum,
+without an invented significance or tolerance threshold. The budget is fit on
+this frozen schedule, so the report is a detector and must not select artifact
+calibration content. Until a physical paired measurement and a replacement
+shipping policy are approved, the old 64/zero values remain fail-closed, #87
+remains `needs-decision`, and this instrument cannot promote an artifact.
 
 **Spec-decode refusal.** `_spec_decode_on` scrapes `/metrics` for
 `vllm:spec_decode`; if present the perplexity check **refuses a verdict** rather than return

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,17 @@
 # PrismaQuant Architecture
 
+Re-stamped (2026-09-04, `codex/pq-87-control-relative`) for the paired
+instrument's **exact native weight identity** (§7.2). Each boundary binding
+carries the existing model-metadata hash plus the shared safetensors content
+manifest; its compound `artifact_id` is recomputed during replay. The client
+hashes before and after measurement and uses the existing weight-stat
+attestation around each hash and across the interval to refuse mutation,
+including same-size replacement or change-and-restore. Generic shipcard
+identity is unchanged. These observations attest source content during the
+measurement, not what a pre-existing server loaded earlier: the physical
+campaign must pin/freeze the same artifact before launch. Gate:
+`tests/test_measure_boundary_control_identity.py`.
+
 Re-stamped (2026-09-04, `codex/pq-87-control-relative`) for shared serve
 process discovery. `tools/serve_fingerprint.py` now identifies the vLLM
 executable, Python module/script or worker process title rather than searching

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,12 @@
 # PrismaQuant Architecture
 
+Re-stamped (2026-09-04, `codex/pq-87-control-relative`) for the boundary
+probe's input refusal (§7.2). Empty prompt/repetition populations, non-finite
+or nonpositive sampling temperatures, nonpositive token caps and malformed
+defect bounds now fail before HTTP, rather than producing an empty pass or
+asking the endpoint to validate the measurement contract. This does not
+change any shipping threshold. Gate: `tests/test_ship_boundary_behavior.py`.
+
 As of: 2026-09-03 · `muse/pq-172-173-append`. Stamps
 follow, newest first, each recording its own branch and date.
 
@@ -7245,6 +7252,11 @@ reasoning-side and answer-side content are non-empty. A later close remains
 visible as stutter, while either empty side remains zero-tag/cap-truncation.
 Both schema identities and the endpoint are filed in the shipcard and replayed
 offline.
+
+The live check refuses an empty prompt/repetition population, non-finite or
+nonpositive temperature, nonpositive integer token cap, or negative/noninteger
+defect bound before contacting the endpoint. An empty sample cannot certify a
+boundary check, regardless of its nominal defect count.
 
 This endpoint fix is necessary and insufficient. Physical evidence invalidated
 the current 64-token cap and a universal zero roster: healthy DSV4 still filed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,12 @@
 # PrismaQuant Architecture
 
+Re-stamped (2026-09-04, `codex/pq-87-control-relative`) for shared serve
+process discovery. `tools/serve_fingerprint.py` now identifies the vLLM
+executable, Python module/script or worker process title rather than searching
+arbitrary argv payloads. A measurement client's `--image spark-vllm@...` and
+a shell's quoted launch command no longer join the server process census or
+change its session identity. Gate: `tests/test_serve_fingerprint_descendants.py`.
+
 Re-stamped (2026-09-04, `codex/pq-87-control-relative`) for the **opt-in
 paired boundary instrument** (§7.2). `prismaquant/boundary_control.py`
 records a frozen prompt/seed schedule and replays every raw scored outcome.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,6 +14,11 @@ raw-request arm in the same control session. Per-stratum defect deltas are
 does not replace the historical mandatory 64/zero policy. No physical served
 result is claimed by implementation or CPU tests.
 
+Review follow-up on the same branch binds the actual chat token-ID arrays,
+not merely their lengths, and requires the same producer-source closure digest
+across arms. The BF16 label also refuses an observed non-BF16 dtype or an
+explicit quantization override even when the source config says bfloat16.
+
 Re-stamped (2026-09-04, `codex/pq-87-control-relative`) for the boundary
 probe's input refusal (§7.2). Empty prompt/repetition populations, non-finite
 or nonpositive sampling temperatures, nonpositive token caps and malformed

--- a/docs/experiments/pq87_boundary_ab.md
+++ b/docs/experiments/pq87_boundary_ab.md
@@ -1,0 +1,67 @@
+# PrismaQuant #87: boundary instrument A/B
+
+Status: prepared, opt-in; no physical measurement claimed. Run after the
+Tessera #113/#5 GPU campaign, through one exclusive PrismaBuild action.
+
+The first population is the local Qwen3-0.6B BF16 checkpoint. It is a small
+non-DeepSeek thinking model, so it tests the contributor's claim about the
+request contract without re-serving the retired 87 GB Gridbook artifact.
+It cannot reproduce that artifact's reported 83/180 result.
+
+Use the same immutable container image and live BF16 server for A/B:
+
+1. A: raw `/v1/completions` at the historical 64-token cap.
+2. B: chat `/v1/chat/completions` at the identical cap.
+3. Grow the BF16 chat cap by doubling, stopping at an uncensored schedule or
+   the exact live context remainder. Save every step, including an inconclusive
+   context/backstop stop. The contract's 11-step backstop covers the initial
+   64 through 65,536 budget; it does not define a successful result.
+4. Repeat the BF16 schedule as candidate for a same-session A/A control at
+   the selected cap. A quantized candidate can subsequently use the exact
+   control receipt, provided its observed stack, boot, input tokenization and
+   action/campaign identity match. Preserve distinct live serve identities.
+
+The frozen input is `experiments/pq87_boundary_contract.json`: the existing
+five terse prompts, six seeded repetitions, temperature 1, top-p 1. Every
+outcome is retained and re-scored. No rate or zero-defect threshold decides
+artifact eligibility. The fixed-point cap is selected on this schedule, so
+these observations must not select calibration content or claim an unbiased
+artifact-selection test.
+
+Example client invocations inside the already running serving container,
+with the exact read-only source at `/repo`, BF16 model at `/model`, persistent
+run output at `/run`, and a unique nonce as the served model name:
+
+```sh
+python3 -P /repo/tools/measure_boundary_control.py control \
+  --base-url http://127.0.0.1:8000 --model-name "$BOUNDARY_MODEL_NONCE" \
+  --model-dir /model --image "$BOUNDARY_IMAGE_DIGEST" \
+  --campaign-id "$BOUNDARY_CAMPAIGN_ID" \
+  --contract /repo/experiments/pq87_boundary_contract.json \
+  --legacy-ab --out /run/bf16-control.json
+
+python3 -P /repo/tools/measure_boundary_control.py candidate \
+  --base-url http://127.0.0.1:8000 --model-name "$BOUNDARY_MODEL_NONCE" \
+  --model-dir /model --image "$BOUNDARY_IMAGE_DIGEST" \
+  --campaign-id "$BOUNDARY_CAMPAIGN_ID" \
+  --control /run/bf16-control.json --out /run/bf16-repeat.json
+```
+
+Warm up the live server before either pre-manifest is taken, so first-use
+library loading is not confused with a stable-stack A/B. The client discovers
+the actual serve processes, source model path, nonce, context and chat-token
+counts and refuses a changed pre/post session. It uses the existing stdlib
+source bootstrap and fingerprint collector without importing torch into the
+measurement client. The numerical-stack fingerprint must agree across paired
+arms; any mismatch is a refusal, not permission to weaken the pairing.
+
+The enclosing action must reserve the entire physical GPU token capacity,
+use one server at a time with explicit KV bytes/max-sequences/context limits,
+and collect the server log, profiler window, power and Netdata series from
+both boxes. Report work per joule if making a speed claim; GPU utilization
+alone is not diagnostic. No launch permission or capacity is implied by this
+document, and this preparation has consumed no GPU slot.
+
+After the physical result, the remaining decision is which versioned,
+control-relative rule replaces the current mandatory 64/zero boundary gate.
+That is separate from merging the endpoint/schema and empty-population fixes.

--- a/docs/experiments/pq87_boundary_ab.md
+++ b/docs/experiments/pq87_boundary_ab.md
@@ -55,6 +55,15 @@ source bootstrap and fingerprint collector without importing torch into the
 measurement client. The numerical-stack fingerprint must agree across paired
 arms; any mismatch is a refusal, not permission to weaken the pairing.
 
+Capture the exact safetensors content manifest before server startup, serve
+that frozen artifact through a read-only mount, and compare the client's
+recorded content identity with the pre-launch identity. The client retains
+full pre/post content manifests and hashes their combination with the existing
+model metadata into `artifact_id`; weight-stat checks also refuse a write
+restored to its original bytes during the interval. This client alone cannot
+prove what an already-running server loaded before its first observation.
+The outer launcher owns that pre-launch/frozen-source assertion.
+
 The enclosing action must reserve the entire physical GPU token capacity,
 use one server at a time with explicit KV bytes/max-sequences/context limits,
 and collect the server log, profiler window, power and Netdata series from

--- a/docs/results/pq87_boundary_control_2026-09-04.md
+++ b/docs/results/pq87_boundary_control_2026-09-04.md
@@ -58,3 +58,39 @@ compares raw64 versus chat64 versus an uncensored context-bounded control on
 one Qwen BF16 session, with an A/A repeat. Its GPU slot remains ordered after
 Tessera #113/#5. No AQUA/Gridbook reproduction, candidate-model discrimination,
 power delta, profiler delta or default-policy validation has been measured.
+
+## Review follow-up
+
+The bounded review found three new-instrument provenance gaps and one shared
+process-discovery defect. All were fixed on this branch, in separate commits
+from the initial implementation: actual token IDs and producer source now
+participate in pairing; BF16 attestation reads live dtype/quantization arguments
+and refuses aliases, repeated dtype and configuration overrides; shared serve
+discovery no longer calls a client a server because its image argument contains
+`vllm`.
+
+- Pairing red `2673ed77fb4828b96f64a51690c7658d6d01defc6b3a88fd6090ef94b488de2b`:
+  5 failed, 13 deselected. The equal-length/different-token and changed-source
+  cases both failed with `DID NOT RAISE <class 'ValueError'>`; the new live-BF16
+  guard was absent. The subsequent alias/repeated-argv API test, action
+  `4466eeca0bfb`, failed 3 with the `launch_argv` input absent before the fix.
+- Shared classifier red
+  `384f6e3d064b59cb359adce584b1f257004a767137c81fe7e438c5eaedcbf3ca`:
+  3 failed, 5 passed, 10 deselected on dl380 CPU. Failure line: `assert True is
+  False` for the measurement client's image argument, a model-path argument,
+  and a shell's quoted launch command. Legitimate server/worker cases passed.
+- Expanded post-review run `c5bf7e89fbbb`: 225 passed, 9 failed. All nine were
+  in `test_tessera_serve_fingerprint.py`: existing installed-Tessera versus
+  PENDING-pin/schema drift. Only that failed file was run against pristine
+  `483ff9ca`, action `860d5526cb14`: the identical 9 failures, 19 passes.
+  The separate release consumer/v4 work owns those rows; no duplicate issue
+  or pin change was made here.
+- Final source `df44f6d2`, action
+  `b5da2968616280679717305628147cec2fdba6fbe484a01e9d41106c30a8b0fd`,
+  receipt `4a9b4d22ba9d92b0d096be0c51a516a177f187e1c22c372ba9034dd115100766`:
+  **209 passed, 0 failed, 0 skipped** in 17.75 seconds, CPU-only Sparky.
+  Population: the original six files plus `test_serve_fingerprint_descendants.py`,
+  `test_kl_ab.py`, and `test_measure_served_gold.py`. The already-baselined
+  fingerprint file remains red and is not represented as green by this subset.
+  All three changed executable modules also passed compilation. No GPU result
+  or changed shipping threshold is claimed.

--- a/docs/results/pq87_boundary_control_2026-09-04.md
+++ b/docs/results/pq87_boundary_control_2026-09-04.md
@@ -94,3 +94,55 @@ discovery no longer calls a client a server because its image argument contains
   fingerprint file remains red and is not represented as green by this subset.
   All three changed executable modules also passed compilation. No GPU result
   or changed shipping threshold is claimed.
+
+## Exact native weight identity follow-up
+
+Root review found that generic `shipcard.compute_model_sha` represents native
+safetensors by names and sizes, so equal-size content changes could retain the
+paired instrument's artifact ID. The instrument now combines that existing
+metadata identity with `build_weight_content_manifest`, retains the composite
+inside each measurement binding, and recomputes its digest during replay.
+`weight_stat_attestation` brackets each full hash and the measurement interval;
+both content and stats must stay unchanged before a receipt is written.
+Generic shipcard identity and the mandatory boundary policy are unchanged.
+
+Pre-fix action
+`cf18a78f7fd2e1949d137ee200525960db79c61c4335748cebe0982745645604`
+sealed tests-only snapshot `616f7d94db198e0e70fa7df1979cb4ff3a84504c`:
+**6 failed, 0 passed, 0 skipped** in 3.01 seconds. Exact regression lines:
+
+- Equal-size replacement: `AssertionError: assert
+  '081c4cfa9808771bd1338272b6401b50b3b0058771c04f8304e3e5ab91b94aed'
+  != '081c4cfa9808771bd1338272b6401b50b3b0058771c04f8304e3e5ab91b94aed'`.
+- During-measurement replacement and change-and-restore: both
+  `Failed: DID NOT RAISE <class 'ValueError'>`.
+- Missing native weights: `Failed: DID NOT RAISE <class 'FileNotFoundError'>`.
+- Stable-content receipt and replay-tamper checks: `KeyError: 'artifact_pre'`
+  and `KeyError: 'artifact_content'` respectively, because those exact
+  content records did not yet exist. These two failures establish missing
+  evidence fields, not an already-existing replay arithmetic defect.
+
+After merging main `b6d6824e` (merge `088264b4`), action
+`bbca6ff0659d4a64bf365943c79df5b903b7d0a1ad405146c3fe5e1aa7b4c6bc`
+sealed snapshot `79d2218cec02530ac9216e4898f15c9304b924f8`; CAS receipt
+`1d99c6cace6e6e5cf2c0474d5771a39edfee9d4f949078c11407fd6e7409bc8f`.
+**243 passed, 0 failed, 0 skipped**, 17.79 seconds. Population: CPU-only
+Sparky, one CPU, 3 GiB, `CUDA_VISIBLE_DEVICES=''`, the eleven explicit files
+from the prior nine-file population plus `test_tessera_serve_fingerprint.py`
+and `test_measure_boundary_control_identity.py`. All selected modules
+collected; skip reasons: none. No CUDA-gated surface or master suite was run.
+The three changed executable modules also passed `py_compile`.
+
+This run used the immutable Tessera `1221d2a` source archive
+`/mnt/shared/pq-v4-source.o2Tc3O/tessera-1221d2a-src.tar`, verifying SHA-256
+`b4755a30d60974ec2758c2060fc4d3954f2e1b7c7bb11602a05f0b783ba60bc8`
+before extracting it on the worker. The nine previously baselined fingerprint
+failures are now green with main's reviewed v4 consumer; no release sentinel
+was promoted. As above, only the three unused calibration symlinks were
+omitted from snapshots and immediately restored locally.
+
+The physical campaign still has to capture the same exact content before
+server startup and serve a frozen artifact. These client observations prove
+source-content stability during the measurement, not what an already-running
+server loaded earlier. No GPU A/B, speed claim, or new policy promotion is
+implied by these CPU results.

--- a/docs/results/pq87_boundary_control_2026-09-04.md
+++ b/docs/results/pq87_boundary_control_2026-09-04.md
@@ -1,0 +1,60 @@
+# Boundary control preparation, 2026-09-04
+
+Measured source: `24adebb9` on `codex/pq-87-control-relative`, based on the
+endpoint/schema fix `483ff9ca` (PR177). This is CPU implementation evidence,
+not a served result and not grounds to close #87 or promote a policy.
+
+## Regressions and populations
+
+All valid runs below used PrismaBuild on Sparky, one CPU, 3 GiB reservation,
+`CUDA_VISIBLE_DEVICES=''`, and the existing `prismaquant-cu130` interpreter.
+They exercised no GPU-gated tests. No tests were skipped or uncollected in
+these explicit file populations; pytest emitted 14 existing Torch deprecation
+warnings. No master/full suite was run.
+
+- Existing sampling-input defect, pre-fix action
+  `96cf3d26563033250f6d6daa4538bdea12d723a7e37732861926d8a1d47ebdb4`:
+  8 failed, 22 deselected. Failure line: `AssertionError: all 0 sampled
+  generations clean (5 prompts × 0 reps)`. Empty prompts likewise passed;
+  NaN/infinite temperature and malformed bounds reached the HTTP stub.
+- New paired instrument, absent-before-implementation action
+  `59b306c17287174d1612a4440895e9f06571b266c94dac2d76bd75dac580e2ec`:
+  13 failed with `ModuleNotFoundError: No module named
+  'prismaquant.boundary_control'`. This proves the new API was absent; it is
+  not presented as a numerical before/after measurement.
+- Final action
+  `4c8600c1dfd16f75ba35813b68f9d8699e47cdc023251e3b8fcb8437d5d1e1c1`,
+  CAS receipt
+  `4241901c5dcfc83aa2fb5e2ba0858906883778403161975882f86f2fcc33382b`:
+  **140 passed, 0 failed, 0 skipped**, 17.39 seconds in pytest. Files:
+  `test_ship_boundary_behavior.py`, `test_boundary_control.py`,
+  `test_validate_quantized_model.py`, `test_shipcard.py`,
+  `test_architecture_doc.py`, `test_docs_staleness.py`. Both new modules then
+  passed `py_compile`, and the stdlib CLI's `--help` completed.
+
+An earlier combined run had 139 passes and one failure because the historical
+temperature-zero test pins the diagnostic phrase `not sampling`; retaining
+that phrase corrected the regression. An initial x86 probe
+`09eeba660c2add35b91f6da0c9d036c05fc6ef3565cc1048fcc0552b7d66aafc`
+failed on missing `compressed_tensors` in that interpreter. It is environment
+evidence only and is excluded from the pre-fix evidence above.
+
+The repository carries three absolute `calibration/*.jsonl` symlinks, which
+PrismaBuild correctly refuses to put in a hermetic snapshot. Only those links
+were temporarily omitted from these targeted test snapshots; they were
+restored to the source worktree immediately after submission. None of these
+tests loads calibration data. The module source and test bytes were sealed by
+PrismaBuild, and no scheduler source/runtime was changed.
+
+## Scope and next measurement
+
+Separate commits fix stale prose and the online empty/malformed-input defect.
+The opt-in instrument records context-bounded control growth, exact paired
+prompt/seeds/caps, raw outcomes and control-relative per-stratum counts. It
+does not change the mandatory historical 64/zero gate or fill a shipcard.
+
+The physical A/B recipe is `docs/experiments/pq87_boundary_ab.md`. It first
+compares raw64 versus chat64 versus an uncensored context-bounded control on
+one Qwen BF16 session, with an A/A repeat. Its GPU slot remains ordered after
+Tessera #113/#5. No AQUA/Gridbook reproduction, candidate-model discrimination,
+power delta, profiler delta or default-policy validation has been measured.

--- a/experiments/pq87_boundary_contract.json
+++ b/experiments/pq87_boundary_contract.json
@@ -1,0 +1,13 @@
+{
+  "prompts": [
+    {"text": "144÷12", "stratum": "numeric"},
+    {"text": "9²", "stratum": "numeric"},
+    {"text": "How many legs does a spider have?", "stratum": "terse_qa"},
+    {"text": "What is 7×8?", "stratum": "numeric"},
+    {"text": "Name the capital of France.", "stratum": "short_recall"}
+  ],
+  "seeds": [0, 1, 2, 3, 4, 5],
+  "temperature": 1.0,
+  "initial_max_tokens": 64,
+  "max_steps": 11
+}

--- a/prismaquant/boundary_control.py
+++ b/prismaquant/boundary_control.py
@@ -29,6 +29,32 @@ def _positive(value, field):
     return value
 
 
+def require_bf16_control(config, live_dtype, live_quantization, *, launch_argv=None):
+    if launch_argv is not None:
+        dtypes = []
+        override_flags = ("--quantization", "--quantization-config", "--hf-overrides",
+                          "--hf-config-path")
+        for i, token in enumerate(launch_argv):
+            flag, separator, value = token.partition("=")
+            if (flag.startswith("-q") and not flag.startswith("--")) or any(
+                flag == option or flag.startswith(option + ".") for option in override_flags
+            ):
+                raise ValueError(f"BF16 control refuses live override {flag}")
+            if flag == "--dtype":
+                if not separator:
+                    value = launch_argv[i + 1] if i + 1 < len(launch_argv) else ""
+                dtypes.append(value)
+        if len(dtypes) > 1:
+            raise ValueError("BF16 control refuses repeated --dtype")
+        live_dtype = dtypes[0] if dtypes else None
+    source_dtype = config.get("dtype", config.get("torch_dtype"))
+    if (source_dtype not in ("bfloat16", "torch.bfloat16")
+            or config.get("quantization_config")
+            or live_dtype not in (None, "auto", "bfloat16")
+            or live_quantization is not None):
+        raise ValueError("BF16 control requires BF16 source and observed BF16/auto unquantized serve")
+
+
 def _validate(contract, binding):
     if not isinstance(contract, dict) or set(contract) != {
         "prompts", "seeds", "temperature", "initial_max_tokens", "max_steps"
@@ -53,7 +79,7 @@ def _validate(contract, binding):
     _positive(contract["initial_max_tokens"], "initial_max_tokens")
     _positive(contract["max_steps"], "max_steps")
     for field in ("campaign_id", "artifact_id", "serve_session_id",
-                  "serve_fingerprint", "host_boot_id"):
+                  "serve_fingerprint", "host_boot_id", "producer_source_sha256"):
         if not isinstance(binding.get(field), str) or not binding[field].strip():
             raise ValueError(f"missing {field}")
     context = _positive(binding.get("model_context_tokens"), "model_context_tokens")
@@ -64,6 +90,12 @@ def _validate(contract, binding):
         _positive(n, "prompt_tokens")
         if n >= context:
             raise ValueError("prompt_tokens exhaust model context")
+    tokens = binding.get("prompt_token_ids")
+    if (not isinstance(tokens, list) or len(tokens) != len(counts)
+            or any(not isinstance(row, list) or len(row) != n
+                   or any(type(token) is not int or token < 0 for token in row)
+                   for row, n in zip(tokens, counts))):
+        raise ValueError("prompt_tokens and prompt_token_ids disagree or are malformed")
     return min(context - n for n in counts)
 
 
@@ -216,7 +248,8 @@ def _paired(control, binding):
         raise ValueError("BF16 control did not reach a finishing fixed point")
     _validate(control["contract"], binding)
     for field in ("campaign_id", "host_boot_id", "serve_fingerprint",
-                  "model_context_tokens", "prompt_tokens"):
+                  "model_context_tokens", "prompt_tokens", "prompt_token_ids",
+                  "producer_source_sha256"):
         if binding[field] != control["binding"][field]:
             raise ValueError(f"paired {field} differs")
     if (binding["artifact_id"] != control["binding"]["artifact_id"]

--- a/prismaquant/boundary_control.py
+++ b/prismaquant/boundary_control.py
@@ -11,6 +11,7 @@ import copy
 import hashlib
 import json
 import math
+import re
 
 from prismaquant import validate_quantized_model as vqm
 
@@ -21,6 +22,20 @@ SCORER = "prismaquant.boundary_close_count/1"
 def digest(value):
     return hashlib.sha256(json.dumps(value, sort_keys=True, ensure_ascii=False,
                                     separators=(",", ":"), allow_nan=False).encode()).hexdigest()
+
+
+def artifact_content_id(content):
+    """Bind exact safetensors bytes plus the existing model metadata scope."""
+    from prismaquant.shipcard import _closed_weight_content_manifest
+
+    if (not isinstance(content, dict)
+            or set(content) != {"model_sha", "weight_content_manifest"}
+            or not isinstance(content["model_sha"], str)
+            or re.fullmatch(r"[0-9a-f]{64}", content["model_sha"]) is None):
+        raise ValueError("artifact_content requires model_sha and exact weight content manifest")
+    _closed_weight_content_manifest(content["weight_content_manifest"],
+                                    where="boundary artifact_content")
+    return digest(content)
 
 
 def _positive(value, field):
@@ -82,6 +97,8 @@ def _validate(contract, binding):
                   "serve_fingerprint", "host_boot_id", "producer_source_sha256"):
         if not isinstance(binding.get(field), str) or not binding[field].strip():
             raise ValueError(f"missing {field}")
+    if binding["artifact_id"] != artifact_content_id(binding.get("artifact_content")):
+        raise ValueError("artifact_id differs from exact artifact_content")
     context = _positive(binding.get("model_context_tokens"), "model_context_tokens")
     counts = binding.get("prompt_tokens")
     if not isinstance(counts, list) or len(counts) != len(prompts):

--- a/prismaquant/boundary_control.py
+++ b/prismaquant/boundary_control.py
@@ -1,0 +1,257 @@
+"""Opt-in paired boundary measurement; deliberately not a shipping verdict.
+
+The BF16 control determines a finishing budget for a frozen prompt/seed
+schedule. A token or iteration bound is an inconclusive stop, never proof of
+convergence. Candidate and control are then compared at the identical cap.
+This module reuses the shipping probe's HTTP, response and scoring contracts.
+"""
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import math
+
+from prismaquant import validate_quantized_model as vqm
+
+SCHEMA = "prismaquant.boundary_control/1"
+SCORER = "prismaquant.boundary_close_count/1"
+
+
+def digest(value):
+    return hashlib.sha256(json.dumps(value, sort_keys=True, ensure_ascii=False,
+                                    separators=(",", ":"), allow_nan=False).encode()).hexdigest()
+
+
+def _positive(value, field):
+    if type(value) is not int or value < 1:
+        raise ValueError(f"{field} must be a positive integer")
+    return value
+
+
+def _validate(contract, binding):
+    if not isinstance(contract, dict) or set(contract) != {
+        "prompts", "seeds", "temperature", "initial_max_tokens", "max_steps"
+    }:
+        raise ValueError("measurement contract fields differ from schema")
+    prompts, seeds = contract["prompts"], contract["seeds"]
+    if not isinstance(prompts, list) or not prompts:
+        raise ValueError("prompts must be non-empty")
+    for row in prompts:
+        if (not isinstance(row, dict) or set(row) != {"text", "stratum"}
+                or any(not isinstance(v, str) or not v.strip() for v in row.values())):
+            raise ValueError("prompt requires text and stratum")
+    if len({row["text"] for row in prompts}) != len(prompts):
+        raise ValueError("prompts must be unique")
+    if (not isinstance(seeds, list) or not seeds
+            or any(type(s) is not int or s < 0 for s in seeds)
+            or len(set(seeds)) != len(seeds)):
+        raise ValueError("seeds must be distinct non-negative integers")
+    temp = contract["temperature"]
+    if type(temp) not in (int, float) or not math.isfinite(temp) or temp <= 0:
+        raise ValueError("temperature must be finite and positive")
+    _positive(contract["initial_max_tokens"], "initial_max_tokens")
+    _positive(contract["max_steps"], "max_steps")
+    for field in ("campaign_id", "artifact_id", "serve_session_id",
+                  "serve_fingerprint", "host_boot_id"):
+        if not isinstance(binding.get(field), str) or not binding[field].strip():
+            raise ValueError(f"missing {field}")
+    context = _positive(binding.get("model_context_tokens"), "model_context_tokens")
+    counts = binding.get("prompt_tokens")
+    if not isinstance(counts, list) or len(counts) != len(prompts):
+        raise ValueError("prompt_tokens does not cover the prompt schedule")
+    for n in counts:
+        _positive(n, "prompt_tokens")
+        if n >= context:
+            raise ValueError("prompt_tokens exhaust model context")
+    return min(context - n for n in counts)
+
+
+def _summary(outcomes):
+    by_kind = {kind: 0 for kind in vqm.BOUNDARY_DEFECTS}
+    n_defects = 0
+    for row in outcomes:
+        score = vqm.score_boundary_text(row["text"], row["finish_reason"])
+        if row["score"] != score:
+            raise ValueError("outcome score disagrees with the frozen scorer")
+        n_defects += bool(score["defects"])
+        for kind in score["defects"]:
+            by_kind[kind] += 1
+    return {"n_generations": len(outcomes), "n_defects": n_defects,
+            "defects_by_kind": by_kind}
+
+
+def measure_step(base_url, model_name, contract, max_tokens, *, raw=False):
+    outcomes = []
+    for index, prompt in enumerate(contract["prompts"]):
+        for seed in contract["seeds"]:
+            body = {"model": model_name, "max_tokens": max_tokens,
+                    "temperature": contract["temperature"], "seed": seed,
+                    "top_p": 1.0, "skip_special_tokens": False}
+            if raw:
+                body["prompt"] = prompt["text"]
+                endpoint = "/v1/completions"
+            else:
+                body.update(messages=[{"role": "user", "content": prompt["text"]}],
+                            include_reasoning=True,
+                            chat_template_kwargs=dict(vqm.BOUNDARY_CHAT_TEMPLATE_KWARGS))
+                endpoint = vqm.BOUNDARY_ENDPOINT
+            response = vqm._post_json(vqm._server_root(base_url) + endpoint, body)
+            choices = response.get("choices")
+            if not isinstance(choices, list) or len(choices) != 1:
+                raise ValueError("response must contain exactly one choice")
+            choice = choices[0]
+            if raw:
+                text, mode = choice.get("text"), "raw_completion"
+                if not isinstance(text, str):
+                    raise ValueError("raw completion text must be a string")
+            else:
+                text, mode = vqm._boundary_text_from_chat_choice(choice)
+            finish = choice.get("finish_reason")
+            if finish not in ("stop", "length"):
+                raise ValueError(f"unsupported finish_reason: {finish!r}")
+            tokens = response.get("usage", {}).get("completion_tokens")
+            _positive(tokens, "completion_tokens")
+            if tokens > max_tokens:
+                raise ValueError("completion_tokens exceeds requested cap")
+            outcomes.append({"prompt_index": index, "seed": seed, "text": text,
+                             "response_mode": mode, "finish_reason": finish,
+                             "completion_tokens": tokens,
+                             "score": vqm.score_boundary_text(text, finish)})
+    return {"max_tokens": max_tokens, "endpoint": endpoint,
+            "outcomes": outcomes, **_summary(outcomes)}
+
+
+def _receipt(contract, binding, role):
+    return {"schema": SCHEMA, "scorer": SCORER,
+            "request_schema": vqm.BOUNDARY_REQUEST_SCHEMA,
+            "response_schema": vqm.BOUNDARY_RESPONSE_SCHEMA,
+            "promptset_sha256": digest(contract["prompts"]),
+            "contract": copy.deepcopy(contract), "binding": copy.deepcopy(binding),
+            "role": role, "advisory_only": True}
+
+
+def measure_control(base_url, model_name, contract, binding):
+    bound = _validate(contract, binding)
+    cap = min(contract["initial_max_tokens"], bound)
+    receipt = _receipt(contract, binding, "bf16_control")
+    receipt.update(steps=[], fixed_point=False, stop_reason="iteration_backstop")
+    for _ in range(contract["max_steps"]):
+        step = measure_step(base_url, model_name, contract, cap)
+        receipt["steps"].append(step)
+        if not step["defects_by_kind"]["cap_truncation"]:
+            receipt.update(fixed_point=True, stop_reason="uncensored_control")
+            break
+        if cap == bound:
+            receipt["stop_reason"] = "context_bound"
+            break
+        cap = min(2 * cap, bound)
+    replay_control(receipt)
+    return receipt
+
+
+def _replay_step(step, contract, cap):
+    if step.get("max_tokens") != cap or step.get("endpoint") != vqm.BOUNDARY_ENDPOINT:
+        raise ValueError("step cap or endpoint differs from measurement contract")
+    schedule = [(i, seed) for i in range(len(contract["prompts"]))
+                for seed in contract["seeds"]]
+    outcomes = step.get("outcomes")
+    if not isinstance(outcomes, list) or [
+        (row.get("prompt_index"), row.get("seed")) for row in outcomes
+    ] != schedule:
+        raise ValueError("outcomes do not match exact prompt/seed schedule")
+    for row in outcomes:
+        if not isinstance(row.get("text"), str) or row.get("finish_reason") not in ("stop", "length"):
+            raise ValueError("malformed outcome text or finish_reason")
+        if _positive(row.get("completion_tokens"), "completion_tokens") > cap:
+            raise ValueError("outcome completion_tokens exceeds cap")
+    for key, value in _summary(outcomes).items():
+        if step.get(key) != value:
+            raise ValueError(f"step {key} disagrees with outcomes")
+    return not step["defects_by_kind"]["cap_truncation"]
+
+
+def _replay_header(receipt):
+    expected = {"schema": SCHEMA, "scorer": SCORER,
+                "request_schema": vqm.BOUNDARY_REQUEST_SCHEMA,
+                "response_schema": vqm.BOUNDARY_RESPONSE_SCHEMA,
+                "advisory_only": True}
+    for field, value in expected.items():
+        if receipt.get(field) != value:
+            raise ValueError(f"receipt {field} differs from measurement contract")
+    contract, binding = receipt["contract"], receipt["binding"]
+    bound = _validate(contract, binding)
+    if receipt.get("promptset_sha256") != digest(contract["prompts"]):
+        raise ValueError("promptset_sha256 does not bind measured prompts")
+    return contract, bound
+
+
+def replay_control(receipt):
+    contract, bound = _replay_header(receipt)
+    steps = receipt.get("steps")
+    if receipt.get("role") != "bf16_control" or not isinstance(steps, list) or not steps:
+        raise ValueError("control requires BF16 role and nonempty steps")
+    if len(steps) > contract["max_steps"]:
+        raise ValueError("control exceeded its iteration backstop")
+    cap = min(contract["initial_max_tokens"], bound)
+    finished = False
+    for i, step in enumerate(steps):
+        finished = _replay_step(step, contract, cap)
+        if i < len(steps) - 1 and (finished or cap == bound):
+            raise ValueError("control continued after its stopping condition")
+        if i < len(steps) - 1:
+            cap = min(2 * cap, bound)
+    reason = ("uncensored_control" if finished else "context_bound" if cap == bound
+              else "iteration_backstop")
+    if not finished and cap < bound and len(steps) != contract["max_steps"]:
+        raise ValueError("control stopped before its fixed point or backstop")
+    if receipt.get("fixed_point") is not finished or receipt.get("stop_reason") != reason:
+        raise ValueError("control fixed point is not supported by its outcomes")
+    return cap
+
+
+def _paired(control, binding):
+    cap = replay_control(control)
+    if not control["fixed_point"]:
+        raise ValueError("BF16 control did not reach a finishing fixed point")
+    _validate(control["contract"], binding)
+    for field in ("campaign_id", "host_boot_id", "serve_fingerprint",
+                  "model_context_tokens", "prompt_tokens"):
+        if binding[field] != control["binding"][field]:
+            raise ValueError(f"paired {field} differs")
+    if (binding["artifact_id"] != control["binding"]["artifact_id"]
+            and binding["serve_session_id"] == control["binding"]["serve_session_id"]):
+        raise ValueError("distinct artifacts cannot share one serve_session_id")
+    return cap
+
+
+def measure_candidate(base_url, model_name, control, binding):
+    cap = _paired(control, binding)
+    receipt = _receipt(control["contract"], binding, "candidate")
+    receipt["control_sha256"] = digest(control)
+    receipt["step"] = measure_step(base_url, model_name, control["contract"], cap)
+    return receipt
+
+
+def compare(control, candidate):
+    cap = _paired(control, candidate["binding"])
+    _replay_header(candidate)
+    if (candidate.get("role") != "candidate" or candidate["contract"] != control["contract"]
+            or candidate.get("control_sha256") != digest(control)):
+        raise ValueError("candidate does not bind the exact control and contract")
+    _replay_step(candidate["step"], control["contract"], cap)
+    strata = {}
+    for prompt in control["contract"]["prompts"]:
+        strata.setdefault(prompt["stratum"], {"control_defects": 0, "candidate_defects": 0,
+                                               "n_generations_per_arm": 0})
+    for label, step in (("control", control["steps"][-1]), ("candidate", candidate["step"])):
+        for outcome in step["outcomes"]:
+            stratum = control["contract"]["prompts"][outcome["prompt_index"]]["stratum"]
+            strata[stratum][f"{label}_defects"] += bool(outcome["score"]["defects"])
+            if label == "control":
+                strata[stratum]["n_generations_per_arm"] += 1
+    for row in strata.values():
+        row["delta_defects"] = row["candidate_defects"] - row["control_defects"]
+    return {"schema": "prismaquant.boundary_comparison/1", "advisory_only": True,
+            "control_sha256": digest(control), "candidate_sha256": digest(candidate),
+            "max_tokens": cap, "strata": strata}

--- a/prismaquant/shipcard.py
+++ b/prismaquant/shipcard.py
@@ -2919,9 +2919,8 @@ def _verify_ship_gate_record(
         ):
             problems.append(
                 f"{slot}: boundary check reports {defects!r} defective "
-                "generations — the bound is zero "
-                "(any stutter/zero-tag/cap-truncation on a terse prompt "
-                "is a functional failure)"
+                "generations — the historical bound is zero; "
+                "its control-relative replacement remains pending #87"
             )
         temperature = boundary.get("temperature")
         if (

--- a/prismaquant/validate_quantized_model.py
+++ b/prismaquant/validate_quantized_model.py
@@ -149,9 +149,9 @@ BOUNDARY_PROMPTS: tuple[str, ...] = (
 #: Closed defect vocabulary for one sampled generation. `zero_tag` (no
 #: `</think>` emitted — the runaway shape), `think_stutter` (more than one
 #: `</think>` — the stutter/loop shape), and `cap_truncation` (the server
-#: stopped on `length`: on these terse prompts a clean model answers in far
-#: fewer tokens, so hitting the cap means the model never reached its answer
-#: — the hang presentation from the issue).
+#: stopped on `length`). A cap hit describes censored output; healthy thinking
+#: models can also exhaust the historical cap, so it alone does not establish
+#: an artifact defect (issue #87).
 BOUNDARY_DEFECTS: tuple[str, ...] = (
     "zero_tag",
     "think_stutter",
@@ -472,9 +472,10 @@ def check_boundary_behavior(
     not apply the model's chat template and cannot exercise this boundary.
     Reasoning-parser responses are recovered through
     :func:`_boundary_text_from_chat_choice` before scoring. Fails when
-    total defects exceed `max_defects` (default 0: any stutter, zero-tag
-    runaway, or cap-truncation on these terse prompts is a functional
-    failure). Runs alongside KL/PPL, not replacing them.
+    total flagged generations exceed `max_defects`. The historical 64-token
+    cap and zero bound remain fail-closed pending #87's paired-control policy;
+    neither is a calibrated universal artifact-quality threshold. Runs
+    alongside KL/PPL, not replacing them.
     """
     if not temperature or temperature <= 0:
         return CheckResult(

--- a/prismaquant/validate_quantized_model.py
+++ b/prismaquant/validate_quantized_model.py
@@ -477,12 +477,24 @@ def check_boundary_behavior(
     neither is a calibrated universal artifact-quality threshold. Runs
     alongside KL/PPL, not replacing them.
     """
-    if not temperature or temperature <= 0:
+    invalid = []
+    if (isinstance(temperature, bool) or not isinstance(temperature, (int, float))
+            or not math.isfinite(temperature) or temperature <= 0):
+        invalid.append(f"boundary_temperature={temperature!r} is not sampling; must be finite and > 0")
+    if type(reps) is not int or reps <= 0:
+        invalid.append(f"boundary_reps={reps!r} must be a positive integer")
+    if type(max_tokens) is not int or max_tokens <= 0:
+        invalid.append(f"boundary_max_tokens={max_tokens!r} must be a positive integer")
+    if type(max_defects) is not int or max_defects < 0:
+        invalid.append(f"max_boundary_defects={max_defects!r} must be a non-negative integer")
+    if (not isinstance(prompts, (tuple, list)) or not prompts
+            or any(not isinstance(prompt, str) or not prompt.strip() for prompt in prompts)):
+        invalid.append("boundary_prompts must be a nonempty sequence of nonempty strings")
+    if invalid:
         return CheckResult(
             name="boundary_behavior",
             passed=False,
-            detail=f"boundary_temperature={temperature!r} is not sampling — "
-                   "the defect this check exists for is invisible at temp 0",
+            detail="invalid sampling contract: " + "; ".join(invalid),
         )
     n_defects = 0
     by_kind: dict[str, int] = {kind: 0 for kind in BOUNDARY_DEFECTS}

--- a/tests/test_boundary_control.py
+++ b/tests/test_boundary_control.py
@@ -26,7 +26,9 @@ def _binding(artifact="bf16"):
     return {"campaign_id": "paired-test", "artifact_id": artifact,
             "serve_session_id": artifact + "-session",
             "serve_fingerprint": "a" * 64, "host_boot_id": "boot-1",
-            "model_context_tokens": 70, "prompt_tokens": [6]}
+            "model_context_tokens": 70, "prompt_tokens": [6],
+            "prompt_token_ids": [[1, 2, 3, 4, 5, 6]],
+            "producer_source_sha256": "c" * 64}
 
 
 def _control(monkeypatch, *, finish_at=16):
@@ -93,6 +95,8 @@ def test_candidate_matches_control_seeds_cap_and_reports_relative_counts(monkeyp
 @pytest.mark.parametrize("field,value", [
     ("campaign_id", "other-campaign"), ("host_boot_id", "other-boot"),
     ("serve_fingerprint", "b" * 64), ("prompt_tokens", [7]),
+    ("prompt_token_ids", [[6, 5, 4, 3, 2, 1]]),
+    ("producer_source_sha256", "d" * 64),
 ])
 def test_candidate_refuses_unpaired_stack_or_tokenization(monkeypatch, field, value):
     api = _api()
@@ -100,6 +104,24 @@ def test_candidate_refuses_unpaired_stack_or_tokenization(monkeypatch, field, va
     binding = {**_binding("quant"), field: value}
     with pytest.raises(ValueError, match=field):
         api.measure_candidate("http://server", "model", control, binding)
+
+
+@pytest.mark.parametrize("dtype,quantization", [("half", None), ("float16", None),
+                                                ("bfloat16", "fp8")])
+def test_control_refuses_live_dtype_or_quantization_override(dtype, quantization):
+    with pytest.raises(ValueError, match="BF16 control"):
+        _api().require_bf16_control({"torch_dtype": "bfloat16"}, dtype, quantization)
+
+
+@pytest.mark.parametrize("argv", [
+    ["vllm", "serve", "/bf16", "-q", "fp8"],
+    ["vllm", "serve", "/bf16", "--dtype", "bfloat16", "--dtype", "half"],
+    ["vllm", "serve", "/bf16", "--hf-overrides", "{}"],
+])
+def test_control_refuses_ambiguous_or_aliased_live_overrides(argv):
+    with pytest.raises(ValueError, match="BF16 control"):
+        _api().require_bf16_control({"torch_dtype": "bfloat16"}, "bfloat16", None,
+                                   launch_argv=argv)
 
 
 def test_replay_rejects_forged_counts_and_missing_generations(monkeypatch):

--- a/tests/test_boundary_control.py
+++ b/tests/test_boundary_control.py
@@ -1,0 +1,132 @@
+"""Paired boundary measurement must not mistake a token budget for a defect."""
+from __future__ import annotations
+
+import copy
+import importlib
+
+import pytest
+
+
+def _api():
+    return importlib.import_module("prismaquant.boundary_control")
+
+
+def _response(cap, *, finish="stop", text="<think>work</think> answer"):
+    return {"choices": [{"message": {"content": text}, "finish_reason": finish}],
+            "usage": {"completion_tokens": min(cap, 12)}}
+
+
+def _contract():
+    return {"prompts": [{"text": "9²", "stratum": "numeric"}],
+            "seeds": [31, 47], "temperature": 1.0,
+            "initial_max_tokens": 8, "max_steps": 5}
+
+
+def _binding(artifact="bf16"):
+    return {"campaign_id": "paired-test", "artifact_id": artifact,
+            "serve_session_id": artifact + "-session",
+            "serve_fingerprint": "a" * 64, "host_boot_id": "boot-1",
+            "model_context_tokens": 70, "prompt_tokens": [6]}
+
+
+def _control(monkeypatch, *, finish_at=16):
+    api = _api()
+    def post(_url, body):
+        cap = body["max_tokens"]
+        return _response(cap, finish="stop" if cap >= finish_at else "length")
+    monkeypatch.setattr(api.vqm, "_post_json", post)
+    return api.measure_control("http://server", "model", _contract(), _binding())
+
+
+def test_control_grows_until_uncensored_instead_of_zero_defects(monkeypatch):
+    api = _api()
+    def post(_url, body):
+        cap = body["max_tokens"]
+        return _response(cap, finish="stop" if cap >= 16 else "length",
+                         text="answer without a reasoning tag")
+    monkeypatch.setattr(api.vqm, "_post_json", post)
+    control = api.measure_control("http://server", "model", _contract(), _binding())
+    assert [row["max_tokens"] for row in control["steps"]] == [8, 16]
+    assert control["fixed_point"] is True
+    assert control["steps"][-1]["n_defects"] == 2
+
+
+def test_control_uses_exact_context_remainder_and_refuses_a_backstop(monkeypatch):
+    api = _api()
+    monkeypatch.setattr(api.vqm, "_post_json", lambda _url, body: _response(
+        body["max_tokens"], finish="length"))
+    control = api.measure_control("http://server", "model", _contract(), _binding())
+    assert [row["max_tokens"] for row in control["steps"]] == [8, 16, 32, 64]
+    assert control["fixed_point"] is False
+    assert control["stop_reason"] == "context_bound"
+    with pytest.raises(ValueError, match="fixed point"):
+        api.measure_candidate("http://server", "model", control, _binding("quant"))
+
+
+def test_iteration_backstop_never_certifies_fixed_point(monkeypatch):
+    api = _api()
+    monkeypatch.setattr(api.vqm, "_post_json", lambda _url, body: _response(
+        body["max_tokens"], finish="length"))
+    contract = {**_contract(), "max_steps": 1}
+    control = api.measure_control("http://server", "model", contract, _binding())
+    assert control["stop_reason"] == "iteration_backstop"
+    assert control["fixed_point"] is False
+
+
+def test_candidate_matches_control_seeds_cap_and_reports_relative_counts(monkeypatch):
+    api = _api()
+    control = _control(monkeypatch)
+    requests = []
+    def post(_url, body):
+        requests.append(body)
+        return _response(body["max_tokens"], text="runaway", finish="length")
+    monkeypatch.setattr(api.vqm, "_post_json", post)
+    candidate = api.measure_candidate("http://server", "model", control, _binding("quant"))
+    comparison = api.compare(control, candidate)
+    assert [row["seed"] for row in requests] == _contract()["seeds"]
+    assert {row["max_tokens"] for row in requests} == {16}
+    assert comparison["strata"]["numeric"]["delta_defects"] == 2
+    assert comparison["advisory_only"] is True
+    assert "passed" not in comparison
+
+
+@pytest.mark.parametrize("field,value", [
+    ("campaign_id", "other-campaign"), ("host_boot_id", "other-boot"),
+    ("serve_fingerprint", "b" * 64), ("prompt_tokens", [7]),
+])
+def test_candidate_refuses_unpaired_stack_or_tokenization(monkeypatch, field, value):
+    api = _api()
+    control = _control(monkeypatch)
+    binding = {**_binding("quant"), field: value}
+    with pytest.raises(ValueError, match=field):
+        api.measure_candidate("http://server", "model", control, binding)
+
+
+def test_replay_rejects_forged_counts_and_missing_generations(monkeypatch):
+    api = _api()
+    control = _control(monkeypatch)
+    for mutation in ("count", "generation", "fixed_point", "cap"):
+        forged = copy.deepcopy(control)
+        if mutation == "count":
+            forged["steps"][-1]["n_defects"] = 123
+        elif mutation == "generation":
+            forged["steps"][-1]["outcomes"].pop()
+        elif mutation == "fixed_point":
+            forged["steps"][0]["outcomes"][0]["finish_reason"] = "stop"
+        else:
+            forged["steps"][-1]["max_tokens"] += 1
+        with pytest.raises(ValueError):
+            api.replay_control(forged)
+
+
+@pytest.mark.parametrize("field,value", [
+    ("temperature", float("nan")), ("seeds", [1, 1]),
+    ("prompts", []), ("max_steps", 0),
+])
+def test_invalid_measurement_contract_refuses_before_request(monkeypatch, field, value):
+    api = _api()
+    def forbidden(*_args):
+        pytest.fail("invalid contract reached the server")
+    monkeypatch.setattr(api.vqm, "_post_json", forbidden)
+    with pytest.raises(ValueError):
+        api.measure_control("http://server", "model", {**_contract(), field: value}, _binding())

--- a/tests/test_boundary_control.py
+++ b/tests/test_boundary_control.py
@@ -23,7 +23,13 @@ def _contract():
 
 
 def _binding(artifact="bf16"):
-    return {"campaign_id": "paired-test", "artifact_id": artifact,
+    from prismaquant.shipcard import WEIGHT_CONTENT_MANIFEST_SCHEMA
+    content = {"model_sha": _api().digest(artifact), "weight_content_manifest": {
+        "schema": WEIGHT_CONTENT_MANIFEST_SCHEMA, "algorithm": "sha256",
+        "files": {"model.safetensors": {"bytes": len(artifact), "sha256": _api().digest(artifact)}},
+    }}
+    return {"campaign_id": "paired-test", "artifact_id": _api().artifact_content_id(content),
+            "artifact_content": content,
             "serve_session_id": artifact + "-session",
             "serve_fingerprint": "a" * 64, "host_boot_id": "boot-1",
             "model_context_tokens": 70, "prompt_tokens": [6],

--- a/tests/test_measure_boundary_control_identity.py
+++ b/tests/test_measure_boundary_control_identity.py
@@ -1,0 +1,126 @@
+"""The paired instrument binds actual native weight bytes, not their sizes."""
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+from prismaquant import boundary_control as bc
+from tools import measure_boundary_control as tool
+from tools import serve_fingerprint as sf
+
+
+@pytest.fixture
+def campaign(tmp_path, monkeypatch):
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "config.json").write_text(json.dumps({"torch_dtype": "bfloat16"}))
+    weight = model / "model.safetensors"
+    weight.write_bytes(b"original weight bytes")
+    contract = tmp_path / "contract.json"
+    contract.write_text(json.dumps({
+        "prompts": [{"text": "9 squared?", "stratum": "numeric"}],
+        "seeds": [0], "temperature": 1.0,
+        "initial_max_tokens": 16, "max_steps": 1,
+    }))
+    manifest = {
+        "residency_readable": True, "serve_session_id": "same-live-server",
+        "models_endpoint_binding": {"model": {"id": "nonce", "max_model_len": 70}},
+        "model": str(model), "launch_argv": ["vllm", "serve", str(model),
+                                               "--dtype", "bfloat16"],
+        "quantization": None, "performance_stack_fingerprint": "a" * 64,
+        "host_identity": {"boot_id": "same-boot"},
+    }
+    monkeypatch.setattr(tool, "activate_prismaquant_source",
+                        lambda: Path(__file__).resolve().parents[1])
+    monkeypatch.setattr(tool, "_install_exact_package_namespace", lambda _root: None)
+    monkeypatch.setitem(sys.modules, "serve_fingerprint", sf)
+    monkeypatch.setattr(sf, "collect_manifest", lambda **_kwargs: copy.deepcopy(manifest))
+    requests = []
+    def post(url, body):
+        requests.append(url)
+        if url.endswith("/tokenize"):
+            return {"count": 2, "tokens": [9, 81]}
+        return {"choices": [{"message": {"content": "<think>9*9</think>81"},
+                              "finish_reason": "stop"}],
+                "usage": {"completion_tokens": 12}}
+    monkeypatch.setattr(bc.vqm, "_post_json", post)
+    def run(name):
+        output = tmp_path / name
+        result = tool.main([
+            "control", "--base-url", "http://fixture", "--model-name", "nonce",
+            "--model-dir", str(model), "--image", "fixture@sha256:" + "a" * 64,
+            "--contract", str(contract), "--campaign-id", "same-campaign",
+            "--out", str(output),
+        ])
+        assert result == 0
+        return json.loads(output.read_text())
+    return model, weight, run, post, requests
+
+
+def test_same_size_weight_edit_changes_boundary_artifact_identity(campaign):
+    _model, weight, run, _post, _requests = campaign
+    first = run("first.json")
+    weight.write_bytes(b"replacement of weight")
+    assert len(b"replacement of weight") == len(b"original weight bytes")
+    second = run("second.json")
+    assert first["measurement"]["binding"]["artifact_id"] != second["measurement"]["binding"]["artifact_id"]
+
+
+def test_same_size_weight_edit_during_measurement_refuses_receipt(campaign, monkeypatch):
+    model, weight, run, post, _requests = campaign
+    def mutate(url, body):
+        response = post(url, body)
+        if url.endswith("/chat/completions"):
+            weight.write_bytes(b"replacement of weight")
+        return response
+    monkeypatch.setattr(bc.vqm, "_post_json", mutate)
+    with pytest.raises(ValueError, match="artifact changed during measurement"):
+        run("changed.json")
+    assert not (model.parent / "changed.json").exists()
+
+
+def test_unchanged_content_is_stable_and_carries_exact_pre_post_manifests(campaign):
+    _model, weight, run, _post, _requests = campaign
+    first = run("first.json")
+    weight.touch()
+    second = run("second.json")
+    assert first["measurement"]["binding"]["artifact_id"] == second["measurement"]["binding"]["artifact_id"]
+    assert first["artifact_pre"] == first["artifact_post"] == second["artifact_pre"]
+    content = first["artifact_pre"]["weight_content_manifest"]
+    assert content["files"][weight.name]["sha256"] == bc.hashlib.sha256(weight.read_bytes()).hexdigest()
+    assert first["measurement"]["binding"]["artifact_id"] == bc.digest(first["artifact_pre"])
+
+
+def test_missing_native_weights_refuses_before_http(campaign):
+    _model, weight, run, _post, requests = campaign
+    weight.unlink()
+    with pytest.raises(FileNotFoundError, match="no safetensors weights"):
+        run("absent.json")
+    assert requests == []
+
+
+def test_mutation_restored_before_post_hash_still_refuses(campaign, monkeypatch):
+    _model, weight, run, post, _requests = campaign
+    original = weight.read_bytes()
+    def mutate_restore(url, body):
+        response = post(url, body)
+        if url.endswith("/chat/completions"):
+            weight.write_bytes(b"replacement of weight")
+            weight.write_bytes(original)
+        return response
+    monkeypatch.setattr(bc.vqm, "_post_json", mutate_restore)
+    with pytest.raises(ValueError, match="artifact changed during measurement"):
+        run("restored.json")
+
+
+def test_offline_replay_refuses_content_manifest_inconsistent_with_identity(campaign):
+    _model, weight, run, _post, _requests = campaign
+    measurement = run("first.json")["measurement"]
+    manifest = measurement["binding"]["artifact_content"]["weight_content_manifest"]
+    manifest["files"][weight.name]["sha256"] = "b" * 64
+    with pytest.raises(ValueError, match="artifact_id"):
+        bc.replay_control(measurement)

--- a/tests/test_serve_fingerprint_descendants.py
+++ b/tests/test_serve_fingerprint_descendants.py
@@ -10,6 +10,22 @@ import pytest
 import tools.serve_fingerprint as serve_fingerprint
 
 
+@pytest.mark.parametrize("argv,name,expected", [
+    (["python3", "measure_boundary_control.py", "--image", "eugr/spark-vllm@sha256:abc"], "python3", False),
+    (["python3", "client.py", "--model", "/models/vllm-test"], "python3", False),
+    (["bash", "-lc", "vllm serve /model"], "bash", False),
+    (["python3", "/usr/local/bin/vllm", "serve", "/model"], "python3", True),
+    (["vllm", "serve", "/model"], "vllm", True),
+    (["python3", "-m", "vllm.entrypoints.openai.api_server"], "python3", True),
+    (["VLLM::EngineCore"], "VLLM::EngineCor", True),
+    (["python3", "-c", "multiprocessing.spawn"], "VLLM::Worker_TP0", True),
+])
+def test_server_discovery_uses_process_identity_not_payload_substrings(monkeypatch, argv, name, expected):
+    monkeypatch.setattr(serve_fingerprint, "_read_cmdline", lambda _pid: argv)
+    monkeypatch.setattr(serve_fingerprint, "_read_process_name", lambda _pid: name)
+    assert serve_fingerprint._looks_like_vllm_process(123) is expected
+
+
 def test_stable_fingerprint_excludes_phase_but_binds_runtime_stack_fields():
     pre = {
         "attestation_phase": "pre",
@@ -261,4 +277,3 @@ def test_required_engine_descendant_fails_closed(monkeypatch):
 )
 def test_engine_witness_requires_engine_argv(argv, expected):
     assert serve_fingerprint.argv_identifies_vllm_engine(argv) is expected
-

--- a/tests/test_ship_boundary_behavior.py
+++ b/tests/test_ship_boundary_behavior.py
@@ -73,6 +73,20 @@ def test_scorer_passes_a_clean_single_tag_completion():
     assert scored["defects"] == []
 
 
+@pytest.mark.parametrize("kwargs", [
+    {"reps": 0}, {"prompts": []}, {"temperature": float("nan")},
+    {"temperature": float("inf")}, {"reps": True},
+    {"max_tokens": 0}, {"max_defects": -1}, {"prompts": [""]},
+])
+def test_boundary_check_refuses_invalid_sampling_contract_before_http(monkeypatch, kwargs):
+    def forbidden(*_args, **_kwargs):
+        pytest.fail("invalid sampling contract reached HTTP")
+    monkeypatch.setattr(vqm, "_post_json", forbidden)
+    result = vqm.check_boundary_behavior("http://unused", "model", **kwargs)
+    assert not result.passed, result.detail
+    assert "invalid sampling contract" in result.detail
+
+
 def test_scorer_flags_zero_tag_runaway():
     scored = vqm.score_boundary_text("The answer is 12.", "stop")
     assert scored["think_tag_count"] == 0

--- a/tools/measure_boundary_control.py
+++ b/tools/measure_boundary_control.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Measure the opt-in #87 instrument inside an already running serve container.
+
+Use one PrismaBuild action for sequential BF16-control/candidate serves. This
+client starts no server and allocates no GPU context. The same immutable image,
+source snapshot, prompt contract and action/campaign ID must cover both arms.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+import time
+
+# Reuse the source bootstrap's stdlib namespace, avoiding package __init__ and
+# its torch import in the serving container. The exact directory is this tool's.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from prismaquant_source_bootstrap import (  # noqa: E402
+    activate_prismaquant_source, _install_exact_package_namespace,
+)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("role", choices=("control", "candidate"))
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--model-name", required=True)
+    parser.add_argument("--model-dir", required=True)
+    parser.add_argument("--image", required=True, help="immutable repository@sha256 digest")
+    parser.add_argument("--contract", help="frozen prompt/seed/cap contract JSON (control)")
+    parser.add_argument("--control", help="completed BF16 control receipt (candidate)")
+    parser.add_argument("--campaign-id", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--legacy-ab", action="store_true",
+                        help="also measure historical raw request at initial cap on control")
+    args = parser.parse_args(argv)
+    if "@sha256:" not in args.image:
+        parser.error("--image must be immutable")
+    output = Path(args.out)
+    if output.exists():
+        parser.error("--out already exists; use a fresh receipt path")
+    root = activate_prismaquant_source()
+    _install_exact_package_namespace(root)
+    from prismaquant import boundary_control as bc
+    from prismaquant.shipcard import compute_model_sha
+    import serve_fingerprint as sf
+
+    if args.role == "control":
+        if not args.contract or args.control:
+            parser.error("control requires --contract and no --control")
+        contract = json.loads(Path(args.contract).read_text())
+        model_config = json.loads((Path(args.model_dir) / "config.json").read_text())
+        if model_config.get("quantization_config") or model_config.get(
+            "dtype", model_config.get("torch_dtype")
+        ) not in ("bfloat16", "torch.bfloat16"):
+            parser.error("BF16 control requires an unquantized bfloat16 model config")
+        control = None
+    else:
+        if not args.control or args.contract or args.legacy_ab:
+            parser.error("candidate requires --control, no --contract/--legacy-ab")
+        control = json.loads(Path(args.control).read_text())["measurement"]
+        bc.replay_control(control)
+        contract = control["contract"]
+
+    before = sf.collect_manifest(image=args.image, base_url=args.base_url,
+                                 attestation_phase="pre")
+    if not before["residency_readable"] or not before.get("serve_session_id"):
+        raise ValueError("serve process/residency attestation is incomplete")
+    model = before["models_endpoint_binding"]["model"]
+    if model["id"] != args.model_name:
+        raise ValueError("requested model is not the observed live serve")
+    if Path(before["model"]).resolve() != Path(args.model_dir).resolve():
+        raise ValueError("model-dir differs from the observed server argv")
+    counts = []
+    for prompt in contract["prompts"]:
+        tokenized = bc.vqm._post_json(bc.vqm._server_root(args.base_url) + "/tokenize", {
+            "model": args.model_name,
+            "messages": [{"role": "user", "content": prompt["text"]}],
+            "add_generation_prompt": True,
+            "chat_template_kwargs": dict(bc.vqm.BOUNDARY_CHAT_TEMPLATE_KWARGS),
+        })
+        counts.append(tokenized["count"])
+    binding = {
+        "campaign_id": args.campaign_id,
+        "artifact_id": compute_model_sha(args.model_dir),
+        "serve_session_id": before["serve_session_id"],
+        "serve_fingerprint": before["performance_stack_fingerprint"],
+        "host_boot_id": before["host_identity"]["boot_id"],
+        "model_context_tokens": model["max_model_len"],
+        "prompt_tokens": counts,
+    }
+    context_bound = bc._validate(contract, binding)
+    started = time.time()
+    historical = None
+    if args.legacy_ab:
+        historical = bc.measure_step(args.base_url, args.model_name, contract,
+                                     min(contract["initial_max_tokens"], context_bound), raw=True)
+    if control is None:
+        measurement = bc.measure_control(args.base_url, args.model_name, contract, binding)
+        comparison = None
+    else:
+        measurement = bc.measure_candidate(args.base_url, args.model_name, control, binding)
+        comparison = bc.compare(control, measurement)
+    finished = time.time()
+    after = sf.collect_manifest(image=args.image, base_url=args.base_url,
+                                attestation_phase="post")
+    for field in ("serve_session_id", "performance_stack_fingerprint", "models_endpoint_binding"):
+        if before[field] != after[field]:
+            raise ValueError(f"serve changed during measurement: {field}")
+    receipt = {"schema": "prismaquant.boundary_campaign_arm/1",
+               "measurement": measurement, "legacy_raw": historical,
+               "comparison": comparison, "started_unix": started,
+               "finished_unix": finished, "serve_pre": before, "serve_post": after,
+               "source_sha256": {path: bc.hashlib.sha256((root / path).read_bytes()).hexdigest()
+                   for path in ("prismaquant/boundary_control.py",
+                                "prismaquant/validate_quantized_model.py",
+                                "tools/measure_boundary_control.py",
+                                "tools/serve_fingerprint.py")}}
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("x") as handle:
+        json.dump(receipt, handle, indent=2, ensure_ascii=False, allow_nan=False)
+        handle.write("\n")
+    print(json.dumps({"receipt": str(output), "sha256": bc.digest(receipt),
+                      "comparison": comparison, "fixed_point": measurement.get("fixed_point")}))
+    return 0 if measurement.get("fixed_point", True) else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/measure_boundary_control.py
+++ b/tools/measure_boundary_control.py
@@ -51,10 +51,6 @@ def main(argv=None):
             parser.error("control requires --contract and no --control")
         contract = json.loads(Path(args.contract).read_text())
         model_config = json.loads((Path(args.model_dir) / "config.json").read_text())
-        if model_config.get("quantization_config") or model_config.get(
-            "dtype", model_config.get("torch_dtype")
-        ) not in ("bfloat16", "torch.bfloat16"):
-            parser.error("BF16 control requires an unquantized bfloat16 model config")
         control = None
     else:
         if not args.control or args.contract or args.legacy_ab:
@@ -72,7 +68,12 @@ def main(argv=None):
         raise ValueError("requested model is not the observed live serve")
     if Path(before["model"]).resolve() != Path(args.model_dir).resolve():
         raise ValueError("model-dir differs from the observed server argv")
+    if args.role == "control":
+        bc.require_bf16_control(model_config,
+            sf._flag_value(before["launch_argv"], "--dtype"), before["quantization"],
+            launch_argv=before["launch_argv"])
     counts = []
+    token_ids = []
     for prompt in contract["prompts"]:
         tokenized = bc.vqm._post_json(bc.vqm._server_root(args.base_url) + "/tokenize", {
             "model": args.model_name,
@@ -81,6 +82,13 @@ def main(argv=None):
             "chat_template_kwargs": dict(bc.vqm.BOUNDARY_CHAT_TEMPLATE_KWARGS),
         })
         counts.append(tokenized["count"])
+        token_ids.append(tokenized["tokens"])
+    source_hashes = {path: bc.hashlib.sha256((root / path).read_bytes()).hexdigest()
+        for path in ("prismaquant/boundary_control.py",
+                     "prismaquant/validate_quantized_model.py", "prismaquant/shipcard.py",
+                     "tools/measure_boundary_control.py", "tools/serve_fingerprint.py",
+                     "tools/prismaquant_source_bootstrap.py",
+                     "prismaquant/tessera_runtime/tessera_serving_runtime_pin.json")}
     binding = {
         "campaign_id": args.campaign_id,
         "artifact_id": compute_model_sha(args.model_dir),
@@ -89,6 +97,8 @@ def main(argv=None):
         "host_boot_id": before["host_identity"]["boot_id"],
         "model_context_tokens": model["max_model_len"],
         "prompt_tokens": counts,
+        "prompt_token_ids": token_ids,
+        "producer_source_sha256": bc.digest(source_hashes),
     }
     context_bound = bc._validate(contract, binding)
     started = time.time()
@@ -112,11 +122,7 @@ def main(argv=None):
                "measurement": measurement, "legacy_raw": historical,
                "comparison": comparison, "started_unix": started,
                "finished_unix": finished, "serve_pre": before, "serve_post": after,
-               "source_sha256": {path: bc.hashlib.sha256((root / path).read_bytes()).hexdigest()
-                   for path in ("prismaquant/boundary_control.py",
-                                "prismaquant/validate_quantized_model.py",
-                                "tools/measure_boundary_control.py",
-                                "tools/serve_fingerprint.py")}}
+               "source_sha256": source_hashes}
     output.parent.mkdir(parents=True, exist_ok=True)
     with output.open("x") as handle:
         json.dump(receipt, handle, indent=2, ensure_ascii=False, allow_nan=False)

--- a/tools/measure_boundary_control.py
+++ b/tools/measure_boundary_control.py
@@ -21,6 +21,21 @@ from prismaquant_source_bootstrap import (  # noqa: E402
 )
 
 
+def _capture_artifact(model_dir):
+    """Hash native source weights, refusing mutation during the hash itself."""
+    from prismaquant.shipcard import (
+        build_weight_content_manifest, compute_model_sha, weight_stat_attestation,
+    )
+
+    before = weight_stat_attestation(model_dir)
+    content = {"model_sha": compute_model_sha(model_dir),
+               "weight_content_manifest": build_weight_content_manifest(model_dir)}
+    after = weight_stat_attestation(model_dir)
+    if before != after:
+        raise ValueError("artifact changed during measurement identity capture")
+    return content, after
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("role", choices=("control", "candidate"))
@@ -43,7 +58,6 @@ def main(argv=None):
     root = activate_prismaquant_source()
     _install_exact_package_namespace(root)
     from prismaquant import boundary_control as bc
-    from prismaquant.shipcard import compute_model_sha
     import serve_fingerprint as sf
 
     if args.role == "control":
@@ -59,6 +73,7 @@ def main(argv=None):
         bc.replay_control(control)
         contract = control["contract"]
 
+    artifact_pre, weight_stats_pre = _capture_artifact(args.model_dir)
     before = sf.collect_manifest(image=args.image, base_url=args.base_url,
                                  attestation_phase="pre")
     if not before["residency_readable"] or not before.get("serve_session_id"):
@@ -91,7 +106,8 @@ def main(argv=None):
                      "prismaquant/tessera_runtime/tessera_serving_runtime_pin.json")}
     binding = {
         "campaign_id": args.campaign_id,
-        "artifact_id": compute_model_sha(args.model_dir),
+        "artifact_id": bc.artifact_content_id(artifact_pre),
+        "artifact_content": artifact_pre,
         "serve_session_id": before["serve_session_id"],
         "serve_fingerprint": before["performance_stack_fingerprint"],
         "host_boot_id": before["host_identity"]["boot_id"],
@@ -115,6 +131,9 @@ def main(argv=None):
     finished = time.time()
     after = sf.collect_manifest(image=args.image, base_url=args.base_url,
                                 attestation_phase="post")
+    artifact_post, weight_stats_post = _capture_artifact(args.model_dir)
+    if artifact_pre != artifact_post or weight_stats_pre != weight_stats_post:
+        raise ValueError("artifact changed during measurement")
     for field in ("serve_session_id", "performance_stack_fingerprint", "models_endpoint_binding"):
         if before[field] != after[field]:
             raise ValueError(f"serve changed during measurement: {field}")
@@ -122,6 +141,8 @@ def main(argv=None):
                "measurement": measurement, "legacy_raw": historical,
                "comparison": comparison, "started_unix": started,
                "finished_unix": finished, "serve_pre": before, "serve_post": after,
+               "artifact_pre": artifact_pre, "artifact_post": artifact_post,
+               "weight_stats_pre": weight_stats_pre, "weight_stats_post": weight_stats_post,
                "source_sha256": source_hashes}
     output.parent.mkdir(parents=True, exist_ok=True)
     with output.open("x") as handle:

--- a/tools/serve_fingerprint.py
+++ b/tools/serve_fingerprint.py
@@ -907,14 +907,39 @@ def serve_session_fingerprint(manifest: Mapping[str, Any]) -> str:
 
 
 def _looks_like_vllm_process(pid: int, pattern: str = "vllm") -> bool:
-    joined = " ".join(_read_cmdline(pid))
-    name = _read_process_name(pid)
-    return bool(
-        pattern.lower() in joined.lower()
-        or "enginecore" in joined.lower()
-        or "vllm" in name.lower()
-        or "enginecore" in name.lower()
-    )
+    """Identify the executable/module or worker title, never payload arguments.
+
+    A measurement client commonly carries ``--image spark-vllm@sha256:...``.
+    Treating that argument as a process identity adds the client itself to
+    every serve manifest, so a fresh client falsely looks like a fresh serve.
+    """
+    target = pattern.lower()
+
+    def title(value: str) -> bool:
+        value = Path(value).name.lower()
+        return (value == target or value.startswith(target + "::")
+                or re.match(r"^enginecore(?:$|[_:.])", value) is not None)
+
+    argv = _read_cmdline(pid)
+    if title(_read_process_name(pid)) or (argv and title(argv[0])):
+        return True
+    if not argv or not Path(argv[0]).name.lower().startswith("python"):
+        return False
+    index = 1
+    while index < len(argv):
+        value = argv[index]
+        if value == "-m":
+            return index + 1 < len(argv) and (
+                argv[index + 1] == target or argv[index + 1].startswith(target + "."))
+        if value == "-c":
+            return False  # any Python source here is payload, not process identity
+        if value in ("-W", "-X", "--check-hash-based-pycs"):
+            index += 2
+        elif value.startswith("-"):
+            index += 1
+        else:
+            return title(value)  # the script; never scan its arguments
+    return False
 
 
 def find_server_pids(pattern: str = "vllm") -> list[int]:


### PR DESCRIPTION
The mandatory boundary probe could return a clean pass without sampling any generations. This fixes that online refusal and prepares an opt-in BF16-relative measurement for the remaining policy defect in #87.

The new instrument derives a finishing cap from a frozen prompt/seed schedule and the observed context remainder. Reaching a context or iteration bound is inconclusive. Candidate runs require the exact control, cap, token IDs, source closure, campaign, host boot and serving stack. The client captures live pre/post process manifests and validates the BF16 serve's actual dtype/quantization arguments. Its per-stratum deltas are advisory: it changes no shipping threshold and fills no shipcard slot. The physical A/B remains scheduled after Tessera #113/#5.

A separate commit fixes shared serve-process discovery: an image/model argument containing `vllm` no longer turns the measurement client or shell wrapper into a server. Stale universal-cap prose is corrected in its own commit.

PrismaBuild evidence: pre-fix empty-population/input tests 8 failed; source/token pairing review 5 failed; process classifier 3 failed/5 passed. Final CPU-only Sparky population on executable source `df44f6d2`: 209 passed, 0 failed, 0 skipped, plus compile checks. Action `b5da2968616280679717305628147cec2fdba6fbe484a01e9d41106c30a8b0fd`, receipt `4a9b4d22ba9d92b0d096be0c51a516a177f187e1c22c372ba9034dd115100766`.

An expanded run also found nine pre-existing Tessera pin/schema failures in `test_tessera_serve_fingerprint.py`; running only that file on pristine `483ff9ca` reproduced the same nine. The concurrent release-consumer/v4 work owns them. They are documented, not counted as passing here. All run populations, pre-fix lines, and the calibration-symlink snapshot exclusion are in `docs/results/pq87_boundary_control_2026-09-04.md`.

Refs #87. Does not close it: no physical A/B or replacement shipping-policy promotion is claimed.
