### PR TITLE
Integrate reviewed Tessera admission and boundary-request fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,25 +127,50 @@ Before implementing new functionality, read this file,
     the envelope fraction also estimates remaining headroom, which wall-clock
     cannot. Do not diagnose a GPU hot path from utilization.
 
-14. **File the finding before you move on -- and err aggressive.** A defect
-    you noticed and did not file is a defect that dies with your context. The
-    cost of a duplicate issue is thirty seconds and a close; the cost of a lost
-    one is that it is rediscovered months later by an artifact. So the bar for
-    filing is **"I believe this is wrong"**, not "I have proved it is wrong and
-    scoped the fix" -- over-filing is explicitly sanctioned (Rob, 2026-09-03:
-    *"I don't care if we're too aggressive"*).
+14. **Fix the finding where you found it -- file only what you cannot.** A
+    defect you noticed and neither fixed nor filed dies with your context. But a
+    ticket is not the only record, and it is usually the worse one: whoever
+    tripped over the defect understands it better than any fresh agent will, and
+    that understanding evaporates the moment the task returns. A filed one-liner
+    then costs a brief, a worktree, a fresh-context ramp-up, a report and a
+    merge, to re-derive what somebody already knew. (Rob, 2026-09-03, watching a
+    dozen tickets arrive in an hour: *"we're just proliferating issues right now
+    that may make sense to fix in the context of the way in which they were
+    discovered."*)
 
-    The rule is *timely* as well as accurate. File it in the same working
-    session you found it, before starting the next task -- not at the end of the
-    day, not in a handover, not in a summary. A finding held in context for
-    "later" has already failed the rule.
+    **Default: fix it, on your branch, in a separate commit.** One commit does
+    one thing so a reviewer can take it or drop it alone -- that constraint is
+    satisfied by a second *commit*, and was never a reason to leave a defect
+    unfixed. Only the mixed commit is forbidden.
 
-    What a filed issue owes, and it is little: the **evidence at `file:line`**
-    (read the line, do not repeat a claim), what breaks and under what inputs,
-    a **severity** from the rubric below, and what would fix it -- or, when the
-    fix is a judgment call, the options and who decides. Say plainly what you
-    did *not* measure. A finding you are unsure of is filed with the
-    uncertainty stated, not withheld until it is certain.
+    **File instead when the fix is not yours to make:**
+    - it needs a decision only Rob prices -- a default moves, an artifact's bytes
+      move, a format menu or serving lane changes, a ship gate is involved;
+    - it needs a measurement you are not set up to take -- a served A/B, a
+      second model, the other box;
+    - it lives in another agent's live branch (read theirs, never edit theirs);
+    - it is large enough to swamp the diff of the task you came for.
+
+    Two bounds, so this is not a licence to widen scope: it covers what you
+    **trip over** doing the task you came for, never a hunt for adjacent work;
+    and every off-task fix is named in the report, one line each, so nothing
+    lands unannounced.
+
+    **When you do file, timeliness still binds.** Same working session, before
+    starting the next task -- not at the end of the day, not in a handover, not
+    in a summary. A finding held in context for "later" has already failed. The
+    bar is **"I believe this is wrong"**, not "I have proved it is wrong and
+    scoped the fix": over-filing beats losing a finding, and fixing beats both.
+
+    **Say which it was.** An issue filed under this principle records whether the
+    filer could have fixed it and chose not to, and why. Without that, a backlog
+    stops describing the work and starts hiding it.
+
+    What a filed issue otherwise owes is little: the **evidence at `file:line`**
+    (read the line, do not repeat a claim), what breaks and under what inputs, a
+    **severity** from the rubric below, and what would fix it -- or, when the fix
+    is a judgment call, the options and who decides. Say plainly what you did
+    *not* measure, and file an uncertain finding with its uncertainty stated.
 
     **Severity rubric.** `P0` -- can ship or serve a wrong artifact. `P1` -- a
     gate that cannot catch its own defect, or a wrong or underived number that
@@ -154,14 +179,11 @@ Before implementing new functionality, read this file,
     labels: `measurement-needed` when a GPU or served A/B decides it, and
     `needs-decision` when the answer is a trade only Rob prices.
 
-    **Two exceptions, both narrow.** (a) A finding in prose -- a doc, a
-    comment, a docstring -- is *fixed on sight*, not filed: reading the cited
-    line IS the verification, so a stale sentence is a one-line commit, not a
-    ticket. (b) A worker inside a delegated task does not widen scope and does
-    not file; it records the finding in its report with `file:line` and a
-    proposed severity, in a form the coordinator can file verbatim -- and the
-    **coordinator files it before starting the next task**, not after the queue
-    drains.
+    **One exception, narrower than it was.** A finding in prose -- a doc, a
+    comment, a docstring -- is *fixed on sight* and never filed: reading the
+    cited line IS the verification, so a stale sentence is a one-line commit.
+    (The former second exception, that a delegated worker neither fixes nor
+    files, is withdrawn: it described a constraint workers do not have.)
 
 ## Implementation Checklist
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,18 +109,22 @@ fourth lane with a novel gate is one spec file plus one verifier, and neither
 roster exists to be forgotten.
 
 
-Re-stamped (2026-09-03, `muse/pq-87-shipgate`) for the **sampled
-boundary-behavior ship gate** (§7.2; issue #87). KL/PPL and greedy-smoke are
-argmax- and distribution-distance measures, structurally blind to
-boundary-token defects that only manifest under sampling (three DSV4-Flash
-quants within ~3% PPL spanning a 6x behavioral gap). `run_validation` now
-files a fifth check, `boundary_behavior`: 5 terse prompts × 6 reps sampled at
-temperature 1.0 under a 64-token cap, scored by the server-free
-`score_boundary_text` for `zero_tag` / `think_stutter` / `cap_truncation`
-with a zero bound. `verify` replays the ledger membership, the exact
-boundary thresholds, and the evidence (positive generation count, zero
-defects, sampling temperature). Gates:
-`tests/test_ship_boundary_behavior.py` (14).
+Re-stamped (2026-09-04, `codex/pq-87-boundary-chat`) for the **sampled
+boundary-behavior request contract** (§7.2; issue #87, still open). The first
+physical run showed that the original implementation posted bare prompts to
+`/v1/completions`; vLLM applies no chat template there, so healthy DSV4 and
+Qwen references both failed 30/30 before artifact behavior was exercised. The
+check now posts a user `messages` body to `/v1/chat/completions`, explicitly
+enables thinking and reasoning output, and recovers the raw boundary semantics
+from either unparsed `message.content` or vLLM's structured `reasoning` /
+`reasoning_content` split. The endpoint plus request/response schema are filed
+in the check metrics and replayed by `shipcard.verify`, so a copied zero count
+from the old route cannot certify an artifact. **This fixes only the request
+contract.** The same run disproved the universal 64-token/zero-defect policy
+(healthy DSV4: 7/30 at 64; stock Qwen3-8B: 10/15 even at 600), so those values
+remain fail-closed historical defaults pending a same-session control-derived
+cap and control-relative verdict; no artifact is promoted and #87 is not
+closed on this commit. Gate: `tests/test_ship_boundary_behavior.py`.
 
 Re-stamped (2026-09-03, `pq132-fused-licence`) for the **fused module's
 per-member rung licence, read from the contract** (§4.10; PrismaQuant #132
@@ -7214,9 +7218,9 @@ CLI-overridable:
 | `DEFAULT_MAX_MEAN_NLL` | 3.0 | mean NLL |
 | `DEFAULT_MIN_GEN_LEN` | 30 chars | per completion |
 | `DEFAULT_MIN_MTP_ACCEPT_P0` | 0.60 | position-0 draft acceptance |
-| `DEFAULT_MAX_BOUNDARY_DEFECTS` | 0 | any `</think>` stutter/zero-tag/cap-truncation on a terse prompt is a functional failure (the answer is never reached); the clean reference scores 0 on this stratum (official unquantized 0/60 terse) |
+| `DEFAULT_MAX_BOUNDARY_DEFECTS` | 0 | fail-closed historical value, **not a calibrated universal bound**: stock Qwen3-8B produced 10/15 at a 600-token cap. Replacement requires a same-session control-relative policy; #87 remains open |
 | `DEFAULT_BOUNDARY_TEMPERATURE` | 1.0 | the unmodified distribution — any temperature > 0 leaves the argmax path greedy-smoke takes; temp 0 is refused, not sampled |
-| `DEFAULT_BOUNDARY_MAX_TOKENS` | 64 | far above what these prompts need, so `length` means runaway/loop |
+| `DEFAULT_BOUNDARY_MAX_TOKENS` | 64 | fail-closed historical value, **known too short**: healthy DSV4 produced 7/30 cap truncations. It remains only until the paired control derives its finishing cap from the model/context contract |
 | `DEFAULT_BOUNDARY_REPS` | 6 | the published battery's own replication count (30 prompts × 6 reps): 5 prompts × 6 reps = 30 sampled generations |
 
 **Sampled boundary behavior (#87).** KL/PPL (distribution distance) and
@@ -7225,13 +7229,32 @@ distribution defects that only manifest under sampling: three DSV4-Flash
 quants within ~3% PPL spanned a 6x behavioral gap (14/180 to 83/180) on the
 frozen battery, because greedy takes the argmax path where the boundary token
 still wins and KL/PPL average a per-token near-tie at one boundary position
-into noise. `check_boundary_behavior` (`:388`) samples the terse
-boundary-stressing prompts (ultra-short numeric, terse QA, short recall —
-the first three verbatim from the report) at temperature > 0 under a small
-cap and scores every generation with the server-free `score_boundary_text`
-(`:360`) for the closed defect vocabulary `zero_tag` / `think_stutter` /
-`cap_truncation`. It runs alongside KL/PPL, not replacing them: a few dozen
-sampled generations, minutes of serve time, no reference model needed.
+into noise. `check_boundary_behavior` samples the terse boundary-stressing
+prompts (ultra-short numeric, terse QA, short recall — the first three
+verbatim from the report) at temperature > 0 and scores every generation with
+the server-free `score_boundary_text` for the closed defect vocabulary
+`zero_tag` / `think_stutter` / `cap_truncation`. The request contract is
+`prismaquant.boundary_chat_request/1`: POST `/v1/chat/completions`, one user
+`messages` row, thinking enabled in the chat-template kwargs, reasoning
+included, and special tokens retained. The response contract is
+`prismaquant.boundary_chat_response/1`: raw `message.content` is scored
+directly; when vLLM's reasoning parser has consumed the first close token and
+split the response into `reasoning` (or legacy `reasoning_content`) plus
+`content`, the client reconstructs exactly that one boundary only when both
+reasoning-side and answer-side content are non-empty. A later close remains
+visible as stutter, while either empty side remains zero-tag/cap-truncation.
+Both schema identities and the endpoint are filed in the shipcard and replayed
+offline.
+
+This endpoint fix is necessary and insufficient. Physical evidence invalidated
+the current 64-token cap and a universal zero roster: healthy DSV4 still filed
+7/30 cap truncations at 64, while stock Qwen3-8B filed 10/15 even at 600. The
+pending policy is a same-session BF16 control whose cap grows until the control
+reaches its own finishing fixed point, bounded by the declared model context
+and an explicit backstop; the quantized arm is then scored control-relative at
+that exact cap. Until that paired receipt is specified and replayed, the old
+64/zero values remain fail-closed, #87 remains `needs-decision`, and a boundary
+check cannot promote an artifact.
 
 **Spec-decode refusal.** `_spec_decode_on` scrapes `/metrics` for
 `vllm:spec_decode`; if present the perplexity check **refuses a verdict** rather than return
@@ -7241,7 +7264,7 @@ ship-ready requires both. The same refusal now also guards the gold lane (§7.3)
 exist only here.
 
 **The guard fails closed, and the URL it uses is not `--base-url` verbatim (2026-08-14).**
-`--base-url` is the **server** root: the module appends `/v1/completions` itself and reads
+`--base-url` is the **server** root: the module appends its `/v1/*` endpoints itself and reads
 `/health` and `/metrics` off the root. The `compressed_tensors` lane spec published the OpenAI
 root (`http://127.0.0.1:8000/v1`), so on the Qwen3.8-27B ship gate `wait_for_ready` polled
 `/v1/health` — 404 — for 11 minutes and would have burned its whole 900 s timeout without

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,17 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-03 · `muse/pq-172-173-append`. Stamps
+As of: 2026-09-04 · `codex/pq-tessera-v4-consumer`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-04, `codex/pq-tessera-v4-consumer`) for **Tessera lane
+schema v4 consumption** (§5.7, §9.4). Development and export readers now share
+the cell parser. Executed `(symbol, decoder)` pairs and explicit residency
+scope are retained; malformed launches, missing plugin/residency declarations
+and overlapping scopes refuse. Per-unit route resolution requires a residency
+for v4 and records the selected launches. The development answer is reviewed
+against Tessera `1221d2a`, including its window-GEMV native extension, while
+the exact release pin remains PENDING and no routed-MoE attestation is added.
+Tests: `test_lane_eligibility_v4.py`, `test_tessera_contract_v4.py`.
 
 Re-stamped (2026-09-03, `muse/pq-172-173-append`) for the **append-identity
 follow-ups** (§5.4; RobTand/prismaquant#172, #173). Two configurations the
@@ -5806,7 +5816,7 @@ under `vllm.general_plugins`, registering `quant_method = "tessera"`, selected
 by the checkpoint with no enable flag and one operator knob
 `TESSERA_SERVE_MODE=resident|streamed`. `tessera_lane_attested(name)` resolves
 the name to its payload family and rate through
-`gridbook_lane_eligibility.resolve_payload_rung` against the contract that
+`lane_eligibility.resolve_payload_rung` against the contract that
 plugin PACKAGES — `tessera/serving/runtime_contract.json`, reached by
 `importlib.resources.files("tessera.serving")`, never repo-root arithmetic —
 and answers True only on the AND of three conjuncts, each of which fails closed
@@ -5832,7 +5842,7 @@ alone:
    dependency — and a producer-side import is not a serving release.
 
 **It is False today by the PIN, not by an edit and not by an absent table.**
-Tessera's packaged contract publishes both families with `device_qualified`
+Tessera's packaged contract publishes its attested families with `device_qualified`
 native cells and the package imports fine here; what withholds them is
 `prismaquant/tessera_runtime/tessera_serving_runtime_pin.json`, whose `commit`
 and `version` are the conspicuous sentinels `PENDING_TESSERA_RELEASE_COMMIT` /
@@ -5853,18 +5863,18 @@ lane is withdrawn and the Gridbook pin no longer governs Tessera admission**;
 read §9.2's Tessera passage as history. The per-artifact question (this
 platform, this unit's regimes) still stays with `resolve_unit_route` at export.
 
-**The parser is shared, and the widenings are additive.**
-`gridbook_lane_eligibility.py` reads both vendors' tables — the v3 cell grammar
-is identical and a second copy of it would be a drift bug — through three
-additive changes: `LANE_ELIGIBILITY_SCHEMAS` accepts
-`tessera.lane-eligibility.v3` beside `gridbook.lane-eligibility.v3`;
-`FORMAT_KIND_TESSERA_WIRE` joins `tcq_trellis` in
-`RATE_ADDRESSED_FORMAT_KINDS`, so `EligibilityCell.is_trellis` now means
-"rate-addressed" and both dispatch sites (`_published_families`,
-`resolve_payload_rung`) test the set rather than one constant; and
-`requires_plugin` is an OPTIONAL cell key, emitted from `as_dict()` only when
-non-empty, so a Gridbook cell serializes byte-for-byte as it did. Every
-pre-existing Gridbook eligibility test passes unchanged.
+**One cell parser, with explicit version semantics.** `lane_eligibility.py`
+reads Tessera's v4 table for export and for `tessera_runtime_contract.py`'s
+development pin. A v4 cell requires `requires_plugin: "tessera"`, non-empty
+`executes` pairs and exactly one residency selector bounded by its family's
+`residency_modes`. Two cells may not claim the same platform/family/structure/
+regime/residency scope, even at different rungs. `resolve_unit_route` takes an
+explicit `residency`; omission is unattested, and a resolved `RegimeRoute`
+carries both the residency and launches. The reviewed development answer
+includes those values, so changing a decoder cannot retain the old answer.
+Explicit legacy Tessera v3 tables retain their original grammar and carry no
+fabricated launches. Gridbook schemas remain refused. Release admission is
+still gated by the exact PENDING release pin.
 
 **What is not here.** No PrismaQuant exporter writes a Tessera wire
 (`export_native_compressed.py` has no Tessera codec; every Tessera checkpoint
@@ -8857,7 +8867,7 @@ are NAMED by the lane spec, never vendored.
 (`prismaquant.tessera_serving_runtime_pin.v1`), read by
 `tessera_serving_runtime_pin.py`; and the contract the plugin packages,
 `tessera/serving/runtime_contract.json` (`tessera.runtime-contract.v1`, lane
-table `tessera.lane-eligibility.v3`), read through `importlib.resources`.
+table `tessera.lane-eligibility.v4`), read through `importlib.resources`.
 PrismaQuant never vendors or imports the serving half. Unlike the Gridbook
 serving pin this one binds no wheel digest: Tessera publishes no wheel and is
 installed from a source checkout, so a digest would be a claim about an

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,5 @@
 # PrismaQuant Architecture
 
-<<<<<<< HEAD
 As of: 2026-09-03 · `muse/pq-172-173-append`. Stamps
 follow, newest first, each recording its own branch and date.
 
@@ -20,10 +19,6 @@ different hash refuses, since the bytes on disk are the first render's.
 Deliberately still unbound: the render narrowing on both paths. Gates:
 `tests/test_packed_append_streaming_and_pair_identity.py` (8, each shown
 failing before the fix).
-=======
-As of: 2026-09-03 · `muse/pq-146-stamp`. Stamps
-follow, newest first, each recording its own branch and date.
-
 Re-stamped (2026-09-03, `muse/pq-146-stamp`) for the **pre-guard
 trust-admission record** (§5.4; RobTand/prismaquant#146, remaining leg). The
 guard admitted a directory holding shards but no sidecar on trust with a
@@ -44,8 +39,6 @@ receipt echoes the admission; the sidecar is the record. Gates:
 `tests/test_production_cache_render_identity.py` (7 new: a hand-built v1
 sidecar resumes, pre-guard records while fresh does not, the append merge and
 the base adoption preserve, no false mismatch, malformed refuses).
->>>>>>> muse/pq-146-stamp
-
 Re-stamped (2026-09-03, `muse/pq-170-append`) for the **production cache
 append-identity guard** (§5.4; RobTand/prismaquant#170). #146's sidecar
 covered the dense fill only, so the MTP and packed-expert appends — which

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,14 @@
 As of: 2026-09-04 · `codex/pq-tessera-v4-consumer`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-04, `codex/pq-tessera-v4-consumer`) for **development
+admission's predicate refusal** (§5.7). The shared parser retained cell
+predicates, but the shape-free development reader discarded them. It now
+refuses non-empty predicates before constructing an unconditional menu; the
+export resolver continues to evaluate predicates against unit facts. The
+reviewed contract has no predicated cells, so its current menu is unchanged.
+Test: `test_tessera_dev_predicates.py`.
+
 Re-stamped (2026-09-04, `codex/pq-tessera-v4-consumer`) for **Tessera lane
 schema v4 consumption** (§5.7, §9.4). Development and export readers now share
 the cell parser. Executed `(symbol, decoder)` pairs and explicit residency
@@ -5875,6 +5883,9 @@ includes those values, so changing a decoder cannot retain the old answer.
 Explicit legacy Tessera v3 tables retain their original grammar and carry no
 fabricated launches. Gridbook schemas remain refused. Release admission is
 still gated by the exact PENDING release pin.
+The development reader also refuses non-empty cell predicates: its family/rate
+menu lookup has no unit facts with which to evaluate a shape constraint.
+Export's `resolve_unit_route` has those facts and evaluates the predicates.
 
 **What is not here.** No PrismaQuant exporter writes a Tessera wire
 (`export_native_compressed.py` has no Tessera codec; every Tessera checkpoint

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5887,22 +5887,19 @@ The development reader also refuses non-empty cell predicates: its family/rate
 menu lookup has no unit facts with which to evaluate a shape constraint.
 Export's `resolve_unit_route` has those facts and evaluates the predicates.
 
-**What is not here.** No PrismaQuant exporter writes a Tessera wire
-(`export_native_compressed.py` has no Tessera codec; every Tessera checkpoint
-served so far was written by the Tessera repository's own exporter), no ship
-gate has been RUN on this lane, no `run-pipeline.sh` stage names a Tessera
-format, and `FORMATS` stays `NVFP4,FP8_DYNAMIC,BF16`. What IS here since
-2026-09-02 is the declared bar: `prismaquant/lane_specs/tessera.json` (§9.4)
-states the serve, endpoint, gates, KL evaluator and executed activation
-contracts before an exporter exists, which is the order that makes the bar
-something an exporter is built against.
-`tessera_{allocator,footprint,rate_surface}.py` are the §4.9 trellis trio
-re-pointed at Tessera families (36 lines differ after renaming), imported by
-nothing in the pipeline; `trellis_menu` remains the only allocation-time seam
-and still refuses (§4.9). Tests (collected):
-`tests/test_tessera_formats.py` (44), `tests/test_tessera_footprint.py` (42),
-`tests/test_tessera_shape_dependent_recipe.py` (15),
-`tests/test_tessera_lane_admission.py` (16). Register entry: D33.
+**The boundary has an export arm, not a second codec.**
+`prismaquant/run-pipeline.sh` selects `EXPORT_CONTAINER=tessera`, preflights
+the lane and calls Tessera's own plan and encoding tools under `TESSERA_REPO`.
+`export_native_compressed.py` deliberately has no Tessera codec. The arm opens
+a lane-gated shipcard; `prismaquant/lane_specs/tessera.json` (§9.4) declares the
+serve, endpoint, gates, KL evaluator and executed activation contracts.
+Allocation uses `tessera_menu` and its reviewed development contract; that
+research menu does not bypass the exact release pin required for export.
+The pending release and supported producer-tool boundary remain D33, rather
+than an absence of pipeline integration. Tests include
+`test_tessera_formats.py`, `test_tessera_footprint.py`,
+`test_tessera_shape_dependent_recipe.py`, `test_tessera_lane_admission.py`,
+`test_tessera_menu.py` and `test_tessera_export_lane.py`.
 
 ## 6. Export & serving invariants
 
@@ -8860,9 +8857,11 @@ hours rather than after them.
 **The runtime is Tessera's.** Package `tessera.serving` in the Tessera
 repository: a `vllm.general_plugins` entry point
 `tessera = "tessera.serving:register"` registering `quant_method = "tessera"`,
-two dense routes (NVFP4 W4A4 at `e2m1_group16_ue4m3_static`, per-channel FP8
-W8A8 at `fp8_per_token_dynamic`), a streamed window decoder and the span-2
-NVFP4 CUDA decoder. **There is no enable flag**: the checkpoint's
+the routes and executed decoders published by its packaged contract. The
+reviewed development contract includes NVFP4 W4A4 at
+`e2m1_group16_ue4m3_static`, FP8 W8A8 at `fp8_per_token_dynamic` and BF16 at
+`bf16_unquantized`; each route's cells name its residency and launches.
+**There is no enable flag**: the checkpoint's
 `quantization_config.quant_method` selects the plugin, and the single operator
 knob is `TESSERA_SERVE_MODE=resident|streamed`, declared rather than defaulted
 because it changes the artifact's footprint and is folded into vLLM's
@@ -8888,14 +8887,15 @@ artifact that does not exist.
 `requires_plugin: "tessera"` — stock vLLM has no reader for these bytes, so the
 route is not merely flag-gated, and an export gate has to be able to refuse an
 artifact whose serve command would not install the runtime. The shared parser
-carries it as an optional cell key and aggregates it as `requires_plugins`
+carries it as a required v4 cell key (optional only in legacy v3) and
+aggregates it as `requires_plugins`
 through `RegimeRoute` / `UnitRoute` / `EligibilityTable.provenance()`;
 `tessera_lane_attested` RAISES on a cell that claims a native route without it,
 because a contract defect must be loud rather than silently admitted.
 
 **Scope, from the table and not from prose.** `structures: ["dense"]` and no
 `routed_moe` cell — no served measurement covers routed experts, and absence is
-the honest state under a closed-world v3 table, not a refusal. Both
+the honest state under a closed-world v4 table, not a refusal. The published
 `tensor_parallel` units declare `max_world_size: 1`: a Tessera unit is one blob
 per vLLM module against a shared rate schedule, so a sharded form needs
 per-rank wires rather than a byte range. `expert_parallel.units` is empty.

--- a/docs/results/tessera_v4_integration_2026-09-04.md
+++ b/docs/results/tessera_v4_integration_2026-09-04.md
@@ -1,0 +1,47 @@
+# Tessera consumer integration — 2026-09-04
+
+Source `a0c8cf25` integrates main's pinned CI dependency, the reviewed
+boundary request fixes from PR #177, and PR #179's v4 consumer. The only
+merge conflict was the architecture-document preamble; both records remain.
+No release pin, shipping threshold, or MoE eligibility is advanced here.
+
+## PrismaBuild receipt
+
+- Action: `446880313ebc79c732e6170f97849247bd2dd5fef35974d4e8b7583b87bf9026`.
+- Receipt: `04edf74ae248f59b3f6323aedc43cf0171150a668aa1851c067b07e76d80155c`.
+- Result SHA256: `e216c67fa411d63a959e2823409f6ea5e7966d7b950f86a90fb26dbb4fe20826`.
+- Worker: Sparky, one CPU, 4 GiB reservation, CUDA hidden; serial pytest.
+- Result: **196 passed, 0 failed, 0 skipped, 0 collection errors**, 135.93 s.
+  There are no skip reasons to report. This was CPU-only and does not cover
+  the GPU surface or the entire repository.
+- Compilation checks passed for `lane_eligibility.py`,
+  `tessera_runtime_contract.py`, and `resolve_tessera_dev_pin.py`.
+
+The run used the verified Tessera `1221d2a` source archive,
+`/mnt/shared/pq-v4-source.o2Tc3O/tessera-1221d2a-src.tar`, SHA256
+`b4755a30d60974ec2758c2060fc4d3954f2e1b7c7bb11602a05f0b783ba60bc8`.
+The exact command is retained in PrismaBuild's action request.
+
+Targeted files: `test_lane_eligibility_v4.py`, `test_tessera_contract_v4.py`,
+`test_tessera_dev_predicates.py`, `test_tessera_lane_admission.py`,
+`test_tessera_export_lane.py`, `test_tessera_substitute_decoder.py`,
+`test_tessera_serve_fingerprint.py`, `test_tessera_serving_contract_path.py`,
+`test_tessera_menu.py`, `test_tessera_menu_real_table.py`,
+`test_docs_staleness.py`, `test_architecture_doc.py`, and
+`test_ci_tessera_install.py`.
+
+## Snapshot boundary and remaining work
+
+PrismaBuild correctly refused the first submission because the repository
+contains absolute external calibration symlinks. For this targeted test
+snapshot only, `calibration/diverse-v1.jsonl`, `calibration/xdom-fit-v1.jsonl`,
+and `calibration/xdom-gate-v1.jsonl` were omitted. All three links were restored
+to their exact HEAD values immediately after queueing; no target data was
+removed or changed. These tests do not use those datasets. Consequently this
+is a source-and-test integration receipt, not a claim of a byte-identical
+whole-checkout snapshot or a calibration measurement.
+
+The separate #87 paired-instrument work and its GPU A/B remain pending.
+Runtime-scoped v5 consumption is a separate reviewed change. Hosted CI's
+private Tessera checkout remains #175, explicitly deferred until publication;
+the local receipt does not claim hosted CI is green.

--- a/prismaquant/lane_eligibility.py
+++ b/prismaquant/lane_eligibility.py
@@ -37,7 +37,7 @@ The shape of the fix is therefore as important as the values:
 * Route status alone never removes an honestly priced rung from the allocator's
   menu (principle 1). It gates EXPORT, per artifact, per principle 9.
 
-Schema v3, and why absence carries the whole weight
+Schemas v3/v4, and why absence carries the whole weight
 ---------------------------------------------------
 ``tessera.lane-eligibility.v3`` is a **closed-world cell table**. It declares
 ``platforms``, ``regimes``, ``structures`` and a list of ``cells``, each cell
@@ -48,6 +48,13 @@ cell uses is NOT a key on the cell: it is decided by whether the cell's family
 appears in ``formats[]`` with a rate-addressed ``kind``
 (:data:`RATE_ADDRESSED_FORMAT_KINDS`), exactly as the publisher's own
 validator decides it.
+
+``tessera.lane-eligibility.v4`` adds a required non-empty ``executes`` set of
+``{symbol, decoder}`` launches and makes residency an explicit resolution
+axis. A caller must name a residency; two cells in the same scope may never
+claim the same residency. The published serve flag selects that axis, and the
+family's ``residency_modes`` bounds it. Legacy v3 tables retain their original
+resolution semantics and never acquire fabricated launch claims.
 
 One parser, and why the vocabulary is wider than one publisher
 ---------------------------------------------------------------
@@ -97,23 +104,29 @@ from typing import Any, Mapping, Sequence
 #: Schema of the eligibility table PrismaQuant consumes, published by Tessera's
 #: own vLLM plugin
 #: (``tessera.serving``, entry point ``tessera``, ``quant_method: "tessera"``).
-#: v3 is a closed-world, platform-scoped cell table, and the parser below is
-#: deliberately ONE parser: a second copy of the cell grammar is a drift bug
-#: waiting for a field to move. ``requires_plugin`` is an OPTIONAL cell key.
+#: v4 adds executed launches and residency to v3's closed-world cell table.
+#: The parser owns both grammars; plugin requirements remain optional only
+#: for explicitly identified legacy v3 tables.
 #:
 #: Until 2026-09-02 this set also carried ``gridbook.lane-eligibility.v3``, the
 #: same wire format published by the retired Gridbook codebook lane. That lane
 #: was removed with Rob's decision to put Tessera in PrismaQuant and remove
 #: Gridbook; see ``archive/gridbook_lane_2026-09-02/README.md``.
-LANE_ELIGIBILITY_SCHEMA_TESSERA = "tessera.lane-eligibility.v3"
+LANE_ELIGIBILITY_SCHEMA_TESSERA = "tessera.lane-eligibility.v4"
+LANE_ELIGIBILITY_SCHEMA_TESSERA_LEGACY_V3 = "tessera.lane-eligibility.v3"
 
 #: Every eligibility-table schema this parser accepts. The check is a set
 #: membership, never a prefix match: an unrecognised vendor is a table this
-#: repository was not handed, and an older *version* of the vendor's table
-#: is not a subset of v3 (see ``_parse_table``).
+#: repository was not handed, and an unlisted version is not treated as a
+#: subset of either supported grammar (see ``_parse_table``).
 LANE_ELIGIBILITY_SCHEMAS = frozenset({
     LANE_ELIGIBILITY_SCHEMA_TESSERA,
+    LANE_ELIGIBILITY_SCHEMA_TESSERA_LEGACY_V3,
 })
+
+#: The residency vocabulary in Tessera's v4 flag grammar. Each format row
+#: publishes the subset its route supports; no cell can widen that subset.
+TESSERA_RESIDENCY_MODES = frozenset({"resident", "streamed"})
 
 #: Schema of the provenance payload this module produces. It was
 #: ``prismaquant.cb_route_attestation.v2`` until 2026-09-02, when the Gridbook
@@ -143,7 +156,7 @@ LANE_ROUTE_STATUSES = frozenset({
 })
 REGIME_ROUTE_STATUSES = LANE_ROUTE_STATUSES | {ROUTE_STATUS_FALLBACK}
 
-#: The CLOSED set a packaged v3 cell may declare, mirroring the publisher's
+#: The CLOSED set a packaged cell may declare, mirroring the publisher's
 #: ``_LANE_ROUTE_STATUSES`` exactly. ``unbacked`` is absent on purpose: the
 #: runtime never enumerates what it refuses, so a cell claiming ``unbacked`` is
 #: a table this repository must not have been handed. Accepting one would make
@@ -296,13 +309,13 @@ _PREDICABLE_FACTS: dict[str, str] = {
 # ---------------------------------------------------------------------------
 @dataclass(frozen=True)
 class EligibilityCell:
-    """One packaged v3 cell: which bytes, where, in which regime, on what route.
+    """One packaged cell: bytes, platform, regime, residency and launch.
 
     A cell is scoped to exactly one ``(platform, family, structure, regime)``
-    and covers an explicit, non-empty rung list. It carries no prose: a v3
+    and covers an explicit, non-empty rung list. It carries no prose: a
     validator refuses ``detail``/``rationale`` keys on a cell, because a gate
-    cannot read prose (principle 14). ``requires_plugin`` is the one optional
-    key, absent from every retired-lane cell and present on every Tessera one.
+    cannot read prose (principle 14). Legacy v3 alone permits an absent plugin
+    key. v4 requires Tessera, launch declarations and residency flags.
     """
 
     id: str
@@ -333,6 +346,10 @@ class EligibilityCell:
     #: The name is historical -- ``tcq_trellis`` was the only such kind when it
     #: was chosen -- and ``tessera_wire`` families set it too.
     is_trellis: bool = False
+    #: v4's published launches, retained as pairs rather than inferred from IDs.
+    executes: tuple[tuple[str, str], ...] = ()
+    #: Parsed from the v4 cell's explicit TESSERA_SERVE_MODE flag.
+    residency_modes: tuple[str, ...] = ()
 
     @classmethod
     def from_dict(
@@ -341,9 +358,13 @@ class EligibilityCell:
         where: str,
         *,
         trellis_families: frozenset[str],
+        schema: str = LANE_ELIGIBILITY_SCHEMA_TESSERA_LEGACY_V3,
+        residency_modes: Sequence[str] = (),
     ) -> "EligibilityCell":
         if not isinstance(payload, Mapping):
             raise LaneEligibilityError(f"{where} must be a JSON object")
+        if schema not in LANE_ELIGIBILITY_SCHEMAS:
+            raise LaneEligibilityError(f"{where}: unsupported lane schema {schema!r}")
         family = str(payload.get("family", ""))
         if not family:
             raise LaneEligibilityError(
@@ -359,11 +380,11 @@ class EligibilityCell:
         }
         if is_trellis:
             required.add("activation_contract")
-        # ``requires_plugin`` is OPTIONAL, which is the whole of what keeps
-        # this widening additive: a retired-lane v3 cell never carried the key
-        # and must keep parsing unchanged.
+        is_v4 = schema == LANE_ELIGIBILITY_SCHEMA_TESSERA
+        if is_v4:
+            required.update({"requires_plugin", "executes"})
         _require_keys(payload, where, required=required,
-                      optional={"requires_plugin"})
+                      optional=set() if is_v4 else {"requires_plugin"})
 
         status = str(payload["route_status"])
         if status not in CELL_ROUTE_STATUSES:
@@ -371,7 +392,7 @@ class EligibilityCell:
                 f"{where}.route_status must be one of "
                 f"{sorted(CELL_ROUTE_STATUSES)}, got {status!r}. The runtime "
                 "does not enumerate what it refuses; absence, not an "
-                f"{ROUTE_STATUS_UNBACKED!r} cell, is how a v3 table says no.")
+                f"{ROUTE_STATUS_UNBACKED!r} cell, is how a lane table says no.")
         qualification = str(payload["qualification"])
         if qualification not in CELL_QUALIFICATIONS:
             raise LaneEligibilityError(
@@ -394,6 +415,10 @@ class EligibilityCell:
                     "route executes; an empty one attests nothing")
 
         requires_plugin = str(payload.get("requires_plugin", ""))
+        if is_v4 and payload["requires_plugin"] != "tessera":
+            raise LaneEligibilityError(
+                f"{where}.requires_plugin must be 'tessera'; stock vLLM "
+                "has no reader for these bytes")
         if requires_plugin and status not in LANE_ROUTE_STATUSES:
             # Mirrors the ``requires_serve_flags`` rule below. A plugin
             # requirement is an instruction for reaching a route that EXISTS;
@@ -405,6 +430,11 @@ class EligibilityCell:
                 f"route_status is {status!r}; a plugin requirement is only "
                 f"meaningful on a cell whose route is one of "
                 f"{sorted(LANE_ROUTE_STATUSES)}")
+        executes: tuple[tuple[str, str], ...] = ()
+        cell_modes: tuple[str, ...] = ()
+        if is_v4:
+            executes, cell_modes = parse_v4_cell_contract(
+                payload, where, residency_modes=residency_modes)
         flags = tuple(str(v) for v in payload["requires_serve_flags"])
         if flags and status != ROUTE_STATUS_BACKED_WITH_SERVE_FLAG:
             raise LaneEligibilityError(
@@ -413,7 +443,7 @@ class EligibilityCell:
                 f"{ROUTE_STATUS_BACKED_WITH_SERVE_FLAG!r} by definition")
         if status == ROUTE_STATUS_BACKED_WITH_SERVE_FLAG and not flags:
             raise LaneEligibilityError(
-                f"{where}: route_status is "
+                f"{where}.requires_serve_flags: route_status is "
                 f"{ROUTE_STATUS_BACKED_WITH_SERVE_FLAG!r} but no serve flag is "
                 "named; an operator cannot reach an unnamed flag")
 
@@ -432,6 +462,8 @@ class EligibilityCell:
             requires_plugin=requires_plugin,
             predicates=_parse_predicates(payload["predicates"], where),
             is_trellis=is_trellis,
+            executes=executes,
+            residency_modes=cell_modes,
         )
 
     def covers_rung(self, facts: UnitStructuralFacts) -> bool:
@@ -472,6 +504,11 @@ class EligibilityCell:
             # Emitted only when non-empty, so a keyless cell's serialization
             # is byte-identical to what it was before this key existed.
             payload["requires_plugin"] = self.requires_plugin
+        if self.executes:
+            payload["executes"] = [
+                {"symbol": symbol, "decoder": decoder}
+                for symbol, decoder in self.executes
+            ]
         return payload
 
 
@@ -551,6 +588,8 @@ class RegimeRoute:
     qualification: str = ""
     activation_contract: str = ""
     detail: str = ""
+    executes: tuple[tuple[str, str], ...] = ()
+    residency: str = ""
 
     def as_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -564,6 +603,13 @@ class RegimeRoute:
         }
         if self.requires_plugins:
             payload["requires_plugins"] = list(self.requires_plugins)
+        if self.executes:
+            payload["executes"] = [
+                {"symbol": symbol, "decoder": decoder}
+                for symbol, decoder in self.executes
+            ]
+        if self.residency:
+            payload["residency"] = self.residency
         return payload
 
 
@@ -650,6 +696,7 @@ def resolve_unit_route(
     table: EligibilityTable,
     *,
     platform: str | None = None,
+    residency: str | None = None,
 ) -> UnitRoute:
     """Resolve one unit's route status against the pinned eligibility table.
 
@@ -657,9 +704,14 @@ def resolve_unit_route(
     guess, and never principle 9's ``backed`` by default.
 
     ``platform`` is the exact runtime platform id the artifact targets (the
-    serving profile's ``target_platform``, e.g. ``sm_121``). v3 cells are
+    serving profile's ``target_platform``, e.g. ``sm_121``). Lane cells are
     platform-scoped, so resolving without one cannot name a route: a missing or
     unpublished platform yields ``unattested``, never a match-any.
+
+    v4 additionally requires ``residency``, the explicit serve mode for the
+    artifact. It filters cells before route selection; omitting it cannot
+    choose whichever same-scope cell happened to be listed first. v3 keeps
+    its original behavior and makes no claim about executed launches.
     """
     if not table.present:
         return UnitRoute(
@@ -688,7 +740,7 @@ def resolve_unit_route(
             route_status=ROUTE_STATUS_UNATTESTED,
             in_scope=True,
             unattested_reason=(
-                "no declared target platform; v3 cells are platform-scoped, so "
+                "no declared target platform; lane cells are platform-scoped, so "
                 "no route can be named without one. Declare "
                 "'target_platform' on the serving profile this artifact "
                 f"targets; the pinned release publishes {list(table.platforms)}"
@@ -706,11 +758,25 @@ def resolve_unit_route(
             ),
         )
 
+    is_v4 = table.schema == LANE_ELIGIBILITY_SCHEMA_TESSERA
+    if is_v4 and residency not in TESSERA_RESIDENCY_MODES:
+        return UnitRoute(
+            facts=facts,
+            route_status=ROUTE_STATUS_UNATTESTED,
+            in_scope=True,
+            unattested_reason=(
+                f"no declared supported residency (got {residency!r}); v4 "
+                "cells require an explicit residency to identify their "
+                f"launches: {sorted(TESSERA_RESIDENCY_MODES)}"
+            ),
+        )
+
     candidates = [
         cell for cell in table.cells
         if cell.platform == platform
         and cell.family == facts.payload_family
         and cell.structure == facts.structure
+        and (not is_v4 or residency in cell.residency_modes)
         and cell.covers_rung(facts)
         and cell.matches(facts)
     ]
@@ -726,7 +792,7 @@ def resolve_unit_route(
                 best = cell
         if best is None:
             # No packaged cell names this unit in this regime. Under a
-            # closed-world v3 table that is the ONLY negative signal there is,
+            # closed-world table that is the ONLY negative signal there is,
             # and it must not be laundered into a verdict: the honest state is
             # "the runtime made no claim", and the export gate fails closed on
             # it for any family the contract governs.
@@ -750,6 +816,8 @@ def resolve_unit_route(
                 (best.requires_plugin,) if best.requires_plugin else ()),
             qualification=best.qualification,
             activation_contract=best.activation_contract,
+            executes=best.executes,
+            residency=str(residency) if is_v4 else "",
         ))
 
     unclaimed = [
@@ -776,6 +844,7 @@ def resolve_unit_route(
             f"{[r.regime for r in unclaimed]} for {facts.payload_family} "
             f"rung {facts.k if facts.k is not None else facts.rate_q256!r} on "
             f"{platform}"
+            + (f" at residency {residency!r}" if is_v4 else "")
         )
         return UnitRoute(
             facts=facts,
@@ -1057,7 +1126,7 @@ def _parse_table(block: Any, formats: Any, version: str, commit: str, sha: str
     # The schema string is checked BEFORE the key set, deliberately. An older
     # table fails both, and "missing field(s) ['cells', 'platforms']" would
     # send its reader off to add keys to a v2 block rather than to
-    # re-materialize the contract from a release that publishes v3.
+    # re-materialize the contract from a release with a supported schema.
     if block.get("schema") not in LANE_ELIGIBILITY_SCHEMAS:
         raise LaneEligibilityError(
             f"{where}.schema must be one of "
@@ -1097,6 +1166,22 @@ def _parse_table(block: Any, formats: Any, version: str, commit: str, sha: str
             f"dispatch path for; the known set is {sorted(STRUCTURES)}")
 
     families, trellis_families = _published_families(formats)
+    schema = str(block["schema"])
+    is_v4 = schema == LANE_ELIGIBILITY_SCHEMA_TESSERA
+    family_modes: dict[str, tuple[str, ...]] = {}
+    if is_v4:
+        for i, entry in enumerate(formats):
+            family = str(entry["family"])
+            modes = entry.get("residency_modes")
+            if (not isinstance(modes, list) or not modes
+                    or any(not isinstance(mode, str)
+                           or mode not in TESSERA_RESIDENCY_MODES for mode in modes)
+                    or len(set(modes)) != len(modes)):
+                raise LaneEligibilityError(
+                    f"runtime_contract.formats[{i}].residency_modes must "
+                    "publish a non-empty list of distinct supported "
+                    f"residencies {sorted(TESSERA_RESIDENCY_MODES)}")
+            family_modes[family] = tuple(modes)
 
     cells_block = block["cells"]
     if not isinstance(cells_block, Sequence) or isinstance(
@@ -1104,7 +1189,10 @@ def _parse_table(block: Any, formats: Any, version: str, commit: str, sha: str
         raise LaneEligibilityError(f"{where}.cells must be a JSON array")
     cells = tuple(
         EligibilityCell.from_dict(
-            cell, f"{where}.cells[{i}]", trellis_families=trellis_families)
+            cell, f"{where}.cells[{i}]", trellis_families=trellis_families,
+            schema=schema,
+            residency_modes=(family_modes.get(str(cell.get("family", "")), ())
+                             if isinstance(cell, Mapping) else ()))
         for i, cell in enumerate(cells_block)
     )
 
@@ -1130,13 +1218,25 @@ def _parse_table(block: Any, formats: Any, version: str, commit: str, sha: str
     ids = [cell.id for cell in cells]
     if len(set(ids)) != len(ids):
         raise LaneEligibilityError(f"{where}.cells ids must be unique")
+    if is_v4:
+        scopes: dict[tuple[str, ...], str] = {}
+        for cell in cells:
+            for mode in cell.residency_modes:
+                scope = (cell.platform, cell.family, cell.structure, cell.regime, mode)
+                previous = scopes.get(scope)
+                if previous is not None:
+                    raise LaneEligibilityError(
+                        f"{where}.cells {previous!r} and {cell.id!r} both cover "
+                        f"{scope}; overlapping residency scopes make route "
+                        "resolution depend on cell order")
+                scopes[scope] = cell.id
 
     return EligibilityTable(
         present=True,
         runtime_version=version,
         runtime_commit=commit,
         contract_sha256=sha,
-        schema=str(block["schema"]),
+        schema=schema,
         platforms=platforms,
         regimes=regimes,
         structures=structures,
@@ -1144,6 +1244,62 @@ def _parse_table(block: Any, formats: Any, version: str, commit: str, sha: str
         families=families,
         trellis_families=trellis_families,
     )
+
+
+def parse_v4_cell_contract(
+    payload: Mapping[str, Any],
+    where: str,
+    *,
+    residency_modes: Sequence[str],
+) -> tuple[tuple[tuple[str, str], ...], tuple[str, ...]]:
+    """Parse the v4 launch set and residency selector, without runtime imports.
+
+    The runtime owns whether a launch is correct for its route. This consumer
+    verifies the published grammar and preserves that claim; it never derives
+    a launch from a family name or a cell ID.
+    """
+    raw_executes = payload.get("executes")
+    if not isinstance(raw_executes, list) or not raw_executes:
+        raise LaneEligibilityError(
+            f"{where}.executes must be a non-empty JSON array of "
+            "{symbol, decoder} objects")
+    launches: list[tuple[str, str]] = []
+    for i, launch in enumerate(raw_executes):
+        spot = f"{where}.executes[{i}]"
+        if not isinstance(launch, Mapping):
+            raise LaneEligibilityError(f"{spot} must be a JSON object")
+        _require_keys(launch, spot, required={"symbol", "decoder"}, optional=set())
+        if any(not isinstance(launch[key], str) or not launch[key].strip()
+               for key in ("symbol", "decoder")):
+            raise LaneEligibilityError(
+                f"{spot}.symbol and decoder must be non-empty strings")
+        launches.append((launch["symbol"], launch["decoder"]))
+    if len(set(launches)) != len(launches):
+        raise LaneEligibilityError(
+            f"{where}.executes must not repeat a (symbol, decoder) pair")
+
+    head = "TESSERA_SERVE_MODE="
+    flags = payload.get("requires_serve_flags")
+    if (not isinstance(flags, list)
+            or any(not isinstance(flag, str) or not flag for flag in flags)):
+        raise LaneEligibilityError(
+            f"{where}.requires_serve_flags must be a JSON array of non-empty strings")
+    named = [flag for flag in flags if flag.startswith(head)]
+    if len(named) != 1:
+        raise LaneEligibilityError(
+            f"{where}.requires_serve_flags must name exactly one "
+            "TESSERA_SERVE_MODE residency flag")
+    modes = tuple(named[0][len(head):].split("|"))
+    if (len(set(modes)) != len(modes)
+            or any(mode not in TESSERA_RESIDENCY_MODES for mode in modes)):
+        raise LaneEligibilityError(
+            f"{where}.requires_serve_flags names invalid or repeated "
+            f"residency values {list(modes)}")
+    if not set(modes).issubset(residency_modes):
+        raise LaneEligibilityError(
+            f"{where}.requires_serve_flags residency {list(modes)} exceeds "
+            f"the family's published residency_modes {list(residency_modes)}")
+    return tuple(launches), modes
 
 
 def _parse_rungs(payload: Any, where: str) -> tuple[int, ...]:
@@ -1237,7 +1393,9 @@ def _sha256(path: Path) -> str:
 
 __all__ = [
     "LANE_ELIGIBILITY_SCHEMA_TESSERA",
+    "LANE_ELIGIBILITY_SCHEMA_TESSERA_LEGACY_V3",
     "LANE_ELIGIBILITY_SCHEMAS",
+    "parse_v4_cell_contract",
     "ROUTE_ATTESTATION_SCHEMA",
     "ROUTE_STATUS_BACKED",
     "ROUTE_STATUS_BACKED_WITH_SERVE_FLAG",

--- a/prismaquant/shipcard.py
+++ b/prismaquant/shipcard.py
@@ -2874,9 +2874,34 @@ def _verify_ship_gate_record(
         problems.append(f"{slot}: missing structured perplexity evidence")
     boundary = metrics.get("boundary_behavior")
     if isinstance(boundary, Mapping):
-        # The behavioral replay: a sampled check with no generations, run at
-        # temp 0, or with defects over the zero-tolerance bound is not
-        # evidence — it is the old argmax-blind gate wearing the new name.
+        # The behavioral replay: raw `/v1/completions` never applies the chat
+        # template, so a clean-looking count from that endpoint is not
+        # boundary evidence.  Pin the producer's request and extraction
+        # schemas independently here, alongside the numerical replay below.
+        endpoint = boundary.get("endpoint")
+        if endpoint != "/v1/chat/completions":
+            problems.append(
+                f"{slot}: boundary endpoint={endpoint!r}, expected "
+                "'/v1/chat/completions'"
+            )
+        request_schema = boundary.get("request_schema")
+        if request_schema != "prismaquant.boundary_chat_request/1":
+            problems.append(
+                f"{slot}: boundary request schema={request_schema!r}, "
+                "expected 'prismaquant.boundary_chat_request/1'"
+            )
+        response_schema = boundary.get("response_schema")
+        if response_schema != "prismaquant.boundary_chat_response/1":
+            problems.append(
+                f"{slot}: boundary response schema={response_schema!r}, "
+                "expected 'prismaquant.boundary_chat_response/1'"
+            )
+
+        # A sampled check with no generations, run at temp 0, or with defects
+        # over the zero-tolerance bound is not evidence — it is the old
+        # argmax-blind gate wearing the new name.  The zero/64 values remain
+        # fail-closed historical defaults pending #87's paired-control policy;
+        # replaying them here does not claim they are calibrated universally.
         generations = boundary.get("n_generations")
         if (
             isinstance(generations, bool)

--- a/prismaquant/tessera_menu.py
+++ b/prismaquant/tessera_menu.py
@@ -456,7 +456,7 @@ def route_admission(name: str) -> RouteAdmission:
     Today it delegates to ``tessera_render.tessera_lane_admission``, which
     resolves the rung against **Tessera's own** packaged
     ``runtime_contract.json`` through the shared ``lane_eligibility`` parser.
-    That table publishes both Tessera families and names the two receipted
+    That table publishes the attested Tessera families and their receipted
     rungs, so what refuses is the third conjunct -- there is no reviewed
     Tessera release tag -- and the answer is :data:`ROUTE_STATUS_UNATTESTED`
     for every rung.  The ``detail`` says which conjunct, verbatim from the

--- a/prismaquant/tessera_runtime/tessera_serving_runtime_pin.json
+++ b/prismaquant/tessera_runtime/tessera_serving_runtime_pin.json
@@ -18,6 +18,15 @@
         "streamed": {"status": "refused",
                      "decoder": null}
       }
+    },
+    {
+      "module_name_prefix": "tessera_window_gemv",
+      "filename_glob": "tessera_window_gemv*.so",
+      "match": "basename_fnmatch",
+      "when_unavailable": {
+        "resident": {"status": "substituted", "decoder": "torch_window"},
+        "streamed": {"status": "substituted", "decoder": "torch_window"}
+      }
     }
   ]
 }

--- a/prismaquant/tessera_runtime_contract.py
+++ b/prismaquant/tessera_runtime_contract.py
@@ -1159,6 +1159,14 @@ def _parse(payload: Mapping[str, Any], *, commit: str, sha: str, path: str
         raise TesseraContractError(f"{path}: {exc}") from exc
     cells: list[TesseraRouteCell] = []
     for cell in table.cells:
+        if cell.predicates:
+            raise TesseraContractError(
+                f"{path}.lane_eligibility.cells[{cell.id!r}].predicates "
+                "cannot be evaluated by shape-free development admission; "
+                "a constrained route must not enter an unconditional menu. "
+                "Pass structural facts through admission before accepting "
+                "predicated cells."
+            )
         cells.append(TesseraRouteCell(
             cell_id=cell.id,
             platform=cell.platform,

--- a/prismaquant/tessera_runtime_contract.py
+++ b/prismaquant/tessera_runtime_contract.py
@@ -13,16 +13,13 @@ is the other §7.4 fact PrismaQuant used to maintain on this side by hand.
 :func:`require_pin_native_extensions_match_contract` is the refusal that keeps
 the serving pin a transcription of it.
 
-**Why this is not** ``lane_eligibility``.  That module is the generic
-engine: it reads a serving release's contract through that lane's pin and
-admits units against it.  It was written for the Gridbook lane's schemas
-(``gridbook.lane-eligibility.v3``, ``cb_product``/``tcq_trellis`` format
-kinds) and kept its shape when that lane was retired on 2026-09-02.  Tessera publishes its own
-contract with its own schema ids and its own ``tessera_wire`` format kind, and
-the honest reading of a second runtime's table is a second reader -- not a
-widened set of accepted schema strings on the first, which would let either
-runtime's table answer a question asked about the other.  The two share only
-the route-status vocabulary, imported rather than restated.
+The cell grammar has one home in ``lane_eligibility``. This reader adds the
+development answer pin, format ranges, native-extension identity and fused
+module licence; export uses the same parsed cells under the separate release
+pin. Since lane schema v4, residency scopes each cell and ``executes`` names
+its launches. Both readers retain those fields and reject malformed or
+overlapping claims through the shared parser. Neither accepts a Gridbook
+schema; that serving lane was retired on 2026-09-02.
 
 **The dev pin.**  PrismaQuant's Tessera admission is fail-closed until a
 Tessera RELEASE tag exists, and none has been cut.  A development override is
@@ -80,9 +77,12 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from .lane_eligibility import (
+    LANE_ELIGIBILITY_SCHEMA_TESSERA,
+    LaneEligibilityError,
     QUALIFICATION_DEVICE_QUALIFIED,
     ROUTE_STATUS_BACKED,
     ROUTE_STATUS_BACKED_WITH_SERVE_FLAG,
+    _parse_table,
 )
 
 __all__ = [
@@ -117,7 +117,7 @@ class TesseraContractError(RuntimeError):
 #: read: an older table is not a subset of this one, and "missing field" is the
 #: wrong error to hand someone whose contract predates the field.
 TESSERA_CONTRACT_SCHEMA = "tessera.runtime-contract.v1"
-TESSERA_LANE_SCHEMA = "tessera.lane-eligibility.v3"
+TESSERA_LANE_SCHEMA = LANE_ELIGIBILITY_SCHEMA_TESSERA
 #: The ``fused_module`` block's own schema id, checked the same way.
 FUSED_MODULE_SCHEMA = "tessera.fused-module.v1"
 
@@ -133,24 +133,18 @@ TESSERA_DEV_PIN_ENV = "PRISMAQUANT_TESSERA_DEV_PIN"
 #: The Tessera commit this pin's answer was reviewed against.  Declared and
 #: recorded; NOT compared to anything.  A moving ``master`` is not a review
 #: event -- :data:`TESSERA_DEV_PIN_ANSWER` is what refuses.  Last re-read at
-#: contract v7 (Tessera master 35f57b4; contract bytes identical to b46ffd2).
-#: Both of v7's additive blocks move a value in :func:`contract_answer`:
-#: ``native_extensions`` (v7, Tessera #28) because the serve fingerprint reads
-#: it (prismaquant #133), and ``fused_module`` (v6, Tessera #37) because the
-#: group knapsack's fold reads it (prismaquant #132) -- so a renamed extension
-#: or a re-tightened fused-module licence re-stales this pin with a named field
-#: instead of passing silently.  Advancing this constant on unchanged bytes is
-#: bookkeeping; it exists so ``bytes_are_the_reviewed_bytes`` keeps meaning
-#: "these are the bytes somebody read" rather than decaying to a permanent
-#: False.
-TESSERA_DEV_PIN_COMMIT = "35f57b49553c4cd0a6f0606e5492aa034b3eaf5e"
+#: contract v14 / lane schema v4 (Tessera 1221d2a). Launches, residency,
+#: native extensions and fused-module licences are part of the reviewed
+#: answer. The release pin remains PENDING: this is development admission,
+#: not a serving release or routed-MoE promotion.
+TESSERA_DEV_PIN_COMMIT = "1221d2a4207a6baeffbe9726bce13125fc1649ae"
 
 #: sha256 of ``tessera/serving/runtime_contract.json`` at that commit -- the
 #: bytes a human read when the answer below was accepted.  Recorded, and
 #: compared into provenance against the bytes this run read, so prose-only
 #: drift is visible; it is not the refusal.
 TESSERA_DEV_PIN_CONTRACT_SHA256 = (
-    "bedb74655ae21a9b6e8f7547271954843ae81388f540dd1146bef5233b462920"
+    "cb0ccccb7d0ec296cacfdb02329e881e0d65761848d03acd8b0ee32158e605b3"
 )
 
 #: The ANSWER this pin was reviewed against -- every value the ADMISSION
@@ -163,102 +157,147 @@ TESSERA_DEV_PIN_CONTRACT_SHA256 = (
 #: routes that need it, or what runs when it is absent) does -- with a
 #: field-level diff naming it.  The git diff of this literal is the review.
 TESSERA_DEV_PIN_ANSWER = {'schema': 'tessera.runtime-contract.v1',
-     'lane_schema': 'tessera.lane-eligibility.v3',
-     'quant_method': 'tessera',
-     'fused_module': {'schema': 'tessera.fused-module.v1',
-                      'fields': {'body': 'shared',
-                                 'columns': 'shared',
-                                 'family': 'shared',
-                                 'grid': 'shared',
-                                 'plane': 'shared',
-                                 'q256': 'per_member',
-                                 'rows': 'per_member',
-                                 'structure': 'shared'},
-                      'sidecar_q256': 'int_or_per_role_list',
-                      'mixed_rung_receipt': False},
-     'native_extensions': [{'module_name_prefix': 'tessera_nvfp4_',
-                            'filename_glob': 'tessera_nvfp4_*.so',
-                            'match': 'basename_fnmatch',
-                            'routes': ['TESSERA_NVFP4'],
-                            'when_unavailable': {'resident': {'status': 'substituted',
-                                                              'decoder': 'torch_materialize_stock'},
-                                                 'streamed': {'status': 'refused',
-                                                              'decoder': None}}}],
-     'families': {'TESSERA_BF16_K1': {'reader_rate_range_q256': [256, 4096],
-                                      'attested_rungs_q256': [1792],
-                                      'max_world_size': 1},
-                  'TESSERA_E2M1_K2': {'reader_rate_range_q256': [896, 896],
-                                      'attested_rungs_q256': [896],
-                                      'max_world_size': 1},
-                  'TESSERA_E4M3_K1': {'reader_rate_range_q256': [256, 2048],
-                                      'attested_rungs_q256': [1024],
-                                      'max_world_size': 1}},
-     'cells': [['tessera_bf16_k1_dense_sm121_batch_mm_w16a16',
-                'sm_121',
-                'TESSERA_BF16_K1',
-                'dense',
-                'batch',
-                [1792],
-                'bf16_unquantized',
-                'backed_with_serve_flag',
-                'device_qualified',
-                'tessera',
-                ['TESSERA_SERVE_MODE=resident|streamed']],
-               ['tessera_bf16_k1_dense_sm121_decode_mm_w16a16',
-                'sm_121',
-                'TESSERA_BF16_K1',
-                'dense',
-                'decode',
-                [1792],
-                'bf16_unquantized',
-                'backed_with_serve_flag',
-                'device_qualified',
-                'tessera',
-                ['TESSERA_SERVE_MODE=resident|streamed']],
-               ['tessera_e2m1_k2_dense_sm121_batch_scaled_mm_w4a4',
-                'sm_121',
-                'TESSERA_E2M1_K2',
-                'dense',
-                'batch',
-                [896],
-                'e2m1_group16_ue4m3_static',
-                'backed_with_serve_flag',
-                'device_qualified',
-                'tessera',
-                ['TESSERA_SERVE_MODE=resident|streamed']],
-               ['tessera_e2m1_k2_dense_sm121_decode_scaled_mm_w4a4',
-                'sm_121',
-                'TESSERA_E2M1_K2',
-                'dense',
-                'decode',
-                [896],
-                'e2m1_group16_ue4m3_static',
-                'backed_with_serve_flag',
-                'device_qualified',
-                'tessera',
-                ['TESSERA_SERVE_MODE=resident|streamed']],
-               ['tessera_e4m3_k1_dense_sm121_batch_scaled_mm_w8a8',
-                'sm_121',
-                'TESSERA_E4M3_K1',
-                'dense',
-                'batch',
-                [1024],
-                'fp8_per_token_dynamic',
-                'backed_with_serve_flag',
-                'device_qualified',
-                'tessera',
-                ['TESSERA_SERVE_MODE=resident|streamed']],
-               ['tessera_e4m3_k1_dense_sm121_decode_scaled_mm_w8a8',
-                'sm_121',
-                'TESSERA_E4M3_K1',
-                'dense',
-                'decode',
-                [1024],
-                'fp8_per_token_dynamic',
-                'backed_with_serve_flag',
-                'device_qualified',
-                'tessera',
-                ['TESSERA_SERVE_MODE=resident|streamed']]]}
+ 'lane_schema': 'tessera.lane-eligibility.v4',
+ 'quant_method': 'tessera',
+ 'fused_module': {'schema': 'tessera.fused-module.v1',
+                  'fields': {'body': 'shared',
+                             'columns': 'shared',
+                             'family': 'shared',
+                             'grid': 'shared',
+                             'plane': 'shared',
+                             'q256': 'per_member',
+                             'rows': 'per_member',
+                             'structure': 'shared'},
+                  'sidecar_q256': 'int_or_per_role_list',
+                  'mixed_rung_receipt': False},
+ 'native_extensions': [{'module_name_prefix': 'tessera_nvfp4_',
+                        'filename_glob': 'tessera_nvfp4_*.so',
+                        'match': 'basename_fnmatch',
+                        'routes': ['TESSERA_NVFP4'],
+                        'when_unavailable': {'resident': {'status': 'substituted',
+                                                          'decoder': 'torch_materialize_stock'},
+                                             'streamed': {'status': 'refused', 'decoder': None}}},
+                       {'module_name_prefix': 'tessera_window_gemv',
+                        'filename_glob': 'tessera_window_gemv*.so',
+                        'match': 'basename_fnmatch',
+                        'routes': ['TESSERA_BF16', 'TESSERA_FP8'],
+                        'when_unavailable': {'resident': {'status': 'substituted',
+                                                          'decoder': 'torch_window'},
+                                             'streamed': {'status': 'substituted',
+                                                          'decoder': 'torch_window'}}}],
+ 'families': {'TESSERA_BF16_K1': {'reader_rate_range_q256': [256, 4096],
+                                  'attested_rungs_q256': [1792],
+                                  'max_world_size': 1},
+              'TESSERA_E2M1_K2': {'reader_rate_range_q256': [896, 896],
+                                  'attested_rungs_q256': [896],
+                                  'max_world_size': 1},
+              'TESSERA_E4M3_K1': {'reader_rate_range_q256': [256, 2048],
+                                  'attested_rungs_q256': [1024],
+                                  'max_world_size': 1}},
+ 'cells': [['tessera_bf16_k1_dense_sm121_batch',
+            'sm_121',
+            'TESSERA_BF16_K1',
+            'dense',
+            'batch',
+            [1792],
+            'bf16_unquantized',
+            'backed_with_serve_flag',
+            'device_qualified',
+            'tessera',
+            ['TESSERA_SERVE_MODE=resident|streamed'],
+            [['torch.mm', 'torch_window']],
+            ['resident', 'streamed']],
+           ['tessera_bf16_k1_dense_sm121_decode',
+            'sm_121',
+            'TESSERA_BF16_K1',
+            'dense',
+            'decode',
+            [1792],
+            'bf16_unquantized',
+            'backed_with_serve_flag',
+            'device_qualified',
+            'tessera',
+            ['TESSERA_SERVE_MODE=resident|streamed'],
+            [['torch.mm', 'torch_window']],
+            ['resident', 'streamed']],
+           ['tessera_e2m1_k2_dense_sm121_batch',
+            'sm_121',
+            'TESSERA_E2M1_K2',
+            'dense',
+            'batch',
+            [896],
+            'e2m1_group16_ue4m3_static',
+            'backed_with_serve_flag',
+            'device_qualified',
+            'tessera',
+            ['TESSERA_SERVE_MODE=resident|streamed'],
+            [['torch._scaled_mm', 'native_span2']],
+            ['resident', 'streamed']],
+           ['tessera_e2m1_k2_dense_sm121_decode',
+            'sm_121',
+            'TESSERA_E2M1_K2',
+            'dense',
+            'decode',
+            [896],
+            'e2m1_group16_ue4m3_static',
+            'backed_with_serve_flag',
+            'device_qualified',
+            'tessera',
+            ['TESSERA_SERVE_MODE=resident|streamed'],
+            [['torch._scaled_mm', 'native_span2']],
+            ['resident', 'streamed']],
+           ['tessera_e4m3_k1_dense_sm121_batch_resident',
+            'sm_121',
+            'TESSERA_E4M3_K1',
+            'dense',
+            'batch',
+            [1024],
+            'fp8_per_token_dynamic',
+            'backed_with_serve_flag',
+            'device_qualified',
+            'tessera',
+            ['TESSERA_SERVE_MODE=resident'],
+            [['torch._scaled_mm', 'torch_window']],
+            ['resident']],
+           ['tessera_e4m3_k1_dense_sm121_batch_streamed',
+            'sm_121',
+            'TESSERA_E4M3_K1',
+            'dense',
+            'batch',
+            [1024],
+            'fp8_per_token_dynamic',
+            'backed_with_serve_flag',
+            'device_qualified',
+            'tessera',
+            ['TESSERA_SERVE_MODE=streamed'],
+            [['tessera_window_gemv::gemv', 'window_gemv'], ['torch._scaled_mm', 'window_gemv']],
+            ['streamed']],
+           ['tessera_e4m3_k1_dense_sm121_decode_resident',
+            'sm_121',
+            'TESSERA_E4M3_K1',
+            'dense',
+            'decode',
+            [1024],
+            'fp8_per_token_dynamic',
+            'backed_with_serve_flag',
+            'device_qualified',
+            'tessera',
+            ['TESSERA_SERVE_MODE=resident'],
+            [['torch._scaled_mm', 'torch_window']],
+            ['resident']],
+           ['tessera_e4m3_k1_dense_sm121_decode_streamed',
+            'sm_121',
+            'TESSERA_E4M3_K1',
+            'dense',
+            'decode',
+            [1024],
+            'fp8_per_token_dynamic',
+            'backed_with_serve_flag',
+            'device_qualified',
+            'tessera',
+            ['TESSERA_SERVE_MODE=streamed'],
+            [['tessera_window_gemv::gemv', 'window_gemv']],
+            ['streamed']]]}
 
 #: Route statuses under which a cell says a native route EXECUTES.
 _NATIVE_ROUTE_STATUSES = frozenset(
@@ -387,6 +426,8 @@ class TesseraRouteCell:
     qualification: str
     requires_plugin: str
     requires_serve_flags: tuple[str, ...]
+    executes: tuple[tuple[str, str], ...]
+    residency_modes: tuple[str, ...]
 
     @property
     def native(self) -> bool:
@@ -627,6 +668,11 @@ def contract_answer(contract: "TesseraContract") -> dict:
     field the route gate reads.  Two contracts with the same answer admit the
     same units.
 
+    Schema v4's executed launches and residency scope are retained per cell.
+    They identify which serving path the route claim covers; a changed
+    decoder or narrowed residency therefore requires the same review as a
+    changed rung, even when the cell's id and route status stay unchanged.
+
     ``native_extensions`` is here for a second gate, not the admission one:
     §7.4 says an A/B's arms must have identical native-extension residency,
     ``tools/serve_fingerprint.py`` decides residency by matching mapped
@@ -690,6 +736,8 @@ def contract_answer(contract: "TesseraContract") -> dict:
                 cell.qualification,
                 cell.requires_plugin,
                 sorted(cell.requires_serve_flags),
+                [list(launch) for launch in sorted(cell.executes)],
+                sorted(cell.residency_modes),
             ]
             for cell in contract.cells
         ),
@@ -1105,31 +1153,26 @@ def _parse(payload: Mapping[str, Any], *, commit: str, sha: str, path: str
             f"{path}.lane_eligibility.schema must be {TESSERA_LANE_SCHEMA!r}, "
             f"got {lane_schema!r}"
         )
+    try:
+        table = _parse_table(lane, formats, "", commit, sha)
+    except LaneEligibilityError as exc:
+        raise TesseraContractError(f"{path}: {exc}") from exc
     cells: list[TesseraRouteCell] = []
-    for i, cell in enumerate(_require(lane, "cells", f"{path}.lane_eligibility")):
-        where = f"{path}.lane_eligibility.cells[{i}]"
-        if not isinstance(cell, Mapping):
-            raise TesseraContractError(f"{where} must be a JSON object")
-        family = str(_require(cell, "family", where))
-        if family not in reader_range:
-            raise TesseraContractError(
-                f"{where} names family {family!r}, which the contract's "
-                "formats table does not publish"
-            )
+    for cell in table.cells:
         cells.append(TesseraRouteCell(
-            cell_id=str(_require(cell, "id", where)),
-            platform=str(_require(cell, "platform", where)),
-            family=family,
-            structure=str(_require(cell, "structure", where)),
-            regime=str(_require(cell, "regime", where)),
-            rungs_q256=frozenset(
-                int(r) for r in _require(cell, "rungs_q256", where)),
-            activation_contract=str(_require(cell, "activation_contract", where)),
-            route_status=str(_require(cell, "route_status", where)),
-            qualification=str(_require(cell, "qualification", where)),
-            requires_plugin=str(cell.get("requires_plugin", "")),
-            requires_serve_flags=tuple(
-                str(f) for f in cell.get("requires_serve_flags", ())),
+            cell_id=cell.id,
+            platform=cell.platform,
+            family=cell.family,
+            structure=cell.structure,
+            regime=cell.regime,
+            rungs_q256=frozenset(cell.rungs_q256),
+            activation_contract=cell.activation_contract,
+            route_status=cell.route_status,
+            qualification=cell.qualification,
+            requires_plugin=cell.requires_plugin,
+            requires_serve_flags=cell.requires_serve_flags,
+            executes=cell.executes,
+            residency_modes=cell.residency_modes,
         ))
 
     extensions = _parse_native_extensions(

--- a/prismaquant/validate_quantized_model.py
+++ b/prismaquant/validate_quantized_model.py
@@ -19,7 +19,10 @@ Checks, in order:
    3. **Boundary behavior** — sampled (temperature > 0) generations over
       terse boundary-stressing prompts (`BOUNDARY_PROMPTS`), scored
       mechanically for `</think>` stutter/loop, zero-tag runaway, and
-      cap-truncation-before-answer. Zero defects allowed by default. This
+      cap-truncation-before-answer. The chat endpoint is mandatory: raw
+      completions do not apply the model's reasoning template. Zero defects
+      under 64 tokens remains a fail-closed historical default pending #87's
+      paired-control policy; it is not a calibrated universal claim. This
       is the axis KL/PPL (distribution distance) and greedy-smoke (argmax
       agreement) cannot see at any threshold: three DSV4-Flash quants
       within ~3% PPL spanned a 6x behavioral gap (14/180 to 83/180).
@@ -85,6 +88,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Mapping
 from dataclasses import dataclass, field, asdict
 
 
@@ -156,6 +160,19 @@ BOUNDARY_DEFECTS: tuple[str, ...] = (
 
 THINK_CLOSE_TAG = "</think>"
 
+# The boundary gate must exercise the model's chat template.  Raw
+# ``/v1/completions`` continues the literal user string and therefore never
+# enters a thinking model's reasoning scaffold.  These values are also filed
+# in the shipcard metrics so offline replay can reject a clean-looking count
+# produced under the old, structurally blind request.
+BOUNDARY_ENDPOINT = "/v1/chat/completions"
+BOUNDARY_REQUEST_SCHEMA = "prismaquant.boundary_chat_request/1"
+BOUNDARY_RESPONSE_SCHEMA = "prismaquant.boundary_chat_response/1"
+BOUNDARY_CHAT_TEMPLATE_KWARGS = {
+    "thinking": True,
+    "enable_thinking": True,
+}
+
 
 # -----------------------------------------------------------------
 # Default thresholds (tune via CLI if needed)
@@ -165,16 +182,14 @@ DEFAULT_MAX_P99_NLL = 6.0
 DEFAULT_MAX_MEAN_NLL = 3.0
 DEFAULT_MIN_GEN_LEN = 30               # chars in each generated completion
 DEFAULT_MIN_MTP_ACCEPT_P0 = 0.60       # position-0 accept fraction
-# Boundary-behavior gate (issue #87). `MAX_BOUNDARY_DEFECTS = 0` is not a
-# tuned knob: any stutter/zero-tag/cap-hit on a terse prompt is a functional
-# failure (the answer is never reached), and the clean reference scores 0 on
-# this stratum (official unquantized 0/60 terse, fixed quant 0/60). Sampling
-# temperature 1.0 is the unmodified distribution — any temperature > 0 leaves
-# the argmax path and exposes the near-tie; 1.0 adds no tuning. `MAX_TOKENS`
-# 64 is far above what these prompts need, so `length` means runaway/loop.
-# `REPS` 6 is the published battery's own replication count (30 prompts × 6
-# reps main + 24 reps × 5 numeric stackext): 5 prompts × 6 reps = 30 sampled
-# generations, minutes of serve time.
+# Boundary-behavior gate (issue #87).  Temperature 1.0 is the unmodified
+# distribution and `REPS` 6 is the published battery's own replication count.
+# The zero bound and 64-token cap are retained as fail-closed historical
+# defaults only while the paired-control policy is unresolved: a first real
+# endpoint audit found healthy DSV4 at 7/30 defects under 64 tokens and stock
+# Qwen3-8B at 10/15 even under 600.  They are not calibrated universal claims
+# and must not be used to close #87 or promote an artifact without the pending
+# same-session control decision.
 DEFAULT_MAX_BOUNDARY_DEFECTS = 0
 DEFAULT_BOUNDARY_TEMPERATURE = 1.0
 DEFAULT_BOUNDARY_MAX_TOKENS = 64
@@ -385,6 +400,59 @@ def score_boundary_text(
     return {"think_tag_count": count, "defects": defects}
 
 
+def _boundary_text_from_chat_choice(choice: Mapping) -> tuple[str, str]:
+    """Recover boundary semantics from one chat-completion choice.
+
+    vLLM without a reasoning parser returns the raw generated text in
+    ``message.content``.  With a parser, it consumes the first ``</think>`` and
+    returns the two sides as ``message.reasoning`` (current spelling) or
+    ``message.reasoning_content`` (older OpenAI-compatible spelling).  In the
+    structured case we synthesize exactly that one consumed delimiter only
+    when both reasoning-side and answer-side content are non-empty.  A second
+    delimiter remains in content and is still scored as stutter; an empty
+    side remains zero-tag/cap-truncation rather than receiving an invented
+    close token.
+
+    The accepted shapes are deliberately closed.  An ambiguous pair of
+    non-null reasoning fields or a non-string field is a malformed response,
+    not a clean generation.
+    """
+    if not isinstance(choice, Mapping):
+        raise TypeError("chat choice is not an object")
+    message = choice.get("message")
+    if not isinstance(message, Mapping):
+        raise TypeError("chat choice is missing message object")
+
+    content = message.get("content")
+    if content is not None and not isinstance(content, str):
+        raise TypeError("chat message.content is not a string or null")
+
+    structured: list[tuple[str, str]] = []
+    for field_name in ("reasoning", "reasoning_content"):
+        value = message.get(field_name)
+        if value is None:
+            continue
+        if not isinstance(value, str):
+            raise TypeError(
+                f"chat message.{field_name} is not a string or null")
+        structured.append((field_name, value))
+    if len(structured) > 1:
+        raise ValueError(
+            "chat message carries both reasoning and reasoning_content")
+
+    if structured:
+        field_name, reasoning = structured[0]
+        if reasoning and content:
+            return reasoning + THINK_CLOSE_TAG + content, field_name
+        if not reasoning:
+            return reasoning, f"{field_name}_empty"
+        return reasoning, f"{field_name}_without_content"
+    if content is None:
+        raise TypeError(
+            "chat message has neither content nor structured reasoning")
+    return content, "content"
+
+
 def check_boundary_behavior(
     base_url: str,
     model_name: str,
@@ -395,11 +463,15 @@ def check_boundary_behavior(
     reps: int = DEFAULT_BOUNDARY_REPS,
     prompts: tuple[str, ...] | list[str] = BOUNDARY_PROMPTS,
 ) -> CheckResult:
-    """Sample boundary-stressing prompts and score `</think>` behavior.
+    """Sample chat-templated prompts and score `</think>` behavior.
 
     Each prompt is sampled `reps` times at `temperature > 0` (sampling, not
     the argmax path greedy-smoke takes) with a small `max_tokens` cap, and
-    every generation is scored by :func:`score_boundary_text`. Fails when
+    every generation is scored by :func:`score_boundary_text`.  The request
+    uses ``/v1/chat/completions`` with a ``messages`` body; raw completions do
+    not apply the model's chat template and cannot exercise this boundary.
+    Reasoning-parser responses are recovered through
+    :func:`_boundary_text_from_chat_choice` before scoring. Fails when
     total defects exceed `max_defects` (default 0: any stutter, zero-tag
     runaway, or cap-truncation on these terse prompts is a functional
     failure). Runs alongside KL/PPL, not replacing them.
@@ -413,23 +485,33 @@ def check_boundary_behavior(
         )
     n_defects = 0
     by_kind: dict[str, int] = {kind: 0 for kind in BOUNDARY_DEFECTS}
+    response_modes: dict[str, int] = {}
     failing_examples: list[dict] = []
     n_generations = 0
     for prompt in prompts:
         for _rep in range(reps):
             try:
                 r = _post_json(
-                    f"{base_url}/v1/completions",
+                    f"{_server_root(base_url)}{BOUNDARY_ENDPOINT}",
                     {
                         "model": model_name,
-                        "prompt": prompt,
+                        "messages": [{"role": "user", "content": prompt}],
                         "max_tokens": max_tokens,
                         "temperature": temperature,
+                        "include_reasoning": True,
+                        "skip_special_tokens": False,
+                        "chat_template_kwargs": dict(
+                            BOUNDARY_CHAT_TEMPLATE_KWARGS),
                     },
                 )
                 choice = r["choices"][0]
-                text = choice.get("text") or ""
+                text, response_mode = _boundary_text_from_chat_choice(choice)
+                response_modes[response_mode] = (
+                    response_modes.get(response_mode, 0) + 1)
                 finish = choice.get("finish_reason")
+                if finish is not None and not isinstance(finish, str):
+                    raise TypeError(
+                        "chat choice.finish_reason is not a string or null")
             except Exception as e:
                 return CheckResult(
                     name="boundary_behavior",
@@ -452,6 +534,10 @@ def check_boundary_behavior(
                         "excerpt": text[:200],
                     })
     metrics = {
+        "endpoint": BOUNDARY_ENDPOINT,
+        "request_schema": BOUNDARY_REQUEST_SCHEMA,
+        "response_schema": BOUNDARY_RESPONSE_SCHEMA,
+        "response_modes": response_modes,
         "n_prompts": len(list(prompts)),
         "reps": reps,
         "n_generations": n_generations,

--- a/tests/test_lane_eligibility_v4.py
+++ b/tests/test_lane_eligibility_v4.py
@@ -1,0 +1,163 @@
+"""Tessera v4 resolves launches at an explicit residency, without a serve."""
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from prismaquant.lane_eligibility import (
+    LaneEligibilityError,
+    ROUTE_STATUS_BACKED_WITH_SERVE_FLAG,
+    ROUTE_STATUS_UNATTESTED,
+    UnitStructuralFacts,
+    _parse_table,
+    resolve_unit_route,
+)
+
+
+def _contract():
+    family = "TESSERA_E4M3_K1"
+    cells = []
+    for regime in ("decode", "batch"):
+        for residency in ("resident", "streamed"):
+            executes = [{"symbol": "torch._scaled_mm", "decoder": "torch_window"}]
+            if residency == "streamed":
+                executes = [{"symbol": "tessera_window_gemv::gemv", "decoder": "window_gemv"}]
+                if regime == "batch":
+                    executes.append({"symbol": "torch._scaled_mm", "decoder": "window_gemv"})
+            cells.append({
+                "id": f"tessera_e4m3_k1_dense_sm121_{regime}_{residency}",
+                "platform": "sm_121", "family": family, "structure": "dense",
+                "regime": regime, "rungs_q256": [1024],
+                "activation_contract": "fp8_per_token_dynamic", "executes": executes,
+                "route_status": "backed_with_serve_flag", "qualification": "device_qualified",
+                "requires_plugin": "tessera",
+                "requires_serve_flags": [f"TESSERA_SERVE_MODE={residency}"], "predicates": [],
+            })
+    return {
+        "schema": "tessera.lane-eligibility.v4",
+        "platforms": {"sm_121": {}}, "regimes": ["decode", "batch"],
+        "structures": ["dense"], "cells": cells,
+    }, [{"family": family, "kind": "tessera_wire", "residency_modes": ["resident", "streamed"]}]
+
+
+def _parse(block=None, formats=None):
+    if block is None:
+        block, formats = _contract()
+    return _parse_table(block, formats, "0.1.0", "test-commit", "test-sha")
+
+
+def _facts(structure="dense"):
+    return UnitStructuralFacts(
+        qname="model.layers.0.self_attn.q_proj", format_name="TESSERA_E4M3_K1_R1024",
+        payload_family="TESSERA_E4M3_K1", k=None, n_sub=None, rate_q256=1024,
+        structure=structure, role_split=False, in_features=1024, out_features=1024,
+    )
+
+
+@pytest.mark.parametrize("residency", ["resident", "streamed"])
+def test_v4_resolves_residency_and_preserves_launches_independent_of_cell_order(residency):
+    block, formats = _contract()
+    expected = {
+        cell["regime"]: cell["executes"] for cell in block["cells"]
+        if cell["requires_serve_flags"] == [f"TESSERA_SERVE_MODE={residency}"]
+    }
+    table = _parse(block, formats)
+    result = resolve_unit_route(_facts(), table, platform="sm_121", residency=residency)
+    assert result.route_status == ROUTE_STATUS_BACKED_WITH_SERVE_FLAG
+    assert {route.regime: route.as_dict()["executes"] for route in result.regimes} == expected
+    assert {cell.id: cell.as_dict()["executes"] for cell in table.cells} == {
+        cell["id"]: cell["executes"] for cell in block["cells"]
+    }
+    block["cells"].reverse()
+    reversed_result = resolve_unit_route(_facts(), _parse(block, formats), platform="sm_121", residency=residency)
+    assert reversed_result.as_dict() == result.as_dict()
+
+
+@pytest.mark.parametrize("residency", [None, "unknown"])
+def test_v4_without_a_declared_residency_is_unattested(residency):
+    result = resolve_unit_route(_facts(), _parse(), platform="sm_121", residency=residency)
+    assert result.route_status == ROUTE_STATUS_UNATTESTED
+    assert "residency" in result.unattested_reason
+    assert result.in_scope is True
+
+
+def test_v4_cannot_invent_moe_attestation_from_dense_cells():
+    result = resolve_unit_route(_facts("routed_moe"), _parse(), platform="sm_121", residency="streamed")
+    assert result.route_status == ROUTE_STATUS_UNATTESTED
+    assert all(route.cell_id is None for route in result.regimes)
+
+
+@pytest.mark.parametrize("launches", [
+    [],
+    [{"symbol": "torch.mm"}],
+    [{"symbol": "torch.mm", "decoder": "torch_window", "rationale": "native"}],
+    [{"symbol": "", "decoder": "torch_window"}],
+    [{"symbol": "torch.mm", "decoder": None}],
+    [{"symbol": "torch.mm", "decoder": "torch_window"}] * 2,
+])
+def test_v4_rejects_malformed_or_repeated_launches(launches):
+    block, formats = _contract()
+    block["cells"][0]["executes"] = launches
+    with pytest.raises(LaneEligibilityError, match="executes"):
+        _parse(block, formats)
+
+
+@pytest.mark.parametrize("plugin", [None, "gridbook", ""])
+def test_v4_requires_tessera_plugin(plugin):
+    block, formats = _contract()
+    if plugin is None:
+        del block["cells"][0]["requires_plugin"]
+    else:
+        block["cells"][0]["requires_plugin"] = plugin
+    with pytest.raises(LaneEligibilityError, match="requires_plugin"):
+        _parse(block, formats)
+
+
+@pytest.mark.parametrize("flags", [
+    [], ["TESSERA_SERVE_MODE=resident|resident"], ["TESSERA_SERVE_MODE=unknown"],
+    ["TESSERA_SERVE_MODE=resident", "TESSERA_SERVE_MODE=streamed"],
+    "TESSERA_SERVE_MODE=resident",
+])
+def test_v4_requires_one_well_formed_residency_flag(flags):
+    block, formats = _contract()
+    block["cells"][0]["requires_serve_flags"] = flags
+    with pytest.raises(LaneEligibilityError, match="requires_serve_flags"):
+        _parse(block, formats)
+
+
+def test_v4_rejects_overlapping_residencies_even_when_rungs_differ():
+    block, formats = _contract()
+    overlapping = deepcopy(block["cells"][0])
+    overlapping["id"] = "another_cell"
+    overlapping["rungs_q256"] = [1280]
+    block["cells"].append(overlapping)
+    with pytest.raises(LaneEligibilityError, match="overlap|both cover"):
+        _parse(block, formats)
+
+
+def test_v4_residency_must_be_published_by_its_family():
+    block, formats = _contract()
+    formats[0]["residency_modes"] = ["resident"]
+    with pytest.raises(LaneEligibilityError, match="residency"):
+        _parse(block, formats)
+
+
+def test_v3_compatibility_keeps_legacy_resolution_without_fabricated_launches():
+    block, formats = _contract()
+    block["schema"] = "tessera.lane-eligibility.v3"
+    block["cells"] = [cell for cell in block["cells"] if cell["requires_serve_flags"] == ["TESSERA_SERVE_MODE=resident"]]
+    for cell in block["cells"]:
+        del cell["executes"]
+        del cell["requires_plugin"]
+    table = _parse(block, formats)
+    result = resolve_unit_route(_facts(), table, platform="sm_121")
+    assert result.route_status == ROUTE_STATUS_BACKED_WITH_SERVE_FLAG
+    assert all("executes" not in route.as_dict() for route in result.regimes)
+
+
+def test_gridbook_schema_is_still_retired():
+    block, formats = _contract()
+    block["schema"] = "gridbook.lane-eligibility.v4"
+    with pytest.raises(LaneEligibilityError, match="schema"):
+        _parse(block, formats)

--- a/tests/test_publish_artifact.py
+++ b/tests/test_publish_artifact.py
@@ -35,6 +35,9 @@ from prismaquant.shipcard import (
 import tools.publish_artifact as publisher
 from tools.publish_artifact import main as publish_cli
 from prismaquant.validate_quantized_model import (
+    BOUNDARY_ENDPOINT,
+    BOUNDARY_REQUEST_SCHEMA,
+    BOUNDARY_RESPONSE_SCHEMA,
     DEFAULT_BOUNDARY_MAX_TOKENS,
     DEFAULT_BOUNDARY_REPS,
     DEFAULT_BOUNDARY_TEMPERATURE,
@@ -122,6 +125,9 @@ def _ship_gate_record(model_sha, *, source, passed=True):
     if "boundary_behavior" in ledger:
         ledger["boundary_behavior"] = {
             "passed": True,
+            "endpoint": BOUNDARY_ENDPOINT,
+            "request_schema": BOUNDARY_REQUEST_SCHEMA,
+            "response_schema": BOUNDARY_RESPONSE_SCHEMA,
             "n_prompts": 5,
             "reps": DEFAULT_BOUNDARY_REPS,
             "n_generations": 5 * DEFAULT_BOUNDARY_REPS,
@@ -854,5 +860,4 @@ def test_ship_gate_ledger_follows_the_producer_not_a_roster(monkeypatch):
     ledger = _ship_gate_record("0" * 64, source="test")["metrics"]
     assert "mtp_acceptance_v2" in ledger
     assert "mtp_acceptance" not in ledger
-
 

--- a/tests/test_ship_boundary_behavior.py
+++ b/tests/test_ship_boundary_behavior.py
@@ -106,7 +106,8 @@ def test_length_sanity_is_blind_to_stutter_the_boundary_scorer_catches():
 # ---------------------------------------------------------------------------
 
 class _BoundaryHandler(BaseHTTPRequestHandler):
-    mode: str = "clean"  # "clean" | "broken"
+    mode: str = "clean"
+    requests: list[dict] = []
 
     def log_message(self, *a, **kw):
         pass
@@ -128,14 +129,63 @@ class _BoundaryHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         n = int(self.headers.get("Content-Length", "0"))
         req = json.loads(self.rfile.read(n))
+        self.requests.append({"path": self.path, "body": req})
+        if self.path != "/v1/chat/completions":
+            self.send_response(404)
+            self.end_headers()
+            return
         if self.mode == "clean":
-            body = {"choices": [{"text": "<think>12</think> 12",
-                                 "finish_reason": "stop"}]}
+            # Current vLLM's reasoning parser removes the delimiter and files
+            # the two sides separately.  The client must reconstruct boundary
+            # semantics before passing text to the frozen scorer.
+            body = {"choices": [{
+                "message": {"reasoning": "12", "content": " 12"},
+                "finish_reason": "stop",
+            }]}
+        elif self.mode == "legacy":
+            # Older OpenAI-compatible vLLM stacks used this field spelling.
+            body = {"choices": [{
+                "message": {"reasoning_content": "12", "content": " 12"},
+                "finish_reason": "stop",
+            }]}
+        elif self.mode == "raw":
+            # With no reasoning parser, chat content retains the raw delimiter
+            # and is scored without synthesis.
+            body = {"choices": [{
+                "message": {"content": "<think>12</think> 12"},
+                "finish_reason": "stop",
+            }]}
+        elif self.mode == "stutter":
+            # A parser consumes the first close token only; any repeated close
+            # remains in content and must still be visible to the scorer.
+            body = {"choices": [{
+                "message": {
+                    "reasoning": "first trace",
+                    "content": "</think> second trace 12",
+                },
+                "finish_reason": "stop",
+            }]}
+        elif self.mode == "empty_reasoning":
+            body = {"choices": [{
+                "message": {"reasoning": "", "content": "12"},
+                "finish_reason": "stop",
+            }]}
+        elif self.mode == "malformed_finish":
+            body = {"choices": [{
+                "message": {"reasoning": "12", "content": " 12"},
+                "finish_reason": ["length"],
+            }]}
         else:
-            # The broken shape from the issue: no clean </think> under
-            # sampling (T10 failing 6/6 on the broken artifact).
-            body = {"choices": [{"text": "12 12 12 12 12 12",
-                                 "finish_reason": "stop"}]}
+            # No answer-side content means the parser never observed a usable
+            # reasoning boundary.  The client must retain zero-tag and cap
+            # defects rather than inventing a close token from this shape.
+            body = {"choices": [{
+                "message": {
+                    "reasoning": "12 12 12 12 12 12",
+                    "content": None,
+                },
+                "finish_reason": "length",
+            }]}
         out = json.dumps(body).encode("utf-8")
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
@@ -146,6 +196,7 @@ class _BoundaryHandler(BaseHTTPRequestHandler):
 @pytest.fixture
 def boundary_server():
     _BoundaryHandler.mode = "clean"
+    _BoundaryHandler.requests = []
     srv = HTTPServer(("127.0.0.1", 0), _BoundaryHandler)
     port = srv.server_address[1]
     t = threading.Thread(target=srv.serve_forever, daemon=True)
@@ -161,6 +212,62 @@ def test_boundary_check_passes_a_clean_serve(boundary_server):
     assert r.passed, r.detail
     assert r.metrics["n_generations"] == 2
     assert r.metrics["n_defects"] == 0
+    assert r.metrics["endpoint"] == "/v1/chat/completions"
+    assert r.metrics["request_schema"] == \
+        "prismaquant.boundary_chat_request/1"
+    assert r.metrics["response_schema"] == \
+        "prismaquant.boundary_chat_response/1"
+    assert len(_BoundaryHandler.requests) == 2
+    for observed in _BoundaryHandler.requests:
+        assert observed["path"] == "/v1/chat/completions"
+        body = observed["body"]
+        assert body["messages"] == [{"role": "user", "content": "9²"}]
+        assert "prompt" not in body
+        assert body["include_reasoning"] is True
+        assert body["skip_special_tokens"] is False
+        assert body["chat_template_kwargs"] == {
+            "thinking": True,
+            "enable_thinking": True,
+        }
+
+
+@pytest.mark.parametrize("mode", ["legacy", "raw"])
+def test_boundary_check_accepts_both_declared_chat_response_shapes(
+    boundary_server, mode,
+):
+    _BoundaryHandler.mode = mode
+    r = vqm.check_boundary_behavior(
+        boundary_server, "any", prompts=("9²",), reps=1)
+    assert r.passed, r.detail
+    assert r.metrics["n_defects"] == 0
+
+
+def test_boundary_check_preserves_stutter_after_reasoning_parser_split(
+    boundary_server,
+):
+    _BoundaryHandler.mode = "stutter"
+    r = vqm.check_boundary_behavior(
+        boundary_server, "any", prompts=("9²",), reps=1)
+    assert not r.passed
+    assert r.metrics["defects_by_kind"]["think_stutter"] == 1
+
+
+def test_boundary_check_does_not_invent_a_close_for_empty_reasoning(
+    boundary_server,
+):
+    _BoundaryHandler.mode = "empty_reasoning"
+    r = vqm.check_boundary_behavior(
+        boundary_server, "any", prompts=("9²",), reps=1)
+    assert not r.passed
+    assert r.metrics["defects_by_kind"]["zero_tag"] == 1
+
+
+def test_boundary_check_refuses_a_malformed_finish_reason(boundary_server):
+    _BoundaryHandler.mode = "malformed_finish"
+    r = vqm.check_boundary_behavior(
+        boundary_server, "any", prompts=("9²",), reps=1)
+    assert not r.passed
+    assert "finish_reason" in r.detail
 
 
 def test_boundary_check_fails_a_broken_serve(boundary_server):
@@ -170,6 +277,7 @@ def test_boundary_check_fails_a_broken_serve(boundary_server):
     assert not r.passed
     assert r.metrics["n_defects"] == 2
     assert r.metrics["defects_by_kind"]["zero_tag"] == 2
+    assert r.metrics["defects_by_kind"]["cap_truncation"] == 2
 
 
 def test_boundary_check_refuses_a_greedy_temperature():
@@ -221,8 +329,17 @@ def _artifact(tmp_path, *, name="exported"):
     return model_dir, compute_model_sha(model_dir)
 
 
-def _ship_gate_record(model_sha, *, source, boundary_defects=0,
-                      boundary_passed=True, drop_boundary=False):
+def _ship_gate_record(
+    model_sha,
+    *,
+    source,
+    boundary_defects=0,
+    boundary_passed=True,
+    boundary_endpoint="/v1/chat/completions",
+    boundary_request_schema="prismaquant.boundary_chat_request/1",
+    boundary_response_schema="prismaquant.boundary_chat_response/1",
+    drop_boundary=False,
+):
     from prismaquant.shipcard import make_record
 
     ledger = {name: {"passed": True} for name in _producer_check_names()}
@@ -236,6 +353,9 @@ def _ship_gate_record(model_sha, *, source, boundary_defects=0,
     }
     ledger["boundary_behavior"] = {
         "passed": boundary_passed,
+        "endpoint": boundary_endpoint,
+        "request_schema": boundary_request_schema,
+        "response_schema": boundary_response_schema,
         "n_prompts": len(vqm.BOUNDARY_PROMPTS),
         "reps": vqm.DEFAULT_BOUNDARY_REPS,
         "n_generations": len(vqm.BOUNDARY_PROMPTS)
@@ -338,3 +458,27 @@ def test_verify_accepts_a_clean_boundary_receipt(tmp_path):
 
     path, model_dir = _full_card(tmp_path)
     assert verify(load_shipcard(path), model_dir=model_dir) == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "needle"),
+    [
+        ("boundary_endpoint", "/v1/completions", "endpoint"),
+        ("boundary_request_schema", "prompt-string-v0", "request schema"),
+        ("boundary_response_schema", "text-choice-v0", "response schema"),
+    ],
+)
+def test_verify_refuses_boundary_receipt_from_the_wrong_http_contract(
+    tmp_path, field, value, needle,
+):
+    """A clean count from the raw endpoint is not boundary evidence.
+
+    Even if a caller copies zeros into the metrics, replay must reject the
+    endpoint/schema that never applied a chat template or exposed the
+    reasoning boundary.
+    """
+    from prismaquant.shipcard import load_shipcard, verify
+
+    path, model_dir = _full_card(tmp_path, **{field: value})
+    problems = verify(load_shipcard(path), model_dir=model_dir)
+    assert any(needle in problem for problem in problems), problems

--- a/tests/test_shipcard.py
+++ b/tests/test_shipcard.py
@@ -37,6 +37,9 @@ from prismaquant.shipcard import (
 )
 from prismaquant.shipcard_cli import main as shipcard_cli
 from prismaquant.validate_quantized_model import (
+    BOUNDARY_ENDPOINT,
+    BOUNDARY_REQUEST_SCHEMA,
+    BOUNDARY_RESPONSE_SCHEMA,
     DEFAULT_BOUNDARY_MAX_TOKENS,
     DEFAULT_BOUNDARY_REPS,
     DEFAULT_BOUNDARY_TEMPERATURE,
@@ -177,6 +180,9 @@ def _ship_gate_record(model_sha, *, passed=True, source="artifact",
         # zero defects, so the fixture must look like a real measurement.
         ledger["boundary_behavior"] = {
             "passed": True,
+            "endpoint": BOUNDARY_ENDPOINT,
+            "request_schema": BOUNDARY_REQUEST_SCHEMA,
+            "response_schema": BOUNDARY_RESPONSE_SCHEMA,
             "n_prompts": 5,
             "reps": 6,
             "n_generations": 30,
@@ -1482,5 +1488,4 @@ def test_build_without_forensics_is_left_alone():
     legacy = {"build": {"achieved_bpp": {"value": 4.3065, "source": "x"}}}
     assert verify(legacy, model_dir=None, required=[]) == []
     assert verify(_forensic_build(), model_dir=None, required=[]) == []
-
 

--- a/tests/test_shipcard_uniform_control.py
+++ b/tests/test_shipcard_uniform_control.py
@@ -40,6 +40,9 @@ from prismaquant.shipcard import (
 )
 from prismaquant.shipcard_cli import main as shipcard_cli
 from prismaquant.validate_quantized_model import (
+    BOUNDARY_ENDPOINT,
+    BOUNDARY_REQUEST_SCHEMA,
+    BOUNDARY_RESPONSE_SCHEMA,
     DEFAULT_BOUNDARY_MAX_TOKENS,
     DEFAULT_BOUNDARY_REPS,
     DEFAULT_BOUNDARY_TEMPERATURE,
@@ -213,6 +216,9 @@ def _ship_gate_record(model_sha, *, source):
     if "boundary_behavior" in ledger:
         ledger["boundary_behavior"] = {
             "passed": True,
+            "endpoint": BOUNDARY_ENDPOINT,
+            "request_schema": BOUNDARY_REQUEST_SCHEMA,
+            "response_schema": BOUNDARY_RESPONSE_SCHEMA,
             "n_prompts": 5,
             "reps": DEFAULT_BOUNDARY_REPS,
             "n_generations": 5 * DEFAULT_BOUNDARY_REPS,

--- a/tests/test_tessera_contract_v4.py
+++ b/tests/test_tessera_contract_v4.py
@@ -1,0 +1,80 @@
+"""A v4 development pin reads the same cell grammar as export admission."""
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from prismaquant import tessera_runtime_contract as contract
+from prismaquant import tessera_serving_runtime_pin as release
+
+
+def _packaged():
+    return json.loads(contract.contract_path().read_text(encoding="utf-8"))
+
+
+def _parse(payload):
+    return contract._parse(payload, commit="fixture", sha="fixture", path="fixture")
+
+
+def test_current_v4_contract_keeps_every_launch_and_residency():
+    payload = _packaged()
+    assert payload["lane_eligibility"]["schema"] == "tessera.lane-eligibility.v4"
+    parsed = _parse(payload)
+    expected = {cell["id"]: cell for cell in payload["lane_eligibility"]["cells"]}
+    assert {cell.cell_id for cell in parsed.cells} == set(expected)
+    for cell in parsed.cells:
+        assert set(cell.executes) == {
+            (launch["symbol"], launch["decoder"])
+            for launch in expected[cell.cell_id]["executes"]
+        }
+        flag = next(flag for flag in expected[cell.cell_id]["requires_serve_flags"]
+                    if flag.startswith("TESSERA_SERVE_MODE="))
+        assert set(cell.residency_modes) == set(flag.split("=", 1)[1].split("|"))
+
+
+def test_v4_reviewed_development_answer_does_not_open_release(monkeypatch):
+    monkeypatch.setenv(contract.TESSERA_DEV_PIN_ENV, "v4-regression")
+    parsed = contract.load_tessera_contract()
+    assert contract.contract_answer(parsed) == contract.TESSERA_DEV_PIN_ANSWER
+    assert parsed.identity()["bytes_are_the_reviewed_bytes"] is True
+    assert parsed.native_cells("TESSERA_E4M3_K1", 1024)
+    assert not any(cell.structure == "routed_moe" for cell in parsed.cells)
+    with pytest.raises(release.TesseraServingRuntimePinError, match="PENDING"):
+        release.require_exact_tessera_runtime_release(
+            release.load_tessera_serving_runtime_pin())
+
+
+def test_launch_change_requires_development_pin_review():
+    payload = _packaged()
+    original = contract.contract_answer(_parse(payload))
+    changed = copy.deepcopy(payload)
+    changed["lane_eligibility"]["cells"][0]["executes"][0]["decoder"] = "unreviewed_decoder"
+    moved = contract.contract_answer(_parse(changed))
+    drift = contract._answer_drift(original, moved)
+    assert drift, "a changed served decoder cannot retain the reviewed answer"
+    assert "cells[" in "\n".join(drift)
+
+
+@pytest.mark.parametrize("bad_launches", [
+    [],
+    [{"symbol": "torch.mm"}],
+    [{"symbol": "torch.mm", "decoder": "torch_window", "unknown": True}],
+    [{"symbol": "", "decoder": "torch_window"}],
+    [{"symbol": "torch.mm", "decoder": "torch_window"}] * 2,
+])
+def test_development_reader_uses_shared_v4_launch_refusals(bad_launches):
+    payload = _packaged()
+    payload["lane_eligibility"]["cells"][0]["executes"] = bad_launches
+    with pytest.raises(contract.TesseraContractError, match="executes"):
+        _parse(payload)
+
+
+def test_development_reader_refuses_overlapping_residency_cells():
+    payload = _packaged()
+    duplicate = copy.deepcopy(payload["lane_eligibility"]["cells"][0])
+    duplicate["id"] += "_duplicate"
+    payload["lane_eligibility"]["cells"].append(duplicate)
+    with pytest.raises(contract.TesseraContractError, match="residenc|overlap"):
+        _parse(payload)

--- a/tests/test_tessera_contract_v4.py
+++ b/tests/test_tessera_contract_v4.py
@@ -40,7 +40,9 @@ def test_v4_reviewed_development_answer_does_not_open_release(monkeypatch):
     assert contract.contract_answer(parsed) == contract.TESSERA_DEV_PIN_ANSWER
     assert parsed.identity()["bytes_are_the_reviewed_bytes"] is True
     assert parsed.native_cells("TESSERA_E4M3_K1", 1024)
-    assert not any(cell.structure == "routed_moe" for cell in parsed.cells)
+    assert {cell.structure for cell in parsed.cells} == {
+        cell["structure"] for cell in _packaged()["lane_eligibility"]["cells"]
+    }
     with pytest.raises(release.TesseraServingRuntimePinError, match="PENDING"):
         release.require_exact_tessera_runtime_release(
             release.load_tessera_serving_runtime_pin())

--- a/tests/test_tessera_dev_predicates.py
+++ b/tests/test_tessera_dev_predicates.py
@@ -1,0 +1,17 @@
+"""Shape-free development admission cannot attest a predicated route."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from prismaquant import tessera_runtime_contract as contract
+
+
+def test_development_reader_refuses_a_cell_it_cannot_evaluate():
+    payload = json.loads(contract.contract_path().read_text(encoding="utf-8"))
+    payload["lane_eligibility"]["cells"][0]["predicates"] = [
+        {"fact": "in_features", "op": "at_least", "value": 2048}
+    ]
+    with pytest.raises(contract.TesseraContractError, match="predicates"):
+        contract._parse(payload, commit="fixture", sha="fixture", path="fixture")

--- a/tests/test_tessera_lane_admission.py
+++ b/tests/test_tessera_lane_admission.py
@@ -278,6 +278,12 @@ def test_the_lookup_fails_closed_on_every_cell_axis(
     contract = _packaged_contract()
     for cell in contract["lane_eligibility"]["cells"]:
         cell.update(mutation)
+    if name == "fallback":
+        # Removing the required v4 plugin/residency declarations is malformed
+        # before it can become a fallback candidate for menu admission.
+        with pytest.raises(LaneEligibilityError, match="requires_plugin"):
+            _load(_write(tmp_path, contract, f"{name}.json"))
+        return
     table, formats = _load(_write(tmp_path, contract, f"{name}.json"))
     assert tr.tessera_lane_attested(
         "TESSERA_E2M1_K2_R896", table=table, formats=formats) is False

--- a/tests/test_tessera_lane_admission.py
+++ b/tests/test_tessera_lane_admission.py
@@ -213,8 +213,8 @@ def test_a_cell_claiming_a_route_with_no_plugin_requirement_is_refused(tmp_path)
     contract = _packaged_contract()
     for cell in contract["lane_eligibility"]["cells"]:
         cell["requires_plugin"] = ""
-    table, formats = _load(_write(tmp_path, contract, "no_plugin.json"))
     with pytest.raises(LaneEligibilityError, match="requires_plugin"):
+        table, formats = _load(_write(tmp_path, contract, "no_plugin.json"))
         tr.tessera_lane_attested(
             "TESSERA_E2M1_K2_R896", table=table, formats=formats)
 

--- a/tests/test_tessera_menu.py
+++ b/tests/test_tessera_menu.py
@@ -611,6 +611,10 @@ def test_a_new_cell_is_a_moved_answer_even_though_nothing_was_removed(
     cells = payload["lane_eligibility"]["cells"]
     extra = copy.deepcopy(cells[0])
     extra["id"] = extra["id"] + "_invented"
+    # A new valid scope reaches the answer pin; a duplicate scope is already
+    # malformed under v4 and must refuse in the shared parser first.
+    extra["platform"] = "test_new_platform"
+    payload["lane_eligibility"]["platforms"][extra["platform"]] = {}
     cells.append(extra)
     moved = tmp_path / "runtime_contract.json"
     moved.write_text(_json.dumps(payload), encoding="utf-8")

--- a/tests/test_tessera_menu.py
+++ b/tests/test_tessera_menu.py
@@ -399,8 +399,11 @@ def test_the_dev_pin_attests_exactly_the_rungs_the_contract_publishes(dev_pin):
     for rung in rungs:
         # Read off the cell, not typed: these cells are backed_with_serve_flag.
         assert rung.admission.route_status == tm.ROUTE_STATUS_BACKED_WITH_SERVE_FLAG
-        assert rung.admission.requires_serve_flags == (
-            "TESSERA_SERVE_MODE=resident|streamed",)
+        cells = contract.native_cells(
+            rung.admission.payload_family, rung.body_rate_q256)
+        assert rung.admission.requires_serve_flags == tuple(sorted({
+            flag for cell in cells for flag in cell.requires_serve_flags
+        }))
         assert rung.admission.source.startswith("tessera_dev_pin:runtime_contract:")
         assert rung.admission.max_world_size == 1
 
@@ -435,9 +438,8 @@ def test_a_prose_only_tessera_edit_does_not_re_stale_the_pin(dev_pin, monkeypatc
     payload["changelog"] = [{"contract_version": 999, "change": "prose only"}]
     for entry in payload["formats"]:
         entry["detail"] = "rewritten prose that no gate reads"
-    for cell in payload["lane_eligibility"]["cells"]:
-        cell["rationale"] = "rewritten prose that no gate reads"
-        cell["detail"] = "also rewritten"
+    # v4 cells contain only grammar fields: injecting detail/rationale there
+    # would create a malformed cell, not rewrite existing publisher prose.
     for unit in payload["tensor_parallel"].get("units", ()):
         for axis in unit.get("loader_axes", ()) or ():
             if isinstance(axis, dict):

--- a/tests/test_tessera_menu_real_table.py
+++ b/tests/test_tessera_menu_real_table.py
@@ -46,6 +46,13 @@ One thing this module does not test, on purpose: **the quality of the
 allocation.**  The surrogate is measured to mis-rank Tessera rungs
 (``tessera_menu.surrogate_selection_caveat``).  What is asserted here is that
 the DP *saw a menu*, not that it chose well.
+
+The campaign predates the required ``provenance.cost_mode`` stamp. Allocation
+tests validate its original schema and row currency, then use a temporary
+copy with that missing metadata reconstructed from the committed producer.
+The source hash and the evidence commits accompany the reconstruction; no
+cost value or campaign artifact is changed, and the production gate still
+refuses an unstamped table.
 """
 from __future__ import annotations
 
@@ -109,6 +116,71 @@ def installed_contract(monkeypatch):
     return contract
 
 
+def _historical_cost_fixture(tmp_path):
+    """Add the producer's later mode stamp to a validated test-only copy.
+
+    ``4d2d9b26`` already requires the scorer to return output_mse and writes
+    every row in the currency below. ``7bc4d249`` adds the unconditional
+    production-render-score stamp without changing that scoring. These are
+    evidence for the reconstruction, not an assertion that either commit
+    produced the historical file.
+    """
+    import pickle
+
+    raw = COSTS.read_bytes()
+    original = pickle.loads(raw)
+    assert isinstance(original, dict), "historical campaign payload must be a mapping"
+    assert original.get("schema") == "prismaquant.tessera_campaign_cost.v1"
+    currency = "output_mse_under_route_activation_contract"
+    assert original.get("currency") == currency
+    provenance = original.get("provenance")
+    assert isinstance(provenance, dict), "historical campaign provenance is missing"
+    assert "cost_mode" not in provenance, "this fixture is the pre-stamp campaign"
+    costs = original.get("costs")
+    assert isinstance(costs, dict) and costs, "historical campaign has no costs"
+    row_formats = set()
+    for unit, rows in costs.items():
+        assert isinstance(rows, dict) and rows, f"{unit}: no campaign rows"
+        for name, row in rows.items():
+            where = f"{unit}/{name}"
+            assert isinstance(name, str) and name.startswith("TESSERA_"), where
+            assert isinstance(row, dict), where
+            assert row.get("currency") == currency, where
+            source = row.get("cost_source")
+            assert source in {
+                "tessera_campaign_measured", "tessera_campaign_interpolated",
+            }, where
+            measured = source == "tessera_campaign_measured"
+            assert row.get("output_mse_measured") is measured, where
+            assert row.get("tessera_provenance") == (
+                "measured" if measured else "interpolated"), where
+            assert "output_mse" in row and "predicted_dloss" not in row, where
+            row_formats.add(name)
+    formats = original.get("formats")
+    assert isinstance(formats, list) and set(formats) == row_formats
+
+    payload = dict(original)
+    payload["provenance"] = {
+        **provenance,
+        "cost_mode": "production-render-score",
+        "test_fixture_reconstruction": {
+            "source_path": str(COSTS),
+            "source_sha256": hashlib.sha256(raw).hexdigest(),
+            "producer_semantics_reviewed_at": "4d2d9b26b64aa9c682724ae701a662a67253ed2f",
+            "cost_mode_stamp_introduced_at": "7bc4d249dd7157cccb807f574917b011b0778345",
+            "note": (
+                "Test-only reconstruction of missing cost_mode from the "
+                "original campaign schema, row currencies and committed "
+                "producer semantics; all historical cost values are retained."
+            ),
+        },
+    }
+    path = tmp_path / "historical-cost-with-mode.pkl"
+    path.write_bytes(pickle.dumps(payload))
+    assert COSTS.read_bytes() == raw, "historical campaign artifact changed"
+    return path
+
+
 def _allocate(tmp_path, monkeypatch, *, target_bits="4.5"):
     """Run the allocator's own entry point; return the parsed layer config.
 
@@ -122,11 +194,12 @@ def _allocate(tmp_path, monkeypatch, *, target_bits="4.5"):
     from prismaquant import allocator
 
     tmp_path.mkdir(parents=True, exist_ok=True)
+    costs = _historical_cost_fixture(tmp_path)
     layer_config = tmp_path / "layer_config.json"
     monkeypatch.setattr("sys.argv", [
         "allocator",
         "--probe", str(PROBE),
-        "--costs", str(COSTS),
+        "--costs", str(costs),
         "--formats", "TESSERA",
         "--target-bits", target_bits,
         "--target-profile", "tessera_research_sm121",

--- a/tests/test_tessera_substitute_decoder.py
+++ b/tests/test_tessera_substitute_decoder.py
@@ -116,10 +116,8 @@ def test_the_tool_reads_the_block_from_the_pin_file(tmp_path):
 
 def _status_manifest(*, resident: bool):
     """A minimal manifest pair whose only stack difference is the decoder."""
-    row = _published_rows()[0]
-    prefix = row["module_name_prefix"]
-    stem = f"{prefix}9f2c"
-    basename = f"{stem}.so"
+    rows = _published_rows()
+    basenames = [f"{row['module_name_prefix']}9f2c.so" for row in rows]
     return {
         "image": "vllm-node:latest",
         "gpu_name": "NVIDIA GB10",
@@ -127,7 +125,7 @@ def _status_manifest(*, resident: bool):
         "enforce_eager": True,
         "quantization": "compressed-tensors",
         "package_versions": {"vllm": "0.21.0", "torch": "2.11.0"},
-        "resident_extensions": ([basename] if resident else []),
+        "resident_extensions": (basenames if resident else []),
         "residency_readable": True,
         "launch_flags": ["vllm", "serve", "<path>", "--enforce-eager"],
         "native_extension_status": [
@@ -143,7 +141,7 @@ def _status_manifest(*, resident: bool):
                         row["when_unavailable"].items())
                 },
             }
-            for row in _published_rows()
+            for row in rows
         ],
         "created": "2026-07-30T10:00:00",
         "launch_argv": ["vllm", "serve", "/dqruns/a/exported",

--- a/tests/test_validate_quantized_model.py
+++ b/tests/test_validate_quantized_model.py
@@ -58,6 +58,20 @@ class _FakeVLLMHandler(BaseHTTPRequestHandler):
         self.requests.append(req)
         prompt = req.get("prompt", "")
 
+        if self.path == "/v1/chat/completions":
+            messages = req.get("messages") or []
+            prompt = messages[-1].get("content", "") if messages else ""
+            body = {"choices": [{
+                "message": {"reasoning": "brief trace", "content": " 12"},
+                "finish_reason": "stop",
+            }]}
+            out = json.dumps(body).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(out)
+            return
+
         if self.path == "/v1/completions":
             mt = int(req.get("max_tokens") or 1)
             echo = bool(req.get("echo", False))
@@ -89,16 +103,9 @@ class _FakeVLLMHandler(BaseHTTPRequestHandler):
                 }
             else:
                 # Plain generation request: return a short stub completion.
-                # Boundary-stressing prompts get a clean boundary shape
-                # (exactly one </think>, finish stop) so the healthy arm is
-                # healthy on every check; anything else gets generic prose.
-                if prompt in vqm.BOUNDARY_PROMPTS:
-                    body = {"choices": [{"text": "<think>12</think> 12",
-                                         "finish_reason": "stop"}]}
-                else:
-                    txt = ("Pretend this is a coherent completion about the topic "
-                           "that goes on for enough characters.")
-                    body = {"choices": [{"text": txt}]}
+                txt = ("Pretend this is a coherent completion about the topic "
+                       "that goes on for enough characters.")
+                body = {"choices": [{"text": txt}]}
 
             out = json.dumps(body).encode("utf-8")
             self.send_response(200)


### PR DESCRIPTION
Integrates the reviewed PR #179 lane-v4 consumer and the boundary-request fixes from merged PR #177 into main, retaining the pinned public-checkout CI preparation from PR #176. Resolves only the architecture-document conflict; both feature histories remain intact. The Tessera release pin stays PENDING, no MoE route is promoted, and the historical boundary threshold is unchanged. Refs #87 and #175; neither issue closes here. This supersedes the conflicting integration of PR #179. PrismaBuild integration action 446880313ebc79c732e6170f97849247bd2dd5fef35974d4e8b7583b87bf9026 is running the targeted admission, fingerprint, real-table allocator, documentation, and CI checks with one CPU and 4 GiB on Sparky, CUDA hidden. Tessera dependency is the hash-verified source archive of 1221d2a. Three external calibration symlinks were omitted from the sealed test snapshot and immediately restored in the working tree; these targeted tests do not use those datasets. This is not a whole-repository or GPU-suite claim. Final result will be added before merge.