### PR TITLE
Let the dead-vendored-override refusal escape profile detection (#201)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,32 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `codex/pq186-campaign-identity`. Stamps
+As of: 2026-09-05 · `claude/pq-201-dead-override`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-05, `claude/pq-201-dead-override`) for **a
+dead-vendored-override refusal that actually refuses** (§8.1; PrismaQuant
+#201). The gate added by #19 was calling `_refuse_dead_vendored_override`
+*inside* `_resolve`'s per-candidate `except Exception: continue`, so its raise
+never left detection: it demoted the profile that matched and `detect_profile`
+answered `DefaultProfile` — the silent substitution the gate's own docstring
+says it refuses. The gate now runs after that `except`, on the candidate that
+won, and raises `DeadVendoredOverrideError` (a `RuntimeError` subclass, so the
+gate's original contract is unchanged) so a caller can tell "nothing matched
+this checkpoint" — a legitimate `DefaultProfile`, guarded downstream by
+`allocator.validate_default_profile_format_menu` — from "a profile matched and
+its vendored modelling path is dead", which has no legitimate answer.
+`detect_profile_with_warning` re-raises it rather than logging a fallback: its
+tolerance is for an unknown architecture, and its warning would otherwise have
+claimed "architecture unregistered or config unreadable", which is false. The
+candidate walk keeps its tolerance for a profile that cannot be asked or built,
+and the `register_vendored_modeling()` swallow is unchanged. No default, format
+menu, serving lane or exported byte moves; what changes is that a checkpoint on
+a dead vendored path now refuses by name instead of being probed under
+`DefaultProfile`. Three call sites that were the same swallow one level up —
+the completeness gate, the incremental probe's shard detection and the native
+export validator — re-raise it too; the other 22 broad-`except` swallows around
+detection, across 11 modules, are censused with `file:line` in #202 rather than
+swept here. Gate: `tests/test_vendored_override_gate.py`.
 
 Re-stamped (2026-09-05, `codex/pq186-campaign-identity`) for **one resume
 identity, including the served A-side contract** (§4.10; merge of the
@@ -8634,6 +8659,38 @@ way. The fix registers a PrismaQuant-owned subclass of the native config through
 `AutoConfig.register` (public API, no internals patched), engages only when the direct route is
 verified dead, and verifies every registration by a config-only resolution before setting the
 "done" flag. Boundary measured, not assumed: healthy through 5.12.1, broken from 5.13.0.
+
+**Where that refusal is allowed to stop** (#201, 2026-09-05). For its first year the gate had no
+teeth: `_resolve` called it from *inside* the per-candidate `try: ... except Exception: continue`,
+so the raise was caught by the walk's own tolerance, the matched profile was demoted, and
+detection fell through to `DefaultProfile(architectures=archs)` with no exception anywhere — the
+same silent-wrong-answer shape #19 was filed about, one level up. The two things that loop does
+are now separated. *Choosing* a candidate stays tolerant: a profile whose `matches()` raises, or
+that cannot be instantiated, is not a match and the walk continues. *The refusal is a statement
+about the candidate that won*, so `_refuse_dead_vendored_override(model_type)` runs after the
+`except`, not inside it, and raises `DeadVendoredOverrideError(RuntimeError)`. Its own class
+because the two failures a caller can see are not interchangeable: "nothing matched" is a
+legitimate `DefaultProfile` for a not-yet-registered architecture, while "a profile matched and
+its vendored path is dead" means the load would run upstream modelling code under a profile that
+promises the vendored copy. `detect_profile_with_warning` — the entrypoint that exists to tolerate
+anything — re-raises this one class and logs the rest, because a printed warning is not a refusal
+and the warning it printed ("architecture unregistered or config unreadable") was not even true.
+This is also why #197's leaked `OVERRIDE_ERRORS["qwen3"]` was invisible: a stray entry silently
+re-routed every later qwen3 detection in the process instead of failing. Gate:
+`tests/test_vendored_override_gate.py`. Three call sites were the same swallow one level up and
+re-raise the class for the same reason: `artifact_completeness._detect_profile_quietly` (a
+completeness *gate* that answered `None`), `incremental_probe._detect_profile_for_shards` (which
+answered `DefaultProfile`) and `validate_native_export._resolve_validation_target_profile` (a
+*validator* that answered `None`). Each documents tolerance for an architecture this build does
+not know, which is a different statement from a known architecture on a dead path.
+**Not fixed here:** 22 further broad-`except` swallows around
+`detect_profile`/`profile_from_config`/`profile_from_model`, across 11 modules, can still convert
+this refusal into `None`, `DefaultProfile`, `False` or a skipped branch at their own call sites.
+Several of those are genuinely optional hints where `None` is the right answer for an *absent*
+profile and the wrong one for a *dead* one, so they need reading one at a time against their own
+contract; censused with `file:line` in #202 rather than swept inside this diff. One site already
+has the right shape and is excluded: `sample_parallel_probe.py:568` re-raises as
+`SampleParallelProbeError(...) from exc`.
 
 The `DefaultProfile` fallback is *guarded, not silent*: `allocator.py:1550-1554` calls
 `validate_default_profile_format_menu(...)` (`:961-988`), which refuses a multi-format menu

--- a/prismaquant/artifact_completeness.py
+++ b/prismaquant/artifact_completeness.py
@@ -235,12 +235,21 @@ def _checkpoint_spellings(unit: str, profile) -> set[str]:
 
 def _detect_profile_quietly(artifact_dir: Path):
     """The artifact's own profile, or None. Never fatal: the gate must still
-    run on an artifact whose architecture this build does not know."""
+    run on an artifact whose architecture this build does not know.
+
+    That tolerance is for an UNKNOWN architecture. A dead vendored-modelling
+    override is a known one whose modelling path is wrong, and quietly
+    answering None there runs this gate name-blind over an artifact the build
+    could name — so it is re-raised (#201)."""
+    from prismaquant.model_profiles import (
+        DeadVendoredOverrideError,
+        detect_profile,
+    )
 
     try:
-        from prismaquant.model_profiles import detect_profile
-
         return detect_profile(str(artifact_dir))
+    except DeadVendoredOverrideError:
+        raise
     except Exception:                      # pragma: no cover - defensive
         return None
 

--- a/prismaquant/incremental_probe.py
+++ b/prismaquant/incremental_probe.py
@@ -561,10 +561,19 @@ def build_layer_shard_regexes(num_hidden_layers: int,
 
 
 def _detect_profile_for_shards(model_path: str):
-    try:
-        from .model_profiles.registry import detect_profile
+    """The checkpoint's profile, or `DefaultProfile` for an unknown one.
 
+    `DeadVendoredOverrideError` is not that case and is re-raised (#201): the
+    architecture IS known, its vendored modelling path is dead, and answering
+    `DefaultProfile` here would shard and probe the model against upstream
+    modelling code under a profile that promises the vendored copy.
+    """
+    from .model_profiles.registry import DeadVendoredOverrideError, detect_profile
+
+    try:
         return detect_profile(model_path)
+    except DeadVendoredOverrideError:
+        raise
     except Exception:
         from .model_profiles.default import DefaultProfile
 

--- a/prismaquant/model_profiles/__init__.py
+++ b/prismaquant/model_profiles/__init__.py
@@ -7,6 +7,9 @@ Exports:
   - Qwen3_5Profile: covers Qwen3.5 and Qwen3.6 MoE (w/ MTP)
   - Gemma4Profile: covers Gemma 4 dense + MoE multimodal
   - detect_profile(model_path): auto-detect profile from HF config
+  - DeadVendoredOverrideError: detection refused — a profile matched but its
+    vendored-modelling override is known dead (distinct from "nothing matched",
+    which answers DefaultProfile)
   - register_profile(cls): register a custom profile at runtime
   - ModelGraph / ModelStructureSpec: typed model decomposition artifacts
 
@@ -23,6 +26,7 @@ from .qwen3 import Qwen3Profile
 from .qwen3_5 import Qwen3_5Profile
 from .qwen3_5_dense import Qwen3_5DenseProfile
 from .registry import (
+    DeadVendoredOverrideError,
     detect_profile,
     detect_profile_with_warning,
     profile_from_config,
@@ -40,6 +44,7 @@ from .structure import (
 
 __all__ = [
     "ModelProfile",
+    "DeadVendoredOverrideError",
     "DefaultProfile",
     "DeepseekV4Profile",
     "Qwen3Profile",

--- a/prismaquant/model_profiles/registry.py
+++ b/prismaquant/model_profiles/registry.py
@@ -95,6 +95,28 @@ def register_profile(cls: type[ModelProfile]) -> None:
         _REGISTRY_GENERATION += 1
 
 
+class DeadVendoredOverrideError(RuntimeError):
+    """A profile matched, but its vendored-modelling override is known dead.
+
+    Its own class, not a bare `RuntimeError`, because the two failures a caller
+    can see out of detection are not the same failure and must not be handled
+    the same way:
+
+      - *nothing matched this checkpoint* — detection answers `DefaultProfile`,
+        which is a legitimate answer for a not-yet-registered architecture and
+        is guarded downstream (`allocator.validate_default_profile_format_menu`);
+      - *a profile matched and its vendored modelling path is dead* — there is
+        no legitimate answer. The run would load UPSTREAM modelling code under
+        a profile that promises the vendored copy, which is a wrong number with
+        no exception attached to it (issue #19).
+
+    A caller that legitimately tolerates the first can therefore refuse the
+    second without catching every `RuntimeError` detection might raise.
+    Subclasses `RuntimeError` so existing `except RuntimeError` handlers and
+    the gate's original contract are unchanged.
+    """
+
+
 def _refuse_dead_vendored_override(model_type: str) -> None:
     """Fail if this model_type's vendored-modeling override is known dead.
 
@@ -114,7 +136,7 @@ def _refuse_dead_vendored_override(model_type: str) -> None:
         return
     detail = OVERRIDE_ERRORS.get(str(model_type))
     if detail:
-        raise RuntimeError(
+        raise DeadVendoredOverrideError(
             f"vendored modelling override for model_type={model_type!r} did "
             f"not take effect, so a load here would silently run UPSTREAM "
             f"modelling code instead of the vendored copy:\n{detail}"
@@ -175,10 +197,19 @@ def detect_profile_with_warning(
     that intentionally keep running on vanilla or not-yet-registered models,
     but it prevents architecture-specific fused/MoE checks from disappearing
     without any log signal.
+
+    What it tolerates is an architecture this build does not know. It does not
+    tolerate `DeadVendoredOverrideError`, which says the architecture IS known
+    and its modelling path is dead: there is no fallback to log there, because
+    continuing runs upstream modelling code under a profile that promises the
+    vendored copy. A printed warning is not a refusal, and this one would have
+    printed "architecture unregistered or config unreadable", which is false.
     """
     reason = ""
     try:
         profile = detect_profile(model_path)
+    except DeadVendoredOverrideError:
+        raise
     except Exception as exc:
         reason = f"detect_profile raised {type(exc).__name__}: {exc}"
         profile = DefaultProfile()
@@ -285,39 +316,52 @@ def _new_instance(candidate) -> ModelProfile:
 
 
 def _resolve(model_type: str, archs: list[str]) -> ModelProfile:
-    """Walk detection candidates in priority order, build the first match."""
+    """Walk detection candidates in priority order, build the first match.
+
+    The candidate walk is deliberately tolerant: a candidate that cannot be
+    asked (`matches()` raises) or cannot be built is not a match, so detection
+    keeps walking rather than failing a whole run over one broken profile.
+    That tolerance is scoped to *choosing* a candidate. It must not extend to
+    the dead-vendored-override refusal, which is a statement about the
+    candidate that WON — so that gate runs after the `except Exception`, not
+    inside it (issue #201). Inside it, the refusal was demoting the matched
+    profile and detection walked on to `DefaultProfile`, which is exactly the
+    silent substitution the gate exists to prevent.
+    """
     for cls in detection_order():
         try:
-            if _claims(cls, model_type, archs):
-                inst = _new_instance(cls)
-                # Hand the profile what the checkpoint declared. A family can
-                # cover several serving classes (a multimodal wrapper and its
-                # text-only carve-out) whose namespaces differ, and only the
-                # declaration distinguishes them. Profiles that ignore it are
-                # unaffected: the stash is inert unless read.
-                inst.declare_config(model_type, archs)
-                # Some profiles need to register vendored modeling code
-                # with transformers before the model loads. Defer to
-                # the profile method (refactor #32) so callers don't
-                # need to know the architecture-specific bootstrap.
-                try:
-                    inst.register_vendored_modeling()
-                except Exception:
-                    # Don't let a vendoring failure block profile
-                    # DETECTION — but do not lose it either. The old
-                    # comment here assumed "the eventual model load
-                    # error" would surface it; that reasoning only holds
-                    # for a failure that raises at load time. The failure
-                    # mode this swallow actually hides is the opposite
-                    # one (issue #19): a registration that silently
-                    # no-ops, after which the load succeeds against the
-                    # WRONG modelling code and nothing ever raises.
-                    # `prismaquant.vendored` records those in
-                    # OVERRIDE_ERRORS; the gate below refuses to hand
-                    # back a profile whose vendored path is known dead.
-                    pass
-                _refuse_dead_vendored_override(model_type)
-                return inst
+            if not _claims(cls, model_type, archs):
+                continue
+            inst = _new_instance(cls)
+            # Hand the profile what the checkpoint declared. A family can
+            # cover several serving classes (a multimodal wrapper and its
+            # text-only carve-out) whose namespaces differ, and only the
+            # declaration distinguishes them. Profiles that ignore it are
+            # unaffected: the stash is inert unless read.
+            inst.declare_config(model_type, archs)
+            # Some profiles need to register vendored modeling code
+            # with transformers before the model loads. Defer to
+            # the profile method (refactor #32) so callers don't
+            # need to know the architecture-specific bootstrap.
+            try:
+                inst.register_vendored_modeling()
+            except Exception:
+                # Don't let a vendoring failure block profile
+                # DETECTION — but do not lose it either. The old
+                # comment here assumed "the eventual model load
+                # error" would surface it; that reasoning only holds
+                # for a failure that raises at load time. The failure
+                # mode this swallow actually hides is the opposite
+                # one (issue #19): a registration that silently
+                # no-ops, after which the load succeeds against the
+                # WRONG modelling code and nothing ever raises.
+                # `prismaquant.vendored` records those in
+                # OVERRIDE_ERRORS; the gate below refuses to hand
+                # back a profile whose vendored path is known dead.
+                pass
         except Exception:
             continue
+        # Outside the swallow, deliberately (see the docstring).
+        _refuse_dead_vendored_override(model_type)
+        return inst
     return DefaultProfile(architectures=archs)

--- a/prismaquant/validate_native_export.py
+++ b/prismaquant/validate_native_export.py
@@ -156,12 +156,21 @@ def _resolve_validation_target_profile(
     model_dir: str | Path,
     requested: str | None,
 ) -> str:
-    """Resolve the serving profile for an exported checkpoint smoke."""
-    from .model_profiles.registry import detect_profile
+    """Resolve the serving profile for an exported checkpoint smoke.
+
+    A profile this build cannot name falls back to the `default=` target below.
+    `DeadVendoredOverrideError` does not (#201): it says the architecture is
+    known and its modelling path is dead, and a validator that answers by
+    fallback on a checkpoint it was just told it cannot reason about is
+    validating the wrong thing.
+    """
+    from .model_profiles.registry import DeadVendoredOverrideError, detect_profile
     from .serving_profiles import resolve_target_profile
 
     try:
         profile = detect_profile(str(model_dir))
+    except DeadVendoredOverrideError:
+        raise
     except Exception:
         profile = None
     return resolve_target_profile(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,10 +26,13 @@ def _restore_profile_detection_globals():
     ``detect_profile`` answers for every test after it in that process:
 
     * ``prismaquant.vendored.OVERRIDE_ERRORS`` -- the dead-vendored-override
-      record. ``registry._refuse_dead_vendored_override`` raises on a hit, and
-      that raise happens *inside* ``_resolve``'s ``except Exception: continue``,
-      so a stray entry does not fail loudly. It DEMOTES the profile that
-      matched, and detection falls through to ``DefaultProfile``.
+      record. ``registry._refuse_dead_vendored_override`` raises on a hit.
+      Since issue #201 that raise escapes ``_resolve`` as a
+      ``DeadVendoredOverrideError``, so a stray entry now fails the next test
+      that detects that architecture, loudly and by name. It used to happen
+      *inside* ``_resolve``'s ``except Exception: continue``, which merely
+      DEMOTED the profile that matched and let detection fall through to
+      ``DefaultProfile`` -- silent, and the reason #197 was so hard to see.
     * ``prismaquant.vendored._QWEN3_REGISTERED`` -- once True, ``register_qwen3``
       returns before the ``OVERRIDE_ERRORS.pop()`` that a successful override
       performs, so a stray ``"qwen3"`` entry can never self-heal.

--- a/tests/test_vendored_override_gate.py
+++ b/tests/test_vendored_override_gate.py
@@ -213,3 +213,57 @@ def test_an_unaskable_candidate_still_falls_through(tmp_path, monkeypatch):
 
     path = _checkpoint(tmp_path, **QWEN3_CONFIG)
     assert detect_profile(path).name == "qwen3"
+
+
+# --- the same swallow one level up (issue #201, census in #202) -------------
+#
+# These three call sites each wrap detection in a broad `except Exception` and
+# continue with a substituted profile, so before this they converted the
+# refusal straight back into the silent wrong answer at their own call site.
+# Each documents its tolerance as "an architecture this build does not know",
+# which is a different statement from "a known architecture on a dead path".
+# They are pinned here rather than in each module's own test file because the
+# rule is the registry's -- where this refusal is allowed to stop -- and it has
+# one home. The other 22 such call sites, across 11 modules, are censused with
+# file:line in #202; several are optional-hint paths where `None` is right for
+# an ABSENT profile and wrong for a DEAD one, so each needs its own judgement.
+
+
+def test_the_completeness_gate_does_not_swallow_the_refusal(tmp_path, monkeypatch):
+    """`artifact_completeness._detect_profile_quietly` answered `None`."""
+    from prismaquant.artifact_completeness import _detect_profile_quietly
+
+    path = _checkpoint(tmp_path, **QWEN3_CONFIG)
+    assert _detect_profile_quietly(path).name == "qwen3"
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        _detect_profile_quietly(path)
+
+
+def test_the_incremental_probe_shard_detection_does_not_swallow_it(
+    tmp_path, monkeypatch
+):
+    """`incremental_probe._detect_profile_for_shards` answered `DefaultProfile`."""
+    from prismaquant.incremental_probe import _detect_profile_for_shards
+
+    path = _checkpoint(tmp_path, **QWEN3_CONFIG)
+    assert _detect_profile_for_shards(path).name == "qwen3"
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        _detect_profile_for_shards(path)
+
+
+def test_the_native_export_validator_does_not_swallow_it(tmp_path, monkeypatch):
+    """`validate_native_export._resolve_validation_target_profile` answered `None`.
+
+    Which then resolved the smoke's serving profile from the `default=`
+    argument — a validator picking its target by fallback, on a checkpoint it
+    had just been told it cannot reason about.
+    """
+    from prismaquant.validate_native_export import _resolve_validation_target_profile
+
+    path = _checkpoint(tmp_path, **QWEN3_CONFIG)
+    assert _resolve_validation_target_profile(path, None)
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        _resolve_validation_target_profile(path, None)

--- a/tests/test_vendored_override_gate.py
+++ b/tests/test_vendored_override_gate.py
@@ -9,13 +9,44 @@ vendoring failure must not break profile *detection*), so the recorded failure
 has to be consulted explicitly or the swallow re-hides it.
 
 These tests pin that consultation, not the vendored machinery itself.
+
+They also pin where the refusal is allowed to STOP (issue #201). A gate that
+raises inside a `try: ... except Exception: continue` is not a gate: until
+`_resolve` was reordered, a recorded dead override merely demoted the profile
+that matched and detection answered `DefaultProfile` — the silent wrong answer
+the gate's own docstring says it refuses. So the refusal must reach the caller
+of `detect_profile`, and it must arrive as its own class, so a caller can tell
+"no profile matched this checkpoint" (a `DefaultProfile`, sometimes fine) from
+"a profile matched and its vendored path is dead" (never fine).
 """
 from __future__ import annotations
+
+import json
 
 import pytest
 
 import prismaquant.vendored as vendored
-from prismaquant.model_profiles.registry import _refuse_dead_vendored_override
+from prismaquant.model_profiles.registry import (
+    DeadVendoredOverrideError,
+    _refuse_dead_vendored_override,
+    detect_profile,
+    detect_profile_with_warning,
+    profile_from_config,
+)
+
+
+def _checkpoint(tmp_path, **config):
+    """A staged checkpoint directory carrying just a `config.json`."""
+    root = tmp_path / "ckpt"
+    root.mkdir()
+    (root / "config.json").write_text(json.dumps(config))
+    return str(root)
+
+
+QWEN3_CONFIG = {
+    "model_type": "qwen3",
+    "architectures": ["Qwen3ForCausalLM"],
+}
 
 
 @pytest.fixture(autouse=True)
@@ -81,3 +112,104 @@ def test_gate_survives_a_missing_vendored_package(monkeypatch):
 
     monkeypatch.setattr(builtins, "__import__", _no_vendored)
     assert _refuse_dead_vendored_override("qwen3") is None
+
+
+# --- where the refusal is allowed to stop (issue #201) ---------------------
+
+
+def test_detect_profile_refuses_a_dead_override_instead_of_defaulting(
+    tmp_path, monkeypatch
+):
+    """The whole point of the gate: `detect_profile` must not answer at all.
+
+    Before #201 this returned `DefaultProfile` — `_resolve` ran the gate inside
+    its per-candidate `except Exception: continue`, which ate the refusal and
+    then walked on to the terminal fallback.
+    """
+    path = _checkpoint(tmp_path, **QWEN3_CONFIG)
+    assert detect_profile(path).name == "qwen3"  # healthy path, for contrast
+
+    monkeypatch.setitem(
+        vendored.OVERRIDE_ERRORS,
+        "qwen3",
+        "synthetic: AutoModelForCausalLM.register no-op'd",
+    )
+    with pytest.raises(DeadVendoredOverrideError) as exc:
+        detect_profile(path)
+    msg = str(exc.value)
+    assert "qwen3" in msg
+    assert "UPSTREAM" in msg
+
+
+def test_the_refusal_has_its_own_class_distinct_from_no_match(
+    tmp_path, monkeypatch
+):
+    """"Nothing matched" and "the match is dead" must not look the same.
+
+    An unregistered architecture legitimately resolves to `DefaultProfile`;
+    a matched profile whose vendored path is dead never does. A caller that
+    tolerates the first must be able to refuse the second without catching
+    every `RuntimeError` detection can raise.
+    """
+    unknown = _checkpoint(
+        tmp_path, model_type="not_an_architecture", architectures=["NopeForCausalLM"]
+    )
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    # Unrelated architecture: unaffected, still the terminal fallback.
+    assert type(detect_profile(unknown)).__name__ == "DefaultProfile"
+
+    assert issubclass(DeadVendoredOverrideError, RuntimeError)
+    assert not issubclass(RuntimeError, DeadVendoredOverrideError)
+
+
+def test_profile_from_config_refuses_a_dead_override(monkeypatch):
+    """The config-object entrypoint shares `_resolve`, so it shares the gate."""
+    assert profile_from_config(dict(QWEN3_CONFIG)).name == "qwen3"
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        profile_from_config(dict(QWEN3_CONFIG))
+
+
+def test_detect_profile_with_warning_does_not_swallow_the_refusal(
+    tmp_path, monkeypatch
+):
+    """The tolerant entrypoint tolerates an unknown arch, not a dead override.
+
+    `detect_profile_with_warning` exists so production entrypoints can keep
+    running on a not-yet-registered model with a logged fallback. Its broad
+    `except Exception` is the same defect one level up: a printed warning is
+    not a refusal, and this failure means the run would execute upstream
+    modelling code.
+    """
+    path = _checkpoint(tmp_path, **QWEN3_CONFIG)
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        detect_profile_with_warning(path, entrypoint="test")
+
+
+def test_an_unaskable_candidate_still_falls_through(tmp_path, monkeypatch):
+    """The reordering must not cost `_resolve` its candidate-walk tolerance.
+
+    A profile whose `matches()` explodes is not a match; detection keeps
+    walking, exactly as before. Only the dead-override refusal is promoted.
+    """
+    from prismaquant.model_profiles import registry
+    from prismaquant.model_profiles.base import ModelProfile
+
+    class ExplodingProfile(ModelProfile):
+        priority = 1
+
+        @classmethod
+        def matches(cls, model_type, architectures):
+            raise ValueError("synthetic: this candidate cannot be asked")
+
+        @property
+        def name(self) -> str:
+            return "exploding"
+
+    monkeypatch.setattr(registry, "_REGISTERED", [ExplodingProfile, *registry._REGISTERED])
+    monkeypatch.setattr(registry, "_REGISTRY_GENERATION", registry._REGISTRY_GENERATION + 1)
+    monkeypatch.setattr(registry, "_DETECTION_ORDER_CACHE", None)
+
+    path = _checkpoint(tmp_path, **QWEN3_CONFIG)
+    assert detect_profile(path).name == "qwen3"


### PR DESCRIPTION
Fixes #201. Refs #202.

## The defect

`model_profiles/registry._resolve` called `_refuse_dead_vendored_override(model_type)` from
**inside** its per-candidate `try: ... except Exception: continue`. So the gate added by #19 —
the one whose own docstring calls a wrong modelling path "exactly the silent-wrong-answer this
project refuses to ship" — had no teeth. Its `RuntimeError` was caught by the walk's own
tolerance, the profile that matched was demoted, and detection fell through to
`DefaultProfile(architectures=archs)` with no exception anywhere.

Reproduced in one interpreter on `468e7534` before touching anything:

```
clean:              Qwen3Profile
with dead override: DefaultProfile name= default
```

Downstream, some paths then refuse for an unrelated-sounding reason
(`tessera_serving_scope.unit_structure_from_profile`: "explicit Tessera scope needs a declared
model profile", because `DefaultProfile.structure_spec()` is None) and everything that accepts
`DefaultProfile` proceeds against UPSTREAM modelling code with no signal at all.

## The fix (commit 1 — the owner)

The loop was doing two jobs and they are now separated.

**Choosing a candidate stays tolerant.** A profile whose `matches()` raises, or that cannot be
instantiated, is not a match and the walk continues — that is what the `except Exception` is for,
and a new test pins that it still works.

**The refusal is a statement about the candidate that WON**, so it runs after the `except`, not
inside it. `_resolve` now computes the match inside the `try` and runs the gate outside it.

It raises **`DeadVendoredOverrideError(RuntimeError)`**, its own class, because the two failures a
caller can see out of detection are not interchangeable:

| what happened | answer | legitimate? |
|---|---|---|
| nothing matched this checkpoint | `DefaultProfile` | yes, for a not-yet-registered architecture — and guarded downstream by `allocator.validate_default_profile_format_menu` |
| a profile matched, its vendored path is dead | refusal, by name | never an answer — the load would run upstream modelling code under a profile that promises the vendored copy |

Subclassing `RuntimeError` keeps the gate's original contract, so existing `except RuntimeError`
handlers and the four pre-existing gate tests are unchanged.

**One rule, one home.** The refusal itself did not move; only where it is allowed to propagate.
`register_vendored_modeling()`'s own swallow is untouched — its documented reason still holds, and
this gate is precisely how the failure it hides is recovered.

## The same swallow one level up

An AST scan (a call to `detect_profile` / `profile_from_config` / `profile_from_model`
lexically inside a `try` whose handler catches `Exception`/`BaseException`) found **26 further
sites across 15 modules** under `prismaquant/`.

**Fixed in this PR — 4:**

- `registry.detect_profile_with_warning` (commit 1, same file as the owner). It exists so
  production entrypoints keep running on a not-yet-registered model with a logged fallback; a
  printed warning is not a refusal, and the warning it printed here was
  `"architecture unregistered or config unreadable"`, which is false.
- `artifact_completeness._detect_profile_quietly` (commit 2) — a completeness *gate* that
  answered `None`, running name-blind over an artifact the build could name.
- `incremental_probe._detect_profile_for_shards` (commit 2) — answered `DefaultProfile`, then
  sharded and probed against upstream modelling code.
- `validate_native_export._resolve_validation_target_profile` (commit 2) — a *validator* that
  answered `None` and picked its serving target from `default=`.

All four document their tolerance as "an architecture this build does not know", which is a
different statement from "a known architecture on a dead path". Each keeps every other tolerance;
only this one class is re-raised.

**Already correct — 1:** `sample_parallel_probe.py:568` re-raises as
`SampleParallelProbeError(...) from exc`. Refuses by name, keeps the cause. No change.

**Filed, not fixed — 22 across 11 modules:** censused with `file:line` and what each handler
substitutes in **#202**. Several are genuinely optional-hint paths (`layer_streaming.py:1140`
returns a count, `streaming_model.py:112` returns a bool) where `None` is the right answer for an
*absent* profile and the wrong one for a *dead* one — so each needs reading against its own
contract, not one mechanical edit. 22 two-line edits across 11 modules is several times the diff
of the fix they hang off; AGENTS.md principle 14, "large enough to swamp the diff of the task you
came for". The issue records that the filer could have fixed it and why they did not.

## Test, shown failing first

`tests/test_vendored_override_gate.py` is the gate's own file — its module docstring is already
"the profile registry must refuse a model_type whose vendored override died". Eight cases added
there, six of them the new rule (the other two pin the tolerance that must survive).

Commit 1, pre-fix — **3 failed, 6 passed**:

```
FAILED test_detect_profile_refuses_a_dead_override_instead_of_defaulting
  - Failed: DID NOT RAISE DeadVendoredOverrideError
FAILED test_profile_from_config_refuses_a_dead_override
FAILED test_detect_profile_with_warning_does_not_swallow_the_refusal
```

post-fix **9 passed**. Commit 2, pre-fix — **3 failed, 9 passed** (the three call sites, same
`DID NOT RAISE` line); post-fix **12 passed**.

The call-site tests live in the registry gate's file rather than each module's, because the rule
being pinned is the registry's — where this refusal is allowed to stop — and it has one home.

## Docs

`docs/ARCHITECTURE.md` re-stamped in **commit 1**, the same commit as the behaviour change
(principle 12): a new dated stamp at the head, and §8.1's dead-override paragraph rewritten —
it described a gate that did not fire. It now records where the refusal is allowed to stop, why
the class exists, the four fixed call sites, and the 22 filed in #202.

`tests/conftest.py`'s autouse-fixture docstring (from #200) explained #197 partly *in terms of*
this swallow — "that raise happens inside `_resolve`'s `except Exception: continue`, so a stray
entry does not fail loudly". True when written, false after this commit, so corrected in place
(AGENTS.md 14: prose is fixed on sight, never filed). It now records that a leaked
`OVERRIDE_ERRORS` entry fails the next test loudly and by name — which is what made #197 hard to
see in the first place.

## Blast radius

None on a healthy tree: `OVERRIDE_ERRORS` is empty at import on the reference box and only ever
gains an entry when a vendored override actually fails to take effect. Verified:

```
OVERRIDE_ERRORS at import: {}
```

What changes is that when it *is* non-empty, detection refuses by name instead of silently
substituting a profile.
