### PR TITLE
pq-decisions: #175 receipt (no token needed), #87 reopened + driver replays the candidate decision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,13 @@ jobs:
           tessera_commit="$(python tools/resolve_tessera_dev_pin.py)"
           printf 'commit=%s\n' "$tessera_commit" >> "$GITHUB_OUTPUT"
 
-      # Tessera becomes public after its release fixes and audit. Until then,
-      # ordinary checkout access fails here; no private credential is required
-      # or exposed to contributor PRs by this workflow.
+      # RobTand/tessera has been public since 2026-09-05, so the ordinary
+      # checkout credential fetches the pin here, for fork PRs as much as for
+      # branches (first receipt: run 33950707718 on main, both jobs green
+      # end-to-end; #175). No private credential is required or exposed by
+      # this workflow, and none should be added: a repository secret is a
+      # cross-repo credential the issue deliberately avoided, and it would not
+      # reach fork PRs anyway.
       - name: Check out pinned Tessera
         uses: actions/checkout@v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,19 @@
 # doc-staleness tests that the project had deliberately written to catch exactly
 # that kind of drift. Nobody was ignoring a red signal — there was no signal.
 #
-# WHAT IT CAN AND CANNOT COVER. Re-measured 2026-08-03 ON THE RUNNER, which is
-# the number that matters here: the suite is ~2762 tests taking 10.5-14 min per
-# interpreter with `CUDA_VISIBLE_DEVICES=""` (2762 passed, 96 skipped,
-# 2 xfailed). The previous note in this header claimed 967 tests in ~51 s,
-# measured on the reference box on 2026-07-28; the suite has roughly tripled
-# since and an ARM workstation is not a free x86 runner, so that figure had
-# become misleading in both directions. The `tests` job allows 30 min, so the
-# margin is about 2x rather than the ~35x the old number implied — a further
-# doubling of the suite is a timeout, not a slow build, and should raise
-# `timeout-minutes` in the same PR. The skips are the CUDA-gated tests.
-# GitHub-hosted runners have no GPU, so
+# WHAT IT CAN AND CANNOT COVER. Re-measured 2026-09-05 ON THE RUNNER, which is
+# the number that matters here: the suite is ~4840 tests (4698 passed, 136
+# skipped, 3 xfailed at `main` 8a77b0ad) and the `tests` JOB — install plus
+# suite, which is what `timeout-minutes` bounds — took 15 to 29.5 min across
+# the ten completed runs of 2026-09-05 (job 33973973959 finished at 29m30s
+# against the then 30 min limit; hosted-runner speed is the variable, not
+# the suite). The previous note here, measured 2026-08-03, said ~2762 tests
+# in 10.5-14 min with a ~2x margin and that a further doubling of the suite
+# "should raise `timeout-minutes` in the same PR"; the suite has since grown
+# 1.75x, so this is that PR: 60 min gives ~2x on the worst observed job. A
+# job that reaches the limit is a timeout, not a slow build — re-measure and
+# raise it here again rather than retrying. The skips are the CUDA-gated
+# tests. GitHub-hosted runners have no GPU, so
 # kernel numerics, real-checkpoint streaming and anything touching a served
 # artifact remain a manual gate on the Spark — this is a correctness net for
 # the allocator/solver/footprint/profile logic, which is where the PRs live and
@@ -44,7 +46,7 @@ jobs:
   tests:
     name: tests (py${{ matrix.python }}, cpu)
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,18 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `claude/pq-201-dead-override`. Stamps
+As of: 2026-09-05 · `claude/pq-decisions`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-05, `claude/pq-decisions`) for the **pinned Tessera CI
+dependency's receipt** (§8.6; RobTand/prismaquant#175). RobTand/tessera went
+public on 2026-09-05; the unchanged workflow then installed the pin with
+ordinary checkout credentials in both jobs and ran green end-to-end (run
+33950707718, `main` at `8a77b0ad`, 06:45Z: `Check out pinned Tessera` and
+`Install pinned Tessera` green, 4698 passed). That is the issue's own
+completion receipt. The `codex/pq-175`
+stamp below recorded "checkout failure is expected until Rob publishes it" as
+the then-current state; this stamp closes that sentence. No token bridge was
+added: the workflow needs no secret now, and one would not reach fork PRs.
 
 Re-stamped (2026-09-05, `claude/pq-201-dead-override`) for **a
 dead-vendored-override refusal that actually refuses** (§8.1; PrismaQuant
@@ -9031,9 +9042,13 @@ every push and PR, on Python 3.12 with CPU torch. Before PrismaQuant is
 installed, both jobs use the stdlib-only `tools/resolve_tessera_dev_pin.py` to
 derive the exact Tessera checkout from `TESSERA_DEV_PIN_COMMIT`, stop
 without publishing a ref if that resolution fails, and install that checkout
-before exercising the package. Ordinary checkout access is sufficient once
-Tessera is public; while it remains private pending fixes and audit, checkout
-failure is expected. §12 D11.
+before exercising the package. Ordinary checkout access is sufficient:
+RobTand/tessera has been public since 2026-09-05, and the first receipt is run
+33950707718 (`main` at `8a77b0ad`, 2026-09-05 06:45Z), where `Check out
+pinned Tessera` fetched `1221d2a4…` and `Install pinned Tessera` reported
+`Successfully installed tessera-quant-0.1.0` in both jobs, and the suite ran
+green (4698 passed, 136 skipped, 3 xfailed, 21m20s). No repository secret
+exists or is wanted for this step (#175). §12 D11.
 
 ### 8.7 A fourth plug-in point: `FormatCostPlugin` (formats, not models)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,20 @@
 As of: 2026-09-05 · `claude/pq-decisions`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-05, `claude/pq-decisions`) for the **replayed candidate
+decision in the paired validation driver** (§7.2; #87). The opt-in
+`experiments/pq87_paired_validation.py` counted a candidate arm as observed
+when the receipt's stored `decision.verdict` agreed with the client's exit
+status — a stored bit, which `replay_no_new_failures` exists to refuse and
+which had no caller outside the tests (pq-190 review, side-finding 3). The
+driver now replays the stored decision against the control receipt of the
+same run before the verdict counts; a decision that does not replay refuses
+by name (`boundary decision differs from replayed paired policy`) and the
+run stays inconclusive. Nothing else moves: no shipcard slot, threshold or
+default. Gate: `tests/test_pq87_paired_validation.py`
+(`test_stored_candidate_verdict_is_replayed_against_the_control_not_trusted`,
+pre-fix: the forged `accepted` on a refused pair counted as observed).
+
 Re-stamped (2026-09-05, `claude/pq-decisions`) for the **pinned Tessera CI
 dependency's receipt** (§8.6; RobTand/prismaquant#175). RobTand/tessera went
 public on 2026-09-05; the unchanged workflow then installed the pin with

--- a/experiments/pq87_paired_validation.py
+++ b/experiments/pq87_paired_validation.py
@@ -66,8 +66,20 @@ def server_argv(nonce, model):
     return argv
 
 
-def completed_candidate(receipt, returncode):
-    verdict = receipt.get("decision", {}).get("verdict")
+def completed_candidate(receipt, returncode, control, replay):
+    """A candidate arm is observed only when its stored decision replays.
+
+    `receipt["decision"]` is written by the measurement client the driver
+    launched; it is a claim, not evidence. `replay` (the module's
+    `replay_no_new_failures`) recomputes the whole decision from the control
+    and candidate measurements and raises by name if the stored one differs,
+    so a verdict bit can never certify the arm on its own. The exit status is
+    then required to agree with the replayed verdict.
+    """
+    decision = receipt.get("decision")
+    if not isinstance(decision, dict) or "measurement" not in receipt:
+        return False
+    verdict = replay(decision, control["measurement"], receipt["measurement"])["verdict"]
     return (verdict == "accepted" and returncode == 0) or (verdict == "refused" and returncode == 2)
 
 
@@ -262,7 +274,11 @@ def inside(args):
                     role_status[population] = {"returncode": result.returncode,
                         "decision": receipt.get("decision"), "ppl": receipt.get("result")}
                     if role == "candidate" and population != "ppl":
-                        observed = completed_candidate(receipt, result.returncode)
+                        # The control arm of this same run wrote this file; the
+                        # candidate client bound its digest. Replay before trusting.
+                        control_receipt = json.loads(Path(f"/run/control-{population}.json").read_text())
+                        observed = completed_candidate(receipt, result.returncode, control_receipt,
+                                                       _bc.replay_no_new_failures)
                     else:
                         observed = bool(receipt) and result.returncode == 0
                     if not observed:

--- a/tests/test_pq87_paired_validation.py
+++ b/tests/test_pq87_paired_validation.py
@@ -57,13 +57,54 @@ def test_both_model_arms_reuse_the_existing_bounded_server_configuration():
     assert "--quantization" not in control + candidate
 
 
-def test_candidate_refusal_is_an_observation_but_missing_measurement_is_not():
+def _arm_receipts(monkeypatch, *, control_texts=None, candidate_texts):
+    """The two `prismaquant.boundary_campaign_arm/1` files the driver reads back."""
+    from prismaquant import boundary_control as bc
+    from test_boundary_policy import CLEAN, _pair
+    control, candidate = _pair(monkeypatch, control_texts or (CLEAN, CLEAN), candidate_texts)
+    decision = bc.decide_no_new_failures(control, candidate)
+    return ({"measurement": control}, {"measurement": candidate, "decision": decision},
+            bc.replay_no_new_failures)
+
+
+def test_candidate_refusal_is_an_observation_but_missing_measurement_is_not(monkeypatch):
+    from test_boundary_policy import CLEAN, ZERO
     driver = _driver()
-    assert driver.completed_candidate({"decision": {"verdict": "refused"}}, 2)
-    assert driver.completed_candidate({"decision": {"verdict": "accepted"}}, 0)
-    assert not driver.completed_candidate({"decision": {"verdict": "accepted"}}, 2)
-    assert not driver.completed_candidate({}, 2)
-    assert not driver.completed_candidate({"decision": {"verdict": "inconclusive"}}, 2)
+    control, accepted, replay = _arm_receipts(monkeypatch, candidate_texts=(CLEAN, CLEAN))
+    _, refused, _ = _arm_receipts(monkeypatch, candidate_texts=(ZERO, CLEAN))
+    assert refused["decision"]["verdict"] == "refused"
+    assert driver.completed_candidate(refused, 2, control, replay)
+    assert driver.completed_candidate(accepted, 0, control, replay)
+    # The exit status and the receipt must agree; either alone is not the observation.
+    assert not driver.completed_candidate(accepted, 2, control, replay)
+    assert not driver.completed_candidate(refused, 0, control, replay)
+    assert not driver.completed_candidate({}, 2, control, replay)
+    assert not driver.completed_candidate({"measurement": accepted["measurement"]}, 0, control, replay)
+
+
+def test_stored_candidate_verdict_is_replayed_against_the_control_not_trusted(monkeypatch):
+    """`decision.verdict` in the receipt is a claim; the driver recomputes it.
+
+    The receipt is written by a subprocess the driver launched seconds earlier,
+    which is exactly why trusting the stored bit would go unnoticed: nothing
+    else between the write and the read re-derives the verdict, and the
+    offline verifier `replay_no_new_failures` otherwise has no caller outside
+    the tests (pq-190 review, side-finding 3).
+    """
+    from test_boundary_policy import CLEAN, ZERO
+    driver = _driver()
+    control, receipt, replay = _arm_receipts(monkeypatch, candidate_texts=(ZERO, CLEAN))
+    assert receipt["decision"]["verdict"] == "refused"
+    forged = copy.deepcopy(receipt)
+    forged["decision"]["verdict"] = "accepted"
+    with pytest.raises(ValueError, match="boundary decision differs from replayed paired policy"):
+        driver.completed_candidate(forged, 0, control, replay)
+    # A verdict that replays only against some other control is not this campaign's.
+    other_control, _, _ = _arm_receipts(monkeypatch, control_texts=(ZERO, ZERO),
+                                        candidate_texts=(ZERO, CLEAN))
+    assert other_control != control
+    with pytest.raises(ValueError, match="boundary decision differs from replayed paired policy"):
+        driver.completed_candidate(receipt, 2, other_control, replay)
 
 
 def test_cpu_only_pool_action_cannot_start_the_physical_controller(monkeypatch):


### PR DESCRIPTION
Closes out the two items parked "for Rob" (worker `pq-decisions`, 2026-09-05). Three commits, each independently droppable.

## #175 — CI and the pinned Tessera: no token bridge, the receipt already exists

The brief's plan was an optional-token bridge (`secrets.TESSERA_REPO_TOKEN || github.token`). It is not needed: **RobTand/tessera went public on 2026-09-05** (between the 03:04Z run that still failed at checkout and the 06:45Z run that succeeded), and the unchanged workflow then installed the pin with the default checkout credential in both jobs and ran green end-to-end.

Receipt, run [33950707718](https://github.com/RobTand/prismaquant/actions/runs/33950707718) (`main` at `8a77b0ad`, push, 06:45Z): `Check out pinned Tessera` fetched `1221d2a4207a6baeffbe9726bce13125fc1649ae` from `https://github.com/RobTand/tessera`, `Install pinned Tessera` → `Successfully installed tessera-quant-0.1.0`, both jobs; suite 4698 passed / 136 skipped / 3 xfailed in 21m20s. That is the issue's own completion criterion ("successful dependency installation on GitHub"). The newest complete run, [33976858139](https://github.com/RobTand/prismaquant/actions/runs/33976858139), has the same two steps green; its 17 failures are all `test_tessera_campaign_resume.py` main-entry cases inherited at the dev pin (`tessera.cached_unit` absent), fixed by the re-pin in #192.

* `05a4683a` — the workflow comment and ARCHITECTURE.md §8.6 still said "checkout failure is expected while Tessera remains private"; corrected on sight (AGENTS.md 14, prose), stamp added. No secret is added or wanted: it would be the cross-repo credential the issue avoided, and it would not reach fork PRs anyway.
* `769c8b75` — **off-task, tripped over reading run durations**: the `tests` job took 15–29.5 min across the ten completed jobs of 2026-09-05 (job 33973973959 finished at **29m30s against the 30 min limit** and passed). The header's own 2026-08-03 rule said a suite doubling "should raise `timeout-minutes` in the same PR"; the suite is 1.75x larger. Raised to 60 (≈2x on the worst observed job), header re-measured. Nothing pins the old value.

#175 is closed with a comment citing the run IDs and step names (coordinator's instruction); Rob has nothing to click.

## #87 — pending GPU validation and `replay_no_new_failures`

**What is pending.** The matched quantized validation that PR #190 (`65cfa6d9`) and `docs/experiments/pq87_quantized_validation.md` describe and that nothing on GitHub tracked: one exclusive PrismaBuild action on Sparky, Qwen3-0.6B BF16 control then the native NVFP4 candidate (`experiments/pq87_validation_manifest.json`), screen + disjoint held-out schedules + PPL screen on both arms. Filed as a bounded `measurement-needed` issue with the exact command, model, box and acceptance numbers; linked from #87.

**#87 itself is reopened.** Its closing criterion — paired validation with a shippable quantized artifact plus representative-population evidence before it closes as a production gate fix (#87 comment 2026-09-04 20:20:22Z; `docs/experiments/pq87_quantized_validation.md:79-80`) — is demonstrably unmet: no quantized paired measurement exists in the tree. The 20:34:11Z close carries no comment or commit, landed two seconds after PR #182 merged (whose body says "does not close #87"), and every later comment, PR #190's body and both dated docs treat the issue as open. The production `boundary_behavior` slot is still the mandatory 64-token / zero-defect gate (`shipcard.py:2826-2828`) that smb209 showed refuses healthy thinking models; the replacement decision is what #87 tracks.

* `e2d6e4ad` — **`replay_no_new_failures` was a wiring gap, not dead code.** `experiments/pq87_paired_validation.py::completed_candidate` read `receipt["decision"]["verdict"]` as a bit and cross-checked only the client's exit status — the stored verdict the replay function exists to refuse (pq-190 review, side-finding 3). The driver now replays the stored decision against `/run/control-<population>.json` (written by the control arm of the same run, whose digest the candidate bound) before the verdict counts; a decision that does not replay refuses by name and the run stays inconclusive. Pre-fix: a forged `decision.verdict="accepted"` on a pair the policy refuses → `completed_candidate(receipt, 0) -> True`. No shipcard slot, threshold or default moves. ARCHITECTURE.md re-stamped.

## Tests

sparklina, CPU only (`CUDA_VISIBLE_DEVICES=""`), `/home/rob/venvs/pq-cu130/bin/python`, `PYTHONPATH=/home/rob/tessera-pin-1221d2a/src`, serial:

```
pytest -q -p no:cacheprovider tests/test_pq87_paired_validation.py tests/test_boundary_policy.py \
  tests/test_boundary_control.py tests/test_measure_boundary_control_identity.py \
  tests/test_pq87_physical_ab.py tests/test_ship_boundary_behavior.py \
  tests/test_ci_tessera_install.py tests/test_architecture_doc.py tests/test_docs_staleness.py
```

**139 passed, 0 failed, 0 skipped.** `py_compile experiments/pq87_paired_validation.py` rc 0; `ci.yml` parses (`timeout-minutes: 60`).

Refs #175, Refs #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWKVQr3UzwTG9BpWavT9p9