### PR TITLE
Restore profile-detection process globals between tests (fixes #197 order dependence)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,82 @@
 """Shared pytest fixtures.
 
-Deliberately minimal: this repo had no conftest before 2026-08-30. It carried
-one NON-autouse fixture, ``synthetic_cb_target``, which let a codebook export
-test declare that its bodies were CPU fixtures rather than served artifacts,
-through the route-status gate's own ``PQ_CB_NON_NATIVE_TARGET`` declaration.
-That gate, that declaration and the export tests that used it all went into
+Formerly minimal: this repo had no conftest before 2026-08-30. It carried one
+NON-autouse fixture, ``synthetic_cb_target``, which let a codebook export test
+declare that its bodies were CPU fixtures rather than served artifacts, through
+the route-status gate's own ``PQ_CB_NON_NATIVE_TARGET`` declaration. That gate,
+that declaration and the export tests that used it all went into
 ``archive/gridbook_lane_2026-09-02/`` when the Gridbook codebook serving lane
-was retired on 2026-09-02, so the fixture has no subject left. Nothing here
-was ever autouse, so collection semantics are unchanged either way.
+was retired on 2026-09-02, so the fixture has no subject left.
+
+What is here now is one autouse fixture, and it exists because profile
+detection is process-global (issue #197). See its docstring.
 """
 from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_profile_detection_globals():
+    """Snapshot and restore the process-global state ``detect_profile`` reads.
+
+    Profile detection is not a pure function of its arguments. It consults five
+    module-level mutables that any test can perturb and that no single test
+    owns, and a perturbation that outlives its test silently changes what
+    ``detect_profile`` answers for every test after it in that process:
+
+    * ``prismaquant.vendored.OVERRIDE_ERRORS`` -- the dead-vendored-override
+      record. ``registry._refuse_dead_vendored_override`` raises on a hit, and
+      that raise happens *inside* ``_resolve``'s ``except Exception: continue``,
+      so a stray entry does not fail loudly. It DEMOTES the profile that
+      matched, and detection falls through to ``DefaultProfile``.
+    * ``prismaquant.vendored._QWEN3_REGISTERED`` -- once True, ``register_qwen3``
+      returns before the ``OVERRIDE_ERRORS.pop()`` that a successful override
+      performs, so a stray ``"qwen3"`` entry can never self-heal.
+    * ``registry._REGISTERED``, ``_REGISTRY_GENERATION`` and
+      ``_DETECTION_ORDER_CACHE`` -- the registration list, and the derived
+      detection order cached against its generation counter.
+
+    Issue #197 was exactly the first two together:
+    ``test_vendored_qwen3.py::test_register_qwen3_does_not_cache_a_failed_registration``
+    forces ``register_qwen3()`` to fail, ``_fatal()`` records
+    ``OVERRIDE_ERRORS["qwen3"]`` on the way past, and nothing puts it back --
+    while ``_QWEN3_REGISTERED`` is restored to True, which is what makes the
+    entry permanent. Every later ``detect_profile()`` on a qwen3 checkpoint in
+    that process then answers ``DefaultProfile``, whose ``structure_spec()`` is
+    None, so ``tessera_serving_scope.unit_structure_from_profile`` refuses with
+    "explicit Tessera scope needs a declared model profile". That is how
+    ``tests/test_tessera_export_scope.py`` came to pass alone and fail in
+    company -- on whichever xdist worker happened to draw the two files in that
+    order, which is why it was invisible in a serial run (``test_tessera_*``
+    sorts before ``test_vendored_*``).
+
+    Restoring is silent and unconditional rather than an assertion. Several
+    tests perturb this state deliberately and are right to; the defect is never
+    the perturbation, only its escape. Restoring at the one place that owns
+    "process-global detection state" fixes the class, where guarding each
+    polluter fixes an instance and waits for the next one.
+
+    Cost is a dict copy and a short list copy per test, and the writes only
+    happen when something actually changed.
+    """
+    from prismaquant.model_profiles import registry
+    import prismaquant.vendored as vendored
+
+    saved_errors = dict(vendored.OVERRIDE_ERRORS)
+    saved_qwen3_registered = vendored._QWEN3_REGISTERED
+    saved_registered = list(registry._REGISTERED)
+    saved_generation = registry._REGISTRY_GENERATION
+    saved_order_cache = registry._DETECTION_ORDER_CACHE
+    try:
+        yield
+    finally:
+        if vendored.OVERRIDE_ERRORS != saved_errors:
+            vendored.OVERRIDE_ERRORS.clear()
+            vendored.OVERRIDE_ERRORS.update(saved_errors)
+        vendored._QWEN3_REGISTERED = saved_qwen3_registered
+        if registry._REGISTERED != saved_registered:
+            # In place: importers bind this list object, not its name.
+            registry._REGISTERED[:] = saved_registered
+        registry._REGISTRY_GENERATION = saved_generation
+        registry._DETECTION_ORDER_CACHE = saved_order_cache


### PR DESCRIPTION
## Root cause

Profile detection is not a pure function of its arguments. It reads process-global
mutable state that no test owns, and one test leaves that state dirty.

`tests/test_vendored_qwen3.py::test_register_qwen3_does_not_cache_a_failed_registration`
forces `register_qwen3()` to fail (that is its subject: a failed registration must not
be cached as done). On the way out, `_fatal()` writes the synthetic failure into a
process-global dict:

```
prismaquant/vendored/__init__.py:135        OVERRIDE_ERRORS[model_type] = msg
```

Nothing puts it back. The sibling test that provokes the same failure,
`test_force_override_raises_loudly_when_resolution_disagrees`, guards the dict with
`monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "")`; this one does not.

The entry is then permanent, because `monkeypatch` restores `_QWEN3_REGISTERED` to
`True` and `register_qwen3()` early-returns before the `pop()` that a successful
override performs:

```
prismaquant/vendored/__init__.py:223    global _QWEN3_REGISTERED
prismaquant/vendored/__init__.py:224    if _QWEN3_REGISTERED:
prismaquant/vendored/__init__.py:225        return                      # never reaches OVERRIDE_ERRORS.pop()
```

From then on, every `detect_profile()` on a qwen3 checkpoint in that process hits

```
prismaquant/model_profiles/registry.py:105  _refuse_dead_vendored_override(model_type)  ->  raises RuntimeError
```

and that raise lands inside `_resolve`'s own swallow:

```
prismaquant/model_profiles/registry.py:322            except Exception:
prismaquant/model_profiles/registry.py:323                continue
```

So `Qwen3Profile` is not refused loudly -- it is silently **demoted**, and detection
falls through to `DefaultProfile`. `DefaultProfile.structure_spec()` is `None` (there
is no `model_profiles/specs/default.json`), which is exactly the condition
`tessera_serving_scope.py:73` refuses on.

Measured, not reasoned -- the whole chain in one interpreter:

```
clean:             Qwen3Profile    structure_spec: True
_QWEN3_REGISTERED: True   OVERRIDE_ERRORS: {}
# after inserting the entry the polluting test leaves behind:
after leak:        DefaultProfile  structure_spec: False
DefaultProfile spec: None
raises: model.layers.0.mlp.experts.0.down_proj: explicit Tessera scope needs a declared model profile
```

**Why it hid from serial runs.** `test_tessera_*` sorts before `test_vendored_*`, so a
serial alphabetical run never puts the polluter first. Under `-n 4` the two files can
land on one worker in the other order, which is what #197 saw.

## Minimal reproducing order

Two tests, deterministic, no xdist needed. Either one alone passes.

```
cd <worktree on origin/main>
CUDA_VISIBLE_DEVICES="" PYTHONPATH=/home/rob/tessera-pin-1221d2a/src \
  /home/rob/venvs/pq-release/bin/python -m pytest -p no:cacheprovider -q --no-header \
  tests/test_vendored_qwen3.py::test_register_qwen3_does_not_cache_a_failed_registration \
  tests/test_tessera_export_scope.py::test_selected_export_units_resolve_their_own_structure
```

Pre-fix failure line, reproduced verbatim from the issue:

```
FAILED tests/test_tessera_export_scope.py::test_selected_export_units_resolve_their_own_structure
prismaquant.tessera_export_lane.TesseraExportLaneError: cannot attest selected Tessera export
scope: model.layers.0.mlp.experts.0.down_proj: explicit Tessera scope needs a declared model profile
prismaquant/tessera_export_lane.py:476
```

Post-fix: `2 passed`.

The file-level pair `tests/test_vendored_qwen3.py tests/test_tessera_export_scope.py`
goes from `9 failed, 33 passed` to `42 passed`.

## A second victim of the same leak

Sweeping the six registry-touching test files with a detector that brackets the whole
runtest protocol (so `monkeypatch.undo` has already run) found exactly one true
`OVERRIDE_ERRORS` leaker -- the test above -- and turned up a second test that the same
leak breaks:

```
FAILED tests/test_model_profile_conformance.py::test_representative_config_resolves_to_its_own_profile[Qwen3Profile-qwen3]
```

Same six files: `1 failed, 855 passed, 72 skipped, 1 xfailed` before, `856 passed, 72
skipped, 1 xfailed` after.

The sweep's other findings are inert and left alone: `tests/test_spec_match_profile.py`
moves `_REGISTRY_GENERATION` and the warmth of `_DETECTION_ORDER_CACHE`, but restores
`_REGISTERED` itself, and the generation counter only keys that derived cache.

Re-run on the merged branch with the fixture in place, the same detector reports
`[LEAKS] 0` across those files plus `test_tessera_export_scope.py` (`890 passed, 72
skipped, 1 xfailed`) -- no test leaves any of the five globals dirty any more.

## The fix

An autouse fixture in `tests/conftest.py` that snapshots and restores the five process
globals detection reads: `vendored.OVERRIDE_ERRORS`, `vendored._QWEN3_REGISTERED`,
`registry._REGISTERED`, `registry._REGISTRY_GENERATION`, `registry._DETECTION_ORDER_CACHE`.

Guarding the one polluter would fix this instance; owning the state fixes the class --
`_resolve`'s swallow means the next leak of this shape is silent again. Restoring is
silent and unconditional rather than an assertion: several tests perturb this state
deliberately and are right to, and the defect is never the perturbation, only its escape.
The writes only happen when something actually changed, so the per-test cost is a dict
copy and an 11-element list copy.

No test is reordered, marked, or `xfail`ed, and no production code changes.

## Commands and counts

All with `CUDA_VISIBLE_DEVICES=""`, `PYTHONPATH=/home/rob/tessera-pin-1221d2a/src`,
`/home/rob/venvs/pq-release/bin/python -m pytest -p no:cacheprovider -q --no-header`.

| run | pre-fix | post-fix |
|---|---|---|
| `tests/test_tessera_export_scope.py` (isolation) | 34 passed | 34 passed |
| `tests/test_cluster_campaign_runner.py` (isolation) | 11 passed | 11 passed |
| minimal pair above | 1 failed, 1 passed | 2 passed |
| `test_vendored_qwen3.py test_tessera_export_scope.py` | 9 failed, 33 passed | 42 passed |
| six registry-touching files | 1 failed, 855 passed, 72 skipped, 1 xfailed | 856 passed, 72 skipped, 1 xfailed |
| `tests/test_architecture_doc.py tests/test_docs_staleness.py` | 19 passed | 19 passed |
| full suite, `-n 4` (4961 collected) | 4830 passed, 129 skipped, 3 xfailed, 174 subtests passed (617.7 s) | 1 failed, 4829 passed, 129 skipped, 3 xfailed, 174 subtests passed (345.1 s) |

The single post-fix full-suite failure is **not this change**:

```
FAILED tests/test_cluster_campaign_runner.py::test_scheduler_refills_a_freed_host_while_another_host_is_active
```

That is a third wall-clock test in the same file as #199's subject -- it drives a helper
that spins on `deadline = time.monotonic() + 12` (`tests/test_cluster_campaign_runner.py:284`)
under `timeout_seconds=20`. It passes in isolation on this branch (`tests/test_cluster_campaign_runner.py`:
`11 passed`) and it touches no profile-detection state. Recorded on #199, which is the
home for that file's fixed deadlines.

The full-suite `-n 4` run was **green pre-fix**, and that is the point rather than a
counter-example: with xdist's default `--dist load`, whether the polluting test lands ahead
of a victim *on the same worker* is chance, which is why #197 arrived as "sometimes, on
gw4". The deterministic two-test pair above is the reproduction of record; the suite runs
are here to show the fixture does not disturb the other 4959 tests.

## docs/ARCHITECTURE.md

Not re-stamped, and it should not be: AGENTS.md principle 12 binds on a change to
pipeline defaults, the stage graph, the format menu, the plugin contract, serving-lane
defaults, or ship gates. This is a test-isolation fixture; none of those move, and no
production file is touched. `tests/test_architecture_doc.py` and
`tests/test_docs_staleness.py` pass unchanged (19 passed).

## Rebase / merge state

Merged `origin/main` (`bf4b589c`, after #187 and #191) into this branch as a merge commit.
No conflict: this branch touches only `tests/conftest.py`, and `docs/ARCHITECTURE.md` came
across from main untouched, so no stamp block needed resolving. `git diff origin/main..HEAD`
is one file, `tests/conftest.py`, +77/-7.

The defect is still live on that tip -- with `tests/conftest.py` checked out from
`origin/main` and everything else at this branch, the minimal pair still fails with the
line above (`1 failed, 1 passed`), and with this branch's conftest it is `2 passed`.

Full suite on the merged branch, `-n 4`:

```
17 failed, 4892 passed, 129 skipped, 3 xfailed, 61 warnings, 174 subtests passed in 287.69s
```

All 17 are `tests/test_tessera_campaign_resume.py`, inherited from #191 and expected at the
declared tessera dev pin `1221d2a`: `RuntimeError: Tessera campaign checkpoint identity
requires the producer's cached_unit input/byte receipt API; refusing unbound resume`
(`tessera.cached_unit` exists at the release, not at the pin). Demonstrably not this
change -- that file is `17 failed, 2 passed` **both** with this branch's `tests/conftest.py`
and with `origin/main`'s checked out in its place. Nothing else failed: no export-scope
failure and no cluster-campaign flake in this run.

The minimal pair also ran 20 consecutive times on the merged branch: 0 failures.

Closes #197

## The other test in the #197 baseline run

`tests/test_cluster_campaign_runner.py::test_resume_after_coordinator_death_recovers_owned_helper_receipt`
is **not** this defect and is not fixed here. It never reaches `detect_profile`, and it
is not an xdist shared-path defect either -- `work_root` is `tmp_path/"sparky-work"` and
the stage lock is `work_root/.prismaquant-cluster/<identity_sha256>/locks/<stage>.lock`
(`prismaquant/cluster_campaign.py:1222-1228`), both per-test.

What it is: a fixed 8.0 s wall-clock deadline (`tests/test_cluster_campaign_runner.py:599`)
whose budget is mostly a cold `python -m prismaquant.cluster_campaign` start. Measured
here, it reaches the state the assertion accepts in 2.96-3.40 s at load ~10 (serial and
four-concurrent alike) but 5.28-5.87 s at load 105-113 -- 38% of the budget consumed
rising to 73% -- while a bare `import prismaquant.cluster_campaign` alone costs 3.4-3.7 s
idle and 4.7-5.0 s at load ~108.

Filed as #199 (P2) with the full table and the suggested fix, per the brief for this task.
It passed 5/5 serially and 3/3 under `-n 4` in my runs; I did not capture a red one.
