### PR TITLE
Thread explicit Tessera runtime scope through campaign, allocator and export

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,13 @@
 As of: 2026-09-04 · `codex/pq-tessera-v5-endpoints`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-04, `codex/pq-tessera-v5-endpoints`) for **scope-preserving
+serve instructions** (§9.4). The printed Tessera launch recipe now supplies
+the validated exact `IMAGE`, eager/compiled `TESSERA_LANE_EAGER`, residency
+and `TS` producer checkout with shell-safe quoting. Legacy unscoped callers
+retain the existing wrapper image/mode defaults. This changes instructions,
+not serving defaults or attestation.
+
 Re-stamped (2026-09-04, `codex/pq-tessera-v5-endpoints`) for **allocation-bound
 Tessera plan reuse** (§9.4). The plan stage now records the full SHA-256 of
 the exact allocation bytes as a late-bound settings key. Changed allocations
@@ -9014,7 +9021,7 @@ decision rather than operator policy. Strix Halo enters this lane first, serving
 
 ### 9.4 tessera — the Tessera wire on Tessera's own vLLM plugin
 
-**Declared, driveable, and fail-closed on one thing.** This lane existed as a
+**Declared, driveable, and fail-closed.** This lane existed as a
 *bar* before it existed as a shipping path: `prismaquant/lane_specs/tessera.json`
 states the serve, the endpoint, the gate set, the KL evaluator and the executed
 activation contracts. Since 2026-09-03 `run-pipeline.sh` has a real
@@ -9034,7 +9041,7 @@ a partial allocation is planned as-is with every other body Linear spelled BF16,
 broadcast by role and stamped as the extrapolation it is; silence must never become
 a 4-bit rung.
 
-**Four preflight gates, each fail-closed on its own** (`tessera_export_lane.py`,
+**Preflight gates, each fail-closed on its own** (`tessera_export_lane.py`,
 run before any GPU work): the checkpoint's structure must be one the packaged
 contract declares (`require_declared_structure`, read from the artifact's own
 `config.json`, because the `qwen3` profile claims both the dense and the MoE
@@ -9044,8 +9051,12 @@ architecture and only one is declared); the lane spec's
 in the field that asserts what the runtime executes; every tool the lane
 declares it shells out to must exist under the env var that declaration names
 (`require_producer_tools`); and the pinned Tessera serving runtime must be an
-exact reviewed release (`require_release_pin`). The last refuses every run
-today and is the only thing that does.
+exact reviewed release (`require_release_pin`). The PENDING release pin still
+refuses shipping. Runtime-scoped v5 adds an explicit validated target before
+work and selected-unit scope/source-shape admission before translation;
+passing the release pin does not bypass those gates. Cached plans must also
+retain their own exact allocation-content binding, independent of the current
+shipcard build anchor.
 
 The producer-tool gate reads `lane_specs/tessera.json`'s `producer_tools`. It
 was a hardcoded `for` loop over two paths in `run-pipeline.sh`, which named two
@@ -9070,10 +9081,13 @@ reviewed development contract includes NVFP4 W4A4 at
 `e2m1_group16_ue4m3_static`, FP8 W8A8 at `fp8_per_token_dynamic` and BF16 at
 `bf16_unquantized`; each route's cells name its residency and launches.
 **There is no enable flag**: the checkpoint's
-`quantization_config.quant_method` selects the plugin, and the single operator
-knob is `TESSERA_SERVE_MODE=resident|streamed`, declared rather than defaulted
+`quantization_config.quant_method` selects the plugin. Residency is
+`TESSERA_SERVE_MODE=resident|streamed`, declared rather than defaulted
 because it changes the artifact's footprint and is folded into vLLM's
-compile-cache key. The serve installs the plugin into the *stock* vLLM image
+compile-cache key. A scoped target additionally fixes exact image and execution
+mode; the printed recipe preserves those through the producer wrapper's
+`IMAGE` and `TESSERA_LANE_EAGER`, plus the selected checkout through `TS`.
+The serve installs the plugin into the *stock* vLLM image
 (`pip install --no-deps --no-build-isolation -e <tessera>`); no core patch, no
 forked runtime. The reference serve script
 (`/home/rob/tessera/experiments/tessera_plugin_served.sh`) and the route census

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,23 @@
 As of: 2026-09-04 · `codex/pq-tessera-v5-endpoints`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-04, `codex/pq-tessera-v5-endpoints`) for **selected
+export scope and shipcard binding** (§5.7, §9.4; Tessera #126). V5 export
+requires a complete runtime target before work and rechecks every selected
+Tessera unit against allocation contexts, source headers/name projection,
+profile topology and same-runtime native, device-qualified cells covering all
+regimes before the external translator runs. Exact two-dimensional source
+units are supported; packed/aggregate shapes and predicates needing the
+producer's fused-unit projection refuse. No projection is guessed. The shell
+threads scope into allocator and export gates and keys plan reuse by the
+resolved platform, image, mode and residency. Name-only body intake checks
+serializability and defers admission to per-unit gates; the head has its own
+explicit context. `--write-build-json` binds exact raw assignment SHA and
+validated scope through the existing shipcard `--build-json` interface,
+providing the independent allocation anchor for scoped census replay. This
+does not yet implement that replay or the prepriced cost-stage repair (#184).
+The release pin stays PENDING and no serving or GPU result is claimed.
+
 Re-stamped (2026-09-04, `codex/pq-tessera-v5-endpoints`) for **scoped
 campaign and allocator entry points** (§5.7; Tessera #126). The real CLIs
 thread the explicit target and each unit's discovered/probed structure

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,15 @@
 As of: 2026-09-04 · `codex/pq-tessera-v5-endpoints`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-04, `codex/pq-tessera-v5-endpoints`) for **allocation-bound
+Tessera plan reuse** (§9.4). The plan stage now records the full SHA-256 of
+the exact allocation bytes as a late-bound settings key. Changed allocations
+refuse cached plans before export, even under an unchanged model/runtime
+target. Existing plans without their own recorded allocation binding refuse
+instead of acquiring today's hash by trust-on-first-use; other stages keep
+their legacy missing-manifest policy. The independently generated shipcard
+build anchor does not substitute for evidence of what an old plan translated.
+
 Re-stamped (2026-09-04, `codex/pq-tessera-v5-endpoints`) for **selected
 export scope and shipcard binding** (§5.7, §9.4; Tessera #126). V5 export
 requires a complete runtime target before work and rechecks every selected

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,21 @@
 As of: 2026-09-04 · `codex/pq-tessera-v5-endpoints`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-04, `codex/pq-tessera-v5-endpoints`) for **scoped
+campaign and allocator entry points** (§5.7; Tessera #126). The real CLIs
+thread the explicit target and each unit's discovered/probed structure
+through menu-token intake, every candidate construction, fallback-route
+caches and final selected-route provenance. Shared-menu intake is the union
+of actual unit contexts; the cached global `FormatSpec` stays a context-free
+byte description and the final candidate mask still gates each unit. The
+exact target and per-unit contexts are recorded under
+`__prismaquant__.tessera_serving_scope` in the allocation recipe. Tests run
+the real allocator endpoint with both literal and token-expanded Tessera
+menus, preserve dense/expert separation and refuse image/mode mismatch.
+This does not add packed expert activation capture: the existing campaign's
+Linear-only population and packed export bridge are tracked in PrismaQuant
+#183. Pins, wire bytes, encoder defaults and promotion thresholds stay put.
+
 Re-stamped (2026-09-04, `codex/pq-tessera-v5-endpoints`) for **explicit
 serving-target intake** (§5.7; Tessera #126). `tessera_serving_scope` owns
 the optional target arguments and per-unit context construction. Image,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5032,7 +5032,7 @@ row-parallel Linear is `cols / tp % 256 == 0`, which is what collapses 3060 to
 **One function owns the encoder call, and it is H-gated**
 (`tessera_render.encode_tessera_unit`). The Tessera encoder's shipping default
 is *H-aware*: given a unit's `H = XᵀX` it applies LDLQ (sigma 1.0, block 32)
-plus an exact full-H row-scale refit, and weights-only encodes stay
+and the producer's plane-specific refit policy, and weights-only encodes stay
 byte-identical. So a rung priced without an H is a price of different bytes at
 the same format name, and the seam refuses rather than downgrade silently:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,18 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-04 · `codex/pq-tessera-v5-scope`. Stamps
+As of: 2026-09-04 · `codex/pq-tessera-v5-endpoints`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-04, `codex/pq-tessera-v5-endpoints`) for **explicit
+serving-target intake** (§5.7; Tessera #126). `tessera_serving_scope` owns
+the optional target arguments and per-unit context construction. Image,
+execution mode and residency are explicit; platform is explicit or comes
+from the selected serving profile, never the probe device. All-absent keeps
+the legacy context-free call; partial/conflicting targets refuse. Probe
+router/expert or packed-module facts determine unit structure, cross-checked
+against the declared model profile. Missing facts cannot silently become
+dense. The helper delegates value validation to `ServingContext`; it does
+not change a runtime default or attest any new serving cell.
 
 Re-stamped (2026-09-04, `codex/pq-tessera-v5-scope`) for **complete encoder
 recipe provenance** (§5.4). The default activation-aware recipe is projected

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,15 @@
 As of: 2026-09-04 · `codex/pq-tessera-v5-endpoints`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-04, `codex/pq-tessera-v5-endpoints`) for **raw scoped
+census handoff instructions** (§9.4). The driver prints the producer's actual
+artifact/output/runtime-image census API, preserving compiled mode when
+requested, and a consumer fill command with the exact allocation and artifact
+paths. A log summary and caller-supplied route list are not v5 evidence. The
+census must run inside the same verified runtime image; instructions explicitly
+note that combined dense compiled traces cannot prove per-regime agreement.
+The scoped receipt implementation remains the separate #126 integration leg.
+
 Re-stamped (2026-09-04, `codex/pq-tessera-v5-endpoints`) for **scope-preserving
 serve instructions** (§9.4). The printed Tessera launch recipe now supplies
 the validated exact `IMAGE`, eager/compiled `TESSERA_LANE_EAGER`, residency

--- a/docs/results/tessera_v5_endpoints_2026-09-04.md
+++ b/docs/results/tessera_v5_endpoints_2026-09-04.md
@@ -1,0 +1,90 @@
+# Explicit Tessera serving targets through real endpoints
+
+2026-09-04. Tessera #126 follow-up to merged PrismaQuant #181.
+Implementation ends at `cbf44281`; merge `577bd89a` includes current main
+`fc5a58c7` (only the architecture provenance stamp conflicted; both retained).
+This is CPU correctness evidence, not a serve, quality, performance or energy
+measurement. DEV contract `1221d2a`/v4 and release PENDING remain unchanged.
+
+## What is connected
+
+`ServingTarget` accepts exact platform/image/execution mode/residency; the
+real campaign and allocator CLIs derive each unit's structure from model/probe
+facts, not a global model-name guess. All candidate paths, fallback-route
+caches and selected provenance retain those contexts. Global token intake is
+the union of actual contexts; final per-unit admission remains authoritative.
+
+Export rechecks selected assignments, recorded target/context and actual
+source headers before the external producer translator. The existing shipcard
+build interface receives exact allocation SHA-256 and validated scope. Plan
+reuse separately binds the full allocation hash, refusing unbound older plans
+instead of retroactively stamping them. The printed serve recipe carries the
+same image/mode/residency and producer checkout with shell-safe quoting.
+
+## Red evidence
+
+PrismaBuild failed-action JSONs below retain the complete output under
+`/mnt/shared/prismabuild-fleet/pb-queue/failed/<action>.json`.
+
+| Action | Pre-fix observation |
+| --- | --- |
+| `f5170909c3af6734804ba13559943bdc8331040ae475c34abe89423b32a70e8b` | 16 failures: serving-target helper absent and actual CLIs reject the four target flags. |
+| `430f151a0e393b44bfdd02ee0e1d040f0cb3d47f94552b8dc5ac84967d38b010` | Corrected-fixture replay: 3 failed, 18 passed. Actual scoped allocator still fails at context-free global literal/token intake before the per-unit gate. |
+| `3a7d3cc57a4d6c00159d2c480be90b01f64e6db0033e15d8a084b96eba898d17` | 23 failures: selected export scope/assignment API, CLI forwarding and scope cache identity absent. |
+| `9d1902afe7a8d1b51c51d797b284adea2e11d3b8a0acbaaace039c47d9eda036` | 3 failed, 30 passed: `--write-build-json` unrecognized and shell lacks `--build-json`. |
+| `f02f32b21d6179c60bb3f662763a2960cb06580c8435ccc0a30a6774925d1892` | Inherited platform regression: expected `sm_121`, received `lm_head` at the scoped sixth policy line. |
+| `71765dd3a4ba27d1ce4fa296fde5b92872c861a0b7dbe7f9b7b40aed8bf3e4bb` | 5 failed, 1 preservation passed: changed or unbound allocation still reaches `TEST_EXPORT_REACHED`; printed eager/compiled commands omit `IMAGE` and split paths containing spaces. |
+
+Supplemental earlier export run `fd5e6b5f52f4` exposed five real new cases:
+matching source-member predicates were admitted despite unavailable executed
+fused projection, body/head policy used context-free admission, and a supplied
+Tessera token reached `get_format` as a literal. Two other failures in that
+run were test-fixture zero activation scores, corrected without production
+changes; they are not claimed as regression evidence. The earlier allocator
+fixture also used invalid 128-column shapes; the corrected replay above is
+the valid red for global intake.
+
+## Green populations
+
+All actions were dispatched through PrismaBuild on Sparky, CPU-only, one
+reserved CPU and 4 GiB, with `CUDA_VISIBLE_DEVICES=''`, `OMP_NUM_THREADS=1`,
+`OPENBLAS_NUM_THREADS=1`. No CUDA-gated population was exercised. Tests used
+the existing PrismaQuant cu130 interpreter and immutable producer source
+archive `tessera-1221d2a-src.tar`, SHA-256
+`b4755a30d60974ec2758c2060fc4d3954f2e1b7c7bb11602a05f0b783ba60bc8`.
+Snapshot sealing excluded only the three tracked external calibration
+symlinks, immediately restored after queue; no test uses those datasets.
+
+- Real allocator endpoint population: **21 passed, 0 failed, 0 skipped**,
+  no collection errors. Action
+  `371f7cf69f732c973c82dcdbab237c83527bb9de99b2d8be44516fbbf38049a2`;
+  receipt `3cd84b4782faa0012f74bb2533d45a88da1ab791b44d217657672ec517625db5`.
+- Main endpoint target population at `28e2d5c6`: **408 passed, 0 failed,
+  5 skipped**, no collection errors, across 26 touched/reachable files.
+  All five skip reasons verbatim: **`Tessera encodes need CUDA`**
+  (`test_tessera_campaign.py` lines 194, 222, 248, 540 and 945 in that snapshot).
+  Action `194a074fc1bb9d3c8f72c9a0212f2d0390737a67d7dcbf7f2737bed7672a077a`;
+  receipt `c299be59a7b246e8f51c23f5156a88482cb469a15a19595eaf917862a99d919e`.
+  Seven touched modules compiled and the shell passed `bash -n` in the same action.
+- Review fixes at `cbf44281`: **112 passed, 0 failed, 0 skipped**, no
+  collection errors, across `test_tessera_plan_input_binding`,
+  `test_tessera_export_scope`, `test_tessera_export_lane`,
+  `test_stage_settings_guard`, `test_pipeline_contracts`,
+  `test_docs_staleness`, and `test_architecture_doc`; shell syntax also passed.
+  Action `a77b1dc88916f55ada1941692bba808aed25a4bd9246b106695c40a1f71999ce`;
+  receipt `99e107e7f946b4a83f04031fc10d35fb513a07df5265c8590a63351a665be570`.
+
+## Boundaries and encountered fixes
+
+This does not close #126 alone. Scoped raw-census/shipcard replay is a separate
+worker's integration; final reviewed producer pin advancement follows actual
+measured MoE publication. Packed/aggregate source projections and nonempty
+executed-shape predicates refuse rather than guess; packed campaign/bridge
+work is tracked and assigned in PrismaQuant #183. Supplied prepriced cost
+input dispatch is separately tracked and assigned in #184. No shipped defaults,
+wire bytes, thresholds or attestation cells change here.
+
+Separate review fixes: `3b3fce05` binds cached plans to allocation content;
+`cbf44281` preserves explicit runtime in printed serve instructions and fixes
+contradictory current-tense architecture prose. The initial recipe-provenance
+and legacy-explicit-scope findings were already isolated in merged #181.

--- a/docs/results/tessera_v5_endpoints_2026-09-04.md
+++ b/docs/results/tessera_v5_endpoints_2026-09-04.md
@@ -88,3 +88,19 @@ Separate review fixes: `3b3fce05` binds cached plans to allocation content;
 `cbf44281` preserves explicit runtime in printed serve instructions and fixes
 contradictory current-tense architecture prose. The initial recipe-provenance
 and legacy-explicit-scope findings were already isolated in merged #181.
+
+## Final handoff-command correction
+
+After the scoped census worker supplied its supported API, `1084bc69`
+replaced the stale printed `--log`/manual-route instructions with complete
+raw-census generation inside the exact verified image and allocation-bound
+consumer filling. The command preserves eager/compiled and residency; a
+printed warning states the producer's unsupported dense compiled proof.
+New actual-shell cases were **2 failed, 6 deselected** before the fix (action
+prefix `3346e432fed4`, failure `assert '--log' not in tokens`). Final
+post-main-merge shell/docs population is **27 passed, 0 failed, 0 skipped**,
+no collection errors, CPU-only Sparky under the same 1-core/4-GiB reservation:
+action `cf4b58ffeb159fd8a23db4e556ba260d0e04a8f5f454aee2adcbdb6fe8c55a83`,
+receipt `d7e752e48920a4a4fe58e2ecff88ee42911ed6860f5c514f0e429632f4600eb4`.
+The receipt-filling implementation is still the separate integration leg;
+printed instructions are not a claim that a gate has been run.

--- a/prismaquant/allocator.py
+++ b/prismaquant/allocator.py
@@ -1660,7 +1660,12 @@ def clip_probe_fisher_outliers(stats: dict, meta: dict | None = None, *,
 
 
 def main():
+    from .tessera_serving_scope import (
+        add_serving_scope_arguments, serving_target_from_args,
+        context_by_unit_from_stats, scope_provenance,
+    )
     ap = argparse.ArgumentParser()
+    add_serving_scope_arguments(ap)
     ap.add_argument("--probe", required=True, help="sensitivity_probe pickle")
     ap.add_argument("--costs", required=True, help="measure_quant_cost pickle")
     ap.add_argument(
@@ -2239,6 +2244,9 @@ def main():
     if target_profile not in serving_profile_names():
         raise SystemExit(f"[alloc] ERROR: unknown target profile {target_profile!r}")
     print(f"[alloc] target profile: {target_profile}", flush=True)
+    from .serving_profiles import load_serving_profile
+    tessera_serving_target = serving_target_from_args(
+        args, target_platform=load_serving_profile(target_profile).target_platform)
 
     if bool(args.research_cost_base) != bool(args.research_cost_segments_dir):
         raise SystemExit(
@@ -2457,6 +2465,8 @@ def main():
         )
     stats = _mark_weight_only_nvfp4_stats(stats, model_profile)
     accounting_stats = dict(stats)
+    tessera_context_by_unit = context_by_unit_from_stats(
+        tessera_serving_target, accounting_stats, model_profile)
 
     if args.formats:
         fmt_names = [s.strip() for s in args.formats.split(",") if s.strip()]
@@ -2482,7 +2492,9 @@ def main():
         if isinstance(n, str) and n.startswith("TESSERA_")
     ]
     fmt_names, unattested = expand_menu_tokens_report(
-        fmt_names, cost_data.get("formats", ()))
+        fmt_names, cost_data.get("formats", ()),
+        **({"context_by_unit": tessera_context_by_unit}
+           if tessera_context_by_unit is not None else {}))
     tessera_menu_widths: dict = {}
     if priced_tessera:
         kept = [n for n in fmt_names if n.startswith("TESSERA_")]
@@ -2530,7 +2542,9 @@ def main():
             )
     try:
         specs = fr.require_producer_formats(
-            fmt_names, where="new allocator assignment menu"
+            fmt_names, where="new allocator assignment menu",
+            **({"context_by_unit": tessera_context_by_unit}
+               if tessera_context_by_unit is not None else {}),
         )
     except ValueError as exc:
         raise SystemExit(
@@ -2938,6 +2952,7 @@ def main():
         # what THIS solver can distinguish rather than to a taste constant.
         bit_precision=float(args.bit_precision),
         tessera_menu_report=tessera_menu_report,
+        context_by_unit=tessera_context_by_unit,
     )
     print(f"[alloc] candidates built for {len(candidates)} Linears")
 
@@ -2989,6 +3004,7 @@ def main():
             # own predicted_dloss/cost_source precedence while making the
             # absence of body activation transfer explicit.
             activation_pricing=None,
+            context_by_unit=tessera_context_by_unit,
         )
         missing_head_candidates = [
             name for name in head_probe_names
@@ -3075,6 +3091,7 @@ def main():
             mask_records=candidate_mask_records,
             cb_serialization_context=cb_serialization_context,
             activation_pricing=activation_pricing,
+            context_by_unit=tessera_context_by_unit,
         )
         missing_mtp_candidates = [
             name for name in mtp_names
@@ -3147,6 +3164,7 @@ def main():
                 mask_records=candidate_mask_records,
                 cb_serialization_context=cb_serialization_context,
                 activation_pricing=activation_pricing,
+                context_by_unit=tessera_context_by_unit,
             )
             visual_aux_candidates = {
                 name: cand for name in visual_cost_names
@@ -3527,7 +3545,7 @@ def main():
             legal_formats=per_linear_legal_formats,
         )
 
-    _serve_lane_cache: dict[str, object] = {}
+    _serve_lane_cache: dict[tuple, object] = {}
 
     def _serve_lane_for(name: str, fmt: str):
         """The concrete serving-lane route one assigned unit would ride (P5b).
@@ -3542,9 +3560,13 @@ def main():
         for cand in candidates.get(name, ()):
             if cand.fmt == fmt:
                 return cand.serving_lane
-        if fmt not in _serve_lane_cache:
-            _serve_lane_cache[fmt] = serving_lane_route(target_profile, fmt)
-        return _serve_lane_cache[fmt]
+        context = None if tessera_context_by_unit is None else tessera_context_by_unit.get(name)
+        key = (fmt, None if context is None else context.key())
+        if key not in _serve_lane_cache:
+            _serve_lane_cache[key] = serving_lane_route(
+                target_profile, fmt,
+                **({"serving_context": context} if context is not None else {}))
+        return _serve_lane_cache[key]
 
     def _serve_feasibility(
         expanded_assignment: Mapping[str, str],
@@ -4994,7 +5016,11 @@ def main():
             "activation_fair_pricing": activation_pricing.as_dict(),
             "cb_ladder_cross_family_verdict": cross_family_verdict,
             "serving_lane_provenance": selection_serving_lane_provenance(
-                chosen_info["assignment"], candidates, target_profile),
+                chosen_info["assignment"], candidates, target_profile,
+                context_by_unit=tessera_context_by_unit),
+            **({"tessera_serving_scope": scope_provenance(
+                tessera_serving_target, tessera_context_by_unit)}
+               if tessera_serving_target is not None else {}),
             # How big the per-unit menu was BEFORE the DP saw it, and which
             # of the two reductions shrank it (see reduce_continuous_menu).
             # Empty on a run with no Tessera rung on the menu. Without this a
@@ -5378,6 +5404,12 @@ def main():
     layer_cfg[LAYER_CONFIG_META_KEY] = {
         "schema": "prismaquant.layer_config_meta.v1",
         "target_profile": target_profile,
+        **({"tessera_serving_scope": scope_provenance(
+                tessera_serving_target, tessera_context_by_unit),
+            "serving_lane_provenance": selection_serving_lane_provenance(
+                assignment_expanded, candidates, target_profile,
+                context_by_unit=tessera_context_by_unit)}
+           if tessera_serving_target is not None else {}),
         "target_profile_requested": args.target_profile,
         "target_profile_default": str(args.target_profile_default or "research"),
         "lm_head_format": lm_head_format_canonical,

--- a/prismaquant/format_registry.py
+++ b/prismaquant/format_registry.py
@@ -1318,7 +1318,7 @@ def list_producer_formats(family: str | None = None) -> list[FormatSpec]:
     ]
 
 
-def format_is_producer_eligible(name: str) -> bool:
+def format_is_producer_eligible(name: str, *, context_by_unit=None) -> bool:
     """Whether a canonical/alias format may be newly produced.
 
     Resolved through :func:`get_format`, not through ``REGISTRY`` directly, so
@@ -1332,9 +1332,23 @@ def format_is_producer_eligible(name: str) -> bool:
     thrown away.  An unknown name still raises ``KeyError`` inside
     ``get_format``; that is "not a format", not "not producer-eligible", and it
     is returned as False here exactly as the absent row was.
+
+    With explicit Tessera contexts this asks whether at least one unit admits
+    the rung. It is only shared-menu intake: each candidate must still pass
+    its own unit's scope. No context-free registry/spec claim is changed.
     """
 
     canonical = canonical_format_name(name)
+    if context_by_unit is not None and is_tessera_format_name(canonical):
+        # A shared allocator menu is the union of its units' admissible rungs,
+        # not a model-wide attestation. build_candidates still tests EACH
+        # unit against its own context. Never install this transient answer
+        # in the registry or in a context-free synthesized FormatSpec.
+        from .tessera_menu import menu_mode, route_admission
+        unique = {context.key(): context for context in context_by_unit.values()
+                  if context is not None}
+        return any(route_admission(canonical, serving_context=context).admits(menu_mode())
+                   for context in unique.values())
     try:
         spec = get_format(canonical)
     except KeyError:
@@ -1352,12 +1366,25 @@ def require_producer_formats(
     names: Iterable[str],
     *,
     where: str = "producer format menu",
+    context_by_unit=None,
 ) -> list[FormatSpec]:
-    """Resolve a new-artifact menu without admitting reader-only wire ids."""
+    """Resolve a new-artifact menu without admitting reader-only wire ids.
+
+    Explicit Tessera contexts admit the union needed by a per-unit allocator.
+    Returned specs remain context-free byte descriptions; scoped serving
+    claims belong to the individual candidates, not a global spec mutation.
+    """
 
     requested = [str(name) for name in names]
+    if context_by_unit is not None:
+        # Every rate asks the same scope union. Reduce the model-sized input
+        # once, while leaving the caller's per-unit evidence untouched.
+        context_by_unit = {context.key(): context for context in context_by_unit.values()
+                           if context is not None}
     nonproducer = [
-        name for name in requested if not format_is_producer_eligible(name)
+        name for name in requested
+        if not format_is_producer_eligible(name, **(
+            {"context_by_unit": context_by_unit} if context_by_unit is not None else {}))
     ]
     if nonproducer:
         raise ValueError(

--- a/prismaquant/lane_eligibility.py
+++ b/prismaquant/lane_eligibility.py
@@ -373,13 +373,14 @@ _PREDICABLE_FACTS: dict[str, str] = {
 # ---------------------------------------------------------------------------
 @dataclass(frozen=True)
 class EligibilityCell:
-    """One packaged cell: bytes, platform, regime, residency and launch.
+    """One packaged cell: bytes, platform, regime, residency, runtime and launch.
 
     A cell is scoped to exactly one ``(platform, family, structure, regime)``
     and covers an explicit, non-empty rung list. It carries no prose: a
     validator refuses ``detail``/``rationale`` keys on a cell, because a gate
     cannot read prose (principle 14). Legacy v3 alone permits an absent plugin
-    key. v4 requires Tessera, launch declarations and residency flags.
+    key. v4 requires Tessera, launch declarations and residency flags; v5
+    additionally scopes every cell to an exact image and execution-mode set.
     """
 
     id: str

--- a/prismaquant/pipeline.py
+++ b/prismaquant/pipeline.py
@@ -288,6 +288,14 @@ _HEAD_SETTINGS: tuple[str, ...] = (
     "LM_HEAD_DP_UNPINNED",
 )
 
+# Scoped Tessera exports carry explicit runtime input in the plan identity.
+# These fields are absent from legacy unscoped manifests, preserving reuse of
+# existing plans. The endpoint, not this projection, refuses incomplete input.
+_TESSERA_SCOPE_SETTINGS: tuple[str, ...] = (
+    "TESSERA_PLATFORM", "TESSERA_RUNTIME_IMAGE", "TESSERA_EXECUTION_MODE",
+    "TESSERA_RESIDENCY", "TESSERA_TARGET_PROFILE",
+)
+
 
 def _key_pairs(*specs: str) -> tuple[tuple[str, str], ...]:
     """``"NS<-PRODUCTION_RENDER_COST_NSAMPLES"`` -> ``("NS", "PRODUCTION_…")``."""
@@ -445,14 +453,16 @@ STAGE_SETTINGS_KEYS: dict[str, tuple[tuple[str, str], ...]] = {
     "gguf-skeleton": _key_pairs("MODEL_PATH"),
     # --- Tessera lane ------------------------------------------------------
     # The plan is a projection of the allocation onto the exporter's per-tensor
-    # vocabulary, so its identity is (checkpoint, coverage decision). The
+    # vocabulary, so its identity includes checkpoint, coverage decision and
+    # explicitly supplied serving scope. The
     # allocation itself is guarded upstream by `layer_config.json`'s own
     # stages; what is NOT recoverable from that file is the coverage mode, and
     # it is the one setting that changes the artifact without changing the
     # allocation: `broadcast-by-role` extrapolates a single-layer allocation to
     # every depth, `as-allocated` does not. A skip-if-exists plan built under
     # the other mode is a different artifact.
-    "tessera-plan": _key_pairs("MODEL_PATH", "COVER<-TESSERA_PLAN_COVER"),
+    "tessera-plan": _key_pairs("MODEL_PATH", "COVER<-TESSERA_PLAN_COVER",
+                               *_TESSERA_SCOPE_SETTINGS),
 }
 
 
@@ -488,6 +498,8 @@ def stage_settings_projection(
     projection: dict[str, str] = {}
     unresolved: list[str] = []
     for manifest_key, source in keys:
+        if stage == "tessera-plan" and source in _TESSERA_SCOPE_SETTINGS and not settings.get(source):
+            continue
         if source in settings:
             projection[manifest_key] = str(settings[source])
         else:

--- a/prismaquant/pipeline.py
+++ b/prismaquant/pipeline.py
@@ -453,15 +453,15 @@ STAGE_SETTINGS_KEYS: dict[str, tuple[tuple[str, str], ...]] = {
     "gguf-skeleton": _key_pairs("MODEL_PATH"),
     # --- Tessera lane ------------------------------------------------------
     # The plan is a projection of the allocation onto the exporter's per-tensor
-    # vocabulary, so its identity includes checkpoint, coverage decision and
-    # explicitly supplied serving scope. The
-    # allocation itself is guarded upstream by `layer_config.json`'s own
-    # stages; what is NOT recoverable from that file is the coverage mode, and
+    # vocabulary, so its identity includes the exact allocation content,
+    # checkpoint, coverage decision and explicitly supplied serving scope.
+    # The allocator can rewrite layer_config.json on every invocation; its
+    # path is not an identity. What is NOT recoverable from that file is the coverage mode, and
     # it is the one setting that changes the artifact without changing the
     # allocation: `broadcast-by-role` extrapolates a single-layer allocation to
     # every depth, `as-allocated` does not. A skip-if-exists plan built under
     # the other mode is a different artifact.
-    "tessera-plan": _key_pairs("MODEL_PATH", "COVER<-TESSERA_PLAN_COVER",
+    "tessera-plan": _key_pairs("MODEL_PATH", "COVER<-TESSERA_PLAN_COVER", "ASSIGNMENT_DIGEST",
                                *_TESSERA_SCOPE_SETTINGS),
 }
 
@@ -554,6 +554,8 @@ def check_stage_settings(
     * artifact present, this stage never recorded -> WARN and record
       (trust-on-first-use: artifacts predating a stage's guard are not
       invalidated, which is the pre-R5 contract for missing manifests).
+      Tessera plans are the exception: an old plan cannot be bound to a new
+      allocation by recording today's hash after translation already happened.
     """
     declared = dict((document.get("artifacts") or {}).get(stage) or {})
     unresolved = list((document.get("unresolved") or {}).get(stage) or [])
@@ -575,6 +577,12 @@ def check_stage_settings(
 
     if artifact_path.exists():
         if not manifest_path.exists():
+            if stage == "tessera-plan":
+                return 2, [
+                    f"[pipeline] ERROR: {stage}: {artifact_path} has no recorded "
+                    "allocation content binding; refusing silent reuse. "
+                    "Rebuild the plan from the current allocation.",
+                ]
             return 0, [
                 f"[pipeline] WARNING: {stage}: reusing {artifact_path} which "
                 "has no settings manifest (predates the settings-hash guard); "
@@ -587,6 +595,12 @@ def check_stage_settings(
             if isinstance(legacy, Mapping) and set(legacy) == set(declared):
                 prev = dict(legacy)
         if prev is None:
+            if stage == "tessera-plan":
+                return 2, [
+                    f"[pipeline] ERROR: {stage}: {artifact_path} has no recorded "
+                    "allocation content binding for this stage; refusing silent reuse. "
+                    "Rebuild the plan from the current allocation.",
+                ]
             messages.append(
                 f"[pipeline] WARNING: {stage}: {artifact_path} predates this "
                 "stage's settings guard; recording the current settings "

--- a/prismaquant/run-pipeline.sh
+++ b/prismaquant/run-pipeline.sh
@@ -2456,8 +2456,8 @@ if [[ "$EXPORT_CONTAINER" == "tessera" ]]; then
   # Tessera lane: one blob per vLLM module on the Tessera wire, served by
   # Tessera's OWN vLLM plugin (package `tessera.serving`, entry point under
   # vllm.general_plugins, quant_method "tessera"). There is no enable flag --
-  # the checkpoint selects the plugin -- and the one operator knob is
-  # TESSERA_SERVE_MODE.
+  # the checkpoint selects the plugin. Scoped targets additionally bind the
+  # exact image and execution mode rather than inheriting wrapper defaults.
   #
   # TWO CALLS OUT, ZERO CODECS IN. The layer_config -> plan translation and
   # the encode both live in the Tessera repository and are NAMED here, never
@@ -2548,7 +2548,22 @@ if [[ "$EXPORT_CONTAINER" == "tessera" ]]; then
     echo "[pipeline] ERROR: EXPORT_CONTAINER=tessera: could not open the Tessera ship record. The artifact is unpublishable without one, and writing a base card by hand would omit this lane's own gates, so the export is not done until this succeeds." >&2
     exit 2
   fi
-  echo "  Serve:       TESSERA_SERVE_MODE=${TESSERA_SERVE_MODE} bash ${TESSERA_REPO%/}/experiments/tessera_plugin_served.sh ${WORK_DIR}/exported <arm> ${TESSERA_SERVE_MODE}"
+  # Print a shell-safe recipe for the same target admission just checked.
+  # Legacy context-free callers retain the wrapper's image/mode defaults.
+  TESSERA_PRINT_SERVE=("TESSERA_SERVE_MODE=${TESSERA_SERVE_MODE}" "TS=${TESSERA_REPO%/}")
+  if [[ -n "${TESSERA_RUNTIME_IMAGE:-}" ]]; then
+    TESSERA_PRINT_SERVE+=("IMAGE=$TESSERA_RUNTIME_IMAGE")
+    case "$TESSERA_EXECUTION_MODE" in
+      eager) TESSERA_PRINT_SERVE+=(TESSERA_LANE_EAGER=1) ;;
+      compiled) TESSERA_PRINT_SERVE+=(TESSERA_LANE_EAGER=0) ;;
+      *) echo "[pipeline] ERROR: invalid scoped Tessera execution mode" >&2; exit 2 ;;
+    esac
+  fi
+  TESSERA_PRINT_SERVE+=(bash "${TESSERA_REPO%/}/experiments/tessera_plugin_served.sh"
+    "${WORK_DIR}/exported" '<arm>' "$TESSERA_SERVE_MODE")
+  printf '  Serve:      '
+  printf ' %q' "${TESSERA_PRINT_SERVE[@]}"
+  printf '\n'
   echo "  Route census: python ${TESSERA_REPO%/}/tools/tessera_route_census.py --log <serve.log>"
   echo "  Close census: python -m prismaquant.shipcard_cli fill-route-census ${WORK_DIR}/exported/shipcard.json --census <census.json> --priced-route TESSERA_NVFP4 [...]"
   echo "  Verify:      python -m prismaquant.shipcard_cli verify ${WORK_DIR}/exported/shipcard.json"

--- a/prismaquant/run-pipeline.sh
+++ b/prismaquant/run-pipeline.sh
@@ -2564,8 +2564,22 @@ if [[ "$EXPORT_CONTAINER" == "tessera" ]]; then
   printf '  Serve:      '
   printf ' %q' "${TESSERA_PRINT_SERVE[@]}"
   printf '\n'
-  echo "  Route census: python ${TESSERA_REPO%/}/tools/tessera_route_census.py --log <serve.log>"
-  echo "  Close census: python -m prismaquant.shipcard_cli fill-route-census ${WORK_DIR}/exported/shipcard.json --census <census.json> --priced-route TESSERA_NVFP4 [...]"
+  echo "  Run the route census inside the same verified runtime image; keep its complete raw JSON."
+  TESSERA_PRINT_CENSUS=("TESSERA_SERVE_MODE=${TESSERA_SERVE_MODE}" python3
+    "${TESSERA_REPO%/}/tools/tessera_route_census.py" "${WORK_DIR}/exported"
+    '<raw-census.json>' --runtime-image "${TESSERA_RUNTIME_IMAGE:-<verified-image@sha256:digest>}")
+  if [[ "${TESSERA_EXECUTION_MODE:-}" == "compiled" ]]; then
+    TESSERA_PRINT_CENSUS+=(--compiled)
+    echo "  Note: the producer's combined dense compiled trace cannot prove per-regime route agreement."
+  fi
+  printf '  Route census:'
+  printf ' %q' "${TESSERA_PRINT_CENSUS[@]}"
+  printf '\n'
+  printf '  Close census:'
+  printf ' %q' python3 -m prismaquant.shipcard_cli fill-route-census \
+    "${WORK_DIR}/exported/shipcard.json" --census '<raw-census.json>' \
+    --layer-config "${WORK_DIR}/artifacts/layer_config.json" --model-dir "${WORK_DIR}/exported"
+  printf '\n'
   echo "  Verify:      python -m prismaquant.shipcard_cli verify ${WORK_DIR}/exported/shipcard.json"
   exit 0
 fi

--- a/prismaquant/run-pipeline.sh
+++ b/prismaquant/run-pipeline.sh
@@ -2478,7 +2478,12 @@ if [[ "$EXPORT_CONTAINER" == "tessera" ]]; then
     exit 2
   fi
   TESSERA_PLAN="${WORK_DIR}/artifacts/tessera_plan.json"
-  require_stage_settings "$TESSERA_PLAN" tessera-plan
+  # The allocator always rewrites its recipe. A path or a newly generated
+  # build anchor cannot establish which allocation an existing plan translated.
+  TESSERA_ASSIGNMENT_DIGEST=$(sha256sum "${WORK_DIR}/artifacts/layer_config.json")
+  TESSERA_ASSIGNMENT_DIGEST=${TESSERA_ASSIGNMENT_DIGEST%% *}
+  require_stage_settings "$TESSERA_PLAN" tessera-plan \
+    "ASSIGNMENT_DIGEST=$TESSERA_ASSIGNMENT_DIGEST"
   if [[ ! -f "$TESSERA_PLAN" ]]; then
     echo "[pipeline] [4/4] translating layer_config.json -> Tessera plan (cover=${TESSERA_PLAN_COVER}) ..."
     # Write-then-rename: a crashed translation must not leave a partial plan

--- a/prismaquant/run-pipeline.sh
+++ b/prismaquant/run-pipeline.sh
@@ -147,7 +147,21 @@ fi
 # It was a shell-local variable while the existence check was a loop in this
 # file, which is exactly the coupling that moved.
 export TESSERA_REPO
+# Keep the existing unscoped default, but do not turn it into an operator's
+# declaration when a v5 runtime target is requested below.
+TESSERA_SERVE_MODE_EXPLICIT=${TESSERA_SERVE_MODE+x}
 : "${TESSERA_SERVE_MODE:=resident}"
+TESSERA_SCOPE_ARGS=()
+if [[ -n "${TESSERA_PLATFORM:-}${TESSERA_RUNTIME_IMAGE:-}${TESSERA_EXECUTION_MODE:-}" ]]; then
+  if [[ "$TESSERA_SERVE_MODE_EXPLICIT" != "x" ]]; then
+    echo "[pipeline] ERROR: an explicit Tessera runtime target requires TESSERA_SERVE_MODE=resident|streamed; the legacy default is not a scoped declaration." >&2
+    exit 2
+  fi
+  [[ -z "${TESSERA_PLATFORM:-}" ]] || TESSERA_SCOPE_ARGS+=(--tessera-platform "$TESSERA_PLATFORM")
+  [[ -z "${TESSERA_RUNTIME_IMAGE:-}" ]] || TESSERA_SCOPE_ARGS+=(--tessera-runtime-image "$TESSERA_RUNTIME_IMAGE")
+  [[ -z "${TESSERA_EXECUTION_MODE:-}" ]] || TESSERA_SCOPE_ARGS+=(--tessera-execution-mode "$TESSERA_EXECUTION_MODE")
+  TESSERA_SCOPE_ARGS+=(--tessera-residency "$TESSERA_SERVE_MODE")
+fi
 # `as-allocated` plans exactly the units the allocation names and spells every
 # other body Linear BF16 explicitly. `broadcast-by-role` EXTRAPOLATES a
 # single-layer allocation to every depth and stamps itself as an
@@ -383,23 +397,21 @@ if [[ "$EXPORT_CONTAINER" == "gguf" ]]; then
   fi
 fi
 
-# Tessera lane consistency gates. Three refusals, cheapest first, and every
-# one of them is a fact read from the pinned runtime's own published table
-# rather than a belief held here (principle 14):
+# Tessera lane consistency gates read the packaged contract and release pin,
+# rather than assuming the checkpoint's class or requested runtime is served.
 #
 #   * the checkpoint's structure must be one the packaged contract declares
-#     (it declares `dense` and carries no routed_moe cell, because no served
-#     measurement covers routed experts);
+#     (a checkpoint class does not determine the structure of each unit);
 #   * lane_specs/tessera.json's `served_activation_quantization.executes` must
 #     EQUAL what the contract's formats[] rows imply;
 #   * the pinned Tessera serving runtime must be an exact reviewed release.
 #
-# The third one refuses every run today, and it is the ONLY thing that does:
-# there is no Tessera release tag (RobTand/tessera#17). That is the honest
-# state of the lane, said here where an operator can act on it, instead of
-# `unknown export lane` from a vocabulary check three layers up.
+# V5 additionally requires an explicit runtime target. The selected-unit
+# check runs again immediately before translation, when the allocation exists.
+# A development pin does not bypass the release export gate (tessera#17).
 if [[ "$EXPORT_CONTAINER" == "tessera" ]]; then
-  if ! python3 -m prismaquant.tessera_export_lane --model "$MODEL_PATH"; then
+  if ! python3 -m prismaquant.tessera_export_lane --model "$MODEL_PATH" \
+      --target-profile "$TARGET_PROFILE_RESOLVED" "${TESSERA_SCOPE_ARGS[@]}"; then
     exit 2
   fi
   # The two Tessera-repository tools this arm shells out to are NOT listed
@@ -477,7 +489,9 @@ if ! LM_HEAD_POLICY_TEXT="$(
   PQ_ALLOW_PINNED="$ALLOW_PINNED" \
   PQ_LM_HEAD_FORMAT="$LM_HEAD_FORMAT" \
   PQ_BODY_FORMATS="$FORMATS" \
-  python3 - <<'PY'
+  PQ_COST_PATH_OVERRIDE="${COST_PATH_OVERRIDE:-}" \
+  python3 - --target-profile "${TARGET_PROFILE_RESOLVED:-}" "${TESSERA_SCOPE_ARGS[@]}" <<'PY'
+import argparse
 import os
 import sys
 
@@ -487,14 +501,34 @@ from prismaquant.fixed_head import (
     remaining_profile_pins,
 )
 from prismaquant.model_profiles import detect_profile
+from prismaquant.serving_profiles import load_serving_profile
+from prismaquant.tessera_serving_scope import (
+    add_serving_scope_arguments,
+    serving_target_from_args,
+    unit_structure_from_profile,
+)
 
 profile = detect_profile(os.environ["PQ_MODEL_PATH"])
+parser = argparse.ArgumentParser()
+parser.add_argument("--target-profile", default=None)
+add_serving_scope_arguments(parser)
+scope_args = parser.parse_args()
+try:
+    serving_profile = load_serving_profile(scope_args.target_profile or None)
+    target = serving_target_from_args(scope_args, target_platform=serving_profile.target_platform)
+except (OSError, ValueError) as exc:
+    print(f"[pipeline] ERROR: invalid Tessera serving target: {exc}", file=sys.stderr)
+    raise SystemExit(2) from None
 try:
     canonical = fr.get_format(os.environ["PQ_LM_HEAD_FORMAT"]).name
 except Exception as exc:
     print(f"[pipeline] ERROR: invalid LM_HEAD_FORMAT: {exc}", file=sys.stderr)
     raise SystemExit(2) from None
-if not fr.format_is_producer_eligible(canonical):
+head_context = None
+if target is not None and fr.is_tessera_format_name(canonical):
+    head_context = {"lm_head": target.context(unit_structure_from_profile("lm_head", profile))}
+if not fr.format_is_producer_eligible(canonical, **(
+        {"context_by_unit": head_context} if head_context is not None else {})):
     print(
         f"[pipeline] ERROR: LM_HEAD_FORMAT={canonical} is reader-only and "
         "cannot enter a new artifact.",
@@ -520,8 +554,29 @@ for raw in os.environ["PQ_BODY_FORMATS"].split(","):
     value = raw.strip()
     if not value:
         continue
+    if value == "TESSERA":
+        # This is a token, never a shape-free FormatSpec. Its cost columns and
+        # per-unit admission are resolved by the allocator. The separate cost
+        # override stage-graph repair is tracked in PrismaQuant #184.
+        if not os.environ.get("PQ_COST_PATH_OVERRIDE"):
+            print("[pipeline] ERROR: TESSERA menu token requires COST_PATH_OVERRIDE", file=sys.stderr)
+            raise SystemExit(2)
+        if value not in seen:
+            seen.add(value)
+            formats.append(value)
+        continue
     fmt = fr.get_format(value).name
-    if not fr.format_is_producer_eligible(fmt):
+    if target is not None and fr.is_tessera_format_name(fmt):
+        from prismaquant.tessera_render import tessera_rung_is_serialisable
+
+        # No unit topology exists at this name-only boundary. Check bytes can
+        # be written, then let the allocator and selected-export gate ask the
+        # same complete context for each actual unit; never fabricate a
+        # model-wide dense or routed claim just to pass this preliminary check.
+        eligible = tessera_rung_is_serialisable(fmt)
+    else:
+        eligible = fr.format_is_producer_eligible(fmt)
+    if not eligible:
         print(
             f"[pipeline] ERROR: FORMATS contains reader-only {fmt}; legacy "
             "wire ids may be inspected but cannot enter a new cost/allocator/"
@@ -540,6 +595,8 @@ print("1" if fixed_quantized else "0")
 print("1" if dp_unpinned else "0")
 print("1" if fixed_quantized or dp_unpinned else "0")
 print(",".join(formats))
+if target is not None:
+    print(target.platform)
 for pin in remaining_profile_pins(
     profile,
     allow_pinned=allow,
@@ -561,7 +618,21 @@ LM_HEAD_FIXED_QUANTIZED="${LM_HEAD_POLICY_LINES[1]}"
 LM_HEAD_DP_UNPINNED="${LM_HEAD_POLICY_LINES[2]}"
 LM_HEAD_RENDER_ACTIVE="${LM_HEAD_POLICY_LINES[3]}"
 COST_FORMATS="${LM_HEAD_POLICY_LINES[4]}"
-REMAINING_PROFILE_PINS=("${LM_HEAD_POLICY_LINES[@]:5}")
+TESSERA_RESOLVED_PLATFORM=""
+TESSERA_SCOPE_RESIDENCY=""
+TESSERA_SCOPE_TARGET_PROFILE=""
+if [[ ${#TESSERA_SCOPE_ARGS[@]} -gt 0 ]]; then
+  if (( ${#LM_HEAD_POLICY_LINES[@]} < 6 )); then
+    echo "[pipeline] ERROR: scoped policy resolver omitted the resolved Tessera platform." >&2
+    exit 2
+  fi
+  TESSERA_RESOLVED_PLATFORM="${LM_HEAD_POLICY_LINES[5]}"
+  TESSERA_SCOPE_RESIDENCY="$TESSERA_SERVE_MODE"
+  TESSERA_SCOPE_TARGET_PROFILE="$TARGET_PROFILE_RESOLVED"
+  REMAINING_PROFILE_PINS=("${LM_HEAD_POLICY_LINES[@]:6}")
+else
+  REMAINING_PROFILE_PINS=("${LM_HEAD_POLICY_LINES[@]:5}")
+fi
 
 LM_HEAD_BASE_COST_ARGS=(--no-include-lm-head)
 if [[ "$LM_HEAD_RENDER_ACTIVE" == "1" ]]; then
@@ -1132,6 +1203,11 @@ STAGE_SETTINGS_ENV=(
   "VALIDATED_FRONTIER_CALIB_SKIP_FIRST=$VALIDATED_FRONTIER_CALIB_SKIP_FIRST"
   "VALIDATED_FRONTIER_KL_SCOPE=$VALIDATED_FRONTIER_KL_SCOPE"
   "TESSERA_PLAN_COVER=$TESSERA_PLAN_COVER"
+  "TESSERA_PLATFORM=$TESSERA_RESOLVED_PLATFORM"
+  "TESSERA_RUNTIME_IMAGE=${TESSERA_RUNTIME_IMAGE:-}"
+  "TESSERA_EXECUTION_MODE=${TESSERA_EXECUTION_MODE:-}"
+  "TESSERA_RESIDENCY=$TESSERA_SCOPE_RESIDENCY"
+  "TESSERA_TARGET_PROFILE=$TESSERA_SCOPE_TARGET_PROFILE"
   "${RENDER_ENV_SETTINGS[@]}"
 )
 STAGE_SETTINGS_ARGS=()
@@ -1740,6 +1816,7 @@ ALLOCATOR_PROFILE_ARGS=(--target-profile-default "$TARGET_PROFILE_DEFAULT")
 if [[ -n "$TARGET_PROFILE" ]]; then
   ALLOCATOR_PROFILE_ARGS+=(--target-profile "$TARGET_PROFILE")
 fi
+ALLOCATOR_PROFILE_ARGS+=("${TESSERA_SCOPE_ARGS[@]}")
 if [[ -n "$ALLOW_PINNED" ]]; then
   ALLOCATOR_PROFILE_ARGS+=(--allow-pinned "$ALLOW_PINNED")
 fi
@@ -2391,6 +2468,15 @@ if [[ "$EXPORT_CONTAINER" == "tessera" ]]; then
   # place a wire recipe can drift, which is exactly what the producer/consumer
   # boundary exists to prevent. The lane preflight above has already refused
   # if TESSERA_REPO does not hold both.
+  # Re-read the allocation's scope and actual source header dimensions even
+  # when an old plan exists: a cached plan is not an admission receipt.
+  TESSERA_BUILD_JSON="${WORK_DIR}/artifacts/tessera_build.json"
+  if ! python3 -m prismaquant.tessera_export_lane --model "$MODEL_PATH" \
+      --assignment "${WORK_DIR}/artifacts/layer_config.json" \
+      --write-build-json "$TESSERA_BUILD_JSON" \
+      --target-profile "$TARGET_PROFILE_RESOLVED" "${TESSERA_SCOPE_ARGS[@]}"; then
+    exit 2
+  fi
   TESSERA_PLAN="${WORK_DIR}/artifacts/tessera_plan.json"
   require_stage_settings "$TESSERA_PLAN" tessera-plan
   if [[ ! -f "$TESSERA_PLAN" ]]; then
@@ -2452,7 +2538,8 @@ if [[ "$EXPORT_CONTAINER" == "tessera" ]]; then
   if [[ -f "${WORK_DIR}/exported/shipcard.json" ]]; then
     echo "  Ship record: ${WORK_DIR}/exported/shipcard.json exists, kept (re-open would discard filled slots)"
   elif ! python3 -m prismaquant.lane_shipcard open \
-         --lane tessera --artifact "${WORK_DIR}/exported"; then
+         --lane tessera --artifact "${WORK_DIR}/exported" \
+         --build-json "$TESSERA_BUILD_JSON"; then
     echo "[pipeline] ERROR: EXPORT_CONTAINER=tessera: could not open the Tessera ship record. The artifact is unpublishable without one, and writing a base card by hand would omit this lane's own gates, so the export is not done until this succeeds." >&2
     exit 2
   fi

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -624,8 +624,13 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     from .tessera_render import (
         HessianContractError, tessera_encoder_hessian_status,
     )
+    from .tessera_serving_scope import (
+        add_serving_scope_arguments, serving_target_from_args,
+        context_by_unit_from_stats, scope_provenance,
+    )
 
     ap = argparse.ArgumentParser(description=__doc__)
+    add_serving_scope_arguments(ap)
     ap.add_argument("--model", required=True)
     ap.add_argument("--out", required=True, help="cost payload (.pkl)")
     ap.add_argument("--cache-dir", required=True)
@@ -674,6 +679,7 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     ap.add_argument("--deadline-seconds", type=float, default=0.0,
                     help="stop starting new anchors after this much wall time")
     args = ap.parse_args(argv)
+    serving_target = serving_target_from_args(args)
 
     mode = menu_mode(args.menu_mode)
     hessian_status = tessera_encoder_hessian_status()
@@ -725,6 +731,16 @@ def main(argv: "Sequence[str] | None" = None) -> int:
         targets = keep
     print(f"[campaign] {len(targets)} target Linears, mode={mode}, "
           f"device={device}", flush=True)
+
+    context_by_unit = None
+    if serving_target is not None:
+        from .sensitivity_probe import discover_moe_structure
+        routed = discover_moe_structure(model, profile=profile)
+        topology = {
+            name: dict(zip(("router_path", "expert_id"), routed.get(name, (None, None))))
+            for name in targets
+        }
+        context_by_unit = context_by_unit_from_stats(serving_target, topology, profile)
 
     tokens, corpus_text = _calibration_tokens(
         args.model, args.nsamples, args.seqlen, args.seed)
@@ -795,6 +811,7 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     menus = expand_menus_for_targets(
         weights, targets, mode=mode, tp_degree=args.tp_degree,
         parallel_kind=PARALLEL_NONE,
+        context_by_unit=context_by_unit,
     )
 
     measured: dict[str, dict[str, list[CampaignAnchor]]] = {}
@@ -1081,6 +1098,8 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             "stopped_early": bool(stopped_early),
             "wall_seconds": time.time() - started,
             "cache_dir": str(cache_dir),
+            **({"tessera_serving_scope": scope_provenance(serving_target, context_by_unit)}
+               if serving_target is not None else {}),
             "wire_dir": str(wire_dir),
             "tessera_commit": os.environ.get("TESSERA_COMMIT", ""),
             "hessian": {

--- a/prismaquant/tessera_export_lane.py
+++ b/prismaquant/tessera_export_lane.py
@@ -18,12 +18,12 @@ the encode is Tessera's ``experiments/export_tessera_serving.py``.  Copying
 either here would make this repository the second place a wire recipe lives,
 which is the failure mode principle 14 exists to prevent.
 
-**Four gates, each of which fails closed on its own.**
+**Independent fail-closed gates, before encoding.**
 
 1. :func:`require_release_pin` -- the pinned Tessera serving runtime must be an
    exact reviewed release.  It is not, today: no Tessera release tag exists
-   (RobTand/tessera#17), so this refuses every run and it is the ONLY thing
-   that does.  That is the honest state of the lane and it is stated where an
+   (RobTand/tessera#17), so this refuses release exports regardless of whether
+   development admission is enabled. That is stated where an
    operator can act on it, rather than as ``unknown export lane`` from a
    vocabulary check three layers up.
 2. :func:`require_executes_derived_from_contract` -- principle 14.  The lane
@@ -31,10 +31,9 @@ which is the failure mode principle 14 exists to prevent.
    runtime EXECUTES, so it is DERIVED from the ``formats[]`` table the runtime
    publishes and any disagreement refuses.  Two of our own spec files once
    disagreed about one runtime; the runtime was never ambiguous.
-3. :func:`require_declared_structure` -- the contract declares
-   ``structures: ["dense"]`` and carries no ``routed_moe`` cell, because no
-   served measurement covers routed experts.  A model with routed experts is
-   refused by reading that field, not by a hardcoded list here.
+3. :func:`require_declared_structure` -- the checkpoint's structural class
+   must be declared by the packaged contract. This is a coarse preflight,
+   not permission to treat every unit of an MoE checkpoint as an expert.
 4. :func:`require_producer_tools` -- every external tool the lane DECLARES it
    shells out to must exist under the env var the declaration names.  This was
    a hardcoded ``for`` loop over two paths in ``run-pipeline.sh``; it is now
@@ -42,11 +41,17 @@ which is the failure mode principle 14 exists to prevent.
    carries each tool's stability and its tracking issue, so a shipping lane's
    dependency on a script with no stability promise is a value a reader and a
    gate can both see (RobTand/prismaquant#119).
+5. :func:`require_serving_target` and :func:`require_assignment_scope` -- v5
+   needs an explicit runtime target. Before translation, every selected
+   Tessera unit must retain the allocation's target and per-unit context,
+   agree with the source header and profile topology, and resolve all regimes
+   on that context. Legacy calls without scope retain their existing gates.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import struct
 import sys
 from collections.abc import Mapping
 from pathlib import Path
@@ -67,8 +72,8 @@ ROUTED_EXPERT_COUNT_KEYS = (
 )
 
 #: The structure id this repository uses for a checkpoint with routed experts.
-#: It is one of ``lane_eligibility.STRUCTURES``; the contract simply does not
-#: declare it.
+#: It is one of ``lane_eligibility.STRUCTURES``; admission reads whether the
+#: packaged contract declares it rather than inferring support from this id.
 STRUCTURE_ROUTED_MOE = "routed_moe"
 STRUCTURE_DENSE = "dense"
 
@@ -98,9 +103,9 @@ def require_release_pin() -> None:
             f"{exc}\n"
             "  There is no Tessera release tag yet (RobTand/tessera#17), and "
             "cutting one is Rob's decision, not this pipeline's. Until then "
-            "the lane is declared and gated but cannot build: every Tessera "
-            "rung is producer-ineligible, so an allocation cannot select one "
-            "either.\n"
+            "the release export lane is declared and gated but cannot build. "
+            "Explicit development admission may allocate research artifacts; "
+            "it does not satisfy this release gate.\n"
             "  Resolving it is ONE reviewed commit: "
             "prismaquant/tessera_runtime/tessera_serving_runtime_pin.json's "
             "commit/version/version_is_release AND the two release constants "
@@ -238,11 +243,9 @@ def require_declared_structure(model_path: str | Path) -> str:
         raise TesseraExportLaneError(
             f"this checkpoint's structure is {structure!r} and the pinned "
             f"Tessera runtime declares structures {list(table.structures)}.\n"
-            "  Absence is the honest state, not an oversight: no served "
-            "measurement covers routed experts, so the plugin refuses a routed "
-            "MoE module by name rather than degrading it, and the exporter "
-            "would pass every expert through as BF16 -- an artifact that is "
-            "not the allocation that justified it."
+            "  A checkpoint class absent from the published table is not "
+            "attested. Do not replace its selected units with BF16 merely "
+            "to build an artifact different from the allocation that priced it."
         )
     return structure
 
@@ -308,14 +311,202 @@ def require_producer_tools(
 
 
 # ---------------------------------------------------------------------------
+# Runtime-scoped export -- the allocation and source, not a model-wide guess
+# ---------------------------------------------------------------------------
+def require_serving_target(target=None, *, table=None):
+    """Validate explicit v5 target input without inventing a per-unit claim."""
+    from .lane_eligibility import (
+        LANE_ELIGIBILITY_SCHEMA_TESSERA, legacy_runtime_scope_refusal,
+        load_eligibility_table,
+    )
+    from .tessera_serving_scope import ServingTarget
+
+    if table is None:
+        table = load_eligibility_table(contract_path=packaged_contract_path())
+    if target is None:
+        if table.schema == LANE_ELIGIBILITY_SCHEMA_TESSERA:
+            raise TesseraExportLaneError(
+                "an explicit Tessera serving target is required for v5 export; "
+                "supply platform, runtime image, execution mode and residency")
+        return None
+    if table.schema != LANE_ELIGIBILITY_SCHEMA_TESSERA:
+        raise TesseraExportLaneError(legacy_runtime_scope_refusal(table.schema))
+    try:
+        validated = ServingTarget(**target.as_dict())
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise TesseraExportLaneError(f"invalid Tessera serving target: {exc}") from exc
+    if validated.platform not in table.platforms:
+        raise TesseraExportLaneError(
+            f"Tessera target platform {validated.platform!r} is not published "
+            f"by this contract: {list(table.platforms)}")
+    return validated
+
+
+def _source_unit_shapes(model_path: str | Path, profile) -> dict[str, list[tuple[str, tuple]]]:
+    """Read source headers and the shared name projection; never load weights."""
+    from .footprint import _read_safetensors_header
+    from .name_projection import MAPPED, NameProjection
+    from .source_prefetch import _unique_safetensor_shards
+
+    paths = _unique_safetensor_shards(model_path)
+    if not paths:
+        raise TesseraExportLaneError(
+            f"no indexed or model.safetensors source checkpoint under {model_path}")
+    projection = NameProjection(profile)
+    by_unit: dict[str, list[tuple[str, tuple]]] = {}
+    seen: set[str] = set()
+    for path in paths:
+        for name, metadata in _read_safetensors_header(str(path)).items():
+            if name == "__metadata__":
+                continue
+            if name in seen:
+                raise TesseraExportLaneError(
+                    f"source checkpoint tensor {name!r} occurs in multiple shards")
+            seen.add(name)
+            projected = projection.checkpoint_to_live(name)
+            if projected.outcome != MAPPED:
+                continue
+            unit = projection.recipe_unit(projected.target)
+            shape = metadata.get("shape") if isinstance(metadata, Mapping) else None
+            if not isinstance(shape, list) or any(
+                    isinstance(dim, bool) or not isinstance(dim, int) or dim <= 0
+                    for dim in shape):
+                # Zero-size ancillary tensors need not make an otherwise valid
+                # checkpoint unexportable; a selected one has no valid shape.
+                shape = ()
+            by_unit.setdefault(unit, []).append((name, tuple(shape)))
+    return by_unit
+
+
+def require_assignment_scope(model_path: str | Path, assignment_path: str | Path,
+                             *, target=None) -> dict | None:
+    """Re-resolve selected Tessera units before the external translator runs.
+
+    The existing translator still owns serialization and expert aggregation.
+    This gate accepts exact two-dimensional source units, not a guessed slice
+    of a packed source tensor. These are source-member shapes, not a claim
+    about the producer's eventual fused execution unit; predicated cells
+    require that producer projection and are refused here.
+    """
+    from .lane_eligibility import (
+        LANE_ELIGIBILITY_SCHEMA_TESSERA, QUALIFICATION_DEVICE_QUALIFIED, ROUTE_STATUS_BACKED,
+        ROUTE_STATUS_BACKED_WITH_SERVE_FLAG, ServingContext, cell_matches_serving_context,
+        load_eligibility_table, load_published_formats, resolve_unit_route,
+        unit_structural_facts,
+    )
+    from .layer_config import load_assignment, read_layer_config_metadata
+    from .model_profiles import detect_profile
+    from .tessera_serving_scope import ServingTarget, unit_structure_from_profile
+
+    path = packaged_contract_path()
+    table = load_eligibility_table(contract_path=path)
+    # An old context-free export remains the old export. Explicitly scoped
+    # queries never borrow a legacy table's global runtime identity.
+    if target is None and table.schema != LANE_ELIGIBILITY_SCHEMA_TESSERA:
+        return None
+    if target is None:
+        require_serving_target(target, table=table)
+    try:
+        selected = {name: fmt for name, fmt in load_assignment(assignment_path).items()
+                    if fmt.startswith("TESSERA_")}
+        scope = read_layer_config_metadata(assignment_path).get("tessera_serving_scope")
+        if not isinstance(scope, Mapping):
+            raise TesseraExportLaneError(
+                "allocation carries no tessera_serving_scope; re-allocate with an explicit target")
+        if set(scope) != {"target", "by_unit"} or not isinstance(scope["target"], Mapping):
+            raise TesseraExportLaneError(
+                "allocation tessera_serving_scope requires target and by_unit objects")
+        recorded_target = ServingTarget(**scope["target"])
+        if recorded_target.as_dict() != target.as_dict():
+            raise TesseraExportLaneError(
+                "export target disagrees with the allocation target: "
+                f"export={target.as_dict()}, allocation={recorded_target.as_dict()}")
+        target = require_serving_target(target, table=table)
+        by_unit = scope["by_unit"]
+        if not isinstance(by_unit, Mapping):
+            raise TesseraExportLaneError("allocation scope.by_unit must be an object")
+        profile = detect_profile(str(model_path))
+        shapes = _source_unit_shapes(model_path, profile)
+        formats = load_published_formats(contract_path=path)
+        routes = {}
+        for name, fmt in sorted(selected.items()):
+            matches = shapes.get(name, ())
+            if len(matches) != 1 or len(matches[0][1]) != 2:
+                raise TesseraExportLaneError(
+                    f"{name}: scoped export needs one exact 2-D source checkpoint shape; "
+                    f"found {list(matches)}. Packed or aggregate source units require "
+                    "the producer's explicit projection, not a guessed slice.")
+            structure = unit_structure_from_profile(name, profile)
+            expected = target.context(structure)
+            context_payload = by_unit.get(name)
+            if not isinstance(context_payload, Mapping):
+                raise TesseraExportLaneError(f"{name}: allocation is missing per-unit serving context")
+            recorded = ServingContext(**context_payload)
+            if recorded != expected:
+                raise TesseraExportLaneError(
+                    f"{name}: allocation context disagrees with the export target or source "
+                    f"structure: recorded={recorded.as_dict()}, expected={expected.as_dict()}")
+            rows, columns = matches[0][1]
+            facts = unit_structural_facts(
+                name, fmt, is_routed_moe=structure == STRUCTURE_ROUTED_MOE,
+                # Tessera's per-Linear wire has no split codebooks. Expert
+                # aggregation remains the producer's job, not a local guess.
+                role_split=False, in_features=columns, out_features=rows,
+                published_formats=formats)
+            predicated = [cell.id for cell in table.cells
+                          if cell.family == facts.payload_family and cell.covers_rung(facts)
+                          and cell_matches_serving_context(cell, expected) and cell.predicates]
+            if predicated:
+                raise TesseraExportLaneError(
+                    f"{name}: selected route is unattested at this boundary: cells {predicated} "
+                    "carry predicates requiring the producer's executed-unit projection; "
+                    "source-member dimensions do not attest a fused execution shape")
+            route = resolve_unit_route(facts, table, **target.as_dict())
+            if (route.route_status not in (ROUTE_STATUS_BACKED, ROUTE_STATUS_BACKED_WITH_SERVE_FLAG)
+                    or any(row.qualification != QUALIFICATION_DEVICE_QUALIFIED for row in route.regimes)):
+                raise TesseraExportLaneError(
+                    f"{name}: selected Tessera route is {route.route_status}: "
+                    f"{route.unattested_reason or 'every regime must be device_qualified and native'}")
+            routes[name] = route.as_dict()
+        return {"target": target.as_dict(), "by_unit": routes,
+                "contract": table.provenance()}
+    except TesseraExportLaneError:
+        raise
+    except (OSError, ValueError, TypeError, KeyError, struct.error) as exc:
+        raise TesseraExportLaneError(f"cannot attest selected Tessera export scope: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
 # The driver's entry point
 # ---------------------------------------------------------------------------
-def preflight(model_path: str | Path) -> dict:
+def preflight(model_path: str | Path, *, target=None,
+              assignment_path: str | Path | None = None) -> dict:
     """Every gate, in the order that puts the cheapest refusal first."""
     structure = require_declared_structure(model_path)
+    target = require_serving_target(target)
     executes = require_executes_derived_from_contract()
     producer_tools = require_producer_tools()
     require_release_pin()
+    scope = None
+    build = None
+    if assignment_path is not None:
+        from .layer_config import read_layer_config_metadata
+        from .shipcard import file_sha256
+
+        assignment_sha = file_sha256(assignment_path)
+        if assignment_sha is None:
+            raise TesseraExportLaneError(f"cannot hash allocation {assignment_path}")
+        scope = require_assignment_scope(model_path, assignment_path, target=target)
+        build = {
+            "source_model": str(model_path), "layer_config": str(assignment_path),
+            "layer_config_sha": assignment_sha,
+        }
+        if scope is not None:
+            build["tessera_serving_scope"] = read_layer_config_metadata(
+                assignment_path)["tessera_serving_scope"]
+        if file_sha256(assignment_path) != assignment_sha:
+            raise TesseraExportLaneError(
+                "allocation changed during scoped preflight; no build anchor was produced")
     from .tessera_serving_runtime_pin import (
         load_tessera_serving_runtime_pin,
     )
@@ -325,7 +516,7 @@ def preflight(model_path: str | Path) -> dict:
     from .shipcard import lane_gate_slots
 
     spec = load_lane_spec("tessera")
-    return {
+    report = {
         "structure": structure,
         "executes": list(executes),
         "producer_tools": list(producer_tools),
@@ -342,6 +533,13 @@ def preflight(model_path: str | Path) -> dict:
         "pinned_commit": pin.commit,
         "quant_method": "tessera",
     }
+    if target is not None:
+        report["serving_target"] = target.as_dict()
+    if scope is not None:
+        report["selected_serving_scope"] = scope
+    if build is not None:
+        report["build"] = build
+    return report
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -353,10 +551,37 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     parser.add_argument("--model", required=True,
                         help="the source checkpoint run-pipeline.sh is building")
+    parser.add_argument("--assignment", default=None,
+                        help="selected layer_config.json to attest before plan translation")
+    parser.add_argument("--target-profile", default=None,
+                        help="serving profile supplying or cross-checking the exact platform")
+    parser.add_argument("--write-build-json", default=None,
+                        help="write validated allocation facts for lane_shipcard open --build-json")
+    from .tessera_serving_scope import add_serving_scope_arguments, serving_target_from_args
+
+    add_serving_scope_arguments(parser)
     args = parser.parse_args(argv)
     try:
-        report = preflight(args.model)
-    except TesseraExportLaneError as exc:
+        if args.write_build_json is not None and args.assignment is None:
+            raise TesseraExportLaneError("--write-build-json requires --assignment")
+        platform = None
+        if args.target_profile is not None:
+            from .serving_profiles import load_serving_profile
+
+            platform = load_serving_profile(args.target_profile).target_platform
+        target = serving_target_from_args(args, target_platform=platform)
+        if target is None and args.assignment is None:
+            report = preflight(args.model)
+        else:
+            report = preflight(args.model, target=target, assignment_path=args.assignment)
+        if args.write_build_json is not None:
+            destination = Path(args.write_build_json)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            temporary = destination.with_name(destination.name + ".tmp")
+            temporary.write_text(json.dumps(report["build"], indent=2, sort_keys=True) + "\n",
+                                 encoding="utf-8")
+            temporary.replace(destination)
+    except (TesseraExportLaneError, OSError, ValueError) as exc:
         print(f"[preflight] ERROR: EXPORT_CONTAINER=tessera: {exc}",
               file=sys.stderr)
         return 2
@@ -366,6 +591,11 @@ def main(argv: Sequence[str] | None = None) -> int:
           f"pin={report['pinned_version']}@{report['pinned_commit'][:12]}")
     print("[preflight] ship record this artifact must close: "
           + ", ".join(report["shipcard_slots"]))
+    if "serving_target" in report:
+        print("[preflight] explicit serving target: " + json.dumps(report["serving_target"], sort_keys=True))
+    if "selected_serving_scope" in report:
+        print("[preflight] scoped selected units: "
+              + str(len(report["selected_serving_scope"]["by_unit"])))
     for gate in report["unrecorded_gates"]:
         print(f"[preflight] gate {gate['gate']} is ADVISORY BY DECLARATION "
               f"(closes no shipcard slot): {gate['reason']}")

--- a/prismaquant/tessera_menu.py
+++ b/prismaquant/tessera_menu.py
@@ -1403,14 +1403,19 @@ def expand_menu_tokens(names, priced_formats=()) -> list[str]:
     return expand_menu_tokens_report(names, priced_formats)[0]
 
 
-def expand_menu_tokens_report(names, priced_formats=()) -> tuple[list[str], list[str]]:
+def expand_menu_tokens_report(names, priced_formats=(), *, context_by_unit=None) -> tuple[list[str], list[str]]:
     """``(menu, dropped)`` -- the expansion, and the priced-but-unattested rungs.
 
     Split out so the caller can *print* the narrowing rather than discover it
     as a smaller menu. ``dropped`` is empty whenever the token is absent.
+    With explicit contexts the shared menu is their admitted union; unit-level
+    candidate admission, not this union, decides which unit may use each rung.
     """
     from . import format_registry as fr
 
+    if context_by_unit is not None:
+        context_by_unit = {context.key(): context for context in context_by_unit.values()
+                           if context is not None}
     priced_all = [
         str(name) for name in priced_formats
         if isinstance(name, str) and name.startswith("TESSERA_")
@@ -1418,7 +1423,9 @@ def expand_menu_tokens_report(names, priced_formats=()) -> tuple[list[str], list
     dropped: list[str] = []
     priced: list[str] = []
     for name in priced_all:
-        (priced if fr.format_is_producer_eligible(name) else dropped).append(name)
+        eligible = fr.format_is_producer_eligible(name, **(
+            {"context_by_unit": context_by_unit} if context_by_unit is not None else {}))
+        (priced if eligible else dropped).append(name)
     out: list[str] = []
     seen: set[str] = set()
     for name in names:

--- a/prismaquant/tessera_serving_scope.py
+++ b/prismaquant/tessera_serving_scope.py
@@ -1,0 +1,122 @@
+"""Explicit runtime intake shared by Tessera campaign, allocation and export.
+
+The target describes the requested runtime, not the model. Structure is read
+separately for every unit from probe/discovery facts, checked against the model
+profile's declarations. Neither a model name nor the calibration device is a
+serving target.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import re
+from typing import Mapping
+
+from .lane_eligibility import ServingContext, STRUCTURE_DENSE, STRUCTURE_ROUTED_MOE
+
+
+@dataclass(frozen=True)
+class ServingTarget:
+    platform: str
+    runtime_image: str
+    execution_mode: str
+    residency: str
+
+    def __post_init__(self):
+        # Reuse the owner's validation; this does not classify any model unit.
+        self.context(STRUCTURE_DENSE)
+
+    def context(self, structure: str) -> ServingContext:
+        return ServingContext(structure=structure, **self.as_dict())
+
+    def as_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+def add_serving_scope_arguments(parser) -> None:
+    """No defaults: a legacy context-free call remains context-free."""
+    parser.add_argument("--tessera-platform", default=None,
+                        help="Exact serving platform; otherwise the selected serving profile's target_platform")
+    parser.add_argument("--tessera-runtime-image", default=None,
+                        help="Exact serving repository@sha256 digest, never a mutable tag")
+    parser.add_argument("--tessera-execution-mode", default=None,
+                        help="Explicit serving execution mode: eager or compiled")
+    parser.add_argument("--tessera-residency", default=None,
+                        help="Explicit serving residency: resident or streamed")
+
+
+def serving_target_from_args(args, *, target_platform: str | None = None) -> ServingTarget | None:
+    fields = ("platform", "runtime_image", "execution_mode", "residency")
+    values = {field: getattr(args, "tessera_" + field, None) for field in fields}
+    if all(value is None for value in values.values()):
+        return None
+    explicit_platform = values["platform"]
+    if explicit_platform is not None and target_platform and explicit_platform != target_platform:
+        raise ValueError(
+            f"tessera platform conflict: --tessera-platform={explicit_platform!r} "
+            f"but the selected serving profile declares {target_platform!r}")
+    if explicit_platform is None:
+        values["platform"] = target_platform
+    for field, value in values.items():
+        if value is None:
+            raise ValueError(f"tessera serving target requires explicit {field}; "
+                             f"supply --tessera-{field.replace('_', '-')}")
+    return ServingTarget(**values)
+
+
+def unit_structure_from_profile(qname: str, profile) -> str:
+    """Classify a known checkpoint unit with the profile's declared grammar.
+
+    Export first proves the unit exists in the source headers. This function
+    does not make a missing source tensor or unknown profile into a dense one.
+    """
+    if profile is None or profile.structure_spec() is None:
+        raise ValueError(f"{qname}: explicit Tessera scope needs a declared model profile")
+    if profile.packed_expert_format_group(qname) is not None:
+        return STRUCTURE_ROUTED_MOE
+    for rule in (profile.per_expert_moe_regex(), profile.per_expert_mtp_regex()):
+        if rule and re.fullmatch(rule.removeprefix("re:"), profile.to_vllm_internal_name(qname)):
+            return STRUCTURE_ROUTED_MOE
+    return STRUCTURE_DENSE
+
+
+def unit_structure_from_stats(qname: str, row: Mapping, profile) -> str:
+    """Use owned probe facts, never tensor shape or a model-wide MoE guess."""
+    declared_structure = unit_structure_from_profile(qname, profile)
+    packed_module = row.get("_packed_experts_module")
+    count = row.get("num_experts")
+    if packed_module is not None or count is not None:
+        if not isinstance(packed_module, str) or not packed_module or isinstance(count, bool) \
+                or not isinstance(count, int) or count <= 0:
+            raise ValueError(f"{qname}: ambiguous packed expert topology; "
+                             "need _packed_experts_module and positive num_experts")
+        structure = STRUCTURE_ROUTED_MOE
+    else:
+        if "router_path" not in row or "expert_id" not in row:
+            raise ValueError(f"{qname}: missing per-unit router_path/expert_id topology")
+        router, expert = row["router_path"], row["expert_id"]
+        if router is None and expert is None:
+            structure = STRUCTURE_DENSE
+        elif isinstance(router, str) and router and expert is not None \
+                and not isinstance(expert, bool) and str(expert).isdigit():
+            structure = STRUCTURE_ROUTED_MOE
+        else:
+            raise ValueError(f"{qname}: conflicting router_path/expert_id topology")
+    if declared_structure == STRUCTURE_ROUTED_MOE and structure != STRUCTURE_ROUTED_MOE:
+        raise ValueError(f"{qname}: probe topology conflicts with the profile's routed expert declaration")
+    return structure
+
+
+def context_by_unit_from_stats(target: ServingTarget | None, stats: Mapping[str, Mapping], profile
+                               ) -> dict[str, ServingContext] | None:
+    if target is None:
+        return None
+    return {name: target.context(unit_structure_from_stats(name, row, profile))
+            for name, row in stats.items()}
+
+
+def scope_provenance(target: ServingTarget | None,
+                     contexts: Mapping[str, ServingContext] | None) -> dict:
+    if target is None:
+        return {}
+    return {"target": target.as_dict(),
+            "by_unit": {name: context.as_dict() for name, context in sorted((contexts or {}).items())}}

--- a/tests/test_tessera_export_scope.py
+++ b/tests/test_tessera_export_scope.py
@@ -262,7 +262,8 @@ def test_shell_gates_selected_scope_before_the_external_translator():
     ("TESSERA_EXECUTION_MODE", "eager"), ("TESSERA_RESIDENCY", "resident"),
 ])
 def test_tessera_plan_cache_identity_changes_with_serving_target(key, value):
-    legacy = {"MODEL_PATH": "model", "TESSERA_PLAN_COVER": "as-allocated"}
+    legacy = {"MODEL_PATH": "model", "TESSERA_PLAN_COVER": "as-allocated",
+              "ASSIGNMENT_DIGEST": "a" * 64}
     before, missing = stage_settings_projection("tessera-plan", legacy)
     assert missing == []
     after, _ = stage_settings_projection("tessera-plan", {**legacy, key: value})

--- a/tests/test_tessera_export_scope.py
+++ b/tests/test_tessera_export_scope.py
@@ -271,7 +271,8 @@ def test_tessera_plan_cache_identity_changes_with_serving_target(key, value):
 
 
 def _run_head_policy(monkeypatch, capsys, *, body=FORMAT, head="BF16",
-                     scoped=True, serialisable=True, cost_override="cost.pkl"):
+                     scoped=True, serialisable=True, cost_override="cost.pkl",
+                     explicit_platform=True):
     """Execute the driver's real inline policy under CPU-only mocked formats."""
     from prismaquant import format_registry as fr
     from prismaquant import tessera_render
@@ -297,8 +298,10 @@ def _run_head_policy(monkeypatch, capsys, *, body=FORMAT, head="BF16",
     monkeypatch.setattr(tessera_render, "tessera_rung_is_serialisable", lambda _: serialisable)
     args = ["fixture", "--target-profile", "tessera_research_sm121"]
     if scoped:
-        args += ["--tessera-platform", "sm_121", "--tessera-runtime-image", IMAGE,
+        args += ["--tessera-runtime-image", IMAGE,
                  "--tessera-execution-mode", "eager", "--tessera-residency", "resident"]
+        if explicit_platform:
+            args += ["--tessera-platform", "sm_121"]
     monkeypatch.setattr(sys, "argv", args)
     driver = (Path(__file__).parents[1] / "prismaquant" / "run-pipeline.sh").read_text()
     block = driver[driver.index('if ! LM_HEAD_POLICY_TEXT="$('):]
@@ -322,6 +325,13 @@ def test_actual_shell_head_uses_its_explicit_context(monkeypatch, capsys):
 def test_actual_shell_preserves_the_prepriced_tessera_menu_token(monkeypatch, capsys):
     lines = _run_head_policy(monkeypatch, capsys, body="TESSERA,BF16")
     assert lines[4] == "TESSERA,BF16"
+
+
+def test_actual_shell_binds_inherited_platform_to_plan_identity(monkeypatch, capsys):
+    lines = _run_head_policy(monkeypatch, capsys, explicit_platform=False)
+    assert lines[5] == "sm_121"
+    driver = (Path(__file__).parents[1] / "prismaquant" / "run-pipeline.sh").read_text()
+    assert '"TESSERA_PLATFORM=$TESSERA_RESOLVED_PLATFORM"' in driver
 
 
 @pytest.mark.parametrize("kwargs", [

--- a/tests/test_tessera_export_scope.py
+++ b/tests/test_tessera_export_scope.py
@@ -1,0 +1,259 @@
+"""The real export endpoint binds selected units to their priced v5 scope."""
+from dataclasses import asdict, dataclass, replace
+import json
+from pathlib import Path
+import struct
+from types import SimpleNamespace
+
+import pytest
+
+from prismaquant import tessera_export_lane as export
+from prismaquant import tessera_serving_runtime_pin as pin
+from prismaquant.pipeline import stage_settings_projection
+
+
+IMAGE = "example/runtime@sha256:" + "a" * 64
+OTHER_IMAGE = "example/other@sha256:" + "b" * 64
+DENSE = "model.layers.0.self_attn.o_proj"
+EXPERT = "model.layers.0.mlp.experts.0.down_proj"
+FORMAT = "TESSERA_E4M3_K1_R1024"
+
+
+@dataclass(frozen=True)
+class Target:
+    platform: str = "sm_121"
+    runtime_image: str = IMAGE
+    execution_mode: str = "eager"
+    residency: str = "resident"
+
+    def as_dict(self):
+        return asdict(self)
+
+
+def _context(structure="dense", target=None):
+    return {**(target or Target()).as_dict(), "structure": structure}
+
+
+def _payload():
+    family = "TESSERA_E4M3_K1"
+    cells = []
+    for structure in ("dense", "routed_moe"):
+        for regime in ("decode", "batch"):
+            cells.append({
+                "id": f"{structure}_{regime}", "platform": "sm_121",
+                "family": family, "structure": structure, "regime": regime,
+                "rungs_q256": [1024], "activation_contract": "fp8_per_token_dynamic",
+                "route_status": "backed_with_serve_flag", "qualification": "device_qualified",
+                "requires_plugin": "tessera", "predicates": [],
+                "requires_serve_flags": ["TESSERA_SERVE_MODE=resident"],
+                "executes": [{"symbol": "torch.bmm", "decoder": "torch_window"}],
+                "runtime": {"image": IMAGE, "execution_modes": ["eager"]},
+            })
+    return {
+        "formats": [{"family": family, "kind": "tessera_wire",
+                     "name_pattern": family + "_R{k}",
+                     "reader_rate_range_q256": [256, 2048],
+                     "residency_modes": ["resident", "streamed"]}],
+        "lane_eligibility": {
+            "schema": "tessera.lane-eligibility.v5",
+            "platforms": {"sm_121": {}}, "regimes": ["decode", "batch"],
+            "structures": ["dense", "routed_moe"], "cells": cells,
+        },
+    }
+
+
+@pytest.fixture
+def case(tmp_path, monkeypatch):
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "config.json").write_text(json.dumps({
+        "model_type": "qwen3", "architectures": ["Qwen3MoeForCausalLM"],
+        "num_experts": 2,
+    }))
+    # The endpoint reads headers only; no weight materialization is needed.
+    header = json.dumps({
+        name + ".weight": {"dtype": "BF16", "shape": [64, 64],
+                            "data_offsets": [index * 8192, (index + 1) * 8192]}
+        for index, name in enumerate((DENSE, EXPERT))
+    }).encode()
+    (model / "model.safetensors").write_bytes(struct.pack("<Q", len(header)) + header)
+    contract = tmp_path / "contract.json"
+    contract.write_text(json.dumps(_payload()))
+    monkeypatch.setattr(export, "packaged_contract_path", lambda: contract)
+    assignment = tmp_path / "layer_config.json"
+    payload = {
+        name: {"data_type": "tessera", "bits": 4, "tessera_format": FORMAT}
+        for name in (DENSE, EXPERT)
+    }
+    payload["__prismaquant__"] = {"tessera_serving_scope": {
+        "target": Target().as_dict(),
+        "by_unit": {DENSE: _context(), EXPERT: _context("routed_moe")},
+    }}
+    assignment.write_text(json.dumps(payload))
+    return SimpleNamespace(model=model, assignment=assignment, payload=payload,
+                           contract=contract)
+
+
+def _save(case):
+    case.assignment.write_text(json.dumps(case.payload))
+
+
+def _scope(case):
+    return case.payload["__prismaquant__"]["tessera_serving_scope"]
+
+
+def test_selected_export_units_resolve_their_own_structure(case):
+    report = export.require_assignment_scope(case.model, case.assignment, target=Target())
+    assert set(report["by_unit"]) == {DENSE, EXPERT}
+    assert report["by_unit"][DENSE]["structure"] == "dense"
+    assert report["by_unit"][EXPERT]["structure"] == "routed_moe"
+    for route in report["by_unit"].values():
+        assert route["route_status"] == "backed_with_serve_flag"
+        assert {row["regime"] for row in route["regime_routes"]} == {"decode", "batch"}
+        assert all(row["runtime_image"] == IMAGE for row in route["regime_routes"])
+
+
+@pytest.mark.parametrize("field,value", [
+    ("runtime_image", OTHER_IMAGE), ("execution_mode", "compiled"),
+    ("residency", "streamed"), ("platform", "sm_120"),
+])
+def test_export_target_must_equal_the_allocation_target(case, field, value):
+    with pytest.raises(export.TesseraExportLaneError, match="allocation.*target|target.*allocation"):
+        export.require_assignment_scope(case.model, case.assignment,
+                                        target=replace(Target(), **{field: value}))
+
+
+@pytest.mark.parametrize("missing", ["scope", "target", "unit"])
+def test_v5_export_refuses_missing_recorded_scope(case, missing):
+    if missing == "scope":
+        case.payload["__prismaquant__"].pop("tessera_serving_scope")
+    elif missing == "target":
+        _scope(case).pop("target")
+    else:
+        _scope(case)["by_unit"].pop(EXPERT)
+    _save(case)
+    with pytest.raises(export.TesseraExportLaneError, match="scope|context|target"):
+        export.require_assignment_scope(case.model, case.assignment, target=Target())
+
+
+def test_v5_export_refuses_an_unbound_target_even_when_allocation_is_bound(case):
+    with pytest.raises(export.TesseraExportLaneError, match="explicit.*target|target.*required"):
+        export.require_assignment_scope(case.model, case.assignment)
+
+
+def test_export_rechecks_topology_instead_of_trusting_forged_dense_scope(case):
+    _scope(case)["by_unit"][EXPERT]["structure"] = "dense"
+    _save(case)
+    with pytest.raises(export.TesseraExportLaneError, match="structure|context"):
+        export.require_assignment_scope(case.model, case.assignment, target=Target())
+
+
+def test_export_refuses_selected_source_tensor_that_does_not_exist(case):
+    unknown = "model.layers.99.self_attn.o_proj"
+    case.payload[unknown] = case.payload.pop(DENSE)
+    _scope(case)["by_unit"][unknown] = _scope(case)["by_unit"].pop(DENSE)
+    _save(case)
+    with pytest.raises(export.TesseraExportLaneError, match="source|checkpoint|shape"):
+        export.require_assignment_scope(case.model, case.assignment, target=Target())
+
+
+def test_export_cannot_join_partial_regimes_from_another_runtime(case):
+    payload = _payload()
+    next(row for row in payload["lane_eligibility"]["cells"]
+         if row["id"] == "routed_moe_batch")["runtime"]["image"] = OTHER_IMAGE
+    case.contract.write_text(json.dumps(payload))
+    with pytest.raises(export.TesseraExportLaneError, match="regime|unattested"):
+        export.require_assignment_scope(case.model, case.assignment, target=Target())
+
+
+def test_export_shape_predicates_use_checkpoint_dimensions(case):
+    payload = _payload()
+    for row in payload["lane_eligibility"]["cells"]:
+        row["predicates"] = [{"fact": "in_features", "op": "equals", "value": 128}]
+    case.contract.write_text(json.dumps(payload))
+    with pytest.raises(export.TesseraExportLaneError, match="regime|unattested"):
+        export.require_assignment_scope(case.model, case.assignment, target=Target())
+
+
+def test_export_does_not_change_plain_bf16_assignments(case):
+    case.payload[DENSE] = "BF16"
+    _scope(case)["by_unit"].pop(DENSE)
+    _save(case)
+    report = export.require_assignment_scope(case.model, case.assignment, target=Target())
+    assert set(report["by_unit"]) == {EXPERT}
+
+
+def test_legacy_unscoped_export_keeps_its_existing_behavior(case):
+    payload = _payload()
+    payload["lane_eligibility"]["schema"] = "tessera.lane-eligibility.v4"
+    for row in payload["lane_eligibility"]["cells"]:
+        row.pop("runtime")
+    case.contract.write_text(json.dumps(payload))
+    case.payload.pop("__prismaquant__")
+    _save(case)
+    assert export.require_assignment_scope(case.model, case.assignment) is None
+
+
+def _isolate_other_gates(monkeypatch):
+    monkeypatch.setattr(export, "require_declared_structure", lambda model: "routed_moe")
+    monkeypatch.setattr(export, "require_executes_derived_from_contract", lambda: ())
+    monkeypatch.setattr(export, "require_producer_tools", lambda: ())
+    monkeypatch.setattr(export, "require_release_pin", lambda: None)
+    monkeypatch.setattr(pin, "load_tessera_serving_runtime_pin",
+                        lambda: SimpleNamespace(version="fixture", commit="f" * 40))
+
+
+def test_early_preflight_refuses_v5_without_an_explicit_target(case, monkeypatch):
+    _isolate_other_gates(monkeypatch)
+    with pytest.raises(export.TesseraExportLaneError, match="explicit.*target|target.*required"):
+        export.preflight(case.model)
+
+
+def test_later_preflight_calls_selected_unit_gate(case, monkeypatch):
+    _isolate_other_gates(monkeypatch)
+    _scope(case)["by_unit"][EXPERT]["structure"] = "dense"
+    _save(case)
+    with pytest.raises(export.TesseraExportLaneError, match="structure|context"):
+        export.preflight(case.model, target=Target(), assignment_path=case.assignment)
+
+
+def test_cli_passes_explicit_target_and_assignment_to_preflight(case, monkeypatch):
+    calls = []
+
+    def preflight(model, **kwargs):
+        calls.append((model, kwargs))
+        raise export.TesseraExportLaneError("fixture stop after observing boundary")
+
+    monkeypatch.setattr(export, "preflight", preflight)
+    assert export.main([
+        "--model", str(case.model), "--assignment", str(case.assignment),
+        "--tessera-platform", "sm_121", "--tessera-runtime-image", IMAGE,
+        "--tessera-execution-mode", "eager", "--tessera-residency", "resident",
+    ]) == 2
+    assert len(calls) == 1
+    assert calls[0][1]["target"].as_dict() == Target().as_dict()
+    assert str(calls[0][1]["assignment_path"]) == str(case.assignment)
+
+
+def test_shell_gates_selected_scope_before_the_external_translator():
+    driver = (Path(__file__).parents[1] / "prismaquant" / "run-pipeline.sh").read_text()
+    translator = driver.index('python3 "${TESSERA_REPO%/}/experiments/plan_from_layer_config.py"')
+    gate = driver.rfind("python3 -m prismaquant.tessera_export_lane", 0, translator)
+    invocation = driver[gate:driver.index("; then", gate)]
+    assert '--assignment "${WORK_DIR}/artifacts/layer_config.json"' in invocation
+    assert '"${TESSERA_SCOPE_ARGS[@]}"' in invocation
+    for flag in ("platform", "runtime-image", "execution-mode", "residency"):
+        assert f"--tessera-{flag}" in driver
+
+
+@pytest.mark.parametrize("key,value", [
+    ("TESSERA_PLATFORM", "sm_121"), ("TESSERA_RUNTIME_IMAGE", IMAGE),
+    ("TESSERA_EXECUTION_MODE", "eager"), ("TESSERA_RESIDENCY", "resident"),
+])
+def test_tessera_plan_cache_identity_changes_with_serving_target(key, value):
+    legacy = {"MODEL_PATH": "model", "TESSERA_PLAN_COVER": "as-allocated"}
+    before, missing = stage_settings_projection("tessera-plan", legacy)
+    assert missing == []
+    after, _ = stage_settings_projection("tessera-plan", {**legacy, key: value})
+    assert after != before
+    assert value in after.values()

--- a/tests/test_tessera_export_scope.py
+++ b/tests/test_tessera_export_scope.py
@@ -3,6 +3,7 @@ from dataclasses import asdict, dataclass, replace
 import json
 from pathlib import Path
 import struct
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -175,6 +176,15 @@ def test_export_shape_predicates_use_checkpoint_dimensions(case):
         export.require_assignment_scope(case.model, case.assignment, target=Target())
 
 
+def test_matching_shape_predicate_cannot_claim_the_producers_fused_unit(case):
+    payload = _payload()
+    for row in payload["lane_eligibility"]["cells"]:
+        row["predicates"] = [{"fact": "out_features", "op": "equals", "value": 64}]
+    case.contract.write_text(json.dumps(payload))
+    with pytest.raises(export.TesseraExportLaneError, match="predicate|projection"):
+        export.require_assignment_scope(case.model, case.assignment, target=Target())
+
+
 def test_export_does_not_change_plain_bf16_assignments(case):
     case.payload[DENSE] = "BF16"
     _scope(case)["by_unit"].pop(DENSE)
@@ -257,3 +267,67 @@ def test_tessera_plan_cache_identity_changes_with_serving_target(key, value):
     after, _ = stage_settings_projection("tessera-plan", {**legacy, key: value})
     assert after != before
     assert value in after.values()
+
+
+def _run_head_policy(monkeypatch, capsys, *, body=FORMAT, head="BF16",
+                     scoped=True, serialisable=True, cost_override="cost.pkl"):
+    """Execute the driver's real inline policy under CPU-only mocked formats."""
+    from prismaquant import format_registry as fr
+    from prismaquant import tessera_render
+    from prismaquant import model_profiles
+    from prismaquant.model_profiles.qwen3 import Qwen3Profile
+
+    monkeypatch.setattr(model_profiles, "detect_profile", lambda _: Qwen3Profile())
+    for key, value in {
+        "PQ_MODEL_PATH": "fixture", "PQ_ALLOW_PINNED": "",
+        "PQ_LM_HEAD_FORMAT": head, "PQ_BODY_FORMATS": body,
+        "PQ_COST_PATH_OVERRIDE": cost_override,
+    }.items():
+        monkeypatch.setenv(key, value)
+
+    def get_format(value):
+        if value == "TESSERA":
+            raise KeyError("menu token is not a shape-free format")
+        return SimpleNamespace(name=value)
+
+    monkeypatch.setattr(fr, "get_format", get_format)
+    monkeypatch.setattr(fr, "format_is_producer_eligible", lambda name, **kwargs:
+                        name == "BF16" or bool(kwargs.get("context_by_unit")))
+    monkeypatch.setattr(tessera_render, "tessera_rung_is_serialisable", lambda _: serialisable)
+    args = ["fixture", "--target-profile", "tessera_research_sm121"]
+    if scoped:
+        args += ["--tessera-platform", "sm_121", "--tessera-runtime-image", IMAGE,
+                 "--tessera-execution-mode", "eager", "--tessera-residency", "resident"]
+    monkeypatch.setattr(sys, "argv", args)
+    driver = (Path(__file__).parents[1] / "prismaquant" / "run-pipeline.sh").read_text()
+    block = driver[driver.index('if ! LM_HEAD_POLICY_TEXT="$('):]
+    program = block.split("<<'PY'\n", 1)[1].split("\nPY\n", 1)[0]
+    exec(compile(program, "run-pipeline.sh:head-policy", "exec"), {"__name__": "__main__"})
+    return capsys.readouterr().out.splitlines()
+
+
+def test_actual_shell_body_defers_scoped_tessera_admission_to_per_unit_gate(monkeypatch, capsys):
+    lines = _run_head_policy(monkeypatch, capsys)
+    assert lines[0] == "BF16"
+    assert lines[4] == FORMAT
+
+
+def test_actual_shell_head_uses_its_explicit_context(monkeypatch, capsys):
+    lines = _run_head_policy(monkeypatch, capsys, body="BF16", head=FORMAT)
+    assert lines[0] == FORMAT
+    assert lines[4] == "BF16," + FORMAT
+
+
+def test_actual_shell_preserves_the_prepriced_tessera_menu_token(monkeypatch, capsys):
+    lines = _run_head_policy(monkeypatch, capsys, body="TESSERA,BF16")
+    assert lines[4] == "TESSERA,BF16"
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"scoped": False}, {"serialisable": False},
+    {"body": "TESSERA", "cost_override": ""},
+])
+def test_actual_shell_keeps_unbound_unwritable_and_uncosted_refusals(monkeypatch, capsys, kwargs):
+    with pytest.raises(SystemExit) as error:
+        _run_head_policy(monkeypatch, capsys, **kwargs)
+    assert error.value.code == 2

--- a/tests/test_tessera_export_scope.py
+++ b/tests/test_tessera_export_scope.py
@@ -1,5 +1,6 @@
 """The real export endpoint binds selected units to their priced v5 scope."""
 from dataclasses import asdict, dataclass, replace
+import hashlib
 import json
 from pathlib import Path
 import struct
@@ -331,3 +332,34 @@ def test_actual_shell_keeps_unbound_unwritable_and_uncosted_refusals(monkeypatch
     with pytest.raises(SystemExit) as error:
         _run_head_policy(monkeypatch, capsys, **kwargs)
     assert error.value.code == 2
+
+
+def test_export_cli_writes_existing_build_anchor_from_exact_raw_assignment(case, tmp_path, monkeypatch):
+    _isolate_other_gates(monkeypatch)
+    raw = json.dumps(case.payload, indent=3) + "\n\n"
+    case.assignment.write_text(raw)
+    output = tmp_path / "tessera_build.json"
+    assert export.main([
+        "--model", str(case.model), "--assignment", str(case.assignment),
+        "--tessera-platform", "sm_121", "--tessera-runtime-image", IMAGE,
+        "--tessera-execution-mode", "eager", "--tessera-residency", "resident",
+        "--write-build-json", str(output),
+    ]) == 0
+    build = json.loads(output.read_text())
+    assert build["layer_config_sha"] == hashlib.sha256(raw.encode()).hexdigest()
+    assert build["tessera_serving_scope"] == _scope(case)
+    assert build["layer_config"] == str(case.assignment)
+    assert build["source_model"] == str(case.model)
+
+
+def test_export_build_anchor_requires_an_assignment(case, tmp_path):
+    output = tmp_path / "tessera_build.json"
+    assert export.main(["--model", str(case.model), "--write-build-json", str(output)]) == 2
+    assert not output.exists()
+
+
+def test_shell_passes_the_bound_build_json_to_lane_shipcard():
+    driver = (Path(__file__).parents[1] / "prismaquant" / "run-pipeline.sh").read_text()
+    assert '--write-build-json "$TESSERA_BUILD_JSON"' in driver
+    opening = driver[driver.index("python3 -m prismaquant.lane_shipcard open"):]
+    assert '--build-json "$TESSERA_BUILD_JSON"' in opening.split("; then", 1)[0]

--- a/tests/test_tessera_plan_input_binding.py
+++ b/tests/test_tessera_plan_input_binding.py
@@ -116,3 +116,21 @@ def test_printed_serve_recipe_retains_exact_runtime_scope(tmp_path, mode, eager)
     assert f"TESSERA_LANE_EAGER={eager}" in tokens
     assert f"TS={tmp_path / 'producer tree'}" in tokens
     assert str(tmp_path / "work with spaces/exported") in tokens
+
+
+@pytest.mark.parametrize("mode", ["eager", "compiled"])
+def test_printed_census_recipe_keeps_raw_scope_and_bound_allocation(tmp_path, mode):
+    result = _run(tmp_path, mode=mode)
+    assert result.returncode == 0, result.stdout + result.stderr
+    census = next(line.split("Route census:", 1)[1].strip()
+                  for line in result.stdout.splitlines() if "Route census:" in line)
+    tokens = shlex.split(census)
+    assert "--log" not in tokens
+    assert tokens[tokens.index("--runtime-image") + 1] == IMAGE
+    assert ("--compiled" in tokens) == (mode == "compiled")
+    close = next(line.split("Close census:", 1)[1].strip()
+                 for line in result.stdout.splitlines() if "Close census:" in line)
+    tokens = shlex.split(close)
+    assert tokens[tokens.index("--layer-config") + 1] == str(tmp_path / "work with spaces/artifacts/layer_config.json")
+    assert tokens[tokens.index("--model-dir") + 1] == str(tmp_path / "work with spaces/exported")
+    assert "--priced-route" not in tokens

--- a/tests/test_tessera_plan_input_binding.py
+++ b/tests/test_tessera_plan_input_binding.py
@@ -1,0 +1,118 @@
+"""Execute the real Tessera driver arm without encoding or serving work."""
+import hashlib
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+
+import pytest
+
+from prismaquant import pipeline
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMAGE = "example/runtime@sha256:" + "a" * 64
+
+
+def _run(tmp_path, *, changed=False, manifest="bound", mode="compiled"):
+    work = tmp_path / "work with spaces"
+    for sub in ("artifacts", "logs", "exported"):
+        (work / sub).mkdir(parents=True)
+    assignment = work / "artifacts/layer_config.json"
+    assignment.write_text('{"layer": "BF16"}')
+    plan = work / "artifacts/tessera_plan.json"
+    settings = {
+        "MODEL_PATH": str(tmp_path / "model"), "TESSERA_PLAN_COVER": "as-allocated",
+        "TESSERA_PLATFORM": "sm_121", "TESSERA_RUNTIME_IMAGE": IMAGE,
+        "TESSERA_EXECUTION_MODE": mode, "TESSERA_RESIDENCY": "resident",
+    }
+    document = pipeline.stage_settings_document(settings)
+    stage_path = work / "artifacts/stage_settings.json"
+    stage_path.write_text(json.dumps(document))
+    if manifest == "bound":
+        code, messages = pipeline.check_stage_settings(
+            plan, "tessera-plan", document,
+            overrides={"ASSIGNMENT_DIGEST": hashlib.sha256(assignment.read_bytes()).hexdigest()},
+        )
+        assert code == 0, messages
+    elif manifest == "other-stage":
+        Path(str(plan) + ".settings.json").write_text(json.dumps({
+            "schema": pipeline.STAGE_MANIFEST_SCHEMA, "stages": {"other": {}},
+        }))
+    plan.write_text("old translated plan")
+    (work / "exported/shipcard.json").write_text("{}")
+    if changed:
+        assignment.write_text('{"layer": "TESSERA_E4M3_K1_R1024"}')
+    script = (ROOT / "prismaquant/run-pipeline.sh").read_text()
+    helper = script[script.index("require_stage_settings() {"):].split("\n}\n", 1)[0] + "\n}\n"
+    start = script.index('  # Tessera lane: one blob per vLLM module')
+    start = script.rfind('if [[ "$EXPORT_CONTAINER" == "tessera" ]]; then', 0, start)
+    end = script.index('\nif [[ "$EXPORT_CONTAINER" == "gguf" ]]; then', start)
+    block = script[start:end]
+    preamble = r'''
+set -euo pipefail
+TESSERA_SCOPE_ARGS=()
+python3() {
+  if [[ "$1" == "-m" && "$2" == "prismaquant.pipeline" ]]; then
+    "$PYTEST_PYTHON" "$@"
+  elif [[ "$1" == "-m" && "$2" == "prismaquant.tessera_export_lane" ]]; then
+    return 0
+  elif [[ "$1" == */plan_from_layer_config.py ]]; then
+    echo "TEST_TRANSLATOR_REACHED" >&2
+    return 81
+  elif [[ "$1" == */export_tessera_serving.py ]]; then
+    echo "TEST_EXPORT_REACHED"
+    return 0
+  else
+    echo "unexpected worker: $*" >&2
+    return 99
+  fi
+}
+'''
+    env = dict(os.environ, WORK_DIR=str(work), EXPORT_CONTAINER="tessera",
+               TESSERA_PLAN_COVER="as-allocated", MODEL_PATH=settings["MODEL_PATH"],
+               TESSERA_RUNTIME_IMAGE=IMAGE, TESSERA_EXECUTION_MODE=mode,
+               TESSERA_PLATFORM="sm_121", TESSERA_RESIDENCY="resident",
+               TESSERA_SERVE_MODE="resident", TESSERA_REPO=str(tmp_path / "producer tree"),
+               TARGET_PROFILE_RESOLVED="vllm_tessera", EXPORT_DEVICE="cuda",
+               PIPELINE_SCRIPT_DIR=str(ROOT / "prismaquant"),
+               STAGE_SETTINGS_PATH=str(stage_path), PYTEST_PYTHON=sys.executable)
+    return subprocess.run(["bash", "-c", preamble + helper + block], env=env,
+                          cwd=ROOT, capture_output=True, text=True, timeout=30)
+
+
+def test_actual_driver_refuses_old_plan_after_allocation_bytes_change(tmp_path):
+    result = _run(tmp_path, changed=True)
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "ASSIGNMENT_DIGEST" in result.stdout + result.stderr
+    assert "TEST_EXPORT_REACHED" not in result.stdout
+
+
+@pytest.mark.parametrize("manifest", ["missing", "other-stage"])
+def test_actual_driver_refuses_plan_without_independent_allocation_binding(tmp_path, manifest):
+    result = _run(tmp_path, manifest=manifest)
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "allocation" in (result.stdout + result.stderr).lower()
+    assert "TEST_EXPORT_REACHED" not in result.stdout
+
+
+def test_actual_driver_reuses_plan_for_identical_allocation(tmp_path):
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "TEST_EXPORT_REACHED" in result.stdout
+    assert "TEST_TRANSLATOR_REACHED" not in result.stderr
+
+
+@pytest.mark.parametrize("mode,eager", [("eager", "1"), ("compiled", "0")])
+def test_printed_serve_recipe_retains_exact_runtime_scope(tmp_path, mode, eager):
+    result = _run(tmp_path, mode=mode)
+    assert result.returncode == 0, result.stdout + result.stderr
+    command = next(line.split("Serve:", 1)[1].strip() for line in result.stdout.splitlines()
+                   if "Serve:" in line)
+    tokens = shlex.split(command)
+    assert f"IMAGE={IMAGE}" in tokens
+    assert f"TESSERA_LANE_EAGER={eager}" in tokens
+    assert f"TS={tmp_path / 'producer tree'}" in tokens
+    assert str(tmp_path / "work with spaces/exported") in tokens

--- a/tests/test_tessera_scope_endpoints.py
+++ b/tests/test_tessera_scope_endpoints.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import pickle
 import sys
@@ -146,7 +147,7 @@ def test_campaign_main_passes_live_model_topology_to_real_menu_boundary(tmp_path
     assert seen["context_by_unit"][EXPERT].structure == "routed_moe"
 
 
-def _allocator_inputs(tmp_path):
+def _allocator_inputs(tmp_path, fmt="BF16"):
     model_dir = tmp_path / "model"
     model_dir.mkdir()
     (model_dir / "config.json").write_text(json.dumps({
@@ -158,8 +159,8 @@ def _allocator_inputs(tmp_path):
     costs = tmp_path / "cost.pkl"
     probe.write_bytes(pickle.dumps({"stats": stats, "meta": {"model": str(model_dir)}}))
     costs.write_bytes(pickle.dumps({"costs": {
-        name: {"BF16": {"predicted_dloss": 0.0}} for name in stats}, "formats": ["BF16"]}))
-    return ["--probe", str(probe), "--costs", str(costs), "--formats", "BF16",
+        name: {fmt: {"predicted_dloss": 0.0}} for name in stats}, "formats": [fmt]}))
+    return ["--probe", str(probe), "--costs", str(costs), "--formats", fmt,
             "--allow-legacy-fisher-norm",
             "--target-profile", "tessera_research_sm121", "--target-bits", "16",
             "--pareto-targets", "16", "--bit-precision", "0.1",
@@ -199,3 +200,66 @@ def test_allocator_real_endpoint_records_each_selected_scope(tmp_path, monkeypat
     allocator.main()
     assert seen["context_by_unit"][EXPERT].structure == "routed_moe"
     assert seen["context_by_unit"][DENSE].structure == "dense"
+
+
+def _v5_contract(monkeypatch, *, with_experts=True):
+    from prismaquant import tessera_runtime_contract as contract
+    from prismaquant import tessera_menu as menu
+    payload = json.loads(contract.contract_path().read_text())
+    block = payload["lane_eligibility"]
+    block["schema"] = "tessera.lane-eligibility.v5"
+    for cell in block["cells"]:
+        cell["runtime"] = {"image": IMAGE, "execution_modes": ["eager"]}
+    if with_experts:
+        extra = copy.deepcopy(block["cells"])
+        for cell in extra:
+            cell["id"] += "_expert_fixture"
+            cell["structure"] = "routed_moe"
+        block["cells"].extend(extra)
+        block["structures"].append("routed_moe")
+    parsed = contract._parse(payload, commit="fixture", sha="fixture", path="fixture")
+    monkeypatch.setattr(menu, "tessera_runtime_contract", lambda: parsed)
+    monkeypatch.setenv("PRISMAQUANT_TESSERA_MENU", "attested")
+
+
+@pytest.mark.parametrize("token", [False, True])
+def test_real_allocator_admits_v5_tessera_and_records_each_selected_unit(tmp_path, monkeypatch, token):
+    from prismaquant import allocator
+    _v5_contract(monkeypatch)
+    fmt = "TESSERA_E4M3_K1_R1024"
+    argv = _allocator_inputs(tmp_path, fmt)
+    if token:
+        argv[argv.index("--formats") + 1] = "TESSERA"
+    monkeypatch.setattr(sys, "argv", ["allocator", *argv,
+                                    "--no-fused-aggregation", "--no-packed-aggregation", *_cli_scope()])
+    allocator.main()
+    metadata = json.loads((tmp_path / "layer.json").read_text())["__prismaquant__"]
+    assert metadata["tessera_serving_scope"]["target"]["runtime_image"] == IMAGE
+    by_unit = metadata["serving_lane_provenance"]["by_unit"]
+    for name, structure in ((DENSE, "dense"), (EXPERT, "routed_moe"), (SHARED, "dense")):
+        assert by_unit[name]["format"] == fmt
+        assert by_unit[name]["route"]["route_status"] in {"backed", "backed_with_serve_flag"}
+        assert by_unit[name]["serving_context"]["structure"] == structure
+
+
+def test_real_allocator_never_borrows_dense_admission_for_expert(tmp_path, monkeypatch):
+    from prismaquant import allocator
+    _v5_contract(monkeypatch, with_experts=False)
+    monkeypatch.setattr(sys, "argv", ["allocator", *_allocator_inputs(tmp_path, "TESSERA_E4M3_K1_R1024"),
+                                    "--no-fused-aggregation", "--no-packed-aggregation", *_cli_scope()])
+    with pytest.raises(ValueError, match=EXPERT):
+        allocator.main()
+
+
+@pytest.mark.parametrize("flag,value", [
+    ("--tessera-runtime-image", "example/other@sha256:" + "b" * 64),
+    ("--tessera-execution-mode", "compiled"),
+])
+def test_real_allocator_refuses_runtime_scope_without_matching_cells(tmp_path, monkeypatch, flag, value):
+    from prismaquant import allocator
+    _v5_contract(monkeypatch)
+    scope = _cli_scope()
+    scope[scope.index(flag) + 1] = value
+    monkeypatch.setattr(sys, "argv", ["allocator", *_allocator_inputs(tmp_path, "TESSERA_E4M3_K1_R1024"), *scope])
+    with pytest.raises((ValueError, SystemExit), match="(producer|attest|scope|Tessera|TESSERA)"):
+        allocator.main()

--- a/tests/test_tessera_scope_endpoints.py
+++ b/tests/test_tessera_scope_endpoints.py
@@ -1,0 +1,201 @@
+"""Explicit CLI targets reach Tessera admission with each unit's topology."""
+from __future__ import annotations
+
+import argparse
+import json
+import pickle
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+IMAGE = "example/runtime@sha256:" + "a" * 64
+DENSE = "model.layers.0.self_attn.o_proj"
+EXPERT = "model.layers.0.mlp.experts.0.down_proj"
+SHARED = "model.layers.0.mlp.shared_expert.down_proj"
+
+
+def _scope():
+    from prismaquant import tessera_serving_scope
+    return tessera_serving_scope
+
+
+def _args(**changed):
+    values = dict(tessera_runtime_image=IMAGE, tessera_execution_mode="eager",
+                  tessera_residency="resident", tessera_platform="sm_121")
+    values.update(changed)
+    return argparse.Namespace(**values)
+
+
+def _profile():
+    from prismaquant.model_profiles import Qwen3Profile
+    return Qwen3Profile()
+
+
+def _stats():
+    return {
+        DENSE: dict(router_path=None, expert_id=None),
+        EXPERT: dict(router_path="model.layers.0.mlp.gate", expert_id="0"),
+        SHARED: dict(router_path=None, expert_id=None),
+    }
+
+
+def test_scope_cli_has_no_implicit_runtime_defaults():
+    parser = argparse.ArgumentParser()
+    _scope().add_serving_scope_arguments(parser)
+    assert _scope().serving_target_from_args(parser.parse_args([])) is None
+
+
+@pytest.mark.parametrize("field", [
+    "tessera_runtime_image", "tessera_execution_mode", "tessera_residency",
+    "tessera_platform",
+])
+def test_partial_runtime_target_refuses_named_missing_field(field):
+    with pytest.raises(ValueError, match=field.removeprefix("tessera_")):
+        _scope().serving_target_from_args(_args(**{field: None}))
+
+
+def test_platform_comes_from_selected_profile_not_probe_device():
+    scope = _scope()
+    target = scope.serving_target_from_args(
+        _args(tessera_platform=None), target_platform="sm_121")
+    assert target.platform == "sm_121"
+    with pytest.raises(ValueError, match="platform.*conflict"):
+        scope.serving_target_from_args(_args(), target_platform="sm_120")
+
+
+def test_unit_topology_preserves_dense_shared_and_routed_split():
+    scope = _scope()
+    contexts = scope.context_by_unit_from_stats(
+        scope.serving_target_from_args(_args()), _stats(), _profile())
+    assert {name: ctx.structure for name, ctx in contexts.items()} == {
+        DENSE: "dense", EXPERT: "routed_moe", SHARED: "dense"}
+    assert all(ctx.runtime_image == IMAGE for ctx in contexts.values())
+
+
+def test_packed_expert_and_grouped_attention_are_not_the_same_structure():
+    scope = _scope()
+    packed = "model.layers.0.mlp.experts.gate_up_proj"
+    rows = {
+        packed: dict(num_experts=2, _packed_experts_module="model.layers.0.mlp.experts",
+                     router_path=None, expert_id=None),
+        DENSE: dict(num_groups=2, router_path=None, expert_id=None),
+    }
+    contexts = scope.context_by_unit_from_stats(
+        scope.serving_target_from_args(_args()), rows, _profile())
+    assert contexts[packed].structure == "routed_moe"
+    assert contexts[DENSE].structure == "dense"
+
+
+@pytest.mark.parametrize("name,row", [
+    (DENSE, {}),
+    (EXPERT, dict(router_path=None, expert_id=None)),
+    (DENSE, dict(router_path="router", expert_id=None)),
+    (DENSE, dict(router_path=None, expert_id="0")),
+])
+def test_ambiguous_or_conflicting_unit_topology_is_not_guessed(name, row):
+    scope = _scope()
+    with pytest.raises(ValueError, match=name):
+        scope.context_by_unit_from_stats(
+            scope.serving_target_from_args(_args()), {name: row}, _profile())
+
+
+def test_unscoped_legacy_call_does_not_require_new_topology_fields():
+    assert _scope().context_by_unit_from_stats(None, {"old.row": {}}, None) is None
+
+
+def _cli_scope():
+    return ["--tessera-runtime-image", IMAGE, "--tessera-execution-mode", "eager",
+            "--tessera-residency", "resident", "--tessera-platform", "sm_121"]
+
+
+class EndpointReached(Exception):
+    pass
+
+
+def test_campaign_main_passes_live_model_topology_to_real_menu_boundary(tmp_path, monkeypatch):
+    import torch
+    from prismaquant import tessera_campaign as campaign
+    from prismaquant import tessera_render as render
+    from prismaquant import sensitivity_probe
+    import transformers
+
+    modules = {name: torch.nn.Linear(32, 32, bias=False) for name in (DENSE, EXPERT)}
+    model = SimpleNamespace(named_modules=lambda: modules.items(), eval=lambda: None)
+    monkeypatch.setattr(transformers.AutoModelForCausalLM, "from_pretrained", lambda *a, **k: model)
+    monkeypatch.setattr(render, "tessera_encoder_hessian_status", lambda: {"accepted": True})
+    monkeypatch.setattr(campaign, "_calibration_tokens", lambda *a: ([torch.ones(1, 1, dtype=torch.int64)], "fixture"))
+    monkeypatch.setattr(campaign, "_collect_activations", lambda *a, **k: ({}, {}, {}))
+    monkeypatch.setattr(sensitivity_probe, "discover_moe_structure", lambda *a, **k: {
+        EXPERT: ("model.layers.0.mlp.gate", "0")})
+    seen = {}
+
+    def menus(weights, targets, **kwargs):
+        seen.update(kwargs)
+        raise EndpointReached
+
+    monkeypatch.setattr(campaign, "expand_menus_for_targets", menus)
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(json.dumps({"model_type": "qwen3_moe", "architectures": ["Qwen3MoeForCausalLM"]}))
+    with pytest.raises(EndpointReached):
+        campaign.main(["--model", str(model_dir), "--out", str(tmp_path / "cost.pkl"),
+                       "--cache-dir", str(tmp_path / "cache"), "--hessian", "off", *_cli_scope()])
+    assert seen["context_by_unit"][DENSE].structure == "dense"
+    assert seen["context_by_unit"][EXPERT].structure == "routed_moe"
+
+
+def _allocator_inputs(tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(json.dumps({
+        "model_type": "qwen3_moe", "architectures": ["Qwen3MoeForCausalLM"]}))
+    stats = _stats()
+    for row in stats.values():
+        row.update(h_trace=1.0, n_params=128 * 128, in_features=128, out_features=128)
+    probe = tmp_path / "probe.pkl"
+    costs = tmp_path / "cost.pkl"
+    probe.write_bytes(pickle.dumps({"stats": stats, "meta": {"model": str(model_dir)}}))
+    costs.write_bytes(pickle.dumps({"costs": {
+        name: {"BF16": {"predicted_dloss": 0.0}} for name in stats}, "formats": ["BF16"]}))
+    return ["--probe", str(probe), "--costs", str(costs), "--formats", "BF16",
+            "--allow-legacy-fisher-norm",
+            "--target-profile", "tessera_research_sm121", "--target-bits", "16",
+            "--pareto-targets", "16", "--bit-precision", "0.1",
+            "--layer-config", str(tmp_path / "layer.json"),
+            "--pareto-csv", str(tmp_path / "pareto.csv")]
+
+
+def test_allocator_cli_carries_per_unit_context_into_candidate_builder(tmp_path, monkeypatch):
+    from prismaquant import allocator
+    seen = {}
+
+    def build(*args, **kwargs):
+        seen.update(kwargs)
+        raise EndpointReached
+
+    monkeypatch.setattr(allocator, "build_candidates", build)
+    monkeypatch.setattr(sys, "argv", ["allocator", *_allocator_inputs(tmp_path), *_cli_scope()])
+    with pytest.raises(EndpointReached):
+        allocator.main()
+    assert {name: ctx.structure for name, ctx in seen["context_by_unit"].items()} == {
+        DENSE: "dense", EXPERT: "routed_moe", SHARED: "dense"}
+
+
+def test_allocator_real_endpoint_records_each_selected_scope(tmp_path, monkeypatch):
+    from prismaquant import allocator
+    from prismaquant import allocator_candidates
+    original = allocator_candidates.selection_serving_lane_provenance
+    seen = {}
+
+    def provenance(*args, **kwargs):
+        seen.update(kwargs)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(allocator, "selection_serving_lane_provenance", provenance)
+    monkeypatch.setattr(sys, "argv", ["allocator", *_allocator_inputs(tmp_path),
+                                    "--no-fused-aggregation", "--no-packed-aggregation", *_cli_scope()])
+    allocator.main()
+    assert seen["context_by_unit"][EXPERT].structure == "routed_moe"
+    assert seen["context_by_unit"][DENSE].structure == "dense"

--- a/tests/test_tessera_scope_endpoints.py
+++ b/tests/test_tessera_scope_endpoints.py
@@ -160,8 +160,13 @@ def _allocator_inputs(tmp_path, fmt="BF16"):
     probe = tmp_path / "probe.pkl"
     costs = tmp_path / "cost.pkl"
     probe.write_bytes(pickle.dumps({"stats": stats, "meta": {"model": str(model_dir)}}))
+    # A scoped Tessera route quantizes activations: the legitimate guard must
+    # not mistake this synthetic fixture for a measured zero-cost identity.
+    cost_row = ({"weight_mse": 1e-4, "output_mse": 4e-4,
+                 "output_mse_measured": True}
+                if fmt.startswith("TESSERA_") else {"predicted_dloss": 0.0})
     costs.write_bytes(pickle.dumps({"costs": {
-        name: {fmt: {"predicted_dloss": 0.0}} for name in stats}, "formats": [fmt]}))
+        name: {fmt: dict(cost_row)} for name in stats}, "formats": [fmt]}))
     return ["--probe", str(probe), "--costs", str(costs), "--formats", fmt,
             "--allow-legacy-fisher-norm",
             "--target-profile", "tessera_research_sm121", "--target-bits", "16",

--- a/tests/test_tessera_scope_endpoints.py
+++ b/tests/test_tessera_scope_endpoints.py
@@ -148,13 +148,15 @@ def test_campaign_main_passes_live_model_topology_to_real_menu_boundary(tmp_path
 
 
 def _allocator_inputs(tmp_path, fmt="BF16"):
+    from prismaquant.tessera_formats import SUPERBLOCK_WEIGHTS
     model_dir = tmp_path / "model"
     model_dir.mkdir()
     (model_dir / "config.json").write_text(json.dumps({
         "model_type": "qwen3_moe", "architectures": ["Qwen3MoeForCausalLM"]}))
     stats = _stats()
     for row in stats.values():
-        row.update(h_trace=1.0, n_params=128 * 128, in_features=128, out_features=128)
+        row.update(h_trace=1.0, n_params=SUPERBLOCK_WEIGHTS ** 2,
+                   in_features=SUPERBLOCK_WEIGHTS, out_features=SUPERBLOCK_WEIGHTS)
     probe = tmp_path / "probe.pkl"
     costs = tmp_path / "cost.pkl"
     probe.write_bytes(pickle.dumps({"stats": stats, "meta": {"model": str(model_dir)}}))


### PR DESCRIPTION
Follow-up to #181 for Tessera #126. Connects explicit target intake, topology-derived unit structures, scoped menu/candidate/cache/provenance and selected export admission through real campaign/allocator/export endpoints. Plan and shipcard independently bind exact allocation bytes. Pins, defaults and attestation cells do not move.

PrismaBuild CPU-only Sparky, 1 core/4 GiB: main endpoint population 408 passed/0 failed/5 skipped (all "Tessera encodes need CUDA"), review-fix population 112 passed/0 skipped, final post-main-merge shell/docs 27 passed/0 skipped; no collection errors. Targeted red evidence and immutable receipts are in docs/results/tessera_v5_endpoints_2026-09-04.md.

Separate review commits fix stale-plan/new-build binding, preserve exact runtime in printed serve recipes, and replace stale census instructions with raw scoped input plus allocation binding. Scoped receipt implementation/final producer pin remain separate #126 work; packed bridge #183 and prepriced dispatch #184 are assigned independently. This PR does not close #126 or claim a serve.