### PR TITLE
Bind Tessera campaign resume to current inputs and exact priced wire

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5507,7 +5507,9 @@ Two properties make the numbers comparable with the rest of the menu:
 * **Rendering identity (§P8).** The tensor that is priced *is* the decoded wire:
   `_encode_and_render` returns `read_unit_artifact(unit.blob)`, and the blob is
   stored beside the render in the cache. Not two code paths that agree — one
-  object.
+  object. This proves the cached wire is the priced wire, not that an export
+  or serving runtime reused it; those paths owe their own exact-byte and
+  served receipts. The packed bridge remains tracked by PrismaQuant #183.
 
 Rows are written in the codebase's own currency: `output_mse` and **no**
 `predicted_dloss` field, because in this tree `output_mse` is a raw MSE while

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,22 @@
 As of: 2026-09-04 · `codex/pq186-campaign-identity`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-04, `codex/pq186-campaign-identity`) for **identity-bound
+Tessera campaign resume** (§4.10; PrismaQuant #186). The existing cost journal
+binds the current selected weights, scoring rows even with Hessians off, actual
+Hessians, corpus/token draw, menus/scope, explicit campaign settings, resolved
+encoder configuration and both producer/package source seals. Its original
+`--checkpoint` file path is the manifest; sibling `.parts` shards hold durable
+checksummed per-unit anchors and the producer's own cached-byte receipts.
+Every resumed anchor must belong to the current unit/menu, agree with the
+producer's Hessian applicability and verify its exact wire bytes against a
+fresh producer input identity before entering the cost payload. Legacy unbound
+JSON, changed inputs, extra/missing receipts and missing/changed wire refuse;
+old anchors never acquire today's identity. This consumes the pending producer
+`tessera.cached_unit` API and does not change the release pin, admit packed
+campaigns, or establish served/GPU qualification. Gate:
+`tests/test_tessera_campaign_resume.py`.
+
 Re-stamped (2026-09-04, `codex/pq186-campaign-identity`) for the shared
 checkpoint journal's **explicit manifest pathname** (§4.10; PrismaQuant #186).
 `cost_stage_checkpoint.prepare_journal` can retain a file-oriented caller's
@@ -5444,6 +5460,19 @@ purpose. Each surface records its anchors, encode seconds and which of the two
 stopped it.
 
 **Cost is an anchor campaign, not an enumeration** (`prismaquant/tessera_campaign.py`).
+
+Resume is an identity check, not a name match. The JSON checkpoint manifest
+uses `cost_stage_checkpoint` and stores checksummed per-unit anchor shards in
+its sibling `.parts` directory. It binds actual selected weights, scoring rows,
+Hessians and calibration draw, resolved menus/scope/settings and the producer
+and PrismaQuant source seals. Each priced wire has a `tessera.cached_unit`
+receipt, verified against freshly derived producer inputs before its saved
+cost is admitted. Changed or unverifiable inputs, old identity-free anchor
+lists, absent/corrupt wire and receipt coverage mismatch refuse without
+recomputing or relabelling the old result. Output/cache paths and the wall-clock
+interruption limit are not numerical inputs; moving them is allowed only if
+the same manifest, unit journal and verified priced wire remain available.
+The producer API is required; an older producer without it refuses.
 
 > **Premise correction.** This work was briefed on the belief that Tessera's
 > "embedded rate axis" would let one deep encode per unit yield exact decodes of

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,18 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-04 · `codex/pq183-packed-capture`. Stamps
+As of: 2026-09-04 · `codex/pq186-campaign-identity`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-04, `codex/pq186-campaign-identity`) for the shared
+checkpoint journal's **explicit manifest pathname** (§4.10; PrismaQuant #186).
+`cost_stage_checkpoint.prepare_journal` can retain a file-oriented caller's
+manifest path while storing per-unit shards in its checkpoint directory. It
+uses the existing manifest/unit schemas, exact identity comparison, checksums,
+and durable writes; existing directory-oriented callers are unchanged. This
+adapter enables the campaign's identity-bound resume without changing its
+`--checkpoint` filename/default or introducing another checkpoint grammar.
+The campaign's intake/wire verification is a separate change, not supplied
+merely by this optional argument.
 
 Re-stamped (2026-09-04, `codex/pq183-packed-campaign`) for **profile-pinned
 campaign exclusions** (§4.10). The dense target walk now consults the existing

--- a/docs/measurements/tessera-checkpoint-identity-2026-09-04.md
+++ b/docs/measurements/tessera-checkpoint-identity-2026-09-04.md
@@ -1,0 +1,36 @@
+# Tessera campaign checkpoint identity — 2026-09-04
+
+PrismaQuant #186. Work is on `codex/pq186-campaign-identity`, based on the
+#183 capture branch after integration onto main `10dd23957d6cf9ad784f8eac59fb914f66f6d89e`.
+All tests below run through deployed PrismaBuild `aa6d3cfa2f77`, CPU-only on
+Sparky, serial, 1 CPU / 4 GiB, with `CUDA_VISIBLE_DEVICES=''` and interpreter
+`/home/rob/dq-runs/venvs/prismaquant-cu130/bin/python`. These are not GPU,
+quality, or performance measurements.
+
+## Original defect
+
+Action `88f2bf869834b1ddccce8a2a879ebee89b76b4668c3c98814dbef2c4b9ddfe05`
+ran the real main-entry regressions in `tests/test_tessera_campaign_resume.py`
+before the fix: 2 failed, no skips. Both same-qname legacy anchors and a unit
+from another model reached `campaign_cost_payload` under the current run's
+provenance. Failure line:
+
+```text
+tests/test_tessera_campaign_resume.py:38: AssertionError: unverified checkpoint anchors reached the current cost payload
+```
+
+## Existing journal, explicit manifest pathname
+
+The compatibility adapter preserves the existing `--checkpoint` JSON-file
+path and reuses the cost journal's existing manifest/unit schemas. Its two
+new tests first failed with `TypeError: prepare_journal() got an unexpected
+keyword argument 'manifest_path'` at lines 15 and 34 of
+`tests/test_cost_stage_checkpoint_manifest.py` (PrismaBuild `dd23c1ba41a7`).
+
+Green action `4b5265e28732daea67753713827aecaa3d2e192fa3705c0c76772e2291180d9e`
+ran `tests/test_cost_stage_checkpoint_manifest.py` and
+`tests/test_streamed_cost_checkpoints.py`: 19 passed, no skips or uncollected
+module reported. Receipt:
+`afda5c038374392dc7e1706bb4b32e105ac7c58226cdae59a1eb02213400b2ce`.
+This verifies the adapter and old directory-oriented callers, not the pending
+campaign integration or its producer byte receipts.

--- a/docs/measurements/tessera-checkpoint-identity-2026-09-04.md
+++ b/docs/measurements/tessera-checkpoint-identity-2026-09-04.md
@@ -34,3 +34,75 @@ module reported. Receipt:
 `afda5c038374392dc7e1706bb4b32e105ac7c58226cdae59a1eb02213400b2ce`.
 This verifies the adapter and old directory-oriented callers, not the pending
 campaign integration or its producer byte receipts.
+
+## Campaign and exact priced-wire intake
+
+The campaign now consumes the producer's generic `encoding_input_identity`,
+`make_unit_record` and `verify_cached_unit` APIs; it does not define another
+producer receipt grammar or stamp new identities on old anchors. The existing
+cost journal binds the whole current input population, including actual score
+rows when Hessians are off. An independent read-only review by the producer
+API author found no contract misuse in this adapter.
+
+Tests use immutable Tessera producer source `6343137` from
+`/mnt/shared/tessera-runs/pq183-producer-source-6343137.tar`, SHA-256
+`50b2b29da4b7e0c818cdde442303ebe9e40fd0f4a04d8d8603a2da3450a0d14f`,
+extracted into the worker's temporary directory and supplied through
+`PYTHONPATH`. The installed producer, release pin and frozen serving candidate
+are unchanged. This dependency must land before campaign intake is usable;
+an older producer explicitly refuses for lack of its identity API.
+
+Expanded red action
+`935b09c3641fd0fcdfe8c2875ed36f2fca79fb5da668880b577a30993daadf62`
+restored only `prismaquant/tessera_campaign.py` from the exact published
+pre-fix source `2c22feaca1deff9dc0ca217b9a11d1e7cdf4bca8` in its isolated
+PrismaBuild snapshot, retaining the new tests. Its first completed attempt
+had **17 failures, 0 skips**, in 59.49 seconds. Repeated red attempts were
+withdrawn after reading that completed result. Every fresh priced fixture is
+a real 32x256 BF16-source unit encoded through the production adapter and
+priced through the actual main entry point; no encode or scorer is stubbed.
+
+Failure lines in `tests/test_tessera_campaign_resume.py`:
+
+- `:54`: unverified legacy same-name and foreign-unit anchors reached the
+  current payload (two cases).
+- `:108`: the checkpoint schema was the old identity-free campaign schema,
+  not the shared journal manifest schema (same-input resume regression).
+- `:129`: `DID NOT RAISE <class 'RuntimeError'>` after changing actual Hessian
+  values under the same draw.
+- `:168`: the same refusal failure for changed source weights, score rows
+  with H off, corpus text, token IDs, H mode, menu, recipe, producer source,
+  PrismaQuant source, and TP scope (ten cases).
+- `:190`: the same refusal failure for missing, byte-altered and symlinked
+  priced wire (three cases).
+
+Two earlier expanded-run attempts are not correctness evidence: `07c390a0a3f1`
+failed before pytest because a PB snapshot has no `origin`; `bcafc601f210`
+used a 32-column fixture outside the campaign accountant's 256-column
+superblock contract. The corrected run above supplies the genuine failures.
+
+Fixed action
+`b62e9617fbfef24f65ae0b1491a2c74825ad6ab2b1538e1036d0cfe7e75b9ed9`
+ran these eight targeted files:
+
+- `tests/test_tessera_campaign_resume.py`
+- `tests/test_cost_stage_checkpoint_manifest.py`
+- `tests/test_streamed_cost_checkpoints.py`
+- `tests/test_tessera_campaign.py`
+- `tests/test_tessera_campaign_packed.py`
+- `tests/test_tessera_campaign_pins.py`
+- `tests/test_architecture_doc.py`
+- `tests/test_docs_staleness.py`
+
+**95 passed, 5 skipped**, no uncollected module reported; CPU-only serial
+Sparky, 1 CPU / 4 GiB, 112.32 seconds. All five skip reasons, verbatim:
+`Tessera encodes need CUDA`. Receipt:
+`49a11ee95fc88145da43d1e5c34e47b87355e4015e16265fe4294191afd903e3`.
+The positive resume test preserves the exact measured cost dictionary and
+wire bytes, changes only the output path/interruption limit, and replaces
+`_measure_anchor` with a failing sentinel on the resumed pass. The refusal
+tests also require the original checkpoint file to remain unchanged.
+
+This is correctness evidence for a CPU-tested checkpoint gate. It is not
+GPU qualification, a served quality/performance A/B, or completion of the
+packed campaign/export bridge in #183; that gate remains closed.

--- a/prismaquant/cost_stage_checkpoint.py
+++ b/prismaquant/cost_stage_checkpoint.py
@@ -174,8 +174,14 @@ def prepare_journal(
     resume: bool,
     identity: Mapping[str, object],
     qnames: Sequence[str],
+    manifest_path: str | Path | None = None,
 ) -> tuple[Path, str, dict[str, dict[str, object]]]:
-    """Create/validate a journal and return all exact completed unit states."""
+    """Create/validate a journal and return all exact completed unit states.
+
+    File-oriented callers can retain their explicit manifest pathname while
+    placing unit shards in ``checkpoint_dir``. The same manifest/unit schemas
+    and refusal rules apply; directory-oriented callers keep ``manifest.json``.
+    """
     root = Path(checkpoint_dir)
     if root.exists() and not root.is_dir():
         raise RuntimeError(f"{stage} checkpoint path is not a directory: {root}")
@@ -184,7 +190,7 @@ def prepare_journal(
     identity_sha256 = canonical_json_sha256(
         canonical_identity, where=f"{stage} identity"
     )
-    manifest_path = root / "manifest.json"
+    manifest_path = Path(manifest_path) if manifest_path is not None else root / "manifest.json"
     if manifest_path.is_file():
         if not resume:
             raise RuntimeError(

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -27,9 +27,11 @@ Rendering identity, and the wire
 --------------------------------
 The render is not ``render_tessera_weight``'s reconstruction; it is
 ``read_unit_artifact(encode_linear(...).blob)`` -- **the bytes, decoded**.  So the
-cache entry holds the wire beside the dequantised render, the export leg writes
-exactly the bytes this cost was measured on, and the identity holds by
-construction rather than by two code paths agreeing (principle 8).
+cache entry holds the wire beside the dequantised render. Checkpoint resume
+verifies those bytes against their producer input receipt. That proves the
+cached wire is the priced wire; export reuse and served qualification still
+owe their own receipts. The packed producer-plan/cached-wire bridge remains
+the separate work tracked by PrismaQuant #183 (principle 8).
 
 What this stage does NOT do
 ---------------------------

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -287,7 +287,7 @@ def _measure_anchor(
     # The wire, beside the render.  A ``.tessera`` shard per (qname, rung),
     # named the way the cache names its weight shards, so the export leg can
     # find the exact bytes this row was priced on instead of re-encoding.
-    wire_path = wire_dir / f"{qname.replace('.', '__')}__{format_name}.tessera"
+    wire_path = _wire_path(wire_dir, qname, format_name)
     tmp = wire_path.with_suffix(".tessera.tmp")
     tmp.write_bytes(blob)
     os.replace(tmp, wire_path)
@@ -475,6 +475,104 @@ def campaign_cost_payload(
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
+
+def _wire_path(wire_dir: Path, qname: str, format_name: str) -> Path:
+    return wire_dir / f"{qname.replace('.', '__')}__{format_name}.tessera"
+
+
+def _checkpoint_identity_api():
+    try:
+        from tessera import cached_unit
+    except ImportError as exc:
+        raise RuntimeError(
+            "Tessera campaign checkpoint identity requires the producer's "
+            "cached_unit input/byte receipt API; refusing unbound resume") from exc
+    return cached_unit
+
+
+def _campaign_checkpoint_identity(*, weights, acts, hessians, menus, args,
+                                  calibration_identity, serving_scope):
+    """Bind the priced population, including score inputs when H is off."""
+    from .production_weight_cache import _production_cache_source_sha256
+
+    api = _checkpoint_identity_api()
+    settings = vars(args).copy()
+    # Locations and a wall-clock interruption limit are not encoding/scoring
+    # inputs. All other explicit campaign settings remain bound by default.
+    for name in ("out", "cache_dir", "checkpoint", "deadline_seconds"):
+        settings.pop(name, None)
+    return {
+        "campaign_schema": SCHEMA,
+        "currency": CURRENCY,
+        "settings": settings,
+        "calibration": calibration_identity,
+        "serving_scope": serving_scope,
+        "encoder_recipe": th.encoder_recipe(),
+        "prismaquant_source_sha256": _production_cache_source_sha256(),
+        "encoder_source_sha256": api.encoder_source_sha256(),
+        "units": {
+            name: {
+                "weight": api.tensor_identity(weight),
+                "scoring_rows": (None if acts.get(name) is None
+                                 else api.tensor_identity(acts[name])),
+                "hessian": (None if hessians.get(name) is None
+                            else api.tensor_identity(hessians[name])),
+                "menu": sorted(rung.format_name for rung in menus[name]),
+            }
+            for name, weight in sorted(weights.items())
+        },
+    }
+
+
+def _checkpoint_anchor_identity(anchor, *, weights, menus, calibration_source):
+    from .tessera_formats import parse_tessera_format_name, tessera_wire_recipe
+    from .tessera_render import rung_accepts_hessian
+
+    if anchor.qname not in weights:
+        raise RuntimeError(f"checkpoint anchor names an unknown unit: {anchor.qname!r}")
+    parsed = parse_tessera_format_name(anchor.format_name)
+    if parsed is None:
+        raise RuntimeError(f"checkpoint anchor format is not Tessera: {anchor.format_name!r}")
+    family, rung = parsed
+    if (anchor.family, anchor.body_rate_q256) != (family.name, rung):
+        raise RuntimeError("checkpoint anchor family/rung disagrees with its format")
+    if anchor.format_name not in {entry.format_name for entry in menus[anchor.qname]}:
+        raise RuntimeError(f"checkpoint anchor is outside the current menu: {anchor.format_name}")
+    wire = tessera_wire_recipe(family, rung)
+    activation = (calibration_source if calibration_source is not None
+                  and rung_accepts_hessian(anchor.format_name, wire) else None)
+    if bool(anchor.hessian_applied) != (activation is not None):
+        raise RuntimeError("checkpoint anchor Hessian applicability disagrees with the producer")
+    return _checkpoint_identity_api().encoding_input_identity(
+        weights[anchor.qname], anchor.qname, family.payload_grid(), int(rung),
+        activation=activation,
+    )
+
+
+def _checkpoint_wire_record(anchor, wire_dir, identity, *, existing=None):
+    """Use the producer's one receipt grammar for fresh and resumed bytes."""
+    path = _wire_path(wire_dir, anchor.qname, anchor.format_name)
+    if path.is_symlink() or path.resolve().parent != wire_dir.resolve():
+        raise RuntimeError(f"checkpoint cached wire escapes its directory: {path}")
+    try:
+        blob = path.read_bytes()
+        api = _checkpoint_identity_api()
+        if existing is None:
+            record = api.make_unit_record(blob, identity, filename=path.name)
+        else:
+            record = existing
+            api.verify_cached_unit(blob, record, identity)
+            if record.get("file") != path.name:
+                raise ValueError("cached wire filename differs from the priced unit/rung")
+        # CampaignAnchor.wire_bytes means the full blob, not plane-region bytes.
+        if anchor.wire_bytes != record["blob_bytes"]:
+            raise ValueError("cached wire length differs from the measured anchor")
+        return record
+    except (OSError, ValueError, TypeError, KeyError) as exc:
+        raise RuntimeError(
+            f"checkpoint cached wire identity refused for {anchor.qname} "
+            f"{anchor.format_name}: {exc}") from exc
+
 
 def _collect_activations(model, targets, tokens, max_rows: int, device,
                          *, want_hessian: bool = False, profile=None):
@@ -743,7 +841,8 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     ap.add_argument("--out", required=True, help="cost payload (.pkl)")
     ap.add_argument("--cache-dir", required=True)
     ap.add_argument("--checkpoint", default=None,
-                    help="resumable per-anchor JSON; defaults beside --out")
+                    help="identity-bound JSON manifest with sibling .parts "
+                         "unit shards; defaults beside --out")
     ap.add_argument("--menu-mode", default=None, choices=sorted(MENU_MODES))
     ap.add_argument("--nsamples", type=int, default=8)
     ap.add_argument("--seqlen", type=int, default=512)
@@ -918,24 +1017,53 @@ def main(argv: "Sequence[str] | None" = None) -> int:
         context_by_unit=context_by_unit,
     )
 
+    from .cost_stage_checkpoint import prepare_journal, write_unit
+
+    checkpoint_identity = _campaign_checkpoint_identity(
+        weights=weights, acts=acts, hessians=hessians, menus=menus, args=args,
+        calibration_identity=hessian_identity,
+        serving_scope=(scope_provenance(serving_target, context_by_unit)
+                       if serving_target is not None else None),
+    )
+    journal, identity_sha256, resumed = prepare_journal(
+        checkpoint.with_name(checkpoint.name + ".parts"), manifest_path=checkpoint,
+        stage="Tessera campaign", resume=True, identity=checkpoint_identity,
+        qnames=targets,
+    )
     measured: dict[str, dict[str, list[CampaignAnchor]]] = {}
-    if checkpoint.is_file():
-        raw = json.loads(checkpoint.read_text())
-        for row in raw.get("anchors", []):
+    wire_records = {name: {} for name in targets}
+    dirty_checkpoint_units = set()
+    for name, state in resumed.items():
+        if set(state) != {"anchors", "wire_records"} or not isinstance(state["anchors"], list) \
+                or not isinstance(state["wire_records"], dict):
+            raise RuntimeError(f"checkpoint state has an invalid anchor/record envelope for {name}")
+        formats = set()
+        for row in state["anchors"]:
             anchor = CampaignAnchor(**row)
-            measured.setdefault(anchor.qname, {}).setdefault(
-                anchor.family, []).append(anchor)
+            if anchor.qname != name or anchor.format_name in formats:
+                raise RuntimeError(f"checkpoint anchor has a wrong or duplicate unit/rung: {name}")
+            formats.add(anchor.format_name)
+            if anchor.format_name not in state["wire_records"]:
+                raise RuntimeError(f"checkpoint anchor has no priced-wire receipt: {name}")
+            identity = _checkpoint_anchor_identity(
+                anchor, weights=weights, menus=menus, calibration_source=calibration_source)
+            wire_records[name][anchor.format_name] = _checkpoint_wire_record(
+                anchor, wire_dir, identity, existing=state["wire_records"][anchor.format_name])
+            measured.setdefault(name, {}).setdefault(anchor.family, []).append(anchor)
+        if formats != set(state["wire_records"]):
+            raise RuntimeError(f"checkpoint has wire receipts outside its measured anchors: {name}")
+    if resumed:
         print(f"[campaign] resumed {sum(len(v) for f in measured.values() for v in f.values())} "
-              f"anchors from {checkpoint}", flush=True)
+              f"verified anchors from {checkpoint}", flush=True)
 
     def flush_checkpoint() -> None:
-        rows = [
-            vars(a) for by_f in measured.values()
-            for anchors in by_f.values() for a in anchors
-        ]
-        tmp = checkpoint.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps({"schema": SCHEMA, "anchors": rows}))
-        os.replace(tmp, checkpoint)
+        for name in sorted(dirty_checkpoint_units):
+            rows = [vars(anchor) for anchors in measured.get(name, {}).values()
+                    for anchor in anchors]
+            write_unit(journal, stage="Tessera campaign", qname=name,
+                       identity_sha256=identity_sha256,
+                       state={"anchors": rows, "wire_records": wire_records[name]})
+        dirty_checkpoint_units.clear()
 
     started = time.time()
     deadline = float(args.deadline_seconds)
@@ -1126,7 +1254,11 @@ def main(argv: "Sequence[str] | None" = None) -> int:
                 print(f"[campaign] {name} {fmt}: FAILED {type(exc).__name__}: "
                       f"{exc}", flush=True)
                 continue
+            identity = _checkpoint_anchor_identity(
+                anchor, weights=weights, menus=menus, calibration_source=calibration_source)
+            wire_records[name][fmt] = _checkpoint_wire_record(anchor, wire_dir, identity)
             measured.setdefault(name, {}).setdefault(family, []).append(anchor)
+            dirty_checkpoint_units.add(name)
             if index % 10 == 0:
                 flush_checkpoint()
                 print(f"[campaign] r{round_index} {index}/{len(pending)} "

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -100,12 +100,10 @@ class CampaignAnchor:
     activation_quantized: bool
     wire_bytes: int
     seconds: float
-    #: Was a Hessian actually applied to these bytes?  A property of the RUNG'S
-    #: WIRE and not of the run: only a CHANNEL scale plane admits LDLQ and the
-    #: H refit, so every E2M1 rung is False even under ``--hessian require``.
-    #: Stamped per row rather than per table, because a mixed-family campaign
-    #: is legitimately half H-aware and a table-level flag would have to lie in
-    #: one direction or the other.
+    #: Was a Hessian actually applied to these bytes? Admission comes from the
+    #: producer's ActivationSource settings for this rung's scale plane, via
+    #: rung_accepts_hessian, not a campaign-owned plane roster. Stamped per
+    #: measured row so weights-only and H-aware results cannot be conflated.
     hessian_applied: bool = False
 
 

--- a/tests/test_cost_stage_checkpoint_manifest.py
+++ b/tests/test_cost_stage_checkpoint_manifest.py
@@ -1,0 +1,44 @@
+"""A file-oriented stage reuses the journal's existing identity envelope."""
+import json
+
+import pytest
+
+from prismaquant.cost_stage_checkpoint import (
+    MANIFEST_SCHEMA, prepare_journal, write_unit,
+)
+
+
+def test_explicit_manifest_path_preserves_same_identity_resume(tmp_path):
+    root = tmp_path / "cost.anchors.json.parts"
+    manifest = tmp_path / "cost.anchors.json"
+    identity = {"source": "one", "units": ["unit"]}
+    journal, digest, state = prepare_journal(
+        root, stage="tessera campaign", resume=True, identity=identity,
+        qnames=["unit"], manifest_path=manifest,
+    )
+    assert journal == root and state == {}
+    assert json.loads(manifest.read_text())["schema"] == MANIFEST_SCHEMA
+    assert not (root / "manifest.json").exists()
+    write_unit(root, stage="tessera campaign", qname="unit",
+               identity_sha256=digest, state={"anchors": [1]})
+    assert prepare_journal(
+        root, stage="tessera campaign", resume=True, identity=identity,
+        qnames=["unit"], manifest_path=manifest,
+    )[2] == {"unit": {"anchors": [1]}}
+    with pytest.raises(RuntimeError, match="checkpoint identity"):
+        prepare_journal(
+            root, stage="tessera campaign", resume=True,
+            identity={"source": "changed", "units": ["unit"]},
+            qnames=["unit"], manifest_path=manifest,
+        )
+
+
+def test_explicit_manifest_path_refuses_legacy_without_overwrite(tmp_path):
+    manifest = tmp_path / "cost.anchors.json"
+    manifest.write_text(json.dumps({"schema": "old campaign", "anchors": []}))
+    with pytest.raises(RuntimeError, match="checkpoint identity"):
+        prepare_journal(
+            tmp_path / "parts", stage="tessera campaign", resume=True,
+            identity={"source": "current"}, qnames=["unit"], manifest_path=manifest,
+        )
+    assert json.loads(manifest.read_text())["schema"] == "old campaign"

--- a/tests/test_tessera_campaign_resume.py
+++ b/tests/test_tessera_campaign_resume.py
@@ -1,0 +1,192 @@
+"""A resumed cost must belong to this run's actual encoding inputs."""
+import json
+import pickle
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+UNIT = "model.layers.0.proj"
+
+
+def _main_fixture(monkeypatch, tmp_path, *, priced=False):
+    from prismaquant import model_profiles, tessera_campaign, tessera_render
+    from prismaquant.model_profiles import DefaultProfile
+
+    model = torch.nn.Module()
+    model.model = torch.nn.Module()
+    model.model.layers = torch.nn.ModuleList([torch.nn.Module()])
+    model.model.layers[0].proj = torch.nn.Linear(256, 32, bias=False, dtype=torch.bfloat16)
+    with torch.no_grad():
+        model.model.layers[0].proj.weight.copy_(
+            torch.randn(32, 256, generator=torch.Generator().manual_seed(186)))
+    inputs = {
+        "tokens": [torch.ones(1, 256, dtype=torch.long)],
+        "text": "one draw",
+        "rows": torch.randn(4, 256, generator=torch.Generator().manual_seed(183)),
+        "hessian": torch.eye(256),
+        "menu": ([SimpleNamespace(
+            format_name="TESSERA_E4M3_K1_R1024", family="TESSERA_E4M3_K1",
+            body_rate_q256=1024, bpp=4.0)] if priced else []),
+    }
+    transformers = ModuleType("transformers")
+    transformers.AutoModelForCausalLM = SimpleNamespace(
+        from_pretrained=lambda *_args, **_kwargs: model)
+    monkeypatch.setitem(sys.modules, "transformers", transformers)
+    monkeypatch.setattr(model_profiles, "detect_profile", lambda _path: DefaultProfile())
+    monkeypatch.setattr(tessera_render, "tessera_encoder_hessian_status", lambda: {
+        "accepted": True, "reason": "CPU test fixture", "kwargs": [], "recipe": {},
+    })
+    monkeypatch.setattr(tessera_campaign, "_calibration_tokens",
+                        lambda *_args: (inputs["tokens"], inputs["text"]))
+    monkeypatch.setattr(tessera_campaign, "_collect_activations", lambda *_args, **kwargs: (
+        {UNIT: inputs["rows"]},
+        {UNIT: inputs["hessian"]} if kwargs["want_hessian"] else {},
+        {UNIT: len(inputs["rows"]) if kwargs["want_hessian"] else 0},
+    ))
+    monkeypatch.setattr(tessera_campaign, "expand_menus_for_targets",
+                        lambda _weights, targets, **_kwargs: {
+                            name: inputs["menu"] for name in targets})
+
+    def unverified_anchors_reached_payload(anchors, *_args, **_kwargs):
+        assert not anchors, "unverified checkpoint anchors reached the current cost payload"
+        return {"costs": {}, "formats": []}
+
+    if not priced:
+        monkeypatch.setattr(tessera_campaign, "campaign_cost_payload",
+                            unverified_anchors_reached_payload)
+    checkpoint = tmp_path / "campaign.anchors.json"
+    argv = ["--model", "synthetic-current-model", "--out", str(tmp_path / "cost.pkl"),
+            "--cache-dir", str(tmp_path / "cache"), "--checkpoint", str(checkpoint),
+            "--hessian", "off", "--menu-mode", "research", "--max-rounds", "1"]
+    return tessera_campaign, checkpoint, argv, model, inputs
+
+
+@pytest.mark.parametrize("checkpoint_unit", [UNIT, "model.layers.8.other_model"])
+def test_main_refuses_unbound_checkpoint_before_accepting_anchors(
+    monkeypatch, tmp_path, checkpoint_unit,
+):
+    campaign, checkpoint, argv, _model, _inputs = _main_fixture(monkeypatch, tmp_path)
+    anchor = campaign.CampaignAnchor(
+        qname=checkpoint_unit, family="TESSERA_E4M3_K1",
+        format_name="TESSERA_E4M3_K1_R1024", body_rate_q256=1024,
+        dloss=0.25, dloss_stderr=0.0, memory_bytes=8, bits_per_param=4.0,
+        activation_contract="a8", activation_quantized=True, wire_bytes=8,
+        seconds=1.0, hessian_applied=False,
+    )
+    checkpoint.write_text(json.dumps({"schema": campaign.SCHEMA, "anchors": [vars(anchor)]}))
+    with pytest.raises(RuntimeError, match="checkpoint.*identity|resume.*identity"):
+        campaign.main(argv)
+
+
+def _fresh_priced_campaign(monkeypatch, tmp_path, *, hessian=False):
+    fixture = _main_fixture(monkeypatch, tmp_path, priced=True)
+    campaign, checkpoint, argv, _model, _inputs = fixture
+    if hessian:
+        argv[argv.index("--hessian") + 1] = "require"
+    assert campaign.main(argv) == 0
+    with (tmp_path / "cost.pkl").open("rb") as handle:
+        payload = pickle.load(handle)
+    assert payload["costs"][UNIT]["TESSERA_E4M3_K1_R1024"]["output_mse_measured"]
+    return fixture, payload
+
+
+def _forbid_reencode(monkeypatch, campaign):
+    def forbidden(**_kwargs):
+        pytest.fail("resume attempted another encode instead of validating the priced bytes")
+    monkeypatch.setattr(campaign, "_measure_anchor", forbidden)
+
+
+def test_main_resumes_identical_cost_and_wire_without_reencoding(monkeypatch, tmp_path):
+    from prismaquant.cost_stage_checkpoint import MANIFEST_SCHEMA
+
+    (campaign, checkpoint, argv, _model, _inputs), initial = _fresh_priced_campaign(
+        monkeypatch, tmp_path)
+    manifest = json.loads(checkpoint.read_text())
+    assert manifest["schema"] == MANIFEST_SCHEMA
+    original_manifest = checkpoint.read_bytes()
+    wire = next((tmp_path / "cache" / "wire").glob("*.tessera"))
+    original_wire = wire.read_bytes()
+    _forbid_reencode(monkeypatch, campaign)
+    # Output location and interruption limit are not encoding/scoring inputs.
+    argv[argv.index("--out") + 1] = str(tmp_path / "resumed.pkl")
+    assert campaign.main([*argv, "--deadline-seconds", "1"]) == 0
+    with (tmp_path / "resumed.pkl").open("rb") as handle:
+        resumed = pickle.load(handle)
+    assert resumed["costs"] == initial["costs"]
+    assert checkpoint.read_bytes() == original_manifest
+    assert wire.read_bytes() == original_wire
+
+
+def test_main_refuses_changed_hessian_values_under_same_draw(monkeypatch, tmp_path):
+    (campaign, checkpoint, argv, _model, inputs), _payload = _fresh_priced_campaign(
+        monkeypatch, tmp_path, hessian=True)
+    original_manifest = checkpoint.read_bytes()
+    _forbid_reencode(monkeypatch, campaign)
+    inputs["hessian"][0, 0] += 1
+    with pytest.raises(RuntimeError, match="checkpoint identity mismatch"):
+        campaign.main(argv)
+    assert checkpoint.read_bytes() == original_manifest
+
+
+@pytest.mark.parametrize("changed", [
+    "weight", "scoring_rows", "corpus", "tokens", "hessian_mode", "menu",
+    "recipe", "encoder_source", "prismaquant_source", "scope",
+])
+def test_main_refuses_changed_encoding_or_scoring_inputs(monkeypatch, tmp_path, changed):
+    (campaign, checkpoint, argv, model, inputs), _payload = _fresh_priced_campaign(
+        monkeypatch, tmp_path)
+    original_manifest = checkpoint.read_bytes()
+    _forbid_reencode(monkeypatch, campaign)
+    if changed == "weight":
+        with torch.no_grad():
+            model.model.layers[0].proj.weight[0, 0] += 1
+    elif changed == "scoring_rows":
+        inputs["rows"][0, 0] += 1
+    elif changed == "corpus":
+        inputs["text"] = "different corpus, same selected tokens"
+    elif changed == "tokens":
+        inputs["tokens"][0][0, 0] += 1
+    elif changed == "hessian_mode":
+        argv[argv.index("--hessian") + 1] = "require"
+    elif changed == "menu":
+        inputs["menu"] = []
+    elif changed == "recipe":
+        recipe = campaign.th.encoder_recipe()
+        monkeypatch.setattr(campaign.th, "encoder_recipe", lambda: {**recipe, "changed": True})
+    elif changed == "encoder_source":
+        from tessera import cached_unit
+        monkeypatch.setattr(cached_unit, "encoder_source_sha256", lambda: "0" * 64)
+    elif changed == "prismaquant_source":
+        from prismaquant import production_weight_cache
+        monkeypatch.setattr(production_weight_cache, "_production_cache_source_sha256",
+                            lambda: "0" * 64)
+    elif changed == "scope":
+        argv.extend(["--tp-degree", "2"])
+    with pytest.raises(RuntimeError, match="checkpoint identity mismatch"):
+        campaign.main(argv)
+    assert checkpoint.read_bytes() == original_manifest
+
+
+@pytest.mark.parametrize("damage", ["missing", "bytes", "symlink"])
+def test_main_refuses_missing_or_changed_priced_wire(monkeypatch, tmp_path, damage):
+    (campaign, checkpoint, argv, _model, _inputs), _payload = _fresh_priced_campaign(
+        monkeypatch, tmp_path)
+    _forbid_reencode(monkeypatch, campaign)
+    original_manifest = checkpoint.read_bytes()
+    wire = next((tmp_path / "cache" / "wire").glob("*.tessera"))
+    if damage == "missing":
+        wire.unlink()
+    elif damage == "bytes":
+        blob = bytearray(wire.read_bytes())
+        blob[-1] ^= 1
+        wire.write_bytes(blob)
+    else:
+        moved = wire.with_suffix(".elsewhere")
+        wire.rename(moved)
+        wire.symlink_to(moved.name)
+    with pytest.raises(RuntimeError, match="checkpoint cached wire"):
+        campaign.main(argv)
+    assert checkpoint.read_bytes() == original_manifest


### PR DESCRIPTION
## Outcome

Fixes #186. Identity-free or mismatched checkpoint anchors can no longer enter a Tessera campaign's current cost payload. A same-input resume reuses its exact measured costs and wire without re-encoding.

This PR is stacked on #187 until that capture/endpoint base lands. It also depends on the isolated Tessera producer API at `6343137` (`codex/ts-cached-producer-api`, receipt tip `fe3e996`); the release pin and frozen MoE serving candidate are untouched. An older producer lacking that API fails closed. **Do not read this as completion of #183**, whose packed main-entry refusal remains closed pending the real producer bridge and served measurements.

## Changes

- Reuse the existing identity-bound cost-stage journal; an optional manifest pathname preserves the current `--checkpoint` file/default, with existing per-unit shards under a sibling `.parts` directory.
- Bind selected weight/score-row/Hessian values, corpus and token identities, menus/scope, explicit campaign settings, resolved encoder settings and both package source seals. Actual score rows are bound even with `--hessian off`.
- Use the producer's existing generic input/byte receipt APIs. Before any resumed cost is admitted, validate unit/rung/menu/Hessian applicability, exact receipt coverage, full-blob bytes/digest and the freshly derived encoding identity. No current identity is stamped onto an old anchor.
- Preserve exact measured costs and bytes for a valid resume. Refuse missing, changed or symlinked wire without silently recomputing it.

Separate commits keep the shared journal adapter, campaign gate and on-sight prose corrections independently reviewable. Off-task prose corrections: the old Hessian comment incorrectly claimed a fixed plane roster; the opening docstring overclaimed export/serve identity from the cached rendering proof. Both now describe the actual owner/proof boundary.

## Evidence

All computation went through deployed PrismaBuild `aa6d3cfa2f77`, CPU-only serial Sparky, 1 CPU / 4 GiB; immutable producer source archive `6343137` was extracted in the worker. No GPU or served/performance result is claimed.

- Shared journal adapter red: two `unexpected keyword argument 'manifest_path'` failures; green: **19 passed / 0 skipped** (`4b5265e28732`).
- Real main-entry expanded red: **17 failed / 0 skipped** (`935b09c3641f`, completed first attempt; redundant retries withdrawn). Only `campaign.py` was restored to exact pre-fix `2c22feac`; fixture models/menus/calibration rows are synthetic, but their 32x256 units are really encoded and priced. Old code accepted changed weights, score rows, corpus/tokens, actual H, H mode, recipe/menu/source/scope, and missing/corrupt/symlinked wire. All failure lines are recorded in the measurement document.
- Fixed eight-file targeted run: **95 passed / 5 skipped**, no uncollected module reported (`b62e9617fbfef24f65ae0b1491a2c74825ad6ab2b1538e1036d0cfe7e75b9ed9`, 112.32s). Five skip reasons verbatim: `Tessera encodes need CUDA`. Receipt `49a11ee95fc88145da43d1e5c34e47b87355e4015e16265fe4294191afd903e3`.
- Producer API author independently reviewed the adapter; no API misuse found.

Detailed append-only evidence: `docs/measurements/tessera-checkpoint-identity-2026-09-04.md`. `docs/ARCHITECTURE.md` changes with the gate. No full-master baseline or uncoordinated full suite was run.
