### PR TITLE
Tessera export: name which path produced the routed-expert bytes (#222) and stop bundling when no expert is selected (#229)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,37 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `claude/pq-218`. Stamps
+As of: 2026-09-05 · `claude/pq-222`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-05, `claude/pq-222`) for **the routed re-encode fallback
+being readable in the receipt** (§5 export lane; RobTand/prismaquant#222, P3).
+#220 made the producer's expert projection an UNLOCK, not a requirement: an
+allocation carrying none keeps the pre-#183 lane byte for byte, and
+`require_assignment_scope` refuses only the INCOHERENT case (priced wires,
+`tessera_expert_stack_formats` or a wire directory carried with the projection
+stripped). That call stands and is unchanged here — the fallback is not
+refused, no unit's bytes move, and making the projection mandatory (#222's
+option (b)) remains Rob's to price, because it would force every profile that
+gains a producer tool to re-run its campaign before it could export again.
+What was wrong is that the fallback was **silent**: an allocation with all
+four keys absent re-encodes its routed units from source and nothing said the
+bytes about to ship were not the bytes the campaign priced. It now says so.
+`_carried_expert_projection` returns the ANSWER beside the bundle —
+`priced_wires`, `reencoded_from_source`, or `no_routed_units` when the
+allocation selects no routed unit at all, so a dense export is never
+mislabelled a fallback — because it is the only function that sees both the
+carried keys and the selection, and a receipt derived anywhere else could
+disagree with the path taken. `require_assignment_scope` stamps it as
+`routed_expert_bytes` in the scope receipt and `preflight` copies it into the
+build anchor as `tessera_routed_expert_bytes`, whence `lane_shipcard open
+--build-json` carries it onto the artifact's ship record. **A reader of the
+old shape sees neither key, and that absence means "this preflight predates
+#222 and does not say" — never `priced_wires`.** New anchors stay readable by
+older consumers: the build block is an open schema (`build_shipcard` stores it
+verbatim, `_verify_build_block` checks only keys it knows and states that a
+card written before a key existed is left alone), so an unknown key is
+carried and ignored. No default, format menu, serving lane, ship gate or byte
+changes.
 
 Re-stamped (2026-09-05, `claude/pq-218`) for **format-name resolution: case is
 the registry's question, and a predicate over a format menu must be total**
@@ -6164,6 +6194,28 @@ Two properties make the numbers comparable with the rest of the menu:
   blobs instead of re-encoding the source. An allocation with no routed
   expert unit bundles nothing and the encode is byte-identical to one built
   before this existed.
+
+* **And the receipt names which path produced the routed bytes (PrismaQuant
+  #222).** The projection is an unlock, not a requirement, so an allocation
+  carrying none is not refused — its routed units resolve on source-member
+  shapes and the exporter **re-encodes them from the source checkpoint**.
+  That lane is sanctioned and unchanged, but it does not ship the bytes the
+  campaign priced, so it is stated rather than inferred.
+  `_carried_expert_projection` returns which path it took beside the bundle —
+  it is the only function that sees both the carried keys and whether any
+  routed unit was selected — and `require_assignment_scope` stamps that answer
+  into its receipt as `routed_expert_bytes`: `priced_wires`,
+  `reencoded_from_source`, or `no_routed_units` for an allocation that selects
+  none, so a dense export never reads as a fallback. `preflight` copies the
+  same value into the build anchor as `tessera_routed_expert_bytes`, and
+  `lane_shipcard open --build-json` stamps the anchor whole onto the
+  artifact's ship record, so a consumer of the shipped bytes reads it there.
+  **Absence of the key means the preflight predates #222 and does not say; it
+  never means `priced_wires`** — every artifact built before this stamp is in
+  that state, and most of them re-encoded. Whether the fallback should instead
+  be REFUSED once a profile has a producer tool is #222's option (b), open and
+  Rob's to price: it would make every lane whose profile gains one re-run its
+  campaign before its next export.
 
 Rows are written in the codebase's own currency: `output_mse` and **no**
 `predicted_dloss` field, because in this tree `output_mse` is a raw MSE while

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,31 @@
 As of: 2026-09-05 · `claude/pq-222`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-05, `claude/pq-222`) for **an allocation that keeps every
+routed expert in BF16 no longer being refused by its own export gate** (§5
+export lane; RobTand/prismaquant#229, P1). Selecting Tessera for a dense
+Linear while every routed expert stays BF16 is a decision the allocator is
+built to emit: `allocation_expert_projection_block` keeps the population and
+the producer's projection, records the stack's format as `BF16`, and carries
+an empty `tessera_expert_wires` map. The export lane filters the assignment
+to Tessera rows, so the selected routed subset is empty — yet
+`_carried_expert_projection` still returned a projection (with empty `units`
+and `stacks`) and `preflight` tested only that it was non-null, handing the
+empty map to the bundle writer, whose `cached_units_manifest` refuses `no
+priced expert wires to bundle`. Because `run-pipeline.sh` **always** passes
+`--write-cached-expert-units` on the Tessera export path, a valid mixed
+allocation exited 2 and published no build anchor, against `preflight`'s own
+documented contract that an allocation selecting no routed expert unit
+bundles nothing. The predicate is now the receipt's own value from the stamp
+below: the bundle is written exactly when `routed_expert_bytes` is
+`priced_wires`, so an anchor names a bundle in precisely the runs whose bytes
+come from one. The projection provenance is kept, not discarded, and
+`cached_units_manifest` still refuses an empty bundle where one is genuinely
+required. This is the case #222's third value (`no_routed_units`) exists to
+name, and it is distinct from #222's own: #222 is a routed **Tessera**
+selection carrying no projection, which silently re-encodes; #229 has a valid
+carried projection and **no selected Tessera expert at all**.
+
 Re-stamped (2026-09-05, `claude/pq-222`) for **the routed re-encode fallback
 being readable in the receipt** (§5 export lane; RobTand/prismaquant#222, P3).
 #220 made the producer's expert projection an UNLOCK, not a requirement: an
@@ -6273,7 +6298,15 @@ Two properties make the numbers comparable with the rest of the menu:
   `priced == written` on the routed leg: the exporter reuses the campaign's
   blobs instead of re-encoding the source. An allocation with no routed
   expert unit bundles nothing and the encode is byte-identical to one built
-  before this existed.
+  before this existed — **including one that carries the producer's projection
+  and keeps every routed expert in BF16** (#229). That allocation is one the
+  allocator emits by design (`allocation_expert_projection_block` records the
+  stack as BF16 with no wire receipts), and the gate refused it with exit 2
+  until the bundle was made conditional on `routed_expert_bytes ==
+  priced_wires` rather than on a projection merely being carried. Zero
+  selected Tessera experts means no bundle and no `--cached-expert-units`
+  handoff; where a bundle IS required, `cached_units_manifest` still refuses
+  an empty one.
 
 * **And the receipt names which path produced the routed bytes (PrismaQuant
   #222).** The projection is an unlock, not a requirement, so an allocation

--- a/prismaquant/tessera_export_lane.py
+++ b/prismaquant/tessera_export_lane.py
@@ -1212,7 +1212,10 @@ def preflight(model_path: str | Path, *, target=None,
     bundle for the priced expert wires this allocation selected, into the
     campaign's own wire directory, and names it in the build anchor so the
     driver hands the exporter the path rather than reconstructing it.  An
-    allocation that selects no routed expert unit bundles nothing.
+    allocation that selects no routed expert unit bundles nothing -- including
+    one that CARRIES the producer's projection and keeps every routed expert
+    in BF16, which is a decision the allocator emits and this gate refused
+    until #229.
     """
     structure = require_declared_structure(model_path)
     target = require_serving_target(target)
@@ -1250,7 +1253,23 @@ def preflight(model_path: str | Path, *, target=None,
             projection = scope.get("expert_projection")
             if projection is not None:
                 build["tessera_expert_stack_formats"] = dict(projection["stacks"])
-                if cached_expert_units:
+                # Bundle exactly when priced wires are what produce the routed
+                # bytes -- not merely when a projection is carried (#229).  An
+                # allocation that keeps every routed expert in BF16 and selects
+                # Tessera only for a dense Linear is one the allocator is
+                # designed to emit: `allocation_expert_projection_block` keeps
+                # the population and the projection and records the stack as
+                # BF16, so the projection here is non-null with no selected
+                # unit under it.  Testing non-null-ness handed that empty map
+                # to the bundle writer, which refuses "no priced expert wires
+                # to bundle" -- exit 2, no build anchor, on the normal driver
+                # path, which always passes the flag.  The receipt's own value
+                # is the predicate, so the anchor names a bundle in exactly the
+                # runs whose bytes come from one, and `cached_units_manifest`
+                # keeps refusing an empty bundle where one IS required.
+                if cached_expert_units and (
+                        scope[ROUTED_EXPERT_BYTES_KEY]
+                        == ROUTED_EXPERT_BYTES_PRICED_WIRES):
                     build["cached_expert_units"] = str(
                         write_cached_expert_units(projection))
         if file_sha256(assignment_path) != assignment_sha:

--- a/prismaquant/tessera_export_lane.py
+++ b/prismaquant/tessera_export_lane.py
@@ -46,6 +46,13 @@ which is the failure mode principle 14 exists to prevent.
    Tessera unit must retain the allocation's target and per-unit context,
    agree with the source header and profile topology, and resolve all regimes
    on that context. Legacy calls without scope retain their existing gates.
+   This gate also RECORDS one thing it deliberately does not refuse: whether
+   the routed-expert bytes come from the campaign's priced wires or are
+   re-encoded from source (:data:`ROUTED_EXPERT_BYTES_KEY`, #222). Both lanes
+   are sanctioned -- a carried producer projection is an unlock, not a
+   requirement (#183, #220) -- but which one shipped is a fact about the
+   artifact, so it is a field in the receipt rather than a difference a
+   consumer has to infer.
 """
 from __future__ import annotations
 
@@ -386,15 +393,44 @@ def _source_unit_shapes(model_path: str | Path, profile,
     return by_unit
 
 
+#: What produced the routed-expert bytes this export is about to ship, as the
+#: one function that decides it answers (PrismaQuant #222).  Three values,
+#: because a dense export is not a fallback:
+#:
+#: * ``priced_wires`` -- the allocation carried the producer's projection, its
+#:   priced blobs were checked against their receipts here, and the exporter is
+#:   handed those bytes (``--cached-expert-units``).  Priced == written.
+#: * ``reencoded_from_source`` -- no projection was carried, so the routed
+#:   units resolve on source-member shapes and the exporter RE-ENCODES them
+#:   from the source checkpoint.  Legitimate, unchanged since before #183, and
+#:   the bytes that ship are not the bytes the campaign priced.
+#: * ``no_routed_units`` -- this allocation selects no routed expert unit at
+#:   all, so no routed byte is produced by either path.
+ROUTED_EXPERT_BYTES_PRICED_WIRES = "priced_wires"
+ROUTED_EXPERT_BYTES_REENCODED = "reencoded_from_source"
+ROUTED_EXPERT_BYTES_NONE = "no_routed_units"
+
+#: The key :func:`require_assignment_scope`'s receipt carries it under ...
+ROUTED_EXPERT_BYTES_KEY = "routed_expert_bytes"
+#: ... and the key the build anchor carries the same value under, whence
+#: ``lane_shipcard open --build-json`` stamps it onto the artifact's ship
+#: record.  Namespaced there because that block is shared across lanes.
+#:
+#: **Absence is not a value.** A build anchor, shipcard or scope receipt
+#: written before #222 carries neither key; a reader must take that as "this
+#: preflight predates #222 and does not say", never as ``priced_wires``.
+BUILD_ROUTED_EXPERT_BYTES_KEY = "tessera_routed_expert_bytes"
+
+
 def _carried_expert_projection(meta: Mapping[str, Any], selected_routed: Mapping[str, str],
-                               shards: Mapping[str, str]) -> dict | None:
+                               shards: Mapping[str, str]) -> tuple[str, dict | None]:
     """Re-bind the selected routed units to the projection the allocation carries.
 
     A carried projection is an UNLOCK, not a new requirement: an allocation
     that carries none keeps the pre-#183 lane exactly -- routed units resolve
     on their source-member shapes and a predicated cell is still refused for
-    lacking the producer's executed-unit attestation -- so this returns
-    ``None``.  What it will not do is read priced-wire receipts that are bound
+    lacking the producer's executed-unit attestation -- so this returns no
+    bundle.  What it will not do is read priced-wire receipts that are bound
     to nothing: an allocation carrying wires, stack formats or a wire
     directory with the projection stripped out is refused by name.
 
@@ -404,8 +440,16 @@ def _carried_expert_projection(meta: Mapping[str, Any], selected_routed: Mapping
     actually lives in, each executed stack must be selected whole at one rung
     (the stamp the allocator wrote must agree), and every selected rung's
     priced bytes must sit in the campaign's wire directory under their
-    receipt.  What comes back is the bundle the exporter's
+    receipt.  The bundle that comes back is what the exporter's
     ``--cached-expert-units`` intake consumes.
+
+    Returned WITH the bundle, and not derived from it by the caller, is which
+    of the two paths this run took (PrismaQuant #222).  The unlock is one
+    decision and it is made here -- this is the only function that sees both
+    the carried keys and whether any routed unit was selected -- so the receipt
+    that names the path and the code that takes it cannot disagree.  Deriving
+    it at the call site from ``bundle is not None`` would be a second rule for
+    one question, and would read a dense export as a re-encode.
     """
     from .tessera_expert_projection import (
         EXPERT_WIRES_KEY, PROJECTION_KEY, STACK_FORMATS_KEY, WIRE_DIR_KEY,
@@ -414,6 +458,12 @@ def _carried_expert_projection(meta: Mapping[str, Any], selected_routed: Mapping
     )
     from .tessera_formats import parse_tessera_format_name
 
+    # No routed unit selected, no routed bytes: neither path runs, whatever the
+    # allocation happens to carry.  Decided before the keys are read so a dense
+    # export is never stamped as a fallback -- and it changes nothing below,
+    # because every check that follows already iterates over ``selected_routed``.
+    fallback = (ROUTED_EXPERT_BYTES_REENCODED if selected_routed
+                else ROUTED_EXPERT_BYTES_NONE)
     carried = meta.get(PROJECTION_KEY)
     if carried is None:
         orphaned = sorted(key for key in (EXPERT_WIRES_KEY, STACK_FORMATS_KEY, WIRE_DIR_KEY)
@@ -423,7 +473,7 @@ def _carried_expert_projection(meta: Mapping[str, Any], selected_routed: Mapping
                 f"the allocation carries {orphaned} but no producer expert projection "
                 f"({PROJECTION_KEY}); priced expert wires that are bound to no executed "
                 "unit cannot be handed to the exporter (PrismaQuant #183)")
-        return None
+        return fallback, None
     try:
         source, units, stack_of = carried_units(carried)
         for name in sorted(selected_routed):
@@ -465,10 +515,14 @@ def _carried_expert_projection(meta: Mapping[str, Any], selected_routed: Mapping
                 grid=family.payload_grid().name, wire_dir=Path(wire_dir))
     except ExpertProjectionError as exc:
         raise TesseraExportLaneError(f"expert projection: {exc}") from exc
-    return {"source": source, "units": records, "stacks": stack_formats,
-            "wire_dir": wire_dir,
-            "geometry": {name: (units[name]["rows"], units[name]["cols"])
-                         for name in selected_routed}}
+    # A carried projection that no selected unit rides is still not priced
+    # wires shipping: ``records`` is empty and the exporter re-encodes nothing,
+    # so ``fallback`` (``no_routed_units``) is the honest answer.
+    return (ROUTED_EXPERT_BYTES_PRICED_WIRES if selected_routed else fallback), {
+        "source": source, "units": records, "stacks": stack_formats,
+        "wire_dir": wire_dir,
+        "geometry": {name: (units[name]["rows"], units[name]["cols"])
+                     for name in selected_routed}}
 
 
 #: The bundle's name inside the campaign's wire directory.  One name: the
@@ -522,6 +576,13 @@ def require_assignment_scope(model_path: str | Path, assignment_path: str | Path
     checked against their receipts here, where they are about to be handed to
     the exporter.  See :func:`_carried_expert_projection` for what that
     binding refuses by name.
+
+    Either way the receipt SAYS which it was, under
+    :data:`ROUTED_EXPERT_BYTES_KEY` (#222): the fallback is a legitimate lane
+    and is not refused here, but an export whose routed bytes were re-encoded
+    from source rather than taken from the campaign's priced wires is not the
+    same artifact, and a consumer must not have to infer which one it holds
+    from the absence of another key.
     """
     from .lane_eligibility import (
         LANE_ELIGIBILITY_SCHEMA_TESSERA, QUALIFICATION_DEVICE_QUALIFIED, ROUTE_STATUS_BACKED,
@@ -568,7 +629,7 @@ def require_assignment_scope(model_path: str | Path, assignment_path: str | Path
         # The producer's projection first: it is the structural refusal, it is
         # cheaper than a route resolution, and it is what attests the executed
         # geometry the rest of this loop resolves a routed unit on.
-        projection = _carried_expert_projection(
+        routed_expert_bytes, projection = _carried_expert_projection(
             meta, {name: fmt for name, fmt in selected.items()
                    if structures[name] == STRUCTURE_ROUTED_MOE}, shards)
         attested = projection["geometry"] if projection is not None else {}
@@ -619,7 +680,11 @@ def require_assignment_scope(model_path: str | Path, assignment_path: str | Path
                     f"{route.unattested_reason or 'every regime must be device_qualified and native'}")
             routes[name] = route.as_dict()
         report = {"target": target.as_dict(), "by_unit": routes,
-                  "contract": table.provenance()}
+                  "contract": table.provenance(),
+                  # Which path produced the routed bytes, as the function that
+                  # chose it answered -- never re-derived from what else is in
+                  # this report (#222).
+                  ROUTED_EXPERT_BYTES_KEY: routed_expert_bytes}
         if projection is not None:
             report["expert_projection"] = projection
         return report
@@ -1089,6 +1154,13 @@ def preflight(model_path: str | Path, *, target=None,
         if scope is not None:
             build["tessera_serving_scope"] = read_layer_config_metadata(
                 assignment_path)["tessera_serving_scope"]
+            # Copied from the scope receipt, never recomputed: the anchor is
+            # the only machine-readable thing this CLI writes, and
+            # `lane_shipcard open --build-json` stamps it whole onto the
+            # artifact's ship record, so this is where a consumer of the
+            # shipped bytes reads which path produced its routed experts
+            # (#222).  Absence means a pre-#222 preflight, not priced wires.
+            build[BUILD_ROUTED_EXPERT_BYTES_KEY] = scope[ROUTED_EXPERT_BYTES_KEY]
             projection = scope.get("expert_projection")
             if projection is not None:
                 build["tessera_expert_stack_formats"] = dict(projection["stacks"])

--- a/tests/test_tessera_export_projection.py
+++ b/tests/test_tessera_export_projection.py
@@ -282,6 +282,53 @@ def test_scope_without_a_projection_is_the_unchanged_pre_bridge_lane(case):
     assert "expert_projection" not in report
 
 
+def test_the_receipt_names_which_path_produced_the_routed_bytes(case):
+    # PrismaQuant #222.  The fallback above is legitimate and stays -- but it
+    # was SILENT: an allocation with all four keys stripped re-encodes its
+    # routed units from source, and nothing in the export's own output said the
+    # bytes about to ship were not the bytes the campaign priced.  The two
+    # paths are now distinguishable in the scope receipt, derived where the
+    # choice is made, without changing what either path refuses or encodes.
+    priced = _scope(case)
+    assert priced[export.ROUTED_EXPERT_BYTES_KEY] == export.ROUTED_EXPERT_BYTES_PRICED_WIRES
+    assert set(priced["expert_projection"]["units"]) == set(_units())
+
+    # The INCOHERENT case is #220's refusal and must not weaken: priced wires
+    # bound to no executed unit are still refused by name, never stamped as a
+    # fallback and shipped.
+    _meta(case).pop(PROJECTION_KEY)
+    _save(case)
+    with pytest.raises(export.TesseraExportLaneError,
+                       match="no producer expert projection"):
+        _scope(case)
+
+    # All four gone: the pre-#183 lane, which still succeeds and still resolves
+    # every unit exactly as the priced run did.  Only the receipt is different.
+    for key in (EXPERT_WIRES_KEY, STACK_FORMATS_KEY, WIRE_DIR_KEY):
+        _meta(case).pop(key)
+    _save(case)
+    fallback = _scope(case)
+    assert fallback[export.ROUTED_EXPERT_BYTES_KEY] == export.ROUTED_EXPERT_BYTES_REENCODED
+    assert "expert_projection" not in fallback
+    assert fallback["by_unit"] == priced["by_unit"]
+
+
+def test_an_export_that_ships_no_routed_bytes_is_not_stamped_as_a_re_encode(case):
+    # The stamp names what produced the ROUTED bytes, so an export that ships
+    # none must not read as the fallback -- a dense allocation re-encodes no
+    # routed unit because it selects none.  True on both sides of the carried
+    # projection, since neither run hands a routed unit to the exporter.
+    for name in _units():
+        case.payload[name] = "BF16"
+        _meta(case)["tessera_serving_scope"]["by_unit"].pop(name)
+    _save(case)
+    assert _scope(case)[export.ROUTED_EXPERT_BYTES_KEY] == export.ROUTED_EXPERT_BYTES_NONE
+    for key in (PROJECTION_KEY, EXPERT_WIRES_KEY, STACK_FORMATS_KEY, WIRE_DIR_KEY):
+        _meta(case).pop(key)
+    _save(case)
+    assert _scope(case)[export.ROUTED_EXPERT_BYTES_KEY] == export.ROUTED_EXPERT_BYTES_NONE
+
+
 def test_scope_without_a_projection_still_refuses_a_predicated_cell(case):
     # And the refusal that made #183 necessary stays: without the producer's
     # record, a source-member dimension does not attest a fused execution unit.
@@ -413,6 +460,29 @@ def test_cli_writes_no_bundle_for_an_allocation_without_a_projection(case, tmp_p
     build = json.loads((tmp_path / "build.json").read_text())
     assert "cached_expert_units" not in build
     assert not list(case.wire_dir.glob("*.json"))
+
+
+def test_the_build_anchor_carries_which_path_produced_the_routed_bytes(case, tmp_path,
+                                                                       monkeypatch):
+    # The build anchor is the only thing the CLI serialises, and
+    # `lane_shipcard open --build-json` stamps it whole onto the artifact's
+    # ship record -- so this is where a consumer of the SHIPPED artifact reads
+    # which path produced its routed bytes (#222).  One derivation: the anchor
+    # copies the scope receipt's answer, it does not recompute it.
+    _isolate_other_gates(monkeypatch)
+    assert _cli(case, tmp_path) == 0
+    build = json.loads((tmp_path / "build.json").read_text())
+    assert (build[export.BUILD_ROUTED_EXPERT_BYTES_KEY]
+            == export.ROUTED_EXPERT_BYTES_PRICED_WIRES)
+    assert build["tessera_expert_stack_formats"] == {STACK: FMT}
+    for key in (PROJECTION_KEY, EXPERT_WIRES_KEY, STACK_FORMATS_KEY, WIRE_DIR_KEY):
+        _meta(case).pop(key)
+    _save(case)
+    assert _cli(case, tmp_path) == 0
+    build = json.loads((tmp_path / "build.json").read_text())
+    assert (build[export.BUILD_ROUTED_EXPERT_BYTES_KEY]
+            == export.ROUTED_EXPERT_BYTES_REENCODED)
+    assert "tessera_expert_stack_formats" not in build
 
 
 def test_shell_hands_the_exporter_the_bundle_the_preflight_wrote():

--- a/tests/test_tessera_export_projection.py
+++ b/tests/test_tessera_export_projection.py
@@ -449,6 +449,9 @@ def test_cli_refuses_to_bundle_without_the_producers_schema(case, tmp_path, monk
 
 def test_cli_writes_no_bundle_for_an_allocation_without_a_projection(case, tmp_path,
                                                                      monkeypatch):
+    # The control below covers the STOCK-table shape: no projection metadata at
+    # all.  It is not the shape a #220 allocator emits, which is why it never
+    # caught #229 -- see the next test.
     _isolate_other_gates(monkeypatch)
     for name in _units():
         case.payload[name] = "BF16"
@@ -460,6 +463,69 @@ def test_cli_writes_no_bundle_for_an_allocation_without_a_projection(case, tmp_p
     build = json.loads((tmp_path / "build.json").read_text())
     assert "cached_expert_units" not in build
     assert not list(case.wire_dir.glob("*.json"))
+
+
+def _allocator_metadata(case, assignment):
+    """The projection block a REAL allocation carries, from the allocator's helper.
+
+    ``allocation_expert_projection_block`` is what `allocator.main` stamps, and
+    it is the producer side of the seam #229 was filed against: hand-built
+    metadata cannot show that the allocator and the export lane disagree about
+    what a retained projection means.  Shaped like the campaign cost table the
+    allocator reads -- population, projection and wire directory in
+    ``provenance``, the priced receipts keyed by rung at the top level.
+    """
+    meta = _meta(case)
+    payload = {
+        "provenance": {
+            POPULATION_KEY: meta[POPULATION_KEY],
+            PROJECTION_KEY: meta[PROJECTION_KEY],
+            "wire_dir": str(case.wire_dir),
+        },
+        EXPERT_WIRES_KEY: {name: {FMT: receipt}
+                           for name, receipt in case.receipts.items()},
+    }
+    return tep.allocation_expert_projection_block(payload, assignment)
+
+
+def test_cli_bundles_nothing_when_the_allocation_keeps_every_expert_in_bf16(
+        case, tmp_path, monkeypatch):
+    # PrismaQuant #229 (P1).  Selecting Tessera for a dense Linear while every
+    # routed expert stays BF16 is a decision the allocator is DESIGNED to
+    # produce: `allocation_expert_projection_block` keeps the population and
+    # the projection, records the stack as BF16, and carries no wire receipts.
+    # The export lane then filtered the assignment to Tessera rows, found no
+    # routed unit, and still handed the empty bundle to the writer -- so the
+    # driver, which always passes --write-cached-expert-units, refused a valid
+    # allocation with exit 2 and wrote no build anchor.
+    _isolate_other_gates(monkeypatch)
+    block = _allocator_metadata(
+        case, {DENSE: FMT, **{name: "BF16" for name in _units()}})
+    assert block[EXPERT_WIRES_KEY] == {}
+    assert block[STACK_FORMATS_KEY] == {STACK: "BF16"}
+    _meta(case).update(block)
+    for name in _units():
+        case.payload[name] = "BF16"
+        _meta(case)["tessera_serving_scope"]["by_unit"].pop(name)
+    _save(case)
+
+    # #222's third value is what draws the line: a carried projection that no
+    # SELECTED unit rides ships no routed byte, so there is nothing to bundle
+    # and nothing was re-encoded either.
+    scope = _scope(case)
+    assert set(scope["by_unit"]) == {DENSE}
+    assert scope[export.ROUTED_EXPERT_BYTES_KEY] == export.ROUTED_EXPERT_BYTES_NONE
+
+    assert _cli(case, tmp_path, "--write-cached-expert-units") == 0
+    build = json.loads((tmp_path / "build.json").read_text())
+    assert "cached_expert_units" not in build
+    assert not list(case.wire_dir.glob("*.json"))
+    # The provenance the allocator carried is KEPT, not discarded to get here.
+    assert build[export.BUILD_ROUTED_EXPERT_BYTES_KEY] == export.ROUTED_EXPERT_BYTES_NONE
+    carried = json.loads(case.assignment.read_text())["__prismaquant__"]
+    assert carried[PROJECTION_KEY] == _meta(case)[PROJECTION_KEY]
+    assert carried[POPULATION_KEY] == _meta(case)[POPULATION_KEY]
+    assert carried[STACK_FORMATS_KEY] == {STACK: "BF16"}
 
 
 def test_the_build_anchor_carries_which_path_produced_the_routed_bytes(case, tmp_path,


### PR DESCRIPTION
Fixes #222 — option **(c) only**: the re-encode-from-source fallback becomes readable in the receipt. It is **not** refused, and nothing about what is refused or what is encoded changes.

## What was wrong

#220 made the producer's expert projection an **unlock, not a requirement**. An allocation carrying none keeps the pre-#183 lane byte for byte, and `require_assignment_scope` refuses only the *incoherent* case (priced wires, `tessera_expert_stack_formats`, or a wire directory carried with the projection stripped). That call stands.

What was wrong is that the remaining path was **silent**: an allocation with all four keys absent re-encodes its routed units from source, and nothing in the export's own output said the bytes about to ship were not the bytes the campaign priced. Option (b) — refusing the fallback once a profile has a producer tool — would force every such lane to re-run its campaign before its next export, and stays Rob's to price.

## The field

One value, one derivation, two placements:

| where | key | who reads it |
|---|---|---|
| `require_assignment_scope`'s scope receipt | `routed_expert_bytes` | `preflight()["selected_serving_scope"]` |
| the build anchor (`--write-build-json`) | `tessera_routed_expert_bytes` | `lane_shipcard open --build-json` → the artifact's `shipcard.json` |

The anchor **copies** the receipt's answer, it does not recompute it. The anchor is the only machine-readable thing the CLI writes, and the shipcard is where a consumer of the *shipped* bytes looks — so no second receipt was invented.

Three values, as module constants: `priced_wires`, `reencoded_from_source`, and `no_routed_units` for an allocation that selects no routed unit at all. Without the third, every dense export would read as a fallback and the field would be worthless.

## Derived, never passed in

`_carried_expert_projection` now returns `(routed_expert_bytes, bundle)` instead of `dict | None`. It is the only function that sees both the carried keys and whether any routed unit was selected, so it is the only place that can answer all three; deriving it at the call site from `bundle is not None` would be a second rule for one question and would mislabel a dense export. **One caller, and it moves**: `require_assignment_scope` (`tessera_export_lane.py:571`). `grep -rn _carried_expert_projection` outside `archive/` finds the definition, that call, and two prose mentions — no test calls it, so nothing is left destructuring the old shape.

## Compatibility, both directions

* **Old anchor → new reader**: the key is absent. Absence means *"this preflight predates #222 and does not say"* — **never** `priced_wires`. Every artifact built before this commit is in that state, and most of them re-encoded. This rule is written into `docs/ARCHITECTURE.md`, not just the commit, because it is what a future reader of an old shipcard needs.
* **New anchor → older reader**: harmless, because the build block is an **open schema**. `shipcard.build_shipcard` stores it verbatim (`dict(build or {})`); `lane_shipcard.open_lane_shipcard` only `setdefault`s `export_container`; `shipcard._verify_build_block` checks named keys one at a time and says so itself — *"Every check fires only on a key the producer stamps, so a card written before a key existed is left alone"*; `tools/publish_artifact.py` requires only that `build` is a Mapping. There is no key whitelist and no exact key-set comparison anywhere over the build dict, `lane_specs/tessera.json` declares no build keys, and `tests/test_shipcard.py` already round-trips arbitrary build keys. So there was no closed schema to extend, and an unknown key is carried and ignored. The 256 KiB card reservation is unaffected by ~50 bytes.

No test asserts an exact key set on either the scope receipt or the build anchor.

## Regression, shown failing on main first

Pre-fix on `17ca6930` with only the new tests applied — `3 failed, 15 passed, 1 skipped`, each with `AttributeError: module 'prismaquant.tessera_export_lane' has no attribute 'ROUTED_EXPERT_BYTES_KEY'`. Main's receipt does not carry the fact at all, which *is* the defect.

* `test_the_receipt_names_which_path_produced_the_routed_bytes` — a carried projection stamps `priced_wires`; stripping only the projection **still refuses by name** (#220's behaviour, unweakened); stripping all four stamps `reencoded_from_source`, still succeeds, and produces an **identical `by_unit` route table** to the priced run. Only the receipt differs.
* `test_an_export_that_ships_no_routed_bytes_is_not_stamped_as_a_re_encode` — dense-only stamps `no_routed_units`, with and without the carried keys.
* `test_the_build_anchor_carries_which_path_produced_the_routed_bytes` — the CLI's `build.json` carries the value on both paths.

`docs/ARCHITECTURE.md` re-stamped in the same commit (principle 12): header, a new top stamp, and a new §5 export-lane bullet naming the fallback, the three values, where each key lives, what absence means, and that option (b) is open and Rob's.

---

# Second commit — Fixes #229 (P1)

`3c3ef4fc`, on top of the merge of `origin/main` at `eda5b37d` (#225).

**A valid mixed allocation was refused by its own export gate.** Selecting Tessera for a dense Linear while every routed expert stays BF16 is a decision the allocator is built to emit — `allocation_expert_projection_block` keeps the population and the projection, records the stack as `BF16`, and carries an empty `tessera_expert_wires` map (`tests/test_allocator_expert_projection.py:265-268`). The export lane filters the assignment to Tessera rows, so the selected routed subset is empty, yet `_carried_expert_projection` still returned a projection with empty `units`/`stacks` and `preflight` tested only non-null-ness — handing that empty map to the bundle writer, whose `cached_units_manifest` refuses `no priced expert wires to bundle`. `run-pipeline.sh:2520-2525` **always** passes `--write-cached-expert-units`, so the allocation exited 2 and published no build anchor, against `preflight`'s own documented contract.

**The fix is one predicate, and it is the first commit's field.** Bundle exactly when `routed_expert_bytes == priced_wires`, not when a projection merely exists. The two issues resolve through one value:

| case | value | bundles? |
|---|---|---|
| routed Tessera units, **no** carried projection — re-encoded from source (#222) | `reencoded_from_source` | no |
| valid carried projection, **no selected Tessera expert** (#229) | `no_routed_units` | no |
| routed Tessera units under a carried projection | `priced_wires` | yes — the only one |

Since `priced_wires` requires at least one selected routed unit, and each such unit either yields a verified receipt or refuses by name, the writer can no longer be reached with an empty unit map.

**Pre-fix reproduction.** On the merged tip with only the new test applied: `AssertionError: assert 2 == 0`. This checkout's pinned Tessera (1221d2a) has no `tessera.cached_unit`, so the local refusal is #192's import error; injecting only that schema constant and re-running the same test reproduces the issue's own message exactly — `expert projection: no priced expert wires to bundle`. Both are the same defect and both are gone after the fix. The issue's CPU proof on sparky (`pq_bf16_expert_bundle.py`) was read, not modified, and its construction is what the new test reuses.

**The regression exercises the allocator's own metadata** — the point of #229. The existing control `test_cli_writes_no_bundle_for_an_allocation_without_a_projection` sets experts to BF16 *and* deletes the projection/wire/stack/directory keys (the stock-table shape), so it never covered the producer-to-consumer seam; it is kept and now says which shape it covers. The new `test_cli_bundles_nothing_when_the_allocation_keeps_every_expert_in_bf16` builds its metadata by calling `allocation_expert_projection_block` itself, asserts the block really carries empty wires and `{stack: "BF16"}`, and drives the actual CLI with the flag the driver always passes.

Kept per the acceptance criteria: the positive selected-expert bundle case (skips here for want of `tessera.cached_unit`, so also run with the schema constant injected — 20 passed, bundle unchanged); the missing/damaged selected-wire refusals; the projection provenance (the test asserts population, projection and the BF16 stack stamp all survive); and `cached_units_manifest`'s empty-bundle refusal for paths that genuinely require wires.

**No currently-working export path changes behaviour**: a run that bundled still bundles the same manifest to the same path, a run that wrote no bundle still writes none. The only difference is that a case which exited 2 now exits 0.

Counts after both commits: targeted set `290 passed, 4 skipped`; full suite `17 failed, 5032 passed, 138 skipped, 3 xfailed` — the 17 known-inherited `test_tessera_campaign_resume.py` failures, nothing else.