### PR TITLE
[P2] Stop swallowing the dead-vendored-override refusal at the remaining 22 call sites (#202)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,30 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `claude/pq-201-dead-override`. Stamps
+As of: 2026-09-05 · `claude/pq-202-detection-swallows`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-05, `claude/pq-202-detection-swallows`) for **the
+dead-vendored-override refusal reaching every call site** (§8.1; PrismaQuant
+#202, follow-up to #201). #201 made `_resolve` raise
+`DeadVendoredOverrideError` and stopped three gate call sites re-swallowing
+it; the census filed with that issue found 22 more, across 11 modules, each
+wrapping detection in a broad `except Exception` and continuing with a
+substituted profile — so the refusal was converted back into the silent wrong
+answer one level up. All 22 now re-raise this one class ahead of their broad
+handler. Each was read against its own contract, and the answer was the same
+at all 22, including the two the census flagged as possibly legitimate
+swallows: `layer_streaming.py:1140` returns a count, but returning `0` on a
+dead override reports exactly the zero-initialized-experts breakage the
+function exists to prevent; `streaming_model.py:112` returns a bool, but is
+only reached for a native-FP8 block-scaled checkpoint, where `False` runs the
+HF module rewrite the profile would have forbidden. No shared helper was
+added — the rule keeps its single home in the registry, and a helper would
+have had to own each site's differing fallback. No default, format menu,
+serving lane or exported byte moves, and the *absent*-profile path is
+unchanged everywhere; what changes is that a dead vendored path now refuses at
+the call site instead of being answered. The rule is pinned tree-wide by an
+executable census that fails for any future detection call inside a broad
+`except`. Gate: `tests/test_vendored_override_gate.py`.
 
 Re-stamped (2026-09-05, `claude/pq-201-dead-override`) for **a
 dead-vendored-override refusal that actually refuses** (§8.1; PrismaQuant
@@ -8683,14 +8706,30 @@ completeness *gate* that answered `None`), `incremental_probe._detect_profile_fo
 answered `DefaultProfile`) and `validate_native_export._resolve_validation_target_profile` (a
 *validator* that answered `None`). Each documents tolerance for an architecture this build does
 not know, which is a different statement from a known architecture on a dead path.
-**Not fixed here:** 22 further broad-`except` swallows around
-`detect_profile`/`profile_from_config`/`profile_from_model`, across 11 modules, can still convert
-this refusal into `None`, `DefaultProfile`, `False` or a skipped branch at their own call sites.
-Several of those are genuinely optional hints where `None` is the right answer for an *absent*
-profile and the wrong one for a *dead* one, so they need reading one at a time against their own
-contract; censused with `file:line` in #202 rather than swept inside this diff. One site already
-has the right shape and is excluded: `sample_parallel_probe.py:568` re-raises as
-`SampleParallelProbeError(...) from exc`.
+The remaining 22 broad-`except` swallows around
+`detect_profile`/`profile_from_config`/`profile_from_model`, across 11 modules, were closed by
+#202 (2026-09-05). Each was read against its own contract rather than swept: the answer was the
+same at all 22, including the two the census singled out as possible legitimate swallows
+(`layer_streaming.py:1140`, which returns a count, and `streaming_model.py:112`, which returns a
+bool). Both turned out to be the strongest cases rather than the weakest — the first exists
+*because* the packed params would otherwise stay zero-initialized, so a clean `0` reports the
+silent breakage it was written to prevent; the second is only reached for a native-FP8
+block-scaled checkpoint, so `False` is a decision, not a neutral default. Every site keeps its
+other tolerances: the `except DeadVendoredOverrideError: raise` clause sits ahead of the broad
+handler and nothing about the *absent*-profile path changed anywhere.
+
+**Where this rule lives.** No shared "detect or refuse" helper was added, deliberately. The rule —
+what "dead" means and that it must never be answered — has one home, `_refuse_dead_vendored_override`
+and `DeadVendoredOverrideError` in the registry; a helper would have had to own each call site's
+*fallback* too, and those differ (`None`, `DefaultProfile()`, `keep_composite = False`, `return 0`,
+`return False`, a hardcoded prefix guess, `pass`), so it would have moved tolerance policy into the
+registry rather than removing duplication. Each site's import is hoisted just outside its `try` so
+the new `except` clause can always be evaluated. The rule is pinned tree-wide by an executable
+census in `tests/test_vendored_override_gate.py`, which walks `prismaquant/` and fails for any
+detection call inside a broad-`except` `try` that does not either re-raise this class first or
+re-raise unconditionally — so a 23rd such call site fails the suite when it is written.
+`sample_parallel_probe.py:568` already had the second shape (`SampleParallelProbeError(...) from
+exc`) and passes unchanged.
 
 The `DefaultProfile` fallback is *guarded, not silent*: `allocator.py:1550-1554` calls
 `validate_default_profile_format_menu(...)` (`:961-988`), which refuses a multi-format menu

--- a/prismaquant/aqua_activation_cost.py
+++ b/prismaquant/aqua_activation_cost.py
@@ -655,10 +655,21 @@ def main() -> int:
     # no profile claims must not become a hard failure for those models. When
     # one IS detected it supplies the checkpoint aliases the generic index
     # cannot derive (see build_weight_resolver).
+    #
+    # "No profile claims this path" is the tolerated case. A dead vendored
+    # override is not it (#202): the architecture IS claimed, and dropping to
+    # generic name matching would price AQUA activation cost through an index
+    # built without the aliases that profile exists to supply. The import is
+    # hoisted out of the `try` so the handler below can always be evaluated.
     profile = None
+    from .model_profiles.registry import (
+        DeadVendoredOverrideError,
+        detect_profile,
+    )
     try:
-        from .model_profiles.registry import detect_profile
         profile = detect_profile(args.model_path)
+    except DeadVendoredOverrideError:
+        raise
     except Exception as exc:
         log(f"no model profile for {args.model_path} ({exc}); "
             f"falling back to generic name matching")

--- a/prismaquant/build_rtn_cache.py
+++ b/prismaquant/build_rtn_cache.py
@@ -110,10 +110,17 @@ def stage_multimodal(model_path: str):
     # skeleton from it (streaming_model._build_streaming_context).
     keep_composite = False
     if "vision_config" in cfg or "text_config" in cfg:
-        from .model_profiles import detect_profile
+        from .model_profiles import DeadVendoredOverrideError, detect_profile
         try:
             keep_composite = detect_profile(
                 model_path).requires_multimodal_skeleton()
+        except DeadVendoredOverrideError:
+            # Not the tolerated case (#202). `keep_composite = False` is the
+            # right answer for a checkpoint no profile claims; for one whose
+            # vendored modelling path is dead it silently picks the text-only
+            # flatten -- the exact staging the comment above says such a family
+            # "cannot survive" -- and the run continues against upstream code.
+            raise
         except Exception:
             keep_composite = False
 
@@ -282,9 +289,18 @@ def iter_quantizable_tensors(model, profile=None):
     Caller uses module.{param_attr}.data to read, and can REPLACE the data
     attribute to free storage. Handles nn.Linear and 3D packed MoE experts."""
     if profile is None:
+        from prismaquant.model_profiles import (
+            DeadVendoredOverrideError,
+            profile_from_model,
+        )
         try:
-            from prismaquant.model_profiles import profile_from_model
             profile = profile_from_model(model)
+        except DeadVendoredOverrideError:
+            # The profile owns which packed-MoE parameter names are
+            # quantizable. `None` drops to the legacy class-name fallback
+            # below, which silently yields a DIFFERENT set of tensors to
+            # quantize -- a wrong answer, not a missing one (#202).
+            raise
         except Exception:
             profile = None
     for name, mod in model.named_modules():
@@ -495,9 +511,17 @@ def main():
         )
         tokenizer = AutoTokenizer.from_pretrained(staged, trust_remote_code=True)
         device = next(model.parameters()).device
+        from prismaquant.model_profiles import (
+            DeadVendoredOverrideError,
+            detect_profile,
+        )
         try:
-            from prismaquant.model_profiles import detect_profile
             profile = detect_profile(args.model)
+        except DeadVendoredOverrideError:
+            # This profile is handed straight to `iter_quantizable_tensors`
+            # below, so a dead override here decides what the whole RTN cache
+            # quantizes (#202).
+            raise
         except Exception:
             profile = None
         print(f"[rtn-cache]   {sum(p.numel() for p in model.parameters()):,} params", flush=True)

--- a/prismaquant/incremental_measure_quant_cost.py
+++ b/prismaquant/incremental_measure_quant_cost.py
@@ -580,9 +580,15 @@ def _run_body_cost_shard(
     render_path: str = "registry",
 ):
     model = ctx.model
+    from .model_profiles import DeadVendoredOverrideError, profile_from_model
     try:
-        from .model_profiles import profile_from_model
         profile = profile_from_model(model)
+    except DeadVendoredOverrideError:
+        # This shard is about to price quantization for real. A dead override
+        # means the layers it installs and measures came from UPSTREAM
+        # modelling code, so every number it writes is priced against the
+        # wrong model -- refuse rather than shard on (#202).
+        raise
     except Exception:
         profile = None
     num_layers = ctx.num_layers
@@ -1027,9 +1033,13 @@ def _run_visual_cost_shard(
         return mm_ctx
 
     model = mm_ctx.model
+    from .model_profiles import DeadVendoredOverrideError, profile_from_model
     try:
-        from .model_profiles import profile_from_model
         profile = profile_from_model(model)
+    except DeadVendoredOverrideError:
+        # Same as the body shard above (#202): a dead override prices the
+        # visual tower against upstream modelling code.
+        raise
     except Exception:
         profile = None
     live_linears = {n for n, m in model.named_modules()

--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -1010,9 +1010,15 @@ def _build_concat_merger(model: nn.Module, weight_ckpt: dict[str, str]):
     closure carries no architecture names. Used on every path that reads
     source shards into live-named tensors, so a split-source checkpoint loads
     identically for the probe, the cost stages and the exporter."""
+    from .model_profiles import DeadVendoredOverrideError, profile_from_model
     try:
-        from .model_profiles import profile_from_model
         prof = profile_from_model(model)
+    except DeadVendoredOverrideError:
+        # `None` means "no merge needed" and the loader runs unchanged. That
+        # is right when no profile declares `concat_merges`; on a dead
+        # override it means a split-source checkpoint loads with its merge
+        # target unfilled, which is missing weights, not a missing hint (#202).
+        raise
     except Exception:
         return None
     groups = tuple(getattr(prof, "concat_merge_groups", lambda: ())())
@@ -1053,9 +1059,13 @@ def _build_expert_packer(model: nn.Module, weight_ckpt: dict[str, str]):
     probe/cost context and the compressed-tensors exporter so a raw
     per-expert checkpoint loads identically on every path — no out-of-band
     pre-pack."""
+    from .model_profiles import DeadVendoredOverrideError, profile_from_model
     try:
-        from .model_profiles import profile_from_model
         prof = profile_from_model(model)
+    except DeadVendoredOverrideError:
+        # As above (#202): `None` leaves a per-expert-on-disk checkpoint
+        # unpacked against packed live params, so the experts never load.
+        raise
     except Exception:
         return None
     packed_names = prof.packed_expert_param_names()
@@ -1135,9 +1145,20 @@ def fill_packed_experts_from_source(
     Returns the number of packed params filled. Call right after
     ``from_pretrained`` on the calibration model.
     """
+    from .model_profiles import DeadVendoredOverrideError, profile_from_model
     try:
-        from .model_profiles import profile_from_model
         prof = profile or profile_from_model(model)
+    except DeadVendoredOverrideError:
+        # #202 flagged this one as a candidate to keep swallowing, because it
+        # returns a COUNT and every other `return 0` here means "nothing to
+        # do". It is the opposite: this function exists precisely because the
+        # packed params would otherwise stay zero-initialized and "silently
+        # break every activation-scale calibration that depends on the
+        # routed-expert output" (the docstring above). Returning 0 on a dead
+        # override IS that silent break, reported as a clean no-op. The count
+        # is only a legitimate 0 when the profile could be consulted and had
+        # nothing to say.
+        raise
     except Exception:
         return 0
     # Local import: sensitivity_probe imports from this module, so import the
@@ -2504,12 +2525,19 @@ def _head_prefixes(root: nn.Module, base_prefix: str) -> list[str]:
     # Profile-driven extension (refactor #32). Default profile returns
     # an empty list; architecture-specific profiles append their own
     # head-resident prefixes here.
+    from .model_profiles import DeadVendoredOverrideError, profile_from_model
     try:
-        from .model_profiles import profile_from_model
         extra = profile_from_model(root).head_resident_extra_prefixes(root)
         for pref in extra:
             if pref not in prefixes:
                 prefixes.append(pref)
+    except DeadVendoredOverrideError:
+        # The legacy fallback below only knows `hc_head`. On a dead override
+        # it would silently drop the head-resident prefixes a live profile
+        # declares (LFM2.5's `embedding_norm`/`pos_emb`), leaving those
+        # modules streamed instead of resident -- a wrong residency plan
+        # derived from a hardcoded guess about one architecture (#202).
+        raise
     except Exception:
         # Defensive: fall back to the legacy hardcoded check if the
         # profile import path is unavailable for any reason.

--- a/prismaquant/measure_quant_cost.py
+++ b/prismaquant/measure_quant_cost.py
@@ -3381,9 +3381,16 @@ def run_cost_pass(model: nn.Module,
     if chosen_mode == "auto":
         chosen_mode = "batched" if device.startswith("cuda") else "unbatched"
     print(f"[cost] mode: {chosen_mode}")
+    from .model_profiles import DeadVendoredOverrideError, profile_from_model
     try:
-        from .model_profiles import profile_from_model
         model_profile = profile_from_model(model)
+    except DeadVendoredOverrideError:
+        # This pass measures per-(Linear, format) quantization cost and writes
+        # numbers the allocator later spends. A dead override means it would
+        # measure UPSTREAM modelling code under a profile promising the
+        # vendored copy, so the cost table would be a wrong number with no
+        # exception attached (#202).
+        raise
     except Exception:
         model_profile = None
 

--- a/prismaquant/perturbed_x_cache.py
+++ b/prismaquant/perturbed_x_cache.py
@@ -1361,9 +1361,16 @@ def stage_text_only_under_work_root(model_path: str, work_root: str | Path) -> s
         return str(src)
     with open(cfg_path) as f:
         cfg = json.load(f)
+    from .model_profiles import DeadVendoredOverrideError, detect_profile
     try:
-        from .model_profiles import detect_profile
         profile = detect_profile(str(src))
+    except DeadVendoredOverrideError:
+        # The hardcoded default strip-key list below is the answer for a
+        # checkpoint no profile claims. On a dead override it silently stages
+        # the model with a DIFFERENT config than the profile declares, and
+        # every perturbed-activation row cached afterwards is collected from
+        # that wrong staging (#202).
+        raise
     except Exception:
         profile = None
     strip_keys = (

--- a/prismaquant/production_weight_cache.py
+++ b/prismaquant/production_weight_cache.py
@@ -6566,9 +6566,19 @@ def fill_production_weight_cache(
         )
     model_profile = recache_profile
     if model_profile is None:
+        from .model_profiles import (
+            DeadVendoredOverrideError,
+            profile_from_model,
+        )
         try:
-            from .model_profiles import profile_from_model
             model_profile = profile_from_model(model)
+        except DeadVendoredOverrideError:
+            # This is the render that produces the production weight cache --
+            # the bytes an export later ships. A dead override means those
+            # bytes would be rendered from UPSTREAM modelling code, and
+            # `model_profile = None` also drops the profile's pinned names, so
+            # components the profile forbids quantizing get quantized (#202).
+            raise
         except Exception:
             model_profile = None
 

--- a/prismaquant/sensitivity_probe.py
+++ b/prismaquant/sensitivity_probe.py
@@ -127,9 +127,15 @@ def stage_text_only(model_path: str) -> str:
 
     # Profile-driven: ask the registered ModelProfile which config keys
     # to strip and whether to promote `text_config.model_type`.
+    from .model_profiles import DeadVendoredOverrideError, detect_profile
     try:
-        from .model_profiles import detect_profile
         profile = detect_profile(str(src))
+    except DeadVendoredOverrideError:
+        # The hardcoded default strip-key list below is for a checkpoint no
+        # profile claims. On a dead override it stages the model with a
+        # different config than the profile declares -- and every probe
+        # statistic gathered afterwards describes that wrong staging (#202).
+        raise
     except Exception:
         profile = None
     strip_keys = (list(profile.stage_text_only_strip_keys())
@@ -1383,9 +1389,14 @@ def discover_moe_structure(
     That Linear is the router.
     """
     if profile is None:
+        from .model_profiles import DeadVendoredOverrideError, profile_from_model
         try:
-            from .model_profiles import profile_from_model
             profile = profile_from_model(model)
+        except DeadVendoredOverrideError:
+            # The profile names the packed-expert projections this walk looks
+            # for. `None` narrows the candidate set silently, so MoE experts
+            # go undiscovered and simply never get probed (#202).
+            raise
         except Exception:
             profile = None
     projection_candidates = _packed_expert_projection_candidate_names(profile)
@@ -1510,9 +1521,14 @@ def discover_moe_routers(
     numbered expert container or a profile-declared packed 3-D parameter.
     """
     if profile is None:
+        from .model_profiles import DeadVendoredOverrideError, profile_from_model
         try:
-            from .model_profiles import profile_from_model
             profile = profile_from_model(model)
+        except DeadVendoredOverrideError:
+            # As in `discover_moe_structure` (#202): the profile declares the
+            # packed 3-D parameters this discovery keys on, so `None` silently
+            # under-reports routers and the coverage accounting built on them.
+            raise
         except Exception:
             profile = None
     packed_names = _packed_expert_param_name_set(profile)
@@ -2001,9 +2017,20 @@ class FisherAccumulator:
         self._packed_act_snaps: dict[str, list[torch.Tensor]] = defaultdict(list)
         self._packed_act_rows: dict[str, int] = defaultdict(int)
         if model_profile is None:
+            from .model_profiles import (
+                DeadVendoredOverrideError,
+                profile_from_model,
+            )
             try:
-                from .model_profiles import profile_from_model
                 model_profile = profile_from_model(model)
+            except DeadVendoredOverrideError:
+                # The comment below is careful that a DefaultProfile fallback
+                # is "an explicit declaration, not a silent degrade". That
+                # holds when no profile matched. On a dead override the
+                # declaration would be false: a profile DID match, and every
+                # Fisher statistic this accumulator records would be projected
+                # through the wrong names (#202).
+                raise
             except Exception:
                 model_profile = None
         self.model_profile = model_profile
@@ -3535,7 +3562,11 @@ def run_streaming_multimodal_visual_probe_pass(
         _compute_attention_mask,
         _compute_position_embeddings,
     )
-    from .model_profiles import DefaultProfile, profile_from_model
+    from .model_profiles import (
+        DeadVendoredOverrideError,
+        DefaultProfile,
+        profile_from_model,
+    )
     from .streaming_model import _build_streaming_context
 
     try:
@@ -3590,6 +3621,12 @@ def run_streaming_multimodal_visual_probe_pass(
     visual_prefix = ctx.visual_prefix or ""
     try:
         model_profile = profile_from_model(model)
+    except DeadVendoredOverrideError:
+        # `DefaultProfile()` is the answer for an architecture this build does
+        # not know. On a dead override the build DOES know it, and probing the
+        # visual tower under a default profile records Fisher statistics for a
+        # model assembled from upstream modelling code (#202).
+        raise
     except Exception:
         model_profile = DefaultProfile()
 

--- a/prismaquant/streaming_model.py
+++ b/prismaquant/streaming_model.py
@@ -106,10 +106,19 @@ def _bypass_hf_fp8_module_rewrite(model_path: str) -> bool:
     qc = cfg.get("quantization_config") or {}
     if qc.get("quant_method") != "fp8" or "weight_block_size" not in qc:
         return False
-    try:
-        from .model_profiles import profile_from_config
+    from .model_profiles import DeadVendoredOverrideError, profile_from_config
 
+    try:
         return bool(profile_from_config(cfg).bypass_hf_fp8_module_rewrite())
+    except DeadVendoredOverrideError:
+        # #202 listed this as a possible legitimate swallow because it returns
+        # a bool. It is not one. Control only reaches here for a native-FP8
+        # block-scaled checkpoint, and the docstring above states the bypass is
+        # "a static architecture property" the profile declares. Answering
+        # False on a dead override lets transformers run the FP8 module
+        # rewrite on exactly the architecture whose profile would have
+        # forbidden it -- the MiniMax-M2 `experts.0.w1` case named above.
+        raise
     except Exception:
         return False
 
@@ -213,11 +222,20 @@ def _init_rotary_inplace(base_model: nn.Module, device: torch.device,
 
     # Profile-driven dispatch first. If the profile fully handled rotary
     # init (DSv4 multi-layer-type pattern), exit. Otherwise fall through.
+    from .model_profiles import DeadVendoredOverrideError, profile_from_model
     try:
-        from .model_profiles import profile_from_model
         if profile_from_model(base_model).init_rotaries(
                 rotary, cfg, device, dtype, base_model=base_model):
             return
+    except DeadVendoredOverrideError:
+        # Falling through is right when profile dispatch breaks -- that is a
+        # profile bug and the single-rope default is a real answer. It is not
+        # right for a dead override: the multi-layer-type architectures that
+        # override `init_rotaries` (DSv4, Gemma3) would silently get the
+        # single-rope path instead, so their per-layer-type rotary buffers are
+        # never registered and every downstream number is computed against the
+        # wrong positions (#202).
+        raise
     except Exception:
         # Defensive: fall through to default if profile dispatch breaks.
         pass

--- a/prismaquant/streaming_production_cache.py
+++ b/prismaquant/streaming_production_cache.py
@@ -1771,9 +1771,19 @@ def fill_production_weight_cache_streaming(
     )
     try:
         model = ctx.model
+        from prismaquant.model_profiles import (
+            DeadVendoredOverrideError,
+            profile_from_model,
+        )
         try:
-            from prismaquant.model_profiles import profile_from_model
             profile = profile_from_model(model)
+        except DeadVendoredOverrideError:
+            # The streaming twin of the render fixed in 0a0853f3, and the same
+            # two consequences: the rendered bytes come from UPSTREAM
+            # modelling code, and `profile = None` empties `skip_tokens`
+            # below, so the components `pinned_names()` protects get rendered
+            # too (#202).
+            raise
         except Exception:
             profile = None
         if skip_tokens is None:

--- a/prismaquant/weight_session.py
+++ b/prismaquant/weight_session.py
@@ -85,9 +85,19 @@ class WeightSession:
         self._strict_production_cache = bool(strict_production_cache)
         self._linear_by_qname: dict[str, tuple[nn.Module, str]] = {}
         if profile is None:
+            from prismaquant.model_profiles import (
+                DeadVendoredOverrideError,
+                profile_from_model,
+            )
             try:
-                from prismaquant.model_profiles import profile_from_model
                 profile = profile_from_model(model)
+            except DeadVendoredOverrideError:
+                # The profile is handed straight to `iter_quantizable_tensors`
+                # below to build the qname -> live Linear map this session
+                # swaps weights through. A dead override silently builds that
+                # map over a different set of tensors, so the session reverts
+                # and re-renders the wrong ones (#202).
+                raise
             except Exception:
                 profile = None
         self._profile = profile

--- a/tests/test_vendored_override_gate.py
+++ b/tests/test_vendored_override_gate.py
@@ -21,7 +21,9 @@ of `detect_profile`, and it must arrive as its own class, so a caller can tell
 """
 from __future__ import annotations
 
+import ast
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -585,3 +587,102 @@ def test_weight_session_does_not_swallow_the_refusal(monkeypatch):
     monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
     with pytest.raises(DeadVendoredOverrideError):
         WeightSession(_qwen3_model())
+
+
+# --- the rule itself, pinned once over the whole tree (issue #202) ----------
+
+
+DETECTION_ENTRYPOINTS = {
+    "detect_profile",
+    "detect_profile_with_warning",
+    "profile_from_config",
+    "profile_from_model",
+}
+
+
+def _handler_is_broad(handler: ast.ExceptHandler) -> bool:
+    """True for `except:`, `except Exception:`, `except BaseException:`."""
+    node = handler.type
+    if node is None:
+        return True
+    parts = node.elts if isinstance(node, ast.Tuple) else [node]
+    return any(
+        isinstance(p, ast.Name) and p.id in ("Exception", "BaseException")
+        for p in parts
+    )
+
+
+def _handler_always_reraises(handler: ast.ExceptHandler) -> bool:
+    """True when the handler cannot fall through to a substituted answer.
+
+    `sample_parallel_probe.prepare_worker_source_cache` is the shape this
+    allows: it catches broadly and re-raises as `SampleParallelProbeError(...)
+    from exc`, which refuses by name and keeps the cause. A handler that always
+    raises never converts the refusal into an answer, so it needs no
+    `DeadVendoredOverrideError` clause of its own.
+    """
+    return bool(handler.body) and isinstance(handler.body[-1], ast.Raise)
+
+
+def _refuses_dead_override(node: ast.Try) -> bool:
+    """True when a dead override escapes this `try` instead of being answered."""
+    for handler in node.handlers:
+        if _handler_is_broad(handler):
+            # Reached the catch-all without having refused first.
+            return _handler_always_reraises(handler)
+        named = handler.type
+        parts = named.elts if isinstance(named, ast.Tuple) else [named]
+        for part in parts:
+            name = getattr(part, "id", None) or getattr(part, "attr", None)
+            if name == "DeadVendoredOverrideError":
+                return True
+    return True  # no broad handler at all: nothing swallows it
+
+
+def _swallowing_detection_sites() -> list[str]:
+    """Every `file:line` where detection sits in a `try` that answers instead."""
+    root = Path(__file__).resolve().parent.parent / "prismaquant"
+    bad: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        if "archive" in path.parts:
+            continue
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Try) or _refuses_dead_override(node):
+                continue
+            for stmt in node.body:
+                for sub in ast.walk(stmt):
+                    if not isinstance(sub, ast.Call):
+                        continue
+                    func = sub.func
+                    name = getattr(func, "id", None) or getattr(func, "attr", None)
+                    if name in DETECTION_ENTRYPOINTS:
+                        rel = path.relative_to(root.parent)
+                        bad.append(f"{rel}:{sub.lineno} ({name})")
+    return sorted(set(bad))
+
+
+def test_no_call_site_swallows_the_dead_override_refusal():
+    """The refusal must reach the operator from every detection call site.
+
+    #201 made `_resolve` raise `DeadVendoredOverrideError` and stopped three
+    gate call sites from re-swallowing it. #202 is the rest of the census: 22
+    further call sites across 11 modules each wrapped detection in a broad
+    `except Exception` and continued with a substituted profile (`None`,
+    `DefaultProfile()`, `keep_composite = False`, a hardcoded prefix guess, a
+    count of 0, a bare `False`), which converts the refusal straight back into
+    the silent wrong answer one level up.
+
+    This is a structural pin as well as 18 behavioural ones above, because the
+    rule is structural: a dead override must never be *answered*. It therefore
+    also covers the four sites whose enclosing function cannot be reached
+    without a GPU, a loaded checkpoint or a built streaming context
+    (`aqua_activation_cost.py:661`, `build_rtn_cache.py:500`,
+    `sensitivity_probe.py:3592`, `streaming_production_cache.py:1776`) — and it
+    fails for a call site added next month, which no per-site test would.
+
+    The allowed shapes are (a) `except DeadVendoredOverrideError: raise` ahead
+    of the broad handler, or (b) a broad handler that always re-raises, which
+    is what `sample_parallel_probe` already did correctly.
+    """
+    assert _swallowing_detection_sites() == []

--- a/tests/test_vendored_override_gate.py
+++ b/tests/test_vendored_override_gate.py
@@ -325,24 +325,30 @@ def test_rtn_quantizable_tensor_walk_does_not_swallow_the_refusal(monkeypatch):
         list(iter_quantizable_tensors(model))
 
 
-def _dummy_shard_kwargs(**overrides):
+def _dummy_shard_kwargs(tmp_path, **overrides):
     """Filler for a cost-shard runner's arguments.
 
     Every shard runner below detects the profile before it reads any of
-    these, so the refusal must arrive without a real activation cache,
-    format spec list or output path.
+    these, so the refusal must arrive without a real activation cache or
+    format spec list. `output_path` still goes under `tmp_path`: these
+    runners write an empty shard pickle on several of their early-exit
+    paths, so a bare relative name would litter the repo root whenever one
+    of them is reached (as it is when the fix is reverted to re-check that
+    these tests fail).
     """
     kwargs = dict(
         linear_include=".*", probe_stats={}, act_cache=None, specs=[],
         device="cpu", dtype=None, mode="unbatched", chunk_size=1,
-        h_detail=None, output_path="unused", model_name="m",
-        probe_path="p",
+        h_detail=None, output_path=str(tmp_path / "shard.pkl"),
+        model_name="m", probe_path="p",
     )
     kwargs.update(overrides)
     return kwargs
 
 
-def test_incremental_body_cost_shard_does_not_swallow_the_refusal(monkeypatch):
+def test_incremental_body_cost_shard_does_not_swallow_the_refusal(
+    tmp_path, monkeypatch
+):
     """`_run_body_cost_shard` answered `profile = None` and sharded on."""
     from prismaquant.incremental_measure_quant_cost import _run_body_cost_shard
 
@@ -351,10 +357,14 @@ def test_incremental_body_cost_shard_does_not_swallow_the_refusal(monkeypatch):
     )
     monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
     with pytest.raises(DeadVendoredOverrideError):
-        _run_body_cost_shard(ctx, shard_kind="body", **_dummy_shard_kwargs())
+        _run_body_cost_shard(
+            ctx, shard_kind="body", **_dummy_shard_kwargs(tmp_path)
+        )
 
 
-def test_incremental_visual_cost_shard_does_not_swallow_the_refusal(monkeypatch):
+def test_incremental_visual_cost_shard_does_not_swallow_the_refusal(
+    tmp_path, monkeypatch
+):
     """`_run_visual_cost_shard` answered `profile = None` and priced on."""
     from prismaquant.incremental_measure_quant_cost import _run_visual_cost_shard
 
@@ -362,11 +372,13 @@ def test_incremental_visual_cost_shard_does_not_swallow_the_refusal(monkeypatch)
     monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
     with pytest.raises(DeadVendoredOverrideError):
         _run_visual_cost_shard(
-            model_path="unused",
+            model_path=str(tmp_path / "ckpt"),
             mm_ctx=mm_ctx,
             # A non-empty stat the include regex matches, or the runner
             # short-circuits to an empty shard before it ever detects.
-            **_dummy_shard_kwargs(probe_stats={"visual.blocks.0.attn.qkv": {}}),
+            **_dummy_shard_kwargs(
+                tmp_path, probe_stats={"visual.blocks.0.attn.qkv": {}}
+            ),
         )
 
 
@@ -424,7 +436,7 @@ def test_head_resident_prefixes_do_not_swallow_the_refusal(monkeypatch):
         _head_prefixes(_qwen3_model(), "model")
 
 
-def test_cost_pass_does_not_swallow_the_refusal(monkeypatch):
+def test_cost_pass_does_not_swallow_the_refusal(tmp_path, monkeypatch):
     """`measure_quant_cost.run_cost_pass` answered `model_profile = None`.
 
     And went on to measure per-(Linear, format) cost against upstream
@@ -436,7 +448,7 @@ def test_cost_pass_does_not_swallow_the_refusal(monkeypatch):
     with pytest.raises(DeadVendoredOverrideError):
         run_cost_pass(
             _qwen3_model(), None, set(), [], [], "m", "p", "cpu", None,
-            "unbatched", 1, "unused",
+            "unbatched", 1, str(tmp_path / "cost.pkl"),
         )
 
 

--- a/tests/test_vendored_override_gate.py
+++ b/tests/test_vendored_override_gate.py
@@ -22,8 +22,10 @@ of `detect_profile`, and it must arrive as its own class, so a caller can tell
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 import pytest
+import torch.nn as nn
 
 import prismaquant.vendored as vendored
 from prismaquant.model_profiles.registry import (
@@ -47,6 +49,19 @@ QWEN3_CONFIG = {
     "model_type": "qwen3",
     "architectures": ["Qwen3ForCausalLM"],
 }
+
+
+def _qwen3_model():
+    """A live model the qwen3 profile claims, for `profile_from_model` sites.
+
+    `profile_from_config` reads only `model_type` / `architectures` off
+    `model.config`, and every call site below reaches detection before it
+    touches the module tree, so a bare `nn.Module` carrying a config is
+    enough to exercise the refusal.
+    """
+    model = nn.Module()
+    model.config = SimpleNamespace(**QWEN3_CONFIG)
+    return model
 
 
 @pytest.fixture(autouse=True)
@@ -267,3 +282,42 @@ def test_the_native_export_validator_does_not_swallow_it(tmp_path, monkeypatch):
     monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
     with pytest.raises(DeadVendoredOverrideError):
         _resolve_validation_target_profile(path, None)
+
+
+# --- the remaining 22 call sites, one module at a time (issue #202) ---------
+#
+# Same rule, same home: these pin where the registry's refusal is allowed to
+# stop, so they live beside #201's rather than in each module's own test file.
+# A site whose enclosing function cannot be reached without a GPU, a loaded
+# checkpoint or a built streaming context is pinned by the tree-wide census
+# test at the bottom of this file instead.
+
+
+def test_rtn_staging_does_not_swallow_the_refusal(tmp_path, monkeypatch):
+    """`build_rtn_cache.stage_multimodal` answered `keep_composite = False`.
+
+    Which silently selects the text-only flatten for a family whose own
+    comment says it "cannot survive" that flatten.
+    """
+    from prismaquant.build_rtn_cache import stage_multimodal
+
+    path = _checkpoint(
+        tmp_path, **QWEN3_CONFIG, text_config={"model_type": "qwen3"}
+    )
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        stage_multimodal(path)
+
+
+def test_rtn_quantizable_tensor_walk_does_not_swallow_the_refusal(monkeypatch):
+    """`build_rtn_cache.iter_quantizable_tensors` answered `profile = None`.
+
+    The profile owns which packed-MoE parameter names are quantizable, so a
+    dead override silently changed the set of tensors RTN quantizes.
+    """
+    from prismaquant.build_rtn_cache import iter_quantizable_tensors
+
+    model = _qwen3_model()
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        list(iter_quantizable_tensors(model))

--- a/tests/test_vendored_override_gate.py
+++ b/tests/test_vendored_override_gate.py
@@ -451,3 +451,24 @@ def test_perturbed_x_staging_does_not_swallow_the_refusal(tmp_path, monkeypatch)
     monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
     with pytest.raises(DeadVendoredOverrideError):
         stage_text_only_under_work_root(path, tmp_path / "work")
+
+
+def test_production_cache_fill_does_not_swallow_the_refusal(monkeypatch):
+    """`production_weight_cache.fill_production_weight_cache` answered `None`.
+
+    This is the render that produces the bytes an export later ships, and
+    `None` also drops the profile's pinned names, so components the profile
+    forbids quantizing would be quantized.
+    """
+    import torch
+
+    from prismaquant.production_weight_cache import fill_production_weight_cache
+
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        fill_production_weight_cache(
+            _qwen3_model(),
+            torch.zeros(1, 4, dtype=torch.long),
+            ["a"],
+            progress=False,
+        )

--- a/tests/test_vendored_override_gate.py
+++ b/tests/test_vendored_override_gate.py
@@ -436,3 +436,18 @@ def test_cost_pass_does_not_swallow_the_refusal(monkeypatch):
             _qwen3_model(), None, set(), [], [], "m", "p", "cpu", None,
             "unbatched", 1, "unused",
         )
+
+
+def test_perturbed_x_staging_does_not_swallow_the_refusal(tmp_path, monkeypatch):
+    """`perturbed_x_cache.stage_text_only_under_work_root` answered `None`.
+
+    Which stages the checkpoint with the hardcoded default strip-key list
+    instead of the one the profile declares, so every perturbed-activation
+    row is then collected from a differently-staged model.
+    """
+    from prismaquant.perturbed_x_cache import stage_text_only_under_work_root
+
+    path = _checkpoint(tmp_path, **QWEN3_CONFIG)
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        stage_text_only_under_work_root(path, tmp_path / "work")

--- a/tests/test_vendored_override_gate.py
+++ b/tests/test_vendored_override_gate.py
@@ -571,3 +571,17 @@ def test_rotary_init_does_not_swallow_the_refusal(monkeypatch):
     monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
     with pytest.raises(DeadVendoredOverrideError):
         _init_rotary_inplace(base, "cpu", None)
+
+
+def test_weight_session_does_not_swallow_the_refusal(monkeypatch):
+    """`weight_session.WeightSession` answered `profile = None`.
+
+    The profile builds the qname -> live Linear map the session swaps weights
+    through, so a dead override silently builds it over a different set of
+    tensors and the session reverts and re-renders the wrong ones.
+    """
+    from prismaquant.weight_session import WeightSession
+
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        WeightSession(_qwen3_model())

--- a/tests/test_vendored_override_gate.py
+++ b/tests/test_vendored_override_gate.py
@@ -321,3 +321,48 @@ def test_rtn_quantizable_tensor_walk_does_not_swallow_the_refusal(monkeypatch):
     monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
     with pytest.raises(DeadVendoredOverrideError):
         list(iter_quantizable_tensors(model))
+
+
+def _dummy_shard_kwargs(**overrides):
+    """Filler for a cost-shard runner's arguments.
+
+    Every shard runner below detects the profile before it reads any of
+    these, so the refusal must arrive without a real activation cache,
+    format spec list or output path.
+    """
+    kwargs = dict(
+        linear_include=".*", probe_stats={}, act_cache=None, specs=[],
+        device="cpu", dtype=None, mode="unbatched", chunk_size=1,
+        h_detail=None, output_path="unused", model_name="m",
+        probe_path="p",
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_incremental_body_cost_shard_does_not_swallow_the_refusal(monkeypatch):
+    """`_run_body_cost_shard` answered `profile = None` and sharded on."""
+    from prismaquant.incremental_measure_quant_cost import _run_body_cost_shard
+
+    ctx = SimpleNamespace(
+        model=_qwen3_model(), num_layers=1, layers_prefix="model.layers."
+    )
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        _run_body_cost_shard(ctx, shard_kind="body", **_dummy_shard_kwargs())
+
+
+def test_incremental_visual_cost_shard_does_not_swallow_the_refusal(monkeypatch):
+    """`_run_visual_cost_shard` answered `profile = None` and priced on."""
+    from prismaquant.incremental_measure_quant_cost import _run_visual_cost_shard
+
+    mm_ctx = SimpleNamespace(model=_qwen3_model(), visual_module=nn.Module())
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        _run_visual_cost_shard(
+            model_path="unused",
+            mm_ctx=mm_ctx,
+            # A non-empty stat the include regex matches, or the runner
+            # short-circuits to an empty shard before it ever detects.
+            **_dummy_shard_kwargs(probe_stats={"visual.blocks.0.attn.qkv": {}}),
+        )

--- a/tests/test_vendored_override_gate.py
+++ b/tests/test_vendored_override_gate.py
@@ -527,3 +527,47 @@ def test_fisher_accumulator_does_not_swallow_the_refusal(monkeypatch):
     monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
     with pytest.raises(DeadVendoredOverrideError):
         FisherAccumulator(_qwen3_model(), [], {})
+
+
+def test_fp8_rewrite_bypass_does_not_swallow_the_refusal(tmp_path, monkeypatch):
+    """`streaming_model._bypass_hf_fp8_module_rewrite` answered `False`.
+
+    #202 listed this as a possible legitimate swallow because it returns a
+    bool. It is not one: `False` lets transformers run the FP8 module rewrite
+    on exactly the architecture whose profile would have forbidden it.
+    """
+    from prismaquant.streaming_model import _bypass_hf_fp8_module_rewrite
+
+    # The bypass question is only asked of a native-FP8 block-scaled
+    # checkpoint, so the config must carry that quantization_config.
+    path = _checkpoint(
+        tmp_path,
+        **QWEN3_CONFIG,
+        quantization_config={
+            "quant_method": "fp8", "weight_block_size": [128, 128],
+        },
+    )
+    assert _bypass_hf_fp8_module_rewrite(path) in (True, False)
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        _bypass_hf_fp8_module_rewrite(path)
+
+
+def test_rotary_init_does_not_swallow_the_refusal(monkeypatch):
+    """`streaming_model._init_rotary_inplace` fell through to single-rope.
+
+    The multi-layer-type architectures that override `init_rotaries` (DSv4,
+    Gemma3) would silently get the single-rope path, so their per-layer-type
+    rotary buffers are never registered.
+    """
+    from prismaquant.streaming_model import _init_rotary_inplace
+
+    base = _qwen3_model()
+    rotary = nn.Module()
+    rotary.config = base.config
+    rotary.compute_default_rope_parameters = lambda cfg, device: (None, None)
+    base.rotary_emb = rotary
+
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        _init_rotary_inplace(base, "cpu", None)

--- a/tests/test_vendored_override_gate.py
+++ b/tests/test_vendored_override_gate.py
@@ -366,3 +366,57 @@ def test_incremental_visual_cost_shard_does_not_swallow_the_refusal(monkeypatch)
             # short-circuits to an empty shard before it ever detects.
             **_dummy_shard_kwargs(probe_stats={"visual.blocks.0.attn.qkv": {}}),
         )
+
+
+def test_concat_merger_build_does_not_swallow_the_refusal(monkeypatch):
+    """`layer_streaming._build_concat_merger` answered `None`.
+
+    "No merger" leaves the loader unchanged, so a split-source checkpoint
+    would load with its merge target unfilled.
+    """
+    from prismaquant.layer_streaming import _build_concat_merger
+
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        _build_concat_merger(_qwen3_model(), {})
+
+
+def test_expert_packer_build_does_not_swallow_the_refusal(monkeypatch):
+    """`layer_streaming._build_expert_packer` answered `None`.
+
+    Which leaves a per-expert-on-disk checkpoint unpacked against packed
+    live params, so the experts never load.
+    """
+    from prismaquant.layer_streaming import _build_expert_packer
+
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        _build_expert_packer(_qwen3_model(), {})
+
+
+def test_packed_expert_fill_does_not_swallow_the_refusal(tmp_path, monkeypatch):
+    """`layer_streaming.fill_packed_experts_from_source` answered `0`.
+
+    #202 listed this as a candidate to keep swallowing because it returns a
+    count. It is the opposite case: the function exists so packed params do
+    not stay zero-initialized, so a clean `0` on a dead override reports
+    exactly the silent breakage it was written to prevent.
+    """
+    from prismaquant.layer_streaming import fill_packed_experts_from_source
+
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        fill_packed_experts_from_source(_qwen3_model(), str(tmp_path))
+
+
+def test_head_resident_prefixes_do_not_swallow_the_refusal(monkeypatch):
+    """`layer_streaming._head_prefixes` fell back to a hardcoded guess.
+
+    The legacy branch only knows `hc_head`, so a dead override silently
+    dropped whatever head-resident prefixes the live profile declares.
+    """
+    from prismaquant.layer_streaming import _head_prefixes
+
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        _head_prefixes(_qwen3_model(), "model")

--- a/tests/test_vendored_override_gate.py
+++ b/tests/test_vendored_override_gate.py
@@ -420,3 +420,19 @@ def test_head_resident_prefixes_do_not_swallow_the_refusal(monkeypatch):
     monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
     with pytest.raises(DeadVendoredOverrideError):
         _head_prefixes(_qwen3_model(), "model")
+
+
+def test_cost_pass_does_not_swallow_the_refusal(monkeypatch):
+    """`measure_quant_cost.run_cost_pass` answered `model_profile = None`.
+
+    And went on to measure per-(Linear, format) cost against upstream
+    modelling code, writing numbers the allocator later spends.
+    """
+    from prismaquant.measure_quant_cost import run_cost_pass
+
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        run_cost_pass(
+            _qwen3_model(), None, set(), [], [], "m", "p", "cpu", None,
+            "unbatched", 1, "unused",
+        )

--- a/tests/test_vendored_override_gate.py
+++ b/tests/test_vendored_override_gate.py
@@ -472,3 +472,58 @@ def test_production_cache_fill_does_not_swallow_the_refusal(monkeypatch):
             ["a"],
             progress=False,
         )
+
+
+def test_probe_staging_does_not_swallow_the_refusal(tmp_path, monkeypatch):
+    """`sensitivity_probe.stage_text_only` answered `profile = None`.
+
+    The twin of the perturbed-x staging site: the hardcoded strip-key list
+    stages a different config than the profile declares, and every probe
+    statistic gathered afterwards describes that wrong staging.
+    """
+    from prismaquant.sensitivity_probe import stage_text_only
+
+    path = _checkpoint(tmp_path, **QWEN3_CONFIG)
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        stage_text_only(path)
+
+
+def test_moe_structure_discovery_does_not_swallow_the_refusal(monkeypatch):
+    """`sensitivity_probe.discover_moe_structure` answered `profile = None`.
+
+    Which narrows the packed-expert projection candidates, so MoE experts go
+    undiscovered and are simply never probed.
+    """
+    from prismaquant.sensitivity_probe import discover_moe_structure
+
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        discover_moe_structure(_qwen3_model())
+
+
+def test_moe_router_discovery_does_not_swallow_the_refusal(monkeypatch):
+    """`sensitivity_probe.discover_moe_routers` answered `profile = None`.
+
+    Under-reporting routers also under-reports the coverage accounting built
+    on them.
+    """
+    from prismaquant.sensitivity_probe import discover_moe_routers
+
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        discover_moe_routers(_qwen3_model())
+
+
+def test_fisher_accumulator_does_not_swallow_the_refusal(monkeypatch):
+    """`sensitivity_probe.FisherAccumulator` answered `model_profile = None`.
+
+    Then declared a `DefaultProfile` name projection, which its own comment
+    calls "an explicit declaration, not a silent degrade" — true for an
+    unmatched architecture, false for a matched one on a dead path.
+    """
+    from prismaquant.sensitivity_probe import FisherAccumulator
+
+    monkeypatch.setitem(vendored.OVERRIDE_ERRORS, "qwen3", "synthetic failure")
+    with pytest.raises(DeadVendoredOverrideError):
+        FisherAccumulator(_qwen3_model(), [], {})


### PR DESCRIPTION
Closes the census filed with #201. `_resolve` now raises `DeadVendoredOverrideError` and three gate call sites stopped re-swallowing it (PR #203); this branch takes the remaining **22 call sites across 11 modules**, each of which wrapped detection in a broad `except Exception` and continued with a substituted profile — converting the refusal straight back into the silent wrong answer one level up.

Read one at a time against its own local contract, as the issue asked. **The answer was the same at all 22: re-raise.** That includes both sites the census singled out as possible legitimate swallows; details below, because both turned out to be among the strongest cases rather than the weakest.

## The 22, with the decision per row

Enclosing function named, since several sites sit far from their `def`.

| # | file:line | function | call | substituted | decision |
|---|---|---|---|---|---|
| 1 | `aqua_activation_cost.py:661` | `main` | `detect_profile` | logs, then generic name matching | re-raise |
| 2 | `build_rtn_cache.py:115` | `stage_multimodal` | `detect_profile` | `keep_composite = False` | re-raise |
| 3 | `build_rtn_cache.py:287` | `iter_quantizable_tensors` | `profile_from_model` | `profile = None` | re-raise |
| 4 | `build_rtn_cache.py:500` | `main` | `detect_profile` | `profile = None` | re-raise |
| 5 | `incremental_measure_quant_cost.py:585` | `_run_body_cost_shard` | `profile_from_model` | `profile = None` | re-raise |
| 6 | `incremental_measure_quant_cost.py:1032` | `_run_visual_cost_shard` | `profile_from_model` | `profile = None` | re-raise |
| 7 | `layer_streaming.py:1015` | `_build_concat_merger` | `profile_from_model` | `return None` | re-raise |
| 8 | `layer_streaming.py:1058` | `_build_expert_packer` | `profile_from_model` | `return None` | re-raise |
| 9 | `layer_streaming.py:1140` | `fill_packed_experts_from_source` | `profile_from_model` | `return 0` | **re-raise** (flagged as optional; see below) |
| 10 | `layer_streaming.py:2509` | `_head_prefixes` | `profile_from_model` | hardcoded `hc_head` guess | re-raise |
| 11 | `measure_quant_cost.py:3386` | `run_cost_pass` | `profile_from_model` | `model_profile = None` | re-raise |
| 12 | `perturbed_x_cache.py:1366` | `stage_text_only_under_work_root` | `detect_profile` | `profile = None` | re-raise |
| 13 | `production_weight_cache.py:6571` | `fill_production_weight_cache` | `profile_from_model` | `model_profile = None` | re-raise |
| 14 | `sensitivity_probe.py:132` | `stage_text_only` | `detect_profile` | `profile = None` | re-raise |
| 15 | `sensitivity_probe.py:1388` | `discover_moe_structure` | `profile_from_model` | `profile = None` | re-raise |
| 16 | `sensitivity_probe.py:1515` | `discover_moe_routers` | `profile_from_model` | `profile = None` | re-raise |
| 17 | `sensitivity_probe.py:2006` | `FisherAccumulator.__init__` | `profile_from_model` | `model_profile = None` | re-raise |
| 18 | `sensitivity_probe.py:3592` | `run_streaming_multimodal_visual_probe_pass` | `profile_from_model` | `DefaultProfile()` | re-raise |
| 19 | `streaming_model.py:112` | `_bypass_hf_fp8_module_rewrite` | `profile_from_config` | `return False` | **re-raise** (flagged as optional; see below) |
| 20 | `streaming_model.py:218` | `_init_rotary_inplace` | `profile_from_model` | `pass`, falls through | re-raise |
| 21 | `streaming_production_cache.py:1776` | `fill_production_weight_cache_streaming` | `profile_from_model` | `profile = None` | re-raise |
| 22 | `weight_session.py:90` | `WeightSession.__init__` | `profile_from_model` | `profile = None` | re-raise |

### The two "optional hint" sites the issue asked about

The issue said these two might legitimately share an answer between "no profile" and "dead profile". Reading them, both go the other way — and both are clearer cases than the plain `profile = None` sites.

**`layer_streaming.py:1140`** returns a count, and every other `return 0` in it means "nothing to do". But this function exists *because* the packed params would otherwise stay zero-initialized and, in its own docstring, "silently break every activation-scale calibration that depends on the routed-expert output". Returning `0` on a dead override **is** that breakage, reported as a clean no-op. `0` is only honest when the profile could be consulted and had nothing to say.

**`streaming_model.py:112`** returns a bool, but control only reaches it for a checkpoint that is *already* native FP8 with block scales — so `False` is a decision, not a neutral default. Its docstring says the bypass is "a static architecture property, so it is declared in the model profile ... rather than pattern-matched on the model name". A dead override is precisely the case where that declaration exists and cannot be read, so `False` runs transformers' FP8 module rewrite on the architecture whose profile would have forbidden it — the MiniMax-M2 `FP8Experts` / `experts.0.w1` failure the docstring names.

Neither keeps a swallow, so there is no "why we kept it" comment to write.

### The severest rows

`production_weight_cache.py:6571` and `streaming_production_cache.py:1776` render the production weight cache — the bytes an export ships. Both also lose `pinned_names()` when the profile goes to `None`, so components the allocator is *not* allowed to quantize (AGENTS.md 7) would be rendered too. One swallowed refusal changed both what was protected and what the renderer knew.

## One rule, one home — and why no shared helper

No `detect_profile_or_refuse_dead` was added, deliberately. The rule — what "dead" means, and that it must never be answered — keeps its single home in `_refuse_dead_vendored_override` / `DeadVendoredOverrideError`; every site imports the class from the registry and adds nothing of its own.

A helper would not have removed duplication here, because **it would have had to own each site's fallback too**, and those differ across all 22: `None`, `DefaultProfile()`, `keep_composite = False`, `return 0`, `return False`, a hardcoded prefix guess, `pass`, a log line. A helper parameterised on the fallback is longer than the two lines it replaces, and a helper that swallows on the site's behalf would have moved *tolerance policy* into the registry — the one module whose docstring refuses silent fallbacks. Three sites also wrap more than the detection call in the same `try` (`build_rtn_cache:115`, `layer_streaming:2509`, `streaming_model:218`), which no helper can cover without changing what else is tolerated.

So the edit is the uniform two lines the issue itself proposed, matching the shape PR #203 established at its three gate sites. **The "no profile matched" path is unchanged at every one of the 22.**

One consequence worth flagging: each site's import is **hoisted just outside its `try`**, because a handler cannot name a class whose import is inside the block it guards. That makes an `ImportError` on `prismaquant.model_profiles` fatal at these sites rather than silently tolerated. Same trade PR #203 took and documented; these are function-local imports for cycle-avoidance at module load, not because the in-tree package might be absent.

## Tests

18 behavioural regressions plus **one tree-wide census**, all in `tests/test_vendored_override_gate.py` — beside #201's, not scattered per module, because the rule is the registry's and it has one home (the precedent PR #203 set).

The census walks `prismaquant/` and fails for any call to `detect_profile` / `detect_profile_with_warning` / `profile_from_config` / `profile_from_model` inside a `try` whose broad handler would answer instead of refusing. Two shapes pass: `except DeadVendoredOverrideError: raise` ahead of the broad handler, or a broad handler that always re-raises — which is what `sample_parallel_probe.py:568` already did (`SampleParallelProbeError(...) from exc`), and why it was correctly excluded from the census.

It earns its place twice. Four sites cannot be reached without a GPU, a loaded checkpoint or a built streaming context — `aqua_activation_cost.py:661` (inside `main()`, past argparse and two artifact loads), `build_rtn_cache.py:500`, `sensitivity_probe.py:3592`, `streaming_production_cache.py:1776` — so a behavioural test for those would exercise scaffolding, not the fix. And it fails for the 23rd such call site when someone writes it, which no per-site test does.

Run independently before any fix, it reproduced the issue's census table **line for line** — same 22 `file:line` pairs, same entrypoints:

```
FAILED test_no_call_site_swallows_the_dead_override_refusal
  - AssertionError: assert [...] == []
    Left contains 22 more items, first extra item:
    'prismaquant/aqua_activation_cost.py:661 (detect_profile)'
```

Every commit records its own pre-fix failure lines. One is not what it looks like and says so: `weight_session.py:90`'s refusal already arrives once `build_rtn_cache.iter_quantizable_tensors` stops swallowing, so its test passes against the branch tip either way — it fails on the genuine pre-#202 tree, and the site is fixed anyway rather than left covered-by-accident.

## Commits

One per module, twelve plus a test-hygiene commit and the merge:

```
aqua_activation_cost · build_rtn_cache · incremental_measure_quant_cost
layer_streaming · measure_quant_cost · perturbed_x_cache
production_weight_cache · sensitivity_probe · streaming_model
streaming_production_cache · weight_session
+ tree-wide census pin & ARCHITECTURE re-stamp   (Fixes #202)
+ keep the cost-shard regressions inside tmp_path
```

## `docs/ARCHITECTURE.md`

Re-stamped in the same commit as the census pin. §8.1's **body** claimed the 22 "can still convert this refusal", which is now false, so that paragraph is rewritten: what the census found, that both flagged optional-hint sites went the same way as the rest, that no shared helper was added and why, and where the rule is now pinned. #201's **stamp** is left exactly as written — stamps are dated records of their own change, and it described #201's scope accurately.

## Risk

**No behaviour change on a healthy tree.** `OVERRIDE_ERRORS` is empty unless a vendored override actually failed to take effect, so every one of these `except` clauses is unreachable in a normal run. No default, format menu, serving lane, ship gate or exported byte moves. What changes is that a checkpoint on a dead vendored modelling path now refuses at the call site instead of being quietly answered.
