### PR TITLE
Tessera campaign and export lane: ask the contract, not the format name (#221)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,49 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `claude/pq-183-packed-bridge`. Stamps
+As of: 2026-09-05 · `claude/pq-221`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-05, `claude/pq-221`) for **one home for "does this route
+execute a static activation contract"** (§5.1, §5.7; RobTand/prismaquant#221,
+P3). PR #213 (#205) made "which activation quantiser does this spec serve" a
+property of the spec (`FormatSpec.static_activation_contract`) and moved the
+assignment-KL hooks and the production cache scorer onto it; the Tessera
+campaign and export lane kept answering the same question by comparing the
+route's source-format NAME against `"NVFP4"`, in three places and two
+spellings — one of them a helper whose docstring was literally the question.
+The derivation now has one owner:
+`tessera_formats.route_static_activation_contract(route)` returns the contract
+of the registry row the route names (`activation_source_format`), and every
+consumer reads it. `tessera_render.synthesize_tessera_spec` re-stamps its
+result `measured_as_served=True` onto the rung's spec — the one step that
+stays where it was, because turning the ROW's contract into the SPEC's is a
+different question. `tessera_campaign._measure_anchor` prices and refuses
+through the spec's copy (`contract.quantize_dequantize` instead of a hardcoded
+`nvfp4_activation_qdq_served`, and a refusal naming `contract.execution`
+instead of a format name); `_format_executes_static_nvfp4` becomes
+`_format_executes_static_activation_contract` over the same spec field; and
+`tessera_export_lane`'s `--input-scales` gate calls the route accessor
+directly rather than `get_format(<rung>)`, which would reach
+`synthesize_tessera_spec` and pull the `tessera` package into a preflight
+built not to need it (that module's own docstring). **Nothing resolves
+differently today**: over all 80 registry rows `canonical_format_name(name) ==
+"NVFP4"` and `static_activation_contract is not None` agree exactly, and
+`NVFP4` is the only row carrying a contract. The regression is the day a
+second row gets one — `StaticActivationContract` is a general dataclass and
+`FormatSpec` types the field as a spec-level property, not an NVFP4 flag — and
+`test_static_activation_contract_one_home.py` constructs exactly that: with
+`FP8_E4M3` given a static contract the name compare answers "not NVFP4" while
+the cache scorer and the KL hooks, which already read the row, refuse the same
+unit; the campaign then stamps no `input_global_scale` and the export ships a
+unit whose static A-side scale nothing ever bound — the failure #205 was
+opened to close, at a different format name. **Machine-readable change**: the
+preflight report key `w4a4_units` is renamed
+`static_activation_contract_units`, because it can now hold units that are not
+W4A4; its only readers were this module and four test assertions, and no
+receipt, allocation JSON or shipcard carries it (the CLI serialises only
+`report["build"]`). Refusal texts in the campaign and the export lane now name
+the executed contract rather than "NVFP4". No default, format menu, serving
+lane, ship gate or byte changes.
 
 Re-stamped (2026-09-05, `claude/pq-183-packed-bridge`) for **the export lane
 handing the exporter the priced expert wires** (§4.10, §9.4; PrismaQuant
@@ -6398,6 +6440,18 @@ name. The contract's `measured_as_served` is the spec's measurement policy:
 served emulation is `PRISMAQUANT_NVFP4_ACT_EMULATE_SERVED_SCALES`), `True` on
 a Tessera W4A4 spec (§5.7). Dynamic W8A8 (FP8, MX) and A16 rows carry `None`.
 
+That spec-level answer has one derivation beneath it (#221):
+`tessera_formats.route_static_activation_contract(route)` returns the contract
+of the registry row a Tessera route names in `activation_source_format`.
+`tessera_render.synthesize_tessera_spec` re-stamps that result
+`measured_as_served=True` to build the rung's spec, so a consumer that reaches
+for `FormatSpec.static_activation_contract` and one that asks the route
+directly — `tessera_export_lane`'s `--input-scales` gate, which must not reach
+the synthesizer and pull in the `tessera` package — are reading the same row
+through the same rule, and cannot answer differently. A name compare would
+answer the same today only because `NVFP4` is the one row carrying a contract;
+the field is typed as a spec-level property, not an NVFP4 flag.
+
 ### 5.2 Scale rules and JSO
 
 NVFP4 scale rules live in the *exporter*, not the registry
@@ -6810,11 +6864,12 @@ exporter — `TESSERA_HESSIAN` (the campaign's `hessian_capture.pt`) and
 `TESSERA_INPUT_SCALES` (its `input_scales.safetensors`) — and
 `tessera_export_lane.require_priced_export_inputs` fails closed before the
 plan translation when the allocation's `tessera_hessian` stamp or its
-selected W4A4 routes declare a requirement the supplied files do not satisfy
+selected static-activation-contract routes declare a requirement the
+supplied files do not satisfy
 (#193): the artifact built must be the artifact priced. The binding is to
 content, not to names (#204): the allocation carries the campaign capture's
 `capture_sha256` (Tessera's own seal rule, `hessian_capture_sha256`) and the
-`input_global_scale` each selected W4A4 unit was priced under
+`input_global_scale` each selected static-contract unit was priced under
 (`tessera_activation_static_scales`), and the gate digests the `.pt` the
 exporter loads and reads each scalar from the safetensors file, refusing a
 payload, sidecar or value that is not what priced the row, and an allocation

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -291,24 +291,37 @@ def _measure_anchor(
     # the predicate reads and the plane the encode writes are this object --
     # not three lookups that agree only while nothing clears the recipe memo.
     wire = tessera_wire_recipe(family, rung)
-    # The A side, as served.  An NVFP4-materialising route executes vLLM's
-    # static-global-scale ``scaled_fp4_quant`` (UE4M3 block scales) against the
-    # artifact's ``trellis_input_global_scale``; every other route keeps the
-    # serving format's own dynamic quantiser, taken by reference from the spec.
+    # The A side, as served.  A route with a STATIC activation contract
+    # executes vLLM's static-global-scale ``scaled_fp4_quant`` (UE4M3 block
+    # scales) against the artifact's ``trellis_input_global_scale``; every
+    # other route keeps the serving format's own dynamic quantiser, taken by
+    # reference from the spec.
+    #
+    # WHICH of the two is the SPEC's answer, never a compare of the route's
+    # source-format name against ``"NVFP4"`` (#205's rule, #221's fix): the
+    # spec resolved above already carries the contract, because
+    # ``synthesize_tessera_spec`` derived it from the registry row the route
+    # names.  A Tessera rung routed through the same kernel has the same
+    # contract and a different name, and the day a second registry row gets a
+    # contract, a name compare here would price it under a quantiser the
+    # runtime never runs while the cache scorer and the KL hooks -- which
+    # already read the row -- refuse the same unit.
     route = tessera_serving_route(family, wire, rung)
-    if route.activation_source_format == "NVFP4":
+    contract = spec.static_activation_contract
+    if contract is not None:
         if static_input_scale is None or not float(static_input_scale) > 0:
             raise ActivationScaleContractError(
                 f"{qname} {format_name}: this rung's route executes the "
-                f"static NVFP4 activation contract ({route.contract}) and no "
-                "calibrated input_global_scale was supplied. Scoring it with "
-                "the registry's dynamic FP32-scale quantiser would price an "
-                "activation regime the serve does not execute; a lookup that "
-                "misses must refuse, not fall back."
+                f"static activation contract {contract.execution} "
+                f"({route.contract}) and no calibrated input_global_scale was "
+                "supplied. Scoring it with the registry's dynamic FP32-scale "
+                "quantiser would price an activation regime the serve does "
+                "not execute; a lookup that misses must refuse, not fall back."
             )
         input_scale = float(static_input_scale)
+        # The contract's own oracle, not a second spelling of it.
         activation_qdq = (
-            lambda x: fr.nvfp4_activation_qdq_served(x, input_scale))
+            lambda x: contract.quantize_dequantize(x, input_scale))
     else:
         input_scale = None
         activation_qdq = spec.activation_quantize_dequantize
@@ -1201,16 +1214,18 @@ def _population_block(*, dense_priced, expert_priced, dense_all, pinned,
     }
 
 
-def _format_executes_static_nvfp4(format_name: str) -> bool:
-    """Does this rung's route execute the static NVFP4 activation contract?"""
-    from .tessera_formats import (
-        parse_tessera_format_name, tessera_serving_route, tessera_wire_recipe,
-    )
+def _format_executes_static_activation_contract(format_name: str) -> bool:
+    """Does this rung's route execute a STATIC activation contract?
 
-    family, rung = parse_tessera_format_name(format_name)
-    wire = tessera_wire_recipe(family, rung)
-    return tessera_serving_route(
-        family, wire, rung).activation_source_format == "NVFP4"
+    The spec's answer (``FormatSpec.static_activation_contract``), which
+    ``synthesize_tessera_spec`` derives from the registry row the rung's route
+    names -- never a compare of that row's NAME against ``"NVFP4"`` (#205,
+    #221).  Same field ``_measure_anchor`` prices through, so the rung this
+    refuses to resume is exactly the rung it refuses to score.
+    """
+    from . import format_registry as fr
+
+    return fr.get_format(format_name).static_activation_contract is not None
 
 
 def _require_resumable_anchor(anchor: CampaignAnchor, static_scales) -> None:
@@ -1228,7 +1243,7 @@ def _require_resumable_anchor(anchor: CampaignAnchor, static_scales) -> None:
     served A side, and merging one silently is the exact mixed-table failure
     the Hessian identity guard exists to catch on its own axis.
     """
-    if not _format_executes_static_nvfp4(anchor.format_name):
+    if not _format_executes_static_activation_contract(anchor.format_name):
         if anchor.input_global_scale is not None:
             raise ActivationScaleContractError(
                 f"checkpoint anchor {anchor.qname} {anchor.format_name} "

--- a/prismaquant/tessera_export_lane.py
+++ b/prismaquant/tessera_export_lane.py
@@ -815,18 +815,20 @@ def require_priced_export_inputs(
       unbound and refused by name, never read as "any capture of this draw".
 
     * **The static activation scales.**  Every selected rung whose route
-      executes the static NVFP4 contract was priced under a calibrated
-      ``input_global_scale``, and the exporter refuses NVFP4 routes without
+      executes a static activation contract was priced under a calibrated
+      ``input_global_scale``, and the exporter refuses such routes without
       ``--input-scales`` -- but only after encoding everything else.  This
-      gate requires the file, every selected W4A4 unit's key in it, and (#204)
+      gate requires the file, every selected such unit's key in it, and (#204)
       that the VALUE under each key is the value the allocation's
       ``tessera_activation_static_scales`` block says priced that unit,
-      before a single unit is encoded.
+      before a single unit is encoded.  Which rungs those are is the registry
+      row's answer, not its name's (#221).
     """
     from .footprint import _read_safetensors_header
     from .layer_config import load_assignment, read_layer_config_metadata
     from .tessera_formats import (
-        parse_tessera_format_name, tessera_serving_route, tessera_wire_recipe,
+        parse_tessera_format_name, route_static_activation_contract,
+        tessera_serving_route, tessera_wire_recipe,
     )
 
     selected = {name: fmt for name, fmt in load_assignment(assignment_path).items()
@@ -835,7 +837,8 @@ def require_priced_export_inputs(
         "hessian_required": False, "hessian": None,
         "hessian_capture_sha256": None, "hessian_capture_seal_crosscheck": None,
         "input_scales_required": False, "input_scales": None,
-        "w4a4_units": 0, "input_scales_bound_units": 0,
+        "static_activation_contract_units": 0,
+        "input_scales_bound_units": 0,
     }
     if not selected:
         return report
@@ -934,7 +937,15 @@ def require_priced_export_inputs(
             "the flag, or re-price with --hessian require."
         )
 
-    w4a4 = []
+    # Which selected units need a calibrated static A-side scale is the answer
+    # of the registry row the rung's route names, read through the one
+    # derivation that owns it (``route_static_activation_contract``) -- never a
+    # compare of that row's NAME against "NVFP4" (#205's rule, #221's fix).
+    # The ROUTE accessor and not ``format_registry.get_format(fmt)``: resolving
+    # a Tessera rung by name reaches ``synthesize_tessera_spec``, which imports
+    # the ``tessera`` package, and this preflight gates without it (see this
+    # module's docstring).  The accessor reads a plain registry row instead.
+    static_contract_units = []
     for name, fmt in sorted(selected.items()):
         parsed = parse_tessera_format_name(fmt)
         if parsed is None:
@@ -942,18 +953,19 @@ def require_priced_export_inputs(
                 f"{name}: {fmt!r} is not a Tessera format name")
         family, rung = parsed
         wire = tessera_wire_recipe(family, rung)
-        if tessera_serving_route(
-                family, wire, rung).activation_source_format == "NVFP4":
-            w4a4.append(name)
-    report["w4a4_units"] = len(w4a4)
-    if w4a4:
+        route = tessera_serving_route(family, wire, rung)
+        if route_static_activation_contract(route) is not None:
+            static_contract_units.append(name)
+    report["static_activation_contract_units"] = len(static_contract_units)
+    if static_contract_units:
         report["input_scales_required"] = True
         if input_scales_path is None:
             raise TesseraExportLaneError(
-                f"{len(w4a4)} selected unit(s) execute the static NVFP4 "
-                "activation contract (first: " + w4a4[0] + ") and no "
+                f"{len(static_contract_units)} selected unit(s) execute a "
+                "static activation contract (first: "
+                + static_contract_units[0] + ") and no "
                 "--input-scales file was supplied. The exporter requires one "
-                "input_global_scale per W4A4 module and would refuse -- after "
+                "input_global_scale per such module and would refuse -- after "
                 "encoding everything else. Pass TESSERA_INPUT_SCALES= the "
                 "campaign's input_scales.safetensors (written beside its "
                 "--cache-dir), whose values are the scales the costs were "
@@ -968,37 +980,38 @@ def require_priced_export_inputs(
             priced_block, Mapping) else None
         if not isinstance(priced_units, Mapping):
             raise TesseraExportLaneError(
-                f"{len(w4a4)} selected unit(s) execute the static NVFP4 "
-                "activation contract but the allocation's metadata carries "
-                "no tessera_activation_static_scales block, so the "
+                f"{len(static_contract_units)} selected unit(s) execute a "
+                "static activation contract but the allocation's metadata "
+                "carries no tessera_activation_static_scales block, so the "
                 "input_global_scale each was priced under is unbound and "
                 "the file's values cannot be checked. This allocation came "
                 "from a pre-#204 allocator; re-allocate from the campaign's "
                 "cost table, whose rows carry the priced scale."
             )
-        unpriced = [name for name in w4a4
+        unpriced = [name for name in static_contract_units
                     if not isinstance(priced_units.get(name), (int, float))
                     or isinstance(priced_units.get(name), bool)]
         if unpriced:
             raise TesseraExportLaneError(
                 "the allocation priced no input_global_scale for selected "
-                f"W4A4 unit(s) {unpriced[:5]}{'...' if len(unpriced) > 5 else ''}"
+                f"unit(s) {unpriced[:5]}{'...' if len(unpriced) > 5 else ''}"
                 " (tessera_activation_static_scales.units has no numeric "
                 "value for them); a static-contract unit whose priced scale "
                 "is unknown cannot be bound to any file. Re-run the campaign "
-                "so every W4A4 row carries its scale, and re-allocate."
+                "so every static-contract row carries its scale, and "
+                "re-allocate."
             )
         input_scales_path = Path(input_scales_path)
         if not input_scales_path.is_file():
             raise TesseraExportLaneError(
                 f"--input-scales {input_scales_path} does not exist")
         header = _read_safetensors_header(str(input_scales_path))
-        missing = [name for name in w4a4
+        missing = [name for name in static_contract_units
                    if f"{name}.input_global_scale" not in header]
         if missing:
             raise TesseraExportLaneError(
                 f"--input-scales {input_scales_path} carries no "
-                "input_global_scale for selected W4A4 unit(s) "
+                "input_global_scale for selected static-contract unit(s) "
                 f"{missing[:5]}{'...' if len(missing) > 5 else ''}; the "
                 "exporter's fused join cannot invent a member's scale, and a "
                 "partial file exports a module the costs did not price."
@@ -1007,13 +1020,13 @@ def require_priced_export_inputs(
 
         with safe_open(str(input_scales_path), framework="pt",
                        device="cpu") as handle:
-            for name in w4a4:
+            for name in static_contract_units:
                 tensor = handle.get_tensor(f"{name}.input_global_scale")
                 if tensor.numel() != 1:
                     raise TesseraExportLaneError(
                         f"--input-scales {input_scales_path}: "
                         f"{name}.input_global_scale has shape "
-                        f"{list(tensor.shape)}; the static NVFP4 contract "
+                        f"{list(tensor.shape)}; a static activation contract "
                         "reads one scalar per unit and nothing else can be "
                         "compared with the priced scale."
                     )
@@ -1043,7 +1056,7 @@ def require_priced_export_inputs(
                         "this file."
                     )
         report["input_scales"] = str(input_scales_path)
-        report["input_scales_bound_units"] = len(w4a4)
+        report["input_scales_bound_units"] = len(static_contract_units)
     return report
 
 
@@ -1154,7 +1167,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--input-scales", default=None,
                         help="safetensors of <unit>.input_global_scale (the "
                              "campaign's input_scales.safetensors); required "
-                             "to cover every selected W4A4 unit")
+                             "to cover every selected unit whose route "
+                             "executes a static activation contract")
     parser.add_argument("--target-profile", default=None,
                         help="serving profile supplying or cross-checking the exact platform")
     parser.add_argument("--write-build-json", default=None,

--- a/prismaquant/tessera_formats.py
+++ b/prismaquant/tessera_formats.py
@@ -1395,6 +1395,41 @@ def tessera_serving_route(
     return _KERNEL_ROUTE
 
 
+def route_static_activation_contract(
+    route: TesseraServingRoute,
+) -> "StaticActivationContract | None":
+    """The A-side served STATIC-scale contract of ``route``, or None.
+
+    "Does this route execute a static per-unit activation scale" has exactly
+    one derivation, and it is this one: the route names the registry row whose
+    contract it executes (``activation_source_format``), and **the row owns the
+    answer** (``FormatSpec.static_activation_contract``).  Never a compare of
+    that name against ``"NVFP4"`` -- which is the same rule
+    ``StaticActivationContract``'s own docstring states for specs, one level
+    down (#205), and the same shape as :func:`_hardware_min_sm` above, which
+    takes the capability floor by reference from the terminal row rather than
+    restating it.
+
+    A name compare answers the same question today only because ``NVFP4`` is
+    the single row carrying a contract; the field is typed as a spec-level
+    property, not an NVFP4 flag, so the day a second row gets one the compare
+    silently splits the pipeline in two (#221).
+
+    Returned as the CONTRACT, not a bool, because the consumers need what is
+    in it: ``tessera_render.synthesize_tessera_spec`` re-stamps it
+    ``measured_as_served=True`` onto the rung's spec, and the campaign prices
+    and refuses through ``execution`` and ``quantize_dequantize``.  A bool
+    would have sent each of them back to the row for the rest.
+    """
+    source = route.activation_source_format
+    if source is None:
+        # Weight-only (or unquantised-A) route: no A-side row, so no contract.
+        return None
+    from . import format_registry as fr
+
+    return fr.get_format(source).static_activation_contract
+
+
 def materialised_terminal_format(
     family: "str | TesseraFamily",
     recipe: "WireRecipe | None" = None,

--- a/prismaquant/tessera_render.py
+++ b/prismaquant/tessera_render.py
@@ -702,8 +702,8 @@ def synthesize_tessera_spec(
     from . import format_registry as fr
     from .tessera_footprint import TesseraShapeRate
     from .tessera_formats import (
-        artifact_bpp, scale_plane_name, tessera_serving_route,
-        tessera_wire_recipe,
+        artifact_bpp, route_static_activation_contract, scale_plane_name,
+        tessera_serving_route, tessera_wire_recipe,
     )
 
     parsed = parse_tessera_format_name(name)
@@ -782,10 +782,17 @@ def synthesize_tessera_spec(
     else:
         source = fr.get_format(route.activation_source_format)
         activation_qdq = source.activation_quantize_dequantize
+        # WHICH static contract the A side executes is not asked here: it is
+        # ``tessera_formats.route_static_activation_contract``'s one derivation
+        # off the row the route names (#221), shared with the campaign and the
+        # export lane so the three cannot answer it differently.  What stays
+        # here is the step
+        # that is genuinely this function's -- turning the ROW's contract into
+        # the SPEC's by re-stamping the measurement policy.
+        source_contract = route_static_activation_contract(route)
         static_activation_contract = (
-            None if source.static_activation_contract is None
-            else dataclasses.replace(
-                source.static_activation_contract, measured_as_served=True)
+            None if source_contract is None
+            else dataclasses.replace(source_contract, measured_as_served=True)
         )
 
     # The layer_config entry, which is how an allocation survives the trip to

--- a/tests/test_allocator_tessera_priced_inputs.py
+++ b/tests/test_allocator_tessera_priced_inputs.py
@@ -91,7 +91,8 @@ def test_the_allocation_carries_the_digest_and_the_priced_scales(
     report = export.require_priced_export_inputs(
         layer, hessian_path=capture, input_scales_path=scales)
     assert report["hessian_capture_sha256"] == digest
-    assert report["w4a4_units"] == report["input_scales_bound_units"] == 3
+    assert (report["static_activation_contract_units"]
+            == report["input_scales_bound_units"] == 3)
 
 
 def test_the_gate_refuses_other_files_against_that_allocation(

--- a/tests/test_static_activation_contract_one_home.py
+++ b/tests/test_static_activation_contract_one_home.py
@@ -1,0 +1,265 @@
+"""One home for "does this route execute a static activation contract" (#221).
+
+PR #213 (#205) made "which activation quantiser does this spec serve" a
+property of the spec -- ``FormatSpec.static_activation_contract``, reached
+through the registry row that owns it -- and moved the assignment-KL hooks and
+the production cache scorer onto it.  Three call sites kept answering the same
+question by comparing the route's *source-format name* against ``"NVFP4"``:
+``tessera_campaign._measure_anchor``, ``tessera_campaign``'s own
+``_format_executes_static_nvfp4``, and ``tessera_export_lane``'s
+``--input-scales`` gate.
+
+Nothing moves today, and the first test below is the proof: over all 80
+registry rows the two predicates coincide exactly, and ``NVFP4`` is the only
+row carrying a contract.  The rest of the file is the failure that is one
+registry line away.  ``StaticActivationContract`` is a general dataclass with
+``execution``/``group_size`` fields, and ``FormatSpec`` types the field as a
+spec-level property rather than an NVFP4 flag -- so the day a SECOND row gets
+one, a name compare says "not NVFP4" while the row says "static contract", and
+the two halves of #204/#205 disagree about the same rung: the scorer and the
+KL hooks refuse to price it, or the export ships a unit whose static A-side
+scale nothing ever bound.
+
+``fp8_gains_a_static_contract`` builds exactly that world -- the issue's own
+worked example, ``FP8_E4M3`` gaining a static per-tensor scale -- so every
+assertion here is a real regression rather than a pin.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from prismaquant import format_registry as fr
+from prismaquant import nvfp4_activation_contract as owner
+from prismaquant.tessera_formats import (
+    parse_tessera_format_name,
+    route_static_activation_contract,
+    tessera_serving_route,
+    tessera_wire_recipe,
+)
+
+#: An E2M1 rung over a per-16 block plane: the NVFP4 A side, the one static
+#: contract that exists today.
+W4A4 = "TESSERA_E2M1_K2_R896"
+#: An E4M3 rung over a CHANNEL plane: dynamic W8A8 today, and the rung the
+#: issue's worked example turns into a static-contract route.
+W8A8 = "TESSERA_E4M3_K1_R1024"
+#: A BF16 rung: no A-side registry row at all, so no contract either way.
+A16 = "TESSERA_BF16_K1_R4096"
+
+UNIT = "model.layers.0.self_attn.o_proj"
+TRIPLE = {"text_sha256": "a" * 64, "fit_ids_sha256": "b" * 64,
+          "fit_tokens": 4096}
+
+
+def _route(format_name: str):
+    family, rung = parse_tessera_format_name(format_name)
+    return tessera_serving_route(family, tessera_wire_recipe(family, rung), rung)
+
+
+@pytest.fixture
+def fp8_gains_a_static_contract(monkeypatch):
+    """The hazard #221 names, made real: a SECOND row gets a contract.
+
+    One ``dataclasses.replace`` in a distant file -- which is the point.  The
+    execution string is deliberately NOT an NVFP4 one, so a refusal that still
+    says "NVFP4" is visibly restating a name instead of reading the contract.
+    ``group_size`` stays 16 only so the contract's oracle remains callable;
+    nothing here asserts anything about FP8 numerics.
+    """
+    row = fr.REGISTRY["FP8_E4M3"]
+    assert row.static_activation_contract is None, (
+        "fixture precondition: FP8_E4M3 must not already carry a contract")
+    contract = owner.StaticActivationContract(
+        execution="e4m3_per_tensor_static", group_size=16)
+    monkeypatch.setitem(
+        fr.REGISTRY, "FP8_E4M3",
+        dataclasses.replace(row, static_activation_contract=contract))
+    return contract
+
+
+# --------------------------------------------------------------- nothing moves
+
+def test_the_two_predicates_coincide_over_the_whole_registry_today():
+    """The auditor's proof, kept as a pin: this fix changes no resolution.
+
+    If a second row ever gains a contract this test is the one that must be
+    updated -- deliberately, by whoever adds it -- and by then every consumer
+    already reads the row rather than the name.
+    """
+    rows = sorted(fr.REGISTRY)
+    assert len(rows) == 80, (
+        f"the registry grew to {len(rows)} rows; re-derive the equivalence "
+        "below before trusting it")
+    by_name = {n for n in rows if fr.canonical_format_name(n) == "NVFP4"}
+    by_contract = {n for n in rows
+                   if fr.REGISTRY[n].static_activation_contract is not None}
+    assert by_name == by_contract == {"NVFP4"}
+
+
+def test_the_live_routes_are_unchanged_by_the_derivation():
+    assert route_static_activation_contract(_route(W4A4)) is not None
+    assert route_static_activation_contract(_route(W8A8)) is None
+    assert route_static_activation_contract(_route(A16)) is None
+    # A16's route names no A-side row at all; the accessor must not go looking.
+    assert _route(A16).activation_source_format is None
+
+
+def test_the_accessor_reads_the_row_the_route_names():
+    """Not a hardcoded table: the contract returned IS the row's own object."""
+    route = _route(W4A4)
+    assert route.activation_source_format == "NVFP4"
+    assert (route_static_activation_contract(route)
+            is fr.REGISTRY["NVFP4"].static_activation_contract)
+
+
+# ------------------------------------------------- one home, three consumers
+
+def test_the_spec_answer_and_the_route_answer_are_the_same_answer(
+        fp8_gains_a_static_contract):
+    """The campaign asks the spec, the export lane asks the route.
+
+    Two spellings are allowed only because one is computed from the other:
+    ``synthesize_tessera_spec`` derives the spec's contract by calling
+    ``route_static_activation_contract``.  This pins that they cannot drift --
+    in both worlds, including the one where a second row has a contract.
+    """
+    for name in (W4A4, W8A8, A16):
+        spec_says = fr.get_format(name).static_activation_contract is not None
+        route_says = route_static_activation_contract(_route(name)) is not None
+        assert spec_says == route_says, name
+
+
+def test_a_second_contract_reaches_the_synthesized_spec(
+        fp8_gains_a_static_contract):
+    """The render half already read the row, so this passed before #221 --
+    which is precisely why the other three sites disagreeing was a split."""
+    contract = fr.get_format(W8A8).static_activation_contract
+    assert contract is not None
+    assert contract.execution == "e4m3_per_tensor_static"
+    # A Tessera rung has no dynamic serving path, so the served oracle is the
+    # measurement whatever the source row's own screen policy is.
+    assert contract.measured_as_served is True
+    assert fr.REGISTRY["FP8_E4M3"].static_activation_contract.measured_as_served is False
+
+
+def test_the_campaign_predicate_follows_the_contract_not_the_name(
+        fp8_gains_a_static_contract):
+    from prismaquant.tessera_campaign import (
+        _format_executes_static_activation_contract as executes,
+    )
+
+    assert executes(W4A4) is True
+    assert executes(A16) is False
+    # The name compare answers False here: "FP8_E4M3" is not "NVFP4".
+    assert executes(W8A8) is True
+
+
+def test_the_campaign_refuses_a_second_contract_without_its_scale(
+        monkeypatch, tmp_path, fp8_gains_a_static_contract):
+    """The #205 refusal, at a format whose name contains no "NVFP4".
+
+    Without this the campaign scores the rung under the registry's dynamic
+    quantiser and stamps no ``input_global_scale``, while the cache scorer and
+    the KL hooks -- which already read the row -- refuse the same unit.  The
+    refusal must also name the contract it read, not a format it did not.
+    """
+    from types import SimpleNamespace
+
+    from prismaquant import tessera_campaign as campaign
+
+    def _must_not_encode(*a, **k):
+        raise AssertionError("the refusal must precede the encode")
+
+    monkeypatch.setattr(campaign, "_encode_and_render", _must_not_encode)
+    with pytest.raises(campaign.ActivationScaleContractError,
+                       match="e4m3_per_tensor_static"):
+        campaign._measure_anchor(
+            qname="m.q_proj",
+            weight=torch.randn(32, 256, dtype=torch.bfloat16),
+            activations=torch.randn(8, 256),
+            format_name=W8A8,
+            cache=SimpleNamespace(weights={}, cache_dir=None),
+            wire_dir=tmp_path, hessian_required=False,
+            static_input_scale=None)
+
+
+def test_the_resume_guard_follows_the_contract(fp8_gains_a_static_contract):
+    """A resumed row of a second-contract rung is a pre-contract price too."""
+    from prismaquant.tessera_campaign import (
+        ActivationScaleContractError, CampaignAnchor, _require_resumable_anchor,
+    )
+
+    anchor = CampaignAnchor(
+        qname="m.up", family="TESSERA_E4M3_K1", format_name=W8A8,
+        body_rate_q256=1024, dloss=1e-3, dloss_stderr=0.0,
+        memory_bytes=1000, bits_per_param=4.0,
+        activation_contract="w8a8-dynamic-e4m3-channel",
+        activation_quantized=True, wire_bytes=1000, seconds=1.0)
+    with pytest.raises(ActivationScaleContractError,
+                       match="pre-served-.*contract"):
+        _require_resumable_anchor(anchor, {"m.up": 71.68})
+    _require_resumable_anchor(
+        dataclasses.replace(anchor, input_global_scale=71.68), {"m.up": 71.68})
+
+
+def _assignment(tmp_path, format_name):
+    """The minimal weights-only allocation the export gate will read."""
+    path = tmp_path / "layer_config.json"
+    path.write_text(json.dumps({
+        UNIT: {"data_type": "tessera", "bits": 4,
+               "tessera_format": format_name},
+        "__prismaquant__": {
+            "tessera_hessian": {"supplied": False, **TRIPLE}},
+    }))
+    return path
+
+
+def test_the_export_gate_follows_the_contract_not_the_name(
+        tmp_path, fp8_gains_a_static_contract):
+    """Otherwise the export ships a unit whose static A-side scale nothing
+    bound -- the failure #205 was opened to close, at a different name."""
+    from prismaquant import tessera_export_lane as export
+
+    with pytest.raises(export.TesseraExportLaneError,
+                       match="static activation contract.*--input-scales"):
+        export.require_priced_export_inputs(_assignment(tmp_path, W8A8))
+
+
+def test_the_export_gate_still_ignores_a_route_with_no_contract(tmp_path):
+    """No fixture: FP8_E4M3 has no contract, so the E4M3 rung needs no file."""
+    from prismaquant import tessera_export_lane as export
+
+    report = export.require_priced_export_inputs(_assignment(tmp_path, W8A8))
+    assert report["input_scales_required"] is False
+    assert report["static_activation_contract_units"] == 0
+
+
+def test_the_export_gate_does_not_import_the_tessera_package(tmp_path):
+    """``tessera_export_lane`` gates without importing ``tessera`` (its own
+    module docstring), so the gate must not reach ``synthesize_tessera_spec``.
+
+    ``route_static_activation_contract`` reads a plain registry row
+    (``NVFP4``/``FP8_E4M3``) and never a synthesized Tessera spec, which is
+    why the export lane uses it rather than ``fr.get_format(<rung>)``.
+    """
+    import prismaquant.tessera_render as tr
+
+    def _must_not_synthesize(*a, **k):
+        raise AssertionError(
+            "the export gate reached synthesize_tessera_spec; that pulls the "
+            "tessera package into a preflight built not to need it")
+
+    original = tr.synthesize_tessera_spec
+    tr.synthesize_tessera_spec = _must_not_synthesize
+    try:
+        from prismaquant import tessera_export_lane as export
+
+        report = export.require_priced_export_inputs(_assignment(tmp_path, W8A8))
+    finally:
+        tr.synthesize_tessera_spec = original
+    assert report["static_activation_contract_units"] == 0

--- a/tests/test_static_activation_contract_one_home.py
+++ b/tests/test_static_activation_contract_one_home.py
@@ -147,6 +147,42 @@ def test_a_second_contract_reaches_the_synthesized_spec(
     assert fr.REGISTRY["FP8_E4M3"].static_activation_contract.measured_as_served is False
 
 
+def test_the_campaign_predicate_answers_every_rung_as_the_name_compare_did():
+    """Replacing the name compare moved no answer -- it only widened.
+
+    Checked against the old body verbatim, because "nothing resolves
+    differently" is the claim this change rests on.  On every input the helper
+    is actually called with (``anchor.format_name``, always a Tessera rung) the
+    two agree.  Where they differ, the old one *raised* and the new one
+    answers: the old body unpacked ``parse_tessera_format_name`` without
+    checking for None, so it died with ``TypeError`` on any non-Tessera name;
+    a plain registry row now gets the row's own answer.  A widening of the
+    domain, not a changed answer -- and after #218 made ``canonical_format_name``
+    resolve case-insensitively, that includes ``INT4_W4A16_g128``, the one
+    mixed-case registered row, which must classify False rather than raise.
+    """
+    from prismaquant.tessera_campaign import (
+        _format_executes_static_activation_contract as new,
+    )
+
+    def old(format_name):
+        family, rung = parse_tessera_format_name(format_name)
+        return tessera_serving_route(
+            family, tessera_wire_recipe(family, rung), rung
+        ).activation_source_format == "NVFP4"
+
+    for name in (W4A4, W8A8, A16):
+        assert new(name) == old(name), name
+
+    # Non-Tessera rows: the old body raised, the new one answers.
+    for name, expected in (("NVFP4", True), ("FP8_E4M3", False),
+                           ("BF16", False), ("INT4_W4A16_g128", False),
+                           ("INT4_W4A16_G128", False)):
+        assert new(name) is expected, name
+        with pytest.raises(TypeError):
+            old(name)
+
+
 def test_the_campaign_predicate_follows_the_contract_not_the_name(
         fp8_gains_a_static_contract):
     from prismaquant.tessera_campaign import (

--- a/tests/test_tessera_campaign.py
+++ b/tests/test_tessera_campaign.py
@@ -366,7 +366,7 @@ def test_a_w4a4_anchor_with_no_static_scale_refuses_before_encoding(
     from types import SimpleNamespace
 
     with pytest.raises(campaign.ActivationScaleContractError,
-                       match="static NVFP4 activation contract"):
+                       match="static activation contract"):
         campaign._measure_anchor(
             qname="m.q_proj",
             weight=torch.randn(32, 256, dtype=torch.bfloat16),

--- a/tests/test_tessera_priced_export_inputs.py
+++ b/tests/test_tessera_priced_export_inputs.py
@@ -59,10 +59,12 @@ def _assignment(tmp_path, *, formats, hessian_block="modern-supplied",
     if blocks[hessian_block] is not None:
         meta["tessera_hessian"] = blocks[hessian_block]
     if scales is not None:
-        from prismaquant.tessera_campaign import _format_executes_static_nvfp4
+        from prismaquant.tessera_campaign import (
+            _format_executes_static_activation_contract as executes,
+        )
 
         units = ({name: SCALE for name, fmt in formats.items()
-                  if _format_executes_static_nvfp4(fmt)}
+                  if executes(fmt)}
                  if scales == "own" else dict(scales))
         meta["tessera_activation_static_scales"] = {
             "schema": export.PRICED_STATIC_SCALES_SCHEMA, "units": units}
@@ -434,7 +436,8 @@ def test_an_allocation_with_no_tessera_units_needs_nothing(tmp_path):
                       "hessian_capture_sha256": None,
                       "hessian_capture_seal_crosscheck": None,
                       "input_scales_required": False, "input_scales": None,
-                      "w4a4_units": 0, "input_scales_bound_units": 0}
+                      "static_activation_contract_units": 0,
+                      "input_scales_bound_units": 0}
 
 
 def test_the_priced_input_triple_matches_tesseras_roster():
@@ -456,7 +459,7 @@ def test_w4a4_selection_requires_input_scales(tmp_path):
         tmp_path, formats={DENSE_E2M1: "TESSERA_E2M1_K2_R896"},
         hessian_block="modern-weights-only")
     with pytest.raises(export.TesseraExportLaneError,
-                       match="static NVFP4 activation contract.*--input-scales"):
+                       match="static activation contract.*--input-scales"):
         export.require_priced_export_inputs(assignment)
 
 
@@ -480,7 +483,7 @@ def test_the_campaigns_own_scales_file_covers_and_passes(tmp_path):
     report = export.require_priced_export_inputs(
         assignment, input_scales_path=scales)
     assert report["input_scales_required"] is True
-    assert report["w4a4_units"] == 1
+    assert report["static_activation_contract_units"] == 1
     assert report["input_scales"] == str(scales)
     assert report["input_scales_bound_units"] == 1
 
@@ -491,7 +494,7 @@ def test_dense_e4m3_selection_needs_no_scales(tmp_path):
         hessian_block="modern-weights-only")
     report = export.require_priced_export_inputs(assignment)
     assert report["input_scales_required"] is False
-    assert report["w4a4_units"] == 0
+    assert report["static_activation_contract_units"] == 0
 
 
 # -- #204: the VALUE the file carries must be the value that priced the row.


### PR DESCRIPTION
Fixes #221.

## One rule, one home

PR #213 (#205) made "which activation quantiser does this spec serve" a
property of the spec — `nvfp4_activation_contract.StaticActivationContract`,
reached through `FormatSpec.static_activation_contract` — and routed the
assignment-KL hooks and the production cache scorer through it.
`perturbed_x_cache.py:122` states the rule in as many words: *"Which quantizer
a spec serves is the SPEC's answer … **never a compare of its name against
`"NVFP4"`**"*.

Three call sites still answered the same question by comparing the route's
source-format **name**, skipping the registry row entirely — and one of them
was a helper in the same file as another, so there were two spellings inside
one module as well as two homes across three:

| site | was |
|---|---|
| `tessera_campaign._measure_anchor` | `route.activation_source_format == "NVFP4"` |
| `tessera_campaign._format_executes_static_nvfp4` | same compare, 700 lines later |
| `tessera_export_lane` `--input-scales` gate | same compare again |

The derivation now has one owner:
**`tessera_formats.route_static_activation_contract(route)`** returns the
contract of the registry row the route names in `activation_source_format`.
It returns the *contract*, not a bool, because every consumer needs what is
inside it; a bool would have sent each of them back to the row for the rest.

* `tessera_render.synthesize_tessera_spec` derives through it and keeps the
  one step that is genuinely its own — re-stamping the row's contract
  `measured_as_served=True` to build the rung's spec.
* `tessera_campaign._measure_anchor` reads the spec it already resolved, and
  now prices through `contract.quantize_dequantize` instead of a hardcoded
  `fr.nvfp4_activation_qdq_served`, refusing with `contract.execution` instead
  of the literal string "NVFP4".
* `_format_executes_static_nvfp4` → `_format_executes_static_activation_contract`,
  over the same spec field.
* `tessera_export_lane` calls the route accessor **directly**, not
  `get_format(<rung>)` — that would reach `synthesize_tessera_spec` and pull
  the `tessera` package into a preflight whose own docstring says it gates
  "without importing the `tessera` package". A test guards this.

## Behaviour today is unchanged, and that is pinned

Over all 80 registry rows, `canonical_format_name(name) == "NVFP4"` and
`static_activation_contract is not None` agree exactly, and `NVFP4` is the
only row carrying a contract:

```
rows: 80
rows where the name-compare and the contract-check DISAGREE: []
rows with a static contract: ['NVFP4']
```

No format resolves differently. That equivalence is now a test, so the day it
stops holding, it stops holding deliberately.

## Failing-first, not a pin

The hazard #221 names is constructible, so this ships as a real regression
rather than a cleanup. `StaticActivationContract` is a general dataclass with
`execution`/`group_size` fields and `FormatSpec` types the field as a
spec-level property, not an NVFP4 flag. Give `FP8_E4M3` a static contract —
one `dataclasses.replace` in a distant file — and `TESSERA_E4M3_K1_R1024`,
whose default wire recipe is the CHANNEL plane and whose route therefore
already carries `activation_source_format="FP8_E4M3"`, becomes a rung where
the two predicates disagree:

* `tessera_render` stamps the contract onto the spec (it reads the row), so
  the cache scorer and the KL hooks immediately price the rung through the
  served oracle and **refuse by name** any unit with no calibrated maximum;
* the name compare says "not NVFP4", so the campaign demands and stamps no
  `input_global_scale`, and the export gate never requires `--input-scales`.

That is the two halves of #204/#205 disagreeing about the same rung, and the
export shipping a unit whose static A-side scale nothing ever bound — the
failure #205 was opened to close, at a different format name. The fixture uses
execution `e4m3_per_tensor_static`, deliberately not an NVFP4 string, so a
refusal that still says "NVFP4" cannot pass by accident.

## Machine-readable change

The preflight report key **`w4a4_units` is renamed
`static_activation_contract_units`**: it can now hold units that are not W4A4,
and a key whose name encodes an assumption the code no longer makes is a claim
beyond its evidence. This is safe because the value is never persisted —
`require_priced_export_inputs` returns it, `preflight` nests it as
`report["priced_inputs"]`, and the CLI serialises only `report["build"]` under
`--write-build-json`. Grep for readers over `*.py *.sh *.json *.md`:

```
prismaquant/tessera_export_lane.py:685    (the initialiser)
prismaquant/tessera_export_lane.py:795    (the assignment)
tests/test_tessera_priced_export_inputs.py:437,483,494
tests/test_allocator_tessera_priced_inputs.py:94
```

No receipt, allocation JSON, shipcard slot or `run-pipeline.sh` reader touches
it. Refusal texts in the campaign and the export lane now name the executed
contract rather than "NVFP4"; two existing test regexes move with them.

## Prose

`docs/ARCHITECTURE.md` §5.1 claimed that "a consumer holding the unit's
calibrated maximum (the assignment-KL hooks, the production cache scorer, **the
campaign**) asks the contract which quantiser and which G, never the format's
name." That was false for the campaign. This PR makes it true rather than
softening it, and adds the paragraph describing the single derivation
underneath. The provenance block is re-stamped.

## Not changed, deliberately

Other `== "NVFP4"` compares in the tree are different questions and stay:
`perturbed_x_cache:966,969,1151,1153` gates PrismaQuant's own fused CUDA
kernel, which really does only handle the stock NVFP4 packed layout;
`kl_measurement:219` is sidecar-byte accounting for the compressed-tensors
artifact; the `export_native_compressed` / `allocator` / `footprint` hits are
the stock export codec.
