### PR TITLE
Add opt-in paired no-new-boundary-failures decision

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,6 +16,11 @@ is inconclusive, never an automatic retry or a default promotion. The
 reference native NVFP4 candidate's existing shipcard is unfilled. This one
 model cannot cover the additional representative population or gold/downstream
 promotion gates. Gate: `tests/test_pq87_paired_validation.py`.
+Container cleanup uses a Docker-published exact ID and verifies both the
+PrismaBuild action label and a fresh campaign nonce before any stop/remove.
+An unused output directory does not prove Docker-name ownership; prelaunch
+failure cleans nothing, name collisions refuse, and uncertain creation stays
+inconclusive for PrismaBuild's action-owner cleanup.
 
 Re-stamped (2026-09-04, `codex/pq87-paired-policy`) for the **opt-in paired
 no-new-boundary-failures decision** (§7.2; #87). The separately versioned

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,20 @@
 As of: 2026-09-04 · `codex/pq87-paired-policy`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-04, `codex/pq87-paired-policy`) for a **frozen sequential
+native-candidate validation plan**, not a measured result. The opt-in
+`experiments/pq87_paired_validation.py` reuses the existing bounded BF16
+instrument helpers and the paired client. A committed manifest declares
+distinct native BF16/quantized sources, screen and disjoint held-out schedules,
+both-box telemetry URLs and the deadline. It freezes both artifacts before
+startup, serves one model at a time, records the paired policy on each
+population and runs the existing small PPL check on both servers. A candidate
+refusal is retained as a completed observation; missing/incomparable evidence
+is inconclusive, never an automatic retry or a default promotion. The
+reference native NVFP4 candidate's existing shipcard is unfilled. This one
+model cannot cover the additional representative population or gold/downstream
+promotion gates. Gate: `tests/test_pq87_paired_validation.py`.
+
 Re-stamped (2026-09-04, `codex/pq87-paired-policy`) for the **opt-in paired
 no-new-boundary-failures decision** (§7.2; #87). The separately versioned
 `prismaquant.no_new_boundary_failures/1` policy replays both measurement

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,20 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-04 · `codex/pq87-physical-ab`. Stamps
+As of: 2026-09-04 · `codex/pq87-paired-policy`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-04, `codex/pq87-paired-policy`) for the **opt-in paired
+no-new-boundary-failures decision** (§7.2; #87). The separately versioned
+`prismaquant.no_new_boundary_failures/1` policy replays both measurement
+receipts before comparing defect-kind sets on identical prompt/seed pairs at
+the BF16-derived uncensored cap. A newly broken clean pair or a new kind on
+an already-broken pair refuses; repairs never offset failures elsewhere.
+Missing, malformed, incomparable or censored control evidence is inconclusive.
+`measure_boundary_control.py candidate --decision-policy no-new-failures`
+records this optional decision and exits 2 on refusal. Offline replay
+recomputes every decision field. This adds no shipcard waiver, changes no
+production threshold and claims no quantized/held-out measurement. Gates:
+`tests/test_boundary_policy.py`.
 
 Re-stamped (2026-09-04, `codex/pq87-physical-ab`) for the opt-in bounded
 physical boundary controller. `experiments/pq87_physical_ab.py` freezes and
@@ -7401,7 +7414,7 @@ boundary check, regardless of its nominal defect count.
 This endpoint fix is necessary and insufficient. Physical evidence invalidated
 the current 64-token cap and a universal zero roster: healthy DSV4 still filed
 7/30 cap truncations at 64, while stock Qwen3-8B filed 10/15 even at 600. The
-pending policy is a same-session BF16 control whose cap grows until the control
+control-relative instrument uses a same-session BF16 control whose cap grows until the control
 reaches its own finishing fixed point, bounded by the declared model context
 and an explicit backstop; the quantized arm is then scored control-relative at
 that exact cap. The opt-in `boundary_control.py` instrument now specifies and
@@ -7414,9 +7427,15 @@ record raw-request A versus chat-request B at the historical initial cap,
 followed by the uncensored control budget. Relative counts are per stratum,
 without an invented significance or tolerance threshold. The budget is fit on
 this frozen schedule, so the report is a detector and must not select artifact
-calibration content. Until a physical paired measurement and a replacement
-shipping policy are approved, the old 64/zero values remain fail-closed, #87
-remains `needs-decision`, and this instrument cannot promote an artifact.
+calibration content. The optional `--decision-policy no-new-failures` applies
+the versioned paired rule chosen for #87: a new defect kind on any prompt/seed
+refuses, with no offset from repairs on other pairs. The policy replays the
+complete evidence and treats missing/incomparable/censored controls as
+inconclusive. It remains opt-in and does not fill or waive a shipping slot.
+Until matched quantized, disjoint held-out and representative-population
+validation supports a shipping-default promotion, the old 64/zero values
+remain fail-closed. The BF16-only A/B does not establish quantized-artifact
+discrimination.
 
 **Spec-decode refusal.** `_spec_decode_on` scrapes `/metrics` for
 `vllm:spec_decode`; if present the perplexity check **refuses a verdict** rather than return

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,6 +21,9 @@ PrismaBuild action label and a fresh campaign nonce before any stop/remove.
 An unused output directory does not prove Docker-name ownership; prelaunch
 failure cleans nothing, name collisions refuse, and uncertain creation stays
 inconclusive for PrismaBuild's action-owner cleanup.
+The numeric screen distinguishes a measured PPL threshold refusal from
+empty/skipped/speculative logprobs: only finite full-roster metrics with
+scored tokens are completed observations. Missing data stays inconclusive.
 
 Re-stamped (2026-09-04, `codex/pq87-paired-policy`) for the **opt-in paired
 no-new-boundary-failures decision** (§7.2; #87). The separately versioned

--- a/docs/experiments/pq87_boundary_ab.md
+++ b/docs/experiments/pq87_boundary_ab.md
@@ -75,6 +75,14 @@ alone is not diagnostic. No launch permission or capacity is implied by this
 document. The original preparation consumed no GPU slot; the physical run and
 its completed GPU handoff are recorded separately in the results document.
 
-After the physical result, the remaining decision is which versioned,
-control-relative rule replaces the current mandatory 64/zero boundary gate.
-That is separate from merging the endpoint/schema and empty-population fixes.
+The selected follow-up policy is available opt-in with candidate argument
+`--decision-policy no-new-failures`. It rejects any new defect kind on a
+matched prompt/seed pair; a repaired sample cannot offset a newly broken one.
+Existing BF16 defects may persist without introducing another kind. Missing,
+incomparable or censored controls are inconclusive. This separately versioned
+decision does not replace the mandatory historical shipping policy or fill a
+shipcard slot. Actual matched quantized-artifact, disjoint held-out and
+additional representative-population validation is still required before
+shipping-default promotion. A new campaign/source closure needs its own fresh
+BF16 control; the completed raw/chat64 instrument characterization need not
+be repeated.

--- a/docs/experiments/pq87_quantized_validation.md
+++ b/docs/experiments/pq87_quantized_validation.md
@@ -42,9 +42,13 @@ The controller refuses overlap between screen and heldout prompts, mutable
 image tags, ambiguous model identity, missing telemetry URLs and an unbounded
 manifest. Original sources are never edited; copied model bytes are mounted
 read-only through both container aliases. Shutdown must leave no serving
-process before the next arm. Exact-container cleanup is recorded even after
-timeout or refusal, and the coordinator checks actual worker completion before
-releasing the GPU to another task.
+process before the next arm. Docker publishes a fresh CID file; cleanup
+inspects that exact ID and verifies both the pool action label and a new
+campaign nonce before any stop/remove. Output basenames never identify a
+cleanup target. Prelaunch failures clean nothing, and a name collision
+refuses without touching the existing container. Exact-owned-container
+cleanup is recorded even after timeout or refusal, and the coordinator checks
+actual worker completion before releasing the GPU to another task.
 
 Remaining after this first campaign: an additional representative model/shape
 population with its own BF16 control; actual heldout/gold/downstream evidence
@@ -93,3 +97,15 @@ Selected files: `test_boundary_policy.py`, `test_boundary_control.py`,
 inside the bounded CPU-only pool action. These fixtures verify the policy,
 manifest and safety guards; they do not prove a Docker lifecycle or a served
 quantized population.
+
+Independent source review then found the old basename cleanup could touch an
+unrelated container after prelaunch failure. The owned-container correction
+has separate red/green evidence: action
+`d953742a3fea0d650b250951169123b2cac8d4ebdbf7ddcdc46f90a67e2476a3`
+was **5 failed, 11 deselected**, including `Failed: cleaned uncreated container
+pq87-shared-basename` and absent ownership helpers. Action
+`2383a1f48370038e91a8e2384b4e7e89b81bf909e973e75baa3bd3ea24f105a5`
+was **121 passed, 0 failed, 0 skipped**, all eight files collected and the
+same three compile checks successful, on the CPU-only population above.
+Receipt: `4eb9490f3acac4d30aa2f0dad6270df16ad9f96525aefa5bb567c02970a7b547`;
+result: `be4aeb24f9ae8fd7491f3fef903146989165206df6705d80e26c7c40a408fc5f`.

--- a/docs/experiments/pq87_quantized_validation.md
+++ b/docs/experiments/pq87_quantized_validation.md
@@ -37,6 +37,12 @@ It has its own pre/post serve/content bindings. Every HTTP response, cap step,
 server log, process I/O window and both-box Netdata series is retained. GPU
 power is recorded separately from unsupported GB10 memory-utilization metrics.
 No speed or work-per-joule claim is planned.
+An existing PPL `CheckResult(passed=False)` can mean either a real threshold
+failure or missing data. The controller retains the raw result but requires
+finite metrics for the full existing prompt roster, scored tokens and an
+explicit non-speculative observation before counting the phase as completed.
+Empty, skipped or incomparable results are inconclusive; a measured numeric
+threshold refusal remains a completed observation, not a pass.
 
 The controller refuses overlap between screen and heldout prompts, mutable
 image tags, ambiguous model identity, missing telemetry URLs and an unbounded
@@ -49,6 +55,21 @@ cleanup target. Prelaunch failures clean nothing, and a name collision
 refuses without touching the existing container. Exact-owned-container
 cleanup is recorded even after timeout or refusal, and the coordinator checks
 actual worker completion before releasing the GPU to another task.
+The proposed enclosing command is `timeout --signal=TERM --kill-after=90s
+2400s python -P experiments/pq87_paired_validation.py --manifest
+experiments/pq87_validation_manifest.json --out <fresh-absolute-output>` inside
+a deployed-pool action with `--timeout-s 2550`. GNU timeout is required: the
+outer TERM/KILL bound covers synchronous source hashing/copying too, while
+the internal deadline bounds requests and subprocesses. This is a proposed
+launch contract, not authorization or a measurement receipt.
+
+In deployed runtime `aa6d3cfa2f77`, `pool.py:2059` calls
+`cleanup_action_containers` before capacity release; its incomplete path at
+2060–2071 retains the claim/tokens. The owner cleanup at 1593–1597 removes
+only action-labelled containers and verifies the label query is empty.
+Consequently a controller's advisory rc0 is not itself evidence of capacity
+release. The coordinator still verifies the original worker's final state
+and owner cleanup before handoff; no scheduler/runtime change is made here.
 
 Remaining after this first campaign: an additional representative model/shape
 population with its own BF16 control; actual heldout/gold/downstream evidence
@@ -109,3 +130,21 @@ was **121 passed, 0 failed, 0 skipped**, all eight files collected and the
 same three compile checks successful, on the CPU-only population above.
 Receipt: `4eb9490f3acac4d30aa2f0dad6270df16ad9f96525aefa5bb567c02970a7b547`;
 result: `be4aeb24f9ae8fd7491f3fef903146989165206df6705d80e26c7c40a408fc5f`.
+
+The review also found missing PPL results could count as completed. The
+separate PPL correction first failed eight result-shape fixtures under action
+`1bbd62be5ec432ba07ec8a60b9aa91a15640ede68fe1588aea43bed62edd5c64`
+(`AttributeError` for the absent `require_ppl_measurement` guard). Two actual
+`client_phase` regressions then failed with the old unguarded PPL completion
+path: **2 failed, 24 deselected**, `Failed: DID NOT RAISE <class 'ValueError'>`
+under action
+`3a5855f81e6cd37eb602ce8218917e462ff8a0c61fa2c256c25bba2aeafb5cdb`.
+They supplied the real empty and skipped `CheckResult` shapes and observed
+the previous success return; no served endpoint was contacted.
+
+Final action
+`1226efdf25566273bfb14e7d48121a2825e3fe4421a006d757c56a8bc8b56629`
+was **131 passed, 0 failed, 0 skipped**, all eight files collected and the
+same three compile checks successful, on the CPU-only population above.
+Receipt: `d504f29de11609a0852914fa518c92e73b6191f2c7c0dca26a66f0f48184a448`;
+result: `0f425ec14cd0018d78a88eef72722993445a4ed2a4f2e8fd9c89825e43356d15`.

--- a/docs/experiments/pq87_quantized_validation.md
+++ b/docs/experiments/pq87_quantized_validation.md
@@ -1,0 +1,95 @@
+# #87 paired quantized validation plan
+
+Prepared before serving; no result is claimed. The policy implementation is
+recorded in `docs/results/pq87_paired_policy_2026-09-04.md`.
+
+The committed `experiments/pq87_validation_manifest.json` selects Qwen3-0.6B:
+shared BF16 source from the #113 input freeze and the existing native NVFP4
+reference under `tessera-runs/bf16/refs`. Read-only PrismaBuild inventory
+`74cbc51063720a960483cd2be87cedea20bf39d197500d1f9b1eb298bb51aaf8`
+found 1,503,300,328 BF16 safetensors bytes and 870,290,032 candidate bytes,
+identical `tokenizer.json` and `tokenizer_config.json` hashes, and a candidate
+build block naming the original Qwen3-0.6B with 196 NVFP4 assignments. The candidate's shipping slots
+are all unfilled: this is a materialized native candidate, not a ship-certified
+artifact. Exact weight content will be frozen and hashed before startup.
+
+One exclusive PrismaBuild action will run two sequential servers on the same
+box/image/source closure: BF16, then native compressed-tensors NVFP4. Each
+uses the instrument's explicit one sequence, 4096-token context, 1 GiB KV and
+eager settings. Docker has 28 GiB memory/swap and two CPU limits; the fleet
+reservation must be the entire physical GPU capacity plus two CPUs/32 GiB.
+The manifest's 2400-second wall deadline is an inconclusive backstop, not a
+predicted completion time. An enclosing `timeout` must retain cleanup grace.
+No GPU action may be submitted without the coordinator allocating that box.
+
+The BF16 serve derives an uncensored schedule separately for the existing
+30-pair screen and a disjoint 30-pair heldout set. Both prompt sets and seeds
+are committed before either model is observed; no candidate outcome selects
+a cap or prompt. The candidate runs the exact matched BF16 schedules. A
+refused candidate is recorded and the second population still runs. No raw
+endpoint A/B is repeated. A new source/campaign cannot silently reuse the old
+BF16-only receipt as its own control.
+
+Both live servers also run `validate_quantized_model.check_perplexity` under
+its existing bounds and prompt roster. This is the small numeric screening
+check, not gold WikiText PPL, full-vocabulary served KL, or a tool benchmark.
+It has its own pre/post serve/content bindings. Every HTTP response, cap step,
+server log, process I/O window and both-box Netdata series is retained. GPU
+power is recorded separately from unsupported GB10 memory-utilization metrics.
+No speed or work-per-joule claim is planned.
+
+The controller refuses overlap between screen and heldout prompts, mutable
+image tags, ambiguous model identity, missing telemetry URLs and an unbounded
+manifest. Original sources are never edited; copied model bytes are mounted
+read-only through both container aliases. Shutdown must leave no serving
+process before the next arm. Exact-container cleanup is recorded even after
+timeout or refusal, and the coordinator checks actual worker completion before
+releasing the GPU to another task.
+
+Remaining after this first campaign: an additional representative model/shape
+population with its own BF16 control; actual heldout/gold/downstream evidence
+sufficient for any proposed shipping-default promotion. Existing Gridbook-only
+reproduction claims remain third-party/historical and are not substituted by
+Qwen measurements. Nothing here reinstates the retired Gridbook lane or
+waives that difference in scope. #87 stays open until the agreed shipping fix
+and required evidence are complete.
+
+## Controller verification, not served validation
+
+All controller checks used deployed PrismaBuild `aa6d3cfa2f77`, Sparky with
+one CPU/4 GiB, `CUDA_VISIBLE_DEVICES=''`, and all three BLAS/OMP thread limits
+set to one. The serial eight-file population collected every selected module,
+with zero skips or collection errors. No master baseline or full suite ran.
+As for the policy receipt, the three unused absolute calibration symlinks
+were excluded only during snapshot sealing, then immediately restored.
+
+Before implementing the controller, action
+`220734d546405ba7811ab1b61a683c24e7a9421979e773fc41be0bd15caf9b60`
+was **8 failed** with `ModuleNotFoundError: No module named
+'experiments.pq87_paired_validation'`. Before adding physical-admission and
+PPL binding guards, action
+`41e866101a125f3087b962ea99b0f49f6d9bd88a8f7a9223cff82a7ceff37150`
+was **3 failed, 8 deselected**: `Failed: CPU action reached physical
+preparation`, and two missing-`require_ppl_binding` `AttributeError`s.
+Both red wrappers returned success only for pytest status 1; neither is a
+green test claim. A later submission named a nonexistent test file and
+collected nothing; that command error supplies no test evidence.
+
+Final action
+`28a6956f4ef3bc1e9a5203535b0e22e787a67d1c23f9f623f4f4fc1a56321681`
+observed **116 passed, 0 failed, 0 skipped**, plus successful compilation of
+`boundary_control.py`, `measure_boundary_control.py` and this controller.
+Receipt SHA-256:
+`a0220f3c9e8ffb3c217e7e9254108251616b61fa08148e34a30e4067fc6ff99d`.
+Result blob:
+`4b7b4b008403cac3dda1a2341bfa0d985441a79289c6c198f8915acd124420d2`.
+
+Selected files: `test_boundary_policy.py`, `test_boundary_control.py`,
+`test_measure_boundary_control_identity.py`, `test_pq87_physical_ab.py`,
+`test_pq87_paired_validation.py`, `test_ship_boundary_behavior.py`,
+`test_docs_staleness.py`, and `test_architecture_doc.py`. The command was
+`python -m pytest -q -ra --tb=short -p no:cacheprovider` with those eight
+`tests/` paths, followed by `python -m py_compile` on the three modules,
+inside the bounded CPU-only pool action. These fixtures verify the policy,
+manifest and safety guards; they do not prove a Docker lifecycle or a served
+quantized population.

--- a/docs/results/pq87_paired_policy_2026-09-04.md
+++ b/docs/results/pq87_paired_policy_2026-09-04.md
@@ -1,0 +1,64 @@
+# #87: opt-in paired no-new-boundary-failures policy
+
+The chosen rule is `prismaquant.no_new_boundary_failures/1`, implemented as
+an opt-in decision over the existing paired instrument. This is a policy
+implementation receipt, not a quantized-artifact measurement or a promotion
+of the production gate.
+
+`tools/measure_boundary_control.py candidate --decision-policy no-new-failures`
+records the optional decision after measuring the candidate. Accepted exits
+0; refused exits 2. Without the flag the original advisory comparison remains
+unchanged. No shipcard slot or production threshold moves.
+
+The decision first replays the exact control and candidate measurements:
+prompt/seed order, source/content bindings, same runtime/campaign/host,
+tokenization, the control's cap-growth stopping rule, raw outcomes and scores.
+It then compares defect-kind sets on each matched pair. New defects on a
+formerly clean pair refuse, as does any new kind on an already-broken pair.
+Repairs cannot offset newly broken samples, even in the same stratum. Existing
+control defects can persist or disappear. Candidate truncation at the valid
+control cap is a measured defect; a censored control is inconclusive.
+
+The offline decision replay recomputes every field, including the policy ID,
+violation list and counts. Canonical JSON comparison also refuses coercions
+such as integer `0` to boolean `false`; Python object equality alone cannot
+distinguish them.
+
+## PrismaBuild evidence
+
+All actions used frozen deployed runtime `aa6d3cfa2f77`, Sparky with one CPU
+and 4 GiB, no GPU reservation and `CUDA_VISIBLE_DEVICES=''`. These are serial
+CPU fixtures, not CUDA coverage. Each named module collected; zero skips and
+zero collection errors in the final population. The three unused absolute
+calibration symlinks were excluded only while sealing each immutable snapshot
+and restored immediately afterward; their removals were not committed.
+
+| Evidence | Action | Observed result |
+| --- | --- | --- |
+| Policy absent, before implementation | `104fcc9e2cd6d09eaab27a8dff91a6b9f799120daa23ece339591079961ad806` | 18 failed: `AttributeError: module 'prismaquant.boundary_control' has no attribute 'decide_no_new_failures'` |
+| Real CLI before optional argument | `acc7237eb6eedaf57f015468e10223296e2012ee89258b0de9e8cb926f477925` | 2 failed, 18 deselected: `unrecognized arguments: --decision-policy no-new-failures` |
+| Strict receipt counter types before correction | `5c55d41d4d14bccf101a8577b01bebf32b59549f38940ca79f0ed794b2ef00b0` | 2 failed, 20 deselected: `Failed: DID NOT RAISE <class 'ValueError'>` |
+| Final seven-module population and compile | `bfebe89b876b6bab4bb4b5fb27717df2483d112be549eb7a43179f0daf46042f` | 105 passed, 0 failed, 0 skipped; compilation succeeded |
+
+The red wrappers returned success only when pytest exited 1, preventing the
+pool from retrying an expected failure. They are red test evidence, not green
+test runs. Final receipt SHA-256:
+`f3cd6012edb901c2570f8d22756e9b9e2fbb6726fadf8e06e763facb2a5ea5d3`.
+Final result blob:
+`966227b799e5bdc102f3f7b0fea39fbaeac8c42a6d92f6b6e2e3c7b01b87604f`.
+
+The selected modules were `test_boundary_policy.py`, `test_boundary_control.py`,
+`test_measure_boundary_control_identity.py`, `test_pq87_physical_ab.py`,
+`test_ship_boundary_behavior.py`, `test_docs_staleness.py`, and
+`test_architecture_doc.py`. No master baseline or full suite was run.
+
+## Remaining validation
+
+The existing Qwen3-0.6B BF16 A/B establishes that the old 64-token cap
+censored this population; it does not establish quantized discrimination.
+A fresh matched BF16/quantized campaign must freeze its artifact identities
+and disjoint held-out prompts before serving. The completed raw/chat64
+instrument characterization need not be repeated. Held-out/downstream checks
+and an additional representative population remain prerequisites for any
+default promotion. A prior receipt from a different source closure or campaign
+cannot be reused as if it were that campaign's BF16 control. #87 remains open.

--- a/experiments/pq87_paired_validation.py
+++ b/experiments/pq87_paired_validation.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 from dataclasses import asdict
 import json
+import math
 import os
 from pathlib import Path
 import re
@@ -75,6 +76,26 @@ def require_ppl_binding(before, model, nonce):
         raise ValueError("PPL requires readable live residency and serve session")
     if Path(before["model"]).resolve() != Path(model).resolve() or before["models_endpoint_binding"]["model"]["id"] != nonce:
         raise ValueError("PPL source differs from observed server")
+
+
+def require_ppl_measurement(result, prompt_count):
+    """A measured threshold refusal is data; missing/skipped logprobs are not."""
+    metrics = result.metrics
+    if (result.name != "perplexity" or type(result.passed) is not bool
+            or not isinstance(metrics, dict) or metrics.get("skipped", False) is not False
+            or metrics.get("spec_decode_detected") is not False):
+        raise ValueError("PPL measurement is missing, skipped, or speculative")
+    per_prompt = metrics.get("per_prompt_avg_nll")
+    tokens = metrics.get("n_tokens")
+    if (not isinstance(per_prompt, list) or len(per_prompt) != prompt_count
+            or type(tokens) is not int or tokens < prompt_count):
+        raise ValueError("PPL measurement does not cover the full prompt roster with scored tokens")
+    values = [metrics.get(key) for key in ("perplexity", "mean_nll_per_tok",
+                                          "p99_nll_per_tok", "max_nll_per_tok")]
+    if (any(type(value) not in (int, float) or not math.isfinite(value) or value < 0
+            for value in values + per_prompt) or values[0] <= 0):
+        raise ValueError("PPL measurement has missing or nonfinite numeric metrics")
+    return result
 
 
 def require_container_name_available(name):
@@ -163,6 +184,10 @@ def client_phase(args):
             require_ppl_binding(before, model, args.nonce)
             result = bc.vqm.check_perplexity("http://127.0.0.1:8187", args.nonce,
                 bc.vqm.DEFAULT_MAX_PPL, bc.vqm.DEFAULT_MAX_P99_NLL, bc.vqm.DEFAULT_MAX_MEAN_NLL)
+            # Preserve even incomplete results as evidence, but never call an
+            # empty/skipped CheckResult a completed numeric observation.
+            instrument.dump(Path(prefix + "-result.json"), asdict(result))
+            require_ppl_measurement(result, len(bc.vqm.EVAL_PROMPTS))
             after = sf.collect_manifest(image=manifest["image"], base_url="http://127.0.0.1:8187", attestation_phase="post")
             require_ppl_binding(after, model, args.nonce)
             after_content, after_stats = bound_capture(model)

--- a/experiments/pq87_paired_validation.py
+++ b/experiments/pq87_paired_validation.py
@@ -20,6 +20,7 @@ import sys
 import threading
 import time
 from urllib.parse import urlsplit
+import uuid
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import pq87_physical_ab as instrument
@@ -74,6 +75,47 @@ def require_ppl_binding(before, model, nonce):
         raise ValueError("PPL requires readable live residency and serve session")
     if Path(before["model"]).resolve() != Path(model).resolve() or before["models_endpoint_binding"]["model"]["id"] != nonce:
         raise ValueError("PPL source differs from observed server")
+
+
+def require_container_name_available(name):
+    result = subprocess.run(["docker", "inspect", name], stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT, text=True, timeout=10)
+    if result.returncode == 0:
+        raise ValueError("validation container name already exists")
+    if not any(f"no such {kind}: {name}" in result.stdout.lower() for kind in ("object", "container")):
+        raise ValueError("cannot establish validation container name is unused")
+
+
+def cleanup_owned_container(cidfile, name, owner, nonce, *, attempted):
+    """Never stop by a potentially borrowed name, even after failed creation."""
+    evidence = {"safe": not attempted, "commands": [], "attempted": attempted}
+    if not attempted:
+        return evidence
+    try:
+        cid = cidfile.read_text().strip()
+        if not re.fullmatch(r"[0-9a-f]{64}", cid):
+            raise ValueError("Docker did not publish an exact container ID")
+        inspected = subprocess.run(["docker", "inspect", cid], stdout=subprocess.PIPE,
+                                   stderr=subprocess.STDOUT, text=True, timeout=10)
+        evidence["commands"].append({"argv": ["docker", "inspect", cid],
+            "returncode": inspected.returncode, "output": inspected.stdout})
+        if inspected.returncode != 0:
+            if any(f"no such {kind}: {cid}" in inspected.stdout.lower() for kind in ("object", "container")):
+                evidence["safe"] = True
+                return evidence
+            raise ValueError("cannot inspect created container")
+        observed = json.loads(inspected.stdout)[0]
+        labels = observed.get("Config", {}).get("Labels") or {}
+        if (observed.get("Id") != cid or observed.get("Name") != "/" + name
+                or labels.get("prismabuild.action") != owner
+                or labels.get("prismaquant.pq87.campaign") != nonce):
+            raise ValueError("created container ownership differs")
+        cleanup = instrument.cleanup_container(cid)
+        evidence["commands"].extend(cleanup["commands"])
+        evidence.update(safe=cleanup["safe"], container_id=cid)
+    except Exception as exc:
+        evidence["error"] = repr(exc)
+    return evidence
 
 
 def _interrupt(_signal, _frame):
@@ -234,8 +276,13 @@ def host(args):
     out.mkdir(parents=True, exist_ok=False)
     deadline = time.monotonic() + manifest["deadline_seconds"]
     signal.signal(signal.SIGTERM, _interrupt)
-    container = "pq87-" + out.name
+    owner = os.environ["PRISMABUILD_CONTAINER_OWNER"]
+    ownership_nonce = uuid.uuid4().hex
+    container = "pq87-" + owner[:16] + "-" + ownership_nonce
+    cidfile = out / "container.cid"
+    creation_attempted = False
     status = {"status": "inconclusive", "advisory_only": True, "started": time.time(),
+        "container_ownership": {"name": container, "action": owner, "nonce": ownership_nonce},
         "manifest_sha256": bc.digest(manifest), "source_snapshot": subprocess.check_output(
             ["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()}
     instrument.dump(out / "manifest.json", manifest)
@@ -287,7 +334,9 @@ def host(args):
         for directory in ("tmp", "triton", "inductor", "vllm-cache"):
             (out / directory).mkdir()
         threading.Thread(target=telemetry, daemon=True).start()
-        command = ["docker", "run", "--rm", "--pull=never", "--name", container,
+        require_container_name_available(container)
+        command = ["docker", "run", "--pull=never", "--name", container,
+            "--cidfile", str(cidfile), "--label", "prismaquant.pq87.campaign=" + ownership_nonce,
             "--gpus", "all", "--memory=28g", "--memory-swap=28g", "--cpus=2", "--shm-size=1g",
             "--network=host", "--cap-add=SYS_PTRACE", "--security-opt=seccomp=unconfined",
             "-v", f"{root}:/repo:ro", "-v", f"{out}:/run", "-v", f"{out / 'models'}:/models:ro",
@@ -302,6 +351,7 @@ def host(args):
         status["docker_argv"] = command
         instrument.dump(out / "campaign.json", status)
         with (out / "container.log").open("x") as log:
+            creation_attempted = True
             subprocess.run(command, stdout=log, stderr=subprocess.STDOUT,
                            timeout=instrument.remaining(deadline), check=True)
         status["inside"] = json.loads((out / "inside-status.json").read_text())
@@ -310,7 +360,8 @@ def host(args):
         status["error"] = repr(exc)
     finally:
         stop.set()
-        status["cleanup"] = instrument.cleanup_container(container)
+        status["cleanup"] = cleanup_owned_container(cidfile, container, owner, ownership_nonce,
+                                                     attempted=creation_attempted)
         if not status["cleanup"]["safe"]:
             status["status"] = "inconclusive"
         status["finished"] = time.time()

--- a/experiments/pq87_paired_validation.py
+++ b/experiments/pq87_paired_validation.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Frozen sequential native BF16/quantized validation, only through PrismaBuild.
+
+Reuses the instrument's server configuration, content guard, cleanup and
+measurement client. Screen and disjoint heldout schedules are inputs, never
+selected after reading a candidate. A completed run is not a ship decision.
+"""
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import time
+from urllib.parse import urlsplit
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import pq87_physical_ab as instrument
+
+
+def validate_manifest(value):
+    from prismaquant import boundary_control as bc
+    if not isinstance(value, dict) or set(value) != {
+        "schema", "image", "models", "contracts", "deadline_seconds", "netdata_urls"
+    } or value["schema"] != "prismaquant.boundary_validation/1":
+        raise ValueError("validation manifest fields differ from schema")
+    if not isinstance(value["image"], str) or not re.fullmatch(r"[^\s@]+@sha256:[0-9a-f]{64}", value["image"]):
+        raise ValueError("validation image must be an immutable digest")
+    models = value["models"]
+    if (not isinstance(models, dict) or set(models) != {"control", "candidate"}
+            or any(not isinstance(path, str) or not Path(path).is_absolute() for path in models.values())
+            or models["control"] == models["candidate"]):
+        raise ValueError("validation requires distinct explicit control/candidate model paths")
+    contracts = value["contracts"]
+    if not isinstance(contracts, dict) or set(contracts) != {"screen", "heldout"}:
+        raise ValueError("validation requires screen and heldout contracts")
+    for contract in contracts.values():
+        bc.validate_contract(contract)
+    if {p["text"] for p in contracts["screen"]["prompts"]} & {
+            p["text"] for p in contracts["heldout"]["prompts"]}:
+        raise ValueError("screen and heldout prompts overlap")
+    if type(value["deadline_seconds"]) is not int or value["deadline_seconds"] <= 0:
+        raise ValueError("deadline_seconds must be a positive integer")
+    urls = value["netdata_urls"]
+    if not isinstance(urls, list) or len(urls) != 2 or len(set(urls)) != 2:
+        raise ValueError("declare both distinct box telemetry URLs")
+    for url in urls:
+        parsed = urlsplit(url)
+        if parsed.scheme != "http" or not parsed.hostname or parsed.username or parsed.password or parsed.query:
+            raise ValueError("invalid Netdata URL")
+    return value
+
+
+def server_argv(nonce, model):
+    argv = instrument.server_argv(nonce)
+    argv[argv.index("serve") + 1] = model
+    return argv
+
+
+def completed_candidate(receipt, returncode):
+    verdict = receipt.get("decision", {}).get("verdict")
+    return (verdict == "accepted" and returncode == 0) or (verdict == "refused" and returncode == 2)
+
+
+def require_ppl_binding(before, model, nonce):
+    if not before.get("residency_readable") or not before.get("serve_session_id"):
+        raise ValueError("PPL requires readable live residency and serve session")
+    if Path(before["model"]).resolve() != Path(model).resolve() or before["models_endpoint_binding"]["model"]["id"] != nonce:
+        raise ValueError("PPL source differs from observed server")
+
+
+def _interrupt(_signal, _frame):
+    raise TimeoutError("paired validation terminated")
+
+
+def client_phase(args):
+    root, client, bc = instrument.bootstrap()
+    import serve_fingerprint as sf
+    manifest = json.loads(Path("/run/manifest.json").read_text())
+    model = f"/models/{args.role}"
+    expected = json.loads(Path(f"/run/prelaunch-{args.role}.json").read_text())["content"]
+    capture = client._capture_artifact
+    def bound_capture(model_dir):
+        content, stats = capture(model_dir)
+        instrument.require_frozen_content(expected, content)
+        return content, stats
+    client._capture_artifact = bound_capture
+    client.activate_prismaquant_source = lambda: root
+    client._install_exact_package_namespace = lambda _root: None
+    prefix = f"/run/{args.role}-{args.population}"
+    post, step = bc.vqm._post_json, bc.measure_step
+    with open(prefix + "-http.jsonl", "x", buffering=1) as journal, open(
+            prefix + "-steps.jsonl", "x", buffering=1) as steps:
+        def recorded(url, body):
+            row = {"url": url, "request": body, "started": time.time()}
+            try:
+                response = post(url, body)
+                row["response"] = response
+                return response
+            except BaseException as exc:
+                row["error"] = repr(exc)
+                raise
+            finally:
+                row["finished"] = time.time()
+                journal.write(json.dumps(row, ensure_ascii=False, allow_nan=False) + "\n")
+        def recorded_step(*pos, **kwargs):
+            result = step(*pos, **kwargs)
+            steps.write(json.dumps(result, ensure_ascii=False, allow_nan=False) + "\n")
+            return result
+        bc.vqm._post_json, bc.measure_step = recorded, recorded_step
+        if args.population == "ppl":
+            before = sf.collect_manifest(image=manifest["image"], base_url="http://127.0.0.1:8187", attestation_phase="pre")
+            content, stats = bound_capture(model)
+            require_ppl_binding(before, model, args.nonce)
+            result = bc.vqm.check_perplexity("http://127.0.0.1:8187", args.nonce,
+                bc.vqm.DEFAULT_MAX_PPL, bc.vqm.DEFAULT_MAX_P99_NLL, bc.vqm.DEFAULT_MAX_MEAN_NLL)
+            after = sf.collect_manifest(image=manifest["image"], base_url="http://127.0.0.1:8187", attestation_phase="post")
+            require_ppl_binding(after, model, args.nonce)
+            after_content, after_stats = bound_capture(model)
+            if content != after_content or stats != after_stats or any(before[key] != after[key]
+                    for key in ("serve_session_id", "performance_stack_fingerprint", "models_endpoint_binding")):
+                raise ValueError("PPL measurement source or server changed")
+            instrument.dump(Path(prefix + ".json"), {"schema": "prismaquant.boundary_ppl_screen/1",
+                "advisory_only": True, "artifact_id": bc.artifact_content_id(content),
+                "serve_pre": before, "serve_post": after, "result": asdict(result)})
+            return 0
+        argv = [args.role, "--base-url", "http://127.0.0.1:8187", "--model-name", args.nonce,
+                "--model-dir", model, "--image", manifest["image"], "--campaign-id", args.nonce,
+                "--out", prefix + ".json"]
+        argv += (["--contract", f"/run/{args.population}-contract.json"] if args.role == "control" else
+                 ["--control", f"/run/control-{args.population}.json", "--decision-policy", "no-new-failures"])
+        return client.main(argv)
+
+
+def inside(args):
+    _root, _client, _bc = instrument.bootstrap()
+    import serve_fingerprint as sf
+    manifest = validate_manifest(json.loads(Path("/run/manifest.json").read_text()))
+    deadline = time.monotonic() + args.seconds
+    signal.signal(signal.SIGTERM, _interrupt)
+    status = {"status": "inconclusive", "advisory_only": True, "started": time.time(), "phases": {}}
+    stop = threading.Event()
+    def profile():
+        with open("/run/process-io.jsonl", "x", buffering=1) as log:
+            while not stop.is_set():
+                row = {"time": time.time(), "processes": []}
+                for pid in sf.find_server_pids():
+                    try:
+                        row["processes"].append({"pid": pid, "io": Path(f"/proc/{pid}/io").read_text(),
+                            "stat": Path(f"/proc/{pid}/stat").read_text(), "status": Path(f"/proc/{pid}/status").read_text()})
+                    except OSError as exc:
+                        row["processes"].append({"pid": pid, "error": repr(exc)})
+                log.write(json.dumps(row) + "\n")
+                stop.wait(10)
+    monitor = threading.Thread(target=profile, daemon=True)
+    monitor.start()
+    server = None
+    try:
+        for role in ("control", "candidate"):
+            if sf.find_server_pids():
+                raise ValueError("a server remained before the next sequential model arm")
+            role_status = status["phases"][role] = {"argv": server_argv(args.nonce, f"/models/{role}")}
+            with open(f"/run/server-{role}.log", "x") as log:
+                server = subprocess.Popen(role_status["argv"], stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+                while True:
+                    instrument.remaining(deadline)
+                    if server.poll() is not None:
+                        raise RuntimeError(f"{role} server exited {server.returncode}")
+                    try:
+                        instrument._http("http://127.0.0.1:8187/health")
+                        break
+                    except Exception:
+                        time.sleep(min(1, instrument.remaining(deadline)))
+                for raw in (True, False):
+                    body = {"model": args.nonce, "max_tokens": 1, "temperature": 0,
+                            **({"prompt": "Warm up."} if raw else {"messages": [{"role": "user", "content": "Warm up."}]})}
+                    endpoint = "completions" if raw else "chat/completions"
+                    instrument.dump(Path(f"/run/warm-{role}-{raw}.json"), instrument._http(
+                        "http://127.0.0.1:8187/v1/" + endpoint, body, timeout=min(60, instrument.remaining(deadline))))
+                for population in ("screen", "heldout", "ppl"):
+                    instrument.dump(Path("/run/inside-status.json"), status)
+                    with open(f"/run/{role}-{population}-client.log", "x") as client_log:
+                        result = subprocess.run([sys.executable, "-P", __file__, "--client", "--role", role,
+                            "--population", population, "--nonce", args.nonce], stdout=client_log,
+                            stderr=subprocess.STDOUT, timeout=instrument.remaining(deadline))
+                    path = Path(f"/run/{role}-{population}.json")
+                    receipt = json.loads(path.read_text()) if path.exists() else {}
+                    role_status[population] = {"returncode": result.returncode,
+                        "decision": receipt.get("decision"), "ppl": receipt.get("result")}
+                    if role == "candidate" and population != "ppl":
+                        observed = completed_candidate(receipt, result.returncode)
+                    else:
+                        observed = bool(receipt) and result.returncode == 0
+                    if not observed:
+                        raise RuntimeError(f"{role}/{population} did not produce a complete comparable observation")
+                os.killpg(server.pid, signal.SIGTERM)
+                server.wait(timeout=min(20, instrument.remaining(deadline)))
+                server = None
+                # The subsequent arm must not coexist with an orphaned engine.
+                if sf.find_server_pids():
+                    raise ValueError(f"{role} left a serving process after shutdown")
+        status["status"] = "completed"
+    except BaseException as exc:
+        status["error"] = repr(exc)
+    finally:
+        stop.set()
+        if server is not None and server.poll() is None:
+            os.killpg(server.pid, signal.SIGTERM)
+            try:
+                server.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                os.killpg(server.pid, signal.SIGKILL)
+                server.wait(timeout=5)
+        status["finished"] = time.time()
+        instrument.dump(Path("/run/inside-status.json"), status)
+    return 0  # The receipt carries refusal/inconclusive; the pool must not retry observations.
+
+
+def host(args):
+    if not os.environ.get("PRISMABUILD_CONTAINER_OWNER"):
+        raise ValueError("physical validation must be dispatched through PrismaBuild")
+    if os.environ.get("CUDA_VISIBLE_DEVICES") == "":
+        raise ValueError("physical validation requires an allocated GPU, not a CPU-only pool action")
+    root, client, bc = instrument.bootstrap()
+    manifest = validate_manifest(json.loads(Path(args.manifest).read_text()))
+    out = Path(args.out).resolve()
+    out.mkdir(parents=True, exist_ok=False)
+    deadline = time.monotonic() + manifest["deadline_seconds"]
+    signal.signal(signal.SIGTERM, _interrupt)
+    container = "pq87-" + out.name
+    status = {"status": "inconclusive", "advisory_only": True, "started": time.time(),
+        "manifest_sha256": bc.digest(manifest), "source_snapshot": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()}
+    instrument.dump(out / "manifest.json", manifest)
+    stop = threading.Event()
+    def telemetry():
+        with (out / "telemetry.jsonl").open("x", buffering=1) as log:
+            while not stop.is_set():
+                row = {"time": time.time(), "meminfo": Path("/proc/meminfo").read_text()}
+                try:
+                    row["gpu_power_w"] = subprocess.check_output(["nvidia-smi", "--query-gpu=power.draw",
+                        "--format=csv,noheader,nounits"], text=True, timeout=3).strip()
+                except Exception as exc:
+                    row["gpu_power_error"] = repr(exc)
+                for url in manifest["netdata_urls"]:
+                    try:
+                        row[url] = instrument._http(url.rstrip("/") + "/api/v1/allmetrics?format=json", timeout=2)
+                    except Exception as exc:
+                        row[url] = {"error": repr(exc)}
+                log.write(json.dumps(row) + "\n")
+                stop.wait(10)
+    try:
+        inspected = json.loads(subprocess.check_output(["docker", "image", "inspect", manifest["image"]],
+            text=True, timeout=min(10, instrument.remaining(deadline))))[0]
+        if manifest["image"] not in inspected.get("RepoDigests", []):
+            raise ValueError("Docker image lacks the requested immutable digest")
+        instrument.dump(out / "image.json", inspected)
+        for role, model in manifest["models"].items():
+            instrument.remaining(deadline)
+            config = json.loads((Path(model) / "config.json").read_text())
+            if role == "control":
+                bc.require_bf16_control(config, "bfloat16", None)
+            elif (config.get("quantization_config") or {}).get("quant_method") != "compressed-tensors":
+                raise ValueError("this first validation manifest requires a native compressed-tensors candidate")
+            before, stats = client._capture_artifact(model)
+            frozen = out / "models" / role
+            shutil.copytree(model, frozen)
+            content, _ = client._capture_artifact(frozen)
+            after, after_stats = client._capture_artifact(model)
+            instrument.require_frozen_content(before, content)
+            if before != after or stats != after_stats:
+                raise ValueError("source changed while freezing")
+            instrument.dump(out / f"prelaunch-{role}.json", {"content": content,
+                "artifact_id": bc.artifact_content_id(content), "source_stats": stats, "captured": time.time()})
+            for path in frozen.rglob("*"):
+                path.chmod(0o555 if path.is_dir() else 0o444)
+            frozen.chmod(0o555)
+        for population, contract in manifest["contracts"].items():
+            instrument.dump(out / f"{population}-contract.json", contract)
+        for directory in ("tmp", "triton", "inductor", "vllm-cache"):
+            (out / directory).mkdir()
+        threading.Thread(target=telemetry, daemon=True).start()
+        command = ["docker", "run", "--rm", "--pull=never", "--name", container,
+            "--gpus", "all", "--memory=28g", "--memory-swap=28g", "--cpus=2", "--shm-size=1g",
+            "--network=host", "--cap-add=SYS_PTRACE", "--security-opt=seccomp=unconfined",
+            "-v", f"{root}:/repo:ro", "-v", f"{out}:/run", "-v", f"{out / 'models'}:/models:ro",
+            "-v", f"{out / 'models'}:/run/models:ro",
+            "-e", "SPT_NOENV=1", "-e", "OMP_NUM_THREADS=2", "-e", "OPENBLAS_NUM_THREADS=2", "-e", "MKL_NUM_THREADS=2",
+            "-e", "TMPDIR=/run/tmp", "-e", "TRITON_CACHE_DIR=/run/triton", "-e", "TORCHINDUCTOR_CACHE_DIR=/run/inductor",
+            "-e", "VLLM_CACHE_ROOT=/run/vllm-cache", "-e", "HF_HUB_OFFLINE=1", "-e", "PYTHONSAFEPATH=1",
+            "-e", "PYTHONDONTWRITEBYTECODE=1", "-e", "PYTHONNOUSERSITE=1", "-e", "PQ_RUNTIME_PRISMAQUANT_ROOT=/repo",
+            "--entrypoint", "/usr/bin/env", manifest["image"], "-u", "PYTHONPATH", "python3", "-P",
+            "/repo/experiments/pq87_paired_validation.py", "--inside", "--seconds",
+            str(max(1, int(instrument.remaining(deadline)) - 30)), "--nonce", out.name]
+        status["docker_argv"] = command
+        instrument.dump(out / "campaign.json", status)
+        with (out / "container.log").open("x") as log:
+            subprocess.run(command, stdout=log, stderr=subprocess.STDOUT,
+                           timeout=instrument.remaining(deadline), check=True)
+        status["inside"] = json.loads((out / "inside-status.json").read_text())
+        status["status"] = status["inside"]["status"]
+    except BaseException as exc:
+        status["error"] = repr(exc)
+    finally:
+        stop.set()
+        status["cleanup"] = instrument.cleanup_container(container)
+        if not status["cleanup"]["safe"]:
+            status["status"] = "inconclusive"
+        status["finished"] = time.time()
+        instrument.dump(out / "campaign.json", status)
+        print(json.dumps({"out": str(out), **status}), flush=True)
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest")
+    parser.add_argument("--out")
+    parser.add_argument("--inside", action="store_true")
+    parser.add_argument("--client", action="store_true")
+    parser.add_argument("--role", choices=("control", "candidate"))
+    parser.add_argument("--population", choices=("screen", "heldout", "ppl"))
+    parser.add_argument("--nonce")
+    parser.add_argument("--seconds", type=int)
+    args = parser.parse_args()
+    if args.client:
+        return client_phase(args)
+    if args.inside:
+        return inside(args)
+    if not args.manifest or not args.out:
+        parser.error("host invocation requires --manifest and --out")
+    return host(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/pq87_validation_manifest.json
+++ b/experiments/pq87_validation_manifest.json
@@ -1,0 +1,38 @@
+{
+  "schema": "prismaquant.boundary_validation/1",
+  "image": "eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c",
+  "models": {
+    "control": "/mnt/shared/tessera-runs/ts113-fresh-sparklina-aa6-r1/inputs/bf16",
+    "candidate": "/mnt/shared/tessera-runs/bf16/refs/qwen3-0.6b-nvfp4"
+  },
+  "contracts": {
+    "screen": {
+      "prompts": [
+        {"text": "144÷12", "stratum": "numeric"},
+        {"text": "9²", "stratum": "numeric"},
+        {"text": "How many legs does a spider have?", "stratum": "terse_qa"},
+        {"text": "What is 7×8?", "stratum": "numeric"},
+        {"text": "Name the capital of France.", "stratum": "short_recall"}
+      ],
+      "seeds": [0, 1, 2, 3, 4, 5],
+      "temperature": 1.0,
+      "initial_max_tokens": 64,
+      "max_steps": 11
+    },
+    "heldout": {
+      "prompts": [
+        {"text": "13×7", "stratum": "numeric"},
+        {"text": "121÷11", "stratum": "numeric"},
+        {"text": "What do bees collect from flowers?", "stratum": "terse_qa"},
+        {"text": "How many minutes are there in three hours?", "stratum": "numeric"},
+        {"text": "Name the largest planet in our Solar System.", "stratum": "short_recall"}
+      ],
+      "seeds": [0, 1, 2, 3, 4, 5],
+      "temperature": 1.0,
+      "initial_max_tokens": 64,
+      "max_steps": 11
+    }
+  },
+  "deadline_seconds": 2400,
+  "netdata_urls": ["http://sparky:19999", "http://sparklina:19999"]
+}

--- a/prismaquant/boundary_control.py
+++ b/prismaquant/boundary_control.py
@@ -1,9 +1,11 @@
-"""Opt-in paired boundary measurement; deliberately not a shipping verdict.
+"""Paired boundary measurement and an opt-in, non-default acceptance policy.
 
 The BF16 control determines a finishing budget for a frozen prompt/seed
 schedule. A token or iteration bound is an inconclusive stop, never proof of
 convergence. Candidate and control are then compared at the identical cap.
 This module reuses the shipping probe's HTTP, response and scoring contracts.
+The separately versioned no-new-failures decision rejects new defect kinds
+on each matched pair. It does not replace the production shipping gate.
 """
 from __future__ import annotations
 
@@ -17,6 +19,8 @@ from prismaquant import validate_quantized_model as vqm
 
 SCHEMA = "prismaquant.boundary_control/1"
 SCORER = "prismaquant.boundary_close_count/1"
+DECISION_SCHEMA = "prismaquant.boundary_decision/1"
+NO_NEW_FAILURES_POLICY = "prismaquant.no_new_boundary_failures/1"
 
 
 def digest(value):
@@ -305,3 +309,66 @@ def compare(control, candidate):
     return {"schema": "prismaquant.boundary_comparison/1", "advisory_only": True,
             "control_sha256": digest(control), "candidate_sha256": digest(candidate),
             "max_tokens": cap, "strata": strata}
+
+
+def decide_no_new_failures(control, candidate):
+    """Apply the opt-in paired rule only after replaying comparable evidence.
+
+    A repair never offsets a new failure, even within one stratum. Existing
+    BF16 defects may persist or disappear; introducing a new kind on that
+    same prompt/seed refuses. A censored candidate is a measured new defect,
+    whereas a censored control supplies no valid comparison and is
+    inconclusive. This policy is not an estimator of a population failure
+    probability and does not change a production default.
+    """
+    result = {"schema": DECISION_SCHEMA, "policy": NO_NEW_FAILURES_POLICY,
+              "advisory_only": True, "verdict": "inconclusive", "reason": "",
+              "control_sha256": None, "candidate_sha256": None,
+              "pair_count": 0, "max_tokens": None, "newly_broken_pairs": 0,
+              "new_defect_kind_pairs": 0, "violations": []}
+    try:
+        if not isinstance(control, dict) or not isinstance(candidate, dict):
+            raise ValueError("both control and candidate measurement receipts are required")
+        comparison = compare(control, candidate)
+    except (ValueError, TypeError, KeyError, AttributeError, IndexError) as exc:
+        # Malformed serialized evidence is no measurement. Do not coerce a
+        # missing count to zero or accept an asserted fixed-point flag.
+        result["reason"] = f"paired evidence is incomplete or incomparable: {exc}"
+        return result
+    result.update(control_sha256=comparison["control_sha256"],
+                  candidate_sha256=comparison["candidate_sha256"],
+                  max_tokens=comparison["max_tokens"])
+    controls = control["steps"][-1]["outcomes"]
+    candidates = candidate["step"]["outcomes"]
+    result["pair_count"] = len(controls)
+    for reference, observed in zip(controls, candidates):
+        before, after = set(reference["score"]["defects"]), set(observed["score"]["defects"])
+        introduced = after - before
+        if not introduced:
+            continue
+        result["newly_broken_pairs" if not before else "new_defect_kind_pairs"] += 1
+        result["violations"].append({
+            "prompt_index": observed["prompt_index"], "seed": observed["seed"],
+            "stratum": control["contract"]["prompts"][observed["prompt_index"]]["stratum"],
+            "control_defects": sorted(before), "candidate_defects": sorted(after),
+            "new_defects": sorted(introduced),
+        })
+    result["verdict"] = "refused" if result["violations"] else "accepted"
+    result["reason"] = ("candidate introduced new defects on matched prompt/seed pairs"
+                        if result["violations"] else
+                        "no new defect kind on any matched prompt/seed pair")
+    return result
+
+
+def replay_no_new_failures(decision, control, candidate):
+    """Recompute the complete decision; a stored passed/verdict bit is not evidence."""
+    expected = decide_no_new_failures(control, candidate)
+    # Python equality coerces 0/False and 2/2.0. A versioned JSON receipt must
+    # retain the actual counter/boolean types as well as their values.
+    try:
+        matches = digest(decision) == digest(expected)
+    except (TypeError, ValueError):
+        matches = False
+    if not matches:
+        raise ValueError("boundary decision differs from replayed paired policy")
+    return expected

--- a/prismaquant/boundary_control.py
+++ b/prismaquant/boundary_control.py
@@ -74,7 +74,8 @@ def require_bf16_control(config, live_dtype, live_quantization, *, launch_argv=N
         raise ValueError("BF16 control requires BF16 source and observed BF16/auto unquantized serve")
 
 
-def _validate(contract, binding):
+def validate_contract(contract):
+    """Validate the frozen schedule before a controller starts any server."""
     if not isinstance(contract, dict) or set(contract) != {
         "prompts", "seeds", "temperature", "initial_max_tokens", "max_steps"
     }:
@@ -97,6 +98,12 @@ def _validate(contract, binding):
         raise ValueError("temperature must be finite and positive")
     _positive(contract["initial_max_tokens"], "initial_max_tokens")
     _positive(contract["max_steps"], "max_steps")
+    return contract
+
+
+def _validate(contract, binding):
+    validate_contract(contract)
+    prompts = contract["prompts"]
     for field in ("campaign_id", "artifact_id", "serve_session_id",
                   "serve_fingerprint", "host_boot_id", "producer_source_sha256"):
         if not isinstance(binding.get(field), str) or not binding[field].strip():

--- a/tests/test_boundary_policy.py
+++ b/tests/test_boundary_policy.py
@@ -134,6 +134,35 @@ def test_replay_does_not_coerce_serialized_counter_types(monkeypatch, field, val
         bc.replay_no_new_failures(result, control, candidate)
 
 
+def test_default_measurement_records_no_decision_and_no_control_self_certification(campaign, monkeypatch):
+    """Without the flag the instrument stays a measurement: no verdict, no exit change."""
+    from tools import measure_boundary_control as tool
+
+    model, _weight, run, post, _requests = campaign
+    run("control.json")
+    def candidate_post(url, body):
+        if url.endswith("/tokenize"):
+            return post(url, body)
+        return _response(body["max_tokens"], text=ZERO)
+    monkeypatch.setattr(bc.vqm, "_post_json", candidate_post)
+    output = model.parent / "candidate.json"
+    argv = ["candidate", "--base-url", "http://fixture", "--model-name", "nonce",
+            "--model-dir", str(model), "--image", "fixture@sha256:" + "a" * 64,
+            "--control", str(model.parent / "control.json"), "--campaign-id", "same-campaign",
+            "--out", str(output)]
+    assert tool.main(argv) == 0
+    arm = json.loads(output.read_text())
+    assert "decision" not in arm
+    assert "verdict" not in arm["comparison"]
+    # A control arm can never grade itself: the policy needs a candidate.
+    with pytest.raises(SystemExit):
+        tool.main(["control", "--base-url", "http://fixture", "--model-name", "nonce",
+                   "--model-dir", str(model), "--image", "fixture@sha256:" + "a" * 64,
+                   "--contract", str(model.parent / "contract.json"),
+                   "--campaign-id", "same-campaign", "--out", str(model.parent / "self.json"),
+                   "--decision-policy", "no-new-failures"])
+
+
 @pytest.mark.parametrize("broken", [False, True])
 def test_real_measurement_cli_emits_opt_in_decision_and_preserves_exit_status(campaign, monkeypatch, broken):
     from tools import measure_boundary_control as tool

--- a/tests/test_boundary_policy.py
+++ b/tests/test_boundary_policy.py
@@ -1,0 +1,159 @@
+"""The opt-in verdict is paired: repaired samples cannot buy new failures."""
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from prismaquant import boundary_control as bc
+from test_boundary_control import _binding, _contract, _response
+from test_measure_boundary_control_identity import campaign
+
+
+CLEAN = "<think>work</think>81"
+ZERO = "81"
+STUTTER = "<think>work</think></think>81"
+
+
+def _pair(monkeypatch, control_texts=(CLEAN, CLEAN), candidate_texts=(CLEAN, CLEAN),
+          *, candidate_finish="stop"):
+    contract = {**_contract(), "initial_max_tokens": 16}
+    texts = iter(control_texts)
+    monkeypatch.setattr(bc.vqm, "_post_json", lambda _url, body:
+                        _response(body["max_tokens"], text=next(texts)))
+    control = bc.measure_control("http://fixture", "control", contract, _binding())
+    texts = iter(candidate_texts)
+    monkeypatch.setattr(bc.vqm, "_post_json", lambda _url, body:
+                        _response(body["max_tokens"], text=next(texts), finish=candidate_finish))
+    candidate = bc.measure_candidate("http://fixture", "candidate", control, _binding("quant"))
+    return control, candidate
+
+
+def test_clean_paired_candidate_is_accepted_only_by_the_opt_in_policy(monkeypatch):
+    control, candidate = _pair(monkeypatch)
+    assert "verdict" not in bc.compare(control, candidate)
+    result = bc.decide_no_new_failures(control, candidate)
+    assert result["schema"] == "prismaquant.boundary_decision/1"
+    assert result["policy"] == "prismaquant.no_new_boundary_failures/1"
+    assert result["advisory_only"] is True
+    assert result["verdict"] == "accepted"
+    assert result["pair_count"] == 2
+    assert result["violations"] == []
+    assert result["control_sha256"] == bc.digest(control)
+    assert result["candidate_sha256"] == bc.digest(candidate)
+    assert bc.replay_no_new_failures(result, control, candidate) == result
+
+
+def test_repaired_pair_cannot_offset_new_failure_even_in_same_stratum(monkeypatch):
+    control, candidate = _pair(monkeypatch, (ZERO, CLEAN), (CLEAN, ZERO))
+    assert bc.compare(control, candidate)["strata"]["numeric"]["delta_defects"] == 0
+    result = bc.decide_no_new_failures(control, candidate)
+    assert result["verdict"] == "refused"
+    assert result["newly_broken_pairs"] == 1
+    assert result["new_defect_kind_pairs"] == 0
+    assert result["violations"] == [{
+        "prompt_index": 0, "seed": 47, "stratum": "numeric",
+        "control_defects": [], "candidate_defects": ["zero_tag"],
+        "new_defects": ["zero_tag"],
+    }]
+
+
+def test_new_kind_on_already_broken_pair_refuses(monkeypatch):
+    control, candidate = _pair(monkeypatch, (ZERO, CLEAN), (STUTTER, CLEAN))
+    result = bc.decide_no_new_failures(control, candidate)
+    assert result["verdict"] == "refused"
+    assert result["newly_broken_pairs"] == 0
+    assert result["new_defect_kind_pairs"] == 1
+    assert result["violations"][0]["new_defects"] == ["think_stutter"]
+
+
+def test_existing_defects_and_repairs_are_permitted_without_new_kinds(monkeypatch):
+    control, candidate = _pair(monkeypatch, (ZERO, STUTTER), (ZERO, CLEAN))
+    result = bc.decide_no_new_failures(control, candidate)
+    assert result["verdict"] == "accepted"
+    assert result["violations"] == []
+
+
+def test_candidate_truncation_is_a_new_defect_not_an_inconclusive_control(monkeypatch):
+    control, candidate = _pair(monkeypatch, candidate_finish="length")
+    result = bc.decide_no_new_failures(control, candidate)
+    assert result["verdict"] == "refused"
+    assert all(row["new_defects"] == ["cap_truncation"] for row in result["violations"])
+
+
+@pytest.mark.parametrize("mutation", ["missing_control", "missing_candidate", "binding", "score", "schedule", "control_sha"])
+def test_missing_incomparable_or_forged_evidence_is_inconclusive(monkeypatch, mutation):
+    control, candidate = _pair(monkeypatch)
+    if mutation == "missing_control":
+        control = None
+    elif mutation == "missing_candidate":
+        candidate = None
+    elif mutation == "binding":
+        candidate["binding"]["serve_fingerprint"] = "d" * 64
+    elif mutation == "score":
+        candidate["step"]["outcomes"][0]["score"]["defects"] = ["zero_tag"]
+    elif mutation == "schedule":
+        candidate["step"]["outcomes"].reverse()
+    else:
+        candidate["control_sha256"] = "d" * 64
+    result = bc.decide_no_new_failures(control, candidate)
+    assert result["verdict"] == "inconclusive"
+    assert result["reason"]
+    assert result["pair_count"] == 0
+
+
+def test_censored_control_remains_inconclusive(monkeypatch):
+    contract = {**_contract(), "max_steps": 1}
+    monkeypatch.setattr(bc.vqm, "_post_json", lambda _url, body:
+                        _response(body["max_tokens"], finish="length"))
+    control = bc.measure_control("http://fixture", "control", contract, _binding())
+    result = bc.decide_no_new_failures(control, None)
+    assert result["verdict"] == "inconclusive"
+
+
+@pytest.mark.parametrize("field,value", [
+    ("verdict", "accepted"), ("policy", "other/1"),
+    ("violations", []), ("newly_broken_pairs", 0), ("pair_count", 200),
+    ("advisory_only", False),
+])
+def test_offline_replay_recomputes_every_decision_field(monkeypatch, field, value):
+    control, candidate = _pair(monkeypatch, candidate_texts=(ZERO, CLEAN))
+    result = copy.deepcopy(bc.decide_no_new_failures(control, candidate))
+    result[field] = value
+    with pytest.raises(ValueError, match="decision"):
+        bc.replay_no_new_failures(result, control, candidate)
+
+
+@pytest.mark.parametrize("field,value", [("pair_count", 2.0), ("newly_broken_pairs", False)])
+def test_replay_does_not_coerce_serialized_counter_types(monkeypatch, field, value):
+    control, candidate = _pair(monkeypatch)
+    result = bc.decide_no_new_failures(control, candidate)
+    result[field] = value
+    with pytest.raises(ValueError, match="decision"):
+        bc.replay_no_new_failures(result, control, candidate)
+
+
+@pytest.mark.parametrize("broken", [False, True])
+def test_real_measurement_cli_emits_opt_in_decision_and_preserves_exit_status(campaign, monkeypatch, broken):
+    from tools import measure_boundary_control as tool
+
+    model, _weight, run, post, _requests = campaign
+    run("control.json")
+    if broken:
+        def candidate_post(url, body):
+            if url.endswith("/tokenize"):
+                return post(url, body)
+            return _response(body["max_tokens"], text=ZERO)
+        monkeypatch.setattr(bc.vqm, "_post_json", candidate_post)
+    output = model.parent / "candidate.json"
+    status = tool.main([
+        "candidate", "--base-url", "http://fixture", "--model-name", "nonce",
+        "--model-dir", str(model), "--image", "fixture@sha256:" + "a" * 64,
+        "--control", str(model.parent / "control.json"), "--campaign-id", "same-campaign",
+        "--out", str(output), "--decision-policy", "no-new-failures",
+    ])
+    assert status == (2 if broken else 0)
+    arm = json.loads(output.read_text())
+    assert arm["decision"]["verdict"] == ("refused" if broken else "accepted")
+    assert arm["comparison"]["advisory_only"] is True

--- a/tests/test_pq87_paired_validation.py
+++ b/tests/test_pq87_paired_validation.py
@@ -1,0 +1,82 @@
+"""The physical validation is a frozen sequential state machine, not a launch loop."""
+import copy
+import importlib
+import json
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+
+def _driver():
+    return importlib.import_module("experiments.pq87_paired_validation")
+
+
+def _manifest():
+    return json.loads((Path(__file__).parents[1] / "experiments" /
+                       "pq87_validation_manifest.json").read_text())
+
+
+def test_registered_manifest_is_disjoint_and_has_both_roles():
+    result = _driver().validate_manifest(_manifest())
+    assert set(result["models"]) == {"control", "candidate"}
+    screen = {p["text"] for p in result["contracts"]["screen"]["prompts"]}
+    heldout = {p["text"] for p in result["contracts"]["heldout"]["prompts"]}
+    assert not screen & heldout
+    assert result["contracts"]["screen"] == json.loads((Path(__file__).parents[1] /
+        "experiments" / "pq87_boundary_contract.json").read_text())
+
+
+@pytest.mark.parametrize("mutation", ["overlap", "image", "deadline", "same_model", "same_telemetry"])
+def test_manifest_refuses_ambiguous_or_unbounded_campaign(mutation):
+    manifest = copy.deepcopy(_manifest())
+    if mutation == "overlap":
+        manifest["contracts"]["heldout"]["prompts"][0]["text"] = manifest["contracts"]["screen"]["prompts"][0]["text"]
+    elif mutation == "image":
+        manifest["image"] = "runtime:latest"
+    elif mutation == "deadline":
+        manifest["deadline_seconds"] = 0
+    elif mutation == "same_model":
+        manifest["models"]["candidate"] = manifest["models"]["control"]
+    else:
+        manifest["netdata_urls"] *= 0
+    with pytest.raises(ValueError):
+        _driver().validate_manifest(manifest)
+
+
+def test_both_model_arms_reuse_the_existing_bounded_server_configuration():
+    driver = _driver()
+    from tools.serve_fingerprint import normalize_performance_argv
+    control = driver.server_argv("nonce", "/models/control")
+    candidate = driver.server_argv("nonce", "/models/candidate")
+    assert normalize_performance_argv(control) == normalize_performance_argv(candidate)
+    assert control[control.index("--kv-cache-memory-bytes") + 1] == str(1 << 30)
+    assert control[control.index("--max-num-seqs") + 1] == "1"
+    assert "--quantization" not in control + candidate
+
+
+def test_candidate_refusal_is_an_observation_but_missing_measurement_is_not():
+    driver = _driver()
+    assert driver.completed_candidate({"decision": {"verdict": "refused"}}, 2)
+    assert driver.completed_candidate({"decision": {"verdict": "accepted"}}, 0)
+    assert not driver.completed_candidate({"decision": {"verdict": "accepted"}}, 2)
+    assert not driver.completed_candidate({}, 2)
+    assert not driver.completed_candidate({"decision": {"verdict": "inconclusive"}}, 2)
+
+
+def test_cpu_only_pool_action_cannot_start_the_physical_controller(monkeypatch):
+    driver = _driver()
+    monkeypatch.setenv("PRISMABUILD_CONTAINER_OWNER", "cpu-action")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+    monkeypatch.setattr(driver.instrument, "bootstrap", lambda: pytest.fail("CPU action reached physical preparation"))
+    with pytest.raises(ValueError, match="GPU"):
+        driver.host(SimpleNamespace(manifest="unused", out="unused"))
+
+
+@pytest.mark.parametrize("field,value", [("residency_readable", False), ("serve_session_id", None)])
+def test_ppl_binding_requires_observed_live_residency(field, value):
+    before = {"residency_readable": True, "serve_session_id": "live",
+              "model": "/models/candidate", "models_endpoint_binding": {"model": {"id": "nonce"}}}
+    before[field] = value
+    with pytest.raises(ValueError, match="residency|session"):
+        _driver().require_ppl_binding(before, "/models/candidate", "nonce")

--- a/tests/test_pq87_paired_validation.py
+++ b/tests/test_pq87_paired_validation.py
@@ -80,3 +80,57 @@ def test_ppl_binding_requires_observed_live_residency(field, value):
     before[field] = value
     with pytest.raises(ValueError, match="residency|session"):
         _driver().require_ppl_binding(before, "/models/candidate", "nonce")
+
+
+def test_prelaunch_failure_never_cleans_a_basename_container(tmp_path, monkeypatch):
+    driver = _driver()
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps(_manifest()))
+    monkeypatch.setenv("PRISMABUILD_CONTAINER_OWNER", "a" * 64)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    monkeypatch.setattr(driver.instrument, "bootstrap", lambda: (
+        tmp_path, None, SimpleNamespace(digest=lambda value: "digest")))
+    commands = []
+    def check_output(command, **kwargs):
+        commands.append(command)
+        if command[0] == "git":
+            return "source\n"
+        raise RuntimeError("prelaunch image missing")
+    monkeypatch.setattr(driver.subprocess, "check_output", check_output)
+    monkeypatch.setattr(driver.instrument, "cleanup_container", lambda name: pytest.fail(
+        f"cleaned uncreated container {name}"))
+    assert driver.host(SimpleNamespace(manifest=str(manifest), out=str(tmp_path / "shared-basename"))) == 0
+    assert not any(command[1] in {"stop", "rm"} for command in commands)
+
+
+def test_container_name_collision_refuses_without_cleanup(monkeypatch):
+    driver = _driver()
+    commands = []
+    def run(command, **kwargs):
+        commands.append(command)
+        return SimpleNamespace(returncode=0, stdout='[{"Id":"existing"}]')
+    monkeypatch.setattr(driver.subprocess, "run", run)
+    with pytest.raises(ValueError, match="already exists"):
+        driver.require_container_name_available("already-owned")
+    assert commands == [["docker", "inspect", "already-owned"]]
+
+
+@pytest.mark.parametrize("mismatch", ["action", "nonce", "id"])
+def test_cleanup_refuses_an_unowned_container_id(tmp_path, monkeypatch, mismatch):
+    driver = _driver()
+    cid = "c" * 64
+    cidfile = tmp_path / "container.cid"
+    cidfile.write_text(cid + "\n")
+    observed = {"Id": cid, "Name": "/our-name", "Config": {"Labels": {
+        "prismabuild.action": "a" * 64, "prismaquant.pq87.campaign": "nonce"}}}
+    if mismatch == "id":
+        observed["Id"] = "b" * 64
+    else:
+        observed["Config"]["Labels"]["prismabuild.action" if mismatch == "action"
+                                     else "prismaquant.pq87.campaign"] = "other"
+    monkeypatch.setattr(driver.subprocess, "run", lambda *args, **kwargs: SimpleNamespace(
+        returncode=0, stdout=json.dumps([observed])))
+    monkeypatch.setattr(driver.instrument, "cleanup_container", lambda name: pytest.fail(
+        f"cleaned unowned container {name}"))
+    result = driver.cleanup_owned_container(cidfile, "our-name", "a" * 64, "nonce", attempted=True)
+    assert not result["safe"]

--- a/tests/test_pq87_paired_validation.py
+++ b/tests/test_pq87_paired_validation.py
@@ -1,7 +1,9 @@
 """The physical validation is a frozen sequential state machine, not a launch loop."""
 import copy
 import importlib
+import io
 import json
+import sys
 from types import SimpleNamespace
 from pathlib import Path
 
@@ -134,3 +136,65 @@ def test_cleanup_refuses_an_unowned_container_id(tmp_path, monkeypatch, mismatch
         f"cleaned unowned container {name}"))
     result = driver.cleanup_owned_container(cidfile, "our-name", "a" * 64, "nonce", attempted=True)
     assert not result["safe"]
+
+
+def _ppl_result():
+    from prismaquant.validate_quantized_model import CheckResult, EVAL_PROMPTS
+    return CheckResult(name="perplexity", passed=False, detail="measured threshold refusal", metrics={
+        "perplexity": 22026.465794806718, "mean_nll_per_tok": 10.0,
+        "p99_nll_per_tok": 10.0, "max_nll_per_tok": 10.0,
+        "per_prompt_avg_nll": [10.0] * len(EVAL_PROMPTS),
+        "n_tokens": 100, "spec_decode_detected": False})
+
+
+@pytest.mark.parametrize("mutation", ["empty", "skipped", "unknown_spec", "speculative",
+                                      "nonfinite", "n_tokens", "partial"])
+def test_ppl_missing_measurement_is_not_completion(mutation):
+    from prismaquant.validate_quantized_model import EVAL_PROMPTS
+    result = _ppl_result()
+    if mutation == "empty":
+        result.metrics.clear()
+    elif mutation in {"skipped", "unknown_spec", "speculative"}:
+        result.metrics.clear()
+        result.metrics.update(skipped=True, spec_decode_detected={
+            "skipped": False, "unknown_spec": None, "speculative": True}[mutation])
+    elif mutation == "nonfinite":
+        result.metrics["mean_nll_per_tok"] = float("nan")
+    elif mutation == "n_tokens":
+        result.metrics["n_tokens"] = 0
+    else:
+        result.metrics["per_prompt_avg_nll"].pop()
+    with pytest.raises(ValueError, match="PPL"):
+        _driver().require_ppl_measurement(result, len(EVAL_PROMPTS))
+
+
+def test_ppl_measured_threshold_refusal_is_a_complete_observation():
+    from prismaquant.validate_quantized_model import EVAL_PROMPTS
+    result = _ppl_result()
+    assert _driver().require_ppl_measurement(result, len(EVAL_PROMPTS)) is result
+
+
+@pytest.mark.parametrize("metrics", [{}, {"skipped": True, "spec_decode_detected": None}])
+def test_actual_ppl_phase_refuses_missing_numeric_observation(monkeypatch, metrics):
+    driver = _driver()
+    from prismaquant import boundary_control as bc
+    result = bc.vqm.CheckResult(name="perplexity", passed=False, detail="missing logprobs", metrics=metrics)
+    content = {"frozen": "content"}
+    client = SimpleNamespace(_capture_artifact=lambda model: (content, {"stable": True}))
+    before = {"residency_readable": True, "serve_session_id": "live",
+              "performance_stack_fingerprint": "stack", "model": "/models/control",
+              "models_endpoint_binding": {"model": {"id": "nonce"}}}
+    manifest = _manifest()
+    monkeypatch.setattr(driver.instrument, "bootstrap", lambda: (Path("/repo"), client, bc))
+    monkeypatch.setitem(sys.modules, "serve_fingerprint", SimpleNamespace(collect_manifest=lambda **kwargs: before))
+    monkeypatch.setattr(Path, "read_text", lambda self, **kwargs: json.dumps(
+        manifest if str(self) == "/run/manifest.json" else {"content": content}))
+    monkeypatch.setattr(driver, "open", lambda *args, **kwargs: io.StringIO(), raising=False)
+    monkeypatch.setattr(driver.instrument, "dump", lambda *args, **kwargs: None)
+    monkeypatch.setattr(bc.vqm, "check_perplexity", lambda *args: result)
+    monkeypatch.setattr(bc, "artifact_content_id", lambda value: "artifact")
+    # client_phase wraps these attributes for journalling; restore them after the fixture.
+    monkeypatch.setattr(bc.vqm, "_post_json", bc.vqm._post_json)
+    monkeypatch.setattr(bc, "measure_step", bc.measure_step)
+    with pytest.raises(ValueError, match="PPL"):
+        driver.client_phase(SimpleNamespace(role="control", population="ppl", nonce="nonce"))

--- a/tools/measure_boundary_control.py
+++ b/tools/measure_boundary_control.py
@@ -49,6 +49,8 @@ def main(argv=None):
     parser.add_argument("--out", required=True)
     parser.add_argument("--legacy-ab", action="store_true",
                         help="also measure historical raw request at initial cap on control")
+    parser.add_argument("--decision-policy", choices=("no-new-failures",),
+                        help="opt-in candidate decision; leaves the production gate unchanged")
     args = parser.parse_args(argv)
     if "@sha256:" not in args.image:
         parser.error("--image must be immutable")
@@ -61,8 +63,8 @@ def main(argv=None):
     import serve_fingerprint as sf
 
     if args.role == "control":
-        if not args.contract or args.control:
-            parser.error("control requires --contract and no --control")
+        if not args.contract or args.control or args.decision_policy:
+            parser.error("control requires --contract and no --control/--decision-policy")
         contract = json.loads(Path(args.contract).read_text())
         model_config = json.loads((Path(args.model_dir) / "config.json").read_text())
         control = None
@@ -128,6 +130,8 @@ def main(argv=None):
     else:
         measurement = bc.measure_candidate(args.base_url, args.model_name, control, binding)
         comparison = bc.compare(control, measurement)
+    decision = (bc.decide_no_new_failures(control, measurement)
+                if args.decision_policy else None)
     finished = time.time()
     after = sf.collect_manifest(image=args.image, base_url=args.base_url,
                                 attestation_phase="post")
@@ -144,12 +148,17 @@ def main(argv=None):
                "artifact_pre": artifact_pre, "artifact_post": artifact_post,
                "weight_stats_pre": weight_stats_pre, "weight_stats_post": weight_stats_post,
                "source_sha256": source_hashes}
+    if decision is not None:
+        receipt["decision"] = decision
     output.parent.mkdir(parents=True, exist_ok=True)
     with output.open("x") as handle:
         json.dump(receipt, handle, indent=2, ensure_ascii=False, allow_nan=False)
         handle.write("\n")
     print(json.dumps({"receipt": str(output), "sha256": bc.digest(receipt),
-                      "comparison": comparison, "fixed_point": measurement.get("fixed_point")}))
+                      "comparison": comparison, "decision": decision,
+                      "fixed_point": measurement.get("fixed_point")}))
+    if decision is not None:
+        return 0 if decision["verdict"] == "accepted" else 2
     return 0 if measurement.get("fixed_point", True) else 2
 
 


### PR DESCRIPTION
Implements the delegated policy choice for #87 without changing production defaults or shipcard slots. Paired defect-kind comparison rejects new failures without cross-sample offsets; exact control/candidate replay gates every decision, and optional candidate CLI returns 2 on refusal. CPU evidence: 105 passed, zero skipped, seven selected modules collected, compile green in frozen PrismaBuild bfebe89b876b. Pre-fix failures for all 22 added cases and exact receipts are recorded in docs/results/pq87_paired_policy_2026-09-04.md. Quantized, held-out and representative-population validation remains pending and #87 stays open. This PR does not claim a shipping promotion.