### PR TITLE
Tessera lane: carry the priced inputs from allocator to executor to cost-table identity (#193, #194, #195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ### Fixed
 
+- **Tessera W4A4 anchors are priced under the served static UE4M3 activation
+  contract** (#194; `tessera_campaign._measure_anchor`). The campaign scored
+  every E2M1 anchor with NVFP4's registry callback — a dynamic per-group
+  FP32-scale RTN — while Tessera's plugin executes vLLM's static-global-scale
+  `scaled_fp4_quant` against the artifact's `trellis_input_global_scale`,
+  with UE4M3-stored block scales; underflow and midpoint cases diverge (a
+  1e-3 block flushes to exact 0 under the served contract at G=1 and survives
+  under the FP32 scale). W4A4 anchors are now scored through the owned served
+  oracle (`nvfp4_activation_qdq_served`) at the unit's calibrated,
+  fused-sibling-unified static scale — calibrated over every calibration row
+  from the campaign's own forward passes under the resolved NVFP4 policy — a
+  missing scale refuses (`ActivationScaleContractError`) instead of falling
+  back to the dynamic quantiser, and the scale value/policy identity travels
+  on every W4A4 row and in the payload provenance. **Re-pricing:** existing
+  Tessera cost tables' E2M1 rows were priced under the dynamic A side and are
+  stale; re-measure on the same calibration contract (E4M3/BF16 rows are
+  unaffected).
 - **The Tessera cost-table identity guard compares the required Hessian
   identity triple** (#195; `tessera_menu.assert_uniform_hessian_identity`).
   The guard keyed rows only on the legacy `(supplied, text_sha, token_count,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ### Fixed
 
+- **The Tessera export arm fails closed on missing priced inputs, and the
+  campaign supplies them** (#193; `run-pipeline.sh`,
+  `tessera_export_lane.require_priced_export_inputs`,
+  `tessera_campaign.write_export_inputs`). The arm forwarded only
+  `--plan-json`/`--device` to Tessera's exporter: an H-aware allocation (the
+  campaign's default) was re-encoded weights-only — the exporter builds an
+  `ActivationSource` only when `--hessian` is present and raises nothing
+  without one — and any E2M1 selection died inside the exporter, which
+  hard-requires `--input-scales` for NVFP4 routes. The campaign now writes
+  `hessian_capture.pt` (the exact un-normalised per-unit XᵀX plus the
+  identity triple, with a JSON provenance sidecar) and
+  `input_scales.safetensors` beside its cache; the driver threads
+  `TESSERA_HESSIAN`/`TESSERA_INPUT_SCALES` to both the lane preflight and the
+  exporter; and a fifth lane gate refuses, before the plan translation, an
+  H-aware allocation without its identity-matched capture, a weights-only
+  allocation handed a stray one, an undeclared allocation, and a W4A4
+  selection whose scales file does not cover every selected unit.
 - **Tessera W4A4 anchors are priced under the served static UE4M3 activation
   contract** (#194; `tessera_campaign._measure_anchor`). The campaign scored
   every E2M1 anchor with NVFP4's registry callback — a dynamic per-group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixed
 
+- **Campaign resume refuses W4A4 anchors priced under another activation
+  contract** (follow-on to #194; `tessera_campaign._require_resumable_anchor`).
+  A pre-#194 checkpoint's W4A4 rows carry no `input_global_scale` (dynamic
+  pricing) and rows from another calibration carry a different one; merging
+  either silently rebuilds the mixed-currency table on the activation axis
+  that the Hessian identity guard refuses on its own.
 - **The Tessera export arm fails closed on missing priced inputs, and the
   campaign supplies them** (#193; `run-pipeline.sh`,
   `tessera_export_lane.require_priced_export_inputs`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Fixed
 
+- **The Tessera cost-table identity guard compares the required Hessian
+  identity triple** (#195; `tessera_menu.assert_uniform_hessian_identity`).
+  The guard keyed rows only on the legacy `(supplied, text_sha, token_count,
+  kwarg)` projection, so any number of distinct modern identities —
+  `text_sha256` / `fit_tokens` / `fit_ids_sha256`, read from
+  `tessera_hessian.HESSIAN_IDENTITY_FIELDS`, which every current campaign row
+  carries — collapsed to one key and a table merged from two Hessian draws
+  allocated as one. Modern rows now key on the triple AND the legacy aliases,
+  pre-triple rows are their own `legacy` class that never merges with a
+  modern row, a partial triple refuses by name, and the returned stamp
+  carries the canonical triple into `__prismaquant__.tessera_hessian` so
+  export can bind a capture against the allocation.
 - **The group knapsack's per-member rung licence is read from the Tessera
   contract, not from its own docstring** (#132, RobTand/tessera#37;
   `allocator_candidates.tessera_group_composites`,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,31 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-04 · `codex/pq-tessera-v5-endpoints`. Stamps
+As of: 2026-09-05 · `claude/pq-tessera-audit`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-05, `claude/pq-tessera-audit`) for **the Tessera
+priced-inputs contract** (§5, §9.4; RobTand/prismaquant#193/#194/#195, one
+story). The campaign now writes the export leg's inputs beside its cache —
+`hessian_capture.pt` (the exact un-normalised per-unit XᵀX plus the identity
+triple, the shape `ActivationSource.from_capture` loads, with a JSON
+provenance sidecar) and `input_scales.safetensors` (one static
+`input_global_scale` per unit, fused-sibling unified) — and the driver's
+Tessera arm threads `TESSERA_HESSIAN` / `TESSERA_INPUT_SCALES` through one
+array to both the lane preflight and Tessera's exporter, which previously
+received only `--plan-json`/`--device` and so re-encoded H-aware allocations
+weights-only and could not export an E2M1 selection at all. A fifth lane gate
+(`tessera_export_lane.require_priced_export_inputs`) fails closed before the
+plan translation: an H-aware allocation without its identity-matched capture,
+a weights-only allocation handed a stray one, an undeclared allocation, and a
+W4A4 selection whose scales file does not cover every selected unit all
+refuse by name. Feeding it, the campaign prices every W4A4 anchor under the
+**served** static UE4M3 contract (`nvfp4_activation_qdq_served` at the unit's
+calibrated scale; a missing scale refuses rather than falling back to the
+dynamic FP32-scale RTN — existing E2M1 cost rows are stale and need
+re-measuring), and `assert_uniform_hessian_identity` compares the full
+required identity triple, so two draws can no longer collapse to one legacy
+key. Tests: `test_tessera_priced_export_inputs.py` plus the campaign-file
+additions.
 
 Re-stamped (2026-09-04, `codex/pq-tessera-v5-endpoints`) for **raw scoped
 census handoff instructions** (§9.4). The driver prints the producer's actual
@@ -5256,8 +5280,15 @@ the same format name, and the seam refuses rather than downgrade silently:
   `fit_ids_sha256`, source, split role, seed) beside it.
 * **The provenance has a consumer.** `tessera_menu.assert_uniform_hessian_
   identity` refuses a cost table whose Tessera rows carry two different Hessian
-  identities, and the allocator calls it at load and stamps the result into
-  `__prismaquant__.tessera_hessian`. Unstamped rows are counted as
+  identities — compared on the **full required triple** (`text_sha256` /
+  `fit_tokens` / `fit_ids_sha256`, read from
+  `tessera_hessian.HESSIAN_IDENTITY_FIELDS`) beside the legacy aliases, so
+  agreeing aliases cannot launder disagreeing triples (#195); pre-triple rows
+  are their own `legacy` class that never merges with a modern row, and a
+  partial triple refuses by name — and the allocator calls it at load and
+  stamps the result, canonical triple included, into
+  `__prismaquant__.tessera_hessian`, which is the identity the export gate
+  binds a `--hessian` capture against. Unstamped rows are counted as
   *unstamped*, not assumed to match. Provenance that nothing consumes is a
   confession log; this one is a gate.
 
@@ -5425,11 +5456,17 @@ predicts worst — and gated on a measured LOO error, not a taste constant.
 Two properties make the numbers comparable with the rest of the menu:
 
 * **Priced as served.** The render is scored under the route's own activation
-  contract — NVFP4's W4A4 quantiser on E2M1 rungs, per-token FP8 on E4M3 — taken
-  *by reference* from the serving format's registry row, so the A leg is not a
-  second implementation of it. The same weight rate therefore costs differently on
+  contract — the **served static UE4M3** W4A4 quantiser on E2M1 rungs
+  (`nvfp4_activation_qdq_served` at the unit's calibrated, fused-unified
+  `input_global_scale`, the same operation `scaled_fp4_quant` executes against
+  `trellis_input_global_scale`; a missing scale refuses,
+  `ActivationScaleContractError`, rather than falling back to the registry's
+  dynamic FP32-scale RTN — #194), per-token dynamic FP8 on E4M3, taken *by
+  reference* from the owned oracles, so the A leg is not a second
+  implementation of either. The same weight rate therefore costs differently on
   the two routes, which is asserted directly by
-  `test_the_same_weight_rate_costs_differently_on_the_two_routes`.
+  `test_the_same_weight_rate_costs_differently_on_the_two_routes`, and each
+  W4A4 row carries the `input_global_scale` it was scored under.
 * **Rendering identity (§P8).** The tensor that is priced *is* the decoded wire:
   `_encode_and_render` returns `read_unit_artifact(unit.blob)`, and the blob is
   stored beside the render in the cache. Not two code paths that agree — one
@@ -6090,7 +6127,14 @@ Export's `resolve_unit_route` has those facts and evaluates the predicates.
 **The boundary has an export arm, not a second codec.**
 `prismaquant/run-pipeline.sh` selects `EXPORT_CONTAINER=tessera`, preflights
 the lane and calls Tessera's own plan and encoding tools under `TESSERA_REPO`.
-`export_native_compressed.py` deliberately has no Tessera codec. The arm opens
+`export_native_compressed.py` deliberately has no Tessera codec. The arm
+threads the allocation's **priced inputs** to both the preflight and the
+exporter — `TESSERA_HESSIAN` (the campaign's `hessian_capture.pt`) and
+`TESSERA_INPUT_SCALES` (its `input_scales.safetensors`) — and
+`tessera_export_lane.require_priced_export_inputs` fails closed before the
+plan translation when the allocation's `tessera_hessian` stamp or its
+selected W4A4 routes declare a requirement the supplied files do not satisfy
+(#193): the artifact built must be the artifact priced. The arm opens
 a lane-gated shipcard; `prismaquant/lane_specs/tessera.json` (§9.4) declares the
 serve, endpoint, gates, KL evaluator and executed activation contracts.
 Allocation uses `tessera_menu` and its reviewed development contract; that
@@ -6099,7 +6143,8 @@ The pending release and supported producer-tool boundary remain D33, rather
 than an absence of pipeline integration. Tests include
 `test_tessera_formats.py`, `test_tessera_footprint.py`,
 `test_tessera_shape_dependent_recipe.py`, `test_tessera_lane_admission.py`,
-`test_tessera_menu.py` and `test_tessera_export_lane.py`.
+`test_tessera_menu.py`, `test_tessera_export_lane.py` and
+`test_tessera_priced_export_inputs.py`.
 
 ## 6. Export & serving invariants
 

--- a/prismaquant/run-pipeline.sh
+++ b/prismaquant/run-pipeline.sh
@@ -162,6 +162,17 @@ if [[ -n "${TESSERA_PLATFORM:-}${TESSERA_RUNTIME_IMAGE:-}${TESSERA_EXECUTION_MOD
   [[ -z "${TESSERA_EXECUTION_MODE:-}" ]] || TESSERA_SCOPE_ARGS+=(--tessera-execution-mode "$TESSERA_EXECUTION_MODE")
   TESSERA_SCOPE_ARGS+=(--tessera-residency "$TESSERA_SERVE_MODE")
 fi
+# The inputs the allocation was PRICED under, handed back to the exporter.
+# TESSERA_HESSIAN is the campaign's hessian_capture.pt (the exact XtX per unit
+# the cost table and any H-aware bytes were built on); TESSERA_INPUT_SCALES is
+# its input_scales.safetensors (one static input_global_scale per unit, fused
+# siblings unified -- the value the W4A4 costs were scored under and the value
+# the serve reads as trellis_input_global_scale). Both default to unset, and
+# the lane preflight FAILS CLOSED when the allocation declares a priced
+# requirement these do not satisfy (RobTand/prismaquant#193): an export
+# without them would build an artifact that is not the artifact priced.
+: "${TESSERA_HESSIAN:=}"
+: "${TESSERA_INPUT_SCALES:=}"
 # `as-allocated` plans exactly the units the allocation names and spells every
 # other body Linear BF16 explicitly. `broadcast-by-role` EXTRAPOLATES a
 # single-layer allocation to every depth and stamps itself as an
@@ -2471,10 +2482,21 @@ if [[ "$EXPORT_CONTAINER" == "tessera" ]]; then
   # Re-read the allocation's scope and actual source header dimensions even
   # when an old plan exists: a cached plan is not an admission receipt.
   TESSERA_BUILD_JSON="${WORK_DIR}/artifacts/tessera_build.json"
+  # The priced inputs, threaded to the preflight (which refuses when the
+  # allocation declares a requirement they do not satisfy) and to the exporter
+  # (which consumes them). Built inside the arm so the block is self-contained.
+  TESSERA_PRICED_INPUT_ARGS=()
+  if [[ -n "${TESSERA_HESSIAN:-}" ]]; then
+    TESSERA_PRICED_INPUT_ARGS+=(--hessian "$TESSERA_HESSIAN")
+  fi
+  if [[ -n "${TESSERA_INPUT_SCALES:-}" ]]; then
+    TESSERA_PRICED_INPUT_ARGS+=(--input-scales "$TESSERA_INPUT_SCALES")
+  fi
   if ! python3 -m prismaquant.tessera_export_lane --model "$MODEL_PATH" \
       --assignment "${WORK_DIR}/artifacts/layer_config.json" \
       --write-build-json "$TESSERA_BUILD_JSON" \
-      --target-profile "$TARGET_PROFILE_RESOLVED" "${TESSERA_SCOPE_ARGS[@]}"; then
+      --target-profile "$TARGET_PROFILE_RESOLVED" "${TESSERA_SCOPE_ARGS[@]}" \
+      "${TESSERA_PRICED_INPUT_ARGS[@]}"; then
     exit 2
   fi
   TESSERA_PLAN="${WORK_DIR}/artifacts/tessera_plan.json"
@@ -2510,10 +2532,17 @@ if [[ "$EXPORT_CONTAINER" == "tessera" ]]; then
   fi
 
   echo "[pipeline] [4/4] exporting to the Tessera wire ..."
+  # The same priced inputs the preflight just validated, handed to the encode:
+  # the Hessian that shaped the priced bytes and the static activation scales
+  # the W4A4 costs were scored under. Omitting them here while the preflight
+  # accepted an H-free/scale-free allocation is the weights-only lane and
+  # correct; omitting them on an H-aware allocation is unreachable -- the
+  # preflight exits 2 above before this line runs.
   python3 "${TESSERA_REPO%/}/experiments/export_tessera_serving.py" \
     "$MODEL_PATH" "${WORK_DIR}/exported" \
     --plan-json "$TESSERA_PLAN" \
     --device "$EXPORT_DEVICE" \
+    "${TESSERA_PRICED_INPUT_ARGS[@]}" \
     2>&1 | tee "${WORK_DIR}/logs/export.log"
 
   echo

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -725,6 +725,50 @@ def expand_menus_for_targets(weights, targets, *, mode, tp_degree,
     return menus
 
 
+def _format_executes_static_nvfp4(format_name: str) -> bool:
+    """Does this rung's route execute the static NVFP4 activation contract?"""
+    from .tessera_formats import (
+        parse_tessera_format_name, tessera_serving_route, tessera_wire_recipe,
+    )
+
+    family, rung = parse_tessera_format_name(format_name)
+    wire = tessera_wire_recipe(family, rung)
+    return tessera_serving_route(
+        family, wire, rung).activation_source_format == "NVFP4"
+
+
+def _require_resumable_anchor(anchor: CampaignAnchor, static_scales) -> None:
+    """Refuse a resumed anchor priced under a different activation contract.
+
+    Resume merges checkpoint rows into this run's table, and the table's rows
+    must be one currency.  A W4A4 anchor with no ``input_global_scale`` was
+    measured under the pre-#194 dynamic FP32-scale quantiser; one with a
+    *different* scale was measured on a different calibration.  Either way it
+    is not a price of this run's served A side, and merging it silently is the
+    exact mixed-table failure the Hessian identity guard exists to catch on
+    its own axis.
+    """
+    if not _format_executes_static_nvfp4(anchor.format_name):
+        return
+    if anchor.input_global_scale is None:
+        raise ActivationScaleContractError(
+            f"checkpoint anchor {anchor.qname} {anchor.format_name} carries "
+            "no input_global_scale: it was priced under the pre-served-"
+            "contract dynamic activation quantiser and cannot be merged into "
+            "a served-contract table. Delete the checkpoint (or pass a fresh "
+            "--checkpoint) to re-measure these anchors."
+        )
+    expected = static_scales.get(anchor.qname)
+    if expected is None or float(anchor.input_global_scale) != float(expected):
+        raise ActivationScaleContractError(
+            f"checkpoint anchor {anchor.qname} {anchor.format_name} was "
+            f"priced at input_global_scale={anchor.input_global_scale!r} but "
+            f"this run's calibration yields {expected!r}. A resumed anchor "
+            "must have been scored under this run's own static scales, or "
+            "the table mixes two activation calibrations under one identity."
+        )
+
+
 def write_export_inputs(cache_dir: Path, *, hessians, hessian_rows,
                         hessian_identity, static_scales, static_scale_policy):
     """Write the exporter's ``--hessian`` and ``--input-scales`` inputs.
@@ -1012,6 +1056,7 @@ def main(argv: "Sequence[str] | None" = None) -> int:
         raw = json.loads(checkpoint.read_text())
         for row in raw.get("anchors", []):
             anchor = CampaignAnchor(**row)
+            _require_resumable_anchor(anchor, static_scales)
             measured.setdefault(anchor.qname, {}).setdefault(
                 anchor.family, []).append(anchor)
         print(f"[campaign] resumed {sum(len(v) for f in measured.values() for v in f.values())} "

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -81,6 +81,7 @@ __all__ = [
     "campaign_cost_payload",
     "main",
     "next_anchor_rate",
+    "write_export_inputs",
 ]
 
 SCHEMA = "prismaquant.tessera_campaign_cost.v1"
@@ -724,6 +725,69 @@ def expand_menus_for_targets(weights, targets, *, mode, tp_degree,
     return menus
 
 
+def write_export_inputs(cache_dir: Path, *, hessians, hessian_rows,
+                        hessian_identity, static_scales, static_scale_policy):
+    """Write the exporter's ``--hessian`` and ``--input-scales`` inputs.
+
+    ``(hessian_capture_path | None, input_scales_path | None)``.  The
+    allocation an allocator builds on this campaign's table is priced under
+    exactly these Hessians and these static activation scales, so the export
+    leg must be handed them back or the artifact built is not the artifact
+    priced (RobTand/prismaquant#193).  Both files are in the shapes Tessera's
+    exporter consumes:
+
+    * ``hessian_capture.pt`` -- ``{"H": {unit: XᵀX}, "counts", "provenance"}``,
+      what ``ActivationSource.from_capture`` loads; the H tensors are the
+      campaign's own un-normalised accumulators, the identity is the same
+      triple stamped on every cost row, and ``hessian_role: "fit"`` marks it
+      as bytes-shaping (Tessera refuses a held-out capture there).  A JSON
+      sidecar ``<capture>.provenance.json`` repeats the identity so the export
+      gate can bind capture to allocation without loading the tensors.
+    * ``input_scales.safetensors`` -- one ``<unit>.input_global_scale`` F32
+      scalar per unit, the exporter's stock-NVFP4 spelling, valued exactly as
+      the W4A4 costs were scored.
+
+    ``hessians=None`` is the deliberate weights-only campaign: no capture is
+    written, matching the ``supplied=false`` stamp the rows carry.
+    """
+    import torch
+
+    hessian_capture_path = None
+    if hessians is not None:
+        hessian_capture_path = cache_dir / "hessian_capture.pt"
+        capture_provenance = {**dict(hessian_identity), "hessian_role": "fit"}
+        tmp_capture = hessian_capture_path.with_suffix(".pt.tmp")
+        torch.save({
+            "H": {name: h for name, h in hessians.items() if h is not None},
+            "counts": dict(hessian_rows),
+            "provenance": capture_provenance,
+        }, tmp_capture)
+        os.replace(tmp_capture, hessian_capture_path)
+        sidecar = hessian_capture_path.with_name(
+            hessian_capture_path.name + ".provenance.json")
+        sidecar.write_text(json.dumps(capture_provenance, indent=2,
+                                      sort_keys=True) + "\n")
+        print(f"[campaign] wrote {hessian_capture_path} "
+              f"({sum(1 for h in hessians.values() if h is not None)} "
+              "Hessians)", flush=True)
+    input_scales_path = None
+    if static_scales:
+        from safetensors.torch import save_file
+
+        from .nvfp4_activation_contract import input_global_scale_tensor
+
+        input_scales_path = cache_dir / "input_scales.safetensors"
+        save_file(
+            {f"{name}.input_global_scale": input_global_scale_tensor(value)
+             for name, value in static_scales.items()},
+            str(input_scales_path),
+            metadata={"input_global_scale_policy": str(static_scale_policy)},
+        )
+        print(f"[campaign] wrote {input_scales_path} "
+              f"({len(static_scales)} static input scales)", flush=True)
+    return hessian_capture_path, input_scales_path
+
+
 def main(argv: "Sequence[str] | None" = None) -> int:
     import torch
 
@@ -897,6 +961,17 @@ def main(argv: "Sequence[str] | None" = None) -> int:
                for name in targets}
     del model
     torch.cuda.empty_cache()
+
+    # The export leg's inputs, written BEFORE the anchor loop so even a
+    # deadline-stopped campaign leaves them (RobTand/prismaquant#193).
+    hessian_capture_path, input_scales_path = write_export_inputs(
+        cache_dir,
+        hessians=hessians if want_h else None,
+        hessian_rows=hessian_rows,
+        hessian_identity=hessian_identity,
+        static_scales=static_scales,
+        static_scale_policy=static_scale_policy,
+    )
 
     # ONE ActivationSource for the whole campaign, and ONE set of encoder
     # keywords per unit PER SCALE PLANE. The block-LDL is a function of the
@@ -1230,6 +1305,8 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             "activation_static_scales": {
                 "policy": str(static_scale_policy),
                 "source": "campaign_calibration_amax_fused_unified",
+                "path": (None if input_scales_path is None
+                         else str(input_scales_path)),
                 "units": {name: float(value)
                           for name, value in sorted(static_scales.items())},
             },
@@ -1245,6 +1322,10 @@ def main(argv: "Sequence[str] | None" = None) -> int:
                        + ")" if want_h else "")),
                 "kwargs": list(hessian_status["kwargs"]),
                 "recipe": dict(hessian_status["recipe"]),
+                # The exporter-shaped capture of the exact Hessians above,
+                # for the export leg's --hessian input; None on --hessian off.
+                "capture_path": (None if hessian_capture_path is None
+                                 else str(hessian_capture_path)),
                 "token_count": int(hessian_token_count),
                 "token_count_min": int(hessian_token_min),
                 # The identity triple Tessera requires, plus its context. The

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -23,6 +23,19 @@ against a per-token FP8 input.  The same *weight* rate therefore costs
 differently on the two routes, which is the whole reason the allocator may not
 rank them on weight error alone.
 
+The W4A4 leg is the **served static contract**, not the registry's dynamic
+RTN.  ``tessera.serving.nvfp4_route`` reads the artifact's
+``trellis_input_global_scale`` and calls vLLM's compiled ``scaled_fp4_quant``
+-- a static-global-scale operation whose per-16 block scales are stored as
+UE4M3 -- so an E2M1 rung here is scored through
+``format_registry.nvfp4_activation_qdq_served`` at the unit's own calibrated
+``input_global_scale`` (fused-sibling unified, the same joint the exporter's
+scale file carries).  NVFP4's registry callback is a dynamic FP32-scale RTN
+that never snaps through UE4M3 and rounds midpoints differently; pricing with
+it prices an activation tensor the runtime does not execute
+(RobTand/prismaquant#194).  A missing scale refuses rather than falling back
+to the dynamic quantiser.
+
 Rendering identity, and the wire
 --------------------------------
 The render is not ``render_tessera_weight``'s reconstruction; it is
@@ -107,6 +120,11 @@ class CampaignAnchor:
     #: is legitimately half H-aware and a table-level flag would have to lie in
     #: one direction or the other.
     hessian_applied: bool = False
+    #: The static NVFP4 ``input_global_scale`` this anchor's A side was scored
+    #: under, when the rung's route executes the static UE4M3 contract; None
+    #: on every other route.  Carried per row so the price's activation
+    #: identity survives into the cost table beside the Hessian identity.
+    input_global_scale: "float | None" = None
 
 
 def anchor_schedule(lo: int, hi: int, count: int) -> list[int]:
@@ -176,6 +194,19 @@ def next_anchor_rate(
 # Measurement
 # ---------------------------------------------------------------------------
 
+class ActivationScaleContractError(RuntimeError):
+    """A static-activation-contract rung has no calibrated input scale.
+
+    Its own class for the same reason ``HessianContractError`` has one: the
+    anchor loop absorbs per-anchor failures with ``except Exception:
+    continue``, and a scale-contract refusal is about every W4A4 row this run
+    would write, not about one anchor.  Falling back to the registry's dynamic
+    FP32-scale quantiser instead would price an activation regime the serve
+    does not execute -- exactly the defect this refusal exists to make loud
+    (RobTand/prismaquant#194).
+    """
+
+
 def _encode_and_render(weight, format_name: str, *, activation_kwargs=None,
                        hessian_required: bool = True, recipe=None):
     """``(render, blob)`` for one rung: the bytes, and what they decode to.
@@ -202,8 +233,16 @@ def _encode_and_render(weight, format_name: str, *, activation_kwargs=None,
 def _measure_anchor(
     *, qname: str, weight, activations, format_name: str, cache, wire_dir: Path,
     activation_kwargs_for=None, hessian_required: bool = True,
+    static_input_scale: "float | None" = None,
 ):
     """Render one rung, price it as served, and store the wire beside it.
+
+    ``static_input_scale`` is the unit's calibrated NVFP4
+    ``input_global_scale`` (fused-sibling unified), required whenever the
+    rung's route executes the static UE4M3 activation contract and ignored on
+    every other route.  The refusal for a missing one runs BEFORE the encode,
+    because the encode is the expensive half and the refusal is about the
+    whole run.
 
     ``activation_kwargs_for`` is a callable ``(qname, scale_plane) -> encoder
     kwargs`` -- the block-LDL of that unit's regularised ``XᵀX`` and the
@@ -228,7 +267,9 @@ def _measure_anchor(
     from .production_weight_cache import (
         _local_forward_render_score, _store_rendered_weight_entry,
     )
-    from .tessera_formats import parse_tessera_format_name, tessera_wire_recipe
+    from .tessera_formats import (
+        parse_tessera_format_name, tessera_serving_route, tessera_wire_recipe,
+    )
     from .tessera_render import HessianContractError
 
     from .tessera_render import rung_accepts_hessian
@@ -239,6 +280,27 @@ def _measure_anchor(
     # the predicate reads and the plane the encode writes are this object --
     # not three lookups that agree only while nothing clears the recipe memo.
     wire = tessera_wire_recipe(family, rung)
+    # The A side, as served.  An NVFP4-materialising route executes vLLM's
+    # static-global-scale ``scaled_fp4_quant`` (UE4M3 block scales) against the
+    # artifact's ``trellis_input_global_scale``; every other route keeps the
+    # serving format's own dynamic quantiser, taken by reference from the spec.
+    route = tessera_serving_route(family, wire, rung)
+    if route.activation_source_format == "NVFP4":
+        if static_input_scale is None or not float(static_input_scale) > 0:
+            raise ActivationScaleContractError(
+                f"{qname} {format_name}: this rung's route executes the "
+                f"static NVFP4 activation contract ({route.contract}) and no "
+                "calibrated input_global_scale was supplied. Scoring it with "
+                "the registry's dynamic FP32-scale quantiser would price an "
+                "activation regime the serve does not execute; a lookup that "
+                "misses must refuse, not fall back."
+            )
+        input_scale = float(static_input_scale)
+        activation_qdq = (
+            lambda x: fr.nvfp4_activation_qdq_served(x, input_scale))
+    else:
+        input_scale = None
+        activation_qdq = spec.activation_quantize_dequantize
     activation_kwargs = None
     # Whether an H can be applied is a property of the RUNG'S WIRE, not of the
     # run, and it is DERIVED from what the pinned ActivationSource emits for
@@ -267,11 +329,10 @@ def _measure_anchor(
         reference_weight=weight,
         rendered_weight=render,
         activations=activations,
-        activation_quantize=spec.activation_quantize_dequantize,
-        # Tessera's A side is the serving format's own dynamic quantiser, taken
-        # by reference; no calibrated static clip applies (that is NVFP4's
-        # tensor-level scale, and ``_format_uses_static_activation_clip``
-        # names only NVFP4 for it).
+        activation_quantize=activation_qdq,
+        # No pre-clip on top: the static route's clamp lives inside the served
+        # oracle (``nvfp4_activation_qdq_served`` clamps at the stored UE4M3
+        # scale), and the dynamic routes have no calibrated clip at all.
         activation_max_abs=None,
     )
     if metric != "output_mse":
@@ -312,6 +373,7 @@ def _measure_anchor(
         wire_bytes=len(blob),
         seconds=elapsed,
         hessian_applied=hessian_applied,
+        input_global_scale=input_scale,
     )
 
 
@@ -389,6 +451,11 @@ def campaign_cost_payload(
                     "activation_contract": anchor.activation_contract,
                     "wire_bytes": anchor.wire_bytes,
                     "encode_seconds": anchor.seconds,
+                    # The static A-side scale this row was scored under, when
+                    # its route executes the static NVFP4 contract; the value
+                    # identity the export's scale file must reproduce.
+                    **({"input_global_scale": float(anchor.input_global_scale)}
+                       if anchor.input_global_scale is not None else {}),
                     "hessian_identity": {
                         **hessian_identity, "applied": bool(anchor.hessian_applied),
                     },
@@ -438,7 +505,10 @@ def campaign_cost_payload(
                     "activation_contract": rung.admission.activation_contract,
                     # An interpolated row inherits the applicability of the
                     # anchors it was interpolated between; they share a family,
-                    # so they share a scale plane and therefore an answer.
+                    # so they share a scale plane and therefore an answer --
+                    # and, on a static-contract route, a unit-level A scale.
+                    **({"input_global_scale": float(ordered[0].input_global_scale)}
+                       if ordered[0].input_global_scale is not None else {}),
                     "hessian_identity": {
                         **hessian_identity,
                         "applied": bool(ordered[0].hessian_applied),
@@ -482,9 +552,9 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
                          *, want_hessian: bool = False):
     """One forward pass per calibration batch, per Linear.
 
-    Returns ``(rows, hessians, token_counts)``.
+    Returns ``(rows, hessians, token_counts, max_abs)``.
 
-    Two different things come out of the same hook, and they have different
+    Three different things come out of the same hook, and they have different
     row budgets on purpose:
 
     * ``rows`` is capped at ``max_rows`` because it feeds
@@ -496,6 +566,11 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
       ``down_proj`` a rank-256 Hessian -- rank-deficient by a factor of
       twelve, and wrong in a way no downstream check would catch.  So the
       accumulation runs before the keep's early return, not after it.
+    * ``max_abs`` is ``max|x|`` over **every** calibration row, unconditional
+      and for the same reason the Hessian is uncapped: it calibrates the
+      static NVFP4 ``input_global_scale`` the W4A4 routes are priced and
+      served under, and a maximum over a prefix of the rows is a different
+      calibration than the one an exporter would take.
 
     Accumulated in fp32 on the model's device and moved to CPU once at the
     end, matching how the kept rows are handled.
@@ -506,6 +581,7 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
     kept: dict[str, int] = {name: 0 for name in targets}
     hess: dict[str, object] = {name: None for name in targets}
     seen: dict[str, int] = {name: 0 for name in targets}
+    amax: dict[str, float] = {name: 0.0 for name in targets}
     handles = []
 
     def make_hook(name):
@@ -516,6 +592,8 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
             if not isinstance(x, torch.Tensor):
                 return
             flat = x.detach().reshape(-1, x.shape[-1])
+            amax[name] = max(
+                amax[name], float(flat.abs().amax().float().item()))
             if want_hessian:
                 # Every row, before any cap: see the docstring.
                 f32 = flat.to(dtype=torch.float32)
@@ -551,7 +629,39 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
         name: (None if h is None else h.to(device="cpu"))
         for name, h in hess.items()
     } if want_hessian else {}
-    return rows, hessians, dict(seen)
+    return rows, hessians, dict(seen), dict(amax)
+
+
+def _static_input_scales(max_abs: "Mapping[str, float]", *, profile=None):
+    """Per-unit static NVFP4 ``input_global_scale``, fused-sibling unified.
+
+    ``(scales, policy)``.  Everything here is the owned NVFP4 activation
+    contract, reused rather than restated: the resolved default policy names
+    the formula (``resolve_input_global_scale_policy``), the scalar is the
+    F32-rounded value an exported tensor would carry
+    (``input_global_scale_from_max_abs``), and fused siblings share one
+    conservative calibration maximum (``unify_fused_sibling_max_abs``) --
+    vLLM concatenates q/k/v and gate/up and applies ONE activation scale, and
+    Tessera's exporter joins its members' scales for the same module, so a
+    per-member scale would price an A side no fused module executes.
+
+    A unit whose calibration never saw a row keeps no scale; a W4A4 anchor on
+    it then refuses in :func:`_measure_anchor` rather than pricing dynamically.
+    """
+    from .nvfp4_activation_contract import (
+        input_global_scale_from_max_abs, resolve_input_global_scale_policy,
+        unify_fused_sibling_max_abs,
+    )
+
+    policy = resolve_input_global_scale_policy()
+    positive = {name: float(value) for name, value in max_abs.items()
+                if float(value) > 0.0}
+    unified = unify_fused_sibling_max_abs(
+        positive, profile=profile, tolerate_profile_errors=True)
+    return {
+        name: input_global_scale_from_max_abs(value, policy=policy)
+        for name, value in unified.items()
+    }, policy
 
 
 def _calibration_tokens(model_path: str, n: int, seqlen: int, seed: int):
@@ -745,7 +855,7 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     tokens, corpus_text = _calibration_tokens(
         args.model, args.nsamples, args.seqlen, args.seed)
     want_h = args.hessian == "require"
-    acts, hessians, hessian_rows = _collect_activations(
+    acts, hessians, hessian_rows, act_max_abs = _collect_activations(
         model, targets, tokens, args.max_act_rows, device,
         want_hessian=want_h)
     # For the log line and the run-level provenance only; every encode is
@@ -774,6 +884,14 @@ def main(argv: "Sequence[str] | None" = None) -> int:
         seqlen=int(args.seqlen),
         fit_tokens_min=int(hessian_token_min),
     )
+
+    # The static A-side calibration, from the same forward passes: one
+    # input_global_scale per unit under the resolved contract policy, fused
+    # siblings sharing one value.  Priced by every W4A4 anchor below and
+    # written beside the payload for the export leg, so the scale that priced
+    # the table is the scale the artifact serves (priced == served).
+    static_scales, static_scale_policy = _static_input_scales(
+        act_max_abs, profile=profile)
 
     weights = {name: dict(model.named_modules())[name].weight.detach()
                for name in targets}
@@ -1013,8 +1131,9 @@ def main(argv: "Sequence[str] | None" = None) -> int:
                     activation_kwargs_for=(
                         _activation_kwargs_for if want_h else None),
                     hessian_required=want_h,
+                    static_input_scale=static_scales.get(name),
                 )
-            except HessianContractError:
+            except (HessianContractError, ActivationScaleContractError):
                 # Never absorbed into "one anchor failed": a contract refusal
                 # is about every row this run would write, not this one.
                 raise
@@ -1102,6 +1221,18 @@ def main(argv: "Sequence[str] | None" = None) -> int:
                if serving_target is not None else {}),
             "wire_dir": str(wire_dir),
             "tessera_commit": os.environ.get("TESSERA_COMMIT", ""),
+            # The static A-side identity every W4A4 row was priced under: the
+            # policy names the formula, the values are the F32-rounded scalars
+            # an exported input_global_scale tensor carries, fused siblings
+            # unified. The served contract reads exactly one such scalar per
+            # module (trellis_input_global_scale), so this block is what makes
+            # "the priced A side is the served A side" checkable downstream.
+            "activation_static_scales": {
+                "policy": str(static_scale_policy),
+                "source": "campaign_calibration_amax_fused_unified",
+                "units": {name: float(value)
+                          for name, value in sorted(static_scales.items())},
+            },
             "hessian": {
                 "supplied": bool(want_h),
                 "mode": str(args.hessian),

--- a/prismaquant/tessera_export_lane.py
+++ b/prismaquant/tessera_export_lane.py
@@ -477,10 +477,210 @@ def require_assignment_scope(model_path: str | Path, assignment_path: str | Path
 
 
 # ---------------------------------------------------------------------------
+# Gate 5 -- the inputs the allocation was PRICED under
+# ---------------------------------------------------------------------------
+#: The identity fields an H-aware allocation must be bound against.  Spelled
+#: here rather than imported from ``tessera_hessian`` so the gate can refuse
+#: on a machine that can read the metadata without loading the ``tessera``
+#: package; ``tessera_hessian.HESSIAN_IDENTITY_FIELDS`` derives the same
+#: triple from ``tessera.export.HESSIAN_IDENTITY`` and
+#: ``test_the_priced_input_triple_matches_tesseras_roster`` pins the two
+#: together.
+PRICED_HESSIAN_IDENTITY_FIELDS = ("text_sha256", "fit_tokens", "fit_ids_sha256")
+
+
+def _hessian_capture_identity(hessian_path: Path) -> "Mapping[str, Any]":
+    """The capture's provenance block, sidecar first.
+
+    The campaign writes ``<capture>.provenance.json`` beside the payload so
+    this gate never loads the Hessian tensors; a capture without the sidecar
+    (Tessera's own ``capture_h_full.py`` writes none) is read through
+    ``torch.load``, which is what the exporter does with the same file moments
+    later anyway.
+    """
+    sidecar = hessian_path.with_name(hessian_path.name + ".provenance.json")
+    if sidecar.is_file():
+        loaded = json.loads(sidecar.read_text(encoding="utf-8"))
+        if not isinstance(loaded, Mapping):
+            raise TesseraExportLaneError(
+                f"{sidecar} is not a JSON object; the capture's identity "
+                "cannot be read")
+        return loaded
+    import torch
+
+    payload = torch.load(str(hessian_path), map_location="cpu",
+                         weights_only=False)
+    provenance = payload.get("provenance") if isinstance(payload, Mapping) \
+        else None
+    if not isinstance(provenance, Mapping):
+        raise TesseraExportLaneError(
+            f"{hessian_path} carries no provenance block; a capture whose "
+            "identity cannot be read cannot be bound to the allocation")
+    return provenance
+
+
+def require_priced_export_inputs(
+        assignment_path: str | Path, *, hessian_path: str | Path | None = None,
+        input_scales_path: str | Path | None = None) -> dict:
+    """Refuse an export whose priced inputs are not the supplied inputs.
+
+    The allocation was priced by the campaign under two inputs the external
+    exporter must be handed back, or the artifact built is not the artifact
+    priced (RobTand/prismaquant#193):
+
+    * **The Hessian.**  The encoder's shipping default is activation-aware;
+      an allocation whose ``tessera_hessian`` metadata says ``supplied: true``
+      names bytes shaped by a specific ``XᵀX`` capture, and the exporter's
+      ``--hessian`` must carry that capture -- checked by the identity triple
+      the allocation records (#195's canonical stamp) against the capture's
+      own provenance.  ``supplied: false`` is the deliberate weights-only
+      price, and handing the exporter a Hessian then ships bytes the
+      allocation never priced -- refused in that direction too.  An
+      allocation that declares neither is ambiguous and fails closed
+      (AGENTS.md principle 2).
+
+    * **The static activation scales.**  Every selected rung whose route
+      executes the static NVFP4 contract was priced under a calibrated
+      ``input_global_scale``, and the exporter refuses NVFP4 routes without
+      ``--input-scales`` -- but only after encoding everything else.  This
+      gate requires the file, and every selected W4A4 unit's key in it, before
+      a single unit is encoded.
+    """
+    from .footprint import _read_safetensors_header
+    from .layer_config import load_assignment, read_layer_config_metadata
+    from .tessera_formats import (
+        parse_tessera_format_name, tessera_serving_route, tessera_wire_recipe,
+    )
+
+    selected = {name: fmt for name, fmt in load_assignment(assignment_path).items()
+                if fmt.startswith("TESSERA_")}
+    report = {
+        "hessian_required": False, "hessian": None,
+        "input_scales_required": False, "input_scales": None,
+        "w4a4_units": 0,
+    }
+    if not selected:
+        return report
+
+    block = read_layer_config_metadata(assignment_path).get("tessera_hessian")
+    if not isinstance(block, Mapping) or not isinstance(
+            block.get("supplied"), bool):
+        raise TesseraExportLaneError(
+            "the allocation selects Tessera units but its metadata declares "
+            "no tessera_hessian pricing state (supplied: true|false). Whether "
+            "these bytes were priced H-aware is not recoverable from the "
+            "weights, and an ambiguous allocation fails closed: re-allocate "
+            "from a campaign cost table, which stamps the block."
+        )
+    if block["supplied"]:
+        report["hessian_required"] = True
+        if hessian_path is None:
+            raise TesseraExportLaneError(
+                "the allocation was priced H-aware (tessera_hessian.supplied "
+                "= true) and no --hessian capture was supplied. The exporter "
+                "would encode weights-only without refusing, shipping bytes "
+                "the allocation did not price. Pass TESSERA_HESSIAN= the "
+                "campaign's hessian_capture.pt (written beside its "
+                "--cache-dir), or re-allocate from a --hessian off table to "
+                "price weights-only deliberately."
+            )
+        hessian_path = Path(hessian_path)
+        if not hessian_path.is_file():
+            raise TesseraExportLaneError(
+                f"--hessian {hessian_path} does not exist")
+        expected = {field: block.get(field)
+                    for field in PRICED_HESSIAN_IDENTITY_FIELDS}
+        if any(value is None for value in expected.values()):
+            raise TesseraExportLaneError(
+                "the allocation's tessera_hessian block carries no required "
+                f"identity triple ({sorted(expected)}), so no capture can be "
+                "bound to it. This allocation came from a pre-triple cost "
+                "table; rebuild the cost table with the current campaign and "
+                "re-allocate."
+            )
+        identity = _hessian_capture_identity(hessian_path)
+        role = identity.get("hessian_role")
+        if role is not None and role != "fit":
+            raise TesseraExportLaneError(
+                f"--hessian {hessian_path} is a {role!r} capture and must "
+                "not shape bytes")
+        mismatched = {
+            field: (identity.get(field), value)
+            for field, value in expected.items()
+            if identity.get(field) != value
+        }
+        if mismatched:
+            raise TesseraExportLaneError(
+                f"--hessian {hessian_path} is not the capture that priced "
+                "this allocation: "
+                + "; ".join(
+                    f"{field}: capture={got!r} != allocation={want!r}"
+                    for field, (got, want) in sorted(mismatched.items()))
+                + ". An encode against a different Hessian ships bytes the "
+                  "allocation did not price; hand the campaign's own capture "
+                  "or re-allocate."
+            )
+        report["hessian"] = str(hessian_path)
+    elif hessian_path is not None:
+        raise TesseraExportLaneError(
+            "the allocation was priced weights-only (tessera_hessian."
+            "supplied = false) but --hessian was supplied. An H-aware encode "
+            "of a weights-only-priced allocation ships bytes the allocation "
+            "did not price -- the same drift in the other direction. Drop "
+            "the flag, or re-price with --hessian require."
+        )
+
+    w4a4 = []
+    for name, fmt in sorted(selected.items()):
+        parsed = parse_tessera_format_name(fmt)
+        if parsed is None:
+            raise TesseraExportLaneError(
+                f"{name}: {fmt!r} is not a Tessera format name")
+        family, rung = parsed
+        wire = tessera_wire_recipe(family, rung)
+        if tessera_serving_route(
+                family, wire, rung).activation_source_format == "NVFP4":
+            w4a4.append(name)
+    report["w4a4_units"] = len(w4a4)
+    if w4a4:
+        report["input_scales_required"] = True
+        if input_scales_path is None:
+            raise TesseraExportLaneError(
+                f"{len(w4a4)} selected unit(s) execute the static NVFP4 "
+                "activation contract (first: " + w4a4[0] + ") and no "
+                "--input-scales file was supplied. The exporter requires one "
+                "input_global_scale per W4A4 module and would refuse -- after "
+                "encoding everything else. Pass TESSERA_INPUT_SCALES= the "
+                "campaign's input_scales.safetensors (written beside its "
+                "--cache-dir), whose values are the scales the costs were "
+                "priced under."
+            )
+        input_scales_path = Path(input_scales_path)
+        if not input_scales_path.is_file():
+            raise TesseraExportLaneError(
+                f"--input-scales {input_scales_path} does not exist")
+        header = _read_safetensors_header(str(input_scales_path))
+        missing = [name for name in w4a4
+                   if f"{name}.input_global_scale" not in header]
+        if missing:
+            raise TesseraExportLaneError(
+                f"--input-scales {input_scales_path} carries no "
+                "input_global_scale for selected W4A4 unit(s) "
+                f"{missing[:5]}{'...' if len(missing) > 5 else ''}; the "
+                "exporter's fused join cannot invent a member's scale, and a "
+                "partial file exports a module the costs did not price."
+            )
+        report["input_scales"] = str(input_scales_path)
+    return report
+
+
+# ---------------------------------------------------------------------------
 # The driver's entry point
 # ---------------------------------------------------------------------------
 def preflight(model_path: str | Path, *, target=None,
-              assignment_path: str | Path | None = None) -> dict:
+              assignment_path: str | Path | None = None,
+              hessian_path: str | Path | None = None,
+              input_scales_path: str | Path | None = None) -> dict:
     """Every gate, in the order that puts the cheapest refusal first."""
     structure = require_declared_structure(model_path)
     target = require_serving_target(target)
@@ -489,6 +689,7 @@ def preflight(model_path: str | Path, *, target=None,
     require_release_pin()
     scope = None
     build = None
+    priced_inputs = None
     if assignment_path is not None:
         from .layer_config import read_layer_config_metadata
         from .shipcard import file_sha256
@@ -496,6 +697,9 @@ def preflight(model_path: str | Path, *, target=None,
         assignment_sha = file_sha256(assignment_path)
         if assignment_sha is None:
             raise TesseraExportLaneError(f"cannot hash allocation {assignment_path}")
+        priced_inputs = require_priced_export_inputs(
+            assignment_path, hessian_path=hessian_path,
+            input_scales_path=input_scales_path)
         scope = require_assignment_scope(model_path, assignment_path, target=target)
         build = {
             "source_model": str(model_path), "layer_config": str(assignment_path),
@@ -537,6 +741,8 @@ def preflight(model_path: str | Path, *, target=None,
         report["serving_target"] = target.as_dict()
     if scope is not None:
         report["selected_serving_scope"] = scope
+    if priced_inputs is not None:
+        report["priced_inputs"] = priced_inputs
     if build is not None:
         report["build"] = build
     return report
@@ -553,6 +759,15 @@ def main(argv: Sequence[str] | None = None) -> int:
                         help="the source checkpoint run-pipeline.sh is building")
     parser.add_argument("--assignment", default=None,
                         help="selected layer_config.json to attest before plan translation")
+    parser.add_argument("--hessian", default=None,
+                        help="the Hessian capture the exporter will be handed "
+                             "(the campaign's hessian_capture.pt); required "
+                             "and identity-checked when the allocation was "
+                             "priced H-aware, refused when it was not")
+    parser.add_argument("--input-scales", default=None,
+                        help="safetensors of <unit>.input_global_scale (the "
+                             "campaign's input_scales.safetensors); required "
+                             "to cover every selected W4A4 unit")
     parser.add_argument("--target-profile", default=None,
                         help="serving profile supplying or cross-checking the exact platform")
     parser.add_argument("--write-build-json", default=None,
@@ -570,10 +785,17 @@ def main(argv: Sequence[str] | None = None) -> int:
 
             platform = load_serving_profile(args.target_profile).target_platform
         target = serving_target_from_args(args, target_platform=platform)
+        priced = {"hessian_path": args.hessian,
+                  "input_scales_path": args.input_scales}
         if target is None and args.assignment is None:
+            if args.hessian is not None or args.input_scales is not None:
+                raise TesseraExportLaneError(
+                    "--hessian/--input-scales bind priced inputs to an "
+                    "allocation; pass --assignment")
             report = preflight(args.model)
         else:
-            report = preflight(args.model, target=target, assignment_path=args.assignment)
+            report = preflight(args.model, target=target,
+                               assignment_path=args.assignment, **priced)
         if args.write_build_json is not None:
             destination = Path(args.write_build_json)
             destination.parent.mkdir(parents=True, exist_ok=True)

--- a/prismaquant/tessera_menu.py
+++ b/prismaquant/tessera_menu.py
@@ -1496,9 +1496,38 @@ def assert_uniform_hessian_identity(costs: "dict") -> dict:
     its own rung's shipping bytes -- and refusing the table would refuse the
     mixed-family menu this whole stage exists to build. What must match is the
     DRAW and the run's intent, which is what the key holds.
+
+    **The key is the whole identity, the required triple first.**  Tessera's
+    own required roster -- ``text_sha256`` / ``fit_tokens`` / ``fit_ids_sha256``,
+    read from ``tessera_hessian.HESSIAN_IDENTITY_FIELDS`` rather than retyped
+    -- is what names *which* Hessian shaped the bytes, and until 2026-09-05
+    this guard compared only the legacy ``(supplied, text_sha, token_count,
+    kwarg)`` projection, so any number of distinct modern identities collapsed
+    to one key and a table merged from two draws allocated as one
+    (RobTand/prismaquant#195).  Three row classes now exist and are refused
+    from merging with each other:
+
+    * **modern** -- carries the full required triple; keyed on the triple AND
+      the legacy aliases, so aliases that agree cannot launder a triple that
+      does not.
+    * **legacy** -- carries none of the triple (written before it existed);
+      keyed on the legacy fields alone, and never merged with a modern row:
+      "no claim about the triple" and "a matching triple" are different facts
+      (P14).
+    * **partial** -- carries some of the triple; that is a malformed identity
+      and is refused by name rather than downgraded to the legacy comparison.
+
+    The returned dict carries the canonical triple beside the legacy
+    projection, so the allocator's ``tessera_hessian`` metadata block -- which
+    stamps this return verbatim into ``layer_config.json`` -- gives export a
+    Hessian identity it can bind a capture against.
     """
+    from .tessera_hessian import HESSIAN_IDENTITY_FIELDS
+
+    required = tuple(HESSIAN_IDENTITY_FIELDS)
     seen: dict[tuple, int] = {}
     unstamped = 0
+    legacy_rows = 0
     for _qname, rows in (costs or {}).items():
         if not isinstance(rows, dict):
             continue
@@ -1509,15 +1538,33 @@ def assert_uniform_hessian_identity(costs: "dict") -> dict:
             if not isinstance(ident, dict):
                 unstamped += 1
                 continue
-            key = (bool(ident.get("supplied")), ident.get("text_sha"),
-                   ident.get("token_count"), ident.get("kwarg"))
+            modern = tuple(ident.get(field) for field in required)
+            if any(value is None for value in modern):
+                if any(value is not None for value in modern):
+                    raise ValueError(
+                        f"{_qname}[{fmt}]: hessian_identity carries a partial "
+                        f"required triple "
+                        f"{ {f: ident.get(f) for f in required} }; "
+                        f"tessera.export.HESSIAN_IDENTITY requires all of "
+                        f"{list(required)}. A partial identity cannot name a "
+                        "draw and is refused rather than collapsed to the "
+                        "legacy fields."
+                    )
+                schema, modern = "legacy", None
+                legacy_rows += 1
+            else:
+                schema = "modern"
+            key = (schema, modern, bool(ident.get("supplied")),
+                   ident.get("text_sha"), ident.get("token_count"),
+                   ident.get("kwarg"))
             seen[key] = seen.get(key, 0) + 1
     if len(seen) > 1:
         raise ValueError(
             "Tessera cost table mixes Hessian identities: "
             + "; ".join(
-                f"supplied={k[0]} text_sha={str(k[1])[:12]} "
-                f"tokens={k[2]} kwarg={k[3]} ({n} rows)"
+                f"{k[0]} triple={None if k[1] is None else tuple(str(v)[:12] for v in k[1])} "
+                f"supplied={k[2]} text_sha={str(k[3])[:12]} "
+                f"tokens={k[4]} kwarg={k[5]} ({n} rows)"
                 for k, n in sorted(seen.items(), key=lambda kv: -kv[1]))
             + ". Rows priced with and without a Hessian, or on different "
               "calibration draws, are not comparable prices of the same bytes. "
@@ -1525,12 +1572,17 @@ def assert_uniform_hessian_identity(costs: "dict") -> dict:
               "separately."
         )
     (key,) = tuple(seen) if seen else (None,)
+    triple = dict(zip(required, key[1])) if key is not None and key[1] is not None \
+        else {field: None for field in required}
     return {
-        "supplied": None if key is None else key[0],
-        "text_sha": None if key is None else key[1],
-        "token_count": None if key is None else key[2],
-        "kwarg": None if key is None else key[3],
+        "supplied": None if key is None else key[2],
+        "text_sha": None if key is None else key[3],
+        "token_count": None if key is None else key[4],
+        "kwarg": None if key is None else key[5],
+        **triple,
+        "identity_schema": None if key is None else key[0],
         "stamped_rows": sum(seen.values()),
+        "legacy_rows": int(legacy_rows),
         "unstamped_rows": int(unstamped),
     }
 

--- a/tests/test_tessera_campaign.py
+++ b/tests/test_tessera_campaign.py
@@ -679,6 +679,123 @@ def test_one_cost_table_carries_one_hessian_identity():
     assert got["unstamped_rows"] == 1 and got["supplied"] is None
 
 
+def test_the_guard_compares_the_required_hessian_identity_triple():
+    """Two modern identities differing in one required field must refuse.
+
+    ``tessera.export.HESSIAN_IDENTITY`` is the required roster
+    (``text_sha256`` / ``fit_tokens`` / ``fit_ids_sha256``), and every current
+    campaign row carries it. A guard that keys only the legacy
+    ``(supplied, text_sha, token_count, kwarg)`` projection collapses any
+    number of distinct modern identities to one key, so a cost table merged
+    from two different Hessian draws sails through and the DP trades rows
+    priced on different bytes (RobTand/prismaquant#195).
+    """
+    from prismaquant.tessera_menu import assert_uniform_hessian_identity
+
+    a = {"supplied": True, "text_sha256": "a" * 64,
+         "fit_ids_sha256": "b" * 64, "fit_tokens": 128}
+    b = {**a, "fit_ids_sha256": "c" * 64}
+    with pytest.raises(ValueError, match="mixes Hessian identities"):
+        assert_uniform_hessian_identity({"m.up": {
+            "TESSERA_E4M3_K1_R1024": {"hessian_identity": a},
+            "TESSERA_E4M3_K1_R1280": {"hessian_identity": b},
+        }})
+
+
+def test_equal_legacy_aliases_do_not_launder_conflicting_modern_identities():
+    """The campaign writes ``text_sha`` as an alias of ``fit_ids_sha256``.
+
+    Two tables whose aliases happen to agree while the required triple
+    disagrees are still two draws; the aliases are carried for old tables,
+    never as the comparison.
+    """
+    from prismaquant.tessera_menu import assert_uniform_hessian_identity
+
+    a = {"supplied": True, "text_sha": "alias", "token_count": 4096,
+         "kwarg": ("ldl",), "text_sha256": "a" * 64,
+         "fit_ids_sha256": "b" * 64, "fit_tokens": 4096}
+    b = {**a, "text_sha256": "d" * 64}
+    with pytest.raises(ValueError, match="mixes Hessian identities"):
+        assert_uniform_hessian_identity({"m.up": {
+            "TESSERA_E4M3_K1_R1024": {"hessian_identity": a},
+            "TESSERA_E4M3_K1_R1280": {"hessian_identity": b},
+        }})
+
+
+def test_a_partial_identity_triple_is_refused_not_collapsed_to_legacy():
+    """A row claiming part of the triple is malformed, not an old row.
+
+    Pre-triple rows carry none of the modern fields and are reported as
+    ``legacy_rows``; a row carrying some of them was written by a modern
+    campaign and lost a field, which is a defect to refuse by name rather
+    than silently downgrade to the legacy comparison.
+    """
+    from prismaquant.tessera_menu import assert_uniform_hessian_identity
+
+    partial = {"supplied": True, "text_sha256": "a" * 64,
+               "fit_ids_sha256": None, "fit_tokens": 128}
+    with pytest.raises(ValueError, match="partial"):
+        assert_uniform_hessian_identity({"m.up": {
+            "TESSERA_E4M3_K1_R1024": {"hessian_identity": partial},
+        }})
+
+
+def test_a_uniform_modern_table_returns_the_canonical_triple():
+    """The guard's answer carries the triple for allocation provenance.
+
+    ``allocator.py`` stamps the returned dict into layer_config metadata
+    (``tessera_hessian``); an export gate that must bind a Hessian capture to
+    the allocation reads the triple from there, so the guard has to return
+    it rather than only the legacy projection.
+    """
+    from prismaquant.tessera_menu import assert_uniform_hessian_identity
+
+    ident = {"supplied": True, "text_sha": "alias", "token_count": 4096,
+             "kwarg": ("ldl",), "text_sha256": "a" * 64,
+             "fit_ids_sha256": "b" * 64, "fit_tokens": 4096}
+    got = assert_uniform_hessian_identity({"m.up": {
+        "TESSERA_E4M3_K1_R1024": {"hessian_identity": dict(ident)},
+        "TESSERA_E4M3_K1_R1280": {"hessian_identity": dict(ident)},
+    }})
+    assert got["stamped_rows"] == 2 and got["legacy_rows"] == 0
+    assert got["identity_schema"] == "modern"
+    assert got["text_sha256"] == "a" * 64
+    assert got["fit_ids_sha256"] == "b" * 64
+    assert got["fit_tokens"] == 4096
+    # The legacy projection survives for old readers of the stamp.
+    assert got["supplied"] is True and got["text_sha"] == "alias"
+
+
+def test_a_legacy_only_table_is_reported_as_legacy_not_modern():
+    from prismaquant.tessera_menu import assert_uniform_hessian_identity
+
+    ident = {"supplied": True, "text_sha": "abc", "token_count": 4096,
+             "kwarg": "gram"}
+    got = assert_uniform_hessian_identity({"m.up": {
+        "TESSERA_E4M3_K1_R1024": {"hessian_identity": dict(ident)},
+    }})
+    assert got["identity_schema"] == "legacy"
+    assert got["legacy_rows"] == 1 and got["stamped_rows"] == 1
+    assert got["text_sha256"] is None and got["fit_ids_sha256"] is None
+
+
+def test_a_legacy_row_and_a_modern_row_are_two_identities():
+    """A pre-triple table merged with a modern one is refused, even when the
+    legacy aliases agree: 'no claim about the triple' and 'a matching triple'
+    are different facts (P14)."""
+    from prismaquant.tessera_menu import assert_uniform_hessian_identity
+
+    legacy = {"supplied": True, "text_sha": "abc", "token_count": 4096,
+              "kwarg": "gram"}
+    modern = {**legacy, "text_sha256": "a" * 64,
+              "fit_ids_sha256": "b" * 64, "fit_tokens": 4096}
+    with pytest.raises(ValueError, match="mixes Hessian identities"):
+        assert_uniform_hessian_identity({"m.up": {
+            "TESSERA_E4M3_K1_R1024": {"hessian_identity": legacy},
+            "TESSERA_E4M3_K1_R1280": {"hessian_identity": modern},
+        }})
+
+
 def test_the_token_sha_identifies_the_calibration_draw():
     from prismaquant.tessera_hessian import token_ids_sha256
 

--- a/tests/test_tessera_campaign.py
+++ b/tests/test_tessera_campaign.py
@@ -290,6 +290,159 @@ def test_the_same_weight_rate_costs_differently_on_the_two_routes():
     assert e2m1 / e4m3 > 1.5, ratios    # and the two routes are not the same
 
 
+def _anchor_harness(monkeypatch, tmp_path):
+    """Run ``_measure_anchor`` with the encode stubbed to the identity.
+
+    The activation-quantiser choice is the thing under test, not the trellis
+    encode, and a CPU E2M1 encode is ~a minute; the stub returns the weight
+    itself as the render so the score isolates the A leg exactly.
+    """
+    from types import SimpleNamespace
+
+    from prismaquant import tessera_campaign as campaign
+
+    monkeypatch.setattr(
+        campaign, "_encode_and_render", lambda w, name, **kw: (w, b""))
+    cache = SimpleNamespace(weights={}, cache_dir=None)
+    return lambda **kw: campaign._measure_anchor(
+        cache=cache, wire_dir=tmp_path, hessian_required=False, **kw)
+
+
+def test_e2m1_costs_price_the_served_static_ue4m3_contract(monkeypatch, tmp_path):
+    """A W4A4 anchor is scored through the served static-scale oracle.
+
+    Tessera's plugin reads the artifact's ``trellis_input_global_scale`` and
+    calls vLLM's ``scaled_fp4_quant`` -- static global scale, UE4M3 block
+    scales -- while NVFP4's registry callback is a dynamic FP32-scale RTN.
+    On a small-magnitude input the two disagree hard: at G=1 the stored UE4M3
+    scale for a 1e-3 block underflows to byte zero and the served activation
+    is exactly 0, where the dynamic quantiser keeps ~1e-3.  Pricing with the
+    dynamic callback prices an activation tensor the runtime never executes
+    (RobTand/prismaquant#194).
+    """
+    from prismaquant.format_registry import nvfp4_activation_qdq_served
+    from prismaquant.production_weight_cache import _local_forward_render_score
+
+    torch.manual_seed(0)
+    W = torch.randn(32, 256, dtype=torch.bfloat16)
+    X = torch.full((8, 256), 1e-3, dtype=torch.float32)
+    scale = 1.0
+    measure = _anchor_harness(monkeypatch, tmp_path)
+    anchor = measure(
+        qname="m.q_proj", weight=W, activations=X,
+        format_name="TESSERA_E2M1_K2_R896", static_input_scale=scale)
+    served = _local_forward_render_score(
+        reference_weight=W.float(), rendered_weight=W.float(), activations=X,
+        activation_quantize=lambda t: nvfp4_activation_qdq_served(t, scale),
+        activation_max_abs=None)[0]
+    assert anchor.dloss == pytest.approx(served, rel=1e-9)
+    assert anchor.input_global_scale == scale
+    from prismaquant import format_registry as fr
+
+    dynamic = _local_forward_render_score(
+        reference_weight=W.float(), rendered_weight=W.float(), activations=X,
+        activation_quantize=fr.get_format(
+            "TESSERA_E2M1_K2_R896").activation_quantize_dequantize,
+        activation_max_abs=None)[0]
+    assert anchor.dloss > 10 * dynamic, (
+        "the underflow case must separate the two quantisers; if it does not, "
+        "the anchor was scored under the dynamic FP32-scale RTN")
+
+
+def test_a_w4a4_anchor_with_no_static_scale_refuses_before_encoding(
+        monkeypatch, tmp_path):
+    """Missing scale -> refuse, not the dynamic quantiser -- and refuse FIRST.
+
+    The refusal is about every W4A4 row the run would write, so it must not
+    cost an encode, and the campaign loop must not absorb it as one failed
+    anchor.
+    """
+    from prismaquant import tessera_campaign as campaign
+
+    def _must_not_encode(*a, **k):
+        raise AssertionError("the refusal must precede the encode")
+
+    monkeypatch.setattr(campaign, "_encode_and_render", _must_not_encode)
+    from types import SimpleNamespace
+
+    with pytest.raises(campaign.ActivationScaleContractError,
+                       match="static NVFP4 activation contract"):
+        campaign._measure_anchor(
+            qname="m.q_proj",
+            weight=torch.randn(32, 256, dtype=torch.bfloat16),
+            activations=torch.randn(8, 256),
+            format_name="TESSERA_E2M1_K2_R896",
+            cache=SimpleNamespace(weights={}, cache_dir=None),
+            wire_dir=tmp_path, hessian_required=False,
+            static_input_scale=None)
+
+
+def test_dynamic_route_anchors_need_no_static_scale(monkeypatch, tmp_path):
+    """E4M3's route is per-token dynamic at serve; no static scale applies."""
+    measure = _anchor_harness(monkeypatch, tmp_path)
+    torch.manual_seed(0)
+    anchor = measure(
+        qname="m.up", weight=torch.randn(32, 256, dtype=torch.bfloat16),
+        activations=torch.randn(8, 256),
+        format_name="TESSERA_E4M3_K1_R1024", static_input_scale=None)
+    assert anchor.input_global_scale is None
+    assert anchor.dloss >= 0.0
+
+
+def test_the_priced_scale_travels_into_the_cost_rows(monkeypatch, tmp_path):
+    """Measured AND interpolated W4A4 rows carry the value identity.
+
+    The export leg writes one ``input_global_scale`` per module; a cost row
+    that does not say which scale priced it cannot be checked against the
+    artifact, which is how priced and served drift apart silently.
+    """
+    import dataclasses
+
+    from prismaquant.tessera_campaign import campaign_cost_payload
+
+    q, fam = "m.0.q_proj", "TESSERA_E2M1_K2"
+    scale = 448.0 * 6.0 / 37.5
+    anchors = {q: {fam: [
+        dataclasses.replace(_anchor(q, fam, r, d), input_global_scale=scale)
+        for r, d in ((128, 1e-2), (512, 1e-3), (896, 1e-4))]}}
+    payload = campaign_cost_payload(
+        anchors, _menu(q, fam, {128, 384, 512, 896}), loo={}, provenance={})
+    rows = payload["costs"][q]
+    assert rows[f"{fam}_R512"]["input_global_scale"] == pytest.approx(scale)
+    assert rows[f"{fam}_R384"]["input_global_scale"] == pytest.approx(scale)
+
+
+def test_fused_siblings_share_one_static_scale():
+    """q/k/v see one module input and the serve applies ONE scale.
+
+    ``unify_fused_sibling_max_abs`` is the owned join (largest calibration
+    maximum wins); a per-member scale would price an A side no fused module
+    executes.
+    """
+    from prismaquant.nvfp4_activation_contract import (
+        input_global_scale_from_max_abs, resolve_input_global_scale_policy,
+    )
+    from prismaquant.tessera_campaign import _static_input_scales
+
+    amax = {
+        "model.layers.0.self_attn.q_proj": 12.0,
+        "model.layers.0.self_attn.k_proj": 37.5,
+        "model.layers.0.self_attn.v_proj": 8.0,
+        "model.layers.0.mlp.down_proj": 5.0,
+    }
+    scales, policy = _static_input_scales(amax)
+    assert policy == resolve_input_global_scale_policy()
+    shared = input_global_scale_from_max_abs(37.5, policy=policy)
+    for member in ("q_proj", "k_proj", "v_proj"):
+        assert scales[f"model.layers.0.self_attn.{member}"] == shared
+    assert scales["model.layers.0.mlp.down_proj"] == \
+        input_global_scale_from_max_abs(5.0, policy=policy)
+    # A unit the calibration never saw keeps NO scale -- a W4A4 anchor on it
+    # then refuses instead of pricing dynamically.
+    scales, _ = _static_input_scales({"m.q_proj": 0.0})
+    assert "m.q_proj" not in scales
+
+
 # ---------------------------------------------------------------------------
 # The Hessian contract
 # ---------------------------------------------------------------------------
@@ -646,7 +799,7 @@ def test_the_hessian_sees_every_row_not_just_the_scored_ones():
 
     net = _Net().eval()
     tokens = [torch.randn(rows_per_batch, cols) for _ in range(batches)]
-    rows, hess, seen = _collect_activations(
+    rows, hess, seen, amax = _collect_activations(
         net, ["lin"], tokens, max_rows=5, device="cpu", want_hessian=True)
 
     every = torch.cat(tokens, dim=0).to(torch.float32)
@@ -654,6 +807,10 @@ def test_the_hessian_sees_every_row_not_just_the_scored_ones():
     assert rows["lin"].shape[0] == 5           # the score's cap still binds
     torch.testing.assert_close(hess["lin"], every.t() @ every,
                                rtol=1e-4, atol=1e-4)
+    # The static-scale calibration maximum is over EVERY row too, for the
+    # same reason: a max over the kept prefix is a different calibration
+    # than the one the exported input_global_scale carries.
+    assert amax["lin"] == pytest.approx(float(every.abs().amax()), rel=1e-3)
 
 
 def test_one_cost_table_carries_one_hessian_identity():

--- a/tests/test_tessera_campaign.py
+++ b/tests/test_tessera_campaign.py
@@ -412,6 +412,37 @@ def test_the_priced_scale_travels_into_the_cost_rows(monkeypatch, tmp_path):
     assert rows[f"{fam}_R384"]["input_global_scale"] == pytest.approx(scale)
 
 
+def test_resume_refuses_w4a4_anchors_priced_under_another_contract():
+    """A resumed checkpoint row must be a price of THIS run's served A side.
+
+    Pre-#194 checkpoints priced W4A4 anchors under the dynamic FP32-scale
+    quantiser (no ``input_global_scale`` on the row); a row from another
+    calibration carries a different scale. Merging either silently builds the
+    mixed-currency table the Hessian identity guard exists to refuse on its
+    own axis.
+    """
+    import dataclasses
+
+    from prismaquant.tessera_campaign import (
+        ActivationScaleContractError, _require_resumable_anchor,
+    )
+
+    old = _anchor("m.q_proj", "TESSERA_E2M1_K2", 896, 1e-3)
+    with pytest.raises(ActivationScaleContractError,
+                       match="pre-served-.*contract"):
+        _require_resumable_anchor(old, {"m.q_proj": 71.68})
+    other_draw = dataclasses.replace(old, input_global_scale=10.0)
+    with pytest.raises(ActivationScaleContractError,
+                       match="mixes two activation calibrations"):
+        _require_resumable_anchor(other_draw, {"m.q_proj": 71.68})
+    _require_resumable_anchor(
+        dataclasses.replace(old, input_global_scale=71.68),
+        {"m.q_proj": 71.68})
+    # A dynamic-route row never carried a scale and resumes untouched.
+    _require_resumable_anchor(
+        _anchor("m.up", "TESSERA_E4M3_K1", 1024, 1e-3), {})
+
+
 def test_fused_siblings_share_one_static_scale():
     """q/k/v see one module input and the serve applies ONE scale.
 

--- a/tests/test_tessera_export_scope.py
+++ b/tests/test_tessera_export_scope.py
@@ -36,6 +36,24 @@ def _context(structure="dense", target=None):
     return {**(target or Target()).as_dict(), "structure": structure}
 
 
+def _hessian_block(*, supplied):
+    """The allocator's tessera_hessian metadata stamp, as a real one looks.
+
+    The canonical identity triple travels whether or not a Hessian was
+    supplied -- a weights-only campaign still names its calibration draw --
+    which is what lets the priced-inputs gate bind a capture to an H-aware
+    allocation and refuse a stray one on a weights-only allocation.
+    """
+    return {
+        "supplied": supplied, "identity_schema": "modern",
+        "text_sha": "b" * 64, "token_count": 4096,
+        "kwarg": ["ldl", "refit_metric"],
+        "text_sha256": "a" * 64, "fit_ids_sha256": "b" * 64,
+        "fit_tokens": 4096, "stamped_rows": 2, "legacy_rows": 0,
+        "unstamped_rows": 0,
+    }
+
+
 def _payload():
     family = "TESSERA_E4M3_K1"
     cells = []
@@ -90,7 +108,7 @@ def case(tmp_path, monkeypatch):
     payload["__prismaquant__"] = {"tessera_serving_scope": {
         "target": Target().as_dict(),
         "by_unit": {DENSE: _context(), EXPERT: _context("routed_moe")},
-    }}
+    }, "tessera_hessian": _hessian_block(supplied=False)}
     assignment.write_text(json.dumps(payload))
     return SimpleNamespace(model=model, assignment=assignment, payload=payload,
                            contract=contract)

--- a/tests/test_tessera_priced_export_inputs.py
+++ b/tests/test_tessera_priced_export_inputs.py
@@ -1,0 +1,289 @@
+"""The export leg receives the inputs the allocation was priced under.
+
+The campaign prices every rung against a specific Hessian capture and, on the
+W4A4 routes, a specific static ``input_global_scale`` per unit.  Tessera's
+exporter takes both (``--hessian``, ``--input-scales``) -- and encodes
+weights-only without complaint when the first is omitted, and refuses NVFP4
+routes only after everything else is encoded when the second is.  So the
+producer's arm must (a) hand them through and (b) fail closed BEFORE the
+encode when the allocation declares a priced requirement the supplied inputs
+do not satisfy (RobTand/prismaquant#193).
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from prismaquant import tessera_export_lane as export
+
+ROOT = Path(__file__).resolve().parents[1]
+DENSE_E4M3 = "model.layers.0.self_attn.o_proj"
+DENSE_E2M1 = "model.layers.0.mlp.up_proj"
+
+TRIPLE = {"text_sha256": "a" * 64, "fit_ids_sha256": "b" * 64,
+          "fit_tokens": 4096}
+
+
+def _assignment(tmp_path, *, formats, hessian_block="modern-supplied"):
+    payload = {name: {"data_type": "tessera", "bits": 4,
+                      "tessera_format": fmt}
+               for name, fmt in formats.items()}
+    blocks = {
+        "modern-supplied": {"supplied": True, **TRIPLE},
+        "modern-weights-only": {"supplied": False, **TRIPLE},
+        "legacy-supplied": {"supplied": True, "text_sha": "abc",
+                            "token_count": 4096},
+        None: None,
+    }
+    meta = {}
+    if blocks[hessian_block] is not None:
+        meta["tessera_hessian"] = blocks[hessian_block]
+    payload["__prismaquant__"] = meta
+    path = tmp_path / "layer_config.json"
+    path.write_text(json.dumps({
+        name: value for name, value in payload.items()}))
+    return path
+
+
+def _capture(tmp_path, identity=None, *, sidecar=True, role="fit"):
+    from prismaquant.tessera_campaign import write_export_inputs
+
+    identity = dict(TRIPLE if identity is None else identity)
+    hessians = {DENSE_E4M3: torch.eye(4)}
+    capture, _scales = write_export_inputs(
+        tmp_path, hessians=hessians, hessian_rows={DENSE_E4M3: 4},
+        hessian_identity=identity, static_scales={}, static_scale_policy="x")
+    if role != "fit":
+        payload = torch.load(capture, weights_only=False)
+        payload["provenance"]["hessian_role"] = role
+        torch.save(payload, capture)
+        Path(str(capture) + ".provenance.json").write_text(
+            json.dumps(payload["provenance"]))
+    if not sidecar:
+        Path(str(capture) + ".provenance.json").unlink()
+    return capture
+
+
+def _scales_file(tmp_path, units):
+    from prismaquant.tessera_campaign import write_export_inputs
+
+    _capture_path, scales = write_export_inputs(
+        tmp_path, hessians=None, hessian_rows={}, hessian_identity={},
+        static_scales={name: 448.0 * 6.0 / 37.5 for name in units},
+        static_scale_policy="legacy_6_over_calibration_amax.v1")
+    return scales
+
+
+# ---------------------------------------------------------------------------
+# The Hessian half
+# ---------------------------------------------------------------------------
+
+def test_an_h_aware_allocation_with_no_capture_refuses(tmp_path):
+    """The exporter would encode weights-only and raise nothing.
+
+    ``export_tessera_serving.py`` defaults ``--hessian`` to None and builds an
+    ActivationSource only when it is present, so the omission ships different
+    bytes at the same format name -- silently. The producer's gate is the
+    refusal.
+    """
+    assignment = _assignment(
+        tmp_path, formats={DENSE_E4M3: "TESSERA_E4M3_K1_R1024"})
+    with pytest.raises(export.TesseraExportLaneError,
+                       match="priced H-aware.*no --hessian"):
+        export.require_priced_export_inputs(assignment)
+
+
+def test_a_capture_with_the_wrong_identity_refuses(tmp_path):
+    assignment = _assignment(
+        tmp_path, formats={DENSE_E4M3: "TESSERA_E4M3_K1_R1024"})
+    capture = _capture(tmp_path, {**TRIPLE, "fit_ids_sha256": "c" * 64})
+    with pytest.raises(export.TesseraExportLaneError,
+                       match="not the capture that priced"):
+        export.require_priced_export_inputs(assignment, hessian_path=capture)
+
+
+def test_the_campaigns_own_capture_binds_and_passes(tmp_path):
+    """write_export_inputs -> the gate, end to end: the sidecar identity the
+    campaign writes is exactly what the allocation's #195 stamp compares."""
+    assignment = _assignment(
+        tmp_path, formats={DENSE_E4M3: "TESSERA_E4M3_K1_R1024"})
+    capture = _capture(tmp_path)
+    report = export.require_priced_export_inputs(
+        assignment, hessian_path=capture)
+    assert report["hessian_required"] is True
+    assert report["hessian"] == str(capture)
+    assert report["input_scales_required"] is False
+
+
+def test_a_capture_without_a_sidecar_is_read_from_the_payload(tmp_path):
+    assignment = _assignment(
+        tmp_path, formats={DENSE_E4M3: "TESSERA_E4M3_K1_R1024"})
+    capture = _capture(tmp_path, sidecar=False)
+    report = export.require_priced_export_inputs(
+        assignment, hessian_path=capture)
+    assert report["hessian"] == str(capture)
+
+
+def test_a_held_out_capture_must_not_shape_bytes(tmp_path):
+    assignment = _assignment(
+        tmp_path, formats={DENSE_E4M3: "TESSERA_E4M3_K1_R1024"})
+    capture = _capture(tmp_path, role="held-out")
+    with pytest.raises(export.TesseraExportLaneError,
+                       match="held-out.*must not shape bytes"):
+        export.require_priced_export_inputs(assignment, hessian_path=capture)
+
+
+def test_a_weights_only_allocation_refuses_a_stray_capture(tmp_path):
+    """The same drift in the other direction: H-aware bytes under a
+    weights-only price are also not the artifact priced."""
+    assignment = _assignment(
+        tmp_path, formats={DENSE_E4M3: "TESSERA_E4M3_K1_R1024"},
+        hessian_block="modern-weights-only")
+    capture = _capture(tmp_path)
+    with pytest.raises(export.TesseraExportLaneError,
+                       match="priced weights-only.*--hessian"):
+        export.require_priced_export_inputs(assignment, hessian_path=capture)
+
+
+def test_an_undeclared_allocation_fails_closed(tmp_path):
+    assignment = _assignment(
+        tmp_path, formats={DENSE_E4M3: "TESSERA_E4M3_K1_R1024"},
+        hessian_block=None)
+    with pytest.raises(export.TesseraExportLaneError,
+                       match="no tessera_hessian pricing state"):
+        export.require_priced_export_inputs(assignment)
+
+
+def test_a_pre_triple_allocation_cannot_be_bound(tmp_path):
+    assignment = _assignment(
+        tmp_path, formats={DENSE_E4M3: "TESSERA_E4M3_K1_R1024"},
+        hessian_block="legacy-supplied")
+    capture = _capture(tmp_path)
+    with pytest.raises(export.TesseraExportLaneError,
+                       match="no required identity triple"):
+        export.require_priced_export_inputs(assignment, hessian_path=capture)
+
+
+def test_an_allocation_with_no_tessera_units_needs_nothing(tmp_path):
+    path = tmp_path / "layer_config.json"
+    path.write_text(json.dumps({"model.layers.0.mlp.up_proj": "BF16"}))
+    report = export.require_priced_export_inputs(path)
+    assert report == {"hessian_required": False, "hessian": None,
+                      "input_scales_required": False, "input_scales": None,
+                      "w4a4_units": 0}
+
+
+def test_the_priced_input_triple_matches_tesseras_roster():
+    """The gate's spelled triple and Tessera's derived one cannot drift."""
+    from prismaquant.tessera_hessian import HESSIAN_IDENTITY_FIELDS
+
+    assert set(export.PRICED_HESSIAN_IDENTITY_FIELDS) == set(
+        HESSIAN_IDENTITY_FIELDS)
+
+
+# ---------------------------------------------------------------------------
+# The static-activation-scale half
+# ---------------------------------------------------------------------------
+
+def test_w4a4_selection_requires_input_scales(tmp_path):
+    """The exporter refuses NVFP4 routes without scales -- after encoding
+    everything else. This refusal is before a single unit is encoded."""
+    assignment = _assignment(
+        tmp_path, formats={DENSE_E2M1: "TESSERA_E2M1_K2_R896"},
+        hessian_block="modern-weights-only")
+    with pytest.raises(export.TesseraExportLaneError,
+                       match="static NVFP4 activation contract.*--input-scales"):
+        export.require_priced_export_inputs(assignment)
+
+
+def test_input_scales_must_cover_every_selected_w4a4_unit(tmp_path):
+    assignment = _assignment(
+        tmp_path, formats={DENSE_E2M1: "TESSERA_E2M1_K2_R896"},
+        hessian_block="modern-weights-only")
+    scales = _scales_file(tmp_path, ["model.layers.9.some_other_unit"])
+    with pytest.raises(export.TesseraExportLaneError,
+                       match="carries no input_global_scale"):
+        export.require_priced_export_inputs(
+            assignment, input_scales_path=scales)
+
+
+def test_the_campaigns_own_scales_file_covers_and_passes(tmp_path):
+    assignment = _assignment(
+        tmp_path, formats={DENSE_E2M1: "TESSERA_E2M1_K2_R896",
+                           DENSE_E4M3: "TESSERA_E4M3_K1_R1024"},
+        hessian_block="modern-weights-only")
+    scales = _scales_file(tmp_path, [DENSE_E2M1])
+    report = export.require_priced_export_inputs(
+        assignment, input_scales_path=scales)
+    assert report["input_scales_required"] is True
+    assert report["w4a4_units"] == 1
+    assert report["input_scales"] == str(scales)
+
+
+def test_dense_e4m3_selection_needs_no_scales(tmp_path):
+    assignment = _assignment(
+        tmp_path, formats={DENSE_E4M3: "TESSERA_E4M3_K1_R1024"},
+        hessian_block="modern-weights-only")
+    report = export.require_priced_export_inputs(assignment)
+    assert report["input_scales_required"] is False
+    assert report["w4a4_units"] == 0
+
+
+# ---------------------------------------------------------------------------
+# The driver's arm
+# ---------------------------------------------------------------------------
+
+def test_the_shipping_arm_hands_the_priced_inputs_to_the_exporter():
+    """run-pipeline.sh's Tessera arm forwarded only --plan-json and --device.
+
+    The pre-#193 invocation supplied neither --hessian nor --input-scales, so
+    an H-aware allocation re-encoded weights-only and an E2M1 allocation died
+    inside the exporter after the plan translation. Both flags now ride one
+    array that the preflight validates first.
+    """
+    driver = (ROOT / "prismaquant" / "run-pipeline.sh").read_text()
+    exporter = driver.index("experiments/export_tessera_serving.py")
+    invocation = driver[exporter:driver.index("2>&1 | tee", exporter)]
+    assert '"${TESSERA_PRICED_INPUT_ARGS[@]}"' in invocation
+    translator = driver.index(
+        'python3 "${TESSERA_REPO%/}/experiments/plan_from_layer_config.py"')
+    preflight = driver.rfind(
+        "python3 -m prismaquant.tessera_export_lane", 0, translator)
+    gate = driver[preflight:driver.index("; then", preflight)]
+    assert '--assignment "${WORK_DIR}/artifacts/layer_config.json"' in gate
+    assert '"${TESSERA_PRICED_INPUT_ARGS[@]}"' in gate
+    # Built inside the arm, before the preflight consumes it -- the refusal
+    # must fire before the plan translation, let alone the encode.
+    built = driver.index("TESSERA_PRICED_INPUT_ARGS+=(--hessian")
+    assert built < preflight
+    for knob in ('"${TESSERA_HESSIAN:=}"', '"${TESSERA_INPUT_SCALES:=}"'):
+        assert knob in driver, knob
+
+
+def test_cli_passes_priced_inputs_to_preflight(tmp_path, monkeypatch):
+    calls = []
+
+    def preflight(model, **kwargs):
+        calls.append(kwargs)
+        raise export.TesseraExportLaneError("fixture stop after boundary")
+
+    monkeypatch.setattr(export, "preflight", preflight)
+    assert export.main([
+        "--model", str(tmp_path), "--assignment", str(tmp_path / "l.json"),
+        "--hessian", str(tmp_path / "h.pt"),
+        "--input-scales", str(tmp_path / "s.safetensors"),
+        "--tessera-platform", "sm_121",
+        "--tessera-runtime-image", "example/runtime@sha256:" + "a" * 64,
+        "--tessera-execution-mode", "eager", "--tessera-residency", "resident",
+    ]) == 2
+    assert calls[0]["hessian_path"] == str(tmp_path / "h.pt")
+    assert calls[0]["input_scales_path"] == str(tmp_path / "s.safetensors")
+
+
+def test_priced_inputs_without_an_assignment_are_refused(tmp_path):
+    (tmp_path / "config.json").write_text("{}")
+    assert export.main([
+        "--model", str(tmp_path), "--hessian", str(tmp_path / "h.pt"),
+    ]) == 2

--- a/tests/test_tessera_scope_endpoints.py
+++ b/tests/test_tessera_scope_endpoints.py
@@ -127,7 +127,7 @@ def test_campaign_main_passes_live_model_topology_to_real_menu_boundary(tmp_path
     monkeypatch.setattr(transformers.AutoModelForCausalLM, "from_pretrained", lambda *a, **k: model)
     monkeypatch.setattr(render, "tessera_encoder_hessian_status", lambda: {"accepted": True})
     monkeypatch.setattr(campaign, "_calibration_tokens", lambda *a: ([torch.ones(1, 1, dtype=torch.int64)], "fixture"))
-    monkeypatch.setattr(campaign, "_collect_activations", lambda *a, **k: ({}, {}, {}))
+    monkeypatch.setattr(campaign, "_collect_activations", lambda *a, **k: ({}, {}, {}, {}))
     monkeypatch.setattr(sensitivity_probe, "discover_moe_structure", lambda *a, **k: {
         EXPERT: ("model.layers.0.mlp.gate", "0")})
     seen = {}


### PR DESCRIPTION
Audit burn-down, Tessera lane: the three issues are one story — the pricing inputs the campaign measures under (Hessian identity, static activation-scale contract) were not carried from allocator to executor to cost-table identity. The stack fixes them coherently around one shared object: the canonical Hessian identity triple (#195) is what the export gate binds a capture against (#193), and the static scales the served contract executes (#194) are the values the campaign now writes for the exporter (#193). One commit per issue, plus one follow-on guard.

Test environments: local CPU (`/home/rob/venvs/pq-cu130`, tessera importable from a clone of the reference checkout at the dev pin `1221d2a4`) and sparky (`/home/rob/audit-sync/prismaquant`, `/home/rob/dq-runs/venvs/prismaquant-cu130`, CUDA_VISIBLE_DEVICES=""). No full suite was run; targeted files only.

---

## #195 — cost-table identity guard ignores the required Hessian identity triple (P1)

Fixes #195

**Defect.** `tessera_menu.assert_uniform_hessian_identity` keyed rows only on the legacy `(supplied, text_sha, token_count, kwarg)` projection. Every current campaign row carries Tessera's required triple (`text_sha256` / `fit_tokens` / `fit_ids_sha256`), so any number of distinct modern identities collapsed to one key: a cost table merged from two Hessian draws passed as uniformly stamped and the DP traded rows priced on different bytes. The allocator then published only the legacy projection into `layer_config.json`.

**Fix.** The guard reads the required roster from `tessera_hessian.HESSIAN_IDENTITY_FIELDS` (derived from `tessera.export.HESSIAN_IDENTITY`, never retyped), keys modern rows on the triple AND the legacy aliases (agreeing aliases cannot launder disagreeing triples), keeps pre-triple rows as their own `legacy` class that never merges with a modern row, refuses a partial triple by name, and returns the canonical triple (plus `identity_schema`, `legacy_rows`) — which the allocator's existing stamp carries verbatim into `__prismaquant__.tessera_hessian`, where #193's gate reads it.

**Pre-fix failure line** (`test_the_guard_compares_the_required_hessian_identity_triple`):
```
with pytest.raises(ValueError, match="mixes Hessian identities"):
E   Failed: DID NOT RAISE <class 'ValueError'>
```
(The issue's counterexample returned `supplied=True text_sha=None token_count=None kwarg=None, stamped_rows=2` for two identities differing in `fit_ids_sha256` — reproduced verbatim.)

**Tests run.** `tests/test_tessera_campaign.py` (new: triple comparison, alias laundering, partial triple, legacy/modern split, canonical return), `tests/test_tessera_menu.py`, `tests/test_tessera_scope_endpoints.py`.

---

## #194 — E2M1 costs used an FP32-scale activation quantizer instead of the served static UE4M3 contract (P1)

Fixes #194

**Defect.** `tessera_campaign._measure_anchor` scored every E2M1 anchor with the NVFP4 FormatSpec callback — `_make_rtn("fp4_e2m1", 16)`, a dynamic per-group FP32-scale RTN, explicitly with `activation_max_abs=None` — while Tessera serving reads the artifact's `trellis_input_global_scale` and calls vLLM's compiled `scaled_fp4_quant` (static global scale, UE4M3-stored block scales). Scale-underflow and midpoint rounding diverge; the post-#165 agreement gate compares only `(act_bits, act_group_size)`, so both quantizers pass as (4, 16).

**Fix.** `_measure_anchor` resolves the rung's serving route; any NVFP4-materialising route is scored through the owned served oracle `format_registry.nvfp4_activation_qdq_served` at the unit's calibrated static `input_global_scale` — calibrated from max|x| over **every** calibration row of the campaign's own forward passes, unified across fused siblings (`unify_fused_sibling_max_abs`) and converted by the owned policy helpers (`resolve_input_global_scale_policy` / `input_global_scale_from_max_abs`). A missing scale refuses (`ActivationScaleContractError`, re-raised out of the anchor loop like a Hessian refusal) rather than falling back to the dynamic quantizer. The scale value rides on every W4A4 row (measured and interpolated) and the policy + per-unit values ride in payload provenance.

**Pre-fix failure line** (served-contract binding against the old `_measure_anchor`, encode stubbed to identity):
```
AssertionError: E2M1 anchor priced under the dynamic FP32-scale RTN: dloss=0 != served-contract score 0.000346137
```

**Re-pricing implication.** Every existing Tessera cost table's **E2M1 rows are stale** (E4M3/BF16 rows unaffected — their routes are dynamic/identity at serve). Measured on a real 32×256 `TESSERA_E2M1_K2_R896` render with 128×256 activations under the resolved default policy: Gaussian activations served/dynamic = **1.011** (+1.1%), wide-dynamic-range rows **0.966** (−3.4%), and the underflow corner is unbounded (dynamic ≈ 0 vs served 3.46e-4 on a uniform 1e-3 input at G=1). Direction is case-dependent, so affected tables must be **re-measured on the same calibration contract**, not adjusted. No recorded campaign result files were modified.

**Residual (noted, not changed).** `tessera_runtime_contract.cell_activation_projection` still projects cell contracts to `(act_bits, act_group_size)` only; with pricing now on the served static oracle the priced and executed A-sides agree, but a third projection axis (static-vs-dynamic + scale dtype) would let the agreement gate refuse a future drift by name. Left for the contract's owner.

**Tests run.** `tests/test_tessera_campaign.py` (new: served-contract binding, refusal-before-encode, dynamic-route exemption, row scale propagation, fused-sibling sharing, whole-stream amax), `tests/test_tessera_scope_endpoints.py`, `tests/test_cost_currency.py`.

---

## #193 — Tessera pipeline omits the Hessian and static activation scales required by the priced allocation (P0)

Fixes #193

**Defect.** `run-pipeline.sh`'s Tessera arm forwarded only `--plan-json` and `--device` to `experiments/export_tessera_serving.py`. The exporter builds an `ActivationSource` only when `--hessian` is present (and raises nothing without one), so an H-aware allocation — the campaign's default — was re-encoded weights-only: different bytes at the same format names, silently. And the exporter hard-requires `--input-scales` for any NVFP4 route, so an E2M1-containing allocation died inside the exporter after the plan translation instead of producing the selected artifact. Nothing in the pipeline produced either input.

**Fix (three pieces, one contract).**
1. *Requirements are declared:* the allocation already carries `__prismaquant__.tessera_hessian` (now with the canonical triple, #195); the W4A4 scale requirement is structural, derived from the selected units' routes.
2. *Execution fails closed:* `tessera_export_lane` gains `--hessian`/`--input-scales` and a fifth gate, `require_priced_export_inputs`, run from `preflight` before the scope gate and before the plan translation. It refuses: an H-aware allocation without a capture; a capture whose identity triple does not match the allocation's stamp; a held-out capture; a stray capture on a weights-only allocation (the same drift, other direction); an allocation that declares no pricing state (ambiguous → closed, AGENTS.md P2); and a W4A4 selection whose scales file does not cover every selected unit (header check, no tensor load).
3. *Inputs are supplied:* the campaign writes `hessian_capture.pt` (the exact un-normalised per-unit XᵀX it priced with, `ActivationSource.from_capture`-shaped, `hessian_role: "fit"`, JSON provenance sidecar) and `input_scales.safetensors` (the #194 scales as `<unit>.input_global_scale` F32 scalars) beside its cache, before the anchor loop; `run-pipeline.sh` threads `TESSERA_HESSIAN`/`TESSERA_INPUT_SCALES` through one array to both the preflight and the exporter invocation.

`docs/ARCHITECTURE.md` re-stamped and `CHANGELOG.md` updated in the stack per the maintenance contract; `tests/test_docs_staleness.py` + `tests/test_architecture_doc.py` pass.

**Pre-fix failure lines** (`tests/test_tessera_priced_export_inputs.py`):
```
E   assert '"${TESSERA_PRICED_INPUT_ARGS[@]}"' in 'experiments/export_tessera_serving.py" \\n    "$MODEL_PATH" "${WORK_DIR}/exported" \\n    --plan-json "$TESSERA_PLAN" \\n    --device "$EXPORT_DEVICE" \\n    '
E   AttributeError: module 'prismaquant.tessera_export_lane' has no attribute 'require_priced_export_inputs'
```

**Tests run.** `tests/test_tessera_priced_export_inputs.py` (new, 17 tests), `tests/test_tessera_export_scope.py`, `tests/test_tessera_export_lane.py`, `tests/test_tessera_plan_input_binding.py` (real shell-arm execution).

---

## Follow-on guard (separate commit, refs #194)

Campaign `--checkpoint` resume merged saved anchors into this run's table with no currency check on the activation axis: a pre-#194 checkpoint's W4A4 rows (no `input_global_scale`) or rows from another calibration would silently rebuild the mixed table. `_require_resumable_anchor` refuses both by name; dynamic-route rows resume untouched.

## #175 (optional item) — commented, not changed

The merged #176 workflow is correct at `master`: it resolves the exact dev pin and installs Tessera `--no-deps` in both CPU jobs. The five most recent CI runs fail only at `Check out pinned Tessera` with `remote: Repository not found` — the expected refusal while Tessera is private. Remaining options (wait for publication per the agreed plan / interim fine-grained PAT / never soft-fail) need Rob's decision, so they are laid out in a comment on #175 instead of a change: https://github.com/RobTand/prismaquant/issues/175#issuecomment-5550002762

## Side findings (not changed here)

- The Tessera exporter's fused-scale join takes the **max** over member `input_global_scale`s (`export_tessera_serving.py:1771`) while PrismaQuant's own contract joins conservatively on the **min** scale / max amax (`unify_fused_sibling_input_global_scales`). For scales computed from one module input (as the campaign does) the two coincide; for scales from independently calibrated stock exports they diverge, and the max-scale join clips the widest sibling. Tessera-repo territory — flagged for that lane.
- `cell_activation_projection`'s two-axis projection (see #194 residual above).
- **Sparky's shared test env is ahead of the Tessera dev pin.** `/home/rob/dq-runs/venvs/prismaquant-cu130` imports tessera editable from `/home/rob/tessera` (`d52e1ac`), which packages a `tessera.lane-eligibility.v8` contract that master's `lane_eligibility` reader (v3–v5) refuses — **42 tessera-lane tests fail there at baseline master `10dd2395`**, before any change of mine. `/home/rob/tessera-audit` (`2b0b933`) has the same skew locally. All authoritative runs here used a clone of the tessera checkout at the dev pin `1221d2a4`, where baseline and the branch are both clean. Whoever coordinates the pin bump may want this on their radar.

## Test evidence

- Local, tessera at the dev pin `1221d2a4` (CPU, `CUDA_VISIBLE_DEVICES=""`): broad sweep of all 15 touched-module test files (`test_tessera_campaign/menu/menu_context/menu_real_table/scope_endpoints/export_lane/export_scope/priced_export_inputs/plan_input_binding/encoder_recipe.py`, `test_cost_currency.py`, `test_run_pipeline_defaults.py`, `test_run_pipeline_gates_execute.py`, `test_doc_claims_driver_truth.py`, `test_lane_gate_recording.py`): **291 passed, 5 skipped (CUDA-marked), 0 failed**; docs gates (`test_docs_staleness.py`, `test_architecture_doc.py`): **19 passed**. (The final rebase only added CHANGELOG text on top of the tested tree — `git diff` between them is CHANGELOG-only.)
- Sparky (`/home/rob/audit-sync/prismaquant`, shared env with the v8 skew above): branch **46 failed / 150 passed / 5 skipped** vs baseline master **42 failed / 125 passed / 5 skipped** on the same file set. The failure sets differ only by 4 of this PR's new #194 tests, each failing with the identical pre-existing `LaneEligibilityError: ... got 'tessera.lane-eligibility.v8'` — environment skew, not regression; all 4 pass on the pinned tessera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnYbLUvQb2xCH3o99VsfFo
