### PR TITLE
Bind Tessera raw census replay to priced runtime and artifact scope

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,18 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-04 · `codex/pq-tessera-v5-endpoints`. Stamps
+As of: 2026-09-04 · `codex/pq-census-v5-binding`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-04, `codex/pq-census-v5-binding`) for **runtime-bound
+route census replay** (§7.1; Tessera #126). The complete producer
+`tessera.serving.route_census/2` record retains exact runtime, execution mode,
+residency, both driven phases, owner maps, backend-qualified launches and
+checkpoint-sidecar seals. Exact allocation text is rehashed against the
+independent card build anchor, and artifact sidecars are independently
+rehash-checked at fill and verification. Current v5 cells, not an embedded
+agreement or a global decoder blacklist, decide launch eligibility. Legacy
+unscoped rows remain compatible only without a scoped build/current v5 table.
+No default, bytes, promotion threshold or reviewed runtime pin moves.
 
 Re-stamped (2026-09-04, `codex/pq-tessera-v5-endpoints`) for **raw scoped
 census handoff instructions** (§9.4). The driver prints the producer's actual
@@ -70,6 +81,7 @@ router/expert or packed-module facts determine unit structure, cross-checked
 against the declared model profile. Missing facts cannot silently become
 dense. The helper delegates value validation to `ServingContext`; it does
 not change a runtime default or attest any new serving cell.
+
 Re-stamped (2026-09-04, `codex/pq87-physical-ab`) for the opt-in bounded
 physical boundary controller. `experiments/pq87_physical_ab.py` freezes and
 hashes native BF16 source before starting one read-only-model server, then
@@ -6944,14 +6956,48 @@ that the routes the serve actually emitted -- each stamped by the plugin with
 the decoder that ran -- are the routes the artifact priced
 (`prismaquant/tessera_route_receipt.py`, `make_route_census_record`; CLI
 `fill-route-census`; the lane spec's `route.census` gate names this slot).
+For a scoped artifact, `fill-route-census --census <raw-v2.json>
+--layer-config <allocation.json> --model-dir <artifact>` retains the complete
+producer census as `route_census`, exact UTF-8 allocation/config/manifest
+texts as `census_binding`, and the derived `scoped_verdict`. The allocation's
+SHA256 and `__prismaquant__.tessera_serving_scope` must independently match
+`card.build.layer_config_sha` and `card.build.tessera_serving_scope`; audit
+paths are not identity. The raw producer's `checkpoint_sidecars` hashes must
+match the retained texts and the actual artifact files, so host/container
+checkpoint path aliases are valid but an artifact-free replay is not.
+
+Coverage is the exact set of Tessera-selected allocation units (not BF16
+passthrough context keys). Their source tensors join explicit manifest
+projections and config-group owners, with exact shape/grid/rung/context
+checks. Each owner must appear exactly once in both driven phases, with
+recorded owner maps matching the replay. Every unit needs a current
+device-qualified backed cell for the same platform, image, mode and residency
+in every declared regime. Actual state, activation contract, launch pair and
+serve flags must agree. Backend suffixes stay in the retained record; a
+routed launch may compare its declared base plus a nonempty backend suffix.
+Thus a named dense fallback is permitted for MoE only when that exact scoped
+cell declares the pair. Dense compiled aggregate traces, packed/aggregate
+source projections, and nonidentity checkpoint/runtime owner mappings remain
+explicit unsupported refusals, not guessed equivalences.
+Nonempty predicates in relevant scoped/family/rung cells also refuse: a
+manifest member's dimensions are not an attestation of the executed fused
+unit's dimensions or role-split facts. This matches the export endpoint's
+bounded support rather than manufacturing a serving-shape projection.
+Eager phases retain
+canonical shape evidence and must actually name their one-row decode versus
+multi-row prefill regime. No new runtime is attested by this adapter.
+
 The requirement travels with the lane declaration (`required_slots` UNIONS
 the lane's slots), not with a rate-axis special case. `verify` replays the
 priced-vs-served comparison from the carried records
-rather than trusting the carried boolean, and refuses a census run on a known
+rather than trusting the carried boolean. Historical unscoped flat rows retain
+the v4 comparison and refuse a census run on a known
 substitute decoder (derived from the pinned contract's `when_unavailable`,
 never hardcoded), without a decoder, empty, or disagreeing with the priced
 routes in either direction -- plus a hand-set `passed` flag that disagrees
-with the replay. "No census was ever compared" reads as `UNFILLED`. Known
+with the replay; explicit scope fields cannot be flattened into those rows.
+A scoped card or current v5 table refuses a flat legacy receipt instead of
+inventing the missing runtime. "No census was ever compared" reads as `UNFILLED`. Known
 limit: coverage strictness is uncalibrated against a real serve (nothing has
 been served yet on this side) -- both directions refuse, and relaxing either
 needs a measured serve, not an argument.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,16 @@
 As of: 2026-09-05 · `codex/pq-census-v5-integration`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-05, `codex/pq-census-v5-integration`) for **naming the
+scoped census leg dormant at the current pin** (§7.1; Tessera #126). No code
+moved. The scoped replay requires the packaged lane table to carry the schema
+`LANE_ELIGIBILITY_SCHEMA_TESSERA` names and the census to be
+`tessera.serving.route_census/2`; at `TESSERA_DEV_PIN_COMMIT = 1221d2a` the
+packaged table is `tessera.lane-eligibility.v4` and the pinned producer emits
+`route_census/1`, so the leg refuses everything by the pin. The doc said which
+gates the leg applies but not that none of them can be reached yet, which reads
+as a live comparison. Re-pinning, not an edit here, is what makes it reachable.
+
 Re-stamped (2026-09-04, `codex/pq-census-v5-binding`) for **runtime-bound
 route census replay** (§7.1; Tessera #126). The complete producer
 `tessera.serving.route_census/2` record retains exact runtime, execution mode,
@@ -7010,6 +7020,22 @@ SHA256 and `__prismaquant__.tessera_serving_scope` must independently match
 paths are not identity. The raw producer's `checkpoint_sidecars` hashes must
 match the retained texts and the actual artifact files, so host/container
 checkpoint path aliases are valid but an artifact-free replay is not.
+
+**Dormant at the current pin, by the pin rather than by a flag.** The scoped
+path takes the packaged contract's lane table through
+`lane_eligibility.load_eligibility_table` and refuses anything that is not the
+schema `LANE_ELIGIBILITY_SCHEMA_TESSERA` names, and it refuses any census whose
+schema is not `tessera.serving.route_census/2`. Under
+`TESSERA_DEV_PIN_COMMIT = 1221d2a` the packaged table is
+`tessera.lane-eligibility.v4` and the producer's `tools/tessera_route_census.py`
+emits `route_census/1`, so **no** scoped receipt can be filled or replayed
+today: `route.census` on a scoped card stays `UNFILLED` until the pin moves to a
+release publishing both. That is the intended fail-closed direction -- this leg
+is the consumer half of Tessera #126, whose producer/pin half is still open --
+but it means the scoped comparison has never run against a real packaged
+contract, only against tables constructed in
+`tests/test_tessera_scoped_route_receipt.py`. Re-pinning is the measurement
+that would change that claim.
 
 Coverage is the exact set of Tessera-selected allocation units (not BF16
 passthrough context keys). Their source tensors join explicit manifest

--- a/docs/measurements/tessera-scoped-census-binding-2026-09-04.md
+++ b/docs/measurements/tessera-scoped-census-binding-2026-09-04.md
@@ -1,0 +1,86 @@
+# Tessera scoped census binding — 2026-09-04
+
+Source: `2d92542cdbfbe6cd2b4d30f7ab00631d8f16b488`, based on
+`7a5f257a513da687e1d8dad960cba9b8d692dd37` plus the shared target helper
+cherry-pick `7abd8100` (upstream `d4b7451f`). This is the receipt/replay leg
+of approved Tessera #126, not a new runtime attestation or pin change.
+
+The raw producer `tessera.serving.route_census/2` object is retained intact.
+Exact allocation text is bound to the independent card build hash/scope;
+config and manifest text are bound to the producer's in-process sidecar
+seals and independently read artifact files. Current scoped cells are
+replayed per selected source projection, owner and driven phase. Historical
+unscoped rows retain their separate comparison without invented context.
+
+## Final targeted population
+
+PrismaBuild action:
+`77101e9d68a957a139a0da47ddda66e92096d938faec1ae0acdd3cd765ac880b`.
+Result: **148 passed, zero skipped, no collection errors**, 3.75 seconds
+pytest time. Five explicitly selected files:
+
+- `tests/test_tessera_scoped_route_receipt.py` (46 new cases)
+- `tests/test_tessera_route_receipt.py`
+- `tests/test_shipcard.py`
+- `tests/test_shipcard_uniform_control.py`
+- `tests/test_shipcard_git_provenance.py`
+
+This is CPU-only Sparky/aarch64: one CPU, 4 GiB reservation, no GPU demand,
+`CUDA_VISIBLE_DEVICES=''`, OMP/MKL/OpenBLAS threads each 1. The host's GB10
+inventory in its worker attestation is not a CUDA test population. There is
+no GPU, served-quality, performance or full-suite claim. Pytest reported
+14 existing `torch.jit.script_method` deprecation warnings and no skip reasons.
+No modules from the requested five-file population were uncollected; other
+repository tests were not submitted.
+
+CAS receipt:
+`1ba576dedd54650f56210bdfdb1caa81767f7e1a22335512c3acc439f9ce8218`.
+Result log SHA:
+`2a29bb6162253d45ff951b24b038f3742bb7abe3993dce2dffca7a81c272e976`.
+Sealed checkout archive SHA:
+`f7f5d94fcc3b78f179ffee9d32760450f59168b814399a80fb9baa908cddcd9d`.
+The final source commit differs from that tested tree only in docstrings/comments.
+
+## Red before implementation and before review corrections
+
+All runs used the same CPU-only PrismaBuild population. Pre-fix actions are
+retained under `/mnt/shared/prismabuild-fleet/pb-queue/failed/<action>.json`.
+
+| Action | Population and actual failure |
+| --- | --- |
+| `d9191c66049cb6f720d9a98d3eeeb10ca6e50d1d6e90cde2222aef64aa558910` | 36 initial cases failed on pristine `7abd8100`: new calls raised `TypeError: make_route_census_record() got an unexpected keyword argument 'binding'`; legacy parser regression reported `DID NOT RAISE` when runtime fields were silently discarded. |
+| `9c2e6b96c97b7c8004c329c1b0ac2c672c0f74a51dd7515edb17f5103af81db4` | Four added CLI/JSON/schema cases failed on pristine `7abd8100`: legacy CLI raised `SystemExit: 2` demanding `--priced-route`; duplicate-key reader was absent; scoped binding argument was absent. |
+| `c10b2204265666655ba47a5b5cc825943bc5c772a2c91ff8306095da61a60dbc` | Two review cases failed on the provisional adapter: artifact-free replay returned `[]` instead of problems; a missing package escaped as `ModuleNotFoundError: no packaged Tessera`. Both now produce explicit refusal. |
+| `cbe90b3fd5895c568e077e6cfc4db99fc20dcc30e1c0f192128f56ef6f8a2152` | Passing member-dimension predicate case failed with `DID NOT RAISE`: source member dimensions had been used as executed-unit evidence. Relevant nonempty cell predicates now refuse before resolution. |
+| `c84b6ec7a0f9c17224cd6782d26a39b294c5f369a55cfb88fb41a995a406197b` | Correct producer-shaped dense control failed with `structure/state/policy differs from written owner`: the provisional fixture/adapter used `kind=fp8`, while producer telemetry uses `kind=dense`. Both now use the actual wire spelling. |
+| `c8de5ad510d505228a6bc01e1e6db1c25365c9452855fe54d7e134bc8629626c` | Three compiled-scope controls failed on pristine `7abd8100` at the absent binding argument. Final controls admit only scoped single-pair compiled MoE, rejecting combined launch symbols and dense compiled attribution. |
+
+Exploratory runs are not substituted for these reds. The initial shorthand
+recipe fixture was corrected to actual `data_type=tessera` dictionary rows,
+then rerun against pristine source. A predicate fixture initially used
+unsupported `eq`; that passing exploratory action `098360d5071d` is **not**
+red evidence. The valid `equals` predicate produced the red above. Early
+50/144-pass runs predate those corrections and are not the final population.
+
+## Execution and scope boundaries
+
+Every workload used deployed PrismaBuild generation
+`aa6d3cfa2f77-1788542034-2b84265567ac` through `pbrun.py`. The worker checked
+the immutable Tessera source archive
+`/mnt/shared/pq-v4-source.o2Tc3O/tessera-1221d2a-src.tar` against SHA256
+`b4755a30d60974ec2758c2060fc4d3954f2e1b7c7bb11602a05f0b783ba60bc8`,
+extracted it into a fresh worker temporary directory, and set
+`PYTHONPATH=.:<extracted>/src`. Interpreter:
+`/home/rob/dq-runs/venvs/prismaquant-cu130/bin/python`; pytest flags:
+`-q -ra --tb=short -p no:cacheprovider`.
+V5 claims in these tests are explicitly synthetic; the real reviewed pin is
+unchanged. The three external calibration symlinks were excluded only while
+sealing each snapshot and immediately restored; no removals were committed.
+
+Dense compiled runtime eligibility is not dense compiled *census proof*:
+producer telemetry combines launches in a symbolic trace and cannot attribute
+them to each driven regime. This adapter preserves that known refusal.
+Packed/aggregate source projections, nonidentity runtime owner mappings and
+nonempty relevant cell predicates also remain explicit unsupported boundaries.
+No adjacent defect was deferred or filed by this receipt implementation;
+review findings were corrected in its bounded gate before handoff.

--- a/docs/measurements/tessera-scoped-census-binding-2026-09-04.md
+++ b/docs/measurements/tessera-scoped-census-binding-2026-09-04.md
@@ -84,3 +84,22 @@ Packed/aggregate source projections, nonidentity runtime owner mappings and
 nonempty relevant cell predicates also remain explicit unsupported boundaries.
 No adjacent defect was deferred or filed by this receipt implementation;
 review findings were corrected in its bounded gate before handoff.
+
+## Endpoint/main integration
+
+The coordinator branch cherry-picked the reviewed implementation without the
+duplicate helper commit, then merged main `10dd2395` (PR185 endpoints) at
+`118d2afc`. Only architecture stamps needed reconciliation while applying
+the implementation; production source was not rewritten during integration.
+
+The five worker files plus export-scope, actual plan/printed-command, and both
+architecture/doc checks passed **209 tests, 0 failures, 0 skips**, with no
+collection errors. The three modified Python modules compiled in the same
+PrismaBuild action. Population remained CPU-only Sparky, 1 CPU / 4 GiB, no
+GPU demand, with the same immutable producer archive and thread bounds.
+
+Action: `239d642cb5b8eefabc27ea4320a65fd50847acbedc476207ffae5d9b51d86b89`.
+Receipt: `a968fdb7bff5fb078a3efe746909d06acc30a62f3161fd7b66e8b26d6af5dde5`.
+Result log: `f927000db4ca1e679bb70c70eedad995094a0a7b32a6300048eee285b04606c7`.
+This establishes the bounded endpoint/receipt integration, not final producer
+pin compatibility or any served/CUDA population.

--- a/prismaquant/shipcard.py
+++ b/prismaquant/shipcard.py
@@ -34,8 +34,8 @@ choosing a rung per Linear beats spending the same bytes everywhere:
 
 And one lane-declared evidence slot, required of cards stamped with the lane
 that declares it — principle 12's second leg, the priced-vs-served route
-comparison (#136): the priced routes, the served route records with the
-decoder each ran, and the known substitute set:
+comparison (#136, Tessera #126): the exact price/artifact/runtime-bound
+census, or historical unscoped rows with their known substitute set:
 
 | Slot | Filled by |
 |---|---|
@@ -1728,7 +1728,7 @@ def verify(
             # lane-slot registry (#162) so the admission invariant and the
             # replay read the same entry.
             problems.extend(LANE_SLOT_VERIFIERS[ROUTE_CENSUS_SLOT](
-                slot, record))
+                slot, record, card=card, model_dir=model_dir))
             continue
         if record.get("passed") is not True:
             problems.append(
@@ -2958,11 +2958,14 @@ def make_route_census_record(
     *,
     tool: str,
     model_sha: str | None,
-    priced_routes: Sequence[str],
-    route_records: Sequence[Mapping[str, Any]],
-    substitute_decoders: Sequence[str],
+    priced_routes: Sequence[str] = (),
+    route_records: Any,
+    substitute_decoders: Sequence[str] = (),
     serve_fingerprint: str | None = None,
     git_commit: str | None = None,
+    binding: Mapping[str, str] | None = None,
+    build: Mapping[str, Any] | None = None,
+    model_dir: str | os.PathLike | None = None,
 ) -> dict[str, Any]:
     """Close `route.census` from the priced routes and the served records.
 
@@ -2971,7 +2974,23 @@ def make_route_census_record(
     (`_verify_route_census_record`), so filling a `passed=true` over
     substitute-decoder records still refuses at publication.
     """
-    from prismaquant.tessera_route_receipt import check_route_receipt
+    from prismaquant.tessera_route_receipt import (
+        TesseraRouteReceiptError, check_route_receipt, check_scoped_route_receipt,
+    )
+
+    if isinstance(route_records, Mapping):
+        from copy import deepcopy
+        verdict = check_scoped_route_receipt(route_records, binding, build=build, model_dir=model_dir)
+        if priced_routes and sorted(set(priced_routes)) != verdict["served_routes"]:
+            raise TesseraRouteReceiptError("caller priced routes differ from independently bound price projections")
+        return make_record(slot=ROUTE_CENSUS_SLOT, tool=tool, passed=True, model_sha=model_sha,
+            metrics={"n_records": verdict["n_records"], "n_served_routes": len(verdict["served_routes"])},
+            detail=verdict["detail"], serve_fingerprint=serve_fingerprint, git_commit=git_commit,
+            extra={"route_census": deepcopy(route_records), "census_binding": deepcopy(binding),
+                   "scoped_verdict": verdict, "served_routes": verdict["served_routes"],
+                   "served_decoders": verdict["served_decoders"]})
+    if binding is not None or (build or {}).get("tessera_serving_scope") is not None:
+        raise TesseraRouteReceiptError("scoped artifact cannot fill route.census from an unbound legacy flat list")
 
     verdict = check_route_receipt(
         priced_routes=list(priced_routes),
@@ -3018,14 +3037,44 @@ def parse_route_records_for_card(
 def _verify_route_census_record(
     slot: str,
     record: Mapping[str, Any],
+    *,
+    card: Mapping[str, Any] | None = None,
+    model_dir: str | os.PathLike | None = None,
 ) -> list[str]:
     """Replay the priced-vs-served comparison from the carried values."""
     from prismaquant.tessera_route_receipt import (
         TesseraRouteReceiptError,
         check_route_receipt,
+        check_scoped_route_receipt,
     )
 
     problems: list[str] = []
+    build = (card or {}).get("build") or {}
+    if "route_census" in record or "census_binding" in record or "scoped_verdict" in record:
+        try:
+            replay = check_scoped_route_receipt(record.get("route_census"), record.get("census_binding"),
+                                               build=build, model_dir=model_dir)
+        except TesseraRouteReceiptError as exc:
+            return [f"{slot}: scoped census REFUSED: {exc}"]
+        if record.get("passed") is not True or record.get("scoped_verdict") != replay:
+            problems.append(f"{slot}: carried scoped verdict differs from current-contract replay")
+        for key in ("served_routes", "served_decoders"):
+            if record.get(key) != replay[key]:
+                problems.append(f"{slot}: carried {key} differs from scoped replay")
+        return problems
+    if build.get("tessera_serving_scope") is not None:
+        return [f"{slot}: scoped artifact carries an unbound legacy census; retain the producer's v2 receipt"]
+    from prismaquant.tessera_route_receipt import _current_scoped_contract
+    from prismaquant.lane_eligibility import LANE_ELIGIBILITY_SCHEMA_TESSERA
+    try:
+        table, _formats = _current_scoped_contract()
+        if table.schema == LANE_ELIGIBILITY_SCHEMA_TESSERA:
+            return [f"{slot}: current v5 cells cannot attest an unbound legacy flat census"]
+    except ModuleNotFoundError:
+        # Historical, unscoped cards do not acquire a runtime dependency.
+        pass
+    except (ValueError, OSError) as exc:
+        return [f"{slot}: cannot inspect current census contract: {exc}"]
     priced = record.get("priced_routes")
     rows = record.get("route_records")
     substitutes = record.get("substitute_decoders")
@@ -3076,7 +3125,8 @@ def _verify_route_census_record(
 #: adds: the slot's vocabulary membership is derived from the lane's own spec
 #: (:func:`lane_scoped_slots`), and the replay is named here.  A derived slot
 #: with no entry here is REFUSED wherever it is declared, filled, or verified
-#: (RobTand/prismaquant#162).  Lane-slot verifiers take ``(slot, record)``.
+#: (RobTand/prismaquant#162). Lane-slot verifiers take ``(slot, record)``;
+#: the scoped census also receives the independent ``card``/``model_dir``.
 LANE_SLOT_VERIFIERS: dict[str, Callable[..., list[str]]] = {
     ROUTE_CENSUS_SLOT: _verify_route_census_record,
 }

--- a/prismaquant/shipcard_cli.py
+++ b/prismaquant/shipcard_cli.py
@@ -342,18 +342,32 @@ def _cmd_fill_route_census(args: argparse.Namespace) -> int:
     """Close `route.census` from the priced routes and the served records."""
     from prismaquant.tessera_route_receipt import (
         TesseraRouteReceiptError,
+        parse_census_json,
         substitute_decoders_from_contract_answer,
     )
 
     model_dir = args.model_dir or str(Path(args.shipcard).resolve().parent)
     try:
-        records = json.loads(Path(args.census).read_text())
-    except (OSError, json.JSONDecodeError) as exc:
+        records = parse_census_json(Path(args.census).read_bytes().decode("utf-8"), where=str(args.census))
+    except (OSError, ValueError) as exc:
         print(f"[shipcard] ERROR: cannot read census rows from "
               f"{args.census}: {exc}", file=sys.stderr)
         return 2
+    card = load_shipcard(args.shipcard)
+    scoped = isinstance(records, dict)
+    binding = None
+    if scoped:
+        try:
+            if not args.layer_config:
+                raise TesseraRouteReceiptError("v2 census requires --layer-config exact allocation input")
+            binding = {"layer_config_json": Path(args.layer_config).read_bytes().decode("utf-8"),
+                       "config_json": (Path(model_dir) / "config.json").read_bytes().decode("utf-8"),
+                       "manifest_json": (Path(model_dir) / "tessera_serving_manifest.json").read_bytes().decode("utf-8")}
+        except (OSError, ValueError) as exc:
+            print(f"[shipcard] REFUSED: cannot bind scoped census: {exc}", file=sys.stderr)
+            return 2
     substitutes = list(args.substitute_decoder or ())
-    if not substitutes:
+    if not substitutes and not scoped:
         try:
             from prismaquant import tessera_runtime_contract as trc
 
@@ -365,7 +379,7 @@ def _cmd_fill_route_census(args: argparse.Namespace) -> int:
         except trc.TesseraContractError as exc:
             print(f"[shipcard] ERROR: {exc}", file=sys.stderr)
             return 2
-    if not substitutes:
+    if not substitutes and not scoped:
         print("[shipcard] ERROR: no substitute decoder is known -- pass "
               "--substitute-decoder explicitly (repeatable) or set "
               "PRISMAQUANT_TESSERA_DEV_PIN so the pinned contract answer "
@@ -379,6 +393,9 @@ def _cmd_fill_route_census(args: argparse.Namespace) -> int:
             priced_routes=list(args.priced_route),
             route_records=records,
             substitute_decoders=substitutes,
+            binding=binding,
+            build=card.get("build"),
+            model_dir=model_dir,
         )
     except TesseraRouteReceiptError as exc:
         print(f"[shipcard] REFUSED: {args.census} cannot be a census "
@@ -388,7 +405,6 @@ def _cmd_fill_route_census(args: argparse.Namespace) -> int:
     # (`lane_shipcard open --lane tessera`).  Filling a card that never
     # opened it is a refusal, not an auto-added key -- a slot the card does
     # not owe is a slot the receipt does not belong on.
-    card = load_shipcard(args.shipcard)
     if ROUTE_CENSUS_SLOT not in (card.get("slots") or {}):
         print(f"[shipcard] REFUSED: {args.shipcard} has no "
               f"{ROUTE_CENSUS_SLOT} slot; open a Tessera lane card first "
@@ -571,11 +587,12 @@ def main(argv: list[str] | None = None) -> int:
     p_census.add_argument("shipcard")
     p_census.add_argument(
         "--census", required=True,
-        help="JSON array of {route, decoder[, count]} rows as Tessera's "
-             "tools/tessera_route_census.py parses them from the serve log")
+        help="Complete Tessera route_census/2 JSON (scoped), or historical unscoped row array")
+    p_census.add_argument("--layer-config", default=None,
+                         help="Exact allocation JSON bound by card.build.layer_config_sha; required for v2")
     p_census.add_argument(
-        "--priced-route", required=True, action="append", default=[],
-        help="a route the artifact priced (repeatable, at least one)")
+        "--priced-route", action="append", default=[],
+        help="legacy priced route (repeatable, required for flat rows); optional cross-check for v2")
     p_census.add_argument(
         "--substitute-decoder", action="append", default=[],
         help="a decoder a serve falls back to (repeatable; default: derived "

--- a/prismaquant/tessera_route_receipt.py
+++ b/prismaquant/tessera_route_receipt.py
@@ -1,4 +1,12 @@
-"""The priced-vs-served route gate for the Tessera lane (PrismaQuant #136).
+"""The priced-vs-served route gate for the Tessera lane (#136, Tessera #126).
+
+Scoped census v2 retains the producer's complete observations and exact input
+texts. Its replay binds price projections to the independent card build and
+artifact sidecars, then compares each owner's actual launch to current v5
+cells at the exact image/mode/residency. A decoder used as a dense fallback
+may be a legitimate routed-MoE launch only where that cell explicitly says so.
+There is no global substitute veto for scoped rows. Legacy flat rows below
+retain the historical v4 check and can never acquire fabricated scope.
 
 Tessera's runtime contract publishes, per native extension, what a serve
 does when the ``.so`` cannot build (``native_extensions[].when_unavailable``,
@@ -9,11 +17,10 @@ in PrismaQuant read it, so a shipcard could price ``TESSERA_NVFP4`` W4A4
 while a serve produced every number on ``torch_materialize_stock`` with
 nothing refusing.
 
-This module is the refusing consumer.  It reads route records -- the
-``{route, decoder}`` rows Tessera's own ``tools/tessera_route_census.py``
-parses out of a serve log, which this repository names rather than vendors
-(``lane_specs/tessera.json``) -- and compares the routes the serve actually
-emitted against the routes the artifact priced, refusing on:
+The legacy path reads historical ``{route, decoder}`` row arrays. The
+current producer tool remains Tessera-owned (``lane_specs/tessera.json``),
+and its complete v2 object must use the scoped path above. The legacy
+comparison refuses on:
 
 * no records at all (an absent census is not a clean bill);
 * any record without a decoder (a decoder-less row read as native is the
@@ -28,8 +35,8 @@ emitted against the routes the artifact priced, refusing on:
 Stdlib only, no torch: the shipcard replays this at publication through
 ``prismaquant.shipcard``, which is stdlib-only by contract.
 
-What this does not do: the native decoder's NAME is not published anywhere
-this repository reads, so the gate cannot assert "this ran native" -- it
+What the legacy path does not do: its old row protocol carries no matched
+cell launch, so that path cannot assert "this ran native" -- it
 refuses every substitute the pin names and stamps the served decoder set it
 observed, which is the positive claim the receipt carries.  Coverage
 strictness is uncalibrated against a real serve (nothing has been served
@@ -38,6 +45,10 @@ measured serve, not an argument.
 """
 from __future__ import annotations
 
+import hashlib
+import json
+from pathlib import Path
+import re
 from typing import Any, Mapping, Sequence
 
 
@@ -85,8 +96,8 @@ def parse_route_records(
 
     Each row must carry a non-empty ``route`` and a non-empty ``decoder``;
     ``count`` is carried when present (a non-negative integer) and ``None``
-    otherwise.  Extra keys are ignored -- the census schema is Tessera's, and
-    this gate reads two fields out of it rather than owning it.
+    otherwise. Unrelated extra keys remain legacy-compatible, but explicit
+    runtime/owner/phase fields refuse: flattening them would discard scope.
     """
     if not isinstance(records, Sequence) or isinstance(records, (str, bytes)):
         raise TesseraRouteReceiptError(
@@ -96,6 +107,11 @@ def parse_route_records(
         at = f"{where}[{index}]"
         if not isinstance(row, Mapping):
             raise TesseraRouteReceiptError(f"{at} must be an object")
+        if set(row) & {"runtime", "runtime_image", "execution_mode", "structure",
+                       "residency", "phase", "owner", "record_owner"}:
+            raise TesseraRouteReceiptError(
+                f"{at}: scoped runtime observations require the complete v2 census; "
+                "legacy flattening cannot retain or validate their scope")
         route, decoder = row.get("route"), row.get("decoder")
         if not isinstance(route, str) or not route:
             raise TesseraRouteReceiptError(
@@ -176,6 +192,282 @@ def check_route_receipt(
                          if verdict["passed"]
                          else "route census REFUSED: " + "; ".join(reasons))
     return verdict
+
+
+SCOPED_CENSUS_SCHEMA = "tessera.serving.route_census/2"
+# The two forwards in this producer schema; future phases require review.
+CENSUS_PHASE_REGIMES = {"decode": "decode", "prefill": "batch"}
+_SIDECARS = {"config.json": "config_json", "tessera_serving_manifest.json": "manifest_json"}
+
+
+def _require(condition, message):
+    if not condition:
+        raise TesseraRouteReceiptError(message)
+
+
+def _object(value, where):
+    _require(isinstance(value, Mapping), f"{where} must be an object")
+    return value
+
+
+def parse_census_json(text, *, where):
+    """Preserve exact input bytes separately; refuse ambiguous duplicate keys."""
+    def unique(pairs):
+        result = {}
+        for key, value in pairs:
+            _require(key not in result, f"{where}: duplicate JSON key {key!r}")
+            result[key] = value
+        return result
+    _require(isinstance(text, str), f"{where} must retain exact UTF-8 JSON text")
+    try:
+        return json.loads(text, object_pairs_hook=unique)
+    except ValueError as exc:
+        raise TesseraRouteReceiptError(f"{where}: {exc}") from exc
+
+
+def _text_sha(text):
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _current_scoped_contract():
+    """Read the packaged contract through its existing dependency-free home."""
+    from importlib.resources import as_file
+    from . import tessera_runtime_contract as runtime
+    from .lane_eligibility import load_eligibility_table, load_published_formats
+    with as_file(runtime.contract_path()) as path:
+        return (load_eligibility_table(contract_path=path),
+                load_published_formats(contract_path=path))
+
+
+def _declared_projections(scheme, where):
+    """Decode the sidecar's explicit role rows, never guess a packed slice."""
+    structure = scheme.get("structure", "dense")
+    _require(structure in {"dense", "routed_moe"}, f"{where}: unsupported structure")
+    if structure == "routed_moe":
+        experts = scheme.get("experts")
+        _require(type(experts) is int and experts > 0, f"{where}: invalid experts")
+        groups = _object(scheme.get("groups"), where + ".groups")
+        _require(bool(groups), f"{where}: empty groups")
+    else:
+        experts, groups = 1, {None: scheme}
+    declarations = {}
+    for group, spec in groups.items():
+        _object(spec, f"{where}.{group}")
+        roles, columns = spec.get("roles"), spec.get("columns")
+        _require(isinstance(roles, list) and roles and type(columns) is int and columns > 0,
+                 f"{where}: nonempty roles and positive columns required")
+        rates = spec.get("q256")
+        rates = rates if isinstance(rates, list) else [rates] * len(roles)
+        _require(len(rates) == len(roles) and all(type(q) is int and q > 0 for q in rates),
+                 f"{where}: role rates are missing or malformed")
+        row_sum = 0
+        for index, role in enumerate(roles):
+            _require(isinstance(role, list) and len(role) == 2 and
+                     isinstance(role[0], str) and role[0] and type(role[1]) is int and role[1] > 0,
+                     f"{where}: invalid role declaration")
+            row_sum += role[1]
+            for expert in range(experts):
+                key = (expert if structure == "routed_moe" else None, group, role[0])
+                _require(key not in declarations, f"{where}: duplicate projection {key}")
+                declarations[key] = {"rows": role[1], "cols": columns, "q256": rates[index],
+                                     "grid": scheme.get("grid"), "family": scheme.get("family")}
+        _require(spec.get("rows") == row_sum, f"{where}: role rows differ from group rows")
+    return structure, declarations
+
+
+def _priced_projection_population(binding, build, formats):
+    from .layer_config import canonicalize_assignment, layer_config_metadata, strip_weight
+    from .lane_eligibility import ServingContext, resolve_payload_rung
+    from .tessera_serving_scope import ServingTarget
+    recipe = _object(parse_census_json(binding.get("layer_config_json"), where="layer_config_json"), "recipe")
+    _require(build.get("layer_config_sha") == _text_sha(binding["layer_config_json"]),
+             "exact recipe text differs from independent card.build.layer_config_sha")
+    names = [strip_weight(name) for name in recipe if name != "__prismaquant__"]
+    _require(len(names) == len(set(names)), "recipe has duplicate normalized price units")
+    assignment = canonicalize_assignment(recipe)
+    selected = {name: fmt for name, fmt in assignment.items() if fmt.startswith("TESSERA_")}
+    _require(bool(selected), "recipe has no Tessera-selected price units")
+    scope = _object(layer_config_metadata(recipe).get("tessera_serving_scope"), "recipe serving scope")
+    _require(set(scope) == {"target", "by_unit"} and scope == build.get("tessera_serving_scope"),
+             "recipe serving scope differs from independent card.build.tessera_serving_scope")
+    target = ServingTarget(**_object(scope["target"], "scope.target"))
+    contexts = _object(scope["by_unit"], "scope.by_unit")
+    config = _object(parse_census_json(binding.get("config_json"), where="config_json"), "config")
+    manifest = _object(parse_census_json(binding.get("manifest_json"), where="manifest_json"), "manifest")
+    _require("export_partition" not in manifest, "partition sidecars are not an assembled artifact")
+    quant = _object(config.get("quantization_config"), "quantization_config")
+    _require(quant.get("quant_method") == "tessera", "artifact is not Tessera")
+    schemes = {}
+    for key, group in _object(quant.get("config_groups"), "config_groups").items():
+        _object(group, f"config_groups.{key}")
+        targets = group.get("targets")
+        _require(group.get("format") == "TESSERA" and isinstance(targets, list) and targets,
+                 f"config_groups.{key}: exact Tessera targets required")
+        for owner in targets:
+            _require(isinstance(owner, str) and owner and owner not in schemes,
+                     f"config_groups.{key}: duplicate or malformed owner")
+            schemes[owner] = _object(group.get("scheme"), f"scheme.{owner}")
+    modules = _object(manifest.get("modules"), "manifest.modules")
+    _require(bool(schemes) and set(modules) == set(schemes), "config/manifest owner populations differ")
+    by_unit, owners = {}, {}
+    for owner, scheme in schemes.items():
+        structure, expected = _declared_projections(scheme, owner)
+        module = _object(modules[owner], f"manifest.{owner}")
+        _require(module.get("structure", structure) == structure and
+                 all(module.get(field) == scheme.get(field) for field in ("family", "grid")),
+                 f"{owner}: manifest family/grid/structure differs from config")
+        if structure == "routed_moe":
+            _require(module.get("experts") == scheme["experts"], f"{owner}: expert population differs")
+        roles = module.get("roles")
+        _require(isinstance(roles, list) and roles, f"{owner}: manifest has no projections")
+        seen, owner_units = set(), []
+        for role in roles:
+            _object(role, f"{owner} projection")
+            key = (role.get("expert"), role.get("group"), role.get("role"))
+            _require(key in expected and key not in seen, f"{owner}: extra or duplicate projection {key}")
+            seen.add(key)
+            _require(all(role.get(field) == value for field, value in expected[key].items()),
+                     f"{owner}: projection {key} differs from declared shape/grid/rung")
+            source = role.get("source_tensor", role.get("tensor"))
+            _require(isinstance(source, str) and source.endswith(".weight"), f"{owner}: missing source tensor")
+            _require(role.get("tensor") == source, f"{owner}: projected/packed source aliases are unsupported")
+            if structure == "routed_moe":
+                _require(role.get("source_layout") == "unpacked_per_expert" and
+                         role.get("source_slice") == {"expert": role["expert"], "selector": "whole", "transpose": False},
+                         f"{owner}: packed/aggregate source projection is unsupported")
+            unit = strip_weight(source)
+            _require(unit in selected and unit not in by_unit, f"{owner}: unpriced or duplicate source projection {unit}")
+            context = ServingContext(**_object(contexts.get(unit), f"scope.by_unit.{unit}"))
+            _require(context == target.context(structure), f"{unit}: price context differs from artifact structure/target")
+            family, _k, rate = resolve_payload_rung(selected[unit], formats)
+            _require(family in formats and rate == role["q256"] and formats[family].get("grid") == role["grid"],
+                     f"{unit}: price family/grid/rung differs from written projection")
+            by_unit[unit] = {"owner": owner, "format": selected[unit], "context": context.as_dict(),
+                             "rows": role["rows"], "columns": role["cols"], "payload_family": family}
+            owner_units.append(unit)
+        _require(seen == set(expected), f"{owner}: missing declared projections")
+        owners[owner] = {"structure": structure, "family": scheme["family"], "units": sorted(owner_units)}
+    _require(set(by_unit) == set(selected), "not every Tessera-selected price unit has an artifact projection")
+    return target, by_unit, owners
+
+
+def check_scoped_route_receipt(census, binding, *, build, model_dir=None):
+    """Replay v2 observations against current cells and independent artifact anchors.
+
+    Nonidentity checkpoint/runtime mappings and packed source projections are
+    explicit unsupported boundaries, never inferred from a similar name.
+    """
+    from . import lane_eligibility as lane
+    from .shipcard import file_sha256
+    try:
+        _object(census, "route census")
+        _object(binding, "census binding")
+        _object(build, "card.build")
+        _require(model_dir is not None, "scoped replay requires independent artifact files (model_dir)")
+        _require(census.get("schema") == SCOPED_CENSUS_SCHEMA, "unknown scoped census schema")
+        _require(set(binding) == {"layer_config_json", *_SIDECARS.values()}, "census binding fields differ from v2 contract")
+        seals = {name: _text_sha(binding[field]) for name, field in _SIDECARS.items()
+                 if isinstance(binding.get(field), str)}
+        _require(len(seals) == len(_SIDECARS) and census.get("checkpoint_sidecars") == seals,
+                 "census checkpoint sidecar seals differ from exact supplied file bytes")
+        if model_dir is not None:
+            _require(all(file_sha256(Path(model_dir) / name) == sha for name, sha in seals.items()),
+                     "census sidecars differ from independently supplied artifact files")
+        table, formats = _current_scoped_contract()
+        _require(table.present and table.schema == lane.LANE_ELIGIBILITY_SCHEMA_TESSERA,
+                 "scoped census needs a current v5 eligibility table; legacy cells attest no image")
+        target, units, owners = _priced_projection_population(binding, build, formats)
+        _require(census.get("runtime") == {"image": target.runtime_image, "execution_mode": target.execution_mode}
+                 and census.get("compiled") is (target.execution_mode == "compiled"),
+                 "actual census runtime image/execution disagrees with price target")
+        env = _object(census.get("env"), "census.env")
+        _require(env.get("TESSERA_SERVE_MODE") == target.residency, "actual census residency differs from price target")
+        capability = _object(census.get("device"), "census.device").get("capability")
+        _require(isinstance(capability, list) and len(capability) == 2 and
+                 all(type(n) is int and n >= 0 for n in capability) and
+                 target.platform == f"sm_{capability[0]}{capability[1]}", "actual census platform differs from price target")
+        _require(census.get("verdict") == "served" and census.get("problems") == [], "raw census did not pass its served checks")
+        mapping = census.get("declared_name_mapping")
+        _require((mapping is None and census.get("declared_names_mapped_to_module_space") is False) or
+                 (mapping == {owner: owner for owner in owners} and
+                  census.get("declared_names_mapped_to_module_space") is True),
+                 "nonidentity or incomplete runtime owner mapping is unsupported; no mapper grammar is guessed")
+        records = _object(census.get("records"), "census.records")
+        owner_maps = _object(census.get("record_owner"), "census.record_owner")
+        _require(set(records) == set(owner_maps) == set(CENSUS_PHASE_REGIMES) and
+                 set(table.regimes) == set(CENSUS_PHASE_REGIMES.values()), "census must cover exactly both driven phases/all regimes")
+        routes = {}
+        for unit, row in units.items():
+            facts = lane.unit_structural_facts(unit, row["format"], is_routed_moe=row["context"]["structure"] == "routed_moe",
+                role_split=False, in_features=row["columns"], out_features=row["rows"], published_formats=formats)
+            context = lane.ServingContext(**row["context"])
+            # Source member dimensions are not necessarily the fused executed
+            # shape. Match endpoint support: do not evaluate such predicates
+            # until that projection has one shared, attested home.
+            _require(not any(cell.predicates for cell in table.cells
+                             if cell.family == facts.payload_family and cell.covers_rung(facts)
+                             and lane.cell_matches_serving_context(cell, context)),
+                     f"{unit}: executed-unit predicates are unsupported by this receipt projection")
+            resolved = lane.resolve_unit_route(facts, table, **target.as_dict())
+            _require(all(r.route_status in {lane.ROUTE_STATUS_BACKED, lane.ROUTE_STATUS_BACKED_WITH_SERVE_FLAG}
+                         and r.qualification == lane.QUALIFICATION_DEVICE_QUALIFIED for r in resolved.regimes)
+                     and len(resolved.regimes) == len(table.regimes), f"{unit}: current contract does not back every required regime")
+            routes[unit] = {r.regime: r for r in resolved.regimes}
+            row["regime_routes"] = {r.regime: r.as_dict() for r in resolved.regimes}
+        served_routes, decoders, n_records = set(), set(), 0
+        for phase, regime in CENSUS_PHASE_REGIMES.items():
+            seen, replay_owners = set(), {}
+            for name, record in _object(records[phase], f"records.{phase}").items():
+                _object(record, f"{phase}.{name}")
+                candidates = [name] if name in owners else [owner for owner in owners
+                    if record.get("kind") == "moe" and name.startswith(owner + ".")]
+                _require(len(candidates) == 1 and candidates[0] not in seen,
+                         f"{phase}.{name}: extra, duplicate or ambiguous runtime owner")
+                owner = candidates[0]
+                seen.add(owner)
+                replay_owners[name] = owner
+                facts = owners[owner]
+                structure = facts["structure"]
+                kind = "moe" if structure == "routed_moe" else "dense"
+                _require(record.get("kind") == kind and record.get("state") == "served" and
+                         record.get("policy") == f"{facts['family']}:{target.residency}",
+                         f"{phase}.{name}: structure/state/policy differs from written owner")
+                if target.execution_mode == "eager":
+                    shape = re.fullmatch(r"M([1-9][0-9]*):N([1-9][0-9]*):K([1-9][0-9]*)", str(record.get("shape", "")))
+                    _require(shape is not None and (int(shape[1]) == 1) == (regime == "decode"),
+                             f"{phase}.{name}: malformed shape or wrong driven regime")
+                else:
+                    _require(structure == "routed_moe" and str(record.get("shape", "")).startswith("M*:"),
+                             f"{phase}.{name}: compiled dense/ambiguous trace agreement unsupported")
+                symbol, decoder = record.get("symbol"), record.get("decoder")
+                _require(isinstance(symbol, str) and symbol and isinstance(decoder, str) and decoder,
+                         f"{phase}.{name}: missing observed launch pair")
+                for unit in facts["units"]:
+                    route = routes[unit][regime]
+                    _require(record.get("contract") == route.activation_contract,
+                             f"{phase}.{name}: activation contract mismatch")
+                    _require(any(decoder == expected_decoder and (symbol == expected_symbol or
+                                 (structure == "routed_moe" and symbol.startswith(expected_symbol + ":") and
+                                  bool(symbol[len(expected_symbol) + 1:])))
+                                 for expected_symbol, expected_decoder in route.executes),
+                             f"{phase}.{name}: observed launch pair is not declared by its scoped cell")
+                    for flag in route.requires_serve_flags:
+                        key, _, values = flag.partition("=")
+                        _require(env.get(key) in values.split("|"), f"{phase}.{name}: required serve flag {flag} not observed")
+                served_routes.add(facts["family"])
+                decoders.add(decoder)
+                n_records += 1
+            _require(seen == set(owners) and owner_maps[phase] == replay_owners,
+                     f"{phase}: incomplete owner bijection or forged recorded owner map")
+        return {"schema": "prismaquant.tessera-scoped-census.v1", "passed": True,
+                "target": target.as_dict(), "by_unit": units, "owners": owners,
+                "served_routes": sorted(served_routes), "served_decoders": sorted(decoders),
+                "n_records": n_records, "contract": table.provenance(),
+                "detail": "route census agrees with exact price/artifact/runtime scope in both driven phases"}
+    except (TypeError, KeyError, ValueError, OSError, ImportError) as exc:
+        if isinstance(exc, TesseraRouteReceiptError):
+            raise
+        raise TesseraRouteReceiptError(f"malformed scoped route census: {exc}") from exc
 
 
 __all__ = [

--- a/tests/test_tessera_scoped_route_receipt.py
+++ b/tests/test_tessera_scoped_route_receipt.py
@@ -1,0 +1,319 @@
+"""Producer-shaped census v2 remains bound to price, artifact and actual runtime."""
+from copy import deepcopy
+import hashlib
+import json
+
+import pytest
+
+from prismaquant import lane_eligibility as lane
+from prismaquant import shipcard
+from prismaquant import tessera_route_receipt as receipt
+
+
+IMAGE = "example/runtime@sha256:" + "a" * 64
+FORMAT = "TESSERA_E4M3_K1_R1024"
+FAMILY = "TESSERA_E4M3_K1"
+OWNER = "model.layers.0.feed_forward.experts"
+
+
+def _text(value):
+    return json.dumps(value, indent=2) + "\n"
+
+
+def _sha(text):
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def fixture(tmp_path, monkeypatch, *, structure="routed_moe"):
+    owner = OWNER if structure == "routed_moe" else "model.layers.0.self_attn.o_proj"
+    target = {"platform": "sm_121", "runtime_image": IMAGE,
+              "execution_mode": "eager", "residency": "resident"}
+    context = {**target, "structure": structure}
+    roles = []
+    groups = {"w13": {"rows": 128, "columns": 128, "q256": 1024,
+                      "roles": [["gate_proj", 64], ["up_proj", 64]], "wire_stride": 4096},
+              "w2": {"rows": 128, "columns": 64, "q256": 1024,
+                     "roles": [["down_proj", 128]], "wire_stride": 4096}}
+    if structure == "routed_moe":
+        for expert in range(2):
+            for group, row in groups.items():
+                for name, rows in row["roles"]:
+                    source = f"{owner}.{expert}.{name}.weight"
+                    roles.append({"tensor": source, "source_tensor": source,
+                                  "source_layout": "unpacked_per_expert",
+                                  "source_slice": {"expert": expert, "selector": "whole", "transpose": False},
+                                  "expert": expert, "group": group, "role": name,
+                                  "rows": rows, "cols": row["columns"], "q256": 1024,
+                                  "grid": "E4M3", "family": "TESSERA_FP8"})
+        scheme = {"family": "TESSERA_FP8", "structure": structure, "grid": "E4M3",
+                  "body": "WINDOW", "plane": "CHANNEL", "experts": 2, "groups": groups}
+        symbol, decoder, kind = "vllm.fused_moe.modular_kernel:TRITON", "torch_materialize_stock", "moe"
+    else:
+        roles = [{"tensor": owner + ".weight", "role": "o_proj", "rows": 128,
+                  "cols": 128, "q256": 1024, "grid": "E4M3", "family": "TESSERA_FP8"}]
+        scheme = {"family": "TESSERA_FP8", "structure": "dense", "grid": "E4M3",
+                  "body": "WINDOW", "plane": "CHANNEL", "q256": 1024,
+                  "rows": 128, "columns": 128, "roles": [["o_proj", 128]], "wire_bytes": 8192}
+        symbol, decoder, kind = "torch._scaled_mm", "torch_window", "dense"
+    units = [role["tensor"].removesuffix(".weight") for role in roles]
+    scope = {"target": target, "by_unit": {unit: context for unit in units}}
+    scope["by_unit"]["model.embed_tokens"] = {**target, "structure": "dense"}
+    assignment = {unit: {"data_type": "tessera", "tessera_format": FORMAT} for unit in units}
+    assignment["model.embed_tokens"] = "BF16"
+    assignment["__prismaquant__"] = {"tessera_serving_scope": scope}
+    config = {"architectures": ["Lfm2MoeForCausalLM"], "model_type": "lfm2_moe",
+              "quantization_config": {"quant_method": "tessera", "config_groups": {
+                  "group_0": {"format": "TESSERA", "targets": [owner], "scheme": scheme}}}}
+    manifest = {"modules": {owner: {"structure": structure, "family": "TESSERA_FP8",
+                                   "grid": "E4M3", "q256": 1024, "roles": roles}}}
+    if structure == "routed_moe":
+        manifest["modules"][owner]["experts"] = 2
+    binding = {"layer_config_json": _text(assignment), "config_json": _text(config),
+               "manifest_json": _text(manifest)}
+    build = {"layer_config_sha": _sha(binding["layer_config_json"]), "tessera_serving_scope": scope}
+    model_dir = tmp_path / structure
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(binding["config_json"])
+    (model_dir / "tessera_serving_manifest.json").write_text(binding["manifest_json"])
+    (model_dir / "model.safetensors").write_bytes(b"fixture-weight-bytes")
+    module = owner + ".routed_experts" if kind == "moe" else owner
+    census = {"schema": "tessera.serving.route_census/2", "checkpoint": "/model",
+              "runtime": {"image": IMAGE, "execution_mode": "eager"}, "compiled": False,
+              "env": {"TESSERA_SERVE_MODE": "resident"}, "device": {"capability": [12, 1]},
+              "verdict": "served", "problems": [], "declared_name_mapping": None,
+              "declared_names_mapped_to_module_space": False,
+              "checkpoint_sidecars": {"config.json": _sha(binding["config_json"]),
+                                      "tessera_serving_manifest.json": _sha(binding["manifest_json"])},
+              "records": {}, "record_owner": {}}
+    for phase, m in (("decode", 1), ("prefill", 64)):
+        census["records"][phase] = {module: {"kind": kind, "policy": "TESSERA_FP8:resident",
+                                            "symbol": symbol, "decoder": decoder,
+                                            "contract": "fp8_per_token_dynamic", "state": "served",
+                                            "shape": f"M{m}:N128:K128"}}
+        census["record_owner"][phase] = {module: owner}
+    formats = {FAMILY: {"family": FAMILY, "kind": "tessera_wire", "grid": "E4M3",
+                        "name_pattern": "TESSERA_E4M3_K1_R{k}", "reader_rate_range_q256": [256, 2048],
+                        "residency_modes": ["resident", "streamed"]}}
+    cells = [{"id": f"{structure}_{regime}", "platform": "sm_121", "family": FAMILY,
+              "structure": structure, "regime": regime, "rungs_q256": [1024],
+              "activation_contract": "fp8_per_token_dynamic", "route_status": "backed_with_serve_flag",
+              "qualification": "device_qualified", "requires_plugin": "tessera", "predicates": [],
+              "requires_serve_flags": ["TESSERA_SERVE_MODE=resident"],
+              "executes": [{"symbol": symbol.split(":", 1)[0], "decoder": decoder}],
+              "runtime": {"image": IMAGE, "execution_modes": ["eager"]}}
+             for regime in ("decode", "batch")]
+    block = {"schema": lane.LANE_ELIGIBILITY_SCHEMA_TESSERA, "platforms": {"sm_121": {}},
+             "structures": [structure], "regimes": ["decode", "batch"], "cells": cells}
+    table = lane._parse_table(block, list(formats.values()), "fixture", "fixture", "fixture")
+    monkeypatch.setattr(receipt, "_current_scoped_contract", lambda: (table, formats), raising=False)
+    return census, binding, build, model_dir, units
+
+
+def make(data):
+    census, binding, build, model_dir, _units = data
+    return shipcard.make_route_census_record(tool="test", model_sha=shipcard.compute_model_sha(model_dir),
+        route_records=census, priced_routes=[], substitute_decoders=[],
+        binding=binding, build=build, model_dir=model_dir)
+
+
+@pytest.mark.parametrize("structure", ["dense", "routed_moe"])
+def test_raw_v2_positive_retains_runtime_phase_owner_and_exact_price(tmp_path, monkeypatch, structure):
+    data = fixture(tmp_path, monkeypatch, structure=structure)
+    record = make(data)
+    assert record["passed"] is True
+    assert record["route_census"] == data[0]
+    assert record["census_binding"] == data[1]
+    assert set(record["scoped_verdict"]["by_unit"]) == set(data[4])
+    assert record["scoped_verdict"]["target"] == data[2]["tessera_serving_scope"]["target"]
+    if structure == "routed_moe":
+        assert record["served_decoders"] == ["torch_materialize_stock"]
+        assert ":TRITON" in next(iter(record["route_census"]["records"]["decode"].values()))["symbol"]
+    assert shipcard._verify_route_census_record("route.census", record,
+        card={"build": data[2]}, model_dir=data[3]) == []
+
+
+@pytest.mark.parametrize("mutation", ["missing_image", "wrong_image", "wrong_mode", "compiled_disagrees",
+    "wrong_residency", "wrong_platform", "missing_phase", "extra_phase", "missing_owner", "extra_owner",
+    "forged_owner", "wrong_kind", "wrong_policy", "wrong_decoder", "wrong_symbol", "wrong_activation",
+    "wrong_state", "missing_seal", "wrong_seal", "failed_verdict", "malformed_shape", "wrong_regime",
+    "nonidentity_mapping"])
+def test_raw_v2_refuses_unbound_or_contradictory_observations(tmp_path, monkeypatch, mutation):
+    data = fixture(tmp_path, monkeypatch)
+    raw = data[0]
+    row = next(iter(raw["records"]["decode"].values()))
+    if mutation == "missing_image": del raw["runtime"]["image"]
+    elif mutation == "wrong_image": raw["runtime"]["image"] = IMAGE.replace("a" * 64, "b" * 64)
+    elif mutation == "wrong_mode": raw["runtime"]["execution_mode"] = "compiled"
+    elif mutation == "compiled_disagrees": raw["compiled"] = True
+    elif mutation == "wrong_residency": raw["env"]["TESSERA_SERVE_MODE"] = "streamed"
+    elif mutation == "wrong_platform": raw["device"]["capability"] = [9, 0]
+    elif mutation == "missing_phase": del raw["records"]["prefill"]
+    elif mutation == "extra_phase": raw["records"]["unknown"] = {}
+    elif mutation == "missing_owner": raw["records"]["decode"] = {}
+    elif mutation == "extra_owner": raw["records"]["decode"]["unexpected"] = deepcopy(row)
+    elif mutation == "forged_owner": raw["record_owner"]["decode"][OWNER + ".routed_experts"] = "forged"
+    elif mutation == "wrong_kind": row["kind"] = "fp8"
+    elif mutation == "wrong_policy": row["policy"] = "TESSERA_FP8:streamed"
+    elif mutation == "wrong_decoder": row["decoder"] = "unpublished"
+    elif mutation == "wrong_symbol": row["symbol"] = "torch.mm"
+    elif mutation == "wrong_activation": row["contract"] = "other"
+    elif mutation == "wrong_state": row["state"] = "prepared"
+    elif mutation == "missing_seal": del raw["checkpoint_sidecars"]
+    elif mutation == "wrong_seal": raw["checkpoint_sidecars"]["config.json"] = "0" * 64
+    elif mutation == "failed_verdict": raw["verdict"] = "REFUSED"
+    elif mutation == "malformed_shape": row["shape"] = "1:128:128"
+    elif mutation == "wrong_regime": row["shape"] = "M2:N128:K128"
+    elif mutation == "nonidentity_mapping":
+        raw["declared_name_mapping"] = {OWNER: "new_owner"}
+        raw["declared_names_mapped_to_module_space"] = True
+    with pytest.raises(receipt.TesseraRouteReceiptError): make(data)
+
+
+@pytest.mark.parametrize("mutation", ["recipe", "target", "structure", "projection", "price_rung",
+                                      "missing_build", "sidecar_on_disk"])
+def test_independent_build_and_artifact_anchors_reject_rewritten_binding(tmp_path, monkeypatch, mutation):
+    data = fixture(tmp_path, monkeypatch)
+    census, binding, build, model_dir, units = data
+    if mutation == "recipe": binding["layer_config_json"] += " "
+    elif mutation == "target": build["tessera_serving_scope"] = {"target": {}, "by_unit": {}}
+    elif mutation in {"structure", "price_rung"}:
+        recipe = json.loads(binding["layer_config_json"])
+        if mutation == "structure": recipe["__prismaquant__"]["tessera_serving_scope"]["by_unit"][units[0]]["structure"] = "dense"
+        else: recipe[units[0]] = {"data_type": "tessera", "tessera_format": "TESSERA_E4M3_K1_R1025"}
+        binding["layer_config_json"] = _text(recipe)
+        build["layer_config_sha"] = _sha(binding["layer_config_json"])
+        build["tessera_serving_scope"] = recipe["__prismaquant__"]["tessera_serving_scope"]
+    elif mutation == "projection":
+        manifest = json.loads(binding["manifest_json"])
+        manifest["modules"][OWNER]["roles"][0]["source_tensor"] = "forged.weight"
+        binding["manifest_json"] = _text(manifest)
+        census["checkpoint_sidecars"]["tessera_serving_manifest.json"] = _sha(binding["manifest_json"])
+        (model_dir / "tessera_serving_manifest.json").write_text(binding["manifest_json"])
+    elif mutation == "missing_build": build.clear()
+    elif mutation == "sidecar_on_disk": (model_dir / "config.json").write_text("{}")
+    with pytest.raises(receipt.TesseraRouteReceiptError): make(data)
+
+
+def test_offline_replay_rejects_edited_scope_raw_record_and_stale_verdict(tmp_path, monkeypatch):
+    data = fixture(tmp_path, monkeypatch)
+    record = make(data)
+    record["route_census"]["runtime"]["image"] = "example/other@sha256:" + "b" * 64
+    record["scoped_verdict"]["target"]["runtime_image"] = record["route_census"]["runtime"]["image"]
+    assert shipcard._verify_route_census_record("route.census", record,
+        card={"build": data[2]}, model_dir=data[3])
+
+
+def test_dense_undeclared_materialized_fallback_is_not_moe_permission(tmp_path, monkeypatch):
+    data = fixture(tmp_path, monkeypatch, structure="dense")
+    for rows in data[0]["records"].values(): next(iter(rows.values()))["decoder"] = "torch_materialize_stock"
+    with pytest.raises(receipt.TesseraRouteReceiptError): make(data)
+
+
+def test_legacy_flat_parser_never_discards_explicit_runtime_context():
+    with pytest.raises(receipt.TesseraRouteReceiptError, match="scope|runtime"):
+        receipt.parse_route_records([{"route": "TESSERA_FP8", "decoder": "torch_window",
+                                      "runtime_image": IMAGE, "execution_mode": "eager"}])
+
+
+def test_scoped_card_cannot_replay_flat_legacy_receipt(tmp_path, monkeypatch):
+    data = fixture(tmp_path, monkeypatch)
+    legacy = shipcard.make_route_census_record(tool="legacy", model_sha="fixture",
+        priced_routes=["TESSERA_FP8"], route_records=[{"route": "TESSERA_FP8", "decoder": "native"}],
+        substitute_decoders=["fallback"])
+    assert shipcard._verify_route_census_record("route.census", legacy, card={"build": data[2]})
+
+
+def test_scoped_verification_requires_independent_artifact_files(tmp_path, monkeypatch):
+    data = fixture(tmp_path, monkeypatch)
+    record = make(data)
+    assert shipcard._verify_route_census_record("route.census", record, card={"build": data[2]})
+
+
+def test_missing_packaged_contract_is_typed_refusal(tmp_path, monkeypatch):
+    data = fixture(tmp_path, monkeypatch)
+    def unavailable():
+        raise ModuleNotFoundError("no packaged Tessera")
+    monkeypatch.setattr(receipt, "_current_scoped_contract", unavailable)
+    with pytest.raises(receipt.TesseraRouteReceiptError, match="packaged Tessera"):
+        make(data)
+
+
+@pytest.mark.parametrize("missing_recipe", [False, True])
+def test_cli_retains_full_v2_and_replays_against_card_and_model(tmp_path, monkeypatch, missing_recipe):
+    from prismaquant.shipcard_cli import main
+    data = fixture(tmp_path, monkeypatch)
+    census, binding, build, model_dir, _units = data
+    card_path = model_dir / "shipcard.json"
+    shipcard.write_shipcard(card_path, shipcard.build_shipcard(model_dir, build=build, lane="tessera"))
+    census_path = tmp_path / "census.json"
+    census_path.write_text(_text(census))
+    recipe_path = tmp_path / "layer_config.json"
+    recipe_path.write_text(binding["layer_config_json"])
+    args = ["fill-route-census", str(card_path), "--census", str(census_path), "--model-dir", str(model_dir)]
+    if not missing_recipe:
+        args += ["--layer-config", str(recipe_path)]
+    assert main(args) == (2 if missing_recipe else 0)
+    card = shipcard.load_shipcard(card_path)
+    if missing_recipe:
+        assert card["slots"]["route.census"] is None
+    else:
+        assert card["slots"]["route.census"]["route_census"] == census
+        assert not [p for p in shipcard.verify(card, model_dir=model_dir) if p.startswith("route.census:")]
+        card["build"]["layer_config_sha"] = "0" * 64
+        assert any(p.startswith("route.census:") for p in shipcard.verify(card, model_dir=model_dir))
+
+
+def test_duplicate_json_keys_do_not_replace_price_units():
+    with pytest.raises(receipt.TesseraRouteReceiptError, match="duplicate"):
+        receipt.parse_census_json('{"unit": "BF16", "unit": "BF16"}', where="fixture")
+
+
+def test_unknown_raw_schema_and_legacy_table_are_not_v5_evidence(tmp_path, monkeypatch):
+    from dataclasses import replace
+    data = fixture(tmp_path, monkeypatch)
+    data[0]["schema"] = "tessera.serving.route_census/unknown"
+    with pytest.raises(receipt.TesseraRouteReceiptError, match="schema"):
+        make(data)
+    data[0]["schema"] = receipt.SCOPED_CENSUS_SCHEMA
+    table, formats = receipt._current_scoped_contract()
+    monkeypatch.setattr(receipt, "_current_scoped_contract", lambda: (replace(table, schema=lane.LANE_ELIGIBILITY_SCHEMA_TESSERA_V4), formats))
+    with pytest.raises(receipt.TesseraRouteReceiptError, match="v5|legacy"):
+        make(data)
+
+
+def test_member_dimensions_cannot_attest_executed_shape_predicates(tmp_path, monkeypatch):
+    from dataclasses import replace
+    data = fixture(tmp_path, monkeypatch, structure="dense")
+    table, formats = receipt._current_scoped_contract()
+    cells = tuple(replace(cell, predicates=(("out_features", "equals", 128),)) for cell in table.cells)
+    monkeypatch.setattr(receipt, "_current_scoped_contract", lambda: (replace(table, cells=cells), formats))
+    with pytest.raises(receipt.TesseraRouteReceiptError, match="predicate|executed"):
+        make(data)
+
+
+@pytest.mark.parametrize("structure,combined", [("routed_moe", False), ("routed_moe", True), ("dense", False)])
+def test_compiled_scope_needs_single_attributable_moe_launch(tmp_path, monkeypatch, structure, combined):
+    from dataclasses import replace
+    data = fixture(tmp_path, monkeypatch, structure=structure)
+    raw, binding, build, _model_dir, _units = data
+    recipe = json.loads(binding["layer_config_json"])
+    scope = recipe["__prismaquant__"]["tessera_serving_scope"]
+    scope["target"]["execution_mode"] = "compiled"
+    for context in scope["by_unit"].values(): context["execution_mode"] = "compiled"
+    build["tessera_serving_scope"] = scope
+    binding["layer_config_json"] = _text(recipe)
+    build["layer_config_sha"] = _sha(binding["layer_config_json"])
+    raw["runtime"]["execution_mode"], raw["compiled"] = "compiled", True
+    for rows in raw["records"].values():
+        for row in rows.values():
+            row["shape"] = "M*:N128:K128"
+            if combined: row["symbol"] = "torch.bmm+vllm.fused_moe.modular_kernel:TRITON"
+    table, formats = receipt._current_scoped_contract()
+    cells = tuple(replace(cell, execution_modes=("eager", "compiled")) for cell in table.cells)
+    monkeypatch.setattr(receipt, "_current_scoped_contract", lambda: (replace(table, cells=cells), formats))
+    if structure == "dense" or combined:
+        with pytest.raises(receipt.TesseraRouteReceiptError): make(data)
+    else:
+        record = make(data)
+        assert record["passed"] is True
+        assert record["scoped_verdict"]["target"]["execution_mode"] == "compiled"


### PR DESCRIPTION
Completes the scoped raw-census consumer leg of Tessera #126, on merged endpoint PR185. #126 remains open for final reviewed producer/pin integration.

Keeps complete producer `route_census/2` observations and exact allocation/sidecar text, replays allocation SHA against independent card build metadata and sidecar hashes against actual artifact files, then checks exact runtime/mode/residency, each selected source projection, owner, driven phase and launch pair against current v5 cells. Old flat receipts cannot silently acquire v5 scope. No pin, default, bytes or promotion threshold changes.

Boundaries are explicit: no packed source/unknown name projection guesses or nonempty executed-shape predicates; producer combined dense compiled traces cannot establish per-regime route proof, despite dense compiled admission being supported. Scoped single-pair compiled MoE is a parser control, not a new serving attestation.

Worker targeted PrismaBuild evidence: 148 passed, 0 failed/skipped; final endpoint/shipcard integration on main10dd2395: 209 passed, 0 failed/skipped. No collection errors; three Python modules compiled. CPU-only Sparky 1 core / 4 GiB. Valid pre-fix failures, actual-shaped fixture corrections and immutable receipts are in `docs/measurements/tessera-scoped-census-binding-2026-09-04.md`. No GPU or served claim.
