### PR TITLE
Resolve a format name once, in the registry; make the production-cache fill gate total (#218)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,35 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `claude/pq-204`. Stamps
+As of: 2026-09-05 · `claude/pq-218`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-05, `claude/pq-218`) for **format-name resolution: case is
+the registry's question, and a predicate over a format menu must be total**
+(§5.1; RobTand/prismaquant#218, P1 — a regression in #213/#205). `#213`
+replaced a string membership test on the production-cache fill path with a
+registry lookup, and a lookup can raise where a membership test could only
+answer: `_format_uses_static_activation_clip` upper-cased an already
+upper-cased name and called `get_format`, so any fill whose menu or assignment
+carried `INT4_W4A16_g128` — the one mixed-case registry row, and what
+`validation_harness._entry_format_name` maps a 4-bit precision-plan entry to —
+died with an unhandled `KeyError` at `fill_production_weight_cache` before a
+tensor was rendered. Enumerated over the whole registry (80 rows + 3 aliases),
+that name is the **only** one `_render_base_format`'s `.upper()` makes
+unresolvable, and no name resolves to a *different* spec after an upper- or
+lower-case round trip. The fix is therefore not at the caller: (1)
+`format_registry.canonical_format_name` gains a case-insensitive last probe,
+so every caller that normalizes by upper-casing — the render base, the cache
+identity keys, `render_production_weight` (whose own `.upper()` predates #213
+and crashed on the same name at render time, so fixing only the gate would
+have moved the `KeyError` rather than removed it) — resolves again; identity
+spellings are unchanged, and nothing that resolved before resolves
+differently. (2) `production_weight_cache._resolve_format_spec` is one home
+for "does this requested name resolve to a spec, and if so which", shared by
+`_format_uses_static_activation_clip`, `_is_cb_format_name` and
+`_weighted_render_family`; it does not upper-case (the registry settles case)
+and answers `None` rather than raising, so an unresolvable menu entry answers
+`False`. No default, menu, lane or gate moves; `INT4_W4A16_g128` remains
+research/registry-only.
 
 Re-stamped (2026-09-05, `claude/pq-204`) for **binding the Tessera export
 inputs to the payload and the values that priced the allocation** (§5;
@@ -6131,13 +6159,34 @@ shape-exact rather than a nominal scalar:
 and 3-D packed-expert stacks; `memory_bytes_for_shape` / `effective_bits_for_shape`
 (`:157-168`) are what the DP, `footprint.py`, and the Pareto table consume for
 those formats. Aliases:
-`FP8`/`FP8_DYNAMIC` → `FP8_E4M3`, `MXFP8` → `MXFP8_E4M3` (`:170-188`).
+`FP8`/`FP8_DYNAMIC` → `FP8_E4M3`, `MXFP8` → `MXFP8_E4M3` (`:298-308`).
 `act_quant_changes_input` (`:75-106`) is the **single** predicate for "does the serving kernel
 consume quantized activations" (`act_bits` absent or ≥ 16 ⇒ no): the allocator's bit-exact
 short-circuit (§4.5), the KL validator's activation-quant assignment, `layer_state_cache` and
 `perturbed_x_cache` all key off it, so a format's activation semantics cannot drift between
 pricing and emulation. Registry-vs-callable consistency is pinned by
 `tests/test_bit_exact_cost_pricing.py`.
+
+**Name resolution is the registry's job, and case is not part of a format's
+identity.** `canonical_format_name` (`:330-369`) probes the raw spelling, then
+the upper-cased one, then case-insensitively; `get_format` refuses only a name
+no probe resolves (falling through to the Tessera synthesizer first, §5.7).
+The last probe exists because exactly one registered row is mixed case —
+`INT4_W4A16_g128` — while several callers normalize a requested format name by
+upper-casing it (`production_weight_cache._render_base_format`, the cache
+identity keys, `render_production_weight`), which produced a name no resolver
+owned and a bare `KeyError` on a format PrismaQuant ships and a precision plan
+selects (#218). Callers keep their upper-case identity spelling; the registry
+answers to it. Consequently a **predicate over a requested format menu must be
+total**: `production_weight_cache._resolve_format_spec` is the one resolver
+those predicates share (`_format_uses_static_activation_clip`,
+`_is_cb_format_name`, `_weighted_render_family`), and it answers `None` — not
+an exception — for a name this registry does not own, because "not a format we
+know" is an answer. A refusal for an unknown format belongs where the menu is
+validated, named, not thrown out of an activation-scale gate mid-fill. Pinned
+by `tests/test_format_registry.py` (whole-registry upper/lower round trip, and
+the no-two-names-differ-only-by-case precondition) and
+`tests/test_served_activation_contract.py`.
 
 | Format | line | w-bits / group / scale | eff. bpp (2-D) | Status |
 |---|---|---|---|---|

--- a/prismaquant/format_registry.py
+++ b/prismaquant/format_registry.py
@@ -328,6 +328,27 @@ def register_format(spec: FormatSpec) -> FormatSpec:
 
 
 def canonical_format_name(name: str) -> str:
+    """The registry's own spelling of a requested format name.
+
+    Case is not part of a format's identity, and this function is where that
+    is decided -- once, for every consumer.  The raw-then-upper probes below
+    cover "the caller typed lower case and the row is upper case"; they did
+    NOT cover the mirror image, and exactly one registered row is mixed case
+    (``INT4_W4A16_g128``).  So every caller that normalizes a requested name
+    by upper-casing it -- ``production_weight_cache._render_base_format``, the
+    cache identity keys, ``render_production_weight`` -- handed the resolver a
+    name no resolver owned, and ``get_format`` raised ``KeyError`` on a format
+    PrismaQuant ships and a precision plan can select (#218).
+
+    The case-insensitive probe is last, so it fires only where the exact
+    probes have already failed: nothing that resolved before resolves
+    differently now, and an unknown name is still returned unchanged for
+    ``get_format`` to refuse by name.  No two registered names differ only by
+    case (pinned by ``tests/test_format_registry.py``), so the answer is
+    unambiguous.  It is a linear scan over ~80 rows on the MISS path only,
+    which is also the path every synthesized Tessera rung takes; that is
+    string comparison against a fixed-size table, not a hot-loop cost.
+    """
     raw = str(name).strip()
     if raw in FORMAT_ALIASES:
         return FORMAT_ALIASES[raw]
@@ -338,6 +359,13 @@ def canonical_format_name(name: str) -> str:
         return FORMAT_ALIASES[upper]
     if upper in REGISTRY:
         return upper
+    folded = raw.casefold()
+    for alias, target in FORMAT_ALIASES.items():
+        if alias.casefold() == folded:
+            return target
+    for registered in REGISTRY:
+        if registered.casefold() == folded:
+            return registered
     return raw
 
 

--- a/prismaquant/production_weight_cache.py
+++ b/prismaquant/production_weight_cache.py
@@ -166,6 +166,19 @@ NVFP4_RENDER_EQUIVALENT = frozenset({"NVFP4", "NVFP4A16"})
 
 
 def _render_base_format(fmt: str) -> str:
+    """The render-base spelling of a requested format name.
+
+    Upper-casing is this module's one normalizer for a format identity: it
+    also spells the cache filenames, the manifest keys and the render-score
+    records, so the render base has to agree with them and it stays as it is.
+    Enumerated over the whole registry (80 rows + 3 aliases), it changes the
+    spelling of exactly one registered name -- ``INT4_W4A16_g128``, the only
+    mixed-case row -- and no other name, alias or Tessera rung.  That one name
+    is not made unresolvable HERE, though: it is unresolvable because case was
+    decided at each caller instead of in the registry, so the fix is in
+    ``format_registry.canonical_format_name``, which now resolves a name
+    case-insensitively as its last probe (#218).  Do not paper over it here.
+    """
     return str(fmt).strip().upper()
 
 
@@ -1538,6 +1551,36 @@ def _render_score_record(
     }
 
 
+def _resolve_format_spec(fmt):
+    """The ``FormatSpec`` a requested format name resolves to, or ``None``.
+
+    ONE home for "does this requested name resolve to a spec, and if so which"
+    (principle 8).  Every predicate in this module that classifies a name off
+    the format menu goes through here, so they cannot answer that question
+    differently again.  Two properties, both load-bearing:
+
+    * It does not upper-case.  ``fr.canonical_format_name`` settles case
+      itself; an extra ``.upper()`` here is redundant at best, and at worst it
+      destroys a mixed-case registered name before any resolver sees it
+      (#218).  These predicates are handed ``_render_base_format`` output,
+      which has already normalized -- so they resolve the name they are given.
+
+    * It answers ``None`` rather than raising.  These are predicates over a
+      requested format MENU, and a menu can carry a name this registry does
+      not own; "not a format we know" is an answer, not an error.  A caller
+      that wants to refuse an unknown format raises its own named refusal
+      where the menu is validated -- not a bare ``KeyError`` escaping from a
+      question about activation scales, mid-fill, before a tensor is
+      rendered.
+    """
+    from prismaquant import format_registry as fr
+
+    try:
+        return fr.get_format(fr.canonical_format_name(str(fmt).strip()))
+    except Exception:
+        return None
+
+
 def _static_activation_contract_of(spec):
     """``spec.static_activation_contract``, tolerant of the bare stand-ins
     tests hand ``fr.get_format`` back (a namespace with only the callable)."""
@@ -1555,11 +1598,11 @@ def _format_uses_static_activation_clip(fmt: str) -> bool:
     contract.  Whether the maximum is applied as a pre-clip or as the G of the
     served oracle is the contract's ``measured_as_served``; this predicate only
     says the maximum belongs to the row.
-    """
-    from prismaquant import format_registry as fr
 
-    spec = fr.get_format(fr.canonical_format_name(str(fmt).strip().upper()))
-    return _static_activation_contract_of(spec) is not None
+    Total over the menu: a name this registry does not resolve is not served
+    under a static activation contract, so it answers False (#218).
+    """
+    return _static_activation_contract_of(_resolve_format_spec(fmt)) is not None
 
 
 def _formats_need_static_activation_max(formats) -> bool:
@@ -1766,25 +1809,14 @@ def _expert_col_weights(
 def _weighted_render_family(fmt: str) -> str | None:
     """The weighted-render family of ``fmt``, or ``None`` for every format
     whose render ignores ``col_weights`` (NVFP4/FP8/MX/BF16/INT)."""
-    from prismaquant import format_registry as fr
-
-    try:
-        family = fr.get_format(str(fmt).strip().upper()).family
-    except Exception:
-        return None
+    family = getattr(_resolve_format_spec(fmt), "family", None)
     return family if family in WEIGHTED_RENDER_FAMILIES else None
 
 
 def _is_cb_format_name(fmt: str) -> bool:
     """Return whether ``fmt`` is one of the two serialized CB families."""
-    from prismaquant import format_registry as fr
-
-    try:
-        return fr.get_format(
-            fr.canonical_format_name(str(fmt).strip().upper())
-        ).family in {"nvfp4_cb", "fp8_cb"}
-    except Exception:
-        return False
+    return getattr(_resolve_format_spec(fmt), "family", None) in {
+        "nvfp4_cb", "fp8_cb"}
 
 
 def _cb_qnames_in_render_scope(

--- a/tests/test_format_registry.py
+++ b/tests/test_format_registry.py
@@ -310,3 +310,39 @@ def test_mxfp8_activation_quantizer_uses_e4m3_range():
     raw_amax_mse = torch.mean((raw_amax_reference.float() - x) ** 2)
 
     assert corrected_mse < raw_amax_mse * 0.01
+
+
+def test_every_registered_name_resolves_through_an_upper_cased_spelling():
+    """One rule, one home: whether this registry answers to a name's CASE is
+    the registry's question, and it is settled in ``canonical_format_name``.
+
+    ``canonical_format_name`` already tried the raw spelling and then the
+    upper-cased one, which covers "the caller typed lower case, the row is
+    upper case".  It did not cover the mirror image -- "the caller (or an
+    upstream normalizer) upper-cased, the row is mixed case" -- and exactly
+    one registered row is mixed case, ``INT4_W4A16_g128``.  Every caller that
+    normalizes a requested format name by upper-casing it therefore produced
+    a name no resolver owned, and ``get_format`` raised ``KeyError`` (#218).
+    """
+    import pytest
+
+    # The precondition that makes case-insensitive resolution unambiguous.
+    names = [*fr.REGISTRY, *fr.FORMAT_ALIASES]
+    folded = [name.casefold() for name in names]
+    assert len(folded) == len(set(folded)), "two format names differ only by case"
+
+    assert "INT4_W4A16_g128" in fr.REGISTRY
+    assert fr.canonical_format_name("INT4_W4A16_G128") == "INT4_W4A16_g128"
+    assert fr.get_format("INT4_W4A16_G128").name == "INT4_W4A16_g128"
+    assert fr.get_format("int4_w4a16_g128").name == "INT4_W4A16_g128"
+
+    # The whole registry, enumerated: no registered name or alias is lost by
+    # an upper-case round trip, and none of them resolves to a DIFFERENT spec.
+    for name in names:
+        assert fr.get_format(name.upper()).name == fr.get_format(name).name
+        assert fr.get_format(name.lower()).name == fr.get_format(name).name
+
+    # A name the registry does not own is still unknown, and still raises
+    # naming the registry rather than resolving to something arbitrary.
+    with pytest.raises(KeyError):
+        fr.get_format("NOT_A_REGISTERED_FORMAT_pq218")

--- a/tests/test_production_weight_cache.py
+++ b/tests/test_production_weight_cache.py
@@ -1953,3 +1953,35 @@ def test_non_nv_render_gate_scores_on_gptq_clipped_activations():
         step["candidate_score"] if step["accepted"] else step["baseline_score"]
     )
     assert selected_score == pytest.approx(final_clipped, rel=1e-5)
+
+
+def test_the_mixed_case_registry_row_renders_through_the_cache_entry_point():
+    """#218 -- the crash the gate raised was not the only one on this path.
+
+    ``render_production_weight`` normalizes with ``.upper()`` too (and did so
+    before #213), so ``INT4_W4A16_g128`` -- the one mixed-case registry row,
+    and the name ``validation_harness`` maps a 4-bit precision-plan entry to
+    -- was unresolvable at render time as well.  Fixing case resolution in
+    the registry rather than in the gate is what makes the whole fill path
+    answer for this format instead of moving its ``KeyError`` later.
+
+    ``_render_base_format`` deliberately still upper-cases: its output is the
+    cache-identity spelling, and the registry now resolves it.
+    """
+    from prismaquant.production_weight_cache import (
+        _render_base_format,
+        render_production_weight,
+    )
+
+    qname = "model.layers.0.mlp.up_proj"
+    weight = torch.randn(64, 128, dtype=torch.float32)
+    activations = {qname: torch.randn(32, 128, dtype=torch.float32)}
+    for name in ("INT4_W4A16_g128", _render_base_format("INT4_W4A16_g128")):
+        rendered = render_production_weight(
+            weight, name,
+            qname=qname,
+            activations=activations,
+            levers={},
+        )
+        assert rendered.shape == weight.shape
+        assert torch.isfinite(rendered).all()

--- a/tests/test_served_activation_contract.py
+++ b/tests/test_served_activation_contract.py
@@ -241,3 +241,59 @@ def test_kl_preflight_is_quiet_for_stock_nvfp4_and_a16(tmp_path, monkeypatch):
             measure_assignment_kl(
                 model, {"proj": fmt}, calib_ids, refs,
                 work_root=tmp_path, kl_scope="full_sequence")
+
+
+# ------------------------------------- the fill gate must be total (#218)
+#
+# #213 replaced a string membership test with a registry lookup, and a lookup
+# can raise where a membership test could only answer.  Two inputs reach this
+# gate that the lookup cannot survive, and both kill a production cache fill
+# at `fill_production_weight_cache` before one tensor is rendered.
+
+def test_the_fill_gate_answers_for_the_mixed_case_registry_row():
+    """``INT4_W4A16_g128`` is the ONE registry row whose name is mixed case,
+    and it is reachable: ``validation_harness._entry_format_name`` maps the
+    4-bit entry of a precision plan to it, so an assignment carries it into
+    ``render_formats_by_qname`` and hence into ``render_base_fmt_set``.
+
+    The fill hands this gate ``_render_base_format``'s output, which
+    upper-cases.  The gate must still ANSWER -- that row is W4A16, it has no
+    static activation contract, so no calibrated maximum is needed -- rather
+    than raise ``KeyError`` naming the registry (#218).
+    """
+    from prismaquant.production_weight_cache import (
+        _format_uses_static_activation_clip,
+        _formats_need_static_activation_max,
+        _render_base_format,
+    )
+
+    # What the fill actually builds at production_weight_cache.py:6790.
+    render_base_fmt_set = {
+        _render_base_format(f) for f in ("INT4_W4A16_g128", "BF16")
+    }
+    assert "INT4_W4A16_G128" in render_base_fmt_set
+
+    assert _format_uses_static_activation_clip("INT4_W4A16_g128") is False
+    assert _format_uses_static_activation_clip("INT4_W4A16_G128") is False
+    assert _formats_need_static_activation_max(render_base_fmt_set) is False
+
+
+def test_the_fill_gate_is_total_over_names_the_registry_does_not_own():
+    """A predicate over a requested format MENU has to be total.  A menu may
+    carry a name this registry does not own, and "not a format we know" is an
+    answer -- False, there is no static activation contract to calibrate for
+    -- not a bare ``KeyError`` raised from inside an activation-scale gate.
+    A refusal, if the project wants one, belongs where the menu is validated.
+    """
+    from prismaquant.production_weight_cache import (
+        _format_uses_static_activation_clip,
+        _formats_need_static_activation_max,
+        _is_cb_format_name,
+    )
+
+    junk = "NOT_A_REGISTERED_FORMAT_pq218"
+    assert _format_uses_static_activation_clip(junk) is False
+    assert _formats_need_static_activation_max({junk, "BF16"}) is False
+    # The sibling predicate over the same values already answered False here;
+    # they now share one resolver, so they cannot drift apart again.
+    assert _is_cb_format_name(junk) is False


### PR DESCRIPTION
Fixes #218 (P1).

## The crash, and what was actually wrong

PR #213 replaced a string membership test on the production-weight-cache fill
path with a registry lookup, and a lookup can raise where a membership test
could only answer. `_format_uses_static_activation_clip` upper-cased a name
`_render_base_format` (`:168`) had already upper-cased and called
`fr.get_format`, so any fill whose menu or assignment carried
`INT4_W4A16_g128` died with an unhandled `KeyError` at
`fill_production_weight_cache` before a single tensor was rendered. That name
is reachable: `validation_harness._entry_format_name` (`:807`, `:843`) maps
the 4-bit entry of a precision plan to it, and `render_scope == "assignment"`
puts it straight into `render_formats_by_qname`
(`streaming_production_cache.py:1449-1453`).

**What the enumeration says.** Sweeping all 80 registry rows + 3 aliases
through `_render_base_format` then `canonical_format_name`: exactly ONE name
fails to survive the round trip — `INT4_W4A16_g128`, the only mixed-case
registered row. No *other* mixed-case registered format is silently broken by
the upper-casing, no alias is, no Tessera rung is (that grammar is upper by
construction), and no name resolves to a *different* spec after an upper- or
lower-case round trip.

**And the gate was not the only crash on this path.**
`render_production_weight` normalizes with its own `.upper()` at `:4416`, and
that line predates #213 — `INT4_W4A16_g128` has never rendered through this
entry point. #213 moved the `KeyError` earlier rather than introducing the
whole defect, so fixing only the gate would have moved it back, not removed
it. (The issue's "previously ... rendered normally" is not accurate; the
regression is real, but the format was already unrenderable.)

## The fix: where the rule lives, not at each caller

1. **`format_registry.canonical_format_name` gains a case-insensitive last
   probe.** Case is not part of a format's identity, and this function is the
   one place that decides it. The probe is last, so it fires only where the
   exact probes already failed: nothing that resolved before resolves
   differently, and an unknown name is still returned unchanged for
   `get_format` to refuse by name. No two registered names differ only by
   case — now pinned as the precondition. Every caller that normalizes by
   upper-casing (`_render_base_format`, the cache identity keys,
   `render_production_weight`) keeps its spelling and resolves again, so no
   cache filename, manifest key or render-score record changes.

2. **`production_weight_cache._resolve_format_spec` is ONE home** for "does
   this requested name resolve to a spec, and if so which". That question had
   two answers in the file: `_is_cb_format_name`'s `try/except -> False` and
   the new predicate's bare `get_format`. Now
   `_format_uses_static_activation_clip`, `_is_cb_format_name` and
   `_weighted_render_family` all call it. It does not upper-case (the registry
   settles case; these predicates are handed already-normalized names, so they
   resolve the name they are given) and answers `None` rather than raising,
   because a predicate over a requested format MENU must be total: "not a
   format this registry owns" is an answer, not an exception thrown out of a
   question about activation scales mid-fill. A refusal for an unknown format
   belongs where the menu is validated, named.

`_render_base_format` deliberately keeps its `.upper()`, with a comment
recording why and what the enumeration found.

No default, format menu, serving lane or ship gate moves. What any resolvable
format resolves to is unchanged; `INT4_W4A16_g128` stays
research/registry-only. `docs/ARCHITECTURE.md` §5.1 and its provenance block
are re-stamped in the same commit.

## Regressions (shown failing on `553de0af` first)

- `tests/test_served_activation_contract.py::test_the_fill_gate_answers_for_the_mixed_case_registry_row`
  — drives the gate with `{_render_base_format("INT4_W4A16_g128"), "BF16"}`,
  the set the fill actually builds at `:6790`, and asserts "no static
  activation max needed" instead of a raise.
- `tests/test_served_activation_contract.py::test_the_fill_gate_is_total_over_names_the_registry_does_not_own`
  — an unresolvable junk name answers `False` from both predicates.
- `tests/test_format_registry.py::test_every_registered_name_resolves_through_an_upper_cased_spelling`
  — the whole registry enumerated through an upper/lower round trip, plus the
  no-two-names-differ-only-by-case precondition, plus an unknown name still
  raising.
- `tests/test_production_weight_cache.py::test_the_mixed_case_registry_row_renders_through_the_cache_entry_point`
  — the render entry point, so the fix removes the crash rather than moving
  it.

## Also

Prose fix on sight (AGENTS.md principle 14): ARCHITECTURE.md §5.1 cited
`format_registry.py:170-188` for `FORMAT_ALIASES`, which lives at `:298-308`;
`:170-188` is inside `FormatSpec`.
