### PR TITLE
Consume validated prepriced cost overrides without running cost builders

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,18 @@
 As of: 2026-09-04 · `codex/pq184-prepriced-cost-override`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-04, `codex/pq184-prepriced-cost-override`) for the
+**read-only prepriced-input validator** (§4.10; #184). The explicit
+`prepriced_cost` CLI validates existing schema, objective currency,
+research provenance and uniform Tessera Hessian identity, requires
+the exact producer-stamped mode and model reference, and records the
+input bytes' SHA-256. Its separate local receipt retains both the original
+absolute argument path and resolved file; re-verification checks both
+resolution and bytes before allocation. The input is never rewritten,
+model-reference equality is not checkpoint-content attestation, and
+historical unstamped Hessian rows retain their owner-reported no-claim
+status. This helper does not itself wire the shell's cost-stage bypass.
+
 Re-stamped (2026-09-04, `codex/pq184-prepriced-cost-override`) for
 **Tessera currency-stamp completeness** (§4.10), encountered during
 #184 intake work. `cost_currency` recognizes Tessera rows through the
@@ -4692,6 +4704,28 @@ hardcoded family roster. Missing or unknown currency refuses with the
 unit and format named; dropping a stamp cannot opt a price out of the
 gate. Diagnostic error rows are excluded, and legacy stock rows without
 a Tessera format or currency remain outside this gate's jurisdiction.
+
+**Explicit external prepriced input** (`python -m prismaquant.prepriced_cost`).
+The intake CLI takes `--path`, `--cost-mode` and `--model`, reads the supplied
+trusted pickle without rewriting it, and applies those shared gates plus
+`research_cost_acceptance.accepted_cost_provenance` and
+`tessera_menu.assert_uniform_hessian_identity`. The pipeline has no research
+acceptance override, so research-stamped assembly refuses. Missing, unknown
+or mismatched `provenance.cost_mode` also refuses; the helper changes neither
+the input's stamp nor the run's defaults. It requires at least one explicit
+producer-owned model reference (direct metadata/provenance or retained
+baseline/shard metadata), with all present references equal to the exact
+requested string. This is not a checkpoint-content hash claim.
+
+`--report` writes a separate local JSON receipt containing the exact SHA-256,
+actual and declared format rosters separately, usable-row count, model-reference
+evidence and the shared currency/Hessian reports. Existing unstamped Hessian
+rows remain reported as unstamped, not invented matching claims. Report/input
+path aliases and hardlinks refuse. `--verify-report` checks the retained
+original absolute argument path still resolves to the same file and hashes
+the same bytes immediately before allocation; this catches retargeted file
+or parent-directory symlinks as well as content changes. Per-unit coverage,
+rendering identity and serving admission remain allocator/export decisions.
 
 Every other entry on the format menu is a *point*: `NVFP4` is one rate, `FP8_E4M3`
 is one rate, and a menu is the handful of them a launcher lists. A Tessera family

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,17 @@
 As of: 2026-09-04 · `codex/pq184-prepriced-cost-override`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-04, `codex/pq184-prepriced-cost-override`) for **actual
+prepriced cost dispatch** (§4.10; #184). `COST_PATH_OVERRIDE` now runs the
+shared read-only intake before probe/GPU work, passes the original supplied
+path to the allocator, and bypasses the entire local/render/AURA cost-builder
+and finalization stage. Its separate local receipt is reverified immediately
+before allocation, including lexical-path resolution and exact SHA-256.
+Supplied files and their sidecars are not rewritten. No-override generation,
+`COST_MODE` defaults and existing allocator/serving gates remain unchanged;
+the requested mode must match the explicit producer stamp, never be inferred
+by changing a default. Evidence: `docs/results/prepriced_cost_override_2026-09-04.md`.
+
 Re-stamped (2026-09-04, `codex/pq184-prepriced-cost-override`) for the
 **read-only prepriced-input validator** (§4.10; #184). The explicit
 `prepriced_cost` CLI validates existing schema, objective currency,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,15 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-04 · `codex/pq-tessera-v5-endpoints`. Stamps
+As of: 2026-09-04 · `codex/pq184-prepriced-cost-override`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-04, `codex/pq184-prepriced-cost-override`) for
+**finite cost-schema signals** (§4.10), encountered during #184 intake
+work. `schemas.validate_cost_payload` now refuses non-finite values in
+the existing primary scalar fields and per-expert weight-MSE vector,
+naming the input file and exact field/element. Finite signed values,
+diagnostic error rows and non-cost schema behavior are unchanged. This
+adds no numeric threshold, cost estimator or promotion claim.
 
 Re-stamped (2026-09-04, `codex/pq-tessera-v5-endpoints`) for **selected
 export scope and shipcard binding** (§5.7, §9.4; Tessera #126). V5 export
@@ -4659,6 +4667,14 @@ twin of anything live — it is the only one of the two left, and §4.10 is its
 seam.
 
 ### 4.10 The Tessera continuous menu — `FORMATS=TESSERA` (2026-09-02)
+
+**Shared cost intake.** `schemas.validate_cost_payload` requires finite
+numbers in each non-error row's existing cost scalar fields and
+`weight_mse_per_expert` elements. A finite sibling field cannot hide a
+NaN or infinity. Refusals name the source file and exact field/element;
+diagnostic error rows remain non-prices, and probe/router schema rules
+are unchanged. This guard applies to every cost consumer, not only to
+an external pipeline override.
 
 Every other entry on the format menu is a *point*: `NVFP4` is one rate, `FP8_E4M3`
 is one rate, and a menu is the handful of them a launcher lists. A Tessera family

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4717,6 +4717,12 @@ gate. Diagnostic error rows are excluded, and legacy stock rows without
 a Tessera format or currency remain outside this gate's jurisdiction.
 
 **Explicit external prepriced input** (`python -m prismaquant.prepriced_cost`).
+The driver's `COST_PATH_OVERRIDE` runs this preflight before probe/GPU work,
+bypasses all cost builders/finalization, and passes the original input path
+unchanged to the allocator after receipt re-verification. It writes only the
+local `artifacts/prepriced_cost_input.json`, not a supplied cost or its
+settings sidecar. The no-override path keeps normal generation.
+
 The intake CLI takes `--path`, `--cost-mode` and `--model`, reads the supplied
 trusted pickle without rewriting it, and applies those shared gates plus
 `research_cost_acceptance.accepted_cost_provenance` and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,6 +4,14 @@ As of: 2026-09-04 · `codex/pq184-prepriced-cost-override`. Stamps
 follow, newest first, each recording its own branch and date.
 
 Re-stamped (2026-09-04, `codex/pq184-prepriced-cost-override`) for
+**Tessera currency-stamp completeness** (§4.10), encountered during
+#184 intake work. `cost_currency` recognizes Tessera rows through the
+existing format grammar and refuses a usable row with a missing or
+unknown campaign currency. Removing the stamp can no longer evade the
+objective gate. Diagnostic error rows are not prices; unstamped stock
+tables keep their existing behavior. No currency or estimator changes.
+
+Re-stamped (2026-09-04, `codex/pq184-prepriced-cost-override`) for
 **finite cost-schema signals** (§4.10), encountered during #184 intake
 work. `schemas.validate_cost_payload` now refuses non-finite values in
 the existing primary scalar fields and per-expert weight-MSE vector,
@@ -4675,6 +4683,15 @@ NaN or infinity. Refusals name the source file and exact field/element;
 diagnostic error rows remain non-prices, and probe/router schema rules
 are unchanged. This guard applies to every cost consumer, not only to
 an external pipeline override.
+
+`cost_currency.require_run_currency` requires each usable Tessera-format
+row to carry the campaign-owned currency stamp before checking that its
+table's explicit cost mode names the matching objective. Membership comes
+from `tessera_formats.parse_tessera_format_name`, not a prefix guess or
+hardcoded family roster. Missing or unknown currency refuses with the
+unit and format named; dropping a stamp cannot opt a price out of the
+gate. Diagnostic error rows are excluded, and legacy stock rows without
+a Tessera format or currency remain outside this gate's jurisdiction.
 
 Every other entry on the format menu is a *point*: `NVFP4` is one rate, `FP8_E4M3`
 is one rate, and a menu is the handful of them a launcher lists. A Tessera family

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,18 @@
 As of: 2026-09-05 · `codex/pq184-prepriced-cost-override`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-05, `codex/pq184-prepriced-cost-override`) for **the
+prepriced override's handoff to the priced-input export gate** (§4.10; #184
+after #193/#196). The cost-builder bypass never reached the export leg's
+priced inputs, and it still does not: `TESSERA_HESSIAN` /
+`TESSERA_INPUT_SCALES` are resolved before the cost stage and consumed in the
+Tessera arm, and the allocation's `tessera_hessian` block comes from the
+supplied table itself, so `require_priced_export_inputs` still refuses an
+H-aware prepriced allocation exported without its capture. Only the operator
+instruction was wrong: the TESSERA-token refusal told the operator to re-run
+with `COST_PATH_OVERRIDE` alone, and now names both priced-input variables
+and where the campaign writes them. No gate, default or byte changes.
+
 Re-stamped (2026-09-04, `codex/pq184-prepriced-cost-override`) for **actual
 prepriced cost dispatch** (§4.10; #184). `COST_PATH_OVERRIDE` now runs the
 shared read-only intake before probe/GPU work, passes the original supplied
@@ -4788,6 +4800,19 @@ bypasses all cost builders/finalization, and passes the original input path
 unchanged to the allocator after receipt re-verification. It writes only the
 local `artifacts/prepriced_cost_input.json`, not a supplied cost or its
 settings sidecar. The no-override path keeps normal generation.
+
+Bypassing the cost builders does **not** bypass the export leg's priced-input
+gate (§5, `tessera_export_lane.require_priced_export_inputs`). A prepriced run
+means the campaign ran out of band, so the `hessian_capture.pt` and
+`input_scales.safetensors` it wrote beside its `--cache-dir` are not under this
+run's work directory: the operator hands them back through `TESSERA_HESSIAN` /
+`TESSERA_INPUT_SCALES`, which the driver reads before the cost stage and threads
+into the Tessera arm unchanged. The allocation carries the pricing state either
+way — the allocator stamps `tessera_hessian` into `layer_config.json` from the
+supplied table's own identity, the same block `assert_uniform_hessian_identity`
+checked at intake — so an H-aware prepriced table exported without its capture
+refuses by name rather than shipping weights-only bytes. The TESSERA-token
+refusal at the top of the driver names both variables.
 
 The intake CLI takes `--path`, `--cost-mode` and `--model`, reads the supplied
 trusted pickle without rewriting it, and applies those shared gates plus

--- a/docs/results/prepriced_cost_override_2026-09-04.md
+++ b/docs/results/prepriced_cost_override_2026-09-04.md
@@ -1,0 +1,74 @@
+# Prepriced pipeline input dispatch (#184)
+
+2026-09-04. This is intake/dispatch correctness evidence, not a performance,
+quality, served-KL or GPU measurement. No objective, cost mode, format default,
+wire or promotion threshold changes.
+
+## Fix and owner boundaries
+
+`COST_PATH_OVERRIDE` now passes the actual original supplied path to the
+allocator and bypasses the entire incompatible local/render/AURA cost-builder
+and finalization stage. The new read-only intake module delegates to the
+existing schema, currency, research-acceptance and Tessera Hessian identity
+owners. Explicit supplied payload mode must match requested `COST_MODE`.
+Explicit producer model references must all exactly match the requested model
+reference; this is not checkpoint-content attestation.
+
+A local receipt records original lexical path, resolved path and exact file
+SHA-256. Immediately before allocation, the driver rechecks resolution and
+hash. Input bytes are never copied over or rewritten; report destinations
+aliasing input by direct path, symlink or hardlink refuse. Ordinary no-override
+cost generation remains unchanged. Allocator per-unit/renderer/coverage and
+export gates remain authoritative, not bypassed by preflight.
+
+Two defects encountered in owning validation rules were fixed separately:
+
+- Cost schema now refuses nonfinite cost signals instead of accepting NaN or
+  infinities that can enter allocator comparison/objective arithmetic.
+- Cost currency discovery recognizes actual Tessera format rows through the
+  existing grammar. Usable rows with absent or unknown campaign currency no
+  longer evade the currency owner simply because their stamp is wrong.
+
+The shared-owner guards were not copied into the intake module. Error rows
+remain error rows; no unavailable measurement is fabricated.
+
+## Red and green
+
+All tests were dispatched through PrismaBuild, CPU-only Sparky, 1 reserved
+CPU / 4 GiB, `CUDA_VISIBLE_DEVICES=''`, with both thread-count environment
+knobs set to one. No CUDA-gated surface was covered. The existing cu130 venv
+used the immutable reviewed Tessera `1221d2a` source archive (SHA-256
+`b4755a30d60974ec2758c2060fc4d3954f2e1b7c7bb11602a05f0b783ba60bc8`).
+
+Initial red action
+`8d5697e15e8c6a593aa118ff70313e326e55dd285f8be499fb19264707cb4f02`:
+**47 failed, 1 passed, 0 skipped**, no collection errors. Intake API was
+absent; actual driver sections reached `incremental_measure_quant_cost` and
+returned the intercepted builder status 77 instead of allocator status 88
+or expected preflight refusal 2. The existing no-override builder path was
+the positive preservation control.
+
+Supplemental owner red action
+`accd807d92a4361aa62c7bf40637add74391130587001166b74686d20ffb814c`:
+**24 failed, 64 passed, 0 skipped**, no collection errors. Exact pre-fix
+failure conditions were two symlink-retarget cases `DID NOT RAISE ValueError`,
+six missing/unknown currency cases `DID NOT RAISE CostCurrencyError`, and
+16 nonfinite cost cases `DID NOT RAISE SchemaValidationError`.
+
+Combined green action
+`086f848b54dea8793080e8d9823e16ba69b9128f91930863a475308f38c87108`:
+**97 passed, 0 failed, 0 skipped**, no collection errors. Target files:
+`test_prepriced_cost`, `test_run_pipeline_prepriced_override`,
+`test_cost_currency_missing_stamp`, `test_cost_currency`,
+`test_cost_schema_finite`, `test_schema_validation`. The three modified Python
+sources compiled and the real pipeline passed `bash -n` in the same action.
+Receipt SHA-256:
+`36f3393ab02dd01f9f6f0f1a71d56c6adab9e02804281782666132da88add894`;
+result blob:
+`47f708f0c18b7c1e800015f2659a96fccc438e4f3409462b4b9a9704501df589`.
+
+Failed output is retained in
+`/mnt/shared/prismabuild-fleet/pb-queue/failed/<action>.json`; successful
+receipts/results are in the PrismaBuild CAS. Only the three tracked external
+calibration symlinks were excluded for sealing and immediately restored after
+queue; source input semantics and measurement artifacts were preserved.

--- a/docs/results/prepriced_cost_override_2026-09-04.md
+++ b/docs/results/prepriced_cost_override_2026-09-04.md
@@ -83,3 +83,23 @@ without relaxing source gates. The complete endpoint file then passed **21/0/0**
 no collection errors, under the same CPU-only reservation: action
 `f305d657783e16e7dbc4615b5864323dc362281087870360b8ad5d6988f51e77`, receipt
 `1d3e0bb685ebd2ba306a655fe37416bfe6b5ea46a3d30f11408adf3ecfee08a7`.
+
+## Final main/endpoint integration
+
+After merging main `10dd2395` (endpoint PR185) at `784f1674`, the expanded
+15-file targeted population passed **234 tests, 0 failures, 0 skips**, no
+collection errors. It includes all six owner/override files, real scoped
+allocator endpoints, real shell gates/defaults, stage identity, pipeline
+contracts, export scope, plan binding and both documentation checks. Shell
+syntax also passed. The only merge conflict was the architecture provenance
+stamp; shell source merged automatically. No production change followed this
+measurement.
+
+PrismaBuild action:
+`49eae99259307543b4bf86b3b172400efffef5cfbf00eb37d52536291122e4cf`.
+Receipt:
+`5cdaefad68148b88e8d0022b39cdf591b0243b9fbf2ac54af5d6c3d014caf629`.
+Result log:
+`340529b91d351f0a5705e5d5e419661661ff8d86a7117796ae4e79aac83d5dbc`.
+Population remained CPU-only Sparky, 1 core / 4 GiB, CUDA hidden and the same
+immutable reviewed producer archive. This is not a full-suite or GPU claim.

--- a/docs/results/prepriced_cost_override_2026-09-04.md
+++ b/docs/results/prepriced_cost_override_2026-09-04.md
@@ -72,3 +72,14 @@ Failed output is retained in
 receipts/results are in the PrismaBuild CAS. Only the three tracked external
 calibration symlinks were excluded for sealing and immediately restored after
 queue; source input semantics and measurement artifacts were preserved.
+
+## Existing endpoint fixture integration
+
+The stronger currency owner exposed three existing scope-test fixtures whose
+synthetic Tessera rows omitted campaign currency/mode. The previously passing
+file was shown red at that exact missing-stamp boundary (**3 failed, 18 passed**,
+action prefix `13a7c8c2187c`), then corrected using the campaign's own constants
+without relaxing source gates. The complete endpoint file then passed **21/0/0**,
+no collection errors, under the same CPU-only reservation: action
+`f305d657783e16e7dbc4615b5864323dc362281087870360b8ad5d6988f51e77`, receipt
+`1d3e0bb685ebd2ba306a655fe37416bfe6b5ea46a3d30f11408adf3ecfee08a7`.

--- a/prismaquant/cost_currency.py
+++ b/prismaquant/cost_currency.py
@@ -25,9 +25,11 @@ Three rules, all fail-closed:
    against a default, and a COST_MODE naming no objective is refused rather
    than defaulted.
 
-Tables with no Tessera-currency row are outside this gate's jurisdiction and
-pass through untouched: legacy unstamped stock tables keep their behavior,
-and other gates own those rows.
+Every usable Tessera-format row must carry the campaign's currency stamp;
+dropping that stamp cannot remove a price from this gate's jurisdiction.
+Tables with neither a Tessera format nor a Tessera-currency row pass through
+untouched: legacy unstamped stock tables keep their behavior, and other gates
+own those rows. Diagnostic error rows are not prices.
 """
 from __future__ import annotations
 
@@ -67,15 +69,30 @@ def tessera_campaign_currency() -> str:
 
 def _tessera_rows(costs: Mapping[str, Any]) -> list[tuple[str, str]]:
     """``(unit, format)`` pairs priced in the Tessera campaign currency."""
+    from .tessera_formats import parse_tessera_format_name
+
     if not isinstance(costs, Mapping):
         return []
     wanted = tessera_campaign_currency()
     found: list[tuple[str, str]] = []
+    membership: dict[str, bool] = {}
     for unit, rows in costs.items():
         if not isinstance(rows, Mapping):
             continue
         for fmt, entry in rows.items():
-            if isinstance(entry, Mapping) and entry.get("currency") == wanted:
+            if not isinstance(entry, Mapping) or "error" in entry:
+                continue
+            if fmt not in membership:
+                try:
+                    membership[fmt] = parse_tessera_format_name(fmt) is not None
+                except ValueError as exc:
+                    raise CostCurrencyError(f"cost row {unit}/{fmt}: {exc}") from exc
+            if membership[fmt] and entry.get("currency") != wanted:
+                raise CostCurrencyError(
+                    f"Tessera cost row {unit}/{fmt} has missing or unknown "
+                    f"currency={entry.get('currency')!r}; its producer must "
+                    f"stamp the measured campaign currency {wanted!r}")
+            if entry.get("currency") == wanted:
                 found.append((str(unit), str(fmt)))
     return found
 

--- a/prismaquant/prepriced_cost.py
+++ b/prismaquant/prepriced_cost.py
@@ -1,0 +1,274 @@
+"""Read-only preflight for an explicitly supplied pipeline cost table.
+
+This is an intake gate, not a new cost producer or an acceptance override.
+The existing schema, currency, research-provenance and Tessera Hessian owners
+decide their own contracts. A model reference is checked exactly as recorded;
+it is not a checkpoint-content attestation. Allocator and export gates still
+own per-unit coverage, renderer identity and serving eligibility.
+"""
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+import json
+import os
+from pathlib import Path
+import pickle
+import re
+import tempfile
+from typing import Any
+
+
+REPORT_SCHEMA = "prismaquant.prepriced_cost_input.v1"
+
+
+def _input_path(path: str | os.PathLike) -> Path:
+    supplied = Path(path)
+    try:
+        resolved = supplied.resolve(strict=True)
+        if not resolved.is_file():
+            raise ValueError("not a regular file")
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ValueError(f"prepriced cost input {supplied}: {exc}") from exc
+    return resolved
+
+
+def _sha256(path: Path) -> str:
+    from .shipcard import file_sha256
+
+    digest = file_sha256(path)
+    if digest is None:
+        raise ValueError(f"prepriced cost input {path}: cannot read sha256")
+    return digest
+
+
+def _require_sha256(value: Any, *, where: str) -> str:
+    if not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{64}", value) is None:
+        raise ValueError(f"{where}: sha256 must be a full lowercase SHA-256 digest")
+    return value
+
+
+def _model_binding(payload: Mapping, model: str) -> dict[str, Any]:
+    """Follow the metadata edges written by existing cost producers only.
+
+    Monolithic/incremental cost writes ``meta.model``; AURA, the Tessera
+    campaign and empirical expert cost write ``provenance.model``. Incremental
+    merge retains each shard's metadata in ``meta.shards`` (including its
+    ``incremental_shard`` stamp). Production render wraps its baseline metadata
+    in ``meta.baseline_meta``. No model-name or source-path heuristic is used.
+    """
+    if not isinstance(model, str) or not model:
+        raise ValueError("requested model must be an explicit nonempty model reference")
+    fields: dict[str, str] = {}
+    active: set[int] = set()
+
+    def visit(meta: Any, where: str) -> None:
+        if not isinstance(meta, Mapping):
+            raise ValueError(f"{where}: model metadata must be a mapping")
+        if id(meta) in active:
+            raise ValueError(f"{where}: model metadata contains a cycle")
+        active.add(id(meta))
+        try:
+            if "model" in meta:
+                reference = meta["model"]
+                if not isinstance(reference, str) or not reference:
+                    raise ValueError(f"{where}.model must be a nonempty model reference")
+                if reference != model:
+                    raise ValueError(
+                        f"{where}.model={reference!r} does not match requested "
+                        f"model={model!r}; model references must match exactly")
+                fields[f"{where}.model"] = reference
+            for key in ("baseline_meta", "incremental_shard"):
+                if meta.get(key) is not None:
+                    visit(meta[key], f"{where}.{key}")
+            if "shards" in meta:
+                shards = meta["shards"]
+                if not isinstance(shards, Sequence) or isinstance(shards, (str, bytes)):
+                    raise ValueError(f"{where}.shards: model metadata must be a sequence")
+                for index, shard in enumerate(shards):
+                    visit(shard, f"{where}.shards[{index}]")
+        finally:
+            active.remove(id(meta))
+
+    for key in ("meta", "provenance"):
+        if key in payload:
+            visit(payload[key], key)
+    if not fields:
+        raise ValueError(
+            "model reference is unstamped: require the producer's meta.model "
+            "or provenance.model (including retained baseline/shard metadata); "
+            "no checkpoint identity is inferred from the cost file path")
+    return {
+        "kind": "exact_model_reference",
+        "model": model,
+        "fields": fields,
+        "checkpoint_content_attested": False,
+    }
+
+
+def validate_prepriced_cost(
+    path: str | os.PathLike, *, cost_mode: str, model: str,
+    expected_sha256: str | None = None,
+) -> dict[str, Any]:
+    """Validate an external pickle without changing its bytes or run defaults.
+
+    This accepts the project's trusted cost-pickle input, not untrusted pickle
+    data. The exact requested mode must match its existing producer stamp,
+    including legacy spelling: currency equivalence does not rewrite identity.
+    """
+    from .cost_currency import COST_MODE_OBJECTIVE_CURRENCY, require_run_currency
+    from .research_cost_acceptance import accepted_cost_provenance
+    from .schemas import validate_cost_payload
+    from .tessera_menu import assert_uniform_hessian_identity
+
+    input_path = Path(path).absolute()
+    source = _input_path(input_path)
+    before = _sha256(source)
+    if expected_sha256 is not None:
+        expected = _require_sha256(expected_sha256, where=f"prepriced cost input {source}")
+        if before != expected:
+            raise ValueError(
+                f"prepriced cost input {source}: sha256 mismatch: expected "
+                f"{expected}, read {before}")
+    try:
+        with source.open("rb") as handle:
+            payload = pickle.load(handle)
+        validate_cost_payload(payload, str(source))
+        provenance = payload.get("provenance")
+        if not isinstance(provenance, Mapping):
+            raise ValueError("provenance.cost_mode is unstamped; an explicit override requires its producer's mode")
+        stamped = provenance.get("cost_mode")
+        if not isinstance(stamped, str) or stamped not in COST_MODE_OBJECTIVE_CURRENCY:
+            raise ValueError(
+                f"provenance.cost_mode={stamped!r} is missing or unknown; "
+                f"expected a producer stamp from {sorted(COST_MODE_OBJECTIVE_CURRENCY)}")
+        if not isinstance(cost_mode, str) or cost_mode not in COST_MODE_OBJECTIVE_CURRENCY:
+            raise ValueError(f"requested COST_MODE={cost_mode!r} names no owned objective")
+        if stamped != cost_mode:
+            raise ValueError(
+                f"provenance.cost_mode={stamped!r} does not match requested "
+                f"COST_MODE={cost_mode!r}; reprice for the requested mode or "
+                "explicitly select the matching mode, not a rewritten stamp")
+        currency = require_run_currency(payload)
+        if accepted_cost_provenance(payload) is not None:
+            raise ValueError(
+                "research-stamped cost input requires the allocator's explicit "
+                "research acknowledgement; the pipeline override cannot accept it")
+        hessian = assert_uniform_hessian_identity(payload["costs"])
+        binding = _model_binding(payload, model)
+        usable = sum(
+            "error" not in row
+            for rows in payload["costs"].values() for row in rows.values())
+        if not usable:
+            raise ValueError("costs contains no usable cost rows; an external override cannot supply measurements")
+        formats = sorted({fmt for rows in payload["costs"].values() for fmt in rows})
+        declared = sorted(set(payload.get("formats") or []))
+    except Exception as exc:
+        raise ValueError(f"prepriced cost input {source}: {exc}") from exc
+    after = _sha256(source)
+    if _input_path(input_path) != source:
+        raise ValueError(f"prepriced cost input {input_path}: resolved path changed during validation")
+    if after != before:
+        raise ValueError(
+            f"prepriced cost input {source}: sha256 changed during validation: "
+            f"before {before}, after {after}")
+    return {
+        "schema": REPORT_SCHEMA,
+        "input_path": str(input_path),
+        "path": str(source),
+        "sha256": before,
+        "cost_mode": stamped,
+        "formats": formats,
+        "declared_formats": declared,
+        "units": len(payload["costs"]),
+        "usable_rows": usable,
+        "currency": currency,
+        "tessera_hessian_identity": hessian,
+        "model_binding": binding,
+    }
+
+
+def verify_prepriced_cost_report(report_path: str | os.PathLike) -> dict[str, Any]:
+    """Recheck the original file immediately before allocator consumption.
+
+    The receipt records preflight, and this step verifies byte stability. It
+    does not promote the table to a serving or checkpoint-content attestation.
+    """
+    path = Path(report_path)
+    try:
+        report = json.loads(path.read_text())
+        if not isinstance(report, dict) or report.get("schema") != REPORT_SCHEMA:
+            raise ValueError("missing or unsupported report schema")
+        reference = report.get("path")
+        if not isinstance(reference, str) or not Path(reference).is_absolute():
+            raise ValueError("report path must name the original absolute input path")
+        original = report.get("input_path")
+        if not isinstance(original, str) or not Path(original).is_absolute():
+            raise ValueError("report input_path must retain the original absolute argument path")
+        expected = _require_sha256(report.get("sha256"), where="report")
+        source = _input_path(original)
+        if str(source) != reference:
+            raise ValueError(
+                f"input path {original} resolves to {source}, not the preflight "
+                f"path {reference}; the original argument changed after preflight")
+        observed = _sha256(source)
+        if _input_path(original) != source:
+            raise ValueError(f"input path {original} changed during sha256 verification")
+        if observed != expected:
+            raise ValueError(
+                f"input {source}: sha256 mismatch: expected {expected}, read {observed}; "
+                "input changed after preflight")
+    except Exception as exc:
+        raise ValueError(f"prepriced cost report {path}: {exc}") from exc
+    return report
+
+
+def _write_report(path: Path, report: Mapping) -> None:
+    source = Path(report["path"])
+    # Reject both path aliases and hardlinks before touching the receipt.
+    if path.resolve() == source or (path.exists() and path.samefile(source)):
+        raise ValueError(f"report {path} aliases the supplied cost input {source}; refusing to overwrite it")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(mode="w", dir=path.parent, prefix=f".{path.name}.", delete=False) as handle:
+            temporary = Path(handle.name)
+            json.dump(report, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+        os.replace(temporary, path)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--path", help="existing trusted prepriced cost pickle; never rewritten")
+    parser.add_argument("--cost-mode", help="explicit run COST_MODE, matched to the producer stamp")
+    parser.add_argument("--model", help="exact source model reference recorded by the cost producer")
+    parser.add_argument("--report", help="write a separate local JSON receipt")
+    parser.add_argument("--expected-sha256", help="optionally require a previously measured input digest")
+    parser.add_argument("--verify-report", help="verify the receipt's input sha256 immediately before allocation")
+    args = parser.parse_args(argv)
+    if args.verify_report:
+        if any(value is not None for value in (args.path, args.cost_mode, args.model, args.report, args.expected_sha256)):
+            parser.error("--verify-report cannot be combined with validation or report-writing arguments")
+    elif any(value is None for value in (args.path, args.cost_mode, args.model)):
+        parser.error("validation requires --path, --cost-mode and --model")
+    try:
+        if args.verify_report:
+            report = verify_prepriced_cost_report(args.verify_report)
+        else:
+            report = validate_prepriced_cost(
+                args.path, cost_mode=args.cost_mode, model=args.model,
+                expected_sha256=args.expected_sha256)
+            if args.report:
+                _write_report(Path(args.report), report)
+        print(json.dumps(report, sort_keys=True))
+    except (OSError, ValueError) as exc:
+        parser.exit(2, f"[prepriced-cost] ERROR: {exc}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prismaquant/run-pipeline.sh
+++ b/prismaquant/run-pipeline.sh
@@ -71,6 +71,7 @@ if [[ ",${FORMATS}," == *",TESSERA,"* ]]; then
     echo "[pipeline] ERROR: FORMATS contains the TESSERA menu token, whose cost stage is prismaquant.tessera_campaign and is not yet run by this orchestrator. Produce it first:" >&2
     echo "[pipeline]   PRISMAQUANT_TESSERA_MENU=research python -m prismaquant.tessera_campaign --model \"\$MODEL_PATH\" --out \"\$WORK_DIR/artifacts/cost.pkl\" --cache-dir \"\$WORK_DIR/artifacts/tessera-cache\"" >&2
     echo "[pipeline] then re-run with COST_PATH_OVERRIDE pointing at it and COST_MODE matching its explicit provenance.cost_mode. The available Tessera menu comes from the reviewed producer contract and the explicit serving target, not a fixed rung roster. Research mode admits serialisable rungs but does not attest them for export." >&2
+    echo "[pipeline] The campaign also writes the export leg's PRICED INPUTS beside its --cache-dir; hand them back on the re-run or the Tessera export preflight refuses (RobTand/prismaquant#193): TESSERA_HESSIAN=\"\$WORK_DIR/artifacts/tessera-cache/hessian_capture.pt\" TESSERA_INPUT_SCALES=\"\$WORK_DIR/artifacts/tessera-cache/input_scales.safetensors\". A weights-only (--hessian off) campaign supplies neither." >&2
     exit 2
   fi
 fi

--- a/prismaquant/run-pipeline.sh
+++ b/prismaquant/run-pipeline.sh
@@ -70,7 +70,7 @@ if [[ ",${FORMATS}," == *",TESSERA,"* ]]; then
   if [[ -z "${COST_PATH_OVERRIDE:-}" ]]; then
     echo "[pipeline] ERROR: FORMATS contains the TESSERA menu token, whose cost stage is prismaquant.tessera_campaign and is not yet run by this orchestrator. Produce it first:" >&2
     echo "[pipeline]   PRISMAQUANT_TESSERA_MENU=research python -m prismaquant.tessera_campaign --model \"\$MODEL_PATH\" --out \"\$WORK_DIR/artifacts/cost.pkl\" --cache-dir \"\$WORK_DIR/artifacts/tessera-cache\"" >&2
-    echo "[pipeline] then re-run with COST_PATH_OVERRIDE pointing at it. Note PRISMAQUANT_TESSERA_MENU: with no Tessera contract pinned the default (attested) menu is EMPTY; under PRISMAQUANT_TESSERA_DEV_PIN it is three rungs, one per family (E2M1_K2 R896 at 4.0000 bpp, E4M3_K1 R1024 at 4.0781, BF16_K1 R1792 at 7.1406 on a 2048x1024 unit), all at TP world size 1. Research mode admits every serialisable rung and stamps route_status=unattested on each for the export gate to fail closed on." >&2
+    echo "[pipeline] then re-run with COST_PATH_OVERRIDE pointing at it and COST_MODE matching its explicit provenance.cost_mode. The available Tessera menu comes from the reviewed producer contract and the explicit serving target, not a fixed rung roster. Research mode admits serialisable rungs but does not attest them for export." >&2
     exit 2
   fi
 fi
@@ -978,6 +978,19 @@ case "$COST_MODE" in
     ;;
 esac
 
+# An explicit prepriced input is immutable caller data, not a cache to rebuild.
+# Validate before probe/GPU work and keep the allocator's original input path.
+PREPRICED_COST_REPORT=""
+if [[ -n "${COST_PATH_OVERRIDE:-}" ]]; then
+  PREPRICED_COST_REPORT="${WORK_DIR}/artifacts/prepriced_cost_input.json"
+  if ! python3 -m prismaquant.prepriced_cost \
+      --path "$COST_PATH_OVERRIDE" --cost-mode "$COST_MODE" \
+      --model "$MODEL_PATH" --report "$PREPRICED_COST_REPORT"; then
+    exit 2
+  fi
+  COST_PATH="$COST_PATH_OVERRIDE"
+fi
+
 case "${HADAMARD_DUQUANT:-}" in
   0|false|False|FALSE|no|No|NO|"") ;;
   *)
@@ -1501,6 +1514,9 @@ fi
 # 2. Cost measurement (per-(Linear, format) measured RTN error,
 #    body + MTP in one pass)
 # -----------------------------------------------------------------------
+if [[ -n "$PREPRICED_COST_REPORT" ]]; then
+  echo "[pipeline] [2/4] using validated prepriced input: $COST_PATH (cost builders skipped)"
+else
 require_stage_settings "${BASE_COST_PATH}" base-cost
 # Under COST_MODE=local the baseline IS the allocator's cost table, so it is
 # also gated on the stamped cost_mode. Under the other modes cost_baseline.pkl
@@ -1781,6 +1797,7 @@ PY
     echo "[pipeline] [2d/4] AURA allocator cost exists, skipping"
   fi
 fi
+fi  # no prepriced input: normal cost measurement/finalization
 
 
 # -----------------------------------------------------------------------
@@ -1854,6 +1871,13 @@ if [[ -n "$SERVE_DISPATCH_TABLE" ]]; then
   echo "[pipeline] serving constraints ACTIVE: table=$SERVE_DISPATCH_TABLE mix='${SERVE_WORKLOAD_MIX}' (PROPOSAL DATA; the served NATIVE-PARITY protocol is the release gate)"
 fi
 ALLOCATOR_CB_ARGS=()
+# Recheck the exact original input (including symlink target) after probe work
+# and immediately before the allocator consumes it. Never rewrite that input.
+if [[ -n "$PREPRICED_COST_REPORT" ]]; then
+  if ! python3 -m prismaquant.prepriced_cost --verify-report "$PREPRICED_COST_REPORT"; then
+    exit 2
+  fi
+fi
 python3 -m prismaquant.allocator \
   --probe "${PROBE_PATH}" \
   --costs "${COST_PATH}" \

--- a/prismaquant/schemas.py
+++ b/prismaquant/schemas.py
@@ -8,6 +8,7 @@ load while malformed artifacts fail before optimization or export begins.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+import math
 from numbers import Integral, Real
 from typing import NotRequired, TypedDict
 
@@ -70,6 +71,14 @@ def _as_number(value, path: str | None, where: str) -> float:
     if not _is_number(value):
         _fail(path, where, "expected a number")
     return float(value)
+
+
+def _as_finite_cost_number(value, path: str | None, where: str) -> float:
+    """A usable cost must be finite; other handoff schemas keep their rules."""
+    out = _as_number(value, path, where)
+    if not math.isfinite(out):
+        _fail(path, where, "expected a finite number")
+    return out
 
 
 def _validate_router_number_map(
@@ -154,7 +163,7 @@ def validate_probe_payload(payload, path: str | None = None):
 
 
 def validate_cost_payload(payload, path: str | None = None):
-    """Validate the measured quantization-cost pickle contract."""
+    """Validate cost structure and finite numeric signals on non-error rows."""
     if not _is_mapping(payload):
         _fail(path, "", "cost payload is not a mapping")
     costs = payload.get("costs")
@@ -187,7 +196,9 @@ def validate_cost_payload(payload, path: str | None = None):
                 "fisher_output_mse",
             ):
                 if field in entry:
-                    _as_number(entry[field], path, f".costs[{name!r}][{fmt!r}].{field}")
+                    _as_finite_cost_number(
+                        entry[field], path, f".costs[{name!r}][{fmt!r}].{field}"
+                    )
                     has_signal = True
             if "cost_source" in entry and not isinstance(entry["cost_source"], str):
                 _fail(
@@ -205,7 +216,7 @@ def validate_cost_payload(payload, path: str | None = None):
                         "must be a sequence when present",
                     )
                 for idx, value in enumerate(values):
-                    _as_number(
+                    _as_finite_cost_number(
                         value,
                         path,
                         f".costs[{name!r}][{fmt!r}]"

--- a/tests/test_cost_currency_missing_stamp.py
+++ b/tests/test_cost_currency_missing_stamp.py
@@ -1,0 +1,35 @@
+"""A Tessera format cannot hide from its currency gate by dropping a stamp."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.parametrize("currency", [None, "", "not-the-campaign-currency"])
+@pytest.mark.parametrize("mode", ["production-render-score", "aura"])
+def test_tessera_format_requires_its_owned_currency_stamp(currency, mode):
+    from prismaquant.cost_currency import CostCurrencyError, require_run_currency
+    row = {"output_mse": 1e-4, "output_mse_measured": True}
+    if currency is not None:
+        row["currency"] = currency
+    payload = {
+        "provenance": {"cost_mode": mode},
+        "costs": {"named.unit": {"TESSERA_E4M3_K1_R1024": row}},
+    }
+    with pytest.raises(CostCurrencyError, match=r"named\.unit.*currency|currency.*named\.unit"):
+        require_run_currency(payload)
+
+
+def test_error_row_is_not_a_price_requiring_currency():
+    from prismaquant.cost_currency import require_run_currency
+    payload = {"costs": {"unit": {
+        "TESSERA_E4M3_K1_R1024": {"error": "not measured"},
+        "BF16": {"predicted_dloss": 0.0},
+    }}}
+    assert require_run_currency(payload)["tessera_rows"] == 0
+
+
+def test_stock_row_is_not_reclassified_as_tessera_by_a_prefix_guess():
+    from prismaquant.cost_currency import require_run_currency
+    # The actual grammar, not startswith("TESSERA"), owns membership.
+    payload = {"costs": {"unit": {"TESSERA_unrelated": {"output_mse": 1e-4}}}}
+    assert require_run_currency(payload)["tessera_rows"] == 0

--- a/tests/test_cost_schema_finite.py
+++ b/tests/test_cost_schema_finite.py
@@ -1,0 +1,70 @@
+"""Finite-number contract for cost rows before allocator consumption."""
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from prismaquant.schemas import SchemaValidationError, validate_cost_payload
+
+
+_UNIT = "model.layers.0.self_attn.o_proj"
+_FORMAT = "NVFP4"
+_PATH = "external costs.pkl"
+_SCALAR_FIELDS = (
+    "weight_mse", "predicted_dloss", "output_mse", "fisher_output_mse",
+)
+
+
+def _payload(entry):
+    return {"costs": {_UNIT: {_FORMAT: entry}}}
+
+
+@pytest.mark.parametrize("field", _SCALAR_FIELDS)
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -float("inf")],
+                         ids=["nan", "positive-infinity", "negative-infinity"])
+def test_nonfinite_cost_scalar_refuses_at_exact_field(field, value):
+    payload = _payload({field: value})
+    with pytest.raises(SchemaValidationError) as caught:
+        validate_cost_payload(payload, _PATH)
+    assert str(caught.value) == (
+        f"{_PATH}:.costs[{_UNIT!r}][{_FORMAT!r}].{field}: "
+        "expected a finite number"
+    )
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -float("inf")],
+                         ids=["nan", "positive-infinity", "negative-infinity"])
+def test_nonfinite_per_expert_cost_refuses_at_exact_element(value):
+    payload = _payload({
+        "weight_mse": 1.0,
+        "weight_mse_per_expert": [0.0, value],
+    })
+    with pytest.raises(SchemaValidationError) as caught:
+        validate_cost_payload(payload, _PATH)
+    assert str(caught.value) == (
+        f"{_PATH}:.costs[{_UNIT!r}][{_FORMAT!r}].weight_mse_per_expert[1]: "
+        "expected a finite number"
+    )
+
+
+def test_valid_signal_cannot_hide_another_nonfinite_scalar():
+    payload = _payload({"predicted_dloss": 1.0, "output_mse": float("nan")})
+    with pytest.raises(SchemaValidationError, match="output_mse: expected a finite number"):
+        validate_cost_payload(payload, _PATH)
+
+
+@pytest.mark.parametrize("value", [0, 0.0, -1.0, 1e-300, -1e300, 1e300])
+def test_finite_cost_values_have_no_new_threshold_and_are_not_rewritten(value):
+    payload = _payload({
+        **{field: value for field in _SCALAR_FIELDS},
+        "weight_mse_per_expert": [value],
+    })
+    original = copy.deepcopy(payload)
+    assert validate_cost_payload(payload, _PATH) is payload
+    assert payload == original
+
+
+def test_failed_measurement_row_keeps_nonfinite_diagnostics_uninterpreted():
+    payload = _payload({"error": "measurement failed", "weight_mse": float("inf")})
+    assert validate_cost_payload(payload, _PATH) is payload

--- a/tests/test_prepriced_cost.py
+++ b/tests/test_prepriced_cost.py
@@ -1,0 +1,274 @@
+"""Read-only external cost intake; workloads run through PrismaBuild."""
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+import pickle
+import subprocess
+import sys
+
+import pytest
+
+
+def _api():
+    from prismaquant import prepriced_cost
+    return prepriced_cost
+
+
+def _payload(mode="local"):
+    return {
+        "costs": {"model.layers.0.self_attn.o_proj": {
+            "BF16": {"predicted_dloss": 0.0},
+        }},
+        "formats": ["BF16"],
+        "provenance": {"cost_mode": mode},
+        "meta": {"model": "/models/exact source"},
+    }
+
+
+def _write(tmp_path, payload=None):
+    path = tmp_path / "external table with spaces.pkl"
+    path.write_bytes(pickle.dumps(_payload() if payload is None else payload))
+    return path
+
+
+def _validate(path, **kwargs):
+    return _api().validate_prepriced_cost(
+        path, cost_mode=kwargs.pop("cost_mode", "local"),
+        model=kwargs.pop("model", "/models/exact source"), **kwargs)
+
+
+def _tessera_payload():
+    from prismaquant.cost_currency import RENDER_SCORE_COST_MODE
+    from prismaquant.tessera_campaign import CURRENCY
+    payload = _payload(RENDER_SCORE_COST_MODE)
+    fmt = "TESSERA_E4M3_K1_R1024"
+    payload["formats"].append(fmt)
+    payload["costs"]["model.layers.0.self_attn.o_proj"][fmt] = {
+        "output_mse": 1e-4, "output_mse_measured": True,
+        "currency": CURRENCY,
+        "hessian_identity": {
+            "supplied": True, "text_sha": "fixture-draw",
+            "token_count": 4, "kwarg": "hessian",
+        },
+    }
+    return payload
+
+
+@pytest.mark.parametrize("mode", ["local", "production-render-score", "aura", "production-render"])
+def test_valid_input_reports_exact_bytes_without_modifying_file(tmp_path, mode):
+    from prismaquant.cost_currency import COST_MODE_OBJECTIVE_CURRENCY
+    path = _write(tmp_path, _payload(mode))
+    original = path.read_bytes()
+    report = _validate(path, cost_mode=mode)
+    assert report["path"] == str(path.resolve())
+    assert report["sha256"] == hashlib.sha256(original).hexdigest()
+    assert report["cost_mode"] == mode
+    assert report["currency"]["expected_currency"] == COST_MODE_OBJECTIVE_CURRENCY[mode]
+    assert report["formats"] == ["BF16"]
+    assert report["usable_rows"] == 1
+    assert report["model_binding"]["kind"] == "exact_model_reference"
+    assert report["model_binding"]["checkpoint_content_attested"] is False
+    assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize("condition", ["missing", "directory", "invalid-pickle", "schema", "empty", "errors-only"])
+def test_invalid_input_refuses_with_path(tmp_path, condition):
+    path = _write(tmp_path)
+    if condition == "missing":
+        path = tmp_path / "missing.pkl"
+    elif condition == "directory":
+        path = tmp_path
+    elif condition == "invalid-pickle":
+        path.write_bytes(b"this is not a pickle")
+    elif condition == "schema":
+        path.write_bytes(pickle.dumps({"costs": {"unit": {"BF16": {}}}}))
+    elif condition == "empty":
+        payload = _payload()
+        payload["costs"] = {}
+        path.write_bytes(pickle.dumps(payload))
+    elif condition == "errors-only":
+        payload = _payload()
+        payload["costs"] = {"unit": {"BF16": {"error": "not measured"}}}
+        path.write_bytes(pickle.dumps(payload))
+    with pytest.raises(ValueError, match=path.name):
+        _validate(path)
+
+
+@pytest.mark.parametrize("stamped,requested", [(None, "local"), ("unowned-mode", "local"), ("aura", "local"), ("local", "unowned-mode"), ("production-render", "production-render-score")])
+def test_mode_must_be_explicit_known_and_exact(tmp_path, stamped, requested):
+    payload = _payload(stamped)
+    if stamped is None:
+        payload.pop("provenance")
+    path = _write(tmp_path, payload)
+    with pytest.raises(ValueError, match="cost_mode|COST_MODE"):
+        _validate(path, cost_mode=requested)
+
+
+@pytest.mark.parametrize("location", ["meta", "provenance", "shard", "nested-shard", "baseline-meta", "baseline-shard"])
+def test_owned_model_reference_locations_are_reported(tmp_path, location):
+    payload = _payload()
+    model = payload["meta"].pop("model")
+    if location == "shard":
+        payload["meta"]["shards"] = [{"model": model}]
+    elif location == "nested-shard":
+        payload["meta"]["shards"] = [{"incremental_shard": {"model": model}}]
+    elif location == "baseline-meta":
+        payload["meta"]["baseline_meta"] = {"model": model}
+    elif location == "baseline-shard":
+        payload["meta"]["baseline_meta"] = {"shards": [{"model": model}]}
+    else:
+        payload[location]["model"] = model
+    report = _validate(_write(tmp_path, payload))
+    assert report["model_binding"]["model"] == model
+    assert report["model_binding"]["fields"]
+
+
+@pytest.mark.parametrize("condition", ["missing", "different", "basename", "conflict", "malformed"])
+def test_model_reference_missing_or_conflicting_refuses(tmp_path, condition):
+    payload = _payload()
+    if condition == "missing":
+        payload["meta"].pop("model")
+    elif condition == "different":
+        payload["meta"]["model"] = "/other/model"
+    elif condition == "basename":
+        payload["meta"]["model"] = "exact source"
+    elif condition == "conflict":
+        payload["provenance"]["model"] = "/other/model"
+    else:
+        payload["meta"]["model"] = {"source": "/models/exact source"}
+    with pytest.raises(ValueError, match="model"):
+        _validate(_write(tmp_path, payload))
+
+
+def test_format_report_uses_actual_rows_without_fabricating_missing_roster(tmp_path):
+    payload = _payload()
+    payload.pop("formats")
+    payload["costs"]["unit"] = {"NVFP4": {"output_mse": 1e-3}}
+    report = _validate(_write(tmp_path, payload))
+    assert report["formats"] == ["BF16", "NVFP4"]
+    assert report["declared_formats"] == []
+
+
+def test_tessera_currency_and_hessian_owner_reports_are_preserved(tmp_path):
+    from prismaquant.cost_currency import require_run_currency
+    from prismaquant.tessera_menu import assert_uniform_hessian_identity
+    payload = _tessera_payload()
+    report = _validate(_write(tmp_path, payload), cost_mode=payload["provenance"]["cost_mode"])
+    assert report["currency"] == require_run_currency(payload)
+    assert report["tessera_hessian_identity"] == assert_uniform_hessian_identity(payload["costs"])
+
+
+def test_tessera_currency_mismatch_refuses_even_with_matching_run_mode(tmp_path):
+    payload = _tessera_payload()
+    payload["provenance"]["cost_mode"] = "aura"
+    with pytest.raises(ValueError, match="currency|aura"):
+        _validate(_write(tmp_path, payload), cost_mode="aura")
+
+
+def test_mixed_tessera_hessian_identities_refuse(tmp_path):
+    payload = _tessera_payload()
+    other = copy.deepcopy(payload["costs"]["model.layers.0.self_attn.o_proj"])
+    other["TESSERA_E4M3_K1_R1024"]["hessian_identity"]["text_sha"] = "other-draw"
+    payload["costs"]["other.unit"] = other
+    with pytest.raises(ValueError, match="Hessian identities"):
+        _validate(_write(tmp_path, payload), cost_mode=payload["provenance"]["cost_mode"])
+
+
+def test_unstamped_tessera_hessian_remains_no_claim_not_matching_identity(tmp_path):
+    payload = _tessera_payload()
+    payload["costs"]["model.layers.0.self_attn.o_proj"]["TESSERA_E4M3_K1_R1024"].pop("hessian_identity")
+    report = _validate(_write(tmp_path, payload), cost_mode=payload["provenance"]["cost_mode"])
+    assert report["tessera_hessian_identity"]["unstamped_rows"] == 1
+    assert report["tessera_hessian_identity"]["supplied"] is None
+
+
+@pytest.mark.parametrize("manifest_valid", [True, False])
+def test_research_assembly_cannot_be_accepted_by_pipeline_override(tmp_path, manifest_valid):
+    from prismaquant.research_cost_acceptance import RESEARCH_COST_MANIFEST_SCHEMA, RESEARCH_COST_PROVENANCE
+    payload = _payload()
+    payload["provenance"]["cost_provenance"] = RESEARCH_COST_PROVENANCE
+    if manifest_valid:
+        payload["provenance"]["research_cost_manifest"] = {
+            "schema": RESEARCH_COST_MANIFEST_SCHEMA, "assembled_row_count": len(payload["costs"]),
+        }
+    with pytest.raises(ValueError, match="research"):
+        _validate(_write(tmp_path, payload))
+
+
+def test_expected_sha_refuses_changed_bytes(tmp_path):
+    path = _write(tmp_path)
+    with pytest.raises(ValueError, match="sha256"):
+        _validate(path, expected_sha256="0" * 64)
+
+
+def _cli(*args):
+    return subprocess.run(
+        [sys.executable, "-m", "prismaquant.prepriced_cost", *map(str, args)],
+        cwd=Path(__file__).parents[1], capture_output=True, text=True, check=False,
+        timeout=60)
+
+
+def test_cli_report_and_reverification_bind_original_input_bytes(tmp_path):
+    path = _write(tmp_path)
+    report = tmp_path / "local receipt.json"
+    before = path.read_bytes()
+    result = _cli("--path", path, "--cost-mode", "local", "--model", "/models/exact source", "--report", report)
+    assert result.returncode == 0, result.stderr
+    assert json.loads(report.read_text())["sha256"] == hashlib.sha256(before).hexdigest()
+    assert _cli("--verify-report", report).returncode == 0
+    path.write_bytes(before + b"changed after preflight")
+    refused = _cli("--verify-report", report)
+    assert refused.returncode != 0
+    assert "sha256" in refused.stderr
+
+
+@pytest.mark.parametrize("alias", ["same", "symlink", "hardlink"])
+def test_cli_report_never_overwrites_supplied_input(tmp_path, alias):
+    path = _write(tmp_path)
+    before = path.read_bytes()
+    report = path if alias == "same" else tmp_path / "alias.json"
+    if alias == "symlink":
+        report.symlink_to(path)
+    elif alias == "hardlink":
+        report.hardlink_to(path)
+    result = _cli("--path", path, "--cost-mode", "local", "--model", "/models/exact source", "--report", report)
+    assert result.returncode != 0
+    assert "report" in result.stderr
+    assert path.read_bytes() == before
+
+
+def test_verification_rejects_malformed_receipt(tmp_path):
+    report = tmp_path / "receipt.json"
+    report.write_text(json.dumps({"path": "relative.pkl", "sha256": "missing"}))
+    with pytest.raises(ValueError, match="report"):
+        _api().verify_prepriced_cost_report(report)
+
+
+@pytest.mark.parametrize("alias", ["file", "parent"])
+def test_reverification_refuses_original_input_symlink_retarget(tmp_path, alias):
+    original = tmp_path / "original"
+    replacement = tmp_path / "replacement"
+    original.mkdir()
+    replacement.mkdir()
+    source = _write(original)
+    other = _write(replacement, _payload("aura"))
+    link = tmp_path / "input-link"
+    if alias == "file":
+        link.symlink_to(source)
+        supplied = link
+    else:
+        link.symlink_to(original, target_is_directory=True)
+        supplied = link / source.name
+    report = _validate(supplied)
+    receipt = tmp_path / "receipt.json"
+    receipt.write_text(json.dumps(report))
+    link.unlink()
+    link.symlink_to(other if alias == "file" else replacement,
+                    target_is_directory=alias == "parent")
+    # The old resolved file is unchanged, but the driver's original --costs
+    # argument now consumes different bytes. Hashing only report.path misses it.
+    with pytest.raises(ValueError, match="path|sha256"):
+        _api().verify_prepriced_cost_report(receipt)

--- a/tests/test_run_pipeline_prepriced_override.py
+++ b/tests/test_run_pipeline_prepriced_override.py
@@ -1,0 +1,161 @@
+"""Execute the real cost-path, cost-stage and allocator shell wiring.
+
+Only expensive worker commands are intercepted. The driver sections and the
+prepriced-input validator run unchanged under PrismaBuild's CPU reservation.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import pickle
+import re
+import shlex
+import subprocess
+import sys
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[1] / "prismaquant" / "run-pipeline.sh"
+
+
+def _sections():
+    text = SCRIPT.read_text()
+    paths = text[text.index('PROBE_PATH="${WORK_DIR}/artifacts/probe.pkl"'):
+                 text.index('case "${HADAMARD_DUQUANT:-}"')]
+    cost_start = text.index("# 2. Cost measurement")
+    allocation_start = text.index("# 3. Allocator")
+    allocation_end = text.index("# 4. Production cache", allocation_start)
+    return paths, text[cost_start:allocation_start], text[allocation_start:allocation_end]
+
+
+def _input(tmp_path, mode="local", *, tessera=False):
+    path = tmp_path / "external cost with spaces.pkl"
+    model = tmp_path / "model"
+    model.mkdir(exist_ok=True)
+    (model / "config.json").write_text(json.dumps({"model_type": "qwen3"}))
+    fmt = "TESSERA_E4M3_K1_R1024" if tessera else "BF16"
+    row = {"predicted_dloss": 0.0}
+    if tessera:
+        from prismaquant.tessera_campaign import CURRENCY
+        row = {"weight_mse": 1e-4, "output_mse": 2e-4,
+               "output_mse_measured": True, "currency": CURRENCY}
+    payload = {
+        "costs": {"model.layers.0.self_attn.o_proj": {fmt: row}},
+        "formats": [fmt], "provenance": {"cost_mode": mode},
+        "meta": {"model": str(model)},
+    }
+    path.write_bytes(pickle.dumps(payload))
+    return path, model
+
+
+def _run(tmp_path, *, mode="local", override=None, tessera=False,
+         mutate_before_allocator=False):
+    paths, costs, allocator = _sections()
+    work = tmp_path / "work"
+    (work / "artifacts").mkdir(parents=True, exist_ok=True)
+    (work / "logs").mkdir(exist_ok=True)
+    trace = tmp_path / "workers.jsonl"
+    # The scoped driver has arrays that are constructed by earlier stages.
+    # They are irrelevant to the cost-input edge but remain real empty arrays.
+    arrays = sorted(set(re.findall(r"\$\{([A-Z][A-Z0-9_]*)\[@\]", paths + costs + allocator)))
+    declarations = "\n".join(f"{name}=()" for name in arrays)
+    python = shlex.quote(sys.executable)
+    recorder = (
+        "import json,os,sys; "
+        "open(os.environ['TEST_TRACE'],'a').write(json.dumps(sys.argv[1:])+'\\n')"
+    )
+    preamble = f"""set -euo pipefail
+{declarations}
+require_stage_settings() {{ return 0; }}
+cost_table_reusable() {{ return 1; }}
+harvest_cb_col_weights() {{ return 0; }}
+python3() {{
+  if [[ "$1" == '-m' && "$2" == 'prismaquant.prepriced_cost' ]]; then
+    command {python} "$@"
+    return $?
+  fi
+  command {python} -c {shlex.quote(recorder)} "$@"
+  if [[ "$1" == '-m' && "$2" == 'prismaquant.allocator' ]]; then
+    return 88
+  fi
+  return 77
+}}
+"""
+    mutation = ""
+    if mutate_before_allocator:
+        mutation = '\nprintf "changed after validation" >> "$COST_PATH_OVERRIDE"\n'
+    env = os.environ.copy()
+    # Set only script-local knobs. Preserve system paths/home/interpreter state.
+    referenced = set(re.findall(r"\$\{?([A-Z][A-Z0-9_]*)", paths + costs + allocator))
+    for name in referenced - {"HOME", "PATH", "CODEX_HOME", "PYTHONPATH", "TMPDIR"}:
+        env.setdefault(name, "")
+    env.update({
+        "WORK_DIR": str(work), "MODEL_PATH": str(tmp_path / "model"),
+        "COST_MODE": mode, "COST_PATH_OVERRIDE": str(override or ""),
+        "CB_LADDER_INTERP": "0", "COST_CACHE_COL_WEIGHTS_REQUIRED": "0",
+        "SELECTION_MODE": "surrogate", "CALIBRATION_MODALITY": "text-only",
+        "FORMATS": "TESSERA,BF16" if tessera else "BF16",
+        "COST_FORMATS": "TESSERA,BF16" if tessera else "BF16",
+        "TARGET_BITS": "16", "TARGET_PROFILE_DEFAULT": "research",
+        "LM_HEAD_FORMAT_CANONICAL": "BF16", "MTP_FORMAT": "BF16",
+        "VISUAL_FORMAT": "BF16", "TEST_TRACE": str(trace),
+        "CUDA_VISIBLE_DEVICES": "",
+    })
+    result = subprocess.run(
+        ["bash", "-c", preamble + paths + costs + mutation + allocator],
+        cwd=SCRIPT.parents[1], env=env, text=True, capture_output=True,
+        timeout=60, check=False,
+    )
+    calls = [json.loads(line) for line in trace.read_text().splitlines()] if trace.exists() else []
+    return result, calls, work
+
+
+@pytest.mark.parametrize("mode", ["local", "production-render-score", "aura"])
+def test_actual_driver_passes_exact_override_to_allocator_without_builders(tmp_path, mode):
+    supplied, _ = _input(tmp_path, mode)
+    before = hashlib.sha256(supplied.read_bytes()).hexdigest()
+    result, calls, work = _run(tmp_path, mode=mode, override=supplied)
+
+    assert result.returncode == 88, (result.stdout, result.stderr, calls)
+    assert len(calls) == 1 and calls[0][:2] == ["-m", "prismaquant.allocator"]
+    assert calls[0][calls[0].index("--costs") + 1] == str(supplied)
+    assert hashlib.sha256(supplied.read_bytes()).hexdigest() == before
+    receipt = json.loads((work / "artifacts" / "prepriced_cost_input.json").read_text())
+    assert receipt["sha256"] == before
+
+
+def test_actual_driver_preserves_prepriced_tessera_token_for_allocator(tmp_path):
+    supplied, _ = _input(tmp_path, "production-render-score", tessera=True)
+    result, calls, _ = _run(tmp_path, mode="production-render-score", override=supplied, tessera=True)
+    assert result.returncode == 88, (result.stdout, result.stderr, calls)
+    assert calls[0][calls[0].index("--formats") + 1] == "TESSERA,BF16"
+    assert calls[0][calls[0].index("--costs") + 1] == str(supplied)
+
+
+@pytest.mark.parametrize("condition", ["missing", "mode-mismatch", "malformed"])
+def test_override_refusal_precedes_any_cost_worker(tmp_path, condition):
+    supplied, _ = _input(tmp_path)
+    if condition == "missing":
+        supplied = tmp_path / "missing.pkl"
+    elif condition == "malformed":
+        supplied.write_bytes(pickle.dumps({"not_costs": {}}))
+    result, calls, _ = _run(tmp_path, mode="aura" if condition == "mode-mismatch" else "local",
+                            override=supplied)
+    assert result.returncode == 2, (result.stdout, result.stderr, calls)
+    assert calls == []
+
+
+def test_override_changed_after_preflight_never_reaches_allocator(tmp_path):
+    supplied, _ = _input(tmp_path)
+    result, calls, _ = _run(tmp_path, override=supplied, mutate_before_allocator=True)
+    assert result.returncode == 2, (result.stdout, result.stderr, calls)
+    assert calls == []
+
+
+def test_no_override_preserves_the_actual_cost_builder_path(tmp_path):
+    result, calls, _ = _run(tmp_path)
+    assert result.returncode == 77, (result.stdout, result.stderr, calls)
+    assert calls[0][:2] == ["-m", "prismaquant.incremental_measure_quant_cost"]

--- a/tests/test_tessera_scope_endpoints.py
+++ b/tests/test_tessera_scope_endpoints.py
@@ -148,6 +148,8 @@ def test_campaign_main_passes_live_model_topology_to_real_menu_boundary(tmp_path
 
 
 def _allocator_inputs(tmp_path, fmt="BF16"):
+    from prismaquant.cost_currency import RENDER_SCORE_COST_MODE
+    from prismaquant.tessera_campaign import CURRENCY
     from prismaquant.tessera_formats import SUPERBLOCK_WEIGHTS
     model_dir = tmp_path / "model"
     model_dir.mkdir()
@@ -163,10 +165,11 @@ def _allocator_inputs(tmp_path, fmt="BF16"):
     # A scoped Tessera route quantizes activations: the legitimate guard must
     # not mistake this synthetic fixture for a measured zero-cost identity.
     cost_row = ({"weight_mse": 1e-4, "output_mse": 4e-4,
-                 "output_mse_measured": True}
+                 "output_mse_measured": True, "currency": CURRENCY}
                 if fmt.startswith("TESSERA_") else {"predicted_dloss": 0.0})
     costs.write_bytes(pickle.dumps({"costs": {
-        name: {fmt: dict(cost_row)} for name in stats}, "formats": [fmt]}))
+        name: {fmt: dict(cost_row)} for name in stats}, "formats": [fmt],
+        "provenance": {"cost_mode": RENDER_SCORE_COST_MODE}}))
     return ["--probe", str(probe), "--costs", str(costs), "--formats", fmt,
             "--allow-legacy-fisher-norm",
             "--target-profile", "tessera_research_sm121", "--target-bits", "16",


### PR DESCRIPTION
Closes #184.

`COST_PATH_OVERRIDE` now validates and consumes the supplied prepriced file, bypasses incompatible cost builders/finalization, and passes the original path to the allocator. A separate local receipt binds lexical/resolved path and SHA-256, rechecked immediately before use. Supplied input is not rewritten. Existing mode/provenance/currency/Hessian owners remain authoritative; defaults and serving policy do not change.

Two encountered defects are fixed in separate owner commits: nonfinite numeric cost signals, and Tessera rows evading currency checks by omitting their stamp. The validator delegates to those homes. A separate fixture-only integration commit gives existing synthetic endpoint costs their correct campaign stamps.

PrismaBuild CPU-only Sparky, 1 core / 4 GiB:

- Initial red: 47 failed, 1 preservation passed.
- Supplemental owner red: 24 failed, 64 passed.
- Combined targeted green: 97 passed, 0 failed/skipped; Python compilation and shell syntax passed.
- Existing scoped endpoint integration: 21 passed, 0 failed/skipped after a valid three-failure fixture red.

Final 15-file integration on merged PR185/main10dd2395: **234 passed, 0 failed/skipped**, no collection errors; shell syntax passed. No GPU, serving, performance or quality claim. Full immutable action keys/receipts are in `docs/results/prepriced_cost_override_2026-09-04.md`.
