### PR TITLE
Write the export leg's inputs after the resume identity, not before (#211)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,35 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `claude/pq-204`. Stamps
+As of: 2026-09-05 · `claude/pq-211`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-05, `claude/pq-211`) for **the export leg's inputs being
+written only after the resume identity has accepted the run** (§5.7;
+RobTand/prismaquant#211, P1). `tessera_campaign.main()` called
+`write_export_inputs` immediately after collecting activations — before
+`prepare_journal` and before the per-row resume verification — so a resume the
+checkpoint identity **refuses** had already overwritten
+`<cache-dir>/hessian_capture.pt`, its `.provenance.json` sidecar and
+`input_scales.safetensors` with the refused draw's Hessians and static scales.
+The checkpoint and the previous cost file correctly survived that refusal; the
+export half of the same surviving table did not, so the table that survived
+could not be exported and had to be re-priced from scratch. #204 bounded the
+damage (the old allocation now refuses the rewritten capture by
+`capture_sha256` instead of exporting under the wrong Hessian and scale) but
+did not stop the destruction. The call is now made **after** the resume
+verification loop and its `[campaign] resumed …` print and **before**
+`started = time.time()`, so #193's guarantee — written before the anchor loop,
+so even a deadline-stopped campaign leaves them — is unchanged, and an
+accepted resume rewrites byte-identical files because the run-level identity
+binds the Hessians, static scales and scale policy that are exactly that
+call's inputs. Nothing between the two sites consumes `hessian_capture_path`,
+`input_scales_path` or `capture_sha256`; the first consumer remains the
+provenance block, and `_campaign_checkpoint_identity` takes the Hessians and
+the calibration identity, never the digest. No file format, field, default or
+gate changes. Regression:
+`test_tessera_campaign_resume.py::test_refused_resume_leaves_the_surviving_tables_export_inputs`,
+which needs the release Tessera's `cached_unit` receipt API to reach the
+resume and therefore skips at the development pin.
 
 Re-stamped (2026-09-05, `claude/pq-204`) for **binding the Tessera export
 inputs to the payload and the values that priced the allocation** (§5;
@@ -6635,7 +6663,17 @@ content, not to names (#204): the allocation carries the campaign capture's
 (`tessera_activation_static_scales`), and the gate digests the `.pt` the
 exporter loads and reads each scalar from the safetensors file, refusing a
 payload, sidecar or value that is not what priced the row, and an allocation
-that carries no binding at all as unbound. The arm opens
+that carries no binding at all as unbound. The campaign writes those two
+files at one point in `main()`: **after** the resume identity has accepted
+this run's inputs and **before** the anchor loop (#211). Before the loop, so a
+deadline-stopped campaign still leaves them (#193); after the gate, because
+they are the export half of whatever table survives a refusal — a resume the
+checkpoint identity refuses leaves the checkpoint and the previous cost file
+untouched, and must leave the capture, its sidecar and the scales untouched
+for the same reason, or the surviving table can no longer be exported at all.
+An accepted resume rewrites byte-identical files, because the identity binds
+the Hessians, the static scales and the scale policy that are exactly that
+call's inputs. The arm opens
 a lane-gated shipcard; `prismaquant/lane_specs/tessera.json` (§9.4) declares the
 serve, endpoint, gates, KL evaluator and executed activation contracts.
 Allocation uses `tessera_menu` and its reviewed development contract; that

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -1300,18 +1300,6 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     del model
     torch.cuda.empty_cache()
 
-    # The export leg's inputs, written BEFORE the anchor loop so even a
-    # deadline-stopped campaign leaves them (RobTand/prismaquant#193).
-    hessian_capture_path, input_scales_path, capture_sha256 = \
-        write_export_inputs(
-        cache_dir,
-        hessians=hessians if want_h else None,
-        hessian_rows=hessian_rows,
-        hessian_identity=hessian_identity,
-        static_scales=static_scales,
-        static_scale_policy=static_scale_policy,
-    )
-
     # ONE ActivationSource for the whole campaign, and ONE set of encoder
     # keywords per unit PER SCALE PLANE. The block-LDL is a function of the
     # unit's Hessian alone -- not of its rate -- so a twelve-anchor surface
@@ -1393,6 +1381,27 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     if resumed:
         print(f"[campaign] resumed {sum(len(v) for f in measured.values() for v in f.values())} "
               f"verified anchors from {checkpoint}", flush=True)
+
+    # The export leg's inputs, written AFTER the resume identity has accepted
+    # this run's inputs and BEFORE the anchor loop.  Before the loop, so even
+    # a deadline-stopped campaign leaves them (RobTand/prismaquant#193); after
+    # the gate, because they are the export half of whatever table survives a
+    # refusal (RobTand/prismaquant#211).  A refused resume leaves the
+    # checkpoint and the previous cost file alone, so it must leave these
+    # alone too -- overwriting them with the refused draw's Hessians and
+    # scales strands the surviving table, which can then only be re-priced
+    # from scratch.  Nothing above consumes the returned paths or digest, and
+    # an accepted resume re-writes byte-identical files: the identity binds
+    # ``hessians``, ``static_scales`` and ``static_scale_policy``, which are
+    # exactly this call's inputs.
+    hessian_capture_path, input_scales_path, capture_sha256 = write_export_inputs(
+        cache_dir,
+        hessians=hessians if want_h else None,
+        hessian_rows=hessian_rows,
+        hessian_identity=hessian_identity,
+        static_scales=static_scales,
+        static_scale_policy=static_scale_policy,
+    )
 
     def flush_checkpoint() -> None:
         for name in sorted(dirty_checkpoint_units):

--- a/tests/test_tessera_campaign_resume.py
+++ b/tests/test_tessera_campaign_resume.py
@@ -184,6 +184,54 @@ def test_main_refuses_changed_encoding_or_scoring_inputs(monkeypatch, tmp_path, 
     assert checkpoint.read_bytes() == original_manifest
 
 
+def _export_inputs_state(cache_dir):
+    """What the export leg would be handed, read back from the cache."""
+    from safetensors.torch import load_file
+
+    capture = torch.load(cache_dir / "hessian_capture.pt", weights_only=False)
+    sidecar = json.loads(
+        (cache_dir / "hessian_capture.pt.provenance.json").read_text())
+    scales = load_file(str(cache_dir / "input_scales.safetensors"))
+    return {
+        "hessian": float(capture["H"][UNIT][0, 0]),
+        "capture_provenance": capture["provenance"],
+        "capture_sha256": sidecar["capture_sha256"],
+        "input_global_scale": float(scales[f"{UNIT}.input_global_scale"]),
+    }
+
+
+def test_refused_resume_leaves_the_surviving_tables_export_inputs(monkeypatch, tmp_path):
+    """A refused resume must not have rewritten the export leg's inputs first.
+
+    The checkpoint and the previous cost file already survive a refusal, but
+    ``hessian_capture.pt``, its sidecar and ``input_scales.safetensors`` are
+    the export leg's half of the same surviving table: destroy them and the
+    table that survived cannot be exported at all (#211).  The pytest form of
+    ``pq-audit-caches/pq-204/proofs/rejected_resume_postfix.py``; it needs the
+    release Tessera's ``cached_unit`` receipt API to reach ``main()``'s resume
+    at all, so it skips at the development pin.  The menu is left empty (the
+    ``priced=False`` fixture) so the refusal is the run-level identity's and
+    not the released contract's lane-eligibility schema.
+    """
+    pytest.importorskip("tessera.cached_unit")
+    campaign, checkpoint, argv, _model, inputs = _main_fixture(monkeypatch, tmp_path)
+    argv[argv.index("--hessian") + 1] = "require"
+    assert campaign.main(argv) == 0
+    cache_dir = tmp_path / "cache"
+    before = _export_inputs_state(cache_dir)
+    original_manifest = checkpoint.read_bytes()
+    original_cost = (tmp_path / "cost.pkl").read_bytes()
+    # Another draw's Hessian and another static A-side scale: exactly the run
+    # the run-level checkpoint identity refuses.
+    inputs["hessian"] = 2 * torch.eye(256)
+    inputs["max_abs"] *= 2
+    with pytest.raises(RuntimeError, match="checkpoint identity mismatch"):
+        campaign.main(argv)
+    assert checkpoint.read_bytes() == original_manifest
+    assert (tmp_path / "cost.pkl").read_bytes() == original_cost
+    assert _export_inputs_state(cache_dir) == before
+
+
 @pytest.mark.parametrize("damage", ["missing", "bytes", "symlink"])
 def test_main_refuses_missing_or_changed_priced_wire(monkeypatch, tmp_path, damage):
     (campaign, checkpoint, argv, _model, _inputs), _payload = _fresh_priced_campaign(


### PR DESCRIPTION
`tessera_campaign.main()` called `write_export_inputs(...)` immediately after
collecting activations — before `prepare_journal(...)` and before the per-row
resume verification loop. So a resume the checkpoint identity **refuses** had
already overwritten `<cache-dir>/hessian_capture.pt`, its `.provenance.json`
sidecar and `<cache-dir>/input_scales.safetensors` with the refused run's
Hessians and static scales. The checkpoint and the previous cost file correctly
survive that refusal; the export half of the same surviving table did not, so
the table that survived could not be exported at all. #204 bounded the damage —
the old allocation now refuses the rewritten capture by `capture_sha256` rather
than exporting under the wrong Hessian and scale — but did not stop the
destruction.

**The fix is the move the issue prescribes.** The call now sits just after the
resume verification loop and its `[campaign] resumed …` print, still before
`started = time.time()`, so PR #193's guarantee holds unchanged: written before
the anchor loop, so even a deadline-stopped campaign leaves them.

**Read against #212 first, as briefed.** #212 (issue #204) landed in this same
file a few minutes before this branch opened and changed `write_export_inputs`
to a three-value return (`+ capture_sha256`), staged both files with the sidecar
renamed last, and added the digest to `campaign_cost_payload` and to
`provenance.hessian`. None of that makes the move unnecessary or changes its
shape — #212 is a *detection* change (the export gate now refuses the rewritten
capture by name) and this is the *destruction* it detects. Confirmed before
moving anything: nothing between the old and new call sites consumes
`hessian_capture_path`, `input_scales_path` or `capture_sha256` (first consumer
is still the provenance block at the end of `main()`); `write_export_inputs`
does not mutate `hessians`, `static_scales` or `hessian_identity`; and
`_campaign_checkpoint_identity` takes the Hessians and the calibration identity,
never the digest. An accepted resume rewrites byte-identical files, because the
run-level identity binds the Hessians, static scales and scale policy that are
exactly this call's inputs. The diff also un-mangles the continuation
indentation #212 left at the old call site.

No file format, field, default, gate or ordering other than this one moves.
Out of pq-183's region: `_collect_activations` and the packed-expert paths are
untouched; this is `main()`'s call ordering only.

## Regression

`test_tessera_campaign_resume.py::test_refused_resume_leaves_the_surviving_tables_export_inputs`
— the pytest form of `pq-audit-caches/pq-204/proofs/rejected_resume_postfix.py`.
It enters through the real `main()` twice, so it needs the release Tessera's
`cached_unit` receipt API that `_checkpoint_identity_api()` demands, and is
gated `pytest.importorskip("tessera.cached_unit")`: **it skips at the dev pin
`tessera-pin-1221d2a`** and runs only at `tessera-release`. Its menu is left
empty (the existing `priced=False` fixture, which already stubs
`expand_menus_for_targets` and `campaign_cost_payload` exactly as codex's proof
did) so the refusal under test is the run-level identity's, not the released
contract's lane-eligibility v8 schema.

Pre-fix, at `PYTHONPATH=/home/rob/tessera-release/src`:

```
>       assert _export_inputs_state(cache_dir) == before
E       AssertionError: assert {'capture_pro...l_scale': 1.0} == {'capture_pro...l_scale': 2.0}
E         Differing items:
E         {'capture_sha256': 'ba169f0cf881...'} != {'capture_sha256': 'a19e8da92b70...'}
E         {'hessian': 2.0} != {'hessian': 1.0}
E         {'input_global_scale': 1.0} != {'input_global_scale': 2.0}
```

The checkpoint and cost-file assertions beside it held both before and after —
that is the point: those already survived a refusal, and now the export inputs
do too.

## Docs

`docs/ARCHITECTURE.md` §5.7 states the new ordering (and why it is *both* after
the gate and before the loop); the provenance block is re-stamped in the same
commit, header line `claude/pq-211`, stamp paragraph newest-first (AGENTS
principle 12).

Fixes #211
