### PR TITLE
Enforce explicit runtime scope throughout Tessera v5 admission

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,23 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-04 · `codex/pq-tessera-v4-consumer`. Stamps
+As of: 2026-09-04 · `codex/pq-tessera-v5-scope`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-04, `codex/pq-tessera-v5-scope`) for **runtime-scoped
+Tessera admission** (§5.7, §9.4; Tessera #126, approved by Rob). A v5 cell
+requires an exact image digest and explicit eager/compiled execution modes;
+the shared parser retains both and refuses malformed or overlapping scopes.
+An immutable `ServingContext` supplies platform, per-unit structure, residency,
+runtime image and execution mode. Admission requires every declared regime
+under that same context. Menu and candidate provenance retain it, and campaign
+and candidate caches include it in their keys. Missing context remains
+unattested; a unit whose final candidate is excluded is refused by name rather
+than omitted from allocation. Explicit legacy v4 reads remain supported.
+This adds no positive MoE attestation and changes no image default, wire bytes
+or quality threshold. The development source pin remains the reviewed v4
+source until a separate review of the producer's v5 contract; the release pin
+remains PENDING. Name-only/CLI callers without an explicit context remain
+closed under v5 rather than guessing a model-wide MoE or runtime scope.
 
 Re-stamped (2026-09-04, `codex/pq-tessera-v4-consumer`) for **development
 admission's predicate refusal** (§5.7). The shared parser retained cell
@@ -5872,8 +5888,8 @@ read §9.2's Tessera passage as history. The per-artifact question (this
 platform, this unit's regimes) still stays with `resolve_unit_route` at export.
 
 **One cell parser, with explicit version semantics.** `lane_eligibility.py`
-reads Tessera's v4 table for export and for `tessera_runtime_contract.py`'s
-development pin. A v4 cell requires `requires_plugin: "tessera"`, non-empty
+reads Tessera's v4/v5 tables for export and for `tessera_runtime_contract.py`'s
+development pin. A v4 or v5 cell requires `requires_plugin: "tessera"`, non-empty
 `executes` pairs and exactly one residency selector bounded by its family's
 `residency_modes`. Two cells may not claim the same platform/family/structure/
 regime/residency scope, even at different rungs. `resolve_unit_route` takes an
@@ -5883,6 +5899,18 @@ includes those values, so changing a decoder cannot retain the old answer.
 Explicit legacy Tessera v3 tables retain their original grammar and carry no
 fabricated launches. Gridbook schemas remain refused. Release admission is
 still gated by the exact PENDING release pin.
+V5 additionally requires `runtime: {image, execution_modes}` on every cell:
+an immutable image reference and a non-empty subset of `eager`/`compiled`,
+never an implicit fallback to `versions.attested_on`. Its overlap key includes
+the image and each execution mode. `ServingContext` supplies every lookup
+axis explicitly; the shared matcher reads all five fields before admitting
+cells. The development menu and released-pin helpers require all declared
+regimes on that one context, and both the runtime scopes and the required
+regime roster enter the reviewed answer. `context_by_unit` threads explicit
+contexts through campaign and candidate APIs; caches key by shape/format
+**and context**, so a rank-two expert cannot borrow a same-shaped dense menu.
+Research mode can retain a writable but explicitly unattested rung; attested
+mode cannot, and removing a unit's last candidate produces a named refusal.
 The development reader also refuses non-empty cell predicates: its family/rate
 menu lookup has no unit facts with which to evaluate a shape constraint.
 Export's `resolve_unit_route` has those facts and evaluates the predicates.
@@ -8877,7 +8905,8 @@ are NAMED by the lane spec, never vendored.
 (`prismaquant.tessera_serving_runtime_pin.v1`), read by
 `tessera_serving_runtime_pin.py`; and the contract the plugin packages,
 `tessera/serving/runtime_contract.json` (`tessera.runtime-contract.v1`, lane
-table `tessera.lane-eligibility.v4`), read through `importlib.resources`.
+table `tessera.lane-eligibility.v4`, with the consumer also supporting the
+runtime-scoped v5 revision), read through `importlib.resources`.
 PrismaQuant never vendors or imports the serving half. Unlike the Gridbook
 serving pin this one binds no wheel digest: Tessera publishes no wheel and is
 installed from a source checkout, so a digest would be a claim about an
@@ -8887,7 +8916,7 @@ artifact that does not exist.
 `requires_plugin: "tessera"` — stock vLLM has no reader for these bytes, so the
 route is not merely flag-gated, and an export gate has to be able to refuse an
 artifact whose serve command would not install the runtime. The shared parser
-carries it as a required v4 cell key (optional only in legacy v3) and
+carries it as a required v4/v5 cell key (optional only in legacy v3) and
 aggregates it as `requires_plugins`
 through `RegimeRoute` / `UnitRoute` / `EligibilityTable.provenance()`;
 `tessera_lane_attested` RAISES on a cell that claims a native route without it,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5032,7 +5032,7 @@ row-parallel Linear is `cols / tp % 256 == 0`, which is what collapses 3060 to
 **One function owns the encoder call, and it is H-gated**
 (`tessera_render.encode_tessera_unit`). The Tessera encoder's shipping default
 is *H-aware*: given a unit's `H = XᵀX` it applies LDLQ (sigma 1.0, block 32)
-plus an exact full-H row-scale refit, and weights-only encodes stay
+and the producer's plane-specific refit policy, and weights-only encodes stay
 byte-identical. So a rung priced without an H is a price of different bytes at
 the same format name, and the seam refuses rather than downgrade silently:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,15 @@
 As of: 2026-09-04 · `codex/pq-tessera-v5-scope`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-04, `codex/pq-tessera-v5-scope`) for **complete encoder
+recipe provenance** (§5.4). The default activation-aware recipe is projected
+from Tessera's `ActivationSource.config_block()`, excluding only Hessian
+capture identity and explanatory prose. It retains every producer setting,
+including an unset trailing refit objective, a disabled Gauss-Seidel sweep
+and producer-normalized per-plane maps. Encoder defaults and bytes do not
+change. Gate: `tests/test_tessera_encoder_recipe.py`; both completeness
+regressions failed before the fix on the omitted settings.
+
 Re-stamped (2026-09-04, `codex/pq-tessera-v5-scope`) for **legacy scope
 honesty** (§5.7). The context-free v4 lookup remains compatible, but an
 explicit runtime query on a legacy table is now unattested. A caller's image
@@ -5029,9 +5038,8 @@ the same format name, and the seam refuses rather than downgrade silently:
 
 * **The seam is `tessera.export.ActivationSource`**, not a kwarg name.
   `ActivationSource.for_unit(name, in_features, device, scale_plane=...)`
-  turns one unit's H into the encoder keywords it implies — `ldl`,
-  `ldl_block`, `refit_metric`, `refit_reach_floor` — and PrismaQuant forwards
-  that object's output and
+  turns one unit's H into the encoder keywords it implies, including the
+  plane-specific refit settings, and PrismaQuant forwards that object's output and
   nothing else: a keyword it did not emit is refused, so this seam cannot
   become a second place where encode settings are chosen. Capability is
   *probed*, never assumed (principle 14): `_encoder_accepts_hessian` asks a
@@ -5039,6 +5047,11 @@ the same format name, and the seam refuses rather than downgrade silently:
   `inspect.signature(encode_linear_planes)` which it takes, and the seam
   refuses when they disagree. Deliberately *not* "call and catch `TypeError`",
   which would swallow every unrelated argument error.
+  The recorded default recipe comes from the same producer object's
+  `config_block()`, excluding only capture identity and explanatory prose.
+  Unset and disabled settings are retained, as are producer-normalized
+  per-plane maps; a producer setting cannot disappear from provenance merely
+  because a consumer-maintained field list predates it.
 * **Which rungs can take an H is a fact about the WIRE, and it is DERIVED —
   never restated.** The paragraph that stood here quoted two Tessera guards
   verbatim ("LDLQ is implemented for the CHANNEL scale plane", "read only by

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,14 @@
 As of: 2026-09-04 · `codex/pq-tessera-v5-scope`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-04, `codex/pq-tessera-v5-scope`) for **legacy scope
+honesty** (§5.7). The context-free v4 lookup remains compatible, but an
+explicit runtime query on a legacy table is now unattested. A caller's image
+and execution mode cannot be serialized beside a backed family-only claim.
+The same refusal covers generic, development, released-pin and menu admission;
+candidate masking honors an explicit query even when the legacy table itself
+does not require context. Opt-in research remains writable and unattested.
+
 Re-stamped (2026-09-04, `codex/pq-tessera-v5-scope`) for **runtime-scoped
 Tessera admission** (§5.7, §9.4; Tessera #126, approved by Rob). A v5 cell
 requires an exact image digest and explicit eager/compiled execution modes;
@@ -5917,6 +5925,10 @@ includes those values, so changing a decoder cannot retain the old answer.
 Explicit legacy Tessera v3 tables retain their original grammar and carry no
 fabricated launches. Gridbook schemas remain refused. Release admission is
 still gated by the exact PENDING release pin.
+Legacy context-free behavior is preserved, not expanded: supplying new
+runtime-image/execution scope to a legacy schema is refused with the shared
+`legacy_runtime_scope_refusal` message. The caller's requested context remains
+in provenance beside `unattested`, never beside a borrowed backed verdict.
 V5 additionally requires `runtime: {image, execution_modes}` on every cell:
 an immutable image reference and a non-empty subset of `eager`/`compiled`,
 never an implicit fallback to `versions.attested_on`. Its overlap key includes

--- a/docs/results/tessera_v5_scope_2026-09-04.md
+++ b/docs/results/tessera_v5_scope_2026-09-04.md
@@ -1,0 +1,139 @@
+# Tessera v5 consumer capability — 2026-09-04
+
+## Result and limits
+
+The targeted consumer population passed **512 tests, failed 0, skipped 5**
+at implementation `005b007a`. The same PrismaBuild action then compiled the
+eight touched Python modules successfully. This is CPU-only evidence on
+Sparky (aarch64), one reserved CPU and 4 GiB, with `CUDA_VISIBLE_DEVICES=''`.
+There were no collection errors or uncollected test modules. The five skips
+all say, verbatim, **`Tessera encodes need CUDA`**, in
+`tests/test_tessera_campaign.py` at lines 194, 222, 248, 540 and 945 of that
+source. No CUDA encode, kernel, physical serving or whole-suite result is
+claimed here. Eighteen warnings were dependency deprecations.
+
+The consumer now understands required per-cell image/execution scope and
+retains a complete five-axis `ServingContext` through API-level admission,
+menus, candidate masking, provenance and cache keys. Missing or mismatched
+scope refuses. Every required regime must match the same target; modes or
+images from different cells cannot be combined. Context-free v4 behavior is
+preserved, while an explicit runtime query on an unscoped legacy table cannot
+be reported as backed.
+
+This is **capability, not Tessera #126 closure**. Production CLI/campaign/export
+ingress is a separate follow-up. The reviewed development pin remains
+`1221d2a4207a6baeffbe9726bce13125fc1649ae` (lane v4); the release pin remains
+PENDING. Final producer review, measured MoE cells, cross-repository development
+pin/admission integration and the actual release are not replaced by this
+change. There is no new positive MoE attestation or runtime-image default.
+
+## Immutable inputs
+
+Ordinary producer imports use Tessera `1221d2a4207a6baeffbe9726bce13125fc1649ae`.
+The explicit v5 interoperability test independently reads the actual publisher
+contract from `a4927fe51219e809ab5c3138e4328473be1473f3` (contract 15, lane v5,
+eight existing dense cells, no MoE cells). It verifies preserved dense admission
+for both published modes and refusal for absent/mismatched scope. No current
+working-tree producer bytes or fabricated development answer substitute for
+these inputs.
+
+The workers hash-check these source-only Git archives before extraction:
+
+| Source archive under `/mnt/shared/pq-v4-source.o2Tc3O/` | SHA-256 |
+|---|---|
+| `tessera-1221d2a-src.tar` | `b4755a30d60974ec2758c2060fc4d3954f2e1b7c7bb11602a05f0b783ba60bc8` |
+| `tessera-a4927fe-src.tar` | `941b979fe5a246b26a4bf298430bc2ac3727df35c3afd1c406c32bbecd77ffe9` |
+
+`PYTHONPATH` selects the first archive's `src`; only
+`PRISMAQUANT_TEST_TESSERA_V5_CONTRACT` selects the second archive's packaged
+JSON. Thus the actual-v5 test does not silently advance the installed pin.
+
+## Red before green
+
+All actions below used PrismaBuild, CPU-only Sparky, one CPU and 4 GiB.
+Failed actions retain their exact stdout in
+`/mnt/shared/prismabuild-fleet/pb-queue/failed/<action>.json`, or
+`withdrawn/<action>.json` when a repeated failed attempt was stopped after its
+first complete result. Red is not inferred from a collection failure.
+
+| Action | Population / observation |
+|---|---|
+| `3c040b638f4cb8a94977261fd51e9833e6e4360e939e61bd1ef2802ef4a1e734` | Refined old-code v5 regression set: 68 failed, 1 research preservation control passed, 11 setup errors. Setup errors are not counted as functional red evidence. |
+| `4e4e3829c425898c281a68f9b5275d4ef47416f3f75a8df37b1597c309bd38ee` | Corrected-fixture renderer + actual-publisher red: 12 failed, 2 preservation controls passed; no setup/collection errors. Parser v5 was present, renderer/development admission still old. |
+| `adf1c7274538d982f914c79414fc1f8a89be0a66b04023ce559280eedd346177` | Explicit legacy-runtime claims: 11 failed, 27 passed; no skips or setup/collection errors. |
+| `22d031459c1a16f9777b2724ca4c0930ba0c38a41459f1e8ad01a0fdf41e4e9a` | Recipe completeness: both new tests failed because the result omitted trailing-objective and Gauss-Seidel settings. |
+| `bd4b8e9ce69e5aa449e641fcc104e2beb8654970ad497d2291e2e5374771ba66` | Initial integrated v5 core: 114 passed, no skips/collection errors. |
+| `6e2e245279dcb53e4dd8ac054c065d583e68f30fc05bc6f3b035d987643d472d` | Strengthened legacy-scope + v5/core checks: 154 passed, no skips/collection errors. |
+| `1c9ff1e390476074b99244c1a244aa23bb6eb30d9af6eae7b4f0d9cfdda9a7e0` | Final 33-file targeted population: 512 passed, 0 failed, 5 named CUDA skips; compile checks passed. |
+
+Representative pre-fix lines:
+
+* Old v5 parsing failed at the unsupported schema; malformed runtime tests
+  require a field-specific `cells.*runtime` diagnostic rather than accidentally
+  matching the word `runtime` in the schema name.
+* Corrected renderer red: unbound v5 `tessera_attesting_cells(...)` returned
+  four cells instead of `()`; scoped calls raised unexpected
+  `serving_context` keyword errors. Actual publisher development admission
+  also returned native dense cells without a required context.
+* Legacy-scope red: a supplied unsupported runtime context still produced a
+  backed family-only admission; regression controls preserve the context-free
+  v4 lookup.
+* Recipe red at `test_tessera_encoder_recipe.py:31` and `:51`:
+  `Right contains 2 more items: {'refit_gauss_seidel': False,
+  'refit_objective_trailing': None}`; the second case exposes the same omission
+  with normalized per-plane maps.
+
+An earlier renderer attempt (`797412817e490465...`) did not collect because
+the test constructed the new context API during parametrization. It is not
+regression evidence. The later corrected-fixture red above replaces it.
+
+## Findings fixed separately
+
+* Explicit legacy scope could be serialized beside an unrelated backed claim:
+  fixed across generic, development, released-pin, menu and candidate gates
+  in `5f064e8b`, with the owner's shared refusal text.
+* Two campaign tests pinned an obsolete encoder-key roster. The only failing
+  file was rerun against pristine main `b6d6824e5bec0925d088104c8edc879aee240b0f`
+  using the same immutable producer: action
+  `1584de7ded4f375d3a75326f7c36f7888aaa45c8ed1de08ba97ffbfdc273bf44`
+  produced 29 passed, the same 2 failed, and 5 `Tessera encodes need CUDA`
+  skips. The failure was `'refit_gauss_seidel' != 'refit_metric'` at the
+  hard-coded list's index 2. No whole-main baseline was run. Test expectations
+  now derive from producer emissions (`877080af`).
+* The packaged-contract test confused newest accepted schema with the actual
+  reviewed producer schema; its assertion now reads the publisher field
+  (`877080af`).
+* `encoder_recipe()` omitted two actual settings. It now projects the producer
+  object's `config_block()`, excluding only capture identity and explanatory
+  prose (`005b007a`). No encoder input/default changes. Stale keyword-count and
+  full-H-for-every-plane prose was corrected on sight.
+
+## Reproduction and receipt
+
+The final action's complete immutable argv, environment and checkout closure
+are recorded in
+`/mnt/shared/prismabuild-fleet/cas/requests/1c/1c9ff1e390476074b99244c1a244aa23bb6eb30d9af6eae7b4f0d9cfdda9a7e0.json`.
+The submission used `tools/pbrun.py --tag sparky --demand cpu=1,mem_gb=4`,
+no `--gpu`, `TMPDIR=/home/rob/tmp`, `OMP_NUM_THREADS=1`,
+`OPENBLAS_NUM_THREADS=1`; inside the reserved action it ran
+`/home/rob/dq-runs/venvs/prismaquant-cu130/bin/python -m pytest` with
+`-q -ra --tb=short -p no:cacheprovider`, followed by `python -m py_compile`.
+
+The targeted files cover the new context/parser/menu/candidate/renderer tests,
+legacy v4 and predicates, lane/export/runtime-fingerprint paths, menu real
+table, serving profiles/provenance, campaign, affected allocator legality and
+aggregation paths, activation-fair pricing, source passthrough, format-menu
+expansion, cost currency/byte pricing, and both documentation checks. The exact
+33-file list is in the immutable action manifest rather than a mutable shell
+history.
+
+Successful result CAS blob:
+`/mnt/shared/prismabuild-fleet/cas/blobs/99/998b27bbb34de2e4ab37462b2363aeaf2be7afdc7ce913fbc297392f83470535`.
+Receipt SHA-256:
+`a25a4b028f2160071809368eceb5e5d498f69081ed18cc3b9f3d259e69995168`.
+Pytest elapsed time was 238.55 s; this is not a performance claim.
+
+PB sealing excludes three external calibration symlinks in the isolated
+submission index and restores them immediately after the immutable action is
+queued. None of these tests uses the datasets; no symlink removal was committed.
+No PrismaBuild source or fleet configuration was changed.

--- a/docs/results/tessera_v5_scope_2026-09-04.md
+++ b/docs/results/tessera_v5_scope_2026-09-04.md
@@ -137,3 +137,20 @@ PB sealing excludes three external calibration symlinks in the isolated
 submission index and restores them immediately after the immutable action is
 queued. None of these tests uses the datasets; no symlink removal was committed.
 No PrismaBuild source or fleet configuration was changed.
+
+## Current-main merge check
+
+Merged main `6252ef70a4556900d44df53e8c6a2fd2daef375e` at `880cc4d3`.
+Only the architecture stamp conflicted; both sets of dated updates were
+preserved. A targeted post-merge core/legacy/recipe/documentation check at
+`9b65294e` passed **175 tests, 0 failures, 0 skips and 0 collection errors**,
+again CPU-only Sparky, one CPU and 4 GiB. It does not replace or expand the
+earlier 33-file population.
+
+Action: `e10d68772faae48fee940d3dccfdd51c360b4bf46ebbe25ce00c8db1a42c83fd`.
+Receipt SHA-256:
+`b18c9b671aa439646b68d976adb04abd932c9510e0c0fd7c0795cf579712ca35`.
+Result blob:
+`/mnt/shared/prismabuild-fleet/cas/blobs/3a/3a537bb5c8f639739269a0a895c65717660b0adb9b56e165d06af07aa07686b5`.
+Endpoint-only regression tests and unfinished endpoint source were kept on a
+separate follow-up branch, not included in this capability change.

--- a/prismaquant/allocator_candidates.py
+++ b/prismaquant/allocator_candidates.py
@@ -9,6 +9,10 @@ from collections import Counter, defaultdict
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .lane_eligibility import ServingContext
 
 from . import format_registry as fr
 from .activation_fair_pricing import (
@@ -2072,6 +2076,7 @@ def build_candidates(stats: dict, costs: dict, formats: list[fr.FormatSpec],
                      activation_pricing: ActivationFairPricing | None = None,
                      bit_precision: float | None = None,
                      tessera_menu_report: dict | None = None,
+                     context_by_unit: Mapping[str, ServingContext] | None = None,
                      ) -> dict[str, list[Candidate]]:
     """Build runtime-legal format candidates for every measured Linear.
 
@@ -2088,10 +2093,14 @@ def build_candidates(stats: dict, costs: dict, formats: list[fr.FormatSpec],
     ``activation_pricing`` (ultraplan P5a) is the run's ONE per-family
     activation calibration; it corrects the weight-only branches and stamps
     the branch that priced every candidate. ``target_profile``'s declared
-    serving lanes (P5b) are resolved once per format and attached to every
-    candidate, so the concrete route — activation contract, whether the
+    serving lanes (P5b) are resolved once per format and explicit serving
+    context, then attached to every candidate, so the concrete route —
+    activation contract, whether the
     consumer's fused mid-M kernel backs this rung, fallback — travels WITH
     the choice instead of being reconstructed from the format name later.
+    A v5 contract requires each unit's context from ``context_by_unit``; an
+    absent entry remains unbound and cannot borrow another unit's attestation.
+    The existing research menu may still price an unattested writable rung.
     """
     refuse_retired_trellis_surface()
     gains = calibrated_gains or {}
@@ -2100,13 +2109,19 @@ def build_candidates(stats: dict, costs: dict, formats: list[fr.FormatSpec],
     source_counts: Counter[str] = Counter()
     activation_branch_counts: Counter[str] = Counter()
     unpriceable: dict[str, list[str]] = {}
-    lane_by_format: dict[str, object] = {
-        spec.name: serving_lane_route(target_profile, spec.name)
-        for spec in formats
-    }
+    unserved: dict[str, list[str]] = {}
+    lane_cache: dict[tuple, object] = {}
+    admission_cache: dict[tuple, object] = {}
     for name, s in stats.items():
         if name not in costs:
             continue
+        serving_context = (
+            context_by_unit.get(name) if context_by_unit is not None else None
+        )
+        context_key = None if serving_context is None else serving_context.key()
+        scope_kwargs = (
+            {} if serving_context is None else {"serving_context": serving_context}
+        )
         shape = _shape_from_stats(s)
         in_features = int(s.get("in_features", 0) or 0)
         out_features = int(s.get("out_features", 0) or 0)
@@ -2178,6 +2193,38 @@ def build_candidates(stats: dict, costs: dict, formats: list[fr.FormatSpec],
                     [],
                 ).append(name)
                 continue
+            if spec.name.startswith("TESSERA_"):
+                from . import tessera_menu
+
+                cache_key = (spec.name, context_key)
+                if cache_key not in admission_cache:
+                    admission_cache[cache_key] = tessera_menu.route_admission(
+                        spec.name, **scope_kwargs
+                    )
+                admission = admission_cache[cache_key]
+                if (
+                    admission.requires_serving_context
+                    and not admission.admits(tessera_menu.menu_mode())
+                ):
+                    reason = "tessera_serving_context"
+                    if mask_records is not None:
+                        mask_records.append({
+                            "qname": name,
+                            "format": spec.name,
+                            "reason": reason,
+                            "detail": admission.detail,
+                            "shape": [out_features, in_features],
+                            "out_features": out_features,
+                            "in_features": in_features,
+                            "source_kind": source_kind,
+                            "serving_context": (
+                                None if serving_context is None
+                                else serving_context.as_dict()
+                            ),
+                        })
+                    masked.setdefault((spec.name, reason), []).append(name)
+                    unserved.setdefault(name, []).append(spec.name)
+                    continue
             gain = float(gains.get(spec.name, gains.get(entry_fmt, 1.0)))
             # Always use measured joint output perturbation when available.
             # Packed experts can carry an unmeasured output_mse placeholder;
@@ -2248,7 +2295,12 @@ def build_candidates(stats: dict, costs: dict, formats: list[fr.FormatSpec],
                 s.setdefault("_serialized_sidecar_identity_by_format", {})[
                     spec.name
                 ] = serialized_sidecar_identity
-            lane = lane_by_format.get(spec.name)
+            cache_key = (spec.name, context_key)
+            if cache_key not in lane_cache:
+                lane_cache[cache_key] = serving_lane_route(
+                    target_profile, spec.name, **scope_kwargs
+                )
+            lane = lane_cache[cache_key]
             if lane is not None:
                 s.setdefault("_serving_lane_by_format", {})[spec.name] = lane
             cands.append(Candidate(
@@ -2284,6 +2336,19 @@ def build_candidates(stats: dict, costs: dict, formats: list[fr.FormatSpec],
             for branch, count in sorted(activation_branch_counts.items())
         )
         print(f"[alloc] activation-pricing branch: {summary}", flush=True)
+    unserved_units = sorted(name for name in unserved if name not in out)
+    if unserved_units:
+        detail = "\n".join(
+            f"    {name}: unattested formats={sorted(unserved[name])}"
+            for name in unserved_units
+        )
+        raise ValueError(
+            f"{len(unserved_units)} Linear(s) have no serving-eligible format "
+            "left after Tessera serving-context admission:\n"
+            f"{detail}\n"
+            "Provide each unit's explicit attested serving context or a legal "
+            "fallback format. Refusing to omit these units from the allocation."
+        )
     starved = sorted(n for n in unpriceable if n not in out)
     if starved:
         # Excluding the unmeasured-activation candidates left these Linears
@@ -2328,12 +2393,13 @@ def selection_serving_lane_provenance(
     assignment: dict[str, str],
     candidates: dict[str, list[Candidate]] | None = None,
     target_profile: str | None = None,
+    context_by_unit: Mapping[str, ServingContext] | None = None,
 ) -> dict:
     """Per-selected-unit serving-route + activation-pricing provenance (P5b).
 
     "Neither repo can price an unbacked lane" only holds if the shipped
     artifact says which lane every selected unit actually rides. This walks
-    the FINAL (expanded) assignment and reports, per format and in aggregate:
+    the FINAL (expanded) assignment and reports, per unit, format and in aggregate:
     the activation contract, whether the consumer's fused mid-M kernel backs
     that rung, the fallback route it takes when it does not, and which
     estimator priced the unit's activation cost.
@@ -2341,12 +2407,15 @@ def selection_serving_lane_provenance(
     Routes are read from the chosen ``Candidate`` where one exists — the
     candidate is the object the DP actually saw — and re-resolved from the
     target profile for expanded members of aggregated super items, which have
-    no candidate of their own. The two agree by construction (the lane is a
-    function of format and profile); the fallback exists so an expanded
-    packed-expert assignment is not silently reported as laneless.
+    no candidate of their own. Resolution is scoped by the unit's explicit
+    serving context; equal format names need not have equal routes. A format
+    summary carries one route only when all its selected units agree, while
+    ``by_unit`` preserves each route when contexts or conflicting routes exist.
     """
-    lane_cache: dict[str, object] = {}
+    lane_cache: dict[tuple, object] = {}
     by_format: dict[str, dict] = {}
+    by_unit: dict[str, dict] = {}
+    include_by_unit = context_by_unit is not None
     branch_counts: Counter[str] = Counter()
     contract_counts: Counter[str] = Counter()
     route_status_counts: Counter[str] = Counter()
@@ -2356,6 +2425,9 @@ def selection_serving_lane_provenance(
 
     for name in sorted(assignment):
         fmt = str(assignment[name])
+        serving_context = (
+            context_by_unit.get(name) if context_by_unit is not None else None
+        )
         lane = None
         branch = None
         for cand in (candidates or {}).get(name, ()):
@@ -2364,9 +2436,35 @@ def selection_serving_lane_provenance(
                 branch = cand.activation_pricing
                 break
         if lane is None:
-            if fmt not in lane_cache:
-                lane_cache[fmt] = serving_lane_route(target_profile, fmt)
-            lane = lane_cache[fmt]
+            context_key = None if serving_context is None else serving_context.key()
+            cache_key = (fmt, context_key)
+            if cache_key not in lane_cache:
+                scope_kwargs = (
+                    {} if serving_context is None
+                    else {"serving_context": serving_context}
+                )
+                lane_cache[cache_key] = serving_lane_route(
+                    target_profile, fmt, **scope_kwargs
+                )
+            lane = lane_cache[cache_key]
+        route = None if lane is None else lane.as_dict()
+        unit_row = {"format": fmt, "route": route}
+        lane_context = getattr(lane, "serving_context", None)
+        if lane_context is not None:
+            # The chosen candidate's recorded context owns its route even if
+            # a caller now supplies a different context for the same unit.
+            serving_context = lane_context
+            include_by_unit = True
+        if serving_context is not None:
+            unit_row["serving_context"] = serving_context.as_dict()
+        by_unit[name] = unit_row
+        if fmt not in by_format:
+            by_format[fmt] = {"format": fmt, "units": 0, "route": route}
+        row = by_format[fmt]
+        if row["route"] != route:
+            row["route"] = None
+            include_by_unit = True
+        row["units"] += 1
         branch_counts[str(branch) if branch else "unrecorded"] += 1
         if lane is None:
             n_no_lane += 1
@@ -2376,12 +2474,7 @@ def selection_serving_lane_provenance(
             # as evidence of absence (units_on_fallback_route = 0 was reachable
             # only by never having looked).
             route_status_counts["no_declared_lane"] += 1
-            by_format.setdefault(fmt, {
-                "format": fmt, "units": 0, "route": None})["units"] += 1
             continue
-        row = by_format.setdefault(fmt, {
-            "format": fmt, "units": 0, "route": lane.as_dict()})
-        row["units"] += 1
         contract_counts[lane.activation_contract or "unspecified"] += 1
         route_status_counts[
             getattr(lane, "route_status", None) or "no_declared_lane"] += 1
@@ -2394,7 +2487,7 @@ def selection_serving_lane_provenance(
             if lane.rung is not None:
                 fallback_rungs.add(int(lane.rung))
 
-    return {
+    report = {
         "schema": SERVING_LANE_SCHEMA,
         "target_profile": str(target_profile or "research"),
         "serving_runtime_version": serving_runtime_version(),
@@ -2425,6 +2518,9 @@ def selection_serving_lane_provenance(
             fmt: row for fmt, row in sorted(by_format.items())
         },
     }
+    if include_by_unit:
+        report["by_unit"] = by_unit
+    return report
 
 
 def summarize_applicability_masks(

--- a/prismaquant/allocator_candidates.py
+++ b/prismaquant/allocator_candidates.py
@@ -2100,6 +2100,8 @@ def build_candidates(stats: dict, costs: dict, formats: list[fr.FormatSpec],
     the choice instead of being reconstructed from the format name later.
     A v5 contract requires each unit's context from ``context_by_unit``; an
     absent entry remains unbound and cannot borrow another unit's attestation.
+    An explicit context also binds a legacy lookup: a schema without runtime
+    scope cannot admit that query merely because it does not require one.
     The existing research menu may still price an unattested writable rung.
     """
     refuse_retired_trellis_surface()
@@ -2203,7 +2205,7 @@ def build_candidates(stats: dict, costs: dict, formats: list[fr.FormatSpec],
                     )
                 admission = admission_cache[cache_key]
                 if (
-                    admission.requires_serving_context
+                    (admission.requires_serving_context or serving_context is not None)
                     and not admission.admits(tessera_menu.menu_mode())
                 ):
                     reason = "tessera_serving_context"

--- a/prismaquant/lane_eligibility.py
+++ b/prismaquant/lane_eligibility.py
@@ -37,7 +37,7 @@ The shape of the fix is therefore as important as the values:
 * Route status alone never removes an honestly priced rung from the allocator's
   menu (principle 1). It gates EXPORT, per artifact, per principle 9.
 
-Schemas v3/v4, and why absence carries the whole weight
+Schemas v3/v4/v5, and why absence carries the whole weight
 ---------------------------------------------------
 ``tessera.lane-eligibility.v3`` is a **closed-world cell table**. It declares
 ``platforms``, ``regimes``, ``structures`` and a list of ``cells``, each cell
@@ -55,6 +55,10 @@ axis. A caller must name a residency; two cells in the same scope may never
 claim the same residency. The published serve flag selects that axis, and the
 family's ``residency_modes`` bounds it. Legacy v3 tables retain their original
 resolution semantics and never acquire fabricated launch claims.
+
+``tessera.lane-eligibility.v5`` additionally requires every cell to name its
+exact image digest and execution-mode scope. Missing target context is
+unattested, never a request to use the global dense image or another cell.
 
 One parser, and why the vocabulary is wider than one publisher
 ---------------------------------------------------------------
@@ -96,7 +100,8 @@ audit state, the other a lane's executed route under the pinned release.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+import re
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
@@ -104,15 +109,16 @@ from typing import Any, Mapping, Sequence
 #: Schema of the eligibility table PrismaQuant consumes, published by Tessera's
 #: own vLLM plugin
 #: (``tessera.serving``, entry point ``tessera``, ``quant_method: "tessera"``).
-#: v4 adds executed launches and residency to v3's closed-world cell table.
-#: The parser owns both grammars; plugin requirements remain optional only
+#: v4 adds launches/residency; v5 adds exact runtime image/execution scope.
+#: The parser owns these grammars; plugin requirements remain optional only
 #: for explicitly identified legacy v3 tables.
 #:
 #: Until 2026-09-02 this set also carried ``gridbook.lane-eligibility.v3``, the
 #: same wire format published by the retired Gridbook codebook lane. That lane
 #: was removed with Rob's decision to put Tessera in PrismaQuant and remove
 #: Gridbook; see ``archive/gridbook_lane_2026-09-02/README.md``.
-LANE_ELIGIBILITY_SCHEMA_TESSERA = "tessera.lane-eligibility.v4"
+LANE_ELIGIBILITY_SCHEMA_TESSERA = "tessera.lane-eligibility.v5"
+LANE_ELIGIBILITY_SCHEMA_TESSERA_V4 = "tessera.lane-eligibility.v4"
 LANE_ELIGIBILITY_SCHEMA_TESSERA_LEGACY_V3 = "tessera.lane-eligibility.v3"
 
 #: Every eligibility-table schema this parser accepts. The check is a set
@@ -121,12 +127,19 @@ LANE_ELIGIBILITY_SCHEMA_TESSERA_LEGACY_V3 = "tessera.lane-eligibility.v3"
 #: subset of either supported grammar (see ``_parse_table``).
 LANE_ELIGIBILITY_SCHEMAS = frozenset({
     LANE_ELIGIBILITY_SCHEMA_TESSERA,
+    LANE_ELIGIBILITY_SCHEMA_TESSERA_V4,
     LANE_ELIGIBILITY_SCHEMA_TESSERA_LEGACY_V3,
 })
 
 #: The residency vocabulary in Tessera's v4 flag grammar. Each format row
 #: publishes the subset its route supports; no cell can widen that subset.
 TESSERA_RESIDENCY_MODES = frozenset({"resident", "streamed"})
+TESSERA_EXECUTION_MODES = frozenset({"eager", "compiled"})
+_LAUNCH_SCHEMAS = frozenset({
+    LANE_ELIGIBILITY_SCHEMA_TESSERA_V4, LANE_ELIGIBILITY_SCHEMA_TESSERA,
+})
+_DIGEST_IMAGE = re.compile(
+    r"[a-z0-9][a-z0-9._/-]*[a-z0-9]@sha256:[0-9a-f]{64}")
 
 #: Schema of the provenance payload this module produces. It was
 #: ``prismaquant.cb_route_attestation.v2`` until 2026-09-02, when the Gridbook
@@ -213,6 +226,48 @@ RATE_ADDRESSED_FORMAT_KINDS = frozenset({
 
 class LaneEligibilityError(ValueError):
     """The materialized contract or its eligibility table is malformed."""
+
+
+@dataclass(frozen=True)
+class ServingContext:
+    """The explicit target of a cell lookup; no field has a runtime default."""
+
+    platform: str
+    structure: str
+    residency: str
+    runtime_image: str
+    execution_mode: str
+
+    def __post_init__(self) -> None:
+        for name, value in self.as_dict().items():
+            if not isinstance(value, str) or not value.strip():
+                raise LaneEligibilityError(f"serving_context.{name} must be a non-empty string")
+        for name, allowed in (("structure", STRUCTURES),
+                              ("residency", TESSERA_RESIDENCY_MODES),
+                              ("execution_mode", TESSERA_EXECUTION_MODES)):
+            if getattr(self, name) not in allowed:
+                raise LaneEligibilityError(
+                    f"serving_context.{name} must be one of {sorted(allowed)}")
+        if not _DIGEST_IMAGE.fullmatch(self.runtime_image):
+            raise LaneEligibilityError(
+                "serving_context.runtime_image must be an exact repository@sha256:<64 lowercase hex> reference")
+
+    def as_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+    def key(self) -> tuple[str, ...]:
+        return tuple(self.as_dict().values())
+
+
+def cell_matches_serving_context(cell: Any, context: ServingContext) -> bool:
+    """Match a parsed v5 cell's whole scope, shared by every admission path."""
+    return (
+        cell.platform == context.platform
+        and cell.structure == context.structure
+        and context.residency in cell.residency_modes
+        and cell.runtime_image == context.runtime_image
+        and context.execution_mode in cell.execution_modes
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -350,6 +405,8 @@ class EligibilityCell:
     executes: tuple[tuple[str, str], ...] = ()
     #: Parsed from the v4 cell's explicit TESSERA_SERVE_MODE flag.
     residency_modes: tuple[str, ...] = ()
+    runtime_image: str = ""
+    execution_modes: tuple[str, ...] = ()
 
     @classmethod
     def from_dict(
@@ -380,9 +437,12 @@ class EligibilityCell:
         }
         if is_trellis:
             required.add("activation_contract")
-        is_v4 = schema == LANE_ELIGIBILITY_SCHEMA_TESSERA
+        is_v4 = schema in _LAUNCH_SCHEMAS
+        is_v5 = schema == LANE_ELIGIBILITY_SCHEMA_TESSERA
         if is_v4:
             required.update({"requires_plugin", "executes"})
+        if is_v5:
+            required.add("runtime")
         _require_keys(payload, where, required=required,
                       optional=set() if is_v4 else {"requires_plugin"})
 
@@ -435,6 +495,10 @@ class EligibilityCell:
         if is_v4:
             executes, cell_modes = parse_v4_cell_contract(
                 payload, where, residency_modes=residency_modes)
+        runtime_image = ""
+        execution_modes: tuple[str, ...] = ()
+        if is_v5:
+            runtime_image, execution_modes = parse_v5_runtime(payload["runtime"], where + ".runtime")
         flags = tuple(str(v) for v in payload["requires_serve_flags"])
         if flags and status != ROUTE_STATUS_BACKED_WITH_SERVE_FLAG:
             raise LaneEligibilityError(
@@ -464,6 +528,8 @@ class EligibilityCell:
             is_trellis=is_trellis,
             executes=executes,
             residency_modes=cell_modes,
+            runtime_image=runtime_image,
+            execution_modes=execution_modes,
         )
 
     def covers_rung(self, facts: UnitStructuralFacts) -> bool:
@@ -509,6 +575,10 @@ class EligibilityCell:
                 {"symbol": symbol, "decoder": decoder}
                 for symbol, decoder in self.executes
             ]
+        if self.runtime_image:
+            payload["runtime"] = {
+                "image": self.runtime_image, "execution_modes": list(self.execution_modes),
+            }
         return payload
 
 
@@ -590,6 +660,8 @@ class RegimeRoute:
     detail: str = ""
     executes: tuple[tuple[str, str], ...] = ()
     residency: str = ""
+    runtime_image: str = ""
+    execution_mode: str = ""
 
     def as_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -610,6 +682,9 @@ class RegimeRoute:
             ]
         if self.residency:
             payload["residency"] = self.residency
+        if self.runtime_image:
+            payload["runtime_image"] = self.runtime_image
+            payload["execution_mode"] = self.execution_mode
         return payload
 
 
@@ -697,6 +772,8 @@ def resolve_unit_route(
     *,
     platform: str | None = None,
     residency: str | None = None,
+    runtime_image: str | None = None,
+    execution_mode: str | None = None,
 ) -> UnitRoute:
     """Resolve one unit's route status against the pinned eligibility table.
 
@@ -708,10 +785,13 @@ def resolve_unit_route(
     platform-scoped, so resolving without one cannot name a route: a missing or
     unpublished platform yields ``unattested``, never a match-any.
 
-    v4 additionally requires ``residency``, the explicit serve mode for the
+    v4 and v5 additionally require ``residency``, the explicit serve mode for the
     artifact. It filters cells before route selection; omitting it cannot
     choose whichever same-scope cell happened to be listed first. v3 keeps
     its original behavior and makes no claim about executed launches.
+    V5 also requires ``runtime_image`` and ``execution_mode``. Every regime
+    must resolve on that same complete target; cells from different runtime
+    scopes cannot jointly attest one artifact.
     """
     if not table.present:
         return UnitRoute(
@@ -758,7 +838,8 @@ def resolve_unit_route(
             ),
         )
 
-    is_v4 = table.schema == LANE_ELIGIBILITY_SCHEMA_TESSERA
+    is_v4 = table.schema in _LAUNCH_SCHEMAS
+    is_v5 = table.schema == LANE_ELIGIBILITY_SCHEMA_TESSERA
     if is_v4 and residency not in TESSERA_RESIDENCY_MODES:
         return UnitRoute(
             facts=facts,
@@ -771,12 +852,23 @@ def resolve_unit_route(
             ),
         )
 
+    serving_context = None
+    if is_v5:
+        try:
+            serving_context = ServingContext(
+                platform=platform, structure=facts.structure, residency=residency,
+                runtime_image=runtime_image, execution_mode=execution_mode)
+        except LaneEligibilityError as exc:
+            return UnitRoute(facts=facts, route_status=ROUTE_STATUS_UNATTESTED,
+                             in_scope=True, unattested_reason=str(exc))
+
     candidates = [
         cell for cell in table.cells
         if cell.platform == platform
         and cell.family == facts.payload_family
         and cell.structure == facts.structure
         and (not is_v4 or residency in cell.residency_modes)
+        and (not is_v5 or cell_matches_serving_context(cell, serving_context))
         and cell.covers_rung(facts)
         and cell.matches(facts)
     ]
@@ -818,6 +910,8 @@ def resolve_unit_route(
             activation_contract=best.activation_contract,
             executes=best.executes,
             residency=str(residency) if is_v4 else "",
+            runtime_image=str(runtime_image) if is_v5 else "",
+            execution_mode=str(execution_mode) if is_v5 else "",
         ))
 
     unclaimed = [
@@ -845,6 +939,8 @@ def resolve_unit_route(
             f"rung {facts.k if facts.k is not None else facts.rate_q256!r} on "
             f"{platform}"
             + (f" at residency {residency!r}" if is_v4 else "")
+            + (f", runtime_image {runtime_image!r}, execution_mode {execution_mode!r}"
+               if is_v5 else "")
         )
         return UnitRoute(
             facts=facts,
@@ -1167,7 +1263,8 @@ def _parse_table(block: Any, formats: Any, version: str, commit: str, sha: str
 
     families, trellis_families = _published_families(formats)
     schema = str(block["schema"])
-    is_v4 = schema == LANE_ELIGIBILITY_SCHEMA_TESSERA
+    is_v4 = schema in _LAUNCH_SCHEMAS
+    is_v5 = schema == LANE_ELIGIBILITY_SCHEMA_TESSERA
     family_modes: dict[str, tuple[str, ...]] = {}
     if is_v4:
         for i, entry in enumerate(formats):
@@ -1222,14 +1319,17 @@ def _parse_table(block: Any, formats: Any, version: str, commit: str, sha: str
         scopes: dict[tuple[str, ...], str] = {}
         for cell in cells:
             for mode in cell.residency_modes:
-                scope = (cell.platform, cell.family, cell.structure, cell.regime, mode)
-                previous = scopes.get(scope)
-                if previous is not None:
-                    raise LaneEligibilityError(
-                        f"{where}.cells {previous!r} and {cell.id!r} both cover "
-                        f"{scope}; overlapping residency scopes make route "
-                        "resolution depend on cell order")
-                scopes[scope] = cell.id
+                for execution in cell.execution_modes if is_v5 else ("",):
+                    scope = (cell.platform, cell.family, cell.structure, cell.regime, mode)
+                    if is_v5:
+                        scope += (cell.runtime_image, execution)
+                    previous = scopes.get(scope)
+                    if previous is not None:
+                        raise LaneEligibilityError(
+                            f"{where}.cells {previous!r} and {cell.id!r} both cover "
+                            f"{scope}; overlapping serving scopes make route "
+                            "resolution depend on cell order")
+                    scopes[scope] = cell.id
 
     return EligibilityTable(
         present=True,
@@ -1244,6 +1344,25 @@ def _parse_table(block: Any, formats: Any, version: str, commit: str, sha: str
         families=families,
         trellis_families=trellis_families,
     )
+
+
+def parse_v5_runtime(payload: Any, where: str) -> tuple[str, tuple[str, ...]]:
+    """The v5 runtime grammar, shared by both contract readers."""
+    if not isinstance(payload, Mapping):
+        raise LaneEligibilityError(f"{where} must be a JSON object")
+    _require_keys(payload, where, required={"image", "execution_modes"}, optional=set())
+    image = payload["image"]
+    if not isinstance(image, str) or not _DIGEST_IMAGE.fullmatch(image):
+        raise LaneEligibilityError(
+            f"{where}.image must be an exact repository@sha256:<64 lowercase hex> reference")
+    modes = payload["execution_modes"]
+    if (not isinstance(modes, list) or not modes
+            or any(not isinstance(mode, str) or mode not in TESSERA_EXECUTION_MODES for mode in modes)
+            or len(set(modes)) != len(modes)):
+        raise LaneEligibilityError(
+            f"{where}.execution_modes must be a non-empty list of distinct values from "
+            f"{sorted(TESSERA_EXECUTION_MODES)}")
+    return image, tuple(modes)
 
 
 def parse_v4_cell_contract(

--- a/prismaquant/lane_eligibility.py
+++ b/prismaquant/lane_eligibility.py
@@ -373,13 +373,14 @@ _PREDICABLE_FACTS: dict[str, str] = {
 # ---------------------------------------------------------------------------
 @dataclass(frozen=True)
 class EligibilityCell:
-    """One packaged cell: bytes, platform, regime, residency and launch.
+    """One packaged cell: bytes, platform, regime, residency, runtime and launch.
 
     A cell is scoped to exactly one ``(platform, family, structure, regime)``
     and covers an explicit, non-empty rung list. It carries no prose: a
     validator refuses ``detail``/``rationale`` keys on a cell, because a gate
     cannot read prose (principle 14). Legacy v3 alone permits an absent plugin
-    key. v4 requires Tessera, launch declarations and residency flags.
+    key. v4 requires Tessera, launch declarations and residency flags; v5
+    additionally scopes every cell to an exact image and execution-mode set.
     """
 
     id: str

--- a/prismaquant/lane_eligibility.py
+++ b/prismaquant/lane_eligibility.py
@@ -270,6 +270,15 @@ def cell_matches_serving_context(cell: Any, context: ServingContext) -> bool:
     )
 
 
+def legacy_runtime_scope_refusal(schema: str) -> str:
+    """The one refusal for a scoped query a legacy table cannot attest."""
+    return (
+        f"lane schema {schema!r} carries no per-cell runtime scope; an explicit "
+        f"serving context (runtime-image/execution query) requires {LANE_ELIGIBILITY_SCHEMA_TESSERA!r}. "
+        "Global runtime identity is not a scoped admission."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Structural facts of one selected unit
 # ---------------------------------------------------------------------------
@@ -840,6 +849,10 @@ def resolve_unit_route(
 
     is_v4 = table.schema in _LAUNCH_SCHEMAS
     is_v5 = table.schema == LANE_ELIGIBILITY_SCHEMA_TESSERA
+    if not is_v5 and (runtime_image is not None or execution_mode is not None):
+        return UnitRoute(
+            facts=facts, route_status=ROUTE_STATUS_UNATTESTED, in_scope=True,
+            unattested_reason=legacy_runtime_scope_refusal(table.schema))
     if is_v4 and residency not in TESSERA_RESIDENCY_MODES:
         return UnitRoute(
             facts=facts,

--- a/prismaquant/serving_profiles.py
+++ b/prismaquant/serving_profiles.py
@@ -12,7 +12,10 @@ import re
 from dataclasses import dataclass, field
 from importlib import import_module
 from pathlib import Path
-from typing import Any, Collection, Mapping
+from typing import TYPE_CHECKING, Any, Collection, Mapping
+
+if TYPE_CHECKING:
+    from .lane_eligibility import ServingContext
 
 from . import format_registry as fr
 
@@ -430,9 +433,10 @@ class ResolvedServingLane:
     route_status: str = "unattested"
     requires_serve_flags: tuple[str, ...] = ()
     route_status_source: str = ""
+    serving_context: "ServingContext | None" = None
 
     def as_dict(self) -> dict:
-        return {
+        payload = {
             "lane_id": self.lane_id,
             "format": self.format,
             "rung": self.rung,
@@ -451,17 +455,23 @@ class ResolvedServingLane:
             "fused_mid_m_rungs_source": self.rungs_source,
             "detail": self.detail,
         }
+        if self.serving_context is not None:
+            payload["serving_context"] = self.serving_context.as_dict()
+        return payload
 
     def route_key(self) -> str:
         """Stable one-line identity for candidate/provenance comparison."""
+        payload = {
+            "lane": self.lane_id,
+            "act": self.activation_contract,
+            "fused_mid_m": bool(self.fused_mid_m_backed),
+            "runtime": self.runtime_version,
+            "route_status": self.route_status,
+        }
+        if self.serving_context is not None:
+            payload["serving_context"] = self.serving_context.as_dict()
         return json.dumps(
-            {
-                "lane": self.lane_id,
-                "act": self.activation_contract,
-                "fused_mid_m": bool(self.fused_mid_m_backed),
-                "runtime": self.runtime_version,
-                "route_status": self.route_status,
-            },
+            payload,
             separators=(",", ":"),
             sort_keys=True,
         )
@@ -1354,6 +1364,7 @@ def serving_lane_route(
     fmt: str,
     *,
     runtime_version: str | None = None,
+    serving_context: "ServingContext | None" = None,
 ) -> ResolvedServingLane | None:
     """Resolve one format's serving-lane route under a target profile."""
     try:
@@ -1382,7 +1393,9 @@ def serving_lane_route(
     if isinstance(fmt, str) and fmt.startswith("TESSERA_"):
         from .tessera_menu import tessera_resolved_serving_lane
         return tessera_resolved_serving_lane(
-            fmt, runtime_version=(runtime_version or ""))
+            fmt, runtime_version=(runtime_version or ""),
+            **({"serving_context": serving_context}
+               if serving_context is not None else {}))
     return None
 
 

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -54,6 +54,10 @@ import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .lane_eligibility import ServingContext
 
 from . import tessera_hessian as th
 
@@ -575,14 +579,18 @@ def _calibration_tokens(model_path: str, n: int, seqlen: int, seed: int):
 
 
 def expand_menus_for_targets(weights, targets, *, mode, tp_degree,
-                             parallel_kind) -> dict[str, list]:
-    """One Tessera menu per distinct shape, shared across same-shape units.
+                             parallel_kind,
+                             context_by_unit: "Mapping[str, ServingContext] | None" = None,
+                             ) -> dict[str, list]:
+    """One Tessera menu per distinct shape and explicit serving context.
 
     ``expand_tessera_menu`` takes nothing but the shape and the run
-    configuration -- no argument identifies the unit, and ``MenuRung`` carries
-    no unit field -- so two units of one shape get identical lists.  Units
+    configuration and serving context, so units with equal values of those
+    inputs get identical lists. Dense and routed expert units may share one
+    shape; their structural class comes from context_by_unit, never shape or
+    name. A missing map entry remains unbound. Units
     repeat shapes ~1500:1 on a production MoE, so expanding per Linear repeats
-    the same answer thousands of times; keying by shape expands once per
+    the same answer thousands of times; keying by shape and context expands once per
     distinct answer instead.  Exact rather than approximate: same arguments,
     same list.  The lists are shared, not copied -- downstream only iterates
     them -- which is also what makes ``menu_cache_shapes``' retention the
@@ -590,16 +598,19 @@ def expand_menus_for_targets(weights, targets, *, mode, tp_degree,
     """
     from .tessera_menu import expand_tessera_menu
 
-    by_shape: dict[tuple, list] = {}
+    by_shape_and_context: dict[tuple, list] = {}
     menus: dict[str, list] = {}
     for name in targets:
         shape = tuple(weights[name].shape)
-        if shape not in by_shape:
-            by_shape[shape] = expand_tessera_menu(
+        context = None if context_by_unit is None else context_by_unit.get(name)
+        key = (shape, None if context is None else context.key())
+        if key not in by_shape_and_context:
+            by_shape_and_context[key] = expand_tessera_menu(
                 shape, mode=mode, tp_degree=tp_degree,
                 parallel_kind=parallel_kind,
+                **({"serving_context": context} if context is not None else {}),
             )
-        menus[name] = by_shape[shape]
+        menus[name] = by_shape_and_context[key]
     return menus
 
 

--- a/prismaquant/tessera_hessian.py
+++ b/prismaquant/tessera_hessian.py
@@ -153,29 +153,23 @@ def unit_name_for(qname: str) -> str:
 def encoder_recipe() -> dict:
     """The activation-aware recipe an ``ActivationSource`` applies by default.
 
-    Read from Tessera's own dataclass defaults, so a receipt quoting "sigma
-    1.0, block 32, exact-H refit" is quoting the encoder rather than a comment.
+    Read from Tessera's own default object's exported config, so the producer
+    owns both the setting roster and its JSON-safe normalization. In
+    particular, an unset trailing objective and a disabled Gauss-Seidel sweep
+    remain explicit settings; per-plane maps remain maps rather than one
+    plane's answer quoted over another plane's artifact.
 
-    ``refit_objective`` is a **map from scale plane to objective** since
-    Tessera's 2026-09-02 release gave the LUT plane a refit of its own: the
-    receipt records all of it, because a single objective quoted here would be
-    a true statement about one plane printed over an artifact built on
-    another.  It is copied into a plain ``dict`` -- Tessera hands back a
-    ``MappingProxyType``, which this block is stamped into cost payloads that
-    ``json.dumps`` would refuse.
+    Only the Hessian capture identity and explanatory note are excluded: the
+    caller records the capture separately, and prose is not an encoder rule.
     """
     from tessera.export import ActivationSource
 
     source = ActivationSource(
         hessians={}, provenance={f: "" if f.endswith("sha256") else 0
                                  for f in HESSIAN_IDENTITY_FIELDS})
-    objective = source.refit_objective
     return {
-        "ldlq_sigma": source.ldlq_sigma,
-        "ldlq_block": source.ldlq_block,
-        "refit_objective": (objective if isinstance(objective, str)
-                            else dict(objective)),
-        "refit_reach_floor": source.refit_reach_floor,
+        key: value for key, value in source.config_block().items()
+        if key not in {"hessian", "note"}
     }
 
 
@@ -215,13 +209,14 @@ def encoder_kwargs(source, qname: str, in_features: int, device="cpu", *,
     refusal is right: pricing a unit under the other plane's objective prices
     an artifact the export does not ship (principle 8).
 
-    **What is hoistable, and what is not.**  Two of the four keywords are a
-    function of the Hessian alone -- ``ldl`` (the block-LDL factorisation,
-    which is the expensive part) and ``ldl_block`` -- and the other two are a
-    function of the Hessian *and the plane*.  The plane is a function of the
-    grid, not of the rung: measured over every family PrismaQuant allocates
-    (``realisable_rungs`` x ``tessera_wire_recipe``), the plane is constant
-    across every rung of every family, and differs across families --
+    **What is hoistable, and what is not.**  ``ldl`` (the expensive block-LDL
+    factorisation) and ``ldl_block`` depend on the Hessian and the source's
+    fixed settings, not the plane. The refit objective, trailing objective
+    and sweep settings are resolved for the unit's plane. The plane is a
+    function of the grid, not of the rung: measured over every family
+    PrismaQuant allocates (``realisable_rungs`` x ``tessera_wire_recipe``), the
+    plane is constant across every rung of every family, and differs across
+    families --
     ``channel`` on ``TESSERA_E4M3_K1``, ``lut16`` on both E2M1 families and
     every free grid.  ``TESSERA_E2M1_K2`` changes *body* at the coset cap
     (WINDOW below q896, TCQ at it) and keeps its plane through the change.

--- a/prismaquant/tessera_menu.py
+++ b/prismaquant/tessera_menu.py
@@ -78,6 +78,7 @@ if TYPE_CHECKING:
 
 from .lane_eligibility import (
     LANE_ELIGIBILITY_SCHEMA_TESSERA,
+    legacy_runtime_scope_refusal,
     ROUTE_STATUS_BACKED,
     ROUTE_STATUS_BACKED_WITH_SERVE_FLAG,
     ROUTE_STATUS_UNATTESTED,
@@ -481,6 +482,8 @@ def route_admission(
     A v5 development contract requires the caller's complete serving context.
     Its own scoped lookup checks every required regime under that one target;
     an absent context cannot borrow the runtime or structure of another cell.
+    A legacy contract retains its context-free admission but cannot attest a
+    newly supplied runtime context it has no per-cell evidence to answer.
     """
     from .tessera_render import (
         _pinned_serving_table, tessera_attesting_cells, tessera_lane_admission,
@@ -503,10 +506,14 @@ def route_admission(
         source = _tessera_attestation_source(contract)
         world = contract.max_world_size.get(family.name)
         requires_context = bool(getattr(contract, "requires_serving_context", False))
+        legacy_scope_reason = (
+            legacy_runtime_scope_refusal(getattr(contract, "lane_schema", "legacy"))
+            if serving_context is not None and not requires_context else ""
+        )
         cells = (
             (contract.native_cells(family.name, rung, serving_context=serving_context)
              if serving_context is not None else contract.native_cells(family.name, rung))
-            if contract.governs(family.name) else ()
+            if not legacy_scope_reason and contract.governs(family.name) else ()
         )
         if cells:
             # The status is the CELL's, not a constant. A cell that says
@@ -536,7 +543,7 @@ def route_admission(
         else:
             status = ROUTE_STATUS_UNATTESTED
             published = sorted(contract.attested_rungs.get(family.name, ()))
-            detail = (
+            detail = legacy_scope_reason or (
                 f"the pinned Tessera contract publishes {family.name} at "
                 f"rungs {published} and no native cell covers R{rung}"
                 if contract.governs(family.name) else

--- a/prismaquant/tessera_menu.py
+++ b/prismaquant/tessera_menu.py
@@ -71,9 +71,13 @@ from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from fractions import Fraction
 from functools import lru_cache
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
+
+if TYPE_CHECKING:
+    from .lane_eligibility import ServingContext
 
 from .lane_eligibility import (
+    LANE_ELIGIBILITY_SCHEMA_TESSERA,
     ROUTE_STATUS_BACKED,
     ROUTE_STATUS_BACKED_WITH_SERVE_FLAG,
     ROUTE_STATUS_UNATTESTED,
@@ -248,6 +252,10 @@ class RouteAdmission:
     #: family, or ``None`` when no contract governs it.  ``closed_world``
     #: semantics: absence is "not attested at any degree", not "any degree".
     max_world_size: "int | None" = None
+    #: The caller's explicit target, never inferred from a matching cell.
+    serving_context: "ServingContext | None" = None
+    #: Whether this contract requires the complete serving scope for admission.
+    requires_serving_context: bool = False
 
     @property
     def attested(self) -> bool:
@@ -422,7 +430,9 @@ def check_tessera_activation_agreement(name, route, cell_contracts) -> None:
         )
 
 
-def route_admission(name: str) -> RouteAdmission:
+def route_admission(
+    name: str, *, serving_context: "ServingContext | None" = None,
+) -> RouteAdmission:
     """The pinned runtime's verdict on one Tessera rung.  **The one seam.**
 
     This is the single function in the production path that reads a serving
@@ -467,6 +477,10 @@ def route_admission(name: str) -> RouteAdmission:
     whenever cells attest the rung: the priced ``route`` and the executed
     cell ``activation_contract`` must project to the same ``(act_bits,
     act_group_size)``, on both the dev-pin and the packaged-contract paths.
+
+    A v5 development contract requires the caller's complete serving context.
+    Its own scoped lookup checks every required regime under that one target;
+    an absent context cannot borrow the runtime or structure of another cell.
     """
     from .tessera_render import (
         _pinned_serving_table, tessera_attesting_cells, tessera_lane_admission,
@@ -484,11 +498,14 @@ def route_admission(name: str) -> RouteAdmission:
     contract = tessera_runtime_contract()
     flags: tuple[str, ...] = ()
     world: "int | None" = None
+    requires_context = False
     if contract is not None:
         source = _tessera_attestation_source(contract)
         world = contract.max_world_size.get(family.name)
+        requires_context = bool(getattr(contract, "requires_serving_context", False))
         cells = (
-            contract.native_cells(family.name, rung)
+            (contract.native_cells(family.name, rung, serving_context=serving_context)
+             if serving_context is not None else contract.native_cells(family.name, rung))
             if contract.governs(family.name) else ()
         )
         if cells:
@@ -525,14 +542,23 @@ def route_admission(name: str) -> RouteAdmission:
                 if contract.governs(family.name) else
                 f"the pinned Tessera contract does not publish {family.name}"
             )
+            if requires_context:
+                detail += (
+                    "; no explicit serving context was supplied"
+                    if serving_context is None else
+                    f" under serving context {serving_context.as_dict()}"
+                )
     else:
         table, formats = _pinned_serving_table()
         source = _packaged_attestation_source(table)
+        requires_context = table.schema == LANE_ELIGIBILITY_SCHEMA_TESSERA
+        scope = ({"serving_context": serving_context}
+                 if serving_context is not None else {})
         # The VERDICT stays ``tessera_lane_attested``: it is the seam every
         # gate consults and the one the tests substitute.  The REASON is read
         # separately and only when the verdict is False, so patching the
         # verdict cannot invent a rationale the contract never gave.
-        if bool(tessera_lane_attested(name, table=table, formats=formats)):
+        if bool(tessera_lane_attested(name, table=table, formats=formats, **scope)):
             status = ROUTE_STATUS_BACKED
             detail = (
                 "the packaged Tessera contract attests a device-qualified "
@@ -540,8 +566,8 @@ def route_admission(name: str) -> RouteAdmission:
             )
         else:
             status = ROUTE_STATUS_UNATTESTED
-            detail = tessera_lane_admission(name, table=table, formats=formats)[1]
-        attesting = tessera_attesting_cells(name, table=table, formats=formats)
+            detail = tessera_lane_admission(name, table=table, formats=formats, **scope)[1]
+        attesting = tessera_attesting_cells(name, table=table, formats=formats, **scope)
         if attesting:
             check_tessera_activation_agreement(
                 name, route,
@@ -561,6 +587,8 @@ def route_admission(name: str) -> RouteAdmission:
         detail=detail,
         requires_serve_flags=flags,
         max_world_size=world,
+        serving_context=serving_context,
+        requires_serving_context=requires_context,
     )
 
 
@@ -573,7 +601,10 @@ def route_admission(name: str) -> RouteAdmission:
 TESSERA_LANE_ID = "tessera_admission"
 
 
-def tessera_resolved_serving_lane(name: str, *, runtime_version: str = ""):
+def tessera_resolved_serving_lane(
+    name: str, *, runtime_version: str = "",
+    serving_context: "ServingContext | None" = None,
+):
     """The resolved serving route of one Tessera rung, or None.
 
     ``serving_profiles.serving_lane_route`` covers formats by NAME out of a
@@ -598,7 +629,8 @@ def tessera_resolved_serving_lane(name: str, *, runtime_version: str = ""):
 
     if parse_tessera_format_name(name) is None:
         return None
-    admission = route_admission(name)
+    admission = (route_admission(name, serving_context=serving_context)
+                 if serving_context is not None else route_admission(name))
     return ResolvedServingLane(
         lane_id=TESSERA_LANE_ID,
         format=name,
@@ -614,6 +646,7 @@ def tessera_resolved_serving_lane(name: str, *, runtime_version: str = ""):
         route_status=admission.route_status,
         requires_serve_flags=admission.requires_serve_flags,
         route_status_source=admission.source,
+        serving_context=getattr(admission, "serving_context", serving_context),
     )
 
 
@@ -1113,7 +1146,7 @@ class MenuRung:
         return self.admission.route_status
 
     def as_dict(self) -> dict:
-        return {
+        payload = {
             "format": self.format_name,
             "family": self.family,
             "body_rate_q256": self.body_rate_q256,
@@ -1128,6 +1161,9 @@ class MenuRung:
             "tp_degree": int(self.tp_degree),
             "tp_parallel_kind": self.parallel_kind,
         }
+        if self.admission.serving_context is not None:
+            payload["serving_context"] = self.admission.serving_context.as_dict()
+        return payload
 
 
 @lru_cache(maxsize=1)
@@ -1173,6 +1209,7 @@ def expand_tessera_menu(
     tp_degree: int = 1,
     parallel_kind: str = PARALLEL_NONE,
     max_act_bits: "int | None" = None,
+    serving_context: "ServingContext | None" = None,
 ) -> list[MenuRung]:
     """Every Tessera rung legal for one unit, cheapest first.
 
@@ -1205,7 +1242,8 @@ def expand_tessera_menu(
         lo, hi = spec.mathematical_q256_bounds
         for rung in range(lo, hi + 1, max(1, int(step_q256))):
             name = spec.format_name(rung)
-            admission = route_admission(name)
+            admission = (route_admission(name, serving_context=serving_context)
+                         if serving_context is not None else route_admission(name))
             if not admission.admits(mode):
                 continue
             legal, _reason = tessera_tp_legal(

--- a/prismaquant/tessera_render.py
+++ b/prismaquant/tessera_render.py
@@ -26,6 +26,7 @@ A second copy of a rate constant is a drift bug waiting for a rate to change.
 from __future__ import annotations
 
 import functools
+from typing import TYPE_CHECKING
 
 from functools import lru_cache
 
@@ -42,6 +43,9 @@ from .tessera_formats import (
     tessera_wire_recipe,
 )
 from .tessera_serving_runtime_pin import TESSERA_SERVING_PLUGIN_NAME
+
+if TYPE_CHECKING:
+    from .lane_eligibility import ServingContext
 
 __all__ = [
     "TESSERA_CONV_MEMORY",
@@ -160,7 +164,9 @@ def _release_pin_satisfied() -> bool:
     return True
 
 
-def tessera_attesting_cells(name: str, *, table=None, formats=None) -> tuple:
+def tessera_attesting_cells(
+        name: str, *, table=None, formats=None,
+        serving_context: ServingContext | None = None) -> tuple:
     """The native device-qualified cells covering this rung, or ``()``.
 
     The match predicate of :func:`tessera_lane_admission`'s first conjunct,
@@ -170,8 +176,13 @@ def tessera_attesting_cells(name: str, *, table=None, formats=None) -> tuple:
     verdict -- the caller reports *why* (no table, unpublished family, rate
     no cell names), exactly as the admission does.  The plugin-requirement
     check stays in the admission: it is a defect verdict, not a match rule.
+    A v5 table must cover every published regime within the same explicit
+    serving context; neither missing scope nor another image's cell attests it.
     """
-    from .lane_eligibility import resolve_payload_rung
+    from .lane_eligibility import (
+        LANE_ELIGIBILITY_SCHEMA_TESSERA, cell_matches_serving_context,
+        resolve_payload_rung,
+    )
 
     if table is None or formats is None:
         pinned_table, pinned_formats = _pinned_serving_table()
@@ -182,18 +193,26 @@ def tessera_attesting_cells(name: str, *, table=None, formats=None) -> tuple:
     family, _k, rate = resolve_payload_rung(name, published_formats=formats)
     if rate is None or not table.governs(family):
         return ()
-    return tuple(
+    scoped = table.schema == LANE_ELIGIBILITY_SCHEMA_TESSERA
+    if scoped and serving_context is None:
+        return ()
+    matched = tuple(
         cell for cell in table.cells
         if cell.is_trellis
         and cell.family == family
         and rate in cell.rungs_q256
         and cell.qualification == "device_qualified"
         and cell.route_status in _NATIVE_ROUTE_STATUSES
+        and (not scoped or cell_matches_serving_context(cell, serving_context))
     )
+    if scoped and {cell.regime for cell in matched} != set(table.regimes):
+        return ()
+    return matched
 
 
 def tessera_lane_admission(
-        name: str, *, table=None, formats=None) -> tuple[bool, str]:
+        name: str, *, table=None, formats=None,
+        serving_context: ServingContext | None = None) -> tuple[bool, str]:
     """Does a pinned runtime execute this Tessera rung natively, and why not?
 
     Returns ``(attested, reason)``.  ``reason`` is empty when the answer is
@@ -213,7 +232,9 @@ def tessera_lane_admission(
     1. **The table admits the rung.**  The contract publishes the name's
        payload family (``TESSERA_E2M1_K2`` for ``TESSERA_E2M1_K2_R896``) and
        carries a ``device_qualified`` cell whose route executes natively and
-       whose ``rungs_q256`` names this rate, on any platform it names.  No
+       whose ``rungs_q256`` names this rate. V5 additionally requires every
+       regime within the caller's explicit platform, structure, residency,
+       runtime image and execution mode; v3/v4 retain their legacy lookup. No
        table, an unpublished family, a rate no cell names, a ``compile_only``
        cell or a ``fallback`` route all answer False.
     2. **Every matching cell states its plugin requirement.**  Stock vLLM has
@@ -237,9 +258,8 @@ def tessera_lane_admission(
        PENDING sentinels and **every Tessera rung is producer-ineligible by
        the pin, not by an edit here**.
 
-    The per-artifact question -- THIS platform, THIS unit's regimes -- stays
-    with ``lane_eligibility.resolve_unit_route`` at export; this is
-    the menu-level admission, one lookup.
+    This is the scoped menu-level admission, one lookup. Per-unit structural
+    predicates stay with ``lane_eligibility.resolve_unit_route`` at export.
 
     History: until 2026-09-02 this was a module constant (``False``), then a
     lookup against GRIDBOOK's serving pin, whose unreleased contract v13/v14
@@ -247,7 +267,8 @@ def tessera_lane_admission(
     Gridbook pin no longer governs Tessera admission.
     """
     from .lane_eligibility import (
-        LaneEligibilityError, resolve_payload_rung,
+        LANE_ELIGIBILITY_SCHEMA_TESSERA, LaneEligibilityError,
+        resolve_payload_rung,
     )
     if table is None or formats is None:
         pinned_table, pinned_formats = _pinned_serving_table()
@@ -265,8 +286,20 @@ def tessera_lane_admission(
     if not table.governs(family):
         return False, (
             f"the packaged Tessera contract does not publish {family}")
-    matched = list(tessera_attesting_cells(name, table=table, formats=formats))
+    scoped = table.schema == LANE_ELIGIBILITY_SCHEMA_TESSERA
+    if scoped and serving_context is None:
+        return False, (
+            f"{name}: the packaged Tessera v5 contract requires an explicit "
+            "serving context (platform, structure, residency, runtime image "
+            "and execution mode)")
+    scope = {"serving_context": serving_context} if serving_context is not None else {}
+    matched = list(tessera_attesting_cells(name, table=table, formats=formats, **scope))
     if not matched:
+        if scoped:
+            return False, (
+                f"the packaged Tessera contract has no complete device-qualified "
+                f"native regime population for {family} R{rate} in serving "
+                f"context {serving_context.as_dict()}")
         published = _published_rungs(formats, family)
         return False, (
             f"the packaged Tessera contract publishes {family} at rungs "
@@ -303,14 +336,17 @@ def _published_rungs(formats, family: str) -> list[int]:
     return sorted(int(r) for r in row.get("candidate_rungs_q256", ()))
 
 
-def tessera_lane_attested(name: str, *, table=None, formats=None) -> bool:
+def tessera_lane_attested(
+        name: str, *, table=None, formats=None,
+        serving_context: ServingContext | None = None) -> bool:
     """The boolean half of :func:`tessera_lane_admission`.  **The one seam.**
 
     Kept as its own name because it is what every gate consults and what the
     tests substitute; the reason string is a separate read so that patching
     the verdict cannot silently invent a rationale for it.
     """
-    return tessera_lane_admission(name, table=table, formats=formats)[0]
+    scope = {"serving_context": serving_context} if serving_context is not None else {}
+    return tessera_lane_admission(name, table=table, formats=formats, **scope)[0]
 
 
 def is_tessera_format(name: object) -> bool:
@@ -444,7 +480,8 @@ def tessera_rung_is_serialisable(name: str) -> bool:
     return family_grid_is_serialisable(parsed[0])
 
 
-def _producer_eligible(name: str) -> bool:
+def _producer_eligible(
+        name: str, *, serving_context: ServingContext | None = None) -> bool:
     """Producer-eligibility for one rung: the AND of two independent gates.
 
     (a) **The wire can carry it** -- the grid's digest is a permanent
@@ -465,7 +502,8 @@ def _producer_eligible(name: str) -> bool:
 
     if not tessera_rung_is_serialisable(name):
         return False
-    return route_admission(name).admits(menu_mode())
+    scope = {"serving_context": serving_context} if serving_context is not None else {}
+    return route_admission(name, **scope).admits(menu_mode())
 
 
 def _plan(family: TesseraFamily, body_rate_q256: int, n_columns: int, recipe):
@@ -630,7 +668,9 @@ def _identity_activation(x: torch.Tensor) -> torch.Tensor:
     return x
 
 
-def synthesize_tessera_spec(name: str, *, recipe=None, shape=None):
+def synthesize_tessera_spec(
+        name: str, *, recipe=None, shape=None,
+        serving_context: ServingContext | None = None):
     """Build a ``FormatSpec`` for a Tessera rung on demand, or return None.
 
     Returning None rather than raising for a non-Tessera name is what lets
@@ -639,7 +679,9 @@ def synthesize_tessera_spec(name: str, *, recipe=None, shape=None):
     naming the registry, not a Tessera parse failure.
 
     ``recipe`` is the wire being described and defaults to the one the
-    exporter writes for this family at this rung.
+    exporter writes for this family at this rung. ``serving_context`` scopes
+    producer eligibility, not the wire or its price. Under v5 the attested
+    menu requires this context; research keeps its existing unattested policy.
 
     Every recipe charges something **per unit** -- a CHANNEL row field, a
     WINDOW table, a TCQ forest -- so no Tessera rung has a bits-per-parameter
@@ -793,7 +835,8 @@ def synthesize_tessera_spec(name: str, *, recipe=None, shape=None):
         # wire half (a) is unconditional in both modes; only the attestation
         # half (b) relaxes, and it relaxes into ``route_status: unattested``
         # stamped on the candidate, which is what export fails closed on.
-        producer_eligible=_producer_eligible(name),
+        producer_eligible=_producer_eligible(name, **(
+            {"serving_context": serving_context} if serving_context is not None else {})),
         # The shape-aware price, for a wire whose per-unit planes make the
         # rate a function of the tensor.  Exactly one of this and
         # ``exact_bits_per_param`` is set: a rung either has a rate or it has

--- a/prismaquant/tessera_render.py
+++ b/prismaquant/tessera_render.py
@@ -196,6 +196,8 @@ def tessera_attesting_cells(
     scoped = table.schema == LANE_ELIGIBILITY_SCHEMA_TESSERA
     if scoped and serving_context is None:
         return ()
+    if not scoped and serving_context is not None:
+        return ()
     matched = tuple(
         cell for cell in table.cells
         if cell.is_trellis
@@ -268,7 +270,7 @@ def tessera_lane_admission(
     """
     from .lane_eligibility import (
         LANE_ELIGIBILITY_SCHEMA_TESSERA, LaneEligibilityError,
-        resolve_payload_rung,
+        legacy_runtime_scope_refusal, resolve_payload_rung,
     )
     if table is None or formats is None:
         pinned_table, pinned_formats = _pinned_serving_table()
@@ -287,6 +289,8 @@ def tessera_lane_admission(
         return False, (
             f"the packaged Tessera contract does not publish {family}")
     scoped = table.schema == LANE_ELIGIBILITY_SCHEMA_TESSERA
+    if not scoped and serving_context is not None:
+        return False, legacy_runtime_scope_refusal(table.schema)
     if scoped and serving_context is None:
         return False, (
             f"{name}: the packaged Tessera v5 contract requires an explicit "

--- a/prismaquant/tessera_runtime_contract.py
+++ b/prismaquant/tessera_runtime_contract.py
@@ -573,10 +573,13 @@ class TesseraContract:
                      ) -> tuple[TesseraRouteCell, ...]:
         """V5 admits every required regime only under one explicit context.
 
-        Legacy v4 keeps its historical family/rate projection. V5 never uses
+        Context-free v4 keeps its historical family/rate projection. An
+        explicit runtime query cannot borrow that unscoped claim. V5 never uses
         the first matching cell to infer an image, execution mode or structure.
         """
         if self.requires_serving_context and serving_context is None:
+            return ()
+        if not self.requires_serving_context and serving_context is not None:
             return ()
         selected = tuple(
             cell for cell in self.cells

--- a/prismaquant/tessera_runtime_contract.py
+++ b/prismaquant/tessera_runtime_contract.py
@@ -78,11 +78,14 @@ from typing import Any, Mapping, Sequence
 
 from .lane_eligibility import (
     LANE_ELIGIBILITY_SCHEMA_TESSERA,
+    LANE_ELIGIBILITY_SCHEMA_TESSERA_V4,
     LaneEligibilityError,
+    ServingContext,
     QUALIFICATION_DEVICE_QUALIFIED,
     ROUTE_STATUS_BACKED,
     ROUTE_STATUS_BACKED_WITH_SERVE_FLAG,
     _parse_table,
+    cell_matches_serving_context,
 )
 
 __all__ = [
@@ -118,6 +121,7 @@ class TesseraContractError(RuntimeError):
 #: wrong error to hand someone whose contract predates the field.
 TESSERA_CONTRACT_SCHEMA = "tessera.runtime-contract.v1"
 TESSERA_LANE_SCHEMA = LANE_ELIGIBILITY_SCHEMA_TESSERA
+TESSERA_LANE_SCHEMAS = frozenset({TESSERA_LANE_SCHEMA, LANE_ELIGIBILITY_SCHEMA_TESSERA_V4})
 #: The ``fused_module`` block's own schema id, checked the same way.
 FUSED_MODULE_SCHEMA = "tessera.fused-module.v1"
 
@@ -428,6 +432,8 @@ class TesseraRouteCell:
     requires_serve_flags: tuple[str, ...]
     executes: tuple[tuple[str, str], ...]
     residency_modes: tuple[str, ...]
+    runtime_image: str
+    execution_modes: tuple[str, ...]
 
     @property
     def native(self) -> bool:
@@ -551,20 +557,38 @@ class TesseraContract:
     commit: str
     sha256: str
     path: str
+    lane_schema: str
+    regimes: tuple[str, ...]
+
+    @property
+    def requires_serving_context(self) -> bool:
+        return self.lane_schema == LANE_ELIGIBILITY_SCHEMA_TESSERA
 
     def governs(self, family: str) -> bool:
         """Does the contract publish this payload family at all?"""
         return str(family) in self.reader_rate_range
 
-    def native_cells(self, family: str, rate_q256: int
+    def native_cells(self, family: str, rate_q256: int, *,
+                     serving_context: ServingContext | None = None,
                      ) -> tuple[TesseraRouteCell, ...]:
-        """Every native cell covering ``(family, rate)``, on any platform."""
-        return tuple(
+        """V5 admits every required regime only under one explicit context.
+
+        Legacy v4 keeps its historical family/rate projection. V5 never uses
+        the first matching cell to infer an image, execution mode or structure.
+        """
+        if self.requires_serving_context and serving_context is None:
+            return ()
+        selected = tuple(
             cell for cell in self.cells
             if cell.family == str(family)
             and int(rate_q256) in cell.rungs_q256
             and cell.native
+            and (not self.requires_serving_context
+                 or cell_matches_serving_context(cell, serving_context))
         )
+        if self.requires_serving_context and {cell.regime for cell in selected} != set(self.regimes):
+            return ()
+        return selected
 
     def identity(self) -> dict:
         """The ``tessera_dev_pin`` provenance block.
@@ -696,7 +720,9 @@ def contract_answer(contract: "TesseraContract") -> dict:
     """
     return {
         "schema": TESSERA_CONTRACT_SCHEMA,
-        "lane_schema": TESSERA_LANE_SCHEMA,
+        "lane_schema": contract.lane_schema,
+        **({"required_regimes": sorted(contract.regimes)}
+           if contract.requires_serving_context else {}),
         "quant_method": contract.quant_method,
         "fused_module": contract.fused_module.answer(),
         "native_extensions": [
@@ -738,7 +764,9 @@ def contract_answer(contract: "TesseraContract") -> dict:
                 sorted(cell.requires_serve_flags),
                 [list(launch) for launch in sorted(cell.executes)],
                 sorted(cell.residency_modes),
-            ]
+            ] + ([{"image": cell.runtime_image,
+                   "execution_modes": sorted(cell.execution_modes)}]
+                 if contract.requires_serving_context else [])
             for cell in contract.cells
         ),
     }
@@ -748,7 +776,7 @@ def _answer_drift(reviewed: Mapping[str, Any], installed: Mapping[str, Any]
                   ) -> list[str]:
     """Field-level lines naming what moved, so the refusal is reviewable."""
     lines: list[str] = []
-    for key in ("schema", "lane_schema", "quant_method"):
+    for key in ("schema", "lane_schema", "quant_method", "required_regimes"):
         if reviewed.get(key) != installed.get(key):
             lines.append(
                 f"  {key}: reviewed {reviewed.get(key)!r}, installed "
@@ -1148,9 +1176,9 @@ def _parse(payload: Mapping[str, Any], *, commit: str, sha: str, path: str
     if not isinstance(lane, Mapping):
         raise TesseraContractError(f"{path}.lane_eligibility must be an object")
     lane_schema = lane.get("schema")
-    if lane_schema != TESSERA_LANE_SCHEMA:
+    if lane_schema not in TESSERA_LANE_SCHEMAS:
         raise TesseraContractError(
-            f"{path}.lane_eligibility.schema must be {TESSERA_LANE_SCHEMA!r}, "
+            f"{path}.lane_eligibility.schema must be one of {sorted(TESSERA_LANE_SCHEMAS)!r}, "
             f"got {lane_schema!r}"
         )
     try:
@@ -1181,6 +1209,8 @@ def _parse(payload: Mapping[str, Any], *, commit: str, sha: str, path: str
             requires_serve_flags=cell.requires_serve_flags,
             executes=cell.executes,
             residency_modes=cell.residency_modes,
+            runtime_image=cell.runtime_image,
+            execution_modes=cell.execution_modes,
         ))
 
     extensions = _parse_native_extensions(
@@ -1221,6 +1251,8 @@ def _parse(payload: Mapping[str, Any], *, commit: str, sha: str, path: str
         commit=commit,
         sha256=sha,
         path=path,
+        lane_schema=table.schema,
+        regimes=table.regimes,
     )
 
 

--- a/tests/test_lane_eligibility_v5.py
+++ b/tests/test_lane_eligibility_v5.py
@@ -1,0 +1,124 @@
+"""Synthetic v5 claims attest only their exact runtime and execution scope."""
+from copy import deepcopy
+
+import pytest
+
+from prismaquant import lane_eligibility as lane
+
+
+DENSE_IMAGE = "example/dense@sha256:" + "a" * 64
+MOE_IMAGE = "example/moe@sha256:" + "b" * 64
+
+
+def _contract():
+    family = "TESSERA_E4M3_K1"
+    cells = []
+    for structure, image, execution_modes in (
+        ("dense", DENSE_IMAGE, ["eager", "compiled"]),
+        ("routed_moe", MOE_IMAGE, ["eager"]),
+    ):
+        for regime in ("decode", "batch"):
+            cells.append({
+                "id": f"{structure}_{regime}", "platform": "sm_121",
+                "family": family, "structure": structure, "regime": regime,
+                "rungs_q256": [1024], "activation_contract": "fp8_per_token_dynamic",
+                "route_status": "backed_with_serve_flag", "qualification": "device_qualified",
+                "requires_plugin": "tessera", "predicates": [],
+                "requires_serve_flags": ["TESSERA_SERVE_MODE=resident"],
+                "executes": [{"symbol": "torch.bmm" if structure == "routed_moe" else "torch._scaled_mm",
+                              "decoder": "torch_window"}],
+                "runtime": {"image": image, "execution_modes": execution_modes},
+            })
+    return {
+        "schema": "tessera.lane-eligibility.v5", "platforms": {"sm_121": {}},
+        "regimes": ["decode", "batch"], "structures": ["dense", "routed_moe"],
+        "cells": cells,
+    }, [{"family": family, "kind": "tessera_wire", "residency_modes": ["resident", "streamed"]}]
+
+
+def _parse(block=None, formats=None):
+    if block is None:
+        block, formats = _contract()
+    return lane._parse_table(block, formats, "fixture", "fixture", "fixture")
+
+
+def _facts(structure="dense"):
+    return lane.UnitStructuralFacts(
+        qname="synthetic.weight", format_name="TESSERA_E4M3_K1_R1024",
+        payload_family="TESSERA_E4M3_K1", k=None, n_sub=None, rate_q256=1024,
+        structure=structure, role_split=False, in_features=1024, out_features=1024,
+    )
+
+
+@pytest.mark.parametrize("structure,image,mode", [
+    ("dense", DENSE_IMAGE, "eager"), ("dense", DENSE_IMAGE, "compiled"),
+    ("routed_moe", MOE_IMAGE, "eager"),
+])
+def test_v5_exact_scope_resolves_and_retains_observed_context(structure, image, mode):
+    block, formats = _contract()
+    table = _parse(block, formats)
+    result = lane.resolve_unit_route(_facts(structure), table, platform="sm_121",
+                                    residency="resident", runtime_image=image, execution_mode=mode)
+    assert result.route_status == lane.ROUTE_STATUS_BACKED_WITH_SERVE_FLAG
+    assert all(route.as_dict()["runtime_image"] == image for route in result.regimes)
+    assert all(route.as_dict()["execution_mode"] == mode for route in result.regimes)
+    assert {cell.id: cell.as_dict()["runtime"] for cell in table.cells} == {
+        cell["id"]: cell["runtime"] for cell in block["cells"]
+    }
+    block["cells"].reverse()
+    reverse = lane.resolve_unit_route(_facts(structure), _parse(block, formats),
+                                     platform="sm_121", residency="resident",
+                                     runtime_image=image, execution_mode=mode)
+    assert reverse.as_dict() == result.as_dict()
+
+
+@pytest.mark.parametrize("structure,image,mode", [
+    ("routed_moe", MOE_IMAGE, "compiled"), ("routed_moe", DENSE_IMAGE, "eager"),
+    ("dense", MOE_IMAGE, "eager"), ("dense", None, "eager"),
+    ("dense", DENSE_IMAGE, None), ("dense", DENSE_IMAGE, "automatic"),
+])
+def test_v5_missing_or_wrong_runtime_scope_cannot_borrow_a_cell(structure, image, mode):
+    result = lane.resolve_unit_route(_facts(structure), _parse(), platform="sm_121",
+                                    residency="resident", runtime_image=image, execution_mode=mode)
+    assert result.route_status == lane.ROUTE_STATUS_UNATTESTED
+    assert result.in_scope is True
+
+
+@pytest.mark.parametrize("runtime", [
+    None, {}, {"image": DENSE_IMAGE}, {"execution_modes": ["eager"]},
+    {"image": "example/dense:latest", "execution_modes": ["eager"]},
+    {"image": DENSE_IMAGE, "execution_modes": []},
+    {"image": DENSE_IMAGE, "execution_modes": ["automatic"]},
+    {"image": DENSE_IMAGE, "execution_modes": ["eager", "eager"]},
+    {"image": DENSE_IMAGE, "execution_modes": "eager"},
+    {"image": DENSE_IMAGE, "execution_modes": ["eager"], "default": True},
+])
+def test_v5_runtime_grammar_refuses_missing_unknown_or_mutable_scope(runtime):
+    block, formats = _contract()
+    if runtime is None:
+        del block["cells"][0]["runtime"]
+    else:
+        block["cells"][0]["runtime"] = runtime
+    with pytest.raises(lane.LaneEligibilityError, match="runtime"):
+        _parse(block, formats)
+
+
+def test_v5_overlap_is_checked_per_runtime_and_execution_mode():
+    block, formats = _contract()
+    cell = deepcopy(block["cells"][0])
+    cell["id"] = "duplicate"
+    cell["runtime"]["execution_modes"] = ["compiled"]
+    block["cells"].append(cell)
+    with pytest.raises(lane.LaneEligibilityError, match="overlap|both cover"):
+        _parse(block, formats)
+    cell["runtime"]["image"] = MOE_IMAGE
+    assert len(_parse(block, formats).cells) == len(block["cells"])
+
+
+def test_v5_regimes_cannot_combine_across_runtime_images():
+    block, formats = _contract()
+    next(cell for cell in block["cells"] if cell["id"] == "dense_batch")["runtime"]["image"] = MOE_IMAGE
+    result = lane.resolve_unit_route(_facts(), _parse(block, formats), platform="sm_121",
+                                    residency="resident", runtime_image=DENSE_IMAGE, execution_mode="eager")
+    assert result.route_status == lane.ROUTE_STATUS_UNATTESTED
+    assert any(route.cell_id is None for route in result.regimes)

--- a/tests/test_lane_eligibility_v5.py
+++ b/tests/test_lane_eligibility_v5.py
@@ -99,7 +99,7 @@ def test_v5_runtime_grammar_refuses_missing_unknown_or_mutable_scope(runtime):
         del block["cells"][0]["runtime"]
     else:
         block["cells"][0]["runtime"] = runtime
-    with pytest.raises(lane.LaneEligibilityError, match="runtime"):
+    with pytest.raises(lane.LaneEligibilityError, match=r"cells.*runtime"):
         _parse(block, formats)
 
 

--- a/tests/test_tessera_campaign.py
+++ b/tests/test_tessera_campaign.py
@@ -318,7 +318,16 @@ def test_the_pinned_encoder_accepts_every_keyword_the_source_emits():
     # ``refit_metric``), and this tuple is the seam's forwarded-key whitelist.
     # Probing one plane would narrow it and make the seam refuse another
     # plane's legitimate keyword as unknown.
-    assert required == ("ldl", "ldl_block", "refit_metric", "refit_reach_floor")
+    identity = {field: "" if field.endswith("sha256") else 0
+                for field in texport.HESSIAN_IDENTITY}
+    defaults = texport.ActivationSource(hessians={}, provenance=identity)
+    width = int(defaults.ldlq_block)
+    producer = texport.ActivationSource(
+        hessians={"probe": torch.eye(width)}, provenance=identity)
+    emitted = set().union(*(
+        producer.for_unit("probe.weight", width, scale_plane=plane)
+        for plane in texport._PLANE_NAMES))
+    assert required == tuple(sorted(emitted))
     assert accepted, sorted(params)
     assert all(k in params for k in required), sorted(params)
     # And the recipe travels from Tessera's own defaults, not from a comment --
@@ -817,7 +826,10 @@ def test_activation_kwargs_are_rung_independent_but_plane_dependent():
     plane = ScalePlaneKind.CHANNEL
     first = encoder_kwargs(source, "m.up", 256, scale_plane=plane)
     second = encoder_kwargs(source, "m.up", 256, scale_plane=plane)
-    assert sorted(first) == ["ldl", "ldl_block", "refit_metric", "refit_reach_floor"]
+    # The forwarding adapter owes the producer's emitted set, including new
+    # encoder controls, not a historical list of four Hessian keywords.
+    expected = source.for_unit("m.up.weight", 256, scale_plane=plane)
+    assert set(first) == set(expected)
     for key in ("ldl", "refit_metric"):
         assert torch.equal(first[key], second[key])
 

--- a/tests/test_tessera_campaign.py
+++ b/tests/test_tessera_campaign.py
@@ -334,12 +334,9 @@ def test_the_pinned_encoder_accepts_every_keyword_the_source_emits():
     # including the fact that the refit objective is now keyed BY PLANE. A
     # receipt that quoted one objective would print a true statement about one
     # plane over an artifact built on another.
-    assert tessera_encoder_hessian_status()["recipe"] == {
-        "ldlq_sigma": 1.0, "ldlq_block": 32,
-        "refit_objective": {"channel": "hessian", "lut16": "h^1.0",
-                            "s6b": "plain"},
-        "refit_reach_floor": False,
-    }
+    expected_recipe = {key: value for key, value in defaults.config_block().items()
+                       if key not in {"hessian", "note"}}
+    assert tessera_encoder_hessian_status()["recipe"] == expected_recipe
     # Plain dicts all the way down: this block is stamped into cost payloads.
     import json
     json.dumps(tessera_encoder_hessian_status()["recipe"])

--- a/tests/test_tessera_candidate_context.py
+++ b/tests/test_tessera_candidate_context.py
@@ -257,3 +257,22 @@ def test_v5_unmatched_context_masks_only_the_attested_candidate(monkeypatch, mod
         assert "context" in masks[0]["detail"]
     else:
         assert masks == []
+
+
+def test_v5_scope_refusal_cannot_silently_remove_a_whole_unit(monkeypatch):
+    specs = [fr.get_format(_FORMAT)]
+    stats, costs = _tables({"unit.a": None})
+    monkeypatch.setattr(tm, "menu_mode", lambda: tm.MENU_ATTESTED)
+    monkeypatch.setattr(tm, "route_admission", lambda *args, **kwargs: SimpleNamespace(
+        requires_serving_context=True,
+        detail="no explicit serving context was supplied",
+        admits=lambda mode: False,
+    ))
+    monkeypatch.setattr(
+        ac, "check_stats_format_applicability",
+        lambda *args, **kwargs: ac.FormatApplicability(True),
+    )
+    with pytest.raises(ValueError, match="unit.a"):
+        ac.build_candidates(
+            stats, costs, specs, target_profile=_PROFILE, context_by_unit={},
+        )

--- a/tests/test_tessera_candidate_context.py
+++ b/tests/test_tessera_candidate_context.py
@@ -107,8 +107,26 @@ def _tables(contexts):
     return stats, costs
 
 
+def _fixture_specs(monkeypatch, *names):
+    # Build the real specs before admission is mocked. Cost validation asks
+    # the registry for them again; re-synthesizing a Tessera spec would make
+    # the cache spy count factory admission calls rather than candidate calls.
+    original_get_format = fr.get_format
+    specs = [original_get_format(name) for name in names]
+    by_name = {spec.name: spec for spec in specs}
+
+    def get_format(name):
+        canonical = fr.canonical_format_name(name)
+        if canonical in by_name:
+            return by_name[canonical]
+        return original_get_format(name)
+
+    monkeypatch.setattr(fr, "get_format", get_format)
+    return specs
+
+
 def test_candidates_resolve_same_format_separately_for_dense_and_routed_units(monkeypatch):
-    spec = fr.get_format(_FORMAT)
+    spec, = _fixture_specs(monkeypatch, _FORMAT)
     contexts = _contexts()
     stats, costs = _tables(contexts)
     calls, lanes = _record_resolver(monkeypatch)
@@ -206,7 +224,7 @@ def test_selected_candidate_routes_survive_conflicting_same_format_provenance(mo
 @pytest.mark.parametrize("mode", [tm.MENU_ATTESTED, tm.MENU_RESEARCH])
 @pytest.mark.parametrize("context", [None, _Context(structure="routed_moe")])
 def test_v5_unmatched_context_masks_only_the_attested_candidate(monkeypatch, mode, context):
-    specs = [fr.get_format(_FORMAT), fr.get_format("BF16")]
+    specs = _fixture_specs(monkeypatch, _FORMAT, "BF16")
     contexts = {} if context is None else {"unit.a": context}
     stats, costs = _tables({"unit.a": context})
     costs["unit.a"]["BF16"] = {"weight_mse": 0.0, "predicted_dloss": 0.0}
@@ -260,7 +278,7 @@ def test_v5_unmatched_context_masks_only_the_attested_candidate(monkeypatch, mod
 
 
 def test_v5_scope_refusal_cannot_silently_remove_a_whole_unit(monkeypatch):
-    specs = [fr.get_format(_FORMAT)]
+    specs = _fixture_specs(monkeypatch, _FORMAT)
     stats, costs = _tables({"unit.a": None})
     monkeypatch.setattr(tm, "menu_mode", lambda: tm.MENU_ATTESTED)
     monkeypatch.setattr(tm, "route_admission", lambda *args, **kwargs: SimpleNamespace(

--- a/tests/test_tessera_candidate_context.py
+++ b/tests/test_tessera_candidate_context.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections import Counter
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from types import SimpleNamespace
 
 import pytest
@@ -132,7 +132,8 @@ def test_candidates_resolve_same_format_separately_for_dense_and_routed_units(mo
     calls, lanes = _record_resolver(monkeypatch)
     monkeypatch.setattr(
         tm, "route_admission",
-        lambda *args, **kwargs: SimpleNamespace(requires_serving_context=False),
+        lambda *args, **kwargs: SimpleNamespace(
+            requires_serving_context=False, admits=lambda mode: True),
     )
     # This test isolates route threading; shape legality and wire accounting
     # have their own proof harnesses and are not facts inferred by this mock.
@@ -293,4 +294,76 @@ def test_v5_scope_refusal_cannot_silently_remove_a_whole_unit(monkeypatch):
     with pytest.raises(ValueError, match="unit.a"):
         ac.build_candidates(
             stats, costs, specs, target_profile=_PROFILE, context_by_unit={},
+        )
+
+
+def _legacy_scope_candidate_fixture(monkeypatch, *, context, mode, include_bf16=True):
+    names = (_FORMAT, "BF16") if include_bf16 else (_FORMAT,)
+    specs = _fixture_specs(monkeypatch, *names)
+    stats, costs = _tables({"unit.a": context})
+    if include_bf16:
+        costs["unit.a"]["BF16"] = {"weight_mse": 0.0, "predicted_dloss": 0.0}
+    monkeypatch.setattr(tm, "menu_mode", lambda: mode)
+    monkeypatch.setattr(tm, "route_admission", lambda *args, **kwargs: SimpleNamespace(
+        requires_serving_context=False,
+        attested=False,
+        detail="legacy v4 cannot attest an explicit runtime context",
+        admits=lambda selected_mode: selected_mode == tm.MENU_RESEARCH,
+    ))
+    monkeypatch.setattr(
+        ac, "serving_lane_route",
+        lambda profile, fmt, **kwargs: None if fmt == "BF16" else replace(
+            _lane("unattested"), route_status="unattested", serving_context=context),
+    )
+    monkeypatch.setattr(
+        ac, "check_stats_format_applicability",
+        lambda *args, **kwargs: ac.FormatApplicability(True),
+    )
+    monkeypatch.setattr(
+        ac, "serialized_candidate_payload",
+        lambda *args, **kwargs: (32768, None, None),
+    )
+    monkeypatch.setattr(
+        ac, "reduce_continuous_menu",
+        lambda candidates, *args, **kwargs: candidates,
+    )
+    return specs, stats, costs
+
+
+@pytest.mark.parametrize("mode", [tm.MENU_ATTESTED, tm.MENU_RESEARCH])
+@pytest.mark.parametrize("context", [None, _Context(structure="routed_moe")])
+def test_legacy_context_refusal_masks_only_explicit_attested_candidates(
+        monkeypatch, mode, context):
+    specs, stats, costs = _legacy_scope_candidate_fixture(
+        monkeypatch, context=context, mode=mode)
+    masks = []
+
+    candidates = ac.build_candidates(
+        stats, costs, specs, target_profile=_PROFILE,
+        context_by_unit={} if context is None else {"unit.a": context},
+        mask_records=masks,
+    )
+
+    refused = context is not None and mode == tm.MENU_ATTESTED
+    expected = {"BF16"} if refused else {"BF16", _FORMAT}
+    assert {candidate.fmt for candidate in candidates["unit.a"]} == expected
+    if refused:
+        assert len(masks) == 1
+        assert masks[0]["reason"] == "tessera_serving_context"
+        assert masks[0]["serving_context"] == context.as_dict()
+    else:
+        assert masks == []
+        candidate = next(c for c in candidates["unit.a"] if c.fmt == _FORMAT)
+        assert candidate.serving_lane.route_status == "unattested"
+
+
+def test_legacy_explicit_context_refusal_cannot_remove_the_final_unit_choice(monkeypatch):
+    context = _Context()
+    specs, stats, costs = _legacy_scope_candidate_fixture(
+        monkeypatch, context=context, mode=tm.MENU_ATTESTED, include_bf16=False)
+
+    with pytest.raises(ValueError, match="unit.a"):
+        ac.build_candidates(
+            stats, costs, specs, target_profile=_PROFILE,
+            context_by_unit={"unit.a": context},
         )

--- a/tests/test_tessera_candidate_context.py
+++ b/tests/test_tessera_candidate_context.py
@@ -1,0 +1,259 @@
+"""A format name does not identify the serving route of every model unit."""
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import asdict, dataclass
+from types import SimpleNamespace
+
+import pytest
+
+import prismaquant.allocator_candidates as ac
+from prismaquant import format_registry as fr
+from prismaquant import tessera_menu as tm
+from prismaquant.allocator_solver import Candidate
+from prismaquant.serving_profiles import ResolvedServingLane
+
+
+_FORMAT = "TESSERA_E2M1_K2_R896"
+_PROFILE = "tessera_research_sm121"
+
+
+@dataclass(frozen=True)
+class _Context:
+    """The public context protocol, without requiring the new class to import."""
+
+    platform: str = "sm_121"
+    structure: str = "dense"
+    residency: str = "resident"
+    runtime_image: str = "example/vllm@sha256:" + "a" * 64
+    execution_mode: str = "eager"
+
+    def key(self) -> tuple[str, ...]:
+        return (
+            self.platform,
+            self.structure,
+            self.residency,
+            self.runtime_image,
+            self.execution_mode,
+        )
+
+    def as_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+def _contexts():
+    # Equal contexts are separate objects; caching by object identity would
+    # make a full model repeat its contract lookup for every Linear.
+    return {
+        "unit.a": _Context(),
+        "unit.b": _Context(),
+        "unit.c": _Context(structure="routed_moe"),
+    }
+
+
+def _lane(structure: str) -> ResolvedServingLane:
+    return ResolvedServingLane(
+        lane_id=f"tessera-{structure}",
+        format=_FORMAT,
+        activation_contract="W4A4",
+        fallback_route=f"native-{structure}",
+        fused_mid_m_backed=False,
+        fused_mid_m_rungs=(),
+        fused_mid_m_range=None,
+        runtime_version="test-runtime",
+        rungs_source="test-contract",
+        route_status="backed",
+        route_status_source=f"test-contract:{structure}",
+    )
+
+
+def _record_resolver(monkeypatch):
+    calls = []
+    lanes = {structure: _lane(structure) for structure in ("dense", "routed_moe")}
+
+    def resolve(profile, fmt, *, serving_context=None, **kwargs):
+        assert profile == _PROFILE
+        assert fmt == _FORMAT
+        assert serving_context is not None, "unit serving context was discarded"
+        calls.append(serving_context.key())
+        return lanes[serving_context.structure]
+
+    monkeypatch.setattr(ac, "serving_lane_route", resolve)
+    return calls, lanes
+
+
+def _tables(contexts):
+    # The same rank-two shape belongs to both dense and expert units. Shape
+    # alone cannot supply the structure axis of the attestation query.
+    stats = {
+        name: {
+            "h_trace": 1.0,
+            "n_params": 256 * 256,
+            "in_features": 256,
+            "out_features": 256,
+        }
+        for name in contexts
+    }
+    costs = {
+        name: {
+            _FORMAT: {
+                "weight_mse": 1e-4,
+                "output_mse": 4e-4,
+                "output_mse_measured": True,
+            }
+        }
+        for name in contexts
+    }
+    return stats, costs
+
+
+def test_candidates_resolve_same_format_separately_for_dense_and_routed_units(monkeypatch):
+    spec = fr.get_format(_FORMAT)
+    contexts = _contexts()
+    stats, costs = _tables(contexts)
+    calls, lanes = _record_resolver(monkeypatch)
+    monkeypatch.setattr(
+        tm, "route_admission",
+        lambda *args, **kwargs: SimpleNamespace(requires_serving_context=False),
+    )
+    # This test isolates route threading; shape legality and wire accounting
+    # have their own proof harnesses and are not facts inferred by this mock.
+    monkeypatch.setattr(
+        ac, "check_stats_format_applicability",
+        lambda *args, **kwargs: ac.FormatApplicability(True),
+    )
+    monkeypatch.setattr(
+        ac, "serialized_candidate_payload",
+        lambda *args, **kwargs: (32768, None, None),
+    )
+    monkeypatch.setattr(
+        ac, "reduce_continuous_menu",
+        lambda candidates, *args, **kwargs: candidates,
+    )
+
+    candidates = ac.build_candidates(
+        stats, costs, [spec],
+        target_profile=_PROFILE,
+        context_by_unit=contexts,
+    )
+
+    assert set(candidates) == set(contexts)
+    for name, context in contexts.items():
+        assert len(candidates[name]) == 1
+        assert candidates[name][0].serving_lane == lanes[context.structure]
+        assert stats[name]["_serving_lane_by_format"][_FORMAT] == lanes[context.structure]
+    assert Counter(calls) == Counter({context.key(): 1 for context in contexts.values()})
+
+
+def test_expanded_selection_resolves_and_caches_routes_by_explicit_unit_context(monkeypatch):
+    contexts = _contexts()
+    calls, lanes = _record_resolver(monkeypatch)
+    assignment = dict.fromkeys(contexts, _FORMAT)
+
+    report = ac.selection_serving_lane_provenance(
+        assignment, candidates=None, target_profile=_PROFILE,
+        context_by_unit=contexts,
+    )
+
+    assert set(report["by_unit"]) == set(assignment)
+    for name, context in contexts.items():
+        row = report["by_unit"][name]
+        assert row["format"] == _FORMAT
+        assert row["route"] == lanes[context.structure].as_dict()
+    assert Counter(calls) == Counter({context.key(): 1 for context in contexts.values()})
+    assert report["by_format"][_FORMAT]["units"] == len(assignment)
+    assert report["by_format"][_FORMAT]["route"] is None
+    assert report["units_without_declared_lane"] == 0
+    assert report["route_status_counts"] == {"backed": len(assignment)}
+
+
+def test_selected_candidate_routes_survive_conflicting_same_format_provenance(monkeypatch):
+    contexts = _contexts()
+    assignment = dict.fromkeys(contexts, _FORMAT)
+    lanes = {name: _lane(context.structure) for name, context in contexts.items()}
+    candidates = {
+        name: [Candidate(
+            fmt=_FORMAT,
+            bits_per_param=4.0,
+            memory_bytes=32768,
+            predicted_dloss=2e-4,
+            activation_pricing="measured_output_mse",
+            serving_lane=lanes[name],
+        )]
+        for name in assignment
+    }
+
+    def reject_reresolution(*args, **kwargs):
+        raise AssertionError("the selected candidate already carries its priced route")
+
+    monkeypatch.setattr(ac, "serving_lane_route", reject_reresolution)
+    report = ac.selection_serving_lane_provenance(
+        assignment, candidates=candidates, target_profile=_PROFILE,
+        context_by_unit=contexts,
+    )
+
+    assert set(report["by_unit"]) == set(assignment)
+    for name in assignment:
+        assert report["by_unit"][name]["format"] == _FORMAT
+        assert report["by_unit"][name]["route"] == lanes[name].as_dict()
+    # A single summary route would falsely attest every selected unit against
+    # whichever context sorted first. The individual routes remain available.
+    assert report["by_format"][_FORMAT]["route"] is None
+    assert report["by_format"][_FORMAT]["units"] == len(assignment)
+    assert report["activation_pricing_branches"] == {"measured_output_mse": len(assignment)}
+
+
+@pytest.mark.parametrize("mode", [tm.MENU_ATTESTED, tm.MENU_RESEARCH])
+@pytest.mark.parametrize("context", [None, _Context(structure="routed_moe")])
+def test_v5_unmatched_context_masks_only_the_attested_candidate(monkeypatch, mode, context):
+    specs = [fr.get_format(_FORMAT), fr.get_format("BF16")]
+    contexts = {} if context is None else {"unit.a": context}
+    stats, costs = _tables({"unit.a": context})
+    costs["unit.a"]["BF16"] = {"weight_mse": 0.0, "predicted_dloss": 0.0}
+    observed = []
+
+    def admit(name, *, serving_context=None):
+        assert name == _FORMAT
+        observed.append(serving_context)
+        return SimpleNamespace(
+            requires_serving_context=True,
+            attested=False,
+            detail="context does not match any native cell",
+            admits=lambda selected_mode: selected_mode == tm.MENU_RESEARCH,
+        )
+
+    monkeypatch.setattr(tm, "menu_mode", lambda: mode)
+    monkeypatch.setattr(tm, "route_admission", admit)
+    monkeypatch.setattr(
+        ac, "serving_lane_route",
+        lambda profile, fmt, **kwargs: None if fmt == "BF16" else _lane("unattested"),
+    )
+    monkeypatch.setattr(
+        ac, "check_stats_format_applicability",
+        lambda *args, **kwargs: ac.FormatApplicability(True),
+    )
+    monkeypatch.setattr(
+        ac, "serialized_candidate_payload",
+        lambda *args, **kwargs: (32768, None, None),
+    )
+    monkeypatch.setattr(
+        ac, "reduce_continuous_menu",
+        lambda candidates, *args, **kwargs: candidates,
+    )
+    masks = []
+
+    candidates = ac.build_candidates(
+        stats, costs, specs, target_profile=_PROFILE,
+        context_by_unit=contexts, mask_records=masks,
+    )
+
+    assert observed == [context]
+    expected_formats = {"BF16", _FORMAT} if mode == tm.MENU_RESEARCH else {"BF16"}
+    assert {candidate.fmt for candidate in candidates["unit.a"]} == expected_formats
+    if mode == tm.MENU_ATTESTED:
+        assert len(masks) == 1
+        assert masks[0]["qname"] == "unit.a"
+        assert masks[0]["format"] == _FORMAT
+        assert "context" in masks[0]["detail"]
+    else:
+        assert masks == []

--- a/tests/test_tessera_contract_v5.py
+++ b/tests/test_tessera_contract_v5.py
@@ -78,3 +78,11 @@ def test_v5_development_uses_shared_runtime_grammar():
     payload["lane_eligibility"]["cells"][0]["runtime"]["execution_modes"] = ["automatic"]
     with pytest.raises(contract.TesseraContractError, match="runtime.*execution_modes"):
         _parse(payload)
+
+
+def test_v5_required_regimes_are_part_of_the_reviewed_answer():
+    payload = _payload()
+    before = contract.contract_answer(_parse(payload))
+    payload["lane_eligibility"]["regimes"].append("additional_required_regime")
+    after = contract.contract_answer(_parse(payload))
+    assert contract._answer_drift(before, after)

--- a/tests/test_tessera_contract_v5.py
+++ b/tests/test_tessera_contract_v5.py
@@ -1,0 +1,80 @@
+"""V5 development admission retains scope and cannot invent a target."""
+import copy
+import json
+
+import pytest
+
+from prismaquant import lane_eligibility as lane
+from prismaquant import tessera_runtime_contract as contract
+
+
+DENSE_IMAGE = "example/dense@sha256:" + "a" * 64
+MOE_IMAGE = "example/moe@sha256:" + "b" * 64
+
+
+def _payload():
+    payload = json.loads(contract.contract_path().read_text(encoding="utf-8"))
+    payload["lane_eligibility"]["schema"] = "tessera.lane-eligibility.v5"
+    for cell in payload["lane_eligibility"]["cells"]:
+        cell["runtime"] = {"image": DENSE_IMAGE, "execution_modes": ["eager"]}
+    return payload
+
+
+def _parse(payload):
+    return contract._parse(payload, commit="fixture", sha="fixture", path="fixture")
+
+
+def _context(**changed):
+    fields = dict(platform="sm_121", structure="dense", residency="resident",
+                  runtime_image=DENSE_IMAGE, execution_mode="eager")
+    fields.update(changed)
+    return lane.ServingContext(**fields)
+
+
+def test_v5_development_requires_context_and_retains_exact_cell_scope():
+    parsed = _parse(_payload())
+    assert parsed.lane_schema == "tessera.lane-eligibility.v5"
+    assert parsed.requires_serving_context is True
+    assert parsed.native_cells("TESSERA_E4M3_K1", 1024) == ()
+    selected = parsed.native_cells("TESSERA_E4M3_K1", 1024, serving_context=_context())
+    assert {cell.regime for cell in selected} == set(parsed.regimes)
+    assert all(cell.runtime_image == DENSE_IMAGE for cell in selected)
+    assert all(cell.execution_modes == ("eager",) for cell in selected)
+
+
+@pytest.mark.parametrize("changed", [
+    {"runtime_image": MOE_IMAGE}, {"execution_mode": "compiled"},
+    {"structure": "routed_moe"}, {"platform": "sm_120"},
+])
+def test_v5_development_cannot_borrow_cells_from_another_scope(changed):
+    parsed = _parse(_payload())
+    assert parsed.native_cells("TESSERA_E4M3_K1", 1024, serving_context=_context(**changed)) == ()
+
+
+def test_v5_development_requires_all_regimes_on_one_runtime():
+    payload = _payload()
+    for cell in payload["lane_eligibility"]["cells"]:
+        if cell["regime"] == "batch":
+            cell["runtime"]["image"] = MOE_IMAGE
+    parsed = _parse(payload)
+    assert parsed.native_cells("TESSERA_E4M3_K1", 1024, serving_context=_context()) == ()
+
+
+@pytest.mark.parametrize("field,value", [
+    ("image", MOE_IMAGE), ("execution_modes", ["eager", "compiled"]),
+])
+def test_v5_runtime_scope_changes_require_answer_review(field, value):
+    payload = _payload()
+    before = contract.contract_answer(_parse(payload))
+    changed = copy.deepcopy(payload)
+    changed["lane_eligibility"]["cells"][0]["runtime"][field] = value
+    after = contract.contract_answer(_parse(changed))
+    assert before["lane_schema"] == "tessera.lane-eligibility.v5"
+    assert contract._answer_drift(before, after)
+
+
+def test_v5_development_uses_shared_runtime_grammar():
+    payload = _payload()
+    payload["lane_eligibility"]["cells"][0]["runtime"]["execution_modes"] = ["automatic"]
+    with pytest.raises(contract.TesseraContractError, match="runtime.*execution_modes"):
+        _parse(payload)

--- a/tests/test_tessera_contract_v5.py
+++ b/tests/test_tessera_contract_v5.py
@@ -1,6 +1,8 @@
 """V5 development admission retains scope and cannot invent a target."""
 import copy
 import json
+import os
+from pathlib import Path
 
 import pytest
 
@@ -86,3 +88,39 @@ def test_v5_required_regimes_are_part_of_the_reviewed_answer():
     payload["lane_eligibility"]["regimes"].append("additional_required_regime")
     after = contract.contract_answer(_parse(payload))
     assert contract._answer_drift(before, after)
+
+
+def test_explicit_publisher_v5_contract_admits_only_complete_matching_contexts():
+    """Interop uses explicit immutable publisher bytes, never a vendored copy."""
+    path = os.environ.get("PRISMAQUANT_TEST_TESSERA_V5_CONTRACT")
+    if not path:
+        pytest.skip("explicit immutable v5 publisher contract was not supplied")
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    assert payload["lane_eligibility"]["schema"] == "tessera.lane-eligibility.v5"
+    parsed = _parse(payload)
+    # Required scope is not inferred from whichever native cell appears first.
+    for cell in parsed.cells:
+        for rate in cell.rungs_q256:
+            assert parsed.native_cells(cell.family, rate) == ()
+    assert parsed.requires_serving_context
+    positive_contexts = set()
+    for cell in parsed.cells:
+        if not cell.native:
+            continue
+        for rate in cell.rungs_q256:
+            for residency in cell.residency_modes:
+                for execution in cell.execution_modes:
+                    context = lane.ServingContext(
+                        platform=cell.platform, structure=cell.structure,
+                        residency=residency, runtime_image=cell.runtime_image,
+                        execution_mode=execution)
+                    expected = tuple(other for other in parsed.cells
+                                     if other.native and other.family == cell.family
+                                     and rate in other.rungs_q256
+                                     and lane.cell_matches_serving_context(other, context))
+                    complete = {other.regime for other in expected} == set(parsed.regimes)
+                    observed = parsed.native_cells(cell.family, rate, serving_context=context)
+                    assert observed == (expected if complete else ())
+                    if complete:
+                        positive_contexts.add(context.key())
+    assert positive_contexts, "the supplied publisher contract has no complete positive scope"

--- a/tests/test_tessera_encoder_recipe.py
+++ b/tests/test_tessera_encoder_recipe.py
@@ -1,0 +1,54 @@
+"""Recipe provenance records every encoder setting the producer publishes."""
+from __future__ import annotations
+
+import json
+
+from tessera import export as texport
+
+from prismaquant.tessera_hessian import encoder_recipe
+
+
+def _producer_source(**settings):
+    identity = {field: "" if field.endswith("sha256") else 0
+                for field in texport.HESSIAN_IDENTITY}
+    return texport.ActivationSource(hessians={}, provenance=identity, **settings)
+
+
+def _published_settings(source):
+    # The producer owns normalization and the setting roster. Capture identity
+    # and explanatory prose are the only config fields that are not a recipe.
+    config = source.config_block()
+    return {key: value for key, value in config.items()
+            if key not in {"hessian", "note"}}
+
+
+def test_default_recipe_records_all_producer_config_settings():
+    source = _producer_source()
+    expected = _published_settings(source)
+
+    recipe = encoder_recipe()
+
+    assert recipe == expected
+    # In particular, an unset trailing objective and a disabled sweep are
+    # actual settings, not missing values that provenance may omit.
+    assert recipe["refit_objective_trailing"] == expected["refit_objective_trailing"]
+    assert recipe["refit_gauss_seidel"] == expected["refit_gauss_seidel"]
+    assert json.loads(json.dumps(recipe)) == expected
+
+
+def test_recipe_preserves_producer_normalized_per_plane_settings(monkeypatch):
+    source = _producer_source(
+        refit_objective_trailing=dict(texport.DEFAULT_REFIT_OBJECTIVE),
+        refit_gauss_seidel={"lut16": True},
+    )
+    expected = _published_settings(source)
+    # Model a producer default change without changing the installed defaults
+    # or executing an encode. The recipe must read the object it constructs.
+    monkeypatch.setattr(texport, "ActivationSource", lambda **kwargs: source)
+
+    recipe = encoder_recipe()
+
+    assert recipe == expected
+    assert type(recipe["refit_objective_trailing"]) is dict
+    assert type(recipe["refit_gauss_seidel"]) is dict
+    assert json.loads(json.dumps(recipe)) == expected

--- a/tests/test_tessera_lane_admission.py
+++ b/tests/test_tessera_lane_admission.py
@@ -183,9 +183,14 @@ def test_the_packaged_tessera_contract_parses_and_every_cell_names_the_plugin():
 
     with as_file(tr.tessera_serving_contract_path()) as path:
         table, formats = _load(path)
+        published_schema = json.loads(path.read_text(encoding="utf-8"))[
+            "lane_eligibility"]["schema"]
 
     assert table.present
-    assert table.schema == LANE_ELIGIBILITY_SCHEMA_TESSERA
+    # Parser capability can advance before the reviewed development pin does.
+    # This assertion belongs to the actual installed publisher, not the newest
+    # schema the consumer knows how to read.
+    assert table.schema == published_schema
     assert table.cells
     for cell in table.cells:
         assert cell.requires_plugin == TESSERA_SERVING_PLUGIN_NAME

--- a/tests/test_tessera_legacy_scope.py
+++ b/tests/test_tessera_legacy_scope.py
@@ -1,0 +1,80 @@
+"""A legacy family claim cannot attest a newly supplied runtime context."""
+import json
+
+import pytest
+
+from prismaquant import lane_eligibility as lane
+from prismaquant import tessera_render as render
+from prismaquant import tessera_runtime_contract as contract
+
+
+NAME = "TESSERA_E4M3_K1_R1024"
+FAMILY = "TESSERA_E4M3_K1"
+
+
+@pytest.fixture
+def legacy(monkeypatch):
+    payload = json.loads(contract.contract_path().read_text(encoding="utf-8"))
+    assert payload["lane_eligibility"]["schema"] == "tessera.lane-eligibility.v4"
+    parsed = contract._parse(payload, commit="fixture", sha="fixture", path="fixture")
+    table = lane._parse_table(payload["lane_eligibility"], payload["formats"],
+                              "fixture", "fixture", "fixture")
+    formats = {row["family"]: row for row in payload["formats"]}
+    monkeypatch.setattr(render, "_pinned_serving_table", lambda: (table, formats))
+    monkeypatch.setattr(render, "_release_pin_satisfied", lambda: True)
+    context = lane.ServingContext(
+        platform="sm_121", structure="dense", residency="resident",
+        runtime_image=payload["versions"]["attested_on"]["image"],
+        execution_mode="eager")
+    return parsed, table, context
+
+
+def _facts():
+    return lane.UnitStructuralFacts(
+        qname="fixture.weight", format_name=NAME, payload_family=FAMILY,
+        k=None, n_sub=None, rate_q256=1024, structure="dense", role_split=False,
+        in_features=1024, out_features=1024)
+
+
+def test_legacy_development_lookup_keeps_its_context_free_behavior(legacy):
+    parsed, _, _ = legacy
+    assert parsed.native_cells(FAMILY, 1024)
+
+
+def test_legacy_development_cannot_attest_even_a_global_image_context(legacy):
+    parsed, _, context = legacy
+    assert parsed.native_cells(FAMILY, 1024, serving_context=context) == ()
+
+
+def test_legacy_released_lookup_keeps_its_context_free_behavior(legacy):
+    assert render.tessera_lane_attested(NAME)
+
+
+def test_legacy_renderer_cannot_attach_unreviewed_scope_to_backed_route(legacy):
+    _, _, context = legacy
+    assert render.tessera_attesting_cells(NAME, serving_context=context) == ()
+    admitted, reason = render.tessera_lane_admission(NAME, serving_context=context)
+    assert not admitted
+    assert "runtime scope" in reason
+    assert not render.tessera_lane_attested(NAME, serving_context=context)
+
+
+@pytest.mark.parametrize("axes", ["image", "execution", "both"])
+def test_legacy_generic_resolver_refuses_new_runtime_axes(legacy, axes):
+    _, table, context = legacy
+    extra = {}
+    if axes in {"image", "both"}:
+        extra["runtime_image"] = context.runtime_image
+    if axes in {"execution", "both"}:
+        extra["execution_mode"] = context.execution_mode
+    result = lane.resolve_unit_route(_facts(), table, platform=context.platform,
+                                    residency=context.residency, **extra)
+    assert result.route_status == lane.ROUTE_STATUS_UNATTESTED
+    assert "runtime scope" in result.unattested_reason
+
+
+def test_legacy_generic_residency_only_lookup_keeps_v4_behavior(legacy):
+    _, table, context = legacy
+    result = lane.resolve_unit_route(_facts(), table, platform=context.platform,
+                                    residency=context.residency)
+    assert result.route_status == lane.ROUTE_STATUS_BACKED_WITH_SERVE_FLAG

--- a/tests/test_tessera_menu_context.py
+++ b/tests/test_tessera_menu_context.py
@@ -1,0 +1,179 @@
+"""Explicit serving scope survives menu lookup, provenance and campaign reuse."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, replace
+from fractions import Fraction
+from types import SimpleNamespace
+
+import pytest
+
+from prismaquant import serving_profiles as profiles
+from prismaquant import tessera_campaign as campaign
+from prismaquant import tessera_menu as menu
+
+
+@dataclass(frozen=True)
+class _Context:
+    platform: str = "sm_121"
+    structure: str = "dense"
+    residency: str = "resident"
+    runtime_image: str = "fixture/runtime@sha256:" + "1" * 64
+    execution_mode: str = "eager"
+
+    def key(self):
+        return tuple(asdict(self).values())
+
+    def as_dict(self):
+        return asdict(self)
+
+
+def _contract(monkeypatch, expected):
+    observed = []
+    cell = SimpleNamespace(
+        cell_id="fixture_cell", route_status="backed_with_serve_flag",
+        activation_contract="fp8_per_token_dynamic",
+        requires_serve_flags=("TESSERA_SERVE_MODE=resident",),
+    )
+
+    def native_cells(family, rate, *, serving_context=None):
+        observed.append(serving_context)
+        return (cell,) if serving_context == expected else ()
+
+    contract = SimpleNamespace(
+        commit="fixture", requires_serving_context=True,
+        max_world_size={"TESSERA_E4M3_K1": 1},
+        attested_rungs={"TESSERA_E4M3_K1": (1024,)},
+        governs=lambda family: family == "TESSERA_E4M3_K1",
+        native_cells=native_cells,
+    )
+    monkeypatch.setattr(menu, "tessera_runtime_contract", lambda: contract)
+    return observed
+
+
+def test_menu_admission_passes_context_to_the_contract_and_records_it(monkeypatch):
+    context = _Context()
+    observed = _contract(monkeypatch, context)
+    admitted = menu.route_admission("TESSERA_E4M3_K1_R1024", serving_context=context)
+    assert admitted.attested
+    assert observed == [context]
+    assert admitted.serving_context == context
+
+
+@pytest.mark.parametrize("context", [None, _Context(structure="routed_moe")])
+def test_v5_menu_admission_cannot_borrow_another_context(monkeypatch, context):
+    _contract(monkeypatch, _Context())
+    admitted = menu.route_admission("TESSERA_E4M3_K1_R1024", serving_context=context)
+    assert not admitted.attested
+    assert admitted.requires_serving_context
+    assert "context" in admitted.detail
+
+
+def test_menu_expansion_forwards_explicit_scope(monkeypatch):
+    from prismaquant import tessera_footprint
+
+    context = _Context()
+    calls = []
+    admission = SimpleNamespace(admits=lambda mode: True, act_bits=8)
+    family = SimpleNamespace(
+        mathematical_q256_bounds=(1024, 1024), name="TESSERA_E4M3_K1",
+        base="E4M3", arity=1, format_name=lambda rate: f"TESSERA_E4M3_K1_R{rate}",
+    )
+
+    def admit(name, *, serving_context=None):
+        calls.append(serving_context)
+        return admission
+
+    monkeypatch.setattr(menu, "route_admission", admit)
+    monkeypatch.setattr(menu, "tessera_tp_legal", lambda *args, **kwargs: (True, ""))
+    monkeypatch.setattr(menu, "tessera_wire_recipe", lambda *args: None)
+    monkeypatch.setattr(tessera_footprint, "tessera_exact_bits_for_shape",
+                        lambda *args, **kwargs: Fraction(128))
+    rows = menu.expand_tessera_menu((4, 4), families=(family,), serving_context=context)
+    assert len(rows) == 1 and rows[0].admission is admission
+    assert calls == [context]
+
+
+def test_resolved_lane_identity_and_serialization_retain_scope(monkeypatch):
+    calls = []
+
+    def admit(name, *, serving_context=None):
+        calls.append(serving_context)
+        return SimpleNamespace(
+            activation_contract="fp8_per_token_dynamic", source="fixture",
+            detail="fixture", route_status="backed_with_serve_flag",
+            requires_serve_flags=("TESSERA_SERVE_MODE=resident",),
+            serving_context=serving_context,
+        )
+
+    monkeypatch.setattr(menu, "route_admission", admit)
+    first = _Context()
+    second = replace(first, execution_mode="compiled")
+    a = menu.tessera_resolved_serving_lane(
+        "TESSERA_E4M3_K1_R1024", serving_context=first)
+    b = menu.tessera_resolved_serving_lane(
+        "TESSERA_E4M3_K1_R1024", serving_context=second)
+    assert calls == [first, second]
+    assert a.as_dict()["serving_context"] == first.as_dict()
+    assert b.as_dict()["serving_context"] == second.as_dict()
+    assert a.route_key() != b.route_key()
+
+
+def test_profile_tessera_fallback_forwards_explicit_scope(monkeypatch):
+    context = _Context()
+    calls = []
+    sentinel = object()
+    monkeypatch.setattr(profiles, "load_serving_profile", lambda profile: SimpleNamespace(
+        serving_lane_for=lambda *args, **kwargs: None))
+
+    def resolve(name, *, runtime_version="", serving_context=None):
+        calls.append(serving_context)
+        return sentinel
+
+    monkeypatch.setattr(menu, "tessera_resolved_serving_lane", resolve)
+    assert profiles.serving_lane_route(
+        "fixture", "TESSERA_E4M3_K1_R1024", serving_context=context) is sentinel
+    assert calls == [context]
+
+
+@pytest.mark.parametrize("different", [
+    {"structure": "routed_moe"}, {"residency": "streamed"},
+    {"runtime_image": "fixture/runtime@sha256:" + "2" * 64},
+    {"execution_mode": "compiled"}, {"platform": "sm_90"},
+])
+def test_campaign_menu_cache_separates_scope_and_reuses_equal_scope(monkeypatch, different):
+    first = _Context()
+    second = replace(first, **different)
+    calls = []
+
+    def expand(shape, **kwargs):
+        context = kwargs.get("serving_context")
+        calls.append(context)
+        return [context]
+
+    monkeypatch.setattr(menu, "expand_tessera_menu", expand)
+    weights = {name: SimpleNamespace(shape=(32, 32)) for name in ("a", "b", "c")}
+    result = campaign.expand_menus_for_targets(
+        weights, list(weights), mode=menu.MENU_ATTESTED, tp_degree=1,
+        parallel_kind=menu.PARALLEL_NONE,
+        context_by_unit={"a": first, "b": second, "c": replace(first)})
+    assert calls == [first, second]
+    assert result["a"] is result["c"]
+    assert result["a"] is not result["b"]
+
+
+def test_campaign_partial_context_map_keeps_missing_scope_unbound(monkeypatch):
+    first = _Context()
+    calls = []
+
+    def expand(shape, **kwargs):
+        context = kwargs.get("serving_context")
+        calls.append(context)
+        return [context]
+
+    monkeypatch.setattr(menu, "expand_tessera_menu", expand)
+    weights = {name: SimpleNamespace(shape=(32, 32)) for name in ("a", "b")}
+    result = campaign.expand_menus_for_targets(
+        weights, list(weights), mode=menu.MENU_ATTESTED, tp_degree=1,
+        parallel_kind=menu.PARALLEL_NONE, context_by_unit={"a": first})
+    assert calls == [first, None]
+    assert result["b"] == [None]

--- a/tests/test_tessera_menu_context.py
+++ b/tests/test_tessera_menu_context.py
@@ -177,3 +177,56 @@ def test_campaign_partial_context_map_keeps_missing_scope_unbound(monkeypatch):
         parallel_kind=menu.PARALLEL_NONE, context_by_unit={"a": first})
     assert calls == [first, None]
     assert result["b"] == [None]
+
+
+def _legacy_contract(monkeypatch):
+    # A legacy supplier can answer only family/rate, even when its Python
+    # method accepts the new keyword. It supplies no runtime-scope evidence.
+    cell = SimpleNamespace(
+        cell_id="legacy_cell", route_status="backed_with_serve_flag",
+        activation_contract="fp8_per_token_dynamic",
+        requires_serve_flags=("TESSERA_SERVE_MODE=resident",),
+    )
+    contract = SimpleNamespace(
+        commit="legacy-fixture", lane_schema="tessera.lane-eligibility.v4",
+        requires_serving_context=False,
+        max_world_size={"TESSERA_E4M3_K1": 1},
+        attested_rungs={"TESSERA_E4M3_K1": (1024,)},
+        governs=lambda family: family == "TESSERA_E4M3_K1",
+        native_cells=lambda *args, **kwargs: (cell,),
+    )
+    monkeypatch.setattr(menu, "tessera_runtime_contract", lambda: contract)
+
+
+@pytest.mark.parametrize("context", [
+    None, _Context(), _Context(execution_mode="compiled"),
+    _Context(structure="routed_moe"),
+])
+def test_legacy_menu_cannot_attest_a_new_runtime_context(monkeypatch, context):
+    _legacy_contract(monkeypatch)
+
+    admission = menu.route_admission(
+        "TESSERA_E4M3_K1_R1024", serving_context=context)
+
+    assert admission.attested is (context is None)
+    assert admission.admits(menu.MENU_ATTESTED) is (context is None)
+    assert admission.admits(menu.MENU_RESEARCH)
+    assert admission.serving_context == context
+    assert not admission.requires_serving_context
+    if context is not None:
+        assert "context" in admission.detail
+        assert "v4" in admission.detail
+        assert admission.requires_serve_flags == ()
+
+
+def test_legacy_context_refusal_survives_resolved_route_provenance(monkeypatch):
+    _legacy_contract(monkeypatch)
+    context = _Context(structure="routed_moe", execution_mode="compiled")
+
+    resolved = menu.tessera_resolved_serving_lane(
+        "TESSERA_E4M3_K1_R1024", serving_context=context)
+
+    assert resolved.route_status == "unattested"
+    assert resolved.as_dict()["route_status"] == "unattested"
+    assert resolved.as_dict()["serving_context"] == context.as_dict()
+    assert resolved.requires_serve_flags == ()

--- a/tests/test_tessera_render_runtime_context.py
+++ b/tests/test_tessera_render_runtime_context.py
@@ -58,11 +58,12 @@ def test_unbound_v5_released_pin_does_not_admit_any_runtime(released_table):
     assert not render.tessera_lane_attested(NAME)
 
 
-@pytest.mark.parametrize("context", [
-    _context(), _context(execution_mode="compiled"),
-    _context(structure="routed_moe", runtime_image=MOE_IMAGE),
+@pytest.mark.parametrize("overrides", [
+    {}, {"execution_mode": "compiled"},
+    {"structure": "routed_moe", "runtime_image": MOE_IMAGE},
 ])
-def test_explicit_v5_context_selects_its_complete_regime_population(released_table, context):
+def test_explicit_v5_context_selects_its_complete_regime_population(released_table, overrides):
+    context = _context(**overrides)
     table, _ = released_table
     cells = render.tessera_attesting_cells(NAME, serving_context=context)
     assert {cell.regime for cell in cells} == set(table.regimes)
@@ -71,12 +72,13 @@ def test_explicit_v5_context_selects_its_complete_regime_population(released_tab
     assert render.tessera_lane_attested(NAME, serving_context=context)
 
 
-@pytest.mark.parametrize("context", [
-    _context(platform="sm_120"), _context(residency="streamed"),
-    _context(runtime_image=MOE_IMAGE), _context(structure="routed_moe"),
-    _context(structure="routed_moe", runtime_image=MOE_IMAGE, execution_mode="compiled"),
+@pytest.mark.parametrize("overrides", [
+    {"platform": "sm_120"}, {"residency": "streamed"},
+    {"runtime_image": MOE_IMAGE}, {"structure": "routed_moe"},
+    {"structure": "routed_moe", "runtime_image": MOE_IMAGE, "execution_mode": "compiled"},
 ])
-def test_v5_released_pin_cannot_borrow_any_mismatched_scope(released_table, context):
+def test_v5_released_pin_cannot_borrow_any_mismatched_scope(released_table, overrides):
+    context = _context(**overrides)
     assert render.tessera_attesting_cells(NAME, serving_context=context) == ()
     assert not render.tessera_lane_attested(NAME, serving_context=context)
 
@@ -114,3 +116,12 @@ def test_legacy_v4_renderer_keeps_its_prior_context_free_lookup(released_table):
     table, formats = released_table
     legacy = replace(table, schema=lane.LANE_ELIGIBILITY_SCHEMA_TESSERA_V4)
     assert render.tessera_lane_attested(NAME, table=legacy, formats=formats)
+
+
+def test_research_mode_keeps_writable_unattested_rungs(monkeypatch):
+    from prismaquant import tessera_menu as menu
+    monkeypatch.setattr(menu, "route_admission", lambda _name: SimpleNamespace(
+        requires_serving_context=True, admits=lambda _mode: True))
+    monkeypatch.setattr(menu, "menu_mode", lambda: menu.MENU_RESEARCH)
+    monkeypatch.setattr(render, "tessera_rung_is_serialisable", lambda _name: True)
+    assert render._producer_eligible(NAME)

--- a/tests/test_tessera_render_runtime_context.py
+++ b/tests/test_tessera_render_runtime_context.py
@@ -38,6 +38,7 @@ def released_table(monkeypatch):
                 "runtime": {"image": image, "execution_modes": modes},
             })
     formats = {FAMILY: {"family": FAMILY, "kind": "tessera_wire",
+                       "name_pattern": FAMILY + "_R{k}",
                        "candidate_rungs_q256": [1024],
                        "residency_modes": ["resident", "streamed"]}}
     table = lane._parse_table({

--- a/tests/test_tessera_render_runtime_context.py
+++ b/tests/test_tessera_render_runtime_context.py
@@ -1,0 +1,116 @@
+"""Released-pin rendering admission cannot borrow another v5 runtime's cells."""
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from prismaquant import lane_eligibility as lane
+from prismaquant import tessera_render as render
+
+
+NAME = "TESSERA_E4M3_K1_R1024"
+FAMILY = "TESSERA_E4M3_K1"
+IMAGE = "example/dense@sha256:" + "a" * 64
+MOE_IMAGE = "example/moe@sha256:" + "b" * 64
+
+
+def _context(**changed):
+    values = dict(platform="sm_121", structure="dense", residency="resident",
+                  runtime_image=IMAGE, execution_mode="eager")
+    values.update(changed)
+    return lane.ServingContext(**values)
+
+
+@pytest.fixture
+def released_table(monkeypatch):
+    rows = []
+    for structure, image, modes in (("dense", IMAGE, ["eager", "compiled"]),
+                                    ("routed_moe", MOE_IMAGE, ["eager"])):
+        for regime in ("decode", "batch"):
+            rows.append({
+                "id": f"{structure}_{regime}", "platform": "sm_121",
+                "family": FAMILY, "structure": structure, "regime": regime,
+                "rungs_q256": [1024], "activation_contract": "fp8_per_token_dynamic",
+                "route_status": "backed_with_serve_flag", "qualification": "device_qualified",
+                "requires_plugin": "tessera", "predicates": [],
+                "requires_serve_flags": ["TESSERA_SERVE_MODE=resident"],
+                "executes": [{"symbol": "torch.bmm", "decoder": "torch_window"}],
+                "runtime": {"image": image, "execution_modes": modes},
+            })
+    formats = {FAMILY: {"family": FAMILY, "kind": "tessera_wire",
+                       "candidate_rungs_q256": [1024],
+                       "residency_modes": ["resident", "streamed"]}}
+    table = lane._parse_table({
+        "schema": "tessera.lane-eligibility.v5", "platforms": {"sm_121": {}},
+        "regimes": ["decode", "batch"], "structures": ["dense", "routed_moe"],
+        "cells": rows,
+    }, list(formats.values()), "fixture", "fixture", "fixture")
+    monkeypatch.setattr(render, "_pinned_serving_table", lambda: (table, formats))
+    monkeypatch.setattr(render, "_release_pin_satisfied", lambda: True)
+    return table, formats
+
+
+def test_unbound_v5_released_pin_does_not_admit_any_runtime(released_table):
+    assert render.tessera_attesting_cells(NAME) == ()
+    attested, reason = render.tessera_lane_admission(NAME)
+    assert not attested
+    assert "serving context" in reason
+    assert not render.tessera_lane_attested(NAME)
+
+
+@pytest.mark.parametrize("context", [
+    _context(), _context(execution_mode="compiled"),
+    _context(structure="routed_moe", runtime_image=MOE_IMAGE),
+])
+def test_explicit_v5_context_selects_its_complete_regime_population(released_table, context):
+    table, _ = released_table
+    cells = render.tessera_attesting_cells(NAME, serving_context=context)
+    assert {cell.regime for cell in cells} == set(table.regimes)
+    assert all(lane.cell_matches_serving_context(cell, context) for cell in cells)
+    assert render.tessera_lane_admission(NAME, serving_context=context) == (True, "")
+    assert render.tessera_lane_attested(NAME, serving_context=context)
+
+
+@pytest.mark.parametrize("context", [
+    _context(platform="sm_120"), _context(residency="streamed"),
+    _context(runtime_image=MOE_IMAGE), _context(structure="routed_moe"),
+    _context(structure="routed_moe", runtime_image=MOE_IMAGE, execution_mode="compiled"),
+])
+def test_v5_released_pin_cannot_borrow_any_mismatched_scope(released_table, context):
+    assert render.tessera_attesting_cells(NAME, serving_context=context) == ()
+    assert not render.tessera_lane_attested(NAME, serving_context=context)
+
+
+def test_v5_cannot_cover_regimes_by_combining_different_images(released_table):
+    table, formats = released_table
+    cells = tuple(replace(cell, runtime_image=MOE_IMAGE)
+                  if cell.structure == "dense" and cell.regime == "batch" else cell
+                  for cell in table.cells)
+    table = replace(table, cells=cells)
+    assert render.tessera_attesting_cells(
+        NAME, table=table, formats=formats, serving_context=_context()) == ()
+    assert not render.tessera_lane_attested(
+        NAME, table=table, formats=formats, serving_context=_context())
+
+
+def test_spec_synthesis_threads_explicit_context_through_the_menu(monkeypatch):
+    from prismaquant import tessera_menu as menu
+    expected = _context()
+    seen = []
+    def admission(name, *, serving_context=None):
+        assert name == NAME
+        seen.append(serving_context)
+        return SimpleNamespace(admits=lambda _mode: serving_context == expected)
+    monkeypatch.setattr(menu, "route_admission", admission)
+    monkeypatch.setattr(render, "tessera_rung_is_serialisable", lambda _name: True)
+    assert render._producer_eligible(NAME, serving_context=expected)
+    spec = render.synthesize_tessera_spec(NAME, serving_context=expected)
+    assert spec.producer_eligible
+    assert seen == [expected, expected]
+    assert not render._producer_eligible(NAME)
+
+
+def test_legacy_v4_renderer_keeps_its_prior_context_free_lookup(released_table):
+    table, formats = released_table
+    legacy = replace(table, schema=lane.LANE_ELIGIBILITY_SCHEMA_TESSERA_V4)
+    assert render.tessera_lane_attested(NAME, table=legacy, formats=formats)

--- a/tests/test_tessera_render_runtime_context.py
+++ b/tests/test_tessera_render_runtime_context.py
@@ -39,6 +39,7 @@ def released_table(monkeypatch):
             })
     formats = {FAMILY: {"family": FAMILY, "kind": "tessera_wire",
                        "name_pattern": FAMILY + "_R{k}",
+                       "reader_rate_range_q256": [1024, 1024],
                        "candidate_rungs_q256": [1024],
                        "residency_modes": ["resident", "streamed"]}}
     table = lane._parse_table({

--- a/tests/test_tessera_serving_context.py
+++ b/tests/test_tessera_serving_context.py
@@ -1,0 +1,60 @@
+"""Serving context is explicit immutable identity, not a runtime default."""
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from prismaquant import lane_eligibility as lane
+
+
+def _context(**changed):
+    fields = {
+        "platform": "sm_121",
+        "structure": "dense",
+        "residency": "resident",
+        "runtime_image": "example/runtime@sha256:" + "a" * 64,
+        "execution_mode": "eager",
+    }
+    fields.update(changed)
+    return lane.ServingContext(**fields)
+
+
+def test_scope_identity_is_immutable_and_serializes_every_axis():
+    context = _context()
+    assert context.key() == tuple(context.as_dict().values())
+    assert context.as_dict() == {
+        "platform": "sm_121", "structure": "dense", "residency": "resident",
+        "runtime_image": "example/runtime@sha256:" + "a" * 64,
+        "execution_mode": "eager",
+    }
+    assert hash(context) == hash(_context())
+    with pytest.raises(FrozenInstanceError):
+        context.execution_mode = "compiled"
+
+
+@pytest.mark.parametrize("field,value", [
+    ("platform", "sm_120"), ("structure", "routed_moe"),
+    ("residency", "streamed"),
+    ("runtime_image", "example/runtime@sha256:" + "b" * 64),
+    ("execution_mode", "compiled"),
+])
+def test_each_scope_axis_separates_cache_identity(field, value):
+    assert _context(**{field: value}).key() != _context().key()
+
+
+@pytest.mark.parametrize("field", [
+    "platform", "structure", "residency", "runtime_image", "execution_mode",
+])
+def test_blank_scope_axes_are_refused_by_name(field):
+    with pytest.raises(lane.LaneEligibilityError, match=field):
+        _context(**{field: ""})
+
+
+@pytest.mark.parametrize("field,value", [
+    ("structure", "guessed_moe"), ("residency", "automatic"),
+    ("runtime_image", "example/runtime:latest"),
+    ("runtime_image", "sha256:" + "a" * 64),
+    ("execution_mode", "automatic"),
+])
+def test_unknown_or_mutable_scope_is_refused(field, value):
+    with pytest.raises(lane.LaneEligibilityError, match=field):
+        _context(**{field: value})


### PR DESCRIPTION
## Scope

Consumer capability for the approved Tessera #126 runtime-scope revision. Every v5 cell requires an exact image digest and explicit eager/compiled scope. One shared parser and matcher retain these fields; complete admission requires platform, per-unit structure, residency, image and execution mode together, with all declared regimes on that same context.

The scope travels through menu admission, released-pin rendering helpers, synthesized format admission, serving-lane provenance, per-unit candidate lookup and campaign caches. Missing context fails closed in attested mode. Opt-in research can retain a writable but explicitly unattested rung. Removing a unit's final candidate raises a named refusal instead of silently dropping it.

No runtime default, wire bytes, quality threshold, MoE promotion or release pin changes. Context-free v4 behavior is preserved; an explicit runtime query on an unscoped legacy table now refuses instead of serializing the requested image beside an unrelated backed claim. The reviewed DEV pin remains `1221d2a` (v4); actual immutable publisher `a4927fe51219e809ab5c3138e4328473be1473f3` is tested separately through explicit context. DEV answer/pin advances once against the final reviewed producer after measured MoE cells land; release pin changes only at the actual tagged release. **This capability PR does not close Tessera #126.** Real CLI/campaign/export ingress is a separate active follow-up; name-only callers remain closed under v5 rather than guessing context.

## PrismaBuild evidence

All workloads run through PrismaBuild, CPU-only on Sparky, one CPU and 4 GiB; CUDA masked. No GPU or served-quality result is claimed.

- Final 33-file targeted population: **512 passed, zero failures, five skips, zero collection errors**; all five skips are verbatim `Tessera encodes need CUDA`. Eight touched-module compile checks passed in the same action. Action `1c9ff1e390476074b99244c1a244aa23bb6eb30d9af6eae7b4f0d9cfdda9a7e0`; receipt `a25a4b028f2160071809368eceb5e5d498f69081ed18cc3b9f3d259e69995168`.
- After merging current main `6252ef70` (only ARCH stamp conflict, both preserved): **175 passed, zero skipped, zero collection errors** across core/legacy/recipe/docs. Action `e10d68772faae48fee940d3dccfdd51c360b4bf46ebbe25ce00c8db1a42c83fd`; receipt `b18c9b671aa439646b68d976adb04abd932c9510e0c0fd7c0795cf579712ca35`.
- Proper pre-render-fix baseline with the v5 grammar present: **12 failed, 2 preservation controls passed**, zero setup/collection errors. Action prefix `4e4e3829c425`. Concrete failure: unbound `tessera_attesting_cells` returned four cells instead of `()`; explicit publisher development admission also admitted without context. Legacy v4 and research preservation controls passed intentionally.
- Earlier schema/context/candidate regressions were shown failing against v4-only implementation. Tests and fixture corrections are separate commits before the implementation commit.

Separate contextual fixes: obsolete campaign keyword/schema assertions now derive from the pinned publisher (campaign failures reproduced on pristine main, only that file rerun); encoder recipe provenance now retains producer-owned trailing-objective and Gauss-Seidel settings after both new completeness tests failed pre-fix. No encoder inputs/defaults changed. Stale keyword-count/refit-scope prose corrected on sight. Full evidence and exact limitations: `docs/results/tessera_v5_scope_2026-09-04.md`. The coordinator owns final combined integration and release testing.

Source archives are immutable Git exports, SHA-verified inside each worker:

- Reviewed v4 import source `1221d2a`: `b4755a30d60974ec2758c2060fc4d3954f2e1b7c7bb11602a05f0b783ba60bc8`.
- Explicit v5 publisher `a4927fe`: `941b979fe5a246b26a4bf298430bc2ac3727df35c3afd1c406c32bbecd77ffe9`.

Temporary snapshot preparation excludes exactly the three tracked external calibration symlinks; they are restored immediately after sealing, never committed or used by these tests. No PrismaBuild changes.
