### PR TITLE
Read the capture-context roster from Tessera, widen the dead-override census, stop a test leaking its orphan (#216, #217, #219)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,37 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `claude/pq-204`. Stamps
+As of: 2026-09-05 · `claude/pq-gates`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-05, `claude/pq-gates`) for **the export seal's
+capture-context roster read from Tessera rather than typed** (§5;
+RobTand/prismaquant#216, P2). `tessera_export_lane.CAPTURE_CONTEXT_FIELDS` was
+the literal `("model", "seqlen", "source")` and nothing in the tree read
+`tessera.export.CAPTURE_CONTEXT`, so half of the roster
+`ActivationSource.capture_sha256` seals had no owner — while its sibling
+`tessera_hessian.HESSIAN_IDENTITY_FIELDS` derives the identity triple from
+`tessera.export.HESSIAN_IDENTITY` and a test pins the two together. The two
+rules agree today; a field added to Tessera's constant would have split them,
+and at a pin with no `capture_sha256` (the dev pin 1221d2a) the split is
+silent: two captures differing only in the new field digest identically and an
+allocation binds to a capture that did not price it, which is #204's failure
+reintroduced with no signal. Now: `CAPTURE_CONTEXT_FIELDS,
+CAPTURE_CONTEXT_FIELDS_SOURCE = _capture_context_fields()` reads
+`tessera.export.CAPTURE_CONTEXT` where the running Tessera publishes it and
+otherwise falls back to `_CAPTURE_CONTEXT_FALLBACK` — the ONE place the roster
+is typed, commented with the Tessera it was copied from (0.1.0, release
+`3efd690`, `src/tessera/export.py:244`) — and names which was used.
+`_require_capture_context_roster`, called from `hessian_capture_sha256` before
+a byte is digested, re-reads the constant live and refuses by name when it is
+not the roster the digest covers, listing the fields each side names; this is
+the half of the drift guard that needs no `capture_sha256`, so it holds at the
+dev pin where `_crosscheck_capture_seal` compares nothing. No wire bytes, no
+digest values and no report keys change while the rosters agree. Tests:
+`test_tessera_priced_export_inputs.py` — `test_the_capture_context_roster_is_
+tesseras` (roster equality, runs at BOTH pins, unlike the skipped runtime-seal
+comparison), the drift refusal at the digest and at the gate, and the
+documented fallback (pre-fix at the release tip: `DID NOT RAISE
+TesseraExportLaneError`, the bind reaching the seal cross-check instead).
 
 Re-stamped (2026-09-05, `claude/pq-204`) for **binding the Tessera export
 inputs to the payload and the values that priced the allocation** (§5;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,8 +3,37 @@
 As of: 2026-09-05 · `claude/pq-gates`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-05, `claude/pq-gates`) for **the dead-override census
+seeing every handler shape that catches its exception** (§8.1;
+RobTand/prismaquant#217, P3). `tests/test_vendored_override_gate.py`'s
+tree-wide pin that "a dead vendored override must never be *answered*"
+recognised only `except:`, `except Exception:` and `except BaseException:` —
+but `DeadVendoredOverrideError` subclasses `RuntimeError` deliberately, so
+`except RuntimeError:` swallowed the refusal and the census reported the site
+as refusing. Three shapes were invisible: bare `RuntimeError`, a tuple naming
+it, and a dotted `builtins.Exception`; a fourth, a handler that substitutes an
+answer on one branch and re-raises on the fall-through, passed
+`_handler_always_reraises`, which tested only the last statement. The census's
+whole justification is the four call sites with no behavioural test
+(`aqua_activation_cost.py:661`, `build_rtn_cache.py:500`,
+`sensitivity_probe.py:3592`, `streaming_production_cache.py:1776`). Now
+`CATCHES_DEAD_OVERRIDE` is derived from `DeadVendoredOverrideError.__mro__`
+rather than a second typed list, so the census follows the class if it is
+re-parented; `_handler_catches_dead_override` matches bare, dotted and
+tuple clauses against it; and `_handler_always_reraises` additionally requires
+no `return`, and no `break`/`continue` that would carry control past the
+trailing `raise`, ignoring nested scopes and loops written inside the handler.
+No production code changed: the widened census reports **zero** newly
+swallowing sites over `prismaquant/` (31 `try` blocks wrap a detection call —
+25 `except DeadVendoredOverrideError: raise` then broad, 4 `try/finally`, 1
+`SampleParallelProbeError`+broad-that-re-raises, 1 narrow non-catching), so
+the tree was and stays clean; what changed is that the pin now holds the shape
+it claims to hold. The census's own docstring names what it does not cover
+(aliased or dispatched calls, a swallow one frame up, computed exception
+classes, callers outside `prismaquant/`), since it is cited as future-proofing.
+
 Re-stamped (2026-09-05, `claude/pq-gates`) for **the export seal's
-capture-context roster read from Tessera rather than typed** (§5;
+capture-context roster read from Tessera rather than typed** (§5.7;
 RobTand/prismaquant#216, P2). `tessera_export_lane.CAPTURE_CONTEXT_FIELDS` was
 the literal `("model", "seqlen", "source")` and nothing in the tree read
 `tessera.export.CAPTURE_CONTEXT`, so half of the roster
@@ -6660,7 +6689,10 @@ plan translation when the allocation's `tessera_hessian` stamp or its
 selected W4A4 routes declare a requirement the supplied files do not satisfy
 (#193): the artifact built must be the artifact priced. The binding is to
 content, not to names (#204): the allocation carries the campaign capture's
-`capture_sha256` (Tessera's own seal rule, `hessian_capture_sha256`) and the
+`capture_sha256` (Tessera's own seal rule, `hessian_capture_sha256`, whose
+capture-context roster is read from `tessera.export.CAPTURE_CONTEXT` rather
+than typed, with one documented fallback for pins that predate the constant
+and a by-name refusal when the two rosters disagree — #216) and the
 `input_global_scale` each selected W4A4 unit was priced under
 (`tessera_activation_static_scales`), and the gate digests the `.pt` the
 exporter loads and reads each scalar from the safetensors file, refusing a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,27 @@
 As of: 2026-09-05 · `claude/pq-gates`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-05, `claude/pq-gates`) for **a campaign test that cannot
+leak the child it orphans on purpose** (§3.0; RobTand/prismaquant#219, P3).
+`test_resume_after_coordinator_death_recovers_owned_helper_receipt` kills the
+coordinator while a stage child polls a release file, and after #206 replaced
+that child's self-limiting `time.sleep(1.0)` with an unbounded wait, writing
+the release file became the only thing that could ever end it — the worker's
+`timeout_seconds` enforcement (`cluster_campaign.py:1164-1178`,
+`start_new_session=True` then `_terminate_child_process_group`) is dead by
+construction. The write sat outside the guard: anything raising between
+`coordinator.terminate()` and it — most concretely the 120 s wedge backstop, or
+the session being killed, which happened to agents on this box today — left a
+`python -c` polling at 50 Hz forever, on a release file that `tmp_path` cleanup
+then made unreachable. Its sibling
+`test_abrupt_worker_death_leaves_stage_lock_owned_by_child` already had the
+`finally` and the comment explaining why. Now both share one home for it:
+`_orphaned_helper(release_path)` releases and, if the child did not take the
+release, kills its session on every path out, and the child announces its PID
+so `helper.assert_exited()` can make "this test leaves nothing running" an
+assertion rather than an arrangement. Test-only; no production code, no
+pipeline behaviour and no contract changes.
+
 Re-stamped (2026-09-05, `claude/pq-gates`) for **the dead-override census
 seeing every handler shape that catches its exception** (§8.1;
 RobTand/prismaquant#217, P3). `tests/test_vendored_override_gate.py`'s

--- a/prismaquant/tessera_export_lane.py
+++ b/prismaquant/tessera_export_lane.py
@@ -488,10 +488,57 @@ def require_assignment_scope(model_path: str | Path, assignment_path: str | Path
 #: together.
 PRICED_HESSIAN_IDENTITY_FIELDS = ("text_sha256", "fit_tokens", "fit_ids_sha256")
 
+#: The capture-context roster used only where the running Tessera does not
+#: publish ``CAPTURE_CONTEXT``: the pinned development Tessera (1221d2a)
+#: predates the constant, and this gate must refuse on a machine that can read
+#: the payload without importing ``tessera`` at all.  **Copied from tessera
+#: 0.1.0 at release 3efd690** (``src/tessera/export.py:244``), and this is the
+#: ONE place the roster is typed -- a second spelling of a seal's key set is
+#: how the seal goes vacuous (RobTand/prismaquant#216).
+_CAPTURE_CONTEXT_FALLBACK = ("model", "seqlen", "source")
+
+#: Names for where :data:`CAPTURE_CONTEXT_FIELDS` was read, so a refusal can
+#: say whether the digest covered Tessera's own roster or the copied one.
+_CAPTURE_CONTEXT_FROM_TESSERA = "tessera.export.CAPTURE_CONTEXT"
+_CAPTURE_CONTEXT_FROM_FALLBACK = (
+    "prismaquant.tessera_export_lane._CAPTURE_CONTEXT_FALLBACK "
+    "(copied from tessera 0.1.0 release 3efd690)")
+
+
+def _tessera_capture_context() -> "tuple[str, ...] | None":
+    """``tessera.export.CAPTURE_CONTEXT``, or None where the running Tessera
+    predates the constant (the pinned 1221d2a does) or is not importable."""
+    try:
+        from tessera.export import CAPTURE_CONTEXT
+    except ImportError:
+        return None
+    return tuple(CAPTURE_CONTEXT)
+
+
+def _capture_context_fields() -> "tuple[tuple[str, ...], str]":
+    """The capture-context roster this digest covers, and where it was read.
+
+    Read from the installed Tessera where it publishes the constant, exactly
+    as ``tessera_hessian.HESSIAN_IDENTITY_FIELDS`` reads the identity triple
+    from ``tessera.export.HESSIAN_IDENTITY`` -- the roster belongs to the code
+    that owns the seal, and typing a second copy of it is how the two rules
+    drift apart unnoticed.  Where the constant is absent the one documented
+    fallback above is used and named, because such a pin also has no
+    ``ActivationSource.capture_sha256`` and the runtime cross-check cannot see
+    the difference (RobTand/prismaquant#216).
+    """
+    published = _tessera_capture_context()
+    if published is None:
+        return _CAPTURE_CONTEXT_FALLBACK, _CAPTURE_CONTEXT_FROM_FALLBACK
+    return published, _CAPTURE_CONTEXT_FROM_TESSERA
+
+
 #: The capture-context fields Tessera's seal covers beside the triple
 #: (``tessera.export.CAPTURE_CONTEXT``): two captures of one token prefix
-#: differ only here when the sequence layout differs (tessera#214).
-CAPTURE_CONTEXT_FIELDS = ("model", "seqlen", "source")
+#: differ only here when the sequence layout differs (tessera#214).  Read from
+#: Tessera rather than typed, and :func:`_require_capture_context_roster`
+#: refuses when what was read has since drifted from what Tessera publishes.
+CAPTURE_CONTEXT_FIELDS, CAPTURE_CONTEXT_FIELDS_SOURCE = _capture_context_fields()
 
 #: The schema string sealed into the digest, Tessera's own spelling.
 HESSIAN_CAPTURE_SHA256_SCHEMA = "tessera.hessian_capture.v1"
@@ -501,6 +548,41 @@ HESSIAN_CAPTURE_SHA256_SCHEMA = "tessera.hessian_capture.v1"
 #: the static A-side scale VALUE each selected unit's cost row was priced
 #: under (RobTand/prismaquant#204).
 PRICED_STATIC_SCALES_SCHEMA = "prismaquant.tessera_activation_static_scales.v1"
+
+
+def _require_capture_context_roster() -> None:
+    """Refuse a digest whose capture-context roster is not the running
+    Tessera's.
+
+    :data:`CAPTURE_CONTEXT_FIELDS` is resolved once at import; this reads the
+    constant live and compares, so a roster that has since moved -- a Tessera
+    swapped under a long-lived process, an edited fallback, a pin whose
+    ``CAPTURE_CONTEXT`` grew a field this copy lacks -- refuses by name here
+    instead of digesting under the wrong rule.  It is the half of the drift
+    guard that does **not** need ``ActivationSource.capture_sha256``: at a pin
+    that predates the seal (1221d2a) :func:`_crosscheck_capture_seal` returns
+    None and compares nothing, and two captures differing only in a field this
+    roster lacks would digest identically -- binding an allocation to a
+    capture that did not price it, which is exactly the silent state
+    RobTand/prismaquant#204 was opened to close (#216).
+    """
+    published = _tessera_capture_context()
+    if published is None or published == tuple(CAPTURE_CONTEXT_FIELDS):
+        return
+    ours = tuple(CAPTURE_CONTEXT_FIELDS)
+    missing = tuple(f for f in published if f not in ours)
+    extra = tuple(f for f in ours if f not in published)
+    raise TesseraExportLaneError(
+        f"PrismaQuant digests the capture context under {ours} "
+        f"({CAPTURE_CONTEXT_FIELDS_SOURCE}) but tessera.export."
+        f"CAPTURE_CONTEXT names {published} "
+        f"(missing here: {missing or '()'}; not in Tessera: {extra or '()'}). "
+        "The two seal rules cover different provenance, so two captures that "
+        "differ only in a field this roster lacks digest identically and an "
+        "allocation binds to a capture that did not price it. No allocation "
+        "can be bound against this Tessera until the rosters agree: upgrade "
+        "PrismaQuant to a Tessera-derived roster, or pin the Tessera whose "
+        "CAPTURE_CONTEXT this digest was written against.")
 
 
 def hessian_capture_sha256(hessians: "Mapping[str, Any]",
@@ -527,12 +609,16 @@ def hessian_capture_sha256(hessians: "Mapping[str, Any]",
     Where the running Tessera publishes ``capture_sha256`` the gate computes
     both and refuses on disagreement, so a drift in either rule is a refusal
     here rather than a silent divergence
-    (``test_the_digest_rule_is_tesseras_capture_seal``).
+    (``test_the_digest_rule_is_tesseras_capture_seal``).  Where it does not,
+    the roster half of that drift is still caught:
+    :func:`_require_capture_context_roster` refuses before a byte is digested
+    if ``tessera.export.CAPTURE_CONTEXT`` is not the roster covered below.
     """
     import hashlib
 
     import torch
 
+    _require_capture_context_roster()
     identity = {field: provenance.get(field)
                 for field in PRICED_HESSIAN_IDENTITY_FIELDS}
     identity.update({field: provenance.get(field)

--- a/tests/test_cluster_campaign_runner.py
+++ b/tests/test_cluster_campaign_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+import contextlib
 import copy
 import hashlib
 import json
@@ -112,6 +113,92 @@ def _nonempty(path: Path) -> Callable[[], bool]:
             return False
 
     return _ready
+
+
+# ---------------------------------------------------------------------------
+# Children this file deliberately orphans.
+#
+# Two tests here kill the process that would otherwise enforce the stage's
+# `timeout_seconds` -- the coordinator in one, the worker in the other -- and
+# then rely on the stage child polling a release file at 50 Hz.  Once its
+# enforcer is dead, writing that file is the ONLY thing left that can ever end
+# the child (`cluster_campaign.py:1164` gives it its own session; the worker's
+# `TimeoutExpired` -> `_terminate_child_process_group` is what kills it in a
+# healthy run, and that worker is gone by construction).
+#
+# So "the release always happens" is not part of either test's arrangement: it
+# is the difference between a test that failed and a `python -c` that spins on
+# a release file which, once `tmp_path` is cleaned up, can never appear
+# (RobTand/prismaquant#219).  One home for it, below, rather than a copy per
+# test -- and the exit is asserted, not merely arranged, because "this test
+# leaves nothing running" is a property of the test that a shared box pays for.
+# ---------------------------------------------------------------------------
+
+
+class _OrphanedHelper:
+    """The deliberately orphaned stage child, and its release file."""
+
+    def __init__(self, release_path: Path) -> None:
+        self.release_path = release_path
+        self.pid: int | None = None
+        self._ticks: int | None = None
+
+    def adopt(self, pid: int) -> None:
+        """Take the handle the child announced, with its start time, so a
+        recycled pid can never be mistaken for it."""
+        snapshot = campaign._proc_snapshot(pid)
+        assert snapshot is not None, (
+            f"the orphaned helper announced pid {pid}, which is not running"
+        )
+        self.pid, self._ticks = pid, snapshot[0]
+
+    def release(self) -> None:
+        """Let the child finish.  Idempotent, so a test can release in line
+        where the ordering is load-bearing and still be released on the way
+        out of any path that never reached that line."""
+        self.release_path.write_bytes(b"go")
+
+    def running(self) -> bool:
+        if self.pid is None or self._ticks is None:
+            return False
+        snapshot = campaign._proc_snapshot(self.pid)
+        return (snapshot is not None and snapshot[0] == self._ticks
+                and snapshot[1] != "Z")
+
+    def assert_exited(self) -> None:
+        """The property under test, not a side effect: nothing this test
+        started is still running when it ends."""
+        _wait_until(
+            lambda: not self.running(),
+            unmet=(
+                f"the deliberately orphaned helper (pid {self.pid}) is still "
+                "running after its release file landed, so this test would "
+                "have leaked a spinning process onto the box"
+            ),
+        )
+
+
+@contextlib.contextmanager
+def _orphaned_helper(release_path: Path):
+    """Own the release file for a child a test orphans on purpose.
+
+    On EVERY path out -- a passing test, a failing assertion, a wedged wait, a
+    `KeyboardInterrupt`, an interpreter dying between two lines -- the child is
+    released, and killed outright if it did not take the release.
+    """
+    helper = _OrphanedHelper(release_path)
+    try:
+        yield helper
+    finally:
+        helper.release()
+        if helper.running():
+            try:
+                if os.getpgid(helper.pid) == helper.pid:
+                    os.killpg(helper.pid, 9)  # its own session: take the group
+                else:
+                    os.kill(helper.pid, 9)
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
 
 
 def _digest(text: str) -> str:
@@ -678,10 +765,14 @@ def test_resume_after_coordinator_death_recovers_owned_helper_receipt(tmp_path):
     #    sleep to kill the coordinator.  Lose that and the coordinator finishes
     #    the campaign normally, so the resume has nothing to adopt and the
     #    "exact receipts recovered" assertion fails instead.
+    #
+    # It announces its PID rather than a marker word, so this test can hold a
+    # handle on the child it is about to orphan and assert it is gone at the
+    # end instead of hoping (#219).
     script = (
-        "from pathlib import Path; import sys, time; "
+        "from pathlib import Path; import os, sys, time; "
         "release=Path(sys.argv[2]); "
-        "Path(sys.argv[3]).write_bytes(b'started'); "
+        "Path(sys.argv[3]).write_text(str(os.getpid())); "
         "exec(\"while not release.exists():\\n time.sleep(0.02)\"); "
         "Path(sys.argv[1]).write_bytes(b'slow-done')"
     )
@@ -733,7 +824,12 @@ def test_resume_after_coordinator_death_recovers_owned_helper_receipt(tmp_path):
             and attempt["pid"] is not None
         )
 
-    try:
+    # Everything from here on runs with the helper's release owned by the
+    # context manager, because from the moment the coordinator dies nothing
+    # else can end that child: an assertion that fails, a wedged wait, or the
+    # session being killed between `terminate()` and the release used to leave
+    # it polling a file that `tmp_path` cleanup then made unreachable (#219).
+    with _orphaned_helper(release_path) as helper:
         # Nearly all of this latency is the coordinator's cold start rather
         # than its campaign work, so the wait is on the coordinator, not on a
         # clock.
@@ -757,46 +853,57 @@ def test_resume_after_coordinator_death_recovers_owned_helper_receipt(tmp_path):
             unmet="the coordinator never got a stage child running",
             alive=lambda: coordinator.poll() is None,
         )
-    except BaseException:
-        release_path.write_bytes(b"go")
-        raise
+        helper.adopt(int(started_path.read_text(encoding="utf-8").strip()))
 
-    coordinator.terminate()
-    _wait_until(
-        lambda: coordinator.poll() is not None,
-        unmet="coordinator did not exit after terminate()",
-    )
+        try:
+            coordinator.terminate()
+            _wait_until(
+                lambda: coordinator.poll() is not None,
+                unmet="coordinator did not exit after terminate()",
+            )
 
-    # Now let the orphaned helper finish, and wait on its receipt rather than
-    # on the clock. What this test asserts is that a resume ADOPTS a completed
-    # helper's work instead of redoing it -- so the helper has to have
-    # completed. Probing the instant the coordinator dies asserts something
-    # else: that the helper wins a race against the resume. It usually did,
-    # and lost under load, which is how this arrived in CI as a flake.
-    # The helper was deliberately orphaned, so this test holds no handle on it:
-    # the backstop is the only bound available here.
-    release_path.write_bytes(b"go")
-    _wait_until(
-        _nonempty(receipt_path),
-        unmet=(
-            "the orphaned helper never wrote its receipt, so there is nothing "
-            "for the resume to adopt -- the coordinator's termination most "
-            "likely took the helper with it"
-        ),
-    )
+            # Now let the orphaned helper finish, and wait on its receipt
+            # rather than on the clock. What this test asserts is that a resume
+            # ADOPTS a completed helper's work instead of redoing it -- so the
+            # helper has to have completed. Probing the instant the coordinator
+            # dies asserts something else: that the helper wins a race against
+            # the resume. It usually did, and lost under load, which is how
+            # this arrived in CI as a flake.  The release is written here, and
+            # again by `_orphaned_helper` on the way out, because the ordering
+            # matters on the passing path and the guarantee matters on all of
+            # them.
+            helper.release()
+            _wait_until(
+                _nonempty(receipt_path),
+                unmet=(
+                    "the orphaned helper never wrote its receipt, so there is "
+                    "nothing for the resume to adopt -- the coordinator's "
+                    "termination most likely took the helper with it"
+                ),
+            )
 
-    state = campaign.run_campaign_v2(
-        manifest, state_path, poll_interval=0.02
-    )
+            state = campaign.run_campaign_v2(
+                manifest, state_path, poll_interval=0.02
+            )
 
-    attempts = state["stages"]["slow-stage"]["attempts"]
-    assert len(attempts) == 1, (
-        "the resume started a second attempt instead of adopting the "
-        f"completed helper's work: {attempts}"
-    )
-    assert attempts[0]["status"] == "succeeded"
-    assert "exact receipts recovered" in attempts[0]["detail"]
-    assert receipt_path.read_bytes() == b"slow-done"
+            attempts = state["stages"]["slow-stage"]["attempts"]
+            assert len(attempts) == 1, (
+                "the resume started a second attempt instead of adopting the "
+                f"completed helper's work: {attempts}"
+            )
+            assert attempts[0]["status"] == "succeeded"
+            assert "exact receipts recovered" in attempts[0]["detail"]
+            assert receipt_path.read_bytes() == b"slow-done"
+            # The child this test orphaned on purpose has to be gone before
+            # the test is allowed to pass.
+            helper.assert_exited()
+        finally:
+            if coordinator.poll() is None:
+                coordinator.kill()
+                _wait_until(
+                    lambda: coordinator.poll() is not None,
+                    unmet="coordinator did not exit after kill() during cleanup",
+                )
 
 
 def test_abrupt_worker_death_leaves_stage_lock_owned_by_child(tmp_path):
@@ -849,75 +956,65 @@ def test_abrupt_worker_death_leaves_stage_lock_owned_by_child(tmp_path):
         stderr=subprocess.DEVNULL,
         start_new_session=True,
     )
-    child_pid = None
-    child_ticks = None
-    try:
-        assert worker.stdin is not None
-        worker.stdin.write(json.dumps(request).encode("utf-8"))
-        worker.stdin.close()
-        _wait_until(
-            _nonempty(child_pid_path),
-            unmet="the worker never launched the stage child",
-            alive=lambda: worker.poll() is None,
-        )
-        child_pid = int(child_pid_path.read_text(encoding="utf-8").strip())
-        snapshot = campaign._proc_snapshot(child_pid)
-        assert snapshot is not None
-        child_ticks = snapshot[0]
-
-        worker.kill()
-        _wait_until(
-            lambda: worker.poll() is not None,
-            unmet="worker did not exit after kill()",
-        )
-        # The child is still holding the lock by construction -- it is blocked
-        # on the release file -- so a short timeout here is the assertion, not
-        # a budget: the lock must refuse to open promptly.
-        with pytest.raises(TimeoutError, match="worker lock"):
-            campaign._worker_lock(
-                Path(request["lock_path"]),
-                Path(request["work_root"]),
-                timeout_seconds=1,
+    # `_orphaned_helper` owns "the child is unblocked, and gone, on every path
+    # out"; this test owns only its own worker (#219).
+    with _orphaned_helper(release_path) as helper:
+        try:
+            assert worker.stdin is not None
+            worker.stdin.write(json.dumps(request).encode("utf-8"))
+            worker.stdin.close()
+            _wait_until(
+                _nonempty(child_pid_path),
+                unmet="the worker never launched the stage child",
+                alive=lambda: worker.poll() is None,
             )
+            child_pid = int(child_pid_path.read_text(encoding="utf-8").strip())
+            helper.adopt(child_pid)
 
-        release_path.write_bytes(b"go")
-        # The stage child outlived its worker in its own process group, so its
-        # liveness is a pid probe rather than a Popen handle.  Waiting on the
-        # receipt to exist also keeps a slow box from turning this into a
-        # FileNotFoundError instead of a named failure.
-        _wait_until(
-            _nonempty(receipt_path),
-            unmet="the orphaned stage child never wrote its receipt",
-            alive=lambda: campaign._proc_snapshot(child_pid) is not None,
-        )
-        assert receipt_path.read_bytes() == b"orphan-complete"
-        # The child releases the lock by exiting, which it has not necessarily
-        # done at the instant the receipt lands.  Bound that on the backstop
-        # rather than on a guess at how long an interpreter takes to shut down.
-        lock_fd = campaign._worker_lock(
-            Path(request["lock_path"]),
-            Path(request["work_root"]),
-            timeout_seconds=_WEDGE_BACKSTOP_SECONDS,
-        )
-        os.close(lock_fd)
-    finally:
-        # Unblock the child on every path out of this test: a failure above
-        # must not leave an orphan spinning on a release file that never lands.
-        # Its worker is dead by then, so nothing else would enforce a bound.
-        release_path.write_bytes(b"go")
-        if worker.poll() is None:
             worker.kill()
             _wait_until(
                 lambda: worker.poll() is not None,
-                unmet="worker did not exit after kill() during cleanup",
+                unmet="worker did not exit after kill()",
             )
-        if child_pid is not None and child_ticks is not None:
-            snapshot = campaign._proc_snapshot(child_pid)
-            if snapshot is not None and snapshot[0] == child_ticks:
-                try:
-                    os.killpg(child_pid, 9)
-                except ProcessLookupError:
-                    pass
+            # The child is still holding the lock by construction -- it is
+            # blocked on the release file -- so a short timeout here is the
+            # assertion, not a budget: the lock must refuse to open promptly.
+            with pytest.raises(TimeoutError, match="worker lock"):
+                campaign._worker_lock(
+                    Path(request["lock_path"]),
+                    Path(request["work_root"]),
+                    timeout_seconds=1,
+                )
+
+            helper.release()
+            # The stage child outlived its worker in its own process group, so
+            # its liveness is a pid probe rather than a Popen handle.  Waiting
+            # on the receipt to exist also keeps a slow box from turning this
+            # into a FileNotFoundError instead of a named failure.
+            _wait_until(
+                _nonempty(receipt_path),
+                unmet="the orphaned stage child never wrote its receipt",
+                alive=lambda: campaign._proc_snapshot(child_pid) is not None,
+            )
+            assert receipt_path.read_bytes() == b"orphan-complete"
+            # The child releases the lock by exiting, which it has not
+            # necessarily done at the instant the receipt lands.  Bound that on
+            # the backstop rather than on a guess at how long an interpreter
+            # takes to shut down.
+            lock_fd = campaign._worker_lock(
+                Path(request["lock_path"]),
+                Path(request["work_root"]),
+                timeout_seconds=_WEDGE_BACKSTOP_SECONDS,
+            )
+            os.close(lock_fd)
+            helper.assert_exited()
+        finally:
+            if worker.poll() is None:
+                worker.kill()
+                _wait_until(
+                    lambda: worker.poll() is not None,
+                    unmet="worker did not exit after kill() during cleanup",
+                )
 
 
 def test_ambiguous_recorded_pid_fails_closed_without_killing_it(tmp_path):

--- a/tests/test_tessera_priced_export_inputs.py
+++ b/tests/test_tessera_priced_export_inputs.py
@@ -289,7 +289,12 @@ def test_the_digest_rule_is_tesseras_capture_seal(tmp_path):
     """Where the pinned Tessera publishes ``capture_sha256`` (release
     e78959e+), the producer's rule must reproduce it byte for byte and the
     gate cross-checks the two on every bind; at a pin that predates the seal
-    the gate reports the cross-check as unavailable."""
+    the gate reports the cross-check as unavailable.
+
+    This is the *runtime* half of the drift guard and it can only run where
+    the seal exists.  The roster half needs no ``capture_sha256`` and runs at
+    every pin: ``test_the_capture_context_roster_is_tesseras`` below.
+    """
     tessera_export = pytest.importorskip("tessera.export")
     source_cls = tessera_export.ActivationSource
     if not hasattr(source_cls, "capture_sha256"):
@@ -443,6 +448,113 @@ def test_the_priced_input_triple_matches_tesseras_roster():
 
     assert set(export.PRICED_HESSIAN_IDENTITY_FIELDS) == set(
         HESSIAN_IDENTITY_FIELDS)
+
+
+def test_the_capture_context_roster_is_tesseras():
+    """The other half of the same seal's roster, read from its owner.
+
+    Runs at **both** pins, unlike the runtime seal comparison: a tuple
+    equality needs no ``ActivationSource.capture_sha256``.
+
+    * At a Tessera that publishes ``CAPTURE_CONTEXT`` (the release tip), the
+      gate must have read the constant, not a typed copy of it -- compared as
+      an ordered tuple, not a set, because a rename leaves the set alone while
+      the digest's ``.get`` starts sealing ``None``.
+    * At a Tessera that predates the constant (the pinned dev 1221d2a), the
+      gate must be using the ONE documented fallback and saying so, since that
+      pin also has no ``capture_sha256`` and nothing else can see the roster.
+
+    RobTand/prismaquant#216: before this, the roster was typed at
+    ``tessera_export_lane.py:494`` and nothing read
+    ``tessera.export.CAPTURE_CONTEXT`` anywhere in the tree.
+    """
+    tessera_export = pytest.importorskip("tessera.export")
+    published = getattr(tessera_export, "CAPTURE_CONTEXT", None)
+    if published is None:
+        assert export.CAPTURE_CONTEXT_FIELDS == export._CAPTURE_CONTEXT_FALLBACK
+        assert export.CAPTURE_CONTEXT_FIELDS_SOURCE == \
+            export._CAPTURE_CONTEXT_FROM_FALLBACK
+        assert not hasattr(tessera_export.ActivationSource, "capture_sha256"), \
+            "a Tessera that seals but publishes no roster is a new state"
+        return
+    assert tuple(export.CAPTURE_CONTEXT_FIELDS) == tuple(published)
+    assert export.CAPTURE_CONTEXT_FIELDS_SOURCE == \
+        export._CAPTURE_CONTEXT_FROM_TESSERA
+
+
+def _pretend_tessera_publishes(monkeypatch, fields):
+    """Run as if the installed Tessera's ``CAPTURE_CONTEXT`` were ``fields``.
+
+    Patched at the module attribute the release tip publishes, so the refusal
+    is driven through the gate's real read of Tessera; at a pin that predates
+    the constant (1221d2a) there is no such attribute and the gate's own
+    reader is patched instead.  Either way ``CAPTURE_CONTEXT_FIELDS`` keeps
+    the roster it resolved at import -- which is the drift being staged.
+    """
+    tessera_export = pytest.importorskip("tessera.export")
+    if hasattr(tessera_export, "CAPTURE_CONTEXT"):
+        monkeypatch.setattr(tessera_export, "CAPTURE_CONTEXT", tuple(fields))
+    else:
+        monkeypatch.setattr(export, "_tessera_capture_context",
+                            lambda: tuple(fields))
+
+
+def test_a_capture_context_field_our_roster_lacks_refuses(monkeypatch):
+    """Failure state (a) of #216, and it needs no ``capture_sha256``.
+
+    A Tessera whose ``CAPTURE_CONTEXT`` names a field this roster lacks makes
+    the two digest rules cover different provenance.  Where the running
+    Tessera also predates the seal, ``_crosscheck_capture_seal`` compares
+    nothing, so two captures differing only in the new field digest
+    identically and ``require_priced_export_inputs`` binds an allocation to a
+    capture that did not price it -- #204's failure, reintroduced silently.
+    It is now refused by name, before a byte is digested, at every pin.
+    """
+    _pretend_tessera_publishes(
+        monkeypatch, tuple(export.CAPTURE_CONTEXT_FIELDS) + ("layout",))
+    with pytest.raises(export.TesseraExportLaneError,
+                       match="tessera.export.CAPTURE_CONTEXT names"):
+        export.hessian_capture_sha256(HESSIANS, {**TRIPLE,
+                                                 "hessian_role": "fit"})
+
+
+def test_the_roster_refusal_names_both_rosters_and_where_ours_came_from(
+        monkeypatch):
+    """A refusal an operator can act on: which fields each side names, which
+    are missing here, and whether ours was read from Tessera or fell back."""
+    _pretend_tessera_publishes(monkeypatch, ("model", "seqlen", "layout"))
+    with pytest.raises(export.TesseraExportLaneError) as excinfo:
+        export._require_capture_context_roster()
+    message = str(excinfo.value)
+    assert "missing here: ('layout',)" in message
+    assert "not in Tessera: ('source',)" in message
+    assert export.CAPTURE_CONTEXT_FIELDS_SOURCE in message
+
+
+def test_the_gate_refuses_a_bind_under_a_drifted_roster(tmp_path, monkeypatch):
+    """The roster refusal reaches the export gate itself, not only the digest
+    helper: nothing binds while the two rules cover different provenance."""
+    assignment = _assignment(
+        tmp_path, formats={DENSE_E4M3: "TESSERA_E4M3_K1_R1024"})
+    capture = _capture(tmp_path)
+    _pretend_tessera_publishes(
+        monkeypatch, tuple(export.CAPTURE_CONTEXT_FIELDS) + ("layout",))
+    with pytest.raises(export.TesseraExportLaneError,
+                       match="different provenance"):
+        export.require_priced_export_inputs(assignment, hessian_path=capture)
+
+
+def test_a_tessera_without_the_constant_uses_the_documented_fallback(
+        monkeypatch):
+    """The fallback is reached only through ``_tessera_capture_context``
+    returning None, and it is the tuple copied from tessera 3efd690 -- the one
+    place the roster is typed."""
+    monkeypatch.setattr(export, "_tessera_capture_context", lambda: None)
+    fields, source = export._capture_context_fields()
+    assert fields == export._CAPTURE_CONTEXT_FALLBACK == (
+        "model", "seqlen", "source")
+    assert source == export._CAPTURE_CONTEXT_FROM_FALLBACK
+    assert "3efd690" in source
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vendored_override_gate.py
+++ b/tests/test_vendored_override_gate.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import ast
 import json
+import textwrap
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -612,14 +613,34 @@ DETECTION_ENTRYPOINTS = {
 }
 
 
-def _handler_is_broad(handler: ast.ExceptHandler) -> bool:
-    """True for `except:`, `except Exception:`, `except BaseException:`."""
+#: Every class name whose `except` clause catches a `DeadVendoredOverrideError`
+#: — derived from the exception's own MRO, never typed, so the census follows
+#: the class if it is ever re-parented (RobTand/prismaquant#217). Today:
+#: `DeadVendoredOverrideError`, `RuntimeError`, `Exception`, `BaseException`.
+#: `RuntimeError` is in there deliberately: the class subclasses it so that
+#: "existing `except RuntimeError` handlers ... are unchanged" (its own
+#: docstring), which is exactly why such a handler swallows the refusal.
+CATCHES_DEAD_OVERRIDE = frozenset(
+    cls.__name__ for cls in DeadVendoredOverrideError.__mro__
+    if issubclass(cls, BaseException)
+)
+
+
+def _handler_catches_dead_override(handler: ast.ExceptHandler) -> bool:
+    """True when this `except` clause catches a `DeadVendoredOverrideError`.
+
+    `except:` catches everything; otherwise any clause naming a class in
+    :data:`CATCHES_DEAD_OVERRIDE` does, whether written bare (`RuntimeError`),
+    dotted (`builtins.Exception`, `registry.DeadVendoredOverrideError`) or
+    inside a tuple (`except (ImportError, RuntimeError):`).
+    """
     node = handler.type
     if node is None:
         return True
     parts = node.elts if isinstance(node, ast.Tuple) else [node]
     return any(
-        isinstance(p, ast.Name) and p.id in ("Exception", "BaseException")
+        (getattr(p, "id", None) or getattr(p, "attr", None))
+        in CATCHES_DEAD_OVERRIDE
         for p in parts
     )
 
@@ -632,23 +653,46 @@ def _handler_always_reraises(handler: ast.ExceptHandler) -> bool:
     from exc`, which refuses by name and keeps the cause. A handler that always
     raises never converts the refusal into an answer, so it needs no
     `DeadVendoredOverrideError` clause of its own.
+
+    Ending in a `raise` is necessary but not sufficient: a handler that
+    substitutes an answer on one branch and re-raises on the fall-through
+    answers a dead override on that branch (#217). So the body must also
+    contain no `return`, and no `break`/`continue` that would carry control
+    past the trailing `raise` into the enclosing loop. Two scopes are not the
+    handler's own and are not walked into: a nested function or class (its
+    `return` is its own) and a loop written inside the handler (its
+    `break`/`continue` binds there, not to the enclosing loop).
     """
-    return bool(handler.body) and isinstance(handler.body[-1], ast.Raise)
+    if not handler.body or not isinstance(handler.body[-1], ast.Raise):
+        return False
+    stack = [(stmt, True) for stmt in handler.body]
+    while stack:
+        sub, in_handler_loop = stack.pop()
+        if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef,
+                            ast.Lambda, ast.ClassDef)):
+            continue
+        if isinstance(sub, ast.Return):
+            return False
+        if in_handler_loop and isinstance(sub, (ast.Break, ast.Continue)):
+            return False
+        nested = in_handler_loop and not isinstance(
+            sub, (ast.For, ast.AsyncFor, ast.While))
+        stack.extend((child, nested) for child in ast.iter_child_nodes(sub))
+    return True
 
 
 def _refuses_dead_override(node: ast.Try) -> bool:
-    """True when a dead override escapes this `try` instead of being answered."""
+    """True when a dead override escapes this `try` instead of being answered.
+
+    Handlers are tried in source order, as Python does: the first one that
+    catches a `DeadVendoredOverrideError` is the one that decides, and it must
+    be unable to fall through to a substituted answer. A `try` no handler of
+    which catches it lets it escape, which is the point.
+    """
     for handler in node.handlers:
-        if _handler_is_broad(handler):
-            # Reached the catch-all without having refused first.
+        if _handler_catches_dead_override(handler):
             return _handler_always_reraises(handler)
-        named = handler.type
-        parts = named.elts if isinstance(named, ast.Tuple) else [named]
-        for part in parts:
-            name = getattr(part, "id", None) or getattr(part, "attr", None)
-            if name == "DeadVendoredOverrideError":
-                return True
-    return True  # no broad handler at all: nothing swallows it
+    return True  # nothing here catches it: the refusal escapes
 
 
 def _swallowing_detection_sites() -> list[str]:
@@ -674,6 +718,126 @@ def _swallowing_detection_sites() -> list[str]:
     return sorted(set(bad))
 
 
+def _census_flags(handler_source: str) -> bool:
+    """True when the census reports a detection call under this handler as
+    swallowing the refusal."""
+    tree = ast.parse("try:\n    profile = detect_profile(path)\n"
+                     + textwrap.dedent(handler_source).strip("\n"))
+    tries = [n for n in ast.walk(tree) if isinstance(n, ast.Try)]
+    assert len(tries) == 1, handler_source
+    return not _refuses_dead_override(tries[0])
+
+
+#: The handler shapes that answer a dead override instead of letting it out.
+#: The first three are #217's A, B and C — `DeadVendoredOverrideError`
+#: subclasses `RuntimeError` deliberately, so `except RuntimeError` catches it
+#: exactly as `except Exception` did; the fourth is D, a broad handler that
+#: substitutes on one branch and re-raises on the fall-through; the fifth is
+#: the shape #202 actually removed, kept as the control.
+SWALLOWING_HANDLERS = {
+    "except RuntimeError": """
+        except RuntimeError:
+            profile = None
+    """,
+    "except (ImportError, RuntimeError)": """
+        except (ImportError, RuntimeError):
+            profile = None
+    """,
+    "except builtins.Exception (dotted)": """
+        except builtins.Exception:
+            profile = None
+    """,
+    "broad handler returning before its raise": """
+        except Exception as exc:
+            if _looks_recoverable(exc):
+                return DefaultProfile()
+            raise
+    """,
+    "except DeadVendoredOverrideError that answers": """
+        except DeadVendoredOverrideError:
+            profile = None
+    """,
+    "control: except Exception (already caught pre-#217)": """
+        except Exception:
+            profile = None
+    """,
+}
+
+#: Shapes that do NOT answer a dead override and must stay unflagged, so the
+#: widening cannot start reporting correct sites (#217: "do not widen the
+#: census to catch shapes that do not swallow").
+REFUSING_HANDLERS = {
+    "the 28 live sites: named clause first, then broad": """
+        except DeadVendoredOverrideError:
+            raise
+        except Exception:
+            profile = None
+    """,
+    "dotted named clause first": """
+        except registry.DeadVendoredOverrideError:
+            raise
+        except Exception:
+            profile = None
+    """,
+    "sample_parallel_probe: broad, always re-raises by name": """
+        except Exception as exc:
+            raise SampleParallelProbeError("cannot prepare") from exc
+    """,
+    "tessera_export_lane: narrow clauses that do not catch it": """
+        except (OSError, ValueError, TypeError, KeyError):
+            raise TesseraExportLaneError("unreadable")
+    """,
+    "no handler at all": """
+        finally:
+            _close()
+    """,
+    "a loop inside the handler: its continue is not a fall-through": """
+        except Exception:
+            for note in notes:
+                if not note:
+                    continue
+                _log(note)
+            raise
+    """,
+}
+
+
+@pytest.mark.parametrize("shape", sorted(SWALLOWING_HANDLERS))
+def test_the_census_sees_every_handler_shape_that_swallows(shape):
+    """#217's A, B, C and D, plus the control.
+
+    `DeadVendoredOverrideError` subclasses `RuntimeError` so that "existing
+    `except RuntimeError` handlers and the gate's original contract are
+    unchanged" (`model_profiles/registry.py:98,114`) — which is precisely why
+    such a handler swallows the refusal, and `detect_profile` itself raises a
+    bare `RuntimeError` for a non-directory `model_path` (`registry.py:169`),
+    so narrowing one of these handlers from `Exception` to `RuntimeError` is
+    the ordinary edit that silently reopens #202 at that site. Pre-#217 the
+    census reported all of these as refusing.
+    """
+    assert _census_flags(SWALLOWING_HANDLERS[shape]), shape
+
+
+@pytest.mark.parametrize("shape", sorted(REFUSING_HANDLERS))
+def test_the_census_still_passes_the_shapes_that_refuse(shape):
+    """The widening must not start reporting sites that let the refusal out —
+    including every shape the live tree actually uses."""
+    assert not _census_flags(REFUSING_HANDLERS[shape]), shape
+
+
+def test_the_catching_roster_is_derived_from_the_exceptions_mro():
+    """One rule, one home: the class names that catch the refusal come from
+    `DeadVendoredOverrideError.__mro__`, so re-parenting the class moves the
+    census with it instead of leaving a second list to be edited by hand."""
+    assert CATCHES_DEAD_OVERRIDE == frozenset(
+        cls.__name__ for cls in DeadVendoredOverrideError.__mro__
+        if issubclass(cls, BaseException))
+    assert "RuntimeError" in CATCHES_DEAD_OVERRIDE
+    assert "object" not in CATCHES_DEAD_OVERRIDE  # not an exception clause
+    for name in CATCHES_DEAD_OVERRIDE:
+        assert _census_flags(f"except {name}:\n    profile = None"), name
+
+
 def test_no_call_site_swallows_the_dead_override_refusal():
     """The refusal must reach the operator from every detection call site.
 
@@ -694,7 +858,16 @@ def test_no_call_site_swallows_the_dead_override_refusal():
     fails for a call site added next month, which no per-site test would.
 
     The allowed shapes are (a) `except DeadVendoredOverrideError: raise` ahead
-    of the broad handler, or (b) a broad handler that always re-raises, which
-    is what `sample_parallel_probe` already did correctly.
+    of the handler that catches it, or (b) a handler that always re-raises,
+    which is what `sample_parallel_probe` already did correctly.
+
+    What this census does NOT cover, since it is cited as future-proofing
+    (#217): it is a syntactic walk of `prismaquant/`, so it cannot see a
+    detection call reached through an alias or a variable
+    (`fn = detect_profile; fn(path)`), a `getattr`/`importlib` dispatch, a
+    swallow one frame up in a caller's own `try`, an `except` clause whose
+    class is computed rather than named, or anything outside the package tree
+    (`scripts/`, notebooks, callers in other repositories). It pins the shape
+    of the 32 in-tree call sites, not the whole reachability graph.
     """
     assert _swallowing_detection_sites() == []


### PR DESCRIPTION
Three fixes filed by the audit pass, one commit each, on top of `553de0af`.

| | Issue | Sev | What changed |
|---|---|---|---|
| `b42beb01` | #216 | P2 | The export seal's capture-context roster is read from `tessera.export.CAPTURE_CONTEXT` instead of typed, with one documented fallback and a by-name refusal when the rosters disagree |
| `a33cb29c` | #217 | P3 | The dead-override census derives its catching class names from `DeadVendoredOverrideError.__mro__`, so `except RuntimeError` no longer hides a swallow |
| `26e63a16` | #219 | P3 | The resume-after-coordinator-death test can no longer leak the child it orphans on purpose, and now asserts it is gone |

Each commit shows its regression failing on `553de0af` first, carries the
pre-fix line, and re-stamps `docs/ARCHITECTURE.md` in the same commit
(principle 12).

## #216 — `CAPTURE_CONTEXT_FIELDS` had no owner

`tessera_export_lane.py:494` was the literal `("model", "seqlen", "source")`
and nothing in the tree read `tessera.export.CAPTURE_CONTEXT`, while its
sibling one screen up derives the identity triple from Tessera
(`tessera_hessian.HESSIAN_IDENTITY_FIELDS`) and a test pins the two together.
The rules agree today; a field added to Tessera's constant splits them, and at
a pin with no `ActivationSource.capture_sha256` (the dev pin `1221d2a`) the
split is silent — two captures differing only in the new field digest
identically and an allocation binds to a capture that did not price it, which
is #204's failure with no signal.

* `CAPTURE_CONTEXT_FIELDS, CAPTURE_CONTEXT_FIELDS_SOURCE =
  _capture_context_fields()` reads the constant where the running Tessera
  publishes it; otherwise `_CAPTURE_CONTEXT_FALLBACK` — the one place the
  roster is typed, commented with the Tessera it was copied from (0.1.0,
  release `3efd690`, `src/tessera/export.py:244`) — and it records which.
* `_require_capture_context_roster()`, called from `hessian_capture_sha256`
  before a byte is digested, re-reads the constant live and refuses by name
  when it is not the roster the digest covers. This is the half of the drift
  guard that needs no `capture_sha256`, so it holds at the dev pin; the
  campaign's `write_export_inputs` gets it through the same function.
* `test_the_capture_context_roster_is_tesseras` is the roster-equality pin the
  issue asked for, and it runs at **both** pins — a tuple comparison needs no
  seal. `test_the_digest_rule_is_tesseras_capture_seal` still skips at the dev
  pin for the runtime-seal comparison only.

No wire bytes, digest values, report keys or signatures change while the
rosters agree.

## #217 — the census could not see `except RuntimeError`

`DeadVendoredOverrideError` subclasses `RuntimeError` deliberately, so the
handler shape its own docstring invites swallowed the refusal and the census
reported the site as refusing. Four shapes were invisible: bare `RuntimeError`,
a tuple naming it, a dotted `builtins.Exception`, and a broad handler that
substitutes on one branch and re-raises on the fall-through.

`CATCHES_DEAD_OVERRIDE` now comes from `DeadVendoredOverrideError.__mro__`
(one rule, one home — re-parent the class and the census follows);
`_handler_catches_dead_override` matches bare, dotted and tuple clauses against
it; `_handler_always_reraises` additionally rejects a `return`, and a
`break`/`continue` that would carry control past the trailing `raise`.

**The widened census reports zero newly swallowing sites**, so no production
code changes: all 31 `try` blocks wrapping a detection call in `prismaquant/`
are still correct (25 `except DeadVendoredOverrideError: raise` then broad,
4 `try/finally`, 1 `SampleParallelProbeError` + broad-that-re-raises, 1 narrow
non-catching). The census's docstring now names what it does not cover, since
it is cited as future-proofing.

## #219 — an orphan-by-design helper that could outlive its test

The resume test kills the coordinator while a stage child polls a release file;
after #206 that wait is unbounded and the release write is the only thing that
can end it. The write sat outside the guard, so a failure in the ~dozen lines
after `coordinator.terminate()` left a `python -c` spinning at 50 Hz forever on
a file `tmp_path` cleanup then made unreachable.

`_orphaned_helper(release_path)` is now the one home for "the release always
happens": it releases and, if the child did not take the release, kills its
session on every path out. Both orphan-on-a-release-file tests use it, so the
sibling's hand-rolled `finally` and this test's `except BaseException` copy are
gone. The helper announces its PID, and `helper.assert_exited()` makes "this
test leaves nothing running" an assertion rather than an arrangement.

Deterministic pre/post demonstration: injecting an `AssertionError` into that
window on `553de0af` left the orphan behind (`LEAKED=2`, one of them the
scanner itself); the same injection on this tip leaves nothing (`LEAKED=1`,
only the scanner).

## Tests

sparklina, CPU only (`CUDA_VISIBLE_DEVICES=""`), real git worktree,
`/home/rob/venvs/pq-release/bin/python -m pytest -p no:cacheprovider`. Both
Tessera trees, since PQ's roster now depends on which one is importable.

Commands and counts are in the PR comment below.

Fixes #216
Fixes #217
Fixes #219
