### PR TITLE
Refuse incomplete MoE campaigns and capture explicit packed expert inputs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,15 @@
 As of: 2026-09-04 · `codex/pq183-packed-campaign`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-04, `codex/pq183-packed-campaign`) for **profile-pinned
+campaign exclusions** (§4.10). The dense target walk now consults the existing
+`ModelProfile.is_pinned_name` accessor before capture/menuing. In particular,
+LFM's already-pinned router and short-convolution Linears cannot be priced as
+quantizable parameters. The profile still owns every pin; no new roster or
+default is introduced. Real main-entry regressions exercise both LFM's declared
+pins and a changed profile declaration, so the test cannot be satisfied by a
+private campaign pin list. Gate: `tests/test_tessera_campaign_pins.py`.
+
 Re-stamped (2026-09-04, `codex/pq183-packed-campaign`) for **packed
 source-unit capture** (§4.10; PrismaQuant #183). Shared routed-expert
 discovery exposes per-expert projection views using the native exporter's

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,20 @@
 As of: 2026-09-04 · `codex/pq183-packed-campaign`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-04, `codex/pq183-packed-campaign`) for **packed
+source-unit capture** (§4.10; PrismaQuant #183). Shared routed-expert
+discovery exposes per-expert projection views using the native exporter's
+profile-owned split; it does not invent Tessera serving groups. The existing
+packed activation collector offers an optional synchronous full-row consumer,
+leaving its default reservoir behavior unchanged. Campaign capture uses the
+existing router/SwiGLU derivation on those live inputs, accumulating every
+routed row into each selected unit's own Hessian before retaining bounded
+scoring rows. An unobserved selected expert refuses; no shared-Hessian or
+weight-only fallback is introduced. The main-entry packed-population refusal
+remains in force pending the producer's exact cached-wire/stack-plan bridge
+and its measured coverage. This is CPU-tested capture plumbing, not packed
+campaign/export eligibility or a GPU/served performance claim.
+
 Re-stamped (2026-09-04, `codex/pq183-packed-campaign`) for the **campaign
 population refusal** (§4.10; PrismaQuant #183). Before calibration, the
 Tessera campaign checks the profile-declared routed target population against

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,19 @@
 As of: 2026-09-05 · `codex/pq183-packed-capture`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-05, `codex/pq183-packed-capture`) for **one campaign
+capture, dense or packed** (§4.10; merge of the packed source-unit capture
+below with the priced-inputs contract stamped beneath it). The campaign has
+one Hessian-capture accumulator: a dense Linear's pre-hook and a packed
+projection's derived routed rows land in the same three per-unit outputs
+(bounded scoring rows, the exact XᵀX, and the max|x| behind the static
+`input_global_scale`), so a packed unit feeds `hessian_capture.pt` and
+`input_scales.safetensors` by the dense path rather than by a second capture.
+Nothing packed reaches those artifacts yet: the main-entry population refusal
+below still turns a live packed population away before calibration, by name,
+until the exact cached-wire/stack-plan bridge (PrismaQuant #183) lands. Gate:
+`tests/test_tessera_campaign_packed.py` (max|x| asserted per packed unit).
+
 Re-stamped (2026-09-04, `codex/pq183-packed-campaign`) for **profile-pinned
 campaign exclusions** (§4.10). The dense target walk now consults the existing
 `ModelProfile.is_pinned_name` accessor before capture/menuing. In particular,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-04 · `codex/pq183-packed-campaign`. Stamps
+As of: 2026-09-04 · `codex/pq183-packed-capture`. Stamps
 follow, newest first, each recording its own branch and date.
 
 Re-stamped (2026-09-04, `codex/pq183-packed-campaign`) for **profile-pinned

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,18 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-04 · `codex/pq-tessera-v5-endpoints`. Stamps
+As of: 2026-09-04 · `codex/pq183-packed-campaign`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-04, `codex/pq183-packed-campaign`) for the **campaign
+population refusal** (§4.10; PrismaQuant #183). Before calibration, the
+Tessera campaign checks the profile-declared routed target population against
+live rank-three parameters under the same explicit layer stride used by its
+dense walk. Any in-scope packed expert parameters are named and refused;
+they can no longer disappear from a dense-only cost payload. This guard does
+not implement packed activation capture or the exact cached-wire/stack-plan
+producer bridge, and it makes no packed-MoE qualification claim. Gate:
+`tests/test_tessera_campaign_packed.py` (real main-entry synthetic mixed
+dense/packed regressions, both shown failing before the refusal).
 
 Re-stamped (2026-09-04, `codex/pq-tessera-v5-endpoints`) for **raw scoped
 census handoff instructions** (§9.4). The driver prints the producer's actual

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5912,12 +5912,12 @@ different rendering; the export fingerprint records the enumeration the shipped 
 so a shipped artifact names its rendering. Packed experts stamp the hook-only
 `metadata["activation_hook_scope_packed"]` (`fill_packed_expert_cache_entries` hooks the
 full visible module set and `store_qnames` narrows only storage, #145) and the union merge
-requires agreeing packed digests while tolerating dense-only shards. **One caveat remains.**
-The
-cache directory has no render-identity guard at all — resume is file-presence only — so a
-directory whose units were rendered under a narrower hook set will keep those bytes and
-silently mix them with newly rendered ones. Rebuild an assignment-scoped cache directory
-rather than resuming it across this change.
+requires agreeing packed digests while tolerating dense-only shards. Resume is now guarded
+by `render_identity.json` (#146): the base fill and packed append writers compare their
+respective identity sections before admitting file-presence reuse. A changed hook scope
+refuses and requires a fresh cache directory. A pre-guard directory can still be admitted
+on trust, but its existing shard names and count are recorded as `pre_guard_admission`;
+that history is not evidence that those old shards had a verified render identity.
 
 Render mechanisms are a registry with declared ordering semantics, not a lever string parsed in
 spelling order (`render_score.py:188-260`): each `RenderMechanismSpec` declares `operation`,

--- a/docs/measurements/tessera-packed-capture-2026-09-04.md
+++ b/docs/measurements/tessera-packed-capture-2026-09-04.md
@@ -1,0 +1,81 @@
+# Tessera packed campaign capture — CPU evidence, 2026-09-04
+
+Scope: PrismaQuant #183, branch `codex/pq183-packed-campaign`, based on
+`fe7182175bd77d2119b91f4a086c41a36612148a` plus explicit serving-context
+dependencies `86360de3` / `f229b205`. This is capture/refusal evidence, not a
+GPU encoder, streaming-equivalence, exported-artifact, quality, or throughput
+measurement. The campaign's main-entry packed-population refusal remains closed.
+
+All actions used the deployed PrismaBuild runtime generation `aa6d3cfa2f77`,
+Sparky, one CPU, 4 GiB, and `CUDA_VISIBLE_DEVICES=''`. Interpreter:
+`/home/rob/dq-runs/venvs/prismaquant-cu130/bin/python`. Each command was bounded
+by `/usr/bin/timeout -k 30s 240s`, with PB `--timeout-s 300 --wait-s 900`.
+
+## Population refusal
+
+Pre-fix action `5ef3e4795ca7b8da4b794fa36aaf8a0a4778edca582df41fbc9b70d764c14af2`
+ran the real main entry on a mixed dense/packed synthetic LFM model with layer
+strides 1 and 2. Both arms logged one target Linear and attempted calibration,
+raising `AssertionError: started calibration with a dense-only campaign population`
+at `tests/test_tessera_campaign_packed.py:42` (then-current test lines).
+
+After guard `cac126a2`, action
+`16e66f2ffd4e301da733fbfaae5721321a8c0679220e88e8db5cec580a90c8b1`
+ran the packed and existing campaign test files: 33 passed, 5 skipped.
+Receipt: `707c865b41cfafbddd18fef567a6faa062016a03d2a4112f47855c2513e3793d`.
+All five skips are the campaign's `Tessera encodes need CUDA` cases.
+
+## Per-expert capture
+
+Pre-fix action `f8977f5909db4c7bbc8b1dcdec6dd47239396731dce9f45321ab00846b268d7e`
+ran `python -m pytest -q -rs tests/test_tessera_campaign_packed.py` before the
+capture implementation. Result: 4 failed, 2 passed, no skips. Failure line:
+
+```text
+prismaquant/tessera_campaign.py:538: KeyError: 'model.layers.2.feed_forward.experts.0.w1'
+```
+
+The same missing-module lookup failed expert-1 targets in both unobserved-expert
+cases (`want_hessian=False` and `True`). The new tests execute the actual small
+MoE forward and compare captured inputs to inputs recorded by each expert's
+live forward; the expected Hessian does not call the capture implementation.
+Each observed expert sees four rows while the scoring cap is one. Gate/up
+projection views preserve the live source storage and declared split; down
+inputs are the actual post-SwiGLU rows. A selected subset must retain identical
+rows/Hessians. An unobserved selected expert must refuse, with hooks removed.
+
+Green action `ac21275a8d358d9f9924d777f88ac6ea20592f98cbedda62a541dd5cbbeba082`
+ran:
+
+```text
+python -m pytest -q -rs tests/test_tessera_campaign_packed.py tests/test_tessera_campaign.py tests/test_packed_expert_hook_scope.py tests/test_streaming_production_cache.py
+```
+
+Result: 41 passed, 7 skipped. Receipt:
+`20bc55bf30a0cd2fd3cd5fecb8441983a7d26f63309e8cbc532bab2291061dea`.
+Five skip reasons, verbatim: `Tessera encodes need CUDA`.
+Two skip reasons, verbatim: `streaming production render is GPU-or-bust`.
+The packed reservoir tests passed; the GPU streaming-equivalence test did not run.
+
+Final capture/shared-helper/doc action
+`adc2ee3fedc8a015f70b3546f11b49bd49ef024c02df2c659fa5bea049abb8f6`
+ran:
+
+```text
+python -m pytest -q -rs tests/test_tessera_campaign_packed.py tests/test_routed_expert_namespace_aliasing.py tests/test_measure_quant_cost_packed_experts.py tests/test_architecture_doc.py tests/test_docs_staleness.py
+```
+
+Result: 41 passed, no skips. Receipt:
+`f61d9c30c945e9b00d0a69195645887b29704f0c6f9986729b193a6bb294d93d`.
+This additionally checked the shared routed namespace/router behavior and the
+architecture/staleness assertions. No uncollected module was reported in either
+green run. These are overlapping targeted populations, not an 82-test suite.
+
+## Remaining gate
+
+The producer must publish its explicit source-to-stack projection and validate
+source/calibration/recipe/encoder identities and exact unit coverage before
+packing the cached bytes unchanged. Then an actual packed-model campaign,
+export, and matched-byte served measurement must establish full population
+coverage and priced == written == served. No capture helper pass substitutes
+for those measurements, and no production admission was opened here.

--- a/docs/measurements/tessera-packed-capture-2026-09-04.md
+++ b/docs/measurements/tessera-packed-capture-2026-09-04.md
@@ -99,3 +99,22 @@ ran the pin, packed-capture, and existing campaign test files: 39 passed,
 5 skipped. All five skips say `Tessera encodes need CUDA`. Receipt:
 `42f3a7d6c81c5dff4f5091aa14e1a9af1e4abe7ed2aa029ea36d952a0609954c`.
 The same CPU-only resource envelope and interpreter described above applied.
+
+## Capture dtype follow-up
+
+The live-forward capture comparison also runs with original BF16 weights and
+inputs, while its expected Hessian is accumulated in FP32. This checks that
+the full-row consumer keeps the model's live dtype through routing/SwiGLU,
+rather than replaying FP32 reservoir rows against BF16 weights.
+
+For a genuine pre-capture replay, the PB snapshot fetched exact commit
+`4682dcf9a7a91dc48956afa83e9aaf8369c7f38b` and restored only its
+`prismaquant/tessera_campaign.py` into the disposable worker checkout, retaining
+the new test. Both FP32 and BF16 cases failed at the old line 538 with the
+same missing expert-target `KeyError`; no master baseline suite was run.
+
+Green action `87145c9cfd5613f2ec42d33dd085441385ff6d8074a433e22231eb9cb96ca4ba`
+ran the packed capture, pin, architecture, and docs-staleness test files:
+28 passed, no skips. Receipt:
+`3efcb00dcd0f8c45f89f0b43024c9dfd0701d38c587acea076ae5dc13e964609`.
+Both dtypes ran on CPU; this remains no GPU claim.

--- a/docs/measurements/tessera-packed-capture-2026-09-04.md
+++ b/docs/measurements/tessera-packed-capture-2026-09-04.md
@@ -118,3 +118,14 @@ ran the packed capture, pin, architecture, and docs-staleness test files:
 28 passed, no skips. Receipt:
 `3efcb00dcd0f8c45f89f0b43024c9dfd0701d38c587acea076ae5dc13e964609`.
 Both dtypes ran on CPU; this remains no GPU claim.
+
+The exact dtype red-replay action was
+`d46da88826cefffba47b9b853f5344982e0b81af10a5fd87f2f6540a73e5ee5f`.
+
+## Integration base
+
+The distinct fixes were transplanted onto main
+`10dd23957d6cf9ad784f8eac59fb914f66f6d89e` after endpoint PR #185 merged,
+on branch `codex/pq183-packed-capture`. Only the architecture stamp insertion
+needed conflict resolution; both sets of prose were retained. The prior
+dependency copies are not part of this branch's PR diff.

--- a/docs/measurements/tessera-packed-capture-2026-09-04.md
+++ b/docs/measurements/tessera-packed-capture-2026-09-04.md
@@ -79,3 +79,23 @@ packing the cached bytes unchanged. Then an actual packed-model campaign,
 export, and matched-byte served measurement must establish full population
 coverage and priced == written == served. No capture helper pass substitutes
 for those measurements, and no production admission was opened here.
+
+## On-path fix: respect existing profile pins
+
+Reviewing the future packed campaign wiring found the dense target walk did
+not consult `ModelProfile.is_pinned_name`. This was fixed separately, without
+adding or changing any pin: the campaign now honors the existing profile
+declaration before activation capture and menu construction.
+
+Red action `43339f3343aa73919eb1ad463c474f31719b2a62130f064252621e77e394955e`
+ran `tests/test_tessera_campaign_pins.py`: 2 failed, no skips. Both failed at
+line 49 with `AssertionError: campaign attempted to price profile-pinned Linears`.
+The LFM arm included its pinned `conv.in_proj`, `conv.out_proj`, and
+`feed_forward.gate`; a changed explicit pin declaration also failed, proving
+that merely hardcoding LFM's current roster would not fix the tested rule.
+
+Green action `9bbd92484c598dfd25024597b12fd5c7388fd925134574e3952c265270369707`
+ran the pin, packed-capture, and existing campaign test files: 39 passed,
+5 skipped. All five skips say `Tessera encodes need CUDA`. Receipt:
+`42f3a7d6c81c5dff4f5091aa14e1a9af1e4abe7ed2aa029ea36d952a0609954c`.
+The same CPU-only resource envelope and interpreter described above applied.

--- a/docs/measurements/tessera-packed-capture-2026-09-04.md
+++ b/docs/measurements/tessera-packed-capture-2026-09-04.md
@@ -129,3 +129,12 @@ The distinct fixes were transplanted onto main
 on branch `codex/pq183-packed-capture`. Only the architecture stamp insertion
 needed conflict resolution; both sets of prose were retained. The prior
 dependency copies are not part of this branch's PR diff.
+
+Combined targeted action
+`8c87b0777daeda083396c2e5a16f474089125ab860c06701eb0f9c83d5892674`
+on the integrated source ran all nine previously named test files together:
+79 passed, 7 skipped, no uncollected module reported. The five campaign skip
+reasons are `Tessera encodes need CUDA`; the two streaming skip reasons are
+`streaming production render is GPU-or-bust`. CPU-only, serial, one CPU / 4 GiB
+on Sparky; no GPU qualification inferred. Receipt:
+`4ae92d4004626ce1b9015300bb40a62cabc08cf1a2b3828de9b1e3076ea93585`.

--- a/prismaquant/production_weight_cache.py
+++ b/prismaquant/production_weight_cache.py
@@ -7485,6 +7485,11 @@ class _PackedExpertActivationCollector:
     larger than the per-Linear ``max_rows`` budget: with top-k routing over E
     experts each expert only sees ~``top_k/E`` of the tokens, so a stable
     per-expert Hessian needs ``~max_rows_per_expert * E / top_k`` module tokens.
+
+    An optional ``row_consumer(qname, X)`` observes each full, live input before
+    storage selection. It must consume synchronously rather than retain X;
+    campaigns use it to accumulate full-calibration Hessians without creating
+    a second module-input cache. The default leaves reservoir sampling intact.
     """
 
     def __init__(
@@ -7497,9 +7502,11 @@ class _PackedExpertActivationCollector:
         store_dtype: torch.dtype = torch.float32,
         profile=None,
         store_qnames: set[str] | None = None,
+        row_consumer=None,
     ):
         self.model = model
         self.profile = profile
+        self.row_consumer = row_consumer
         # #145: ``experts_qnames`` is the enumeration the collector HOOKS --
         # the full visible module set -- and ``store_qnames`` narrows only
         # which modules keep full activation tensors. One shared generator
@@ -7544,6 +7551,8 @@ class _PackedExpertActivationCollector:
             if not args or not isinstance(args[0], torch.Tensor):
                 return
             x = args[0]
+            if self.row_consumer is not None:
+                self.row_consumer(qname, x)
             # Draw this call's row priorities for EVERY hooked module,
             # stored or not. One generator feeds every module's reservoir, so
             # the slice of the stream a module receives is a function of how

--- a/prismaquant/routed_experts.py
+++ b/prismaquant/routed_experts.py
@@ -295,6 +295,58 @@ def profile_declared_unpacked_expert_linears(
     return sorted(out, key=lambda member: member.qname)
 
 
+@dataclass(frozen=True)
+class PackedExpertProjection:
+    """One profile-declared 2-D view of a live packed expert parameter.
+
+    ``qname`` is the virtual per-expert module spelling in the live namespace,
+    not a Tessera serving-group name. The producer still owns the projection
+    from source units to its executed groups and wire containers.
+    """
+
+    qname: str
+    packed_qname: str
+    module_qname: str
+    module: nn.Module
+    param_name: str
+    expert_id: int
+    projection_name: str
+    weight: torch.Tensor
+
+
+def profile_declared_packed_expert_projections(
+    model: nn.Module, profile=None,
+) -> list[PackedExpertProjection]:
+    """Split declared packed tensors using the native exporter's exact views.
+
+    This shares source topology, not an encoder or a serving grammar. Views
+    retain the live weight device/dtype and do not allocate a second cache.
+    """
+    from .export_native_compressed import _split_packed_expert_tensor
+    from .measure_quant_cost import _enumerate_packed_experts
+
+    profile = resolve_routed_expert_profile(model, profile)
+    targets = set(profile_declared_routed_expert_targets(model, profile))
+    result = []
+    for packed_qname, packed, module_qname, module in _enumerate_packed_experts(
+        model, targets, profile,
+    ):
+        param_name = packed_qname.rsplit(".", 1)[-1]
+        for projection, weight in _split_packed_expert_tensor(packed, param_name, profile):
+            for expert_id in range(int(weight.shape[0])):
+                result.append(PackedExpertProjection(
+                    qname=f"{module_qname}.{expert_id}.{projection}",
+                    packed_qname=packed_qname, module_qname=module_qname,
+                    module=module, param_name=param_name,
+                    expert_id=expert_id, projection_name=projection,
+                    weight=weight[expert_id],
+                ))
+    names = [member.qname for member in result]
+    if len(set(names)) != len(names):
+        raise RuntimeError("profile declares duplicate packed expert projection qnames")
+    return sorted(result, key=lambda member: member.qname)
+
+
 def profile_declared_routed_expert_targets(
     model: nn.Module,
     profile=None,
@@ -319,6 +371,8 @@ __all__ = [
     "ProfileRoutedExpertClassifier",
     "RoutedExpertMatch",
     "UnpackedExpertLinear",
+    "PackedExpertProjection",
+    "profile_declared_packed_expert_projections",
     "profile_declared_routed_expert_targets",
     "profile_declared_unpacked_expert_linears",
     "resolve_routed_expert_profile",

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -831,6 +831,8 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             continue
         if name.endswith("lm_head") or "embed" in name:
             continue
+        if profile.is_pinned_name(name):
+            continue
         targets.append(name)
     targets = _campaign_layer_scope(targets, args.layer_stride)
     print(f"[campaign] {len(targets)} target Linears, mode={mode}, "

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -479,8 +479,8 @@ def campaign_cost_payload(
 # ---------------------------------------------------------------------------
 
 def _collect_activations(model, targets, tokens, max_rows: int, device,
-                         *, want_hessian: bool = False):
-    """One forward pass per calibration batch, per Linear.
+                         *, want_hessian: bool = False, profile=None):
+    """One model forward per batch, for dense and declared packed projections.
 
     Returns ``(rows, hessians, token_counts)``.
 
@@ -498,7 +498,10 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
       accumulation runs before the keep's early return, not after it.
 
     Accumulated in fp32 on the model's device and moved to CPU once at the
-    end, matching how the kept rows are handled.
+    end, matching how the kept rows are handled. Packed units use the existing
+    module-input collector and routing/SwiGLU derivation. The score-row cap
+    never caps routed rows before the Hessian. This capture API does not open
+    the main-entry packed-population/export gate.
     """
     import torch
 
@@ -506,7 +509,31 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
     kept: dict[str, int] = {name: 0 for name in targets}
     hess: dict[str, object] = {name: None for name in targets}
     seen: dict[str, int] = {name: 0 for name in targets}
+    routed_seen: dict[str, int] = {}
     handles = []
+    packed_collector = None
+
+    def accumulate(name, x):
+        flat = x.detach().reshape(-1, x.shape[-1])
+        if name in routed_seen and not flat.shape[0]:
+            return
+        if name in routed_seen:
+            routed_seen[name] += int(flat.shape[0])
+        if want_hessian:
+            # Every row, before any cap: see the docstring.
+            f32 = flat.to(dtype=torch.float32)
+            gram = f32.t() @ f32
+            if hess[name] is None:
+                hess[name] = gram
+            else:
+                hess[name] += gram
+            seen[name] += int(f32.shape[0])
+        room = max_rows - kept[name]
+        if room <= 0:
+            return
+        take = flat[:room].to(dtype=torch.float32, device="cpu")
+        store[name].append(take)
+        kept[name] += int(take.shape[0])
 
     def make_hook(name):
         def hook(_module, args):
@@ -515,34 +542,79 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
             x = args[0]
             if not isinstance(x, torch.Tensor):
                 return
-            flat = x.detach().reshape(-1, x.shape[-1])
-            if want_hessian:
-                # Every row, before any cap: see the docstring.
-                f32 = flat.to(dtype=torch.float32)
-                gram = f32.t() @ f32
-                if hess[name] is None:
-                    hess[name] = gram
-                else:
-                    hess[name] += gram
-                seen[name] += int(f32.shape[0])
-            room = max_rows - kept[name]
-            if room <= 0:
-                return
-            take = flat[:room].to(dtype=torch.float32, device="cpu")
-            store[name].append(take)
-            kept[name] += int(take.shape[0])
+            accumulate(name, x)
         return hook
 
     modules = dict(model.named_modules())
-    for name in targets:
-        handles.append(modules[name].register_forward_pre_hook(make_hook(name)))
+    missing_modules = set(targets) - modules.keys()
+    if missing_modules:
+        from .routed_experts import (
+            profile_declared_packed_expert_projections,
+            resolve_routed_expert_profile,
+        )
+        from .measure_quant_cost import (
+            _packed_experts_parent_module, derive_per_expert_activations,
+        )
+        from .production_weight_cache import _PackedExpertActivationCollector
+
+        profile = resolve_routed_expert_profile(model, profile)
+        inventory = profile_declared_packed_expert_projections(model, profile)
+        by_name = {member.qname: member for member in inventory}
+        unknown = missing_modules - by_name.keys()
+        if unknown:
+            raise RuntimeError(f"campaign activation targets are not declared units: {sorted(unknown)}")
+        selected_by_module = {}
+        # These are the input kinds published by the existing derivation,
+        # not a mapping to the producer's served role/group vocabulary.
+        input_kind = {"gate_up_proj": "gate_up", "down_proj": "down"}
+        for name in sorted(missing_modules):
+            member = by_name[name]
+            if member.param_name not in input_kind:
+                raise RuntimeError(
+                    f"packed activation derivation does not support {member.packed_qname!r}")
+            selected_by_module.setdefault(member.module_qname, []).append(member)
+            routed_seen[name] = 0
+        parents = {name: _packed_experts_parent_module(model, name)
+                   for name in selected_by_module}
+
+        def consume_packed(module_qname, x):
+            selected = selected_by_module.get(module_qname)
+            if not selected:
+                return
+            derived = derive_per_expert_activations(
+                selected[0].module, x, parents[module_qname],
+                capture_down=any(input_kind[member.param_name] == "down"
+                                 for member in selected),
+                max_rows_per_expert=None,
+            )
+            for member in selected:
+                accumulate(member.qname,
+                           derived[input_kind[member.param_name]][member.expert_id])
+
+        packed_collector = _PackedExpertActivationCollector(
+            model, {member.module_qname for member in inventory},
+            module_token_budget=0, store_device=device, store_qnames=set(),
+            profile=profile, row_consumer=consume_packed,
+        )
     try:
+        for name in targets:
+            if name not in missing_modules:
+                handles.append(modules[name].register_forward_pre_hook(make_hook(name)))
+        if packed_collector is not None:
+            packed_collector.install()
         with torch.no_grad():
             for batch in tokens:
                 model(batch.to(device))
     finally:
         for handle in handles:
             handle.remove()
+        if packed_collector is not None:
+            packed_collector.remove()
+    unobserved = [name for name, count in routed_seen.items() if not count]
+    if unobserved:
+        raise RuntimeError(
+            "packed campaign units have no routed calibration rows: "
+            f"{sorted(unobserved)}; refusing a shared-Hessian or weight-only fallback")
     rows = {
         name: (torch.cat(chunks, dim=0) if chunks else None)
         for name, chunks in store.items()

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -614,6 +614,44 @@ def expand_menus_for_targets(weights, targets, *, mode, tp_degree,
     return menus
 
 
+def _campaign_layer_scope(names, layer_stride: int) -> list[str]:
+    """The same explicit layer scope for supported and unsupported units."""
+    if layer_stride <= 1:
+        return list(names)
+    import re
+
+    selected = []
+    for name in names:
+        match = re.search(r"\.layers\.(\d+)\.", name)
+        if match is None or int(match.group(1)) % layer_stride == 0:
+            selected.append(name)
+    return selected
+
+
+def _require_campaign_population(model, profile, layer_stride: int) -> None:
+    """Refuse packed units before an incomplete dense-only campaign starts.
+
+    The profile's routed-target discovery owns membership. An arbitrary 3-D
+    parameter (for example a convolution) is not an expert by shape alone.
+    """
+    from .routed_experts import profile_declared_routed_expert_targets
+
+    parameters = dict(model.named_parameters())
+    packed = {
+        name: tuple(parameters[name].shape)
+        for name in profile_declared_routed_expert_targets(model, profile)
+        if name in parameters and parameters[name].ndim == 3
+    }
+    missing = _campaign_layer_scope(packed, layer_stride)
+    if missing:
+        raise RuntimeError(
+            "Tessera campaign cannot price the packed expert population yet: "
+            + ", ".join(f"{name} {packed[name]}" for name in missing)
+            + ". Refusing an incomplete dense-only cost payload; per-expert "
+            "activation/Hessian capture and the producer's explicit projection "
+            "are required (PrismaQuant #183).")
+
+
 def main(argv: "Sequence[str] | None" = None) -> int:
     import torch
 
@@ -714,6 +752,7 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     from .model_profiles import detect_profile
 
     profile = detect_profile(args.model)
+    _require_campaign_population(model, profile, args.layer_stride)
     targets: list[str] = []
     for name, module in model.named_modules():
         if not isinstance(module, torch.nn.Linear):
@@ -721,14 +760,7 @@ def main(argv: "Sequence[str] | None" = None) -> int:
         if name.endswith("lm_head") or "embed" in name:
             continue
         targets.append(name)
-    if args.layer_stride > 1:
-        import re as _re
-        keep = []
-        for name in targets:
-            match = _re.search(r"\.layers\.(\d+)\.", name)
-            if match is None or int(match.group(1)) % args.layer_stride == 0:
-                keep.append(name)
-        targets = keep
+    targets = _campaign_layer_scope(targets, args.layer_stride)
     print(f"[campaign] {len(targets)} target Linears, mode={mode}, "
           f"device={device}", flush=True)
 

--- a/tests/test_architecture_doc.py
+++ b/tests/test_architecture_doc.py
@@ -1,5 +1,5 @@
-"""Mechanical half of the ARCHITECTURE.md maintenance contract (CLAUDE.md §4
-principle 13, AGENTS.md rule 10): the master document's defaults table must
+"""Mechanical half of the ARCHITECTURE.md maintenance contract in AGENTS.md
+and CLAUDE.md: the master document's defaults table must
 match `prismaquant/run-pipeline.sh`, and its structural anchors must exist.
 
 The judgment half — prose describing behavior that changed — cannot be tested;

--- a/tests/test_tessera_campaign.py
+++ b/tests/test_tessera_campaign.py
@@ -760,7 +760,14 @@ def test_the_seam_forwards_the_activation_source_and_nothing_else():
     real = tr._tessera_export.encode_linear
 
     def capturing(weight, **kw):
-        seen.update(kw)
+        # Record the OUTERMOST call only. The pinned encoder's first call in a
+        # process computes ``encoder_fixture_id()``, which encodes its own
+        # fixture cases through this same module-level ``encode_linear`` --
+        # so with a cold cache the recursion would overwrite ``seen`` with a
+        # fixture's kwargs, and the test passed only after another test had
+        # warmed that cache.
+        if not seen:
+            seen.update(kw)
         return real(weight, **kw)
 
     monkey = pytest.MonkeyPatch()

--- a/tests/test_tessera_campaign_packed.py
+++ b/tests/test_tessera_campaign_packed.py
@@ -10,8 +10,134 @@ torch = pytest.importorskip("torch")
 class Lfm2MoeExperts(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self.gate_up_proj = torch.nn.Parameter(torch.ones(2, 8, 4))
-        self.down_proj = torch.nn.Parameter(torch.ones(2, 4, 4))
+        self.gate_up_proj = torch.nn.Parameter(torch.arange(64.).reshape(2, 8, 4) / 64)
+        self.down_proj = torch.nn.Parameter(torch.arange(32.).reshape(2, 4, 4) / 32)
+        self.num_experts = 2
+        self.act_fn = torch.nn.functional.silu
+        self.observed = {0: {"gate_up": [], "down": []},
+                         1: {"gate_up": [], "down": []}}
+
+    def forward(self, hidden, indices, weights):
+        output = torch.zeros_like(hidden)
+        for expert in range(self.num_experts):
+            tokens, positions = torch.where(indices == expert)
+            x = hidden[tokens]
+            gate, up = torch.nn.functional.linear(
+                x, self.gate_up_proj[expert]).chunk(2, dim=-1)
+            down = self.act_fn(gate) * up
+            self.observed[expert]["gate_up"].append(x.detach().clone())
+            self.observed[expert]["down"].append(down.detach().clone())
+            output.index_add_(0, tokens, torch.nn.functional.linear(
+                down, self.down_proj[expert]) * weights[tokens, positions, None])
+        return output
+
+
+class _Router(torch.nn.Module):
+    def forward(self, hidden):
+        return torch.stack((hidden[:, 0], -hidden[:, 0]), dim=-1)
+
+
+class _RoutedBlock(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.gate = _Router()
+        self.experts = Lfm2MoeExperts()
+
+    def route_tokens_to_experts(self, logits):
+        values, indices = torch.softmax(logits, dim=-1).topk(1, dim=-1)
+        return indices, values / values.sum(dim=-1, keepdim=True)
+
+    def forward(self, hidden):
+        indices, weights = self.route_tokens_to_experts(self.gate(hidden))
+        return self.experts(hidden, indices, weights)
+
+
+class _RoutedModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(model_type="lfm2_moe", architectures=[])
+        self.model = _mixed_model().model
+        self.model.layers[2].feed_forward = _RoutedBlock()
+
+    def forward(self, hidden):
+        hidden = hidden.reshape(-1, hidden.shape[-1])
+        self.model.layers[0].attention(hidden)
+        return self.model.layers[2].feed_forward(hidden)
+
+
+EXPERT_PREFIX = "model.layers.2.feed_forward.experts"
+
+
+def _routed_tokens():
+    return [torch.tensor([[[1., 2., 0., 1.], [-1., 3., 1., 0.],
+                           [2., 1., 1., 0.], [-2., 1., 0., 2.]]]),
+            torch.tensor([[[3., 2., 0., 1.], [-3., 3., 1., 0.],
+                           [4., 1., 1., 0.], [-4., 1., 0., 2.]]])]
+
+
+def test_capture_packed_projections_uses_every_actual_routed_row():
+    from prismaquant.tessera_campaign import _collect_activations
+
+    model = _RoutedModel()
+    targets = [f"{EXPERT_PREFIX}.{expert}.{projection}"
+               for expert in range(2) for projection in ("w1", "w3", "w2")]
+    dense = "model.layers.0.attention"
+    tokens = _routed_tokens()
+    rows, hessians, counts = _collect_activations(
+        model, [dense, *targets], tokens, 1, "cpu", want_hessian=True)
+    from prismaquant.routed_experts import profile_declared_packed_expert_projections
+
+    observed = model.model.layers[2].feed_forward.experts.observed
+    units = {unit.qname: unit for unit in profile_declared_packed_expert_projections(model)}
+    assert set(units) == set(targets)
+    for expert in range(2):
+        for projection, input_kind in (("w1", "gate_up"),
+                                       ("w3", "gate_up"), ("w2", "down")):
+            name = f"{EXPERT_PREFIX}.{expert}.{projection}"
+            actual = torch.cat(observed[expert][input_kind])
+            assert actual.shape[0] == 4  # The score cap must be binding.
+            assert counts[name] == actual.shape[0]
+            torch.testing.assert_close(rows[name], actual[:1])
+            torch.testing.assert_close(hessians[name], actual.T @ actual)
+            unit = units[name]
+            packed = getattr(unit.module, unit.param_name)
+            expected = (packed[expert] if projection == "w2" else
+                        packed[expert, :4] if projection == "w1" else packed[expert, 4:])
+            torch.testing.assert_close(unit.weight, expected)
+            assert unit.weight.untyped_storage().data_ptr() == packed.untyped_storage().data_ptr()
+    flat = torch.cat(tokens).reshape(-1, 4)
+    assert counts[dense] == 8
+    torch.testing.assert_close(hessians[dense], flat.T @ flat)
+    assert not model.model.layers[2].feed_forward.experts._forward_pre_hooks
+    assert not model.model.layers[0].attention._forward_pre_hooks
+
+
+def test_packed_capture_subset_keeps_the_same_routed_rows_and_hessian():
+    from prismaquant.tessera_campaign import _collect_activations
+
+    all_targets = [f"{EXPERT_PREFIX}.{expert}.{projection}"
+                   for expert in range(2) for projection in ("w1", "w3", "w2")]
+    selected = f"{EXPERT_PREFIX}.1.w2"
+    whole = _collect_activations(
+        _RoutedModel(), all_targets, _routed_tokens(), 2, "cpu", want_hessian=True)
+    subset = _collect_activations(
+        _RoutedModel(), [selected], _routed_tokens(), 2, "cpu", want_hessian=True)
+    for index in (0, 1):
+        torch.testing.assert_close(subset[index][selected], whole[index][selected])
+    assert subset[2][selected] == whole[2][selected] == 4
+
+
+@pytest.mark.parametrize("want_hessian", [False, True])
+def test_packed_capture_refuses_an_unobserved_expert(want_hessian):
+    from prismaquant.tessera_campaign import _collect_activations
+
+    model = _RoutedModel()
+    missing = f"{EXPERT_PREFIX}.1.w1"
+    with pytest.raises(RuntimeError, match="no routed calibration rows") as error:
+        _collect_activations(model, [missing], [torch.ones(1, 3, 4)], 1,
+                             "cpu", want_hessian=want_hessian)
+    assert missing in str(error.value)
+    assert not model.model.layers[2].feed_forward.experts._forward_pre_hooks
 
 
 def _mixed_model():

--- a/tests/test_tessera_campaign_packed.py
+++ b/tests/test_tessera_campaign_packed.py
@@ -75,14 +75,15 @@ def _routed_tokens():
                            [4., 1., 1., 0.], [-4., 1., 0., 2.]]])]
 
 
-def test_capture_packed_projections_uses_every_actual_routed_row():
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_capture_packed_projections_uses_every_actual_routed_row(dtype):
     from prismaquant.tessera_campaign import _collect_activations
 
-    model = _RoutedModel()
+    model = _RoutedModel().to(dtype=dtype)
     targets = [f"{EXPERT_PREFIX}.{expert}.{projection}"
                for expert in range(2) for projection in ("w1", "w3", "w2")]
     dense = "model.layers.0.attention"
-    tokens = _routed_tokens()
+    tokens = [batch.to(dtype=dtype) for batch in _routed_tokens()]
     rows, hessians, counts = _collect_activations(
         model, [dense, *targets], tokens, 1, "cpu", want_hessian=True)
     from prismaquant.routed_experts import profile_declared_packed_expert_projections
@@ -94,7 +95,7 @@ def test_capture_packed_projections_uses_every_actual_routed_row():
         for projection, input_kind in (("w1", "gate_up"),
                                        ("w3", "gate_up"), ("w2", "down")):
             name = f"{EXPERT_PREFIX}.{expert}.{projection}"
-            actual = torch.cat(observed[expert][input_kind])
+            actual = torch.cat(observed[expert][input_kind]).float()
             assert actual.shape[0] == 4  # The score cap must be binding.
             assert counts[name] == actual.shape[0]
             torch.testing.assert_close(rows[name], actual[:1])
@@ -105,7 +106,7 @@ def test_capture_packed_projections_uses_every_actual_routed_row():
                         packed[expert, :4] if projection == "w1" else packed[expert, 4:])
             torch.testing.assert_close(unit.weight, expected)
             assert unit.weight.untyped_storage().data_ptr() == packed.untyped_storage().data_ptr()
-    flat = torch.cat(tokens).reshape(-1, 4)
+    flat = torch.cat(tokens).reshape(-1, 4).float()
     assert counts[dense] == 8
     torch.testing.assert_close(hessians[dense], flat.T @ flat)
     assert not model.model.layers[2].feed_forward.experts._forward_pre_hooks

--- a/tests/test_tessera_campaign_packed.py
+++ b/tests/test_tessera_campaign_packed.py
@@ -1,0 +1,54 @@
+"""A campaign must account for the live packed expert population."""
+from types import ModuleType, SimpleNamespace
+import sys
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+class Lfm2MoeExperts(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.gate_up_proj = torch.nn.Parameter(torch.ones(2, 8, 4))
+        self.down_proj = torch.nn.Parameter(torch.ones(2, 4, 4))
+
+
+def _mixed_model():
+    net = torch.nn.Module()
+    net.model = torch.nn.Module()
+    net.model.layers = torch.nn.ModuleList([torch.nn.Module() for _ in range(3)])
+    net.model.layers[0].attention = torch.nn.Linear(4, 4, bias=False)
+    net.model.layers[2].feed_forward = torch.nn.Module()
+    net.model.layers[2].feed_forward.experts = Lfm2MoeExperts()
+    return net
+
+
+@pytest.mark.parametrize("stride", [1, 2])
+def test_main_refuses_missing_packed_population_before_calibration(monkeypatch, tmp_path, stride):
+    from prismaquant import model_profiles, tessera_campaign, tessera_render
+    from prismaquant.model_profiles.lfm2_moe import Lfm2MoeProfile
+
+    model = _mixed_model()
+    transformers = ModuleType("transformers")
+    transformers.AutoModelForCausalLM = SimpleNamespace(
+        from_pretrained=lambda *_args, **_kwargs: model)
+    monkeypatch.setitem(sys.modules, "transformers", transformers)
+    monkeypatch.setattr(model_profiles, "detect_profile", lambda _path: Lfm2MoeProfile())
+    monkeypatch.setattr(tessera_render, "tessera_encoder_hessian_status",
+                        lambda: {"accepted": True})
+
+    def calibration_would_hide_the_omission(*_args, **_kwargs):
+        raise AssertionError("started calibration with a dense-only campaign population")
+
+    monkeypatch.setattr(tessera_campaign, "_calibration_tokens",
+                        calibration_would_hide_the_omission)
+    with pytest.raises(RuntimeError, match="packed expert population") as error:
+        tessera_campaign.main([
+            "--model", "synthetic-lfm", "--out", str(tmp_path / "cost.pkl"),
+            "--cache-dir", str(tmp_path / "cache"), "--hessian", "off",
+            "--menu-mode", "research", "--layer-stride", str(stride),
+        ])
+    for parameter in ("gate_up_proj", "down_proj"):
+        assert f"model.layers.2.feed_forward.experts.{parameter}" in str(error.value)
+    assert not (tmp_path / "cost.pkl").exists()

--- a/tests/test_tessera_campaign_pins.py
+++ b/tests/test_tessera_campaign_pins.py
@@ -1,0 +1,58 @@
+"""The campaign's priced population must obey the profile's immutable floor."""
+from types import ModuleType, SimpleNamespace
+import sys
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+class _CaptureBoundaryReached(Exception):
+    pass
+
+
+@pytest.mark.parametrize("custom_pin", [False, True])
+def test_main_excludes_exactly_the_existing_profile_pins(monkeypatch, tmp_path, custom_pin):
+    from prismaquant import model_profiles, tessera_campaign, tessera_render
+    from prismaquant.model_profiles.lfm2_moe import Lfm2MoeProfile
+
+    model = torch.nn.Module()
+    model.model = torch.nn.Module()
+    layer = torch.nn.Module()
+    model.model.layers = torch.nn.ModuleList([layer])
+    layer.conv = torch.nn.Module()
+    layer.conv.in_proj = torch.nn.Linear(4, 4)
+    layer.conv.out_proj = torch.nn.Linear(4, 4)
+    layer.feed_forward = torch.nn.Module()
+    layer.feed_forward.gate = torch.nn.Linear(4, 4)
+    layer.feed_forward.w1 = torch.nn.Linear(4, 4)
+    layer.self_attn = torch.nn.Module()
+    layer.self_attn.q_proj = torch.nn.Linear(4, 4)
+    profile = Lfm2MoeProfile()
+    if custom_pin:
+        monkeypatch.setattr(profile, "pinned_names", lambda: ("self_attn.q_proj.weight",))
+    expected = {name for name, module in model.named_modules()
+                if isinstance(module, torch.nn.Linear) and not profile.is_pinned_name(name)}
+    assert len(expected) == (4 if custom_pin else 2)
+
+    transformers = ModuleType("transformers")
+    transformers.AutoModelForCausalLM = SimpleNamespace(
+        from_pretrained=lambda *_args, **_kwargs: model)
+    monkeypatch.setitem(sys.modules, "transformers", transformers)
+    monkeypatch.setattr(model_profiles, "detect_profile", lambda _path: profile)
+    monkeypatch.setattr(tessera_render, "tessera_encoder_hessian_status",
+                        lambda: {"accepted": True})
+    monkeypatch.setattr(tessera_campaign, "_calibration_tokens",
+                        lambda *_args: ([], "synthetic calibration"))
+
+    def capture(_model, targets, *_args, **_kwargs):
+        assert set(targets) == expected, "campaign attempted to price profile-pinned Linears"
+        raise _CaptureBoundaryReached
+
+    monkeypatch.setattr(tessera_campaign, "_collect_activations", capture)
+    with pytest.raises(_CaptureBoundaryReached):
+        tessera_campaign.main([
+            "--model", "synthetic-profile", "--out", str(tmp_path / "cost.pkl"),
+            "--cache-dir", str(tmp_path / "cache"), "--hessian", "off",
+            "--menu-mode", "research",
+        ])

--- a/tests/test_tessera_scope_endpoints.py
+++ b/tests/test_tessera_scope_endpoints.py
@@ -123,7 +123,15 @@ def test_campaign_main_passes_live_model_topology_to_real_menu_boundary(tmp_path
     import transformers
 
     modules = {name: torch.nn.Linear(32, 32, bias=False) for name in (DENSE, EXPERT)}
-    model = SimpleNamespace(named_modules=lambda: modules.items(), eval=lambda: None)
+    # The campaign reads the nn.Module API: named_modules for its dense walk
+    # and named_parameters for the packed-population refusal (#183), so the
+    # stand-in presents both, and the parameters are those of its modules.
+    model = SimpleNamespace(
+        named_modules=lambda: modules.items(), eval=lambda: None,
+        named_parameters=lambda: (
+            (f"{name}.{attr}", parameter)
+            for name, module in modules.items()
+            for attr, parameter in module.named_parameters()))
     monkeypatch.setattr(transformers.AutoModelForCausalLM, "from_pretrained", lambda *a, **k: model)
     monkeypatch.setattr(render, "tessera_encoder_hessian_status", lambda: {"accepted": True})
     monkeypatch.setattr(campaign, "_calibration_tokens", lambda *a: ([torch.ones(1, 1, dtype=torch.int64)], "fixture"))


### PR DESCRIPTION
Related to #183; this deliberately does not close it.

The campaign now refuses a live packed-expert population before it can emit an incomplete dense-only cost payload. The capture helper can independently collect each profile-declared expert projection's actual routed inputs and full-row Hessian, reusing the existing packed collector, routing/SwiGLU implementation, and native projection views. Scoring-row limits never truncate the Hessian; unobserved selected experts refuse.

The main packed-population gate remains closed. Exact producer source-to-stack planning, identity-bound cached-blob packing, and an actual matched-byte served campaign are separate remaining work. No new menu, pin roster, encoder default, serving eligibility, or GPU/performance claim is introduced.

Separate on-path commits:

- Honor the profile's existing BF16 pins in dense campaign target enumeration.
- Correct stale architecture resume-identity prose and an obsolete rule-number citation.
- Exercise both FP32 and BF16 live capture inputs.

Based on main `10dd23957d6cf9ad784f8eac59fb914f66f6d89e`, after PR #185; no duplicate endpoint dependency commits are included. Historical red/green actions, commands, populations, and receipts are in `docs/measurements/tessera-packed-capture-2026-09-04.md`.

CPU evidence through deployed PrismaBuild, Sparky / 1 CPU / 4 GiB / no CUDA:

- Genuine pre-fix main omissions: 2 failures; packed capture: 4 failures; pin intake: 2 failures.
- Capture + existing reservoir/campaign/streaming files: 41 passed, 7 skips (5 `Tessera encodes need CUDA`, 2 `streaming production render is GPU-or-bust`). Streaming equivalence was not exercised.
- Shared discovery/router/docs: 41 passed, no skips.
- Pins + campaign regression: 39 passed, 5 `Tessera encodes need CUDA` skips.
- FP32/BF16 capture + pins/docs: 28 passed, no skips; both dtype cases also failed against the exact pre-capture campaign implementation.

The combined targeted population on the updated integration base is queued as PrismaBuild `8c87b0777dae`; its result will be added before merge. These overlapping historical populations must not be summed into a suite count.

Encountered checkpoint-resume identity defect is separately filed and actively assigned as #186. It is not hidden in this capture diff.
