### PR TITLE
Reuse shared anchored shapes for Tessera curve replay

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,14 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `codex/two-anchor-bootstrap`. Stamps
+As of: 2026-09-05 · `codex/tessera-anchored-surface`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-05, `codex/tessera-anchored-surface`) for correlated
+group uncertainty (PrismaQuant #236). Uniform fused/packed groups retain the
+sum of scaled standard errors as a conservative bound; shared AURA probes
+do not establish independence. Default `PRISMAQUANT_COST_UCB_Z=0` candidate
+prices are unchanged, while grouped uncertainty metadata can increase even
+at zero. The mixed-rung Tessera fold still refuses opt-in UCB pricing.
 
 Re-stamped (2026-09-05, `codex/two-anchor-bootstrap`) for campaign
 bootstrapping from two endpoints (§4.10). A requested initial count of one
@@ -6392,8 +6399,11 @@ while the family constraint itself costs 1.008x / 1.000x / 1.000x against an
 unconstrained bound. Exactness is enforced, not claimed: the fold is pinned
 against brute force on a menu with a non-convex pocket, a uniform-rung option
 must price identically through both constructions or the aggregation refuses,
-and the fold refuses outright at `PRISMAQUANT_COST_UCB_Z > 0` because
-`z*sqrt(sum stderr^2)` is not additive. Measured again on a cost table whose
+and the fold still refuses at `PRISMAQUANT_COST_UCB_Z > 0`: mixed-rung UCB
+repricing remains unsupported. Uniform fused/packed groups use a conservative
+sum of scaled standard errors (#236), since shared AURA probes do not imply
+independent estimates. This does not promote mixed-rung uncertainty support.
+Measured again on a cost table whose
 anchors were placed per group (the correct placement) the one-rung constraint
 costs **1.237x / 1.558x / 1.113x**, and at 4.0 the fold is shown to *contain*
 the unconstrained arm's own rung triple, so the family constraint there is free

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,14 @@
 As of: 2026-09-05 · `codex/tessera-anchored-surface`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-05, `codex/tessera-anchored-surface`) for opt-in,
+receipt-bound Tessera anchored-shape replay (§4.10). A declared shared pilot
+and one/two per-unit anchors predict a curve; separate audit rungs, exact
+measured values, a PWL comparison and deterministic measurement requests
+make its limitations inspectable. The CLI emits a research report only and
+imports the campaign's actual output-MSE currency. It does not qualify an
+AURA price, publish allocator rows or replace the campaign scheduler.
+
 Re-stamped (2026-09-05, `codex/tessera-anchored-surface`) for the shared
 `anchored_shape` numerical core. The existing AURA receipt/currency wrappers
 delegate centered log-shape fitting without changing their numerical result
@@ -6497,6 +6505,14 @@ and available-rung limits still apply; fewer than three measurements cannot
 close the leave-one-out gate and report its error as null.
 
 **Cost is an anchor campaign, not an enumeration** (`prismaquant/tessera_campaign.py`).
+
+The separate `tools/tessera_surface_replay.py` research command can compare
+the existing PWL model with shared-shape transfer from one/two anchors. It
+binds current campaign payload and journal identities, checks recorded wire
+hashes, and keeps activation/recipe segments distinct. A successful replay is
+not fresh source/producer attestation or serving qualification. Details and
+the pending joint-AURA/prefill extension (#237) are in
+[`docs/design/tessera_anchored_replay.md`](design/tessera_anchored_replay.md).
 
 Resume is an identity check, not a name match. The JSON checkpoint manifest
 uses `cost_stage_checkpoint` and stores checksummed per-unit anchor shards in

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,13 @@
 As of: 2026-09-05 · `codex/tessera-anchored-surface`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-05, `codex/tessera-anchored-surface`) for the shared
+`anchored_shape` numerical core. The existing AURA receipt/currency wrappers
+delegate centered log-shape fitting without changing their numerical result
+or admission. The neutral core additionally supports a per-unit level and
+slope correction from sparse anchors, with exact measured values and frozen
+independent audit predictions. This adds no production interpolation policy.
+
 Re-stamped (2026-09-05, `codex/tessera-anchored-surface`) for correlated
 group uncertainty (PrismaQuant #236). Uniform fused/packed groups retain the
 sum of scaled standard errors as a conservative bound; shared AURA probes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6435,9 +6435,10 @@ inside one run. Four consequences, all of them enforced rather than described:
 
 * `q256: per_member` is the licence for the fold at all. Withdraw it and the
   fold enumerates nothing, so the group keeps the per-NAME intersection, which
-  asserts nothing per member. **With no contract pinned -- production today,
-  since no Tessera RELEASE tag exists -- there is no licence to read and the
-  fold likewise declines, where before this change it folded.** Either way it
+  asserts nothing per member. With no verified contract pin there is no
+  licence to read and the fold likewise declines. The current exact-commit
+  pin supplies the packaged contract; a release tag is no longer required.
+  Either way it
   stamps `__licence__` into the group report, so a receipt can tell "the
   runtime says one rung" from "nothing was asked" -- but only where the
   question arises: a group with no Tessera rung on any member's menu returns

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,14 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `codex/audit4-integration`. Stamps
+As of: 2026-09-05 · `codex/two-anchor-bootstrap`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-05, `codex/two-anchor-bootstrap`) for campaign
+bootstrapping from two endpoints (§4.10). A requested initial count of one
+or two retains both endpoints; subsequent rounds use the existing widest-gap
+fallback until leave-one-out can be evaluated, subject to the existing budget,
+round limit and available rungs. This repairs scheduling without qualifying
+interpolation quality or changing production defaults.
 
 Re-stamped (2026-09-05, `codex/audit4-integration`) for the coordinated
 producer API pin following Tessera #356: `ba582d476a3b6db9057ebd1385dc52926f171451`.
@@ -6464,6 +6471,12 @@ because a round adds ONE anchor per failing surface, so capping rounds capped
 how far the worst surface could be improved -- the opposite of the loop's
 purpose. Each surface records its anchors, encode seconds and which of the two
 stopped it.
+
+`--anchors 1` and `--anchors 2` both start with the two endpoints when the
+legal range has more than one rung. Before three anchors are available, the
+next round splits the widest gap using the shared legal grid. Budget, round
+and available-rung limits still apply; fewer than three measurements cannot
+close the leave-one-out gate and report its error as null.
 
 **Cost is an anchor campaign, not an enumeration** (`prismaquant/tessera_campaign.py`).
 

--- a/docs/design/tessera_anchored_replay.md
+++ b/docs/design/tessera_anchored_replay.md
@@ -1,0 +1,149 @@
+# Sparse Tessera curve replay and the activation/prefill axis
+
+Status: opt-in research replay, 2026-09-05. This capability emits a report and
+measurement requests, not allocator costs or serving qualification. The normal
+Tessera campaign retains its piecewise log-linear interpolation and adaptive
+measurement policy.
+
+## Recovered mechanism
+
+The former Gridbook campaign used a shared projection-level error curve and a
+per-expert correction. Two measurements fitted both a level and a slope;
+separate audit measurements decided whether to use predictions or measure the
+full declared grid. The retained implementation is in
+`tools/dsv4_afast_campaign.py` and `tools/dsv4_afast_burn.py`, originally adopted
+in `0b34145c17f76a2ec715af13e18715b25b0007af`. The earlier study survives at
+`629cfb79958a4d4400471d8044b5df93b061908f`, under `interp-diagnosis/` and
+`cost-ldlq/interp-diagnosis/`.
+
+That history supports recovering the mechanism, not transferring its constants
+or declaring all ranges predictable. The K28–38 median study recorded worst
+rung errors of 3.50%, 5.87% and 6.34% on held-out L0 gate/up/down projections.
+Broader ranges and heterogeneous experts produced larger misses. The archived
+480-solve regret study used a weight-MSE proxy with uniform sensitivity, not
+served KL or AURA. Its tolerances are not Tessera promotion gates.
+
+`prismaquant.anchored_shape` now supplies the numerical mechanism shared with
+the existing strict AURA fitter. Given a declared segment shape G and a
+centered/scaled rate coordinate x:
+
+```text
+log10 D_i(x) = log10 G(x) + a_i + b_i*x
+```
+
+The pilot fit removes each pilot unit's own log-cost mean before solving its
+feature coefficients. One anchor sets b to zero; two fit level and slope.
+An explicit later fit can use more observations. Real measured points remain
+exact. Invalid costs, unsupported keys and insufficient design rank refuse;
+there is no fabricated epsilon loss or inherited Gridbook modulo-four term.
+The strict `anchored_cost` AURA wrappers keep their currency, render-receipt
+and segment checks.
+
+## Replay inputs and output
+
+Run from the repository with the same Python dependencies as the campaign:
+
+```bash
+python tools/tessera_surface_replay.py \
+  --costs /run/cost.pkl \
+  --checkpoint /run/anchors.json \
+  --plan /run/replay-plan.json \
+  --out /run/replay-report.json
+```
+
+The input is a trusted local campaign pickle plus the existing checkpoint
+manifest, its `.parts` journal, and its recorded wire directory. The plan
+binds the exact payload SHA-256 and checkpoint identity SHA-256. The importer
+reuses the journal reader, checks measured rows against recorded anchors and
+source/encoder/Hessian/static-scale identities, and verifies wire hashes and
+sizes. It does not re-read model tensors or re-run producer wire validation.
+Its report states that boundary explicitly; recorded identity replay is not
+fresh source or serving attestation.
+
+The plan schema is `prismaquant.tessera_anchored_replay.plan.v1`. It declares:
+
+- `input.payload_sha256`, `input.checkpoint_identity_sha256`, and `currency`;
+- a list of `segments`, each with an `id` and a `descriptor` identifying
+  family, explicit profile role, activation contract, geometry, wire recipe
+  without the rate, and Hessian applicability;
+- `features_by_key` and integer rate `coordinates`, keyed by format name;
+- `pilot`, mapping pilot unit names to measured format keys;
+- `heldout`, mapping distinct unit names to one/two `anchors` and separate
+  `audit` keys;
+- `max_absolute_log10_error` and optional `refit_after_audit`.
+
+The exact example construction and executable cases live in
+`tests/test_tessera_anchored_surface.py`. Roles are explicit plan declarations;
+the importer does not certify that a declared transfer class generalizes.
+Actual family, activation, geometry, recipe and Hessian boundaries must agree.
+The pilot covers the target rate envelope; held-out units are distinct from
+pilot units, and audit rungs are distinct from their fit anchors.
+
+Audit predictions are frozen before audit truth can enter an optional refit.
+Reports retain the pre-refit errors, measured/predicted provenance and a
+piecewise log-linear baseline where two anchors bracket the audit rung.
+Missing evidence, failed audits or nonmonotone curves produce deterministic
+measurement requests. Requests propagate to members of existing campaign
+anchor groups. They are requests to the existing measurement machinery, not
+newly encoded wires. Packed experts never become selectable from this report.
+
+Replaying identical inputs is deterministic. A changed report cannot overwrite
+an existing output pathname; choose another path. The plan hash binds the split,
+features and policy. No speedup, full-model quality improvement, or production
+qualification is implied by a successful replay or its numerical tests.
+
+## AURA and overlapping activation families
+
+The importer currently accepts only
+`output_mse_under_route_activation_contract`. That is the actual campaign
+currency. AURA import requires its own attested measurement path; MSE cannot
+be relabeled as AURA. Interpolate within activation/recipe segments, then
+compare candidates in a common validated downstream quality currency.
+
+Current AURA propagates weight deltas through KL/Gauss–Newton adjoints. Current
+Tessera output-MSE scoring includes the local joint weight/activation residual
+but discards its direction before scalar sensitivity weighting. The proposed
+bridge projects the joint residual through AURA's output cotangent G:
+
+```text
+deltaY = Xhat What.T - X W.T
+       = X deltaW.T + deltaX W.T + deltaX deltaW.T
+a[k] = <G[k], deltaY>
+predicted_loss = 0.5 * mean_k(a[k]**2)
+```
+
+This must preserve signed cancellation across terms and repeated invocations
+before squaring. The archived signed-operator helper at
+`32f6b03fc063731b927ad33d143cac923c4950e9` contains an efficient equivalent:
+compute `D = G.T @ deltaX` once per activation contract, then add its projections
+against W and deltaW to the existing weight projection. Its archived harvester
+and persistence wiring were unfinished. Reuse requires adapting today's
+activation-scale contracts, completing signed sample persistence, and testing
+fixed-teacher comparisons; enabling that archive is not an implementation.
+
+Quality and runtime then form distinct axes. The proposed operator control is
+best quality at an exact byte/device budget while meeting a specified prefill
+latency target, with a separate decode guard. The existing prefill SLO flags
+filter assignments after a bytes/quality search; they do not preserve faster
+same-byte alternatives that search discarded. Candidate reduction and search
+must retain the discrete bytes/quality/runtime frontier. A weighted penalty
+sweep or convex hull cannot represent every nonconvex feasible choice.
+
+Use measured kernel/workload costs to propose assignments and end-to-end
+serving measurements to qualify them. Activation width, encode time and weight
+bytes do not determine prefill time. Serialized weights, resident terminal
+weights, activation scratch and KV memory also require distinct accounting.
+
+Validate close cross-family choices using paired probe differences and shared
+held-out calibration, then whole-assignment/close-swap checks against the fixed
+teacher. Probe covariance is not layer-error additivity. Re-centering a Fisher
+square on a quantized assignment alone changes its reference and omits the
+fixed-teacher first-order term. Current historical AURA validation does not
+establish these overlapping families' rankings or cross-layer additivity.
+
+This joint AURA/runtime extension and its required current measurements are
+tracked in [PrismaQuant #237](https://github.com/RobTand/prismaquant/issues/237).
+The separate opt-in grouped-uncertainty defect is
+[#236](https://github.com/RobTand/prismaquant/issues/236). Production defaults,
+serving admission and the existing uniform-control/quality gates do not change
+through research replay.

--- a/prismaquant/allocator_candidates.py
+++ b/prismaquant/allocator_candidates.py
@@ -1866,33 +1866,27 @@ def _resolve_cost_entry(cost_rows: dict, fmt_name: str) -> tuple[dict | None, st
 
 
 def _super_item_ucb_hedge(member_terms, ucb_z: float) -> tuple[float, float]:
-    """Convert a super item's per-member UCB hedge into the independence one.
+    """Separate member hedges and retain a conservative group stderr bound.
 
-    A super item (fused-sibling group, packed serving group) prices one
-    format as the SUM of its members' ``cost_entry_predicted_dloss``. With
-    ``PRISMAQUANT_COST_UCB_Z > 0`` every member term already carries its own
-    ``z·stderr·gain``, so the sum carries a LINEAR ``z·Σ(stderr·gain)``
-    hedge — up to a √N OVER-hedge on an N-member group. The member dloss
-    estimates are independent measurements, so the stderr of the group SUM is
-    ``sqrt(Σ (stderr·gain)²)``.
+    AURA rows share probe samples, so distinct members do not establish
+    independent estimator errors. Without verified joint sample identities
+    or an explicit independence contract, the standard deviation of a sum is
+    bounded by the SUM of its scaled standard deviations. Quadrature can
+    underprice positive covariance; physical perturbation additivity does not
+    establish independence of the cost estimates.
 
-    ``member_terms`` yields ``(stats_entry, cost_entry, member_dloss, scale)``
-    where ``scale`` is every multiplicative factor already applied to that
-    member's dloss but NOT to the raw ``predicted_dloss_stderr`` in the cost
-    row — the calibrated gain and, since ultraplan P5a, the per-family
-    activation penalty. Both scale the point estimate and its stderr
-    identically, so a member whose price was penalized must have its stderr
-    penalized too or the conversion would over-subtract the linear hedge it
-    exists to undo.
+    ``member_terms`` yields ``(stats_entry, cost_entry, member_dloss, scale)``.
+    The scale includes calibrated gain and activation penalty already applied
+    to the member price. Only terms priced with a stderr hedge contribute.
+    Raw per-probe arrays alone do not establish alignment here.
 
-    Returns ``(hedge_linear, stderr_agg)``: subtract ``hedge_linear`` from the
-    member sum and add ``ucb_z * stderr_agg`` to get the independence
-    aggregate. At ``ucb_z == 0`` ``hedge_linear`` is exactly 0.0, so the
-    conversion is a bit-for-bit identity on the sum.
-
-    Both aggregation paths call this so the two constructions cannot drift.
+    Returns ``(hedge_linear, stderr_bound)``: remove the member hedges to
+    recover the base cost, and retain the conservative bound in the grouped
+    cost row for repricing. At ``ucb_z == 0`` the removed hedge is exactly
+    zero, preserving the accumulated candidate price bit for bit. Both fused
+    and packed aggregation use this same policy.
     """
-    stderr_eff_sq = 0.0
+    stderr_bound = 0.0
     hedge_linear = 0.0
     for stats_entry, cost_entry, member_dloss, gain in member_terms:
         if float(member_dloss) <= 0.0:
@@ -1917,9 +1911,9 @@ def _super_item_ucb_hedge(member_terms, ucb_z: float) -> tuple[float, float]:
             stderr = 0.0
         if stderr <= 0.0:
             continue
-        stderr_eff_sq += (stderr * float(gain)) ** 2
+        stderr_bound += abs(stderr * float(gain))
         hedge_linear += ucb_z * stderr * float(gain)
-    return hedge_linear, math.sqrt(stderr_eff_sq)
+    return hedge_linear, stderr_bound
 
 
 def reduce_continuous_menu(
@@ -2892,9 +2886,9 @@ def tessera_group_composites(
       the same numbers the DP would charge if the members were separate units,
       so a uniform-rung option prices identically to the old per-NAME
       aggregation (asserted by the caller);
-    * summing is exact only while the UCB hedge is linear. The group hedge is
-      ``z*sqrt(sum stderr^2)``, which is not additive, so this refuses at
-      ``z > 0`` rather than quietly pricing the hedge wrong.
+    * mixed-rung composites retain their existing ``z > 0`` refusal. The
+      conservative uncertainty bound on uniform groups does not establish
+      support for uncertainty repricing across this separate option path.
     """
     from .tessera_formats import (
         format_promotion_class, fused_shared_signature,
@@ -2974,12 +2968,10 @@ def tessera_group_composites(
     # classes to fold and must be untouched by this path.
     if shared_classes and float(ucb_z) > 0.0:
         raise NotImplementedError(
-            "Tessera group composites are exact by summing member costs, and "
-            "the UCB hedge z*sqrt(sum stderr^2) is not additive: at "
-            f"PRISMAQUANT_COST_UCB_Z={ucb_z} the Minkowski fold would price "
-            "the hedge as if it were linear. Set the hedge to 0 for a "
-            "Tessera group run, or extend the fold to carry sum(stderr^2) as "
-            "a third coordinate."
+            "Tessera mixed-rung group composites do not support UCB pricing: "
+            f"PRISMAQUANT_COST_UCB_Z={ucb_z}. Set the hedge to 0 for a "
+            "Tessera group run; uniform-group uncertainty support does not "
+            "enable uncertainty repricing for mixed-rung options."
         )
 
     out: list["Candidate"] = []
@@ -3194,13 +3186,9 @@ def aggregate_fused_siblings(
                     activation_pricing=activation_pricing)
                 sum_pred += member_pred
                 member_terms.append((stats[m], c, member_pred, act_penalty))
-            # Same UCB conversion as aggregate_packed_serving_groups: the
-            # LINEAR z·Σ(stderr) baked into sum_pred becomes the independence
-            # z·sqrt(Σ stderr²) (a qkv triple over-hedged at 3x linear now
-            # hedges at √3), and the aggregated stderr is stored so consumers
-            # of the aggregated cost table keep the hedge instead of silently
-            # reading stderr 0. weight_mse is derived from the UN-hedged sum
-            # so the super entry's mse is not z-contaminated.
+            # Recover the unhedged sum for weight_mse, and store the shared
+            # conservative stderr bound so grouped-table consumers preserve
+            # the uncertainty price. Shared probes do not justify quadrature.
             hedge_linear, stderr_agg = _super_item_ucb_hedge(
                 member_terms, ucb_z)
             base_pred = sum_pred - hedge_linear
@@ -3303,7 +3291,7 @@ def aggregate_fused_siblings(
             stats_ext[super_name]["_memory_bytes_by_format"][spec.name] = total_bytes
             entry_fmt = super_cost_entry_fmt.get(spec.name, spec.name)
             gain = float(gains.get(spec.name, gains.get(entry_fmt, 1.0)))
-            # gain·(base + z·stderr_agg) == gain·base + z·sqrt(Σ (stderr·gain)²)
+            # gain·(base + z·stderr_agg) == gain·base + z·Σ (stderr·gain)
             # for the single group-wide gain this path applies, i.e. exactly the
             # packed path's construction. At z == 0 this is gain·sum_pred,
             # bit-for-bit what this path produced before the hedge fix.
@@ -3679,9 +3667,9 @@ def aggregate_packed_serving_groups(
                 for m in members
             )
             # UCB hedge (PRISMAQUANT_COST_UCB_Z > 0): each member candidate
-            # was priced independently, so the sum above carries a LINEAR
-            # z·Σ(stderr·gain) hedge. Convert it to the independence
-            # aggregate and store the aggregated stderr on the super cost
+            # was priced separately, so the sum above carries a LINEAR
+            # z·Σ(stderr·gain) hedge. Preserve this conservative bound;
+            # shared probes do not justify independence. Store it on the super cost
             # entry so consumers of the aggregated cost table keep the hedge
             # instead of silently reading stderr 0. At z == 0 this is a no-op
             # and the per-format dloss stays the exact sum of member

--- a/prismaquant/allocator_candidates.py
+++ b/prismaquant/allocator_candidates.py
@@ -2841,9 +2841,9 @@ def tessera_group_composites(
     parsed (``tessera_runtime_contract.FusedModuleLicence``), read through
     ``tessera_menu.fused_module_licence`` and checked on the Tessera side
     against the loader's own ``scheme.FUSED_MODULE_FIELDS``.  It is **never** a
-    literal in this file, and ``None`` -- no contract pinned, which is
-    production, since no Tessera RELEASE tag exists -- is the absence of a
-    licence rather than a permissive default.
+    literal in this file. ``None`` means no applicable licence was supplied,
+    rather than a permissive default. Production can supply the licence from
+    the reviewed commit-and-contract pin; a release tag is not required.
     This function used to assert the licence in its own docstring ("they can
     disagree about the rate"), which is the field shape principle 14 forbids:
     no gate can read a docstring, so nothing refused when the runtime changed

--- a/prismaquant/allocator_candidates.py
+++ b/prismaquant/allocator_candidates.py
@@ -1610,14 +1610,15 @@ def cost_entry_act_dloss(cost_entry: dict) -> float:
     weights BIT-IDENTICALLY (T1) -- so the DP was pricing a W4A4 format as if it
     were weight-only and systematically over-buying 4-bit.
 
-    The term is a Δloss in the same currency as the weight term (both are
-    mean-Δloss over the calibration), derived from the layer's own activation
-    statistics, so it is a SUM. It is deliberately not a multiplicative penalty:
+    The term is a diagonal activation Δloss approximation derived from the
+    layer's own activation statistics and is added to the weight estimate.
+    A shared Δloss label does not establish equivalence to AURA's KL-adjoint
+    currency or capture weight/activation cross terms (PrismaQuant #237).
+    It is deliberately not a multiplicative penalty:
     ``ActivationFairPricing`` (P5a) is the multiplicative, per-FAMILY, fitted
     transfer of a weight-space number onto the measured output scale, and this
-    is a per-UNIT, mechanistic, already-output-space quantity. They compose --
-    the penalty scales the weight term it was fitted on, then the A-side is
-    added -- and they are not substitutes.
+    is a per-UNIT, mechanistic, already-output-space quantity. The current
+    weight-only branches add this term before applying the family penalty.
 
     It is added ONLY on the weight-only branches. The ``_prices_from_output_mse``
     branch is already activation-inclusive by construction (the row's own

--- a/prismaquant/anchored_cost.py
+++ b/prismaquant/anchored_cost.py
@@ -29,6 +29,12 @@ from prismaquant.allocator_candidates import (
     ANCHORED_AURA_COST_SOURCE,
     SOURCE_PASSTHROUGH_COST_SOURCE,
 )
+from prismaquant.anchored_shape import (
+    AnchoredShapeError,
+    LogShapeObservation,
+    fit_centered_log_shape,
+    rank_and_solve as _shape_rank_and_solve,
+)
 from prismaquant.cost_stage_checkpoint import (
     atomic_write_bytes,
     canonical_json,
@@ -954,78 +960,11 @@ def _rank_and_solve(
     x_rows: Sequence[Sequence[float]],
     y_rows: Sequence[float],
 ) -> tuple[int, tuple[float, ...]]:
-    """Solve centered least squares through normal equations with pivoting."""
-    if not x_rows:
-        raise AnchoredCostError("shape design is empty")
-    width = len(x_rows[0])
-    if width < 1 or any(len(row) != width for row in x_rows):
-        raise AnchoredCostError("shape feature width is invalid")
-    # Plugin features have no prescribed unit.  Normalize every column before
-    # rank detection/solving so a plugin expressing the same coordinate in
-    # 1e-7 rather than 1 cannot turn an identifiable design into rank zero.
-    column_scales = [
-        math.sqrt(math.fsum(row[index] * row[index] for row in x_rows))
-        for index in range(width)
-    ]
-    active = [scale > 0.0 and math.isfinite(scale) for scale in column_scales]
-    if not all(active):
-        return sum(active), tuple()
-    normalized = [
-        [row[index] / column_scales[index] for index in range(width)]
-        for row in x_rows
-    ]
-    gram = [
-        [math.fsum(row[i] * row[j] for row in normalized) for j in range(width)]
-        for i in range(width)
-    ]
-    rhs = [
-        math.fsum(row[i] * value for row, value in zip(normalized, y_rows))
-        for i in range(width)
-    ]
-    scale = max((abs(value) for row in gram for value in row), default=1.0)
-    tolerance = scale * 1e-12
-    augmented = [gram[index] + [rhs[index]] for index in range(width)]
-    rank = 0
-    for column in range(width):
-        pivot = max(
-            range(rank, width), key=lambda row: abs(augmented[row][column]),
-        )
-        if abs(augmented[pivot][column]) <= tolerance:
-            continue
-        augmented[rank], augmented[pivot] = augmented[pivot], augmented[rank]
-        divisor = augmented[rank][column]
-        augmented[rank] = [value / divisor for value in augmented[rank]]
-        for row in range(width):
-            if row == rank:
-                continue
-            factor = augmented[row][column]
-            if abs(factor) <= tolerance:
-                continue
-            augmented[row] = [
-                value - factor * pivot_value
-                for value, pivot_value in zip(
-                    augmented[row], augmented[rank],
-                )
-            ]
-        rank += 1
-    if rank != width:
-        return rank, tuple()
-    solution = [0.0] * width
-    for row in range(width):
-        pivot_columns = [
-            column for column in range(width)
-            if abs(augmented[row][column] - 1.0) <= 1e-9
-            and all(
-                abs(augmented[other][column]) <= 1e-9
-                for other in range(width) if other != row
-            )
-        ]
-        if len(pivot_columns) != 1:
-            raise AnchoredCostError("shape solve pivot reconstruction failed")
-        solution[pivot_columns[0]] = augmented[row][-1]
-    return rank, tuple(
-        solution[index] / column_scales[index] for index in range(width)
-    )
+    """Compatibility wrapper around the shared, format-neutral solver."""
+    try:
+        return _shape_rank_and_solve(x_rows, y_rows)
+    except AnchoredShapeError as exc:
+        raise AnchoredCostError(str(exc)) from exc
 
 
 def _fit_currency(
@@ -1039,8 +978,7 @@ def _fit_currency(
     widths = {len(candidate.shape_features) for candidate in candidates}
     if len(widths) != 1:
         raise AnchoredCostError("segment candidates use mixed shape bases")
-    width = next(iter(widths))
-    by_unit: dict[str, list[tuple[tuple[float, ...], float]]] = defaultdict(list)
+    panel: list[LogShapeObservation] = []
     for observation in observations:
         if observation.format_name not in by_format:
             raise AnchoredCostError(
@@ -1054,46 +992,24 @@ def _fit_currency(
             raise AnchoredCostError(
                 f"{currency_name} fit requires positive finite cells"
             )
-        by_unit[observation.qname].append((
-            by_format[observation.format_name].shape_features,
-            math.log10(value),
+        panel.append(LogShapeObservation(
+            observation.qname, observation.format_name, value,
         ))
-    x_rows: list[tuple[float, ...]] = []
-    y_rows: list[float] = []
-    for qname, rows in sorted(by_unit.items()):
-        if len(rows) < 2:
-            raise AnchoredCostError(
-                f"panel unit {qname!r} has fewer than two rungs"
-            )
-        feature_means = tuple(
-            math.fsum(features[index] for features, _value in rows) / len(rows)
-            for index in range(width)
-        )
-        value_mean = math.fsum(value for _features, value in rows) / len(rows)
-        for features, value in rows:
-            x_rows.append(tuple(
-                features[index] - feature_means[index]
-                for index in range(width)
-            ))
-            y_rows.append(value - value_mean)
-    rank, coefficients = _rank_and_solve(x_rows, y_rows)
-    if rank != width:
-        raise AnchoredCostError(
-            f"{currency_name} panel design rank is {rank} of {width}"
-        )
     reference = min(candidates, key=lambda item: (
         item.bits, item.coordinate, item.format_name,
     ))
-    g = {
-        candidate.format_name: 10.0 ** math.fsum(
-            coefficient * (feature - reference.shape_features[index])
-            for index, (coefficient, feature) in enumerate(zip(
-                coefficients, candidate.shape_features,
-            ))
+    try:
+        fit = fit_centered_log_shape(
+            panel,
+            {candidate.format_name: candidate.shape_features for candidate in candidates},
+            reference_key=reference.format_name,
         )
-        for candidate in candidates
-    }
-    return g, coefficients, rank
+    except AnchoredShapeError as exc:
+        raise AnchoredCostError(f"{currency_name} {exc}") from exc
+    # Preserve the established AURA representation and numerical order. The
+    # generic fitter knows no currency; all receipt/segment checks stay here.
+    g = {name: 10.0 ** value for name, value in fit.log_shape_by_key.items()}
+    return g, fit.coefficients, fit.design_rank
 
 
 def fit_segment_shape(

--- a/prismaquant/anchored_shape.py
+++ b/prismaquant/anchored_shape.py
@@ -1,0 +1,369 @@
+"""Format-neutral shared log shapes and sparse per-unit anchor corrections.
+
+All logarithms are base ten. Callers own currency, equivalence segments,
+measurement identity, validation policy and fallback. A shared panel removes
+per-unit log offsets before fitting its feature basis. One anchor restores a
+unit's level; two or more also fit a residual slope in a centered, scaled
+coordinate. Real anchors remain exact, including in an overdetermined fit.
+
+Audit measurements never refit the model. An explicit later fit may consume
+accepted audit measurements without changing the frozen earlier predictions.
+This module performs scalar offline arithmetic and imports no model runtime.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import math
+from types import MappingProxyType
+
+
+class AnchoredShapeError(ValueError):
+    """Invalid or unrepresentable numerical shape input."""
+
+
+def _label(value: str, where: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise AnchoredShapeError(f"{where} must be a nonempty string")
+    return value
+
+
+def _finite(value: float, where: str, *, positive: bool = False) -> float:
+    if isinstance(value, bool):
+        raise AnchoredShapeError(f"{where} must be a finite number")
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise AnchoredShapeError(f"{where} must be a finite number") from exc
+    if not math.isfinite(result) or (positive and result <= 0.0):
+        raise AnchoredShapeError(f"{where} must be finite" + (" and positive" if positive else ""))
+    return result
+
+
+@dataclass(frozen=True)
+class LogShapeObservation:
+    unit: str
+    key: str
+    value: float
+
+    def __post_init__(self) -> None:
+        _label(self.unit, "observation unit")
+        _label(self.key, "observation key")
+        object.__setattr__(self, "value", _finite(self.value, "observation value", positive=True))
+
+
+@dataclass(frozen=True)
+class SharedLogShape:
+    coefficients: tuple[float, ...]
+    reference_key: str
+    log_shape_by_key: Mapping[str, float]
+    design_rank: int
+    n_units: int
+    n_observations: int
+
+    def __post_init__(self) -> None:
+        values = {_label(key, "shape key"): _finite(value, "log shape")
+                  for key, value in self.log_shape_by_key.items()}
+        coefficients = tuple(_finite(value, "shape coefficient") for value in self.coefficients)
+        if not values or self.reference_key not in values:
+            raise AnchoredShapeError("shape reference is absent")
+        if not coefficients or self.design_rank != len(coefficients):
+            raise AnchoredShapeError("shape design rank is insufficient")
+        if self.n_units < 1 or self.n_observations < 2*self.n_units:
+            raise AnchoredShapeError("shape observation count is insufficient")
+        object.__setattr__(self, "coefficients", coefficients)
+        object.__setattr__(self, "log_shape_by_key", MappingProxyType(values))
+
+
+@dataclass(frozen=True)
+class AnchorCorrection:
+    shape: SharedLogShape
+    anchors: Mapping[str, float]
+    coordinates: Mapping[str, float]
+    center: float
+    scale: float
+    intercept: float
+    slope: float
+
+    def __post_init__(self) -> None:
+        # Freeze caller-owned mappings so later measurement/refit cannot
+        # change predictions used to evaluate an earlier audit.
+        if not isinstance(self.shape, SharedLogShape):
+            raise AnchoredShapeError("shared shape type is invalid")
+        anchors = {_label(key, "anchor key"): _finite(value, "anchor value", positive=True)
+                   for key, value in self.anchors.items()}
+        coordinates = {_label(key, "coordinate key"): _finite(value, "coordinate")
+                       for key, value in self.coordinates.items()}
+        if not anchors or not set(anchors) <= set(coordinates):
+            raise AnchoredShapeError("anchor keys are empty or unknown")
+        if set(coordinates) != set(self.shape.log_shape_by_key):
+            raise AnchoredShapeError("coordinate domain differs from shared shape")
+        if len(set(coordinates.values())) != len(coordinates):
+            raise AnchoredShapeError("duplicate coordinates do not identify distinct rungs")
+        for name in ("center", "scale", "intercept", "slope"):
+            object.__setattr__(self, name, _finite(getattr(self, name), name, positive=name == "scale"))
+        object.__setattr__(self, "anchors", MappingProxyType(anchors))
+        object.__setattr__(self, "coordinates", MappingProxyType(coordinates))
+
+
+@dataclass(frozen=True)
+class AnchoredAuditRow:
+    key: str
+    predicted: float
+    measured: float
+    absolute_log10_error: float
+
+
+@dataclass(frozen=True)
+class AnchoredAudit:
+    rows: tuple[AnchoredAuditRow, ...]
+
+    @property
+    def max_absolute_log10_error(self) -> float:
+        return max(row.absolute_log10_error for row in self.rows)
+
+
+def rank_and_solve(
+    x_rows: Sequence[Sequence[float]],
+    y_rows: Sequence[float],
+) -> tuple[int, tuple[float, ...]]:
+    """Solve centered least squares through normal equations with pivoting."""
+    if not x_rows:
+        raise AnchoredShapeError("shape design is empty")
+    width = len(x_rows[0])
+    if width < 1 or any(len(row) != width for row in x_rows):
+        raise AnchoredShapeError("shape feature width is invalid")
+    # Plugin features have no prescribed unit.  Normalize every column before
+    # rank detection/solving so a plugin expressing the same coordinate in
+    # 1e-7 rather than 1 cannot turn an identifiable design into rank zero.
+    column_scales = [
+        math.sqrt(math.fsum(row[index] * row[index] for row in x_rows))
+        for index in range(width)
+    ]
+    active = [scale > 0.0 and math.isfinite(scale) for scale in column_scales]
+    if not all(active):
+        return sum(active), tuple()
+    normalized = [
+        [row[index] / column_scales[index] for index in range(width)]
+        for row in x_rows
+    ]
+    gram = [
+        [math.fsum(row[i] * row[j] for row in normalized) for j in range(width)]
+        for i in range(width)
+    ]
+    rhs = [
+        math.fsum(row[i] * value for row, value in zip(normalized, y_rows))
+        for i in range(width)
+    ]
+    scale = max((abs(value) for row in gram for value in row), default=1.0)
+    tolerance = scale * 1e-12
+    augmented = [gram[index] + [rhs[index]] for index in range(width)]
+    rank = 0
+    for column in range(width):
+        pivot = max(
+            range(rank, width), key=lambda row: abs(augmented[row][column]),
+        )
+        if abs(augmented[pivot][column]) <= tolerance:
+            continue
+        augmented[rank], augmented[pivot] = augmented[pivot], augmented[rank]
+        divisor = augmented[rank][column]
+        augmented[rank] = [value / divisor for value in augmented[rank]]
+        for row in range(width):
+            if row == rank:
+                continue
+            factor = augmented[row][column]
+            if abs(factor) <= tolerance:
+                continue
+            augmented[row] = [
+                value - factor * pivot_value
+                for value, pivot_value in zip(
+                    augmented[row], augmented[rank],
+                )
+            ]
+        rank += 1
+    if rank != width:
+        return rank, tuple()
+    solution = [0.0] * width
+    for row in range(width):
+        pivot_columns = [
+            column for column in range(width)
+            if abs(augmented[row][column] - 1.0) <= 1e-9
+            and all(
+                abs(augmented[other][column]) <= 1e-9
+                for other in range(width) if other != row
+            )
+        ]
+        if len(pivot_columns) != 1:
+            raise AnchoredShapeError("shape solve pivot reconstruction failed")
+        solution[pivot_columns[0]] = augmented[row][-1]
+    return rank, tuple(
+        solution[index] / column_scales[index] for index in range(width)
+    )
+
+
+def fit_centered_log_shape(
+    observations: Sequence[LogShapeObservation],
+    features_by_key: Mapping[str, Sequence[float]],
+    *,
+    reference_key: str | None = None,
+) -> SharedLogShape:
+    """Fit log shape after removing each panel unit's own log-cost level.
+
+    A caller may declare unmeasured target keys, provided the observed panel
+    identifies every feature column. Feature and observation iteration order
+    is retained to preserve the established AURA fitter's arithmetic.
+    """
+    if not observations or not features_by_key:
+        raise AnchoredShapeError("shape input is empty")
+    features = {
+        _label(key, "feature key"): tuple(_finite(value, "shape feature") for value in row)
+        for key, row in features_by_key.items()
+    }
+    widths = {len(row) for row in features.values()}
+    if len(widths) != 1 or not next(iter(widths)):
+        raise AnchoredShapeError("shape feature width is invalid")
+    width = next(iter(widths))
+    reference = min(features) if reference_key is None else reference_key
+    if reference not in features:
+        raise AnchoredShapeError("unknown shape reference key")
+    by_unit: dict[str, list[tuple[tuple[float, ...], float]]] = defaultdict(list)
+    seen: set[tuple[str, str]] = set()
+    duplicate = False
+    for observation in observations:
+        if not isinstance(observation, LogShapeObservation):
+            raise AnchoredShapeError("shape observation type is invalid")
+        pair = observation.unit, observation.key
+        if pair in seen:
+            duplicate = True
+        seen.add(pair)
+        if observation.key not in features:
+            raise AnchoredShapeError("unknown shape observation key")
+        by_unit[observation.unit].append((features[observation.key], math.log10(observation.value)))
+    x_rows: list[tuple[float, ...]] = []
+    y_rows: list[float] = []
+    try:
+        for unit, rows in sorted(by_unit.items()):
+            if len(rows) < 2:
+                raise AnchoredShapeError(f"panel unit {unit!r} has fewer than two rungs")
+            feature_means = tuple(math.fsum(row[index] for row, _ in rows) / len(rows)
+                                  for index in range(width))
+            value_mean = math.fsum(value for _, value in rows) / len(rows)
+            for row, value in rows:
+                x_rows.append(tuple(row[index] - feature_means[index] for index in range(width)))
+                y_rows.append(value - value_mean)
+        rank, coefficients = rank_and_solve(x_rows, y_rows)
+        if rank != width:
+            raise AnchoredShapeError(f"panel design rank is {rank} of {width}")
+        if duplicate:
+            raise AnchoredShapeError("duplicate unit/key shape observation")
+        log_shape = {
+            key: math.fsum(coefficient * (feature - features[reference][index])
+                           for index, (coefficient, feature) in enumerate(zip(coefficients, row)))
+            for key, row in features.items()
+        }
+    except (OverflowError, ZeroDivisionError) as exc:
+        raise AnchoredShapeError("shape design arithmetic is not representable") from exc
+    return SharedLogShape(coefficients, reference, log_shape, rank, len(by_unit), len(observations))
+
+
+def fit_anchor_correction(
+    shape: SharedLogShape,
+    anchors: Mapping[str, float],
+    coordinates: Mapping[str, float],
+) -> AnchorCorrection:
+    """Restore level from one anchor, or fit level and tilt from two or more.
+
+    The coordinate map declares the entire supported target domain. Center
+    and scale it before solving, so coordinate origin and units cannot create
+    an artificial rank failure. Beyond two anchors the affine residual is a
+    least-squares proposal; each measured anchor still predicts exactly.
+    """
+    if not isinstance(shape, SharedLogShape):
+        raise AnchoredShapeError("shared shape type is invalid")
+    if not anchors:
+        raise AnchoredShapeError("anchor input is empty")
+    if set(coordinates) != set(shape.log_shape_by_key):
+        raise AnchoredShapeError("coordinate domain differs from shared shape")
+    coords = {key: _finite(value, "coordinate") for key, value in coordinates.items()}
+    if len(set(coords.values())) != len(coords):
+        raise AnchoredShapeError("duplicate coordinates do not identify distinct rungs")
+    values: dict[str, float] = {}
+    for key, value in anchors.items():
+        if key not in coords:
+            raise AnchoredShapeError("unknown anchor key")
+        values[key] = _finite(value, "anchor value", positive=True)
+    lower, upper = min(coords.values()), max(coords.values())
+    center = lower/2.0 + upper/2.0
+    scale = max(abs(lower - center), abs(upper - center)) or 1.0
+    normalized = {key: (value - center)/scale for key, value in coords.items()}
+    if any(not math.isfinite(value) for value in normalized.values()):
+        raise AnchoredShapeError("coordinate normalization is not representable")
+    if len(set(normalized.values())) != len(coords):
+        raise AnchoredShapeError("coordinate normalization loses distinct rungs")
+    xs = [normalized[key] for key in values]
+    residuals = [_finite(math.log10(value) - shape.log_shape_by_key[key], "anchor residual")
+                 for key, value in values.items()]
+    if len(values) == 1:
+        intercept, slope = residuals[0], 0.0
+    else:
+        try:
+            x_mean = math.fsum(xs)/len(xs)
+            y_mean = math.fsum(residuals)/len(residuals)
+            rank, coefficients = rank_and_solve([(x-x_mean,) for x in xs],
+                                                [y-y_mean for y in residuals])
+        except (OverflowError, ZeroDivisionError) as exc:
+            raise AnchoredShapeError("anchor correction arithmetic is not representable") from exc
+        if rank != 1:
+            raise AnchoredShapeError("anchor correction design rank is insufficient")
+        slope = coefficients[0]
+        intercept = y_mean - slope*x_mean
+    return AnchorCorrection(shape, values, coords, center, scale,
+                            _finite(intercept, "residual intercept"),
+                            _finite(slope, "residual slope"))
+
+
+def predict_anchored(correction: AnchorCorrection, key: str) -> float:
+    """Predict one declared key, returning actual anchor values verbatim."""
+    if not isinstance(correction, AnchorCorrection):
+        raise AnchoredShapeError("anchor correction type is invalid")
+    _label(key, "prediction key")
+    if key not in correction.coordinates:
+        raise AnchoredShapeError("unknown prediction key")
+    if key in correction.anchors:
+        return correction.anchors[key]
+    coordinate = (correction.coordinates[key] - correction.center)/correction.scale
+    try:
+        log_value = math.fsum((correction.shape.log_shape_by_key[key],
+                               correction.intercept, correction.slope*coordinate))
+        value = 10.0**log_value
+    except (OverflowError, ValueError) as exc:
+        raise AnchoredShapeError("prediction is not representable as a positive finite float") from exc
+    if not math.isfinite(value) or value <= 0.0:
+        raise AnchoredShapeError("prediction is not representable as a positive finite float")
+    return value
+
+
+def audit_anchored(
+    correction: AnchorCorrection,
+    observations: Mapping[str, float],
+) -> AnchoredAudit:
+    """Freeze untouched audit predictions and errors without fitting them."""
+    if not observations:
+        raise AnchoredShapeError("audit input is empty")
+    if set(observations) & set(correction.anchors):
+        raise AnchoredShapeError("audit key is also a fitted anchor")
+    rows = []
+    for key, value in sorted(observations.items()):
+        measured = _finite(value, "audit value", positive=True)
+        predicted = predict_anchored(correction, key)
+        rows.append(AnchoredAuditRow(key, predicted, measured,
+                                    abs(math.log10(predicted) - math.log10(measured))))
+    return AnchoredAudit(tuple(rows))
+
+
+__all__ = [
+    "AnchoredShapeError", "LogShapeObservation", "SharedLogShape", "AnchorCorrection",
+    "AnchoredAuditRow", "AnchoredAudit", "fit_centered_log_shape", "fit_anchor_correction",
+    "predict_anchored", "audit_anchored",
+]

--- a/prismaquant/aqua_activation_cost.py
+++ b/prismaquant/aqua_activation_cost.py
@@ -30,8 +30,8 @@ from overshooting the other way. ``activation_dloss_table`` therefore REQUIRES
 the lane's ``served_activation_quantization.executes`` (glob patterns over
 format names) and refuses to guess it.
 
-This stage exists as its own step, rather than inside the cost stage, because
-the A-side is genuinely separable:
+This stage uses a diagonal approximation that treats the activation term
+separately from the weight term:
 
   * It needs NO render. ``activation_dloss`` reads the DENSE weight (as
     ``W[o,j]^2``), the card's ``g_sq_sum``, and the format's activation grid.
@@ -41,7 +41,13 @@ the A-side is genuinely separable:
     ``W^2 @ var`` per unit -- minutes, not the hours a render costs -- and it can
     be recomputed against any existing cost artifact without rebuilding it.
 
-That separability is also the reason the term matters MORE than its size on an
+This computational separation does not establish that the actual errors are
+independent. The approximation omits weight/activation interference and
+channel correlations; its sensitivity card is not the KL/Gauss-Newton
+adjoint used by AURA. Joint downstream pricing must project the full served
+output residual before squaring (tracked in PrismaQuant #237).
+
+That separate accounting is also the reason the term matters MORE than its size on an
 RTN basis suggests: GPTQ and JSO shrink the W-side substantially and do nothing
 whatever to the A-side. Measured on Qwen3.8-27B, production rendering cut
 NVFP4's median W-side to 0.13x its RTN value while the A-side was unchanged, so

--- a/prismaquant/tessera_anchored_surface.py
+++ b/prismaquant/tessera_anchored_surface.py
@@ -1,0 +1,352 @@
+"""Research replay of receipt-bound Tessera costs through shared anchored shapes.
+
+This reader verifies recorded campaign identities and blob hashes. It does not
+recompute source tensors, validate producer wire grammar, qualify a serving lane,
+or emit allocator input. The current campaign importer accepts output MSE only;
+the neutral numerical core never turns that quantity into AURA.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import pickle
+from collections.abc import Mapping
+from pathlib import Path
+
+from .anchored_shape import (
+    AnchoredShapeError, LogShapeObservation, audit_anchored,
+    fit_anchor_correction, fit_centered_log_shape, predict_anchored,
+)
+from .cost_stage_checkpoint import (
+    MANIFEST_SCHEMA, _load_unit, canonical_json_sha256, unit_path,
+)
+
+PLAN_SCHEMA = "prismaquant.tessera_anchored_replay.plan.v1"
+REPORT_SCHEMA = "prismaquant.tessera_anchored_replay.report.v1"
+CAMPAIGN_SCHEMA = "prismaquant.tessera_campaign_cost.v1"
+CURRENCY = "output_mse_under_route_activation_contract"
+
+
+class ReplayError(ValueError):
+    """An explicit replay input or its recorded identity is inconsistent."""
+
+
+def _require(condition, message):
+    if not condition:
+        raise ReplayError(message)
+
+
+def _digest(value):
+    return canonical_json_sha256(value, where="anchored replay identity")
+
+
+def _sha(path):
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _positive(value):
+    return (type(value) in (float, int) and math.isfinite(value) and value > 0)
+
+
+def load_campaign_measurements(cost_path, checkpoint_path, plan):
+    """Read trusted local pickle artifacts, bound to the plan's exact hashes.
+
+    Uses the existing journal reader and existing producer receipt fields.
+    No journal, wire, source, or campaign artifact is created or rewritten.
+    """
+    cost_path, checkpoint_path = Path(cost_path), Path(checkpoint_path)
+    binding = plan["input"]
+    payload_bytes = cost_path.read_bytes()
+    _require(hashlib.sha256(payload_bytes).hexdigest() == binding["payload_sha256"], "payload hash mismatch")
+    manifest = json.loads(checkpoint_path.read_text())
+    _require(manifest.get("schema") == MANIFEST_SCHEMA
+             and manifest.get("stage") == "Tessera campaign", "unsupported checkpoint")
+    identity = manifest["identity"]
+    seal = _digest(identity)
+    _require(seal == manifest.get("identity_sha256")
+             == binding["checkpoint_identity_sha256"], "checkpoint identity mismatch")
+    _require(identity.get("campaign_schema") == CAMPAIGN_SCHEMA
+             and identity.get("currency") == CURRENCY, "unsupported campaign currency")
+    for name in ("prismaquant_source_sha256", "encoder_source_sha256"):
+        value = identity.get(name)
+        _require(isinstance(value, str) and len(value) == 64
+                 and all(c in "0123456789abcdef" for c in value), f"missing {name}")
+    _require(isinstance(identity.get("calibration"), dict)
+             and bool(identity["calibration"]), "missing calibration identity")
+    payload = pickle.loads(payload_bytes)
+    _require(payload.get("schema") == CAMPAIGN_SCHEMA
+             and payload.get("currency") == CURRENCY == plan["currency"],
+             "current campaign importer only accepts recorded output-MSE currency")
+    provenance = payload["provenance"]
+    _require(provenance.get("cost_mode") == "production-render-score",
+             "campaign is not attested production-render-score")
+    wire_dir = Path(provenance["wire_dir"])
+    journal = checkpoint_path.with_name(checkpoint_path.name + ".parts")
+    units = identity["units"]
+    roster = manifest.get("units", [])
+    _require({item["qname"] for item in roster} == set(units)
+             and len(roster) == len(units), "checkpoint unit roster mismatch")
+    measurements = {}
+    receipts = {}
+    for unit, rows in sorted(payload["costs"].items()):
+        _require(unit in units, f"unknown source unit {unit}")
+        state = _load_unit(unit_path(journal, unit), stage="Tessera campaign",
+                           qname=unit, identity_sha256=seal)
+        _require(set(state) == {"anchors", "wire_records"}, "invalid anchor state")
+        anchors = {row["format_name"]: row for row in state["anchors"]}
+        _require(len(anchors) == len(state["anchors"])
+                 and set(anchors) == set(state["wire_records"]), "anchor receipt coverage mismatch")
+        for key, row in sorted(rows.items()):
+            if row.get("output_mse_measured") is not True:
+                continue
+            _require(key in anchors, f"unreceipted measured row {unit}/{key}")
+            anchor = anchors[key]
+            _require(anchor["qname"] == unit and key in units[unit]["menu"],
+                     "anchor is outside checkpoint unit/menu")
+            _require(row.get("currency") == CURRENCY
+                     and row.get("cost_source") == "tessera_campaign_measured"
+                     and row.get("tessera_provenance") == "measured", "measured provenance mismatch")
+            for target, source in (("output_mse", "dloss"), ("tessera_family", "family"),
+                                   ("tessera_body_rate_q256", "body_rate_q256"),
+                                   ("activation_contract", "activation_contract"),
+                                   ("activation_quantized", "activation_quantized"),
+                                   ("wire_bytes", "wire_bytes")):
+                _require(row.get(target) == anchor.get(source), f"anchor {target} mismatch")
+            static_scale = units[unit].get("input_global_scale")
+            _require(row.get("input_global_scale") == anchor.get("input_global_scale")
+                     and (anchor.get("input_global_scale") is None
+                          or anchor["input_global_scale"] == static_scale), "static-scale identity mismatch")
+            hessian = row.get("hessian_identity", {})
+            _require(hessian.get("applied") == anchor.get("hessian_applied"),
+                     "Hessian applicability mismatch")
+            for field in ("supplied", "capture_sha256", "text_sha256", "fit_ids_sha256", "fit_tokens"):
+                _require(hessian.get(field) == provenance.get("hessian", {}).get(field),
+                         f"Hessian {field} mismatch")
+            record = state["wire_records"][key]
+            recorded = record["identity"]
+            _require(recorded.get("unit") == unit
+                     and recorded.get("source") == units[unit]["weight"]
+                     and recorded.get("encoder_source_sha256") == identity["encoder_source_sha256"],
+                     "recorded source/encoder identity mismatch")
+            calibration = recorded.get("calibration")
+            if anchor.get("hessian_applied"):
+                _require(isinstance(calibration, dict)
+                         and calibration.get("hessian") == units[unit]["hessian"],
+                         "recorded Hessian identity mismatch")
+            else:
+                _require(calibration is None, "H-free anchor has an H-aware receipt")
+            recipe = dict(recorded["recipe"])
+            _require(recipe.pop("q256", None) == anchor["body_rate_q256"], "wire rate mismatch")
+            filename = record["file"]
+            _require(isinstance(filename, str) and Path(filename).name == filename
+                     and filename not in {".", ".."}, "wire filename escapes directory")
+            wire = wire_dir / filename
+            _require(not wire.is_symlink() and wire.resolve().parent == wire_dir.resolve(),
+                     "wire path escapes directory")
+            _require(wire.stat().st_size == record["blob_bytes"] == anchor["wire_bytes"]
+                     and _sha(wire) == record["blob_sha256"], "wire blob hash/size mismatch")
+            measurement = {
+                "value": row["output_mse"], "currency": CURRENCY,
+                "coordinate": anchor["body_rate_q256"],
+                "family": row["tessera_family"], "activation_contract": row["activation_contract"],
+                "geometry": units[unit]["weight"]["shape"], "wire_recipe": recipe,
+                "hessian_applied": anchor["hessian_applied"],
+            }
+            measurements[(unit, key)] = measurement
+            receipts[f"{unit}|{key}"] = _digest(record)
+    return measurements, {
+        "payload_sha256": binding["payload_sha256"], "checkpoint_identity_sha256": seal,
+        "recorded_receipts_sha256": _digest(receipts),
+        "recorded_menus": {unit: row["menu"] for unit, row in units.items()},
+        "source_recomputed": False, "producer_wire_grammar_revalidated": False,
+        "verification": "journal_identity_and_recorded_source_and_blob_hashes",
+    }, provenance.get("anchor_groups", {})
+
+
+def replay_measurements(measurements, plan, *, input_identity, groups=None):
+    """Run a declared split; return research predictions and missing work only.
+
+    ``measurements`` is the checked importer output. The explicit currency is
+    carried unchanged; this function provides no mapping between currencies.
+    """
+    _require(plan.get("schema") == PLAN_SCHEMA, "unsupported replay plan")
+    _require(isinstance(plan.get("currency"), str) and bool(plan["currency"]), "missing currency")
+    reports = []
+    requests = set()
+    seen = set()
+    for segment in plan["segments"]:
+        label = segment["id"]
+        _require(label not in seen, "duplicate segment id")
+        seen.add(label)
+        descriptor = segment["descriptor"]
+        _require(isinstance(descriptor.get("role"), str) and bool(descriptor["role"]),
+                 "segment needs an explicit profile role declaration")
+        features = segment["features_by_key"]
+        coordinates = segment["coordinates"]
+        _require(set(features) == set(coordinates) and len(coordinates) >= 3, "invalid segment domain")
+        _require(all(type(v) is int and v > 0 for v in coordinates.values())
+                 and len(set(coordinates.values())) == len(coordinates), "invalid rate coordinates")
+        domain = sorted(coordinates, key=lambda key: (coordinates[key], key))
+        pilots, heldout = segment["pilot"], segment["heldout"]
+        _require(bool(pilots) and bool(heldout) and not set(pilots) & set(heldout),
+                 "pilot and held-out units must be nonempty and disjoint")
+        for unit in set(pilots) | set(heldout):
+            _require(set(domain) <= set(input_identity["recorded_menus"].get(unit, [])),
+                     f"declared domain exceeds recorded source menu for {unit}")
+        threshold = segment["max_absolute_log10_error"]
+        _require(type(threshold) in (int, float) and math.isfinite(threshold) and threshold >= 0,
+                 "invalid audit threshold")
+        _require(type(segment.get("refit_after_audit", False)) is bool, "invalid refit policy")
+
+        def read(unit, key):
+            _require(key in coordinates, "requested rung outside declared domain")
+            row = measurements.get((unit, key))
+            if row is None:
+                return None
+            _require(row.get("currency") == plan["currency"], "measurement currency mismatch")
+            for field in ("family", "activation_contract", "geometry", "wire_recipe", "hessian_applied"):
+                _require(field in descriptor and row.get(field) == descriptor[field],
+                         f"cross-segment {field}: {unit}/{key}")
+            _require(row["coordinate"] == coordinates[key], "coordinate identity mismatch")
+            return row["value"]
+
+        observations = []
+        pilot_missing = []
+        for unit, keys in sorted(pilots.items()):
+            _require(len(keys) >= 2 and len(set(keys)) == len(keys), "invalid pilot rungs")
+            for key in keys:
+                value = read(unit, key)
+                if not _positive(value):
+                    pilot_missing.append((unit, key))
+                else:
+                    observations.append(LogShapeObservation(unit, key, value))
+        pilot_coordinates = [coordinates[key] for keys in pilots.values() for key in keys]
+        _require(min(pilot_coordinates) == min(coordinates.values())
+                 and max(pilot_coordinates) == max(coordinates.values()),
+                 "pilot coordinate envelope must cover the declared domain")
+        fit_reason = None
+        shape = None
+        if not pilot_missing:
+            try:
+                shape = fit_centered_log_shape(observations, features)
+            except AnchoredShapeError as exc:
+                fit_reason = str(exc)
+        else:
+            fit_reason = "missing_or_invalid_pilot_measurements"
+            requests.update((label, unit, key) for unit, key in pilot_missing)
+        units_report = {}
+        for unit, split in sorted(heldout.items()):
+            anchor_keys, audit_keys = split["anchors"], split["audit"]
+            _require(1 <= len(anchor_keys) <= 2 and len(set(anchor_keys)) == len(anchor_keys),
+                     "held-out unit needs one or two distinct anchors")
+            _require(bool(audit_keys) and len(set(audit_keys)) == len(audit_keys)
+                     and not set(anchor_keys) & set(audit_keys), "audit must be disjoint from anchors")
+            needed = {key: read(unit, key) for key in anchor_keys + audit_keys}
+            missing = [key for key, value in needed.items() if not _positive(value)]
+            invalid_extra = [key for key in domain if (unit, key) in measurements
+                             and not _positive(read(unit, key))]
+            result = {"status": "measure_more", "anchors": list(anchor_keys), "audit": [],
+                      "predictions": {}, "refit_after_audit": False,
+                      "pwl_audit": []}
+            for key in audit_keys:
+                if len(anchor_keys) != 2 or any(not _positive(needed[k]) for k in anchor_keys):
+                    result["pwl_audit"].append({"key": key, "unavailable": "needs_two_valid_anchors"})
+                    continue
+                left, right = sorted(anchor_keys, key=coordinates.get)
+                if needed[right] >= needed[left]:
+                    result["pwl_audit"].append({"key": key, "unavailable": "nonmonotone_anchors"})
+                    continue
+                if not coordinates[left] < coordinates[key] < coordinates[right]:
+                    result["pwl_audit"].append({"key": key, "unavailable": "outside_anchor_envelope"})
+                    continue
+                fraction = (coordinates[key] - coordinates[left]) / (coordinates[right] - coordinates[left])
+                predicted = 10 ** (math.log10(needed[left]) * (1 - fraction)
+                                   + math.log10(needed[right]) * fraction)
+                result["pwl_audit"].append({
+                    "key": key, "predicted": predicted,
+                    "measured": needed[key] if _positive(needed[key]) else None,
+                    "absolute_log10_error": (abs(math.log10(predicted) - math.log10(needed[key]))
+                                              if _positive(needed[key]) else None),
+                })
+            if missing or invalid_extra:
+                requests.update((label, unit, key) for key in set(missing + invalid_extra))
+                result["reason"] = "missing_or_invalid_anchor_or_audit"
+            elif shape is None:
+                result["reason"] = fit_reason
+                requests.update((label, unit, key) for key in domain)
+            else:
+                try:
+                    anchors = {key: needed[key] for key in anchor_keys}
+                    correction = fit_anchor_correction(shape, anchors, coordinates)
+                    audit = audit_anchored(correction, {key: needed[key] for key in audit_keys})
+                    result["audit"] = [dict(key=row.key, predicted=row.predicted, measured=row.measured,
+                                            absolute_log10_error=row.absolute_log10_error,
+                                            held_out_axes=(["unit", "rung"] if row.key not in
+                                                           {key for keys in pilots.values() for key in keys}
+                                                           else ["unit"]))
+                                       for row in audit.rows]
+                    passed = audit.max_absolute_log10_error <= threshold
+                    predictions = {key: predict_anchored(correction, key) for key in domain}
+                    passed = passed and all(predictions[b] <= predictions[a]
+                                            for a, b in zip(domain, domain[1:]))
+                    if passed and segment.get("refit_after_audit", False):
+                        correction = fit_anchor_correction(shape, needed, coordinates)
+                        predictions = {key: predict_anchored(correction, key) for key in domain}
+                        passed = all(predictions[b] <= predictions[a] for a, b in zip(domain, domain[1:]))
+                        result["refit_after_audit"] = passed
+                    if passed:
+                        # Preserve every observed domain row; never relabel a prediction as measured.
+                        result["predictions"] = {
+                            key: {"value": value if _positive(value := read(unit, key)) else predictions[key],
+                                  "source": "measured" if _positive(value) else "predicted"}
+                            for key in domain
+                        }
+                        mixed = result["predictions"]
+                        if all(mixed[b]["value"] <= mixed[a]["value"] for a, b in zip(domain, domain[1:])):
+                            result["status"] = "audit_accepted_research_only"
+                        else:
+                            result["predictions"] = {}
+                            result["refit_after_audit"] = False
+                            result["reason"] = "measured_overlay_nonmonotone"
+                            requests.update((label, unit, key) for key in domain)
+                    else:
+                        result["reason"] = "audit_or_monotonicity_failed"
+                        requests.update((label, unit, key) for key in domain)
+                except (AnchoredShapeError, OverflowError) as exc:
+                    result["reason"] = str(exc)
+                    requests.update((label, unit, key) for key in domain)
+            units_report[unit] = result
+        reports.append({"id": label, "descriptor": descriptor, "units": units_report,
+                        "pilot_fit_error": fit_reason,
+                        "pilot_fit": (None if shape is None else {
+                            "coefficients_log10": list(shape.coefficients),
+                            "reference_key": shape.reference_key, "design_rank": shape.design_rank,
+                            "n_units": shape.n_units, "n_observations": shape.n_observations,
+                        })})
+    # Existing campaign group placement is retained even when only one sibling fails.
+    for label, unit, key in sorted(requests.copy()):
+        for members in (groups or {}).values():
+            if unit in members:
+                _require(all(key in input_identity["recorded_menus"].get(member, []) for member in members),
+                         "fused-group measurement request exceeds a recorded member menu")
+                requests.update((label, member, key) for member in members)
+    return {
+        "schema": REPORT_SCHEMA, "currency": plan["currency"], "plan_sha256": _digest(plan),
+        "input_identity": {key: value for key, value in input_identity.items() if key != "recorded_menus"},
+        "production_qualified": False,
+        "allocator_payload": False, "latency_evidence": None,
+        "role_partition": "explicit_plan_declaration", "segments": reports,
+        "measurement_requests": [dict(segment=label, unit=unit, key=key)
+                                 for label, unit, key in sorted(requests)],
+    }
+
+
+def replay_campaign(cost_path, checkpoint_path, plan):
+    _require(plan.get("schema") == PLAN_SCHEMA, "unsupported replay plan")
+    measurements, identity, groups = load_campaign_measurements(cost_path, checkpoint_path, plan)
+    return replay_measurements(measurements, plan, input_identity=identity, groups=groups)

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -1828,11 +1828,14 @@ def main(argv: "Sequence[str] | None" = None) -> int:
                     if value > worst:
                         worst, worst_loo = value, member_loo
                 if not ready:
-                    continue
-                if not interpolable:
+                    # LOO cannot judge two endpoints. Bootstrap an interior
+                    # anchor through next_anchor_rate's widest-gap fallback;
+                    # missing LOO is neither a closed gate nor a refusal.
+                    worst_loo = {}
+                elif not interpolable:
                     surface_stop.setdefault((key, family), "non_interpolable")
                     continue
-                if worst <= args.loo_gate:
+                elif worst <= args.loo_gate:
                     surface_stop.setdefault((key, family), "gate_closed")
                     continue
                 nxt = next_anchor_rate(grid, worst_loo)

--- a/prismaquant/tessera_menu.py
+++ b/prismaquant/tessera_menu.py
@@ -21,22 +21,18 @@ Three gates, and they are deliberately separate
 3. **A pinned runtime executes it.**  :func:`route_admission` -- ONE lookup,
    against the pinned serving release's own published contract (principle 14).
 
-Gate 3 is closed for every Tessera rung today
----------------------------------------------
+Gate 3 reads the current pinned runtime and serving scope
+--------------------------------------------------------
 The table that answers is **Tessera's own** packaged
-``tessera/serving/runtime_contract.json`` -- the plugin Tessera ships under
-``vllm.general_plugins`` since 2026-09-02, when Gridbook's Tessera lane was
-withdrawn (``archive/gridbook_lane_2026-09-02/``).  It publishes
-``TESSERA_E2M1_K2`` and ``TESSERA_E4M3_K1``, and it carries device-qualified
-native cells for the two receipted rungs, so the family and the rate are *not*
-what refuses.  **The pin is.**  Since 2026-09-04 ``tessera_serving_runtime_pin``
-names an exact Tessera commit and the SHA-256 of the ``runtime_contract.json``
-that commit packages; ``require_pinned_tessera_runtime`` admits only the
-Tessera whose installed contract hashes to it, and any other tree on
-``PYTHONPATH`` -- including a master that has moved past the pin -- answers
-:data:`ROUTE_STATUS_UNATTESTED`.  Moving the pin is ONE reviewed commit that
-edits the JSON and the module constants together; an edit here cannot flip it,
-and that is the point.
+``tessera/serving/runtime_contract.json``. Its native cells declare the
+families, rates and serving contexts that are qualified. Since 2026-09-04,
+``tessera_serving_runtime_pin`` names an exact Tessera commit and the SHA-256
+of the contract it packages. Matching cells can be admitted when the installed
+contract matches that digest and the requested scope; an absent cell or a
+different contract remains unattested. Reader support for a wider rate range
+does not qualify every rate for serving. Moving the pin edits the JSON and
+module constants together, including when a new producer API requires a newer
+commit with unchanged contract bytes.
 
 Which is why the ``detail`` on an unattested rung names the conjunct that
 actually refused (``tessera_render.tessera_lane_admission`` returns it beside

--- a/tests/fixtures/super_item_menu_golden.json
+++ b/tests/fixtures/super_item_menu_golden.json
@@ -1,10 +1,11 @@
 {
- "digest": "033adb45e71a51b831f5335047fa56e5fb00dc3137894a983fa0146bf456197d",
+ "digest": "851018a87a3748f6b3a3bab0f2bf91504e597bf273d20f2a267d9566566a10cd",
  "menu": [
   "NVFP4",
   "FP8_E4M3",
   "BF16"
  ],
+ "regen_reason": "PrismaQuant #236: AURA member errors share probes, so grouped UCB retains the conservative sum of scaled standard errors. z=0 candidate prices remain bit-exact; grouped stderr metadata and opt-in z>0 prices intentionally increase.",
  "scenarios": {
   "fused_hedged_gained_priced": {
    "passthrough_rows": [
@@ -23,13 +24,13 @@
       "FP8_E4M3": {
        "activation_pricing_applied": true,
        "predicted_dloss": "0.0013679500000000002",
-       "predicted_dloss_stderr": "0.0004187997880849512",
+       "predicted_dloss_stderr": "0.00058315",
        "weight_mse": "0.001954214285714286"
       },
       "NVFP4": {
        "activation_pricing_applied": true,
        "predicted_dloss": "0.034387",
-       "predicted_dloss_stderr": "0.010527627700484096",
+       "predicted_dloss_stderr": "0.014659000000000002",
        "weight_mse": "0.04912428571428572"
       }
      },
@@ -48,7 +49,7 @@
        "bits_per_param": "4.5",
        "fmt": "NVFP4",
        "memory_bytes": 50724864,
-       "predicted_dloss": "0.061719483107393155",
+       "predicted_dloss": "0.069341865",
        "serialized_identity": null,
        "serialized_sidecar_identity": null,
        "serving_lane": null
@@ -58,7 +59,7 @@
        "bits_per_param": "8.0078125",
        "fmt": "FP8_E4M3",
        "memory_bytes": 90265600,
-       "predicted_dloss": "0.0017566117202721357",
+       "predicted_dloss": "0.001973554",
        "serialized_identity": null,
        "serialized_sidecar_identity": null,
        "serving_lane": null
@@ -87,13 +88,13 @@
       "FP8_E4M3": {
        "activation_pricing_applied": true,
        "predicted_dloss": "0.0010545750000000003",
-       "predicted_dloss_stderr": "0.0003353411173715505",
+       "predicted_dloss_stderr": "0.0005123",
        "weight_mse": "0.0014061000000000004"
       },
       "NVFP4": {
        "activation_pricing_applied": true,
        "predicted_dloss": "0.026509500000000005",
-       "predicted_dloss_stderr": "0.008429675794477507",
+       "predicted_dloss_stderr": "0.012878",
        "weight_mse": "0.03534600000000001"
       }
      },
@@ -113,7 +114,7 @@
        "bits_per_param": "4.5",
        "fmt": "NVFP4",
        "memory_bytes": 14155776,
-       "predicted_dloss": "0.04815943684081101",
+       "predicted_dloss": "0.056366595000000005",
        "serialized_identity": null,
        "serialized_sidecar_identity": null,
        "serving_lane": null
@@ -123,7 +124,7 @@
        "bits_per_param": "8.0078125",
        "fmt": "FP8_E4M3",
        "memory_bytes": 25190400,
-       "predicted_dloss": "0.001370676274930447",
+       "predicted_dloss": "0.0016042620000000002",
        "serialized_identity": null,
        "serialized_sidecar_identity": null,
        "serving_lane": null
@@ -158,12 +159,12 @@
       },
       "FP8_E4M3": {
        "predicted_dloss": "0.001255",
-       "predicted_dloss_stderr": "0.0003842199890687626",
+       "predicted_dloss_stderr": "0.0005350000000000001",
        "weight_mse": "0.0017928571428571431"
       },
       "NVFP4": {
        "predicted_dloss": "0.0251",
-       "predicted_dloss_stderr": "0.007684399781375251",
+       "predicted_dloss_stderr": "0.010700000000000001",
        "weight_mse": "0.03585714285714286"
       }
      },
@@ -219,12 +220,12 @@
       },
       "FP8_E4M3": {
        "predicted_dloss": "0.0009675",
-       "predicted_dloss_stderr": "0.00030765240125830317",
+       "predicted_dloss_stderr": "0.00047",
        "weight_mse": "0.0012900000000000001"
       },
       "NVFP4": {
        "predicted_dloss": "0.01935",
-       "predicted_dloss_stderr": "0.006153048025166064",
+       "predicted_dloss_stderr": "0.009399999999999999",
        "weight_mse": "0.0258"
       }
      },
@@ -289,12 +290,12 @@
       "FP8_E4M3": {
        "activation_pricing_applied": true,
        "predicted_dloss": "0.0020718720000000006",
-       "predicted_dloss_stderr": "0.00037297958867476926"
+       "predicted_dloss_stderr": "0.001035936"
       },
       "NVFP4": {
        "activation_pricing_applied": true,
        "predicted_dloss": "0.07279632000000003",
-       "predicted_dloss_stderr": "0.013104835381064503"
+       "predicted_dloss_stderr": "0.036398160000000006"
       }
      },
      "members": [
@@ -319,7 +320,7 @@
        "bits_per_param": "4.5",
        "fmt": "NVFP4",
        "memory_bytes": 7962624,
-       "predicted_dloss": "0.09245357307159678",
+       "predicted_dloss": "0.12739356000000002",
        "serialized_identity": null,
        "serialized_sidecar_identity": null,
        "serving_lane": null
@@ -329,7 +330,7 @@
        "bits_per_param": "8.024305555555555",
        "fmt": "FP8_E4M3",
        "memory_bytes": 14198784,
-       "predicted_dloss": "0.0026313413830121547",
+       "predicted_dloss": "0.0036257760000000007",
        "serialized_identity": null,
        "serialized_sidecar_identity": null,
        "serving_lane": null
@@ -357,12 +358,12 @@
       "FP8_E4M3": {
        "activation_pricing_applied": true,
        "predicted_dloss": "0.005999796000000002",
-       "predicted_dloss_stderr": "0.0007613413972719467"
+       "predicted_dloss_stderr": "0.002244528"
       },
       "NVFP4": {
        "activation_pricing_applied": true,
        "predicted_dloss": "0.21080601000000002",
-       "predicted_dloss_stderr": "0.026750133205649652"
+       "predicted_dloss_stderr": "0.07886268"
       }
      },
      "members": [
@@ -387,7 +388,7 @@
        "bits_per_param": "4.5",
        "fmt": "NVFP4",
        "memory_bytes": 7962624,
-       "predicted_dloss": "0.2509312098084745",
+       "predicted_dloss": "0.32910003",
        "serialized_identity": null,
        "serialized_sidecar_identity": null,
        "serving_lane": null
@@ -397,7 +398,7 @@
        "bits_per_param": "8.024305555555555",
        "fmt": "FP8_E4M3",
        "memory_bytes": 14198784,
-       "predicted_dloss": "0.007141808095907922",
+       "predicted_dloss": "0.009366588000000002",
        "serialized_identity": null,
        "serialized_sidecar_identity": null,
        "serving_lane": null
@@ -430,11 +431,11 @@
       },
       "FP8_E4M3": {
        "predicted_dloss": "0.0021600000000000005",
-       "predicted_dloss_stderr": "0.0003888444419044717"
+       "predicted_dloss_stderr": "0.0010800000000000002"
       },
       "NVFP4": {
        "predicted_dloss": "0.04320000000000001",
-       "predicted_dloss_stderr": "0.007776888838089434"
+       "predicted_dloss_stderr": "0.0216"
       }
      },
      "members": [
@@ -495,11 +496,11 @@
       },
       "FP8_E4M3": {
        "predicted_dloss": "0.006255",
-       "predicted_dloss_stderr": "0.0007937253933193773"
+       "predicted_dloss_stderr": "0.00234"
       },
       "NVFP4": {
        "predicted_dloss": "0.12510000000000002",
-       "predicted_dloss_stderr": "0.015874507866387545"
+       "predicted_dloss_stderr": "0.04680000000000001"
       }
      },
      "members": [
@@ -569,12 +570,12 @@
       "FP8_E4M3": {
        "activation_pricing_applied": true,
        "predicted_dloss": "0.0006906240000000004",
-       "predicted_dloss_stderr": "0.00021533986592361395"
+       "predicted_dloss_stderr": "0.00034531200000000007"
       },
       "NVFP4": {
        "activation_pricing_applied": true,
        "predicted_dloss": "0.02426544000000001",
-       "predicted_dloss_stderr": "0.007566080234943323"
+       "predicted_dloss_stderr": "0.01213272"
       }
      },
      "members": [
@@ -593,7 +594,7 @@
        "bits_per_param": "4.5",
        "fmt": "NVFP4",
        "memory_bytes": 2654208,
-       "predicted_dloss": "0.03561456035241499",
+       "predicted_dloss": "0.042464520000000006",
        "serialized_identity": null,
        "serialized_sidecar_identity": null,
        "serving_lane": null
@@ -603,7 +604,7 @@
        "bits_per_param": "8.041666666666666",
        "fmt": "FP8_E4M3",
        "memory_bytes": 4743168,
-       "predicted_dloss": "0.0010136337988854213",
+       "predicted_dloss": "0.0012085920000000005",
        "serialized_identity": null,
        "serialized_sidecar_identity": null,
        "serving_lane": null
@@ -631,12 +632,12 @@
       "FP8_E4M3": {
        "activation_pricing_applied": true,
        "predicted_dloss": "0.0013812480000000007",
-       "predicted_dloss_stderr": "0.00030453655890877874"
+       "predicted_dloss_stderr": "0.0006906240000000001"
       },
       "NVFP4": {
        "activation_pricing_applied": true,
        "predicted_dloss": "0.04853088000000002",
-       "predicted_dloss_stderr": "0.01070005328225986"
+       "predicted_dloss_stderr": "0.02426544"
       }
      },
      "members": [
@@ -658,7 +659,7 @@
        "bits_per_param": "4.5",
        "fmt": "NVFP4",
        "memory_bytes": 5308416,
-       "predicted_dloss": "0.0645809599233898",
+       "predicted_dloss": "0.08492904000000001",
        "serialized_identity": null,
        "serialized_sidecar_identity": null,
        "serving_lane": null
@@ -668,7 +669,7 @@
        "bits_per_param": "8.015625",
        "fmt": "FP8_E4M3",
        "memory_bytes": 9455616,
-       "predicted_dloss": "0.0018380528383631688",
+       "predicted_dloss": "0.002417184000000001",
        "serialized_identity": null,
        "serialized_sidecar_identity": null,
        "serving_lane": null
@@ -696,12 +697,12 @@
       "FP8_E4M3": {
        "activation_pricing_applied": true,
        "predicted_dloss": "0.0019999320000000003",
-       "predicted_dloss_stderr": "0.00043956066066016424"
+       "predicted_dloss_stderr": "0.0007481760000000001"
       },
       "NVFP4": {
        "activation_pricing_applied": true,
        "predicted_dloss": "0.07026867",
-       "predicted_dloss_stderr": "0.015444196607140174"
+       "predicted_dloss_stderr": "0.02628756"
       }
      },
      "members": [
@@ -720,7 +721,7 @@
        "bits_per_param": "4.5",
        "fmt": "NVFP4",
        "memory_bytes": 2654208,
-       "predicted_dloss": "0.09343496491071027",
+       "predicted_dloss": "0.10970001000000001",
        "serialized_identity": null,
        "serialized_sidecar_identity": null,
        "serving_lane": null
@@ -730,7 +731,7 @@
        "bits_per_param": "8.041666666666666",
        "fmt": "FP8_E4M3",
        "memory_bytes": 4743168,
-       "predicted_dloss": "0.0026592729909902467",
+       "predicted_dloss": "0.0031221960000000007",
        "serialized_identity": null,
        "serialized_sidecar_identity": null,
        "serving_lane": null
@@ -758,12 +759,12 @@
       "FP8_E4M3": {
        "activation_pricing_applied": true,
        "predicted_dloss": "0.0039998640000000005",
-       "predicted_dloss_stderr": "0.000621632647791282"
+       "predicted_dloss_stderr": "0.001496352"
       },
       "NVFP4": {
        "activation_pricing_applied": true,
        "predicted_dloss": "0.14053734",
-       "predicted_dloss_stderr": "0.021841392301774173"
+       "predicted_dloss_stderr": "0.05257512"
       }
      },
      "members": [
@@ -785,7 +786,7 @@
        "bits_per_param": "4.5",
        "fmt": "NVFP4",
        "memory_bytes": 5308416,
-       "predicted_dloss": "0.17329942845266127",
+       "predicted_dloss": "0.21940002000000003",
        "serialized_identity": null,
        "serialized_sidecar_identity": null,
        "serving_lane": null
@@ -795,7 +796,7 @@
        "bits_per_param": "8.015625",
        "fmt": "FP8_E4M3",
        "memory_bytes": 9455616,
-       "predicted_dloss": "0.004932312971686923",
+       "predicted_dloss": "0.0062443920000000005",
        "serialized_identity": null,
        "serialized_sidecar_identity": null,
        "serving_lane": null

--- a/tests/test_allocator_packed_group_units.py
+++ b/tests/test_allocator_packed_group_units.py
@@ -588,15 +588,9 @@ def test_super_item_stats_do_not_impersonate_one_member_shape():
         assert entry["_memory_bytes_by_format"][cand.fmt] == cand.memory_bytes
 
 
-def test_group_ucb_stderr_aggregates_in_quadrature(monkeypatch):
-    """PRISMAQUANT_COST_UCB_Z hedging on a packed group: member dloss
-    estimates are independent measurements, so the stderr of the group SUM
-    is sqrt(sum stderr^2). Summing per-member UCB'd candidates would charge
-    the linear z*sum(stderr) (a sqrt(N)-factor over-hedge on an N-member
-    group), and dropping the field would silently zero the hedge for any
-    consumer of the aggregated cost table. Pin both: the group candidate
-    carries the quadrature hedge, and the super cost entry keeps the
-    (base sum, aggregated stderr) pair."""
+def test_group_ucb_stderr_preserves_conservative_bound(monkeypatch):
+    """Packed members may share AURA probes. Without verified alignment,
+    prices and grouped cost rows retain the conservative sum of stderrs."""
     from prismaquant.allocator_candidates import build_candidates
 
     z = 2.0
@@ -620,7 +614,7 @@ def test_group_ucb_stderr_aggregates_in_quadrature(monkeypatch):
         stats, costs, _specs(), cands, _PackedProfile())
     super_name = next(n for n in cands2 if _PACKED_GROUP_MARKER in n)
     for fmt in base:
-        agg = (n_members * stderr[fmt] ** 2) ** 0.5
+        agg = n_members * stderr[fmt]
         cand = next(c for c in cands2[super_name] if c.fmt == fmt)
         assert abs(cand.predicted_dloss
                    - (n_members * base[fmt] + z * agg)) < 1e-12
@@ -636,8 +630,10 @@ def test_group_ucb_stderr_aggregates_in_quadrature(monkeypatch):
     super0 = next(n for n in cands0x if _PACKED_GROUP_MARKER in n)
     for fmt in base:
         cand = next(c for c in cands0x[super0] if c.fmt == fmt)
-        assert abs(cand.predicted_dloss - n_members * base[fmt]) < 1e-12
-        agg = (n_members * stderr[fmt] ** 2) ** 0.5
+        exact_sum = sum(next(c.predicted_dloss for c in cands0[name]
+                             if c.fmt == fmt) for name in sorted(stats))
+        assert cand.predicted_dloss.hex() == exact_sum.hex()
+        agg = n_members * stderr[fmt]
         assert abs(costs0[super0][fmt]["predicted_dloss_stderr"] - agg) < 1e-12
 
 

--- a/tests/test_allocator_sibling_aggregation.py
+++ b/tests/test_allocator_sibling_aggregation.py
@@ -785,7 +785,7 @@ def test_feasible_rung_satisfies_the_tolerance_contract(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# UCB hedge on fused super-items: independence aggregate, not linear sum
+# UCB hedge on fused super-items: conservative bound for correlated errors
 # ---------------------------------------------------------------------------
 
 def _mk_qkv_ucb_fixture(base: dict, stderr: dict):
@@ -803,15 +803,9 @@ def _mk_qkv_ucb_fixture(base: dict, stderr: dict):
     return members, stats, costs
 
 
-def test_fused_group_ucb_stderr_aggregates_in_quadrature(monkeypatch):
-    """A qkv triple must hedge at √3-independence, not 3x linear.
-
-    Members' dloss estimates are independent measurements, so the stderr of
-    the group SUM is sqrt(Σ stderr²). Summing per-member UCB'd terms charged
-    the LINEAR z·Σ(stderr) — a √N over-hedge — and the super cost entry
-    dropped predicted_dloss_stderr entirely, zeroing the hedge for consumers
-    of the aggregated table. Same contract the packed path already pins.
-    """
+def test_fused_group_ucb_stderr_preserves_conservative_bound(monkeypatch):
+    """Shared AURA probes can correlate all qkv estimates; absent verified
+    alignment, retain the sum of standard errors in prices and cost rows."""
     z = 2.0
     monkeypatch.setenv("PRISMAQUANT_COST_UCB_Z", str(z))
     base = {"NVFP4": 0.05, "BF16": 0.01}
@@ -830,7 +824,7 @@ def test_fused_group_ucb_stderr_aggregates_in_quadrature(monkeypatch):
     for cand in cands_ext[super_name]:
         fmt = cand.fmt
         assert fmt in base, f"unexpected format {fmt} in fixture"
-        agg = (n_members * stderr[fmt] ** 2) ** 0.5
+        agg = n_members * stderr[fmt]
         exact_sum = 0.0
         for _ in members:
             exact_sum += base[fmt]
@@ -840,8 +834,8 @@ def test_fused_group_ucb_stderr_aggregates_in_quadrature(monkeypatch):
         assert abs(entry["predicted_dloss_stderr"] - agg) < 1e-12
         # weight_mse is derived from the UN-hedged sum (no z contamination).
         assert abs(entry["weight_mse"] - exact_sum / (0.5 * sum_h)) < 1e-12
-        # Strictly cheaper than the linear hedge it replaces.
-        assert z * agg < z * n_members * stderr[fmt] - 1e-12
+        # Fully correlated errors attain this bound: no group-size discount.
+        assert z * agg == z * n_members * stderr[fmt]
         checked += 1
     assert checked >= 1
 
@@ -1018,7 +1012,7 @@ def test_group_options_refuse_a_ucb_hedge_rather_than_price_it_wrong():
     candidates = {
         m: _tessera_member_candidates([(10, 2.0), (20, 1.0)]) for m in members
     }
-    with pytest.raises(NotImplementedError, match="not additive"):
+    with pytest.raises(NotImplementedError, match="do not support UCB pricing"):
         tessera_group_composites(
             members, candidates, n_params=1000,
             licence=_installed_fused_licence(), ucb_z=1.0)

--- a/tests/test_anchored_shape.py
+++ b/tests/test_anchored_shape.py
@@ -1,0 +1,152 @@
+from dataclasses import FrozenInstanceError
+import math
+
+import pytest
+
+from prismaquant.anchored_shape import (
+    AnchoredShapeError,
+    LogShapeObservation,
+    audit_anchored,
+    fit_anchor_correction,
+    fit_centered_log_shape,
+    predict_anchored,
+)
+
+
+def _panel(offsets=(0.0, 2.0)):
+    features = {str(k): (float(k), float(k * k)) for k in range(7)}
+    observations = [
+        LogShapeObservation(str(unit), str(k), 10.0 ** (offset - 0.7*k + 0.04*k*k))
+        for unit, offset in enumerate(offsets) for k in (0, 2, 4, 6)
+    ]
+    return fit_centered_log_shape(observations, features)
+
+
+def test_two_anchors_recover_unit_tilt_over_curved_shared_shape():
+    shape = _panel()
+    coords = {str(k): float(k) for k in range(7)}
+    truth = {str(k): 10.0 ** (1.3 - 0.5*k + 0.04*k*k) for k in range(7)}
+    one = fit_anchor_correction(shape, {"0": truth["0"]}, coords)
+    two = fit_anchor_correction(shape, {k: truth[k] for k in ("0", "6")}, coords)
+    assert predict_anchored(one, "5") == pytest.approx(truth["5"] / 10)
+    for key, value in truth.items():
+        assert predict_anchored(two, key) == pytest.approx(value, rel=3e-14)
+
+
+def test_shared_shape_is_invariant_to_each_panel_units_level():
+    first, shifted = _panel(), _panel((-190.0, 230.0))
+    assert shifted.coefficients == pytest.approx(first.coefficients, abs=2e-14)
+    assert shifted.log_shape_by_key == pytest.approx(first.log_shape_by_key, abs=1e-13)
+
+
+def test_shared_shape_rank_deficiency_and_duplicate_observations_refuse():
+    rows = [LogShapeObservation("u", str(k), 2.0**-k) for k in range(3)]
+    with pytest.raises(AnchoredShapeError, match="rank"):
+        fit_centered_log_shape(rows, {str(k): (k, 2*k) for k in range(3)})
+    with pytest.raises(AnchoredShapeError, match="duplicate"):
+        fit_centered_log_shape([*rows, rows[0]], {str(k): (k,) for k in range(3)})
+    with pytest.raises(AnchoredShapeError, match="fewer than two"):
+        fit_centered_log_shape(rows[:1], {str(k): (k,) for k in range(3)})
+
+
+@pytest.mark.parametrize("offset,step", [(1e15, 0.5), (-1e300, 1e290), (0.0, 1e-290)])
+def test_correction_is_stable_under_coordinate_translation_and_scaling(offset, step):
+    shape = _panel()
+    coords = {str(k): offset + step*k for k in range(7)}
+    anchors = {"0": 2.0, "6": 0.02}
+    fit = fit_anchor_correction(shape, anchors, coords)
+    baseline = fit_anchor_correction(shape, anchors, {str(k): k for k in range(7)})
+    # The extreme-offset input's float coordinates themselves lose ~1e-6 of
+    # their spacing. Compare against the represented coordinate geometry.
+    for key in ("1", "3", "5"):
+        position = (coords[key] - coords["0"]) / (coords["6"] - coords["0"])
+        expected_log = (math.log10(anchors["0"]) + shape.log_shape_by_key[key]
+                        + position*(math.log10(anchors["6"]/anchors["0"])
+                                    - shape.log_shape_by_key["6"]))
+        assert predict_anchored(fit, key) == pytest.approx(10**expected_log, rel=2e-14)
+    assert predict_anchored(baseline, "0") == 2.0
+
+
+def test_exact_measured_anchors_survive_overdetermined_residual_fit():
+    shape = _panel()
+    anchors = {"0": 0.123456789, "3": 7.1, "6": 0.0003456789}
+    correction = fit_anchor_correction(shape, anchors, {str(k): k for k in range(7)})
+    for key, value in anchors.items():
+        assert predict_anchored(correction, key) == value
+
+
+def test_audit_is_independent_immutable_and_does_not_refit():
+    shape = _panel()
+    coords = {str(k): k for k in range(7)}
+    anchors = {"0": 2.0, "6": 0.02}
+    correction = fit_anchor_correction(shape, anchors, coords)
+    before = predict_anchored(correction, "3")
+    audit = audit_anchored(correction, {"3": before*100})
+    assert audit.rows[0].predicted == before
+    assert audit.rows[0].measured == before*100
+    assert audit.max_absolute_log10_error == pytest.approx(2.0)
+    assert predict_anchored(correction, "3") == before
+    refit = fit_anchor_correction(shape, {**anchors, "3": before*100}, coords)
+    assert predict_anchored(refit, "3") == before*100
+    assert audit.rows[0].predicted == before
+    with pytest.raises(AnchoredShapeError, match="anchor"):
+        audit_anchored(correction, {"0": anchors["0"]})
+    with pytest.raises(FrozenInstanceError):
+        audit.rows[0].predicted = 1.0
+    anchors["0"] = 4.0
+    coords["3"] = 999.0
+    assert predict_anchored(correction, "0") == 2.0
+    assert predict_anchored(correction, "3") == before
+    with pytest.raises(TypeError):
+        correction.anchors["0"] = 1.0
+
+
+def test_extreme_costs_use_logs_without_overflowing_ratios():
+    features = {"a": (0.0,), "b": (1.0,), "c": (2.0,)}
+    shape = fit_centered_log_shape([
+        LogShapeObservation("u", "a", 1e-300),
+        LogShapeObservation("u", "c", 1e300),
+    ], features)
+    correction = fit_anchor_correction(shape, {"a": 1e-300, "c": 1e300},
+                                       {"a": 0, "b": 1, "c": 2})
+    assert predict_anchored(correction, "a") == 1e-300
+    assert predict_anchored(correction, "b") == pytest.approx(1.0)
+    assert predict_anchored(correction, "c") == 1e300
+    assert math.isfinite(audit_anchored(correction, {"b": 1e-300}).max_absolute_log10_error)
+
+
+@pytest.mark.parametrize("bad", [0.0, -1.0, math.nan, math.inf, -math.inf, True])
+def test_invalid_observations_refuse(bad):
+    with pytest.raises(AnchoredShapeError):
+        LogShapeObservation("u", "a", bad)
+    with pytest.raises(AnchoredShapeError):
+        fit_anchor_correction(_panel(), {"0": bad}, {str(k): k for k in range(7)})
+
+
+def test_unsupported_missing_duplicate_and_nonfinite_coordinates_refuse():
+    shape = _panel()
+    coords = {str(k): k for k in range(7)}
+    with pytest.raises(AnchoredShapeError, match="coordinate"):
+        fit_anchor_correction(shape, {"0": 1.0}, {"0": 0})
+    for value in (math.nan, math.inf, True, coords["2"]):
+        with pytest.raises(AnchoredShapeError, match="coordinate"):
+            fit_anchor_correction(shape, {"0": 1.0}, {**coords, "1": value})
+    with pytest.raises(AnchoredShapeError, match="unknown"):
+        fit_anchor_correction(shape, {"missing": 1.0}, coords)
+    correction = fit_anchor_correction(shape, {"0": 1.0}, coords)
+    with pytest.raises(AnchoredShapeError, match="unknown"):
+        predict_anchored(correction, "missing")
+    with pytest.raises(AnchoredShapeError, match="empty"):
+        audit_anchored(correction, {})
+
+
+def test_prediction_outside_finite_positive_float_range_refuses():
+    features = {"a": (0.0,), "b": (1.0,), "c": (10.0,)}
+    shape = fit_centered_log_shape([
+        LogShapeObservation("u", "a", 1.0),
+        LogShapeObservation("u", "b", 10.0),
+    ], features)
+    for anchors in ({"a": 1e300}, {"a": 1e-300, "b": 1e-310}):
+        fit = fit_anchor_correction(shape, anchors, {"a": 0, "b": 1, "c": 10})
+        with pytest.raises(AnchoredShapeError, match="representable"):
+            predict_anchored(fit, "c")

--- a/tests/test_group_ucb_covariance.py
+++ b/tests/test_group_ucb_covariance.py
@@ -1,0 +1,43 @@
+"""Grouped UCB cannot assume independent errors from shared AURA probes."""
+import math
+
+import pytest
+
+from prismaquant.allocator_candidates import _super_item_ucb_hedge
+
+
+def _stderr(samples):
+    n = len(samples)
+    mean = sum(samples) / n
+    return 0.5 * math.sqrt(sum((x - mean) ** 2 for x in samples) / (n - 1) / n)
+
+
+@pytest.mark.parametrize("second", [[0.0, 4.0], [4.0, 0.0]])
+@pytest.mark.parametrize("scales", [(1.0, 1.0), (2.0, 0.5)])
+@pytest.mark.parametrize("include_samples", [False, True])
+def test_group_bound_covers_correlated_errors_without_verified_alignment(second, scales, include_samples):
+    samples = [[0.0, 4.0], second]
+    terms = []
+    for row, scale in zip(samples, scales):
+        entry = {"predicted_dloss": 1.0, "predicted_dloss_stderr": _stderr(row)}
+        if include_samples:
+            # Equal-length arrays alone do not prove joint sample identity.
+            entry["x2_per_probe"] = row
+        terms.append(({}, entry, scale * 3.0, scale))
+    removed, bound = _super_item_ucb_hedge(terms, 2.0)
+    actual = _stderr([sum(scale * row[i] for row, scale in zip(samples, scales))
+                      for i in range(2)])
+    assert bound >= actual
+    assert bound == sum(scale * _stderr(row) for row, scale in zip(samples, scales))
+    assert removed == 2.0 * bound
+    if second == samples[0]:
+        assert bound == actual
+
+
+def test_zero_z_keeps_member_sum_bit_exact():
+    terms = [({}, {"predicted_dloss": value, "predicted_dloss_stderr": 1.0}, value, scale)
+             for value, scale in [(0.1, 2.0), (0.2, 0.5)]]
+    total = sum(term[2] for term in terms)
+    removed, bound = _super_item_ucb_hedge(terms, 0.0)
+    assert removed == 0.0
+    assert (total - removed + 0.0 * bound).hex() == total.hex()

--- a/tests/test_super_item_menu_byte_identity.py
+++ b/tests/test_super_item_menu_byte_identity.py
@@ -113,7 +113,7 @@ _FLOAT_FIELDS = frozenset({
 # cost-entry product chain (0.5 * h_trace * mse, then the calibrated gain and
 # the per-family activation penalty) is ~5 roundings; those 9 member terms are
 # then summed (a 9-term reduction, <= 9 roundings naive, ~2 with the 3.12
-# compensated sum); the linear hedge is subtracted and ``z * sqrt(sum stderr^2)``
+# compensated sum); the linear hedge is subtracted and ``z * sum(scaled stderr)``
 # added, another ~4.  ~18 roundings at <= 0.5 ulp each, over an all-positive
 # sum whose condition number is 1, is a bound near 9 ulps; 16 is the next
 # power of two above it and matches the multiplier PR #90 derived the same way.
@@ -509,6 +509,41 @@ def compare_to_golden(current: dict, golden: dict) -> list[str]:
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+@pytest.mark.parametrize("kind", ["fused", "packed"])
+@pytest.mark.parametrize("z", ["0", "1.5"])
+def test_group_prices_preserve_scaled_member_hedges(kind, z):
+    """Gain and activation penalties scale uncertainty on both grouping paths.
+
+    Without bound sample alignment, grouping must not discount the sum of
+    member uncertainty charges. Exercise the actual gained/priced candidates.
+    """
+    pricing = _pricing()
+    stats, costs = _dense_inputs() if kind == "fused" else _packed_inputs()
+    with mock.patch.dict(os.environ, {"PRISMAQUANT_COST_UCB_Z": z}):
+        members = build_candidates(
+            stats, costs, _specs(), calibrated_gains=GAINS,
+            activation_pricing=pricing)
+    if kind == "fused":
+        grouped_stats, _, grouped = _run_fused(z, gains=GAINS, pricing=pricing)
+        member_key = "_fused_siblings"
+    else:
+        grouped_stats, _, grouped = _run_packed(
+            z, gains=GAINS, pricing=pricing, role_split=False)
+        member_key = "_packed_group_members"
+    checked = 0
+    for name, candidates in grouped.items():
+        names = grouped_stats[name].get(member_key)
+        if not names:
+            continue
+        for candidate in candidates:
+            expected = sum(next(c.predicted_dloss for c in members[m]
+                                if c.fmt == candidate.fmt) for m in names)
+            assert candidate.predicted_dloss == pytest.approx(
+                expected, rel=_FLOAT_TOLERANCE_ULPS * _FLOAT64_EPS, abs=0.0)
+            checked += 1
+    assert checked > 0
+
+
 def test_super_item_menus_match_the_golden():
     assert GOLDEN_PATH.exists(), (
         f"{GOLDEN_PATH} is missing. It is the pre-change record of what the "

--- a/tests/test_tessera_anchored_surface.py
+++ b/tests/test_tessera_anchored_surface.py
@@ -1,0 +1,293 @@
+"""CPU replay contracts; synthetic receipts are not producer qualification."""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import pickle
+import subprocess
+import sys
+
+import pytest
+
+from prismaquant.cost_stage_checkpoint import MANIFEST_SCHEMA, canonical_json_sha256, write_unit
+from prismaquant.tessera_anchored_surface import (
+    CAMPAIGN_SCHEMA, CURRENCY, PLAN_SCHEMA, ReplayError, load_campaign_measurements, replay_campaign,
+)
+
+
+def seal(value):
+    return canonical_json_sha256(value, where="test fixture")
+
+
+def make_campaign(tmp_path, *, altered=None, missing=(), extra=()):
+    """Real journal envelopes; inert blobs explicitly exercise hash-only replay."""
+    coordinates = {f"F_R{r}": r for r in range(1, 6)}
+    pilot = {"p1": ["F_R1", "F_R2", "F_R5"], "p2": ["F_R1", "F_R2", "F_R5"]}
+    heldout = {"h": {"anchors": ["F_R1", "F_R5"], "audit": ["F_R3"]}}
+    observed = {**pilot, "h": ["F_R1", "F_R3", "F_R5", *extra], "h_sibling": []}
+    recipe = {"grid": "synthetic-grid", "body": "synthetic-test-only"}
+    descriptor = {"family": "TESSERA_SYNTHETIC", "activation_contract": "fp4_e2m1",
+                  "geometry": [8, 8], "wire_recipe": recipe, "hessian_applied": False,
+                  "role": "profile-declared-q-proj"}
+    wire_dir = tmp_path / "wires"
+    wire_dir.mkdir()
+    source = {"shape": [8, 8], "dtype": "bfloat16", "sha256": "a" * 64}
+    units = {unit: {"weight": {**source, "sha256": hashlib.sha256(unit.encode()).hexdigest()},
+                    "scoring_rows": {"shape": [4, 8], "sha256": "b" * 64},
+                    "hessian": None, "input_global_scale": None, "menu": list(coordinates)}
+             for unit in observed}
+    identity = {"campaign_schema": CAMPAIGN_SCHEMA, "currency": CURRENCY,
+                "units": units, "prismaquant_source_sha256": "c" * 64,
+                "encoder_source_sha256": "d" * 64, "calibration": {"fit_ids_sha256": "e" * 64}}
+    checkpoint = tmp_path / "cost.anchors.json"
+    manifest = {"schema": MANIFEST_SCHEMA, "stage": "Tessera campaign", "identity": identity,
+                "identity_sha256": seal(identity),
+                "units": [{"qname": unit} for unit in observed]}
+    checkpoint.write_text(json.dumps(manifest))
+    costs = {}
+    values = {}
+    for unit, keys in observed.items():
+        anchors, records = [], {}
+        costs[unit] = {}
+        for key in keys:
+            if (unit, key) in missing:
+                continue
+            r = coordinates[key]
+            log_value = -.15 * r - .02 * r * r
+            log_value += {"p1": 0, "p2": .4, "h": .2 + .025 * r}[unit]
+            value = (altered or {}).get((unit, key), 10 ** log_value)
+            values[(unit, key)] = value
+            blob = f"inert fixture {unit} {key}".encode()
+            filename = f"{unit}-{key}.wire"
+            (wire_dir / filename).write_bytes(blob)
+            anchor = {"qname": unit, "format_name": key, "family": descriptor["family"],
+                      "body_rate_q256": r, "dloss": value, "activation_contract": "fp4_e2m1",
+                      "activation_quantized": True, "wire_bytes": len(blob), "hessian_applied": False}
+            anchors.append(anchor)
+            records[key] = {"file": filename, "blob_bytes": len(blob),
+                            "blob_sha256": hashlib.sha256(blob).hexdigest(),
+                            "identity": {"unit": unit, "source": units[unit]["weight"],
+                                         "encoder_source_sha256": "d" * 64, "calibration": None,
+                                         "recipe": {**recipe, "q256": r}}}
+            costs[unit][key] = {"output_mse": value, "output_mse_measured": True,
+                               "cost_source": "tessera_campaign_measured", "tessera_provenance": "measured",
+                               "currency": CURRENCY, "tessera_family": descriptor["family"],
+                               "tessera_body_rate_q256": r, "activation_contract": "fp4_e2m1",
+                               "activation_quantized": True, "wire_bytes": len(blob),
+                               "hessian_identity": {"applied": False, "supplied": False}}
+        write_unit(checkpoint.with_name(checkpoint.name + ".parts"), stage="Tessera campaign",
+                   qname=unit, identity_sha256=seal(identity), state={"anchors": anchors, "wire_records": records})
+    payload = {"schema": CAMPAIGN_SCHEMA, "currency": CURRENCY, "costs": costs,
+               "provenance": {"cost_mode": "production-render-score", "wire_dir": str(wire_dir),
+                              "hessian": {"supplied": False}, "anchor_groups": {"group": ["h", "h_sibling"]}}}
+    cost_path = tmp_path / "cost.pkl"
+    cost_path.write_bytes(pickle.dumps(payload))
+    plan = {"schema": PLAN_SCHEMA, "currency": CURRENCY,
+            "input": {"payload_sha256": hashlib.sha256(cost_path.read_bytes()).hexdigest(),
+                      "checkpoint_identity_sha256": seal(identity)},
+            "segments": [{"id": "fp4-q", "descriptor": descriptor, "pilot": pilot, "heldout": heldout,
+                          "coordinates": coordinates, "features_by_key": {key: [r, r*r] for key, r in coordinates.items()},
+                          "max_absolute_log10_error": .01, "refit_after_audit": False}]}
+    return cost_path, checkpoint, plan, values
+
+
+def unit_report(report):
+    return report["segments"][0]["units"]["h"]
+
+
+def test_two_anchor_curvature_reconstruction_and_exact_measured_rows(tmp_path):
+    costs, checkpoint, plan, values = make_campaign(tmp_path)
+    report = replay_campaign(costs, checkpoint, plan)
+    unit = unit_report(report)
+    assert unit["status"] == "audit_accepted_research_only"
+    assert unit["predictions"]["F_R2"]["value"] == pytest.approx(10 ** (-.15*2-.02*4+.2+.025*2))
+    for key in ("F_R1", "F_R3", "F_R5"):
+        assert unit["predictions"][key] == {"value": values[("h", key)], "source": "measured"}
+    assert not report["production_qualified"] and not report["allocator_payload"]
+    assert report["latency_evidence"] is None and report["currency"] == CURRENCY
+    assert report["measurement_requests"] == []
+    assert unit["pwl_audit"][0]["absolute_log10_error"] > .05
+    assert unit["audit"][0]["held_out_axes"] == ["unit", "rung"]
+    assert replay_campaign(costs, checkpoint, plan) == report
+
+
+def test_one_anchor_does_not_invent_the_missing_slope(tmp_path):
+    costs, checkpoint, plan, _ = make_campaign(tmp_path)
+    plan["segments"][0]["heldout"]["h"]["anchors"] = ["F_R1"]
+    report = replay_campaign(costs, checkpoint, plan)
+    assert unit_report(report)["status"] == "measure_more"
+    assert unit_report(report)["pwl_audit"][0]["unavailable"] == "needs_two_valid_anchors"
+    requests = report["measurement_requests"]
+    assert {r["unit"] for r in requests} == {"h", "h_sibling"}
+    assert {r["key"] for r in requests} == set(plan["segments"][0]["coordinates"])
+
+
+def test_pwl_baseline_refuses_nonmonotone_anchors_like_current_surface(tmp_path):
+    costs, checkpoint, plan, _ = make_campaign(tmp_path, altered={("h", "F_R5"): 100.0})
+    report = replay_campaign(costs, checkpoint, plan)
+    assert unit_report(report)["pwl_audit"][0]["unavailable"] == "nonmonotone_anchors"
+
+
+@pytest.mark.parametrize("anchor_scale,audit_value", [(1e200, 1e-200), (1e-200, 1e200)])
+def test_pwl_audit_extreme_finite_costs_produce_a_serializable_failure(
+    tmp_path, anchor_scale, audit_value,
+):
+    costs, checkpoint, plan, _ = make_campaign(tmp_path, altered={
+        ("h", "F_R1"): anchor_scale, ("h", "F_R5"): anchor_scale / 2,
+        ("h", "F_R3"): audit_value,
+    })
+    report = replay_campaign(costs, checkpoint, plan)
+    assert unit_report(report)["status"] == "measure_more"
+    assert unit_report(report)["pwl_audit"][0]["absolute_log10_error"] == pytest.approx(
+        abs((math.log10(anchor_scale) + math.log10(anchor_scale / 2)) / 2
+            - math.log10(audit_value)))
+    json.dumps(report, allow_nan=False)
+
+
+def test_audit_prediction_is_frozen_before_refit(tmp_path):
+    costs, checkpoint, plan, values = make_campaign(tmp_path)
+    base = replay_campaign(costs, checkpoint, plan)
+    other = tmp_path / "other"
+    other.mkdir()
+    costs2, checkpoint2, plan2, _ = make_campaign(other, altered={("h", "F_R3"): values[("h", "F_R3")] * 1.01})
+    plan2["segments"][0]["refit_after_audit"] = True
+    changed = replay_campaign(costs2, checkpoint2, plan2)
+    assert unit_report(base)["audit"][0]["predicted"] == unit_report(changed)["audit"][0]["predicted"]
+    assert unit_report(changed)["refit_after_audit"] is True
+    assert unit_report(changed)["audit"][0]["measured"] != unit_report(base)["audit"][0]["measured"]
+
+
+def test_missing_audit_and_rank_failure_emit_measurement_requests(tmp_path):
+    costs, checkpoint, plan, _ = make_campaign(tmp_path, missing={("h", "F_R3")})
+    report = replay_campaign(costs, checkpoint, plan)
+    assert unit_report(report)["reason"] == "missing_or_invalid_anchor_or_audit"
+    assert {row["key"] for row in report["measurement_requests"]} == {"F_R3"}
+    other = tmp_path / "rank"
+    other.mkdir()
+    costs, checkpoint, plan, _ = make_campaign(other)
+    plan["segments"][0]["features_by_key"] = {key: [1, 1] for key in plan["segments"][0]["coordinates"]}
+    report = replay_campaign(costs, checkpoint, plan)
+    assert report["segments"][0]["pilot_fit_error"]
+    assert unit_report(report)["predictions"] == {}
+
+
+@pytest.mark.parametrize("field,value", [("activation_contract", "fp8_e4m3"), ("family", "OTHER"),
+                                         ("geometry", [16, 8]), ("hessian_applied", True),
+                                         ("wire_recipe", {"grid": "other"})])
+def test_cross_segment_data_refuses(tmp_path, field, value):
+    costs, checkpoint, plan, _ = make_campaign(tmp_path)
+    plan["segments"][0]["descriptor"][field] = value
+    with pytest.raises(ReplayError, match="cross-segment"):
+        replay_campaign(costs, checkpoint, plan)
+
+
+def test_current_mse_cannot_be_relabelled_aura(tmp_path):
+    costs, checkpoint, plan, _ = make_campaign(tmp_path)
+    plan["currency"] = "aura"
+    with pytest.raises(ReplayError, match="output-MSE"):
+        replay_campaign(costs, checkpoint, plan)
+
+
+@pytest.mark.parametrize("kind", ["payload", "checkpoint", "wire", "source"])
+def test_integrity_boundaries_refuse(tmp_path, kind):
+    costs, checkpoint, plan, _ = make_campaign(tmp_path)
+    if kind == "payload":
+        costs.write_bytes(costs.read_bytes() + b"changed")
+    elif kind == "checkpoint":
+        manifest = json.loads(checkpoint.read_text())
+        manifest["identity"]["encoder_source_sha256"] = "f" * 64
+        checkpoint.write_text(json.dumps(manifest))
+    elif kind == "wire":
+        (tmp_path / "wires" / "h-F_R1.wire").write_bytes(b"corrupt")
+    else:
+        payload = pickle.loads(costs.read_bytes())
+        payload["costs"]["h"]["F_R1"]["output_mse"] = .003
+        costs.write_bytes(pickle.dumps(payload))
+        plan["input"]["payload_sha256"] = hashlib.sha256(costs.read_bytes()).hexdigest()
+    with pytest.raises((ReplayError, RuntimeError), match="mismatch"):
+        replay_campaign(costs, checkpoint, plan)
+
+
+def test_disjoint_split_enforced(tmp_path):
+    costs, checkpoint, plan, _ = make_campaign(tmp_path)
+    plan["segments"][0]["heldout"]["h"]["audit"] = ["F_R1"]
+    with pytest.raises(ReplayError, match="disjoint"):
+        replay_campaign(costs, checkpoint, plan)
+
+
+def test_domain_cannot_extrapolate_beyond_pilot(tmp_path):
+    costs, checkpoint, plan, _ = make_campaign(tmp_path)
+    for keys in plan["segments"][0]["pilot"].values():
+        keys.remove("F_R5")
+    with pytest.raises(ReplayError, match="pilot coordinate envelope"):
+        replay_campaign(costs, checkpoint, plan)
+
+
+def test_unfitted_measured_row_cannot_break_monotonicity(tmp_path):
+    costs, checkpoint, plan, _ = make_campaign(
+        tmp_path, altered={("h", "F_R2"): 10.0}, extra=["F_R2"])
+    report = replay_campaign(costs, checkpoint, plan)
+    assert unit_report(report)["reason"] == "measured_overlay_nonmonotone"
+    assert unit_report(report)["predictions"] == {}
+
+
+def test_invalid_extra_measurement_is_not_replaced_by_a_prediction(tmp_path):
+    costs, checkpoint, plan, _ = make_campaign(
+        tmp_path, altered={("h", "F_R2"): 0.0}, extra=["F_R2"])
+    report = replay_campaign(costs, checkpoint, plan)
+    assert unit_report(report)["status"] == "measure_more"
+    assert unit_report(report)["predictions"] == {}
+    assert {row["key"] for row in report["measurement_requests"]} == {"F_R2"}
+
+
+def test_unrecorded_prediction_rung_refuses(tmp_path):
+    costs, checkpoint, plan, _ = make_campaign(tmp_path)
+    segment = plan["segments"][0]
+    segment["coordinates"]["FAKE"] = 4
+    segment["features_by_key"]["FAKE"] = segment["features_by_key"].pop("F_R4")
+    del segment["coordinates"]["F_R4"]
+    with pytest.raises(ReplayError, match="recorded source menu"):
+        replay_campaign(costs, checkpoint, plan)
+
+
+def test_actual_campaign_main_output_imports(monkeypatch, tmp_path):
+    # Existing fixture runs real campaign main, current journal and wire producer
+    # on a tiny CPU Linear. Only model/capture/menu inputs are synthetic.
+    from test_tessera_campaign_resume import UNIT, _fresh_priced_campaign
+    import torch
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    (_campaign, checkpoint, _argv, _model, _inputs), payload = _fresh_priced_campaign(
+        monkeypatch, tmp_path)
+    cost_path = tmp_path / "cost.pkl"
+    manifest = json.loads(checkpoint.read_text())
+    plan = {"schema": PLAN_SCHEMA, "currency": CURRENCY,
+            "input": {"payload_sha256": hashlib.sha256(cost_path.read_bytes()).hexdigest(),
+                      "checkpoint_identity_sha256": manifest["identity_sha256"]}, "segments": []}
+    measurements, identity, _groups = load_campaign_measurements(cost_path, checkpoint, plan)
+    key = "TESSERA_E4M3_K1_R1024"
+    assert measurements[(UNIT, key)]["value"] == payload["costs"][UNIT][key]["output_mse"]
+    assert identity["source_recomputed"] is False
+
+
+def test_cli_real_file_replay_idempotence_and_no_clobber(tmp_path):
+    costs, checkpoint, plan, _ = make_campaign(tmp_path)
+    plan_path, output = tmp_path / "plan.json", tmp_path / "report.json"
+    plan_path.write_text(json.dumps(plan))
+    tool = Path(__file__).resolve().parents[1] / "tools" / "tessera_surface_replay.py"
+    command = [sys.executable, str(tool), "--costs", str(costs), "--checkpoint", str(checkpoint),
+               "--plan", str(plan_path), "--out", str(output)]
+    for _ in range(2):
+        result = subprocess.run(command, capture_output=True, text=True, env=os.environ.copy())
+        assert result.returncode == 0, result.stderr
+    assert unit_report(json.loads(output.read_text()))["status"] == "audit_accepted_research_only"
+    plan["segments"][0]["max_absolute_log10_error"] = .02
+    plan_path.write_text(json.dumps(plan))
+    before = output.read_bytes()
+    refused = subprocess.run(command, capture_output=True, text=True)
+    assert refused.returncode == 2 and "different replay" in refused.stderr
+    assert output.read_bytes() == before

--- a/tests/test_tessera_campaign_resume.py
+++ b/tests/test_tessera_campaign_resume.py
@@ -100,6 +100,43 @@ def _fresh_priced_campaign(monkeypatch, tmp_path, *, hessian=False):
     return fixture, payload
 
 
+@pytest.mark.parametrize("initial,rounds,budget,rates,expected", [
+    (1, 2, 3, [1024, 1280, 1536], [1024, 1280, 1536]),
+    (2, 2, 3, [1024, 1280, 1536], [1024, 1280, 1536]),
+    (2, 1, 3, [1024, 1280, 1536], [1024, 1536]),
+    (2, 2, 2, [1024, 1280, 1536], [1024, 1536]),
+    (2, 2, 3, [1024, 1536], [1024, 1536]),
+    (2, 2, 3, [1024], [1024]),
+])
+def test_main_bootstraps_loo_from_two_endpoints(
+    monkeypatch, tmp_path, initial, rounds, budget, rates, expected,
+):
+    """One/two requested initial anchors still refine when there is room."""
+    campaign, _checkpoint, argv, _model, inputs = _main_fixture(
+        monkeypatch, tmp_path, priced=True)
+    family = "TESSERA_E4M3_K1"
+    inputs["menu"] = [SimpleNamespace(
+        format_name=f"{family}_R{rate}", family=family,
+        body_rate_q256=rate, bpp=rate / 256,
+        admission=SimpleNamespace(activation_contract="a8"),
+    ) for rate in rates]
+    argv[argv.index("--max-rounds") + 1] = str(rounds)
+    assert campaign.main([
+        *argv, "--anchors", str(initial), "--anchor-budget", str(budget),
+        "--max-artifact-bpp", "0",
+    ]) == 0
+    with (tmp_path / "cost.pkl").open("rb") as handle:
+        payload = pickle.load(handle)
+    surface = payload["provenance"]["surfaces"][UNIT][family]
+    assert surface["rungs"] == expected
+    assert surface["anchors"] == len(expected)
+    for rate in expected:
+        assert payload["costs"][UNIT][f"{family}_R{rate}"]["output_mse_measured"]
+    if len(expected) < 3:
+        assert surface["loo_max_abs_log2_error"] is None
+        assert surface["gate_closed"] is False
+
+
 def _forbid_reencode(monkeypatch, campaign):
     def forbidden(**_kwargs):
         pytest.fail("resume attempted another encode instead of validating the priced bytes")

--- a/tools/tessera_surface_replay.py
+++ b/tools/tessera_surface_replay.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Replay trusted local Tessera campaign measurements; emit research report only."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from prismaquant.cost_stage_checkpoint import atomic_write_bytes
+from prismaquant.tessera_anchored_surface import replay_campaign
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--costs", required=True, help="trusted campaign cost pickle")
+    parser.add_argument("--checkpoint", required=True, help="existing campaign checkpoint manifest")
+    parser.add_argument("--plan", required=True, help="explicit JSON replay plan")
+    parser.add_argument("--out", required=True, help="research JSON report")
+    args = parser.parse_args(argv)
+    try:
+        plan = json.loads(Path(args.plan).read_text())
+        report = replay_campaign(args.costs, args.checkpoint, plan)
+        encoded = json.dumps(report, sort_keys=True, indent=2, allow_nan=False).encode() + b"\n"
+        output = Path(args.out)
+        if output.exists() and output.read_bytes() != encoded:
+            raise ValueError("output already contains a different replay; use another --out")
+        if not output.exists():
+            atomic_write_bytes(output, encoded)
+    except (ValueError, RuntimeError, KeyError, TypeError, OSError) as exc:
+        parser.exit(2, f"replay refused: {exc}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Tessera currently interpolates each unit from its own measured anchors. This adds an opt-in research replay of the retained Gridbook shared-shape mechanism: fit a pilot curve, then recover each held-out unit's level and slope from one or two anchors. The command consumes current campaign receipts, freezes independent audit predictions, compares PWL where supported, preserves measured values, and emits deterministic requests for additional measurements when evidence is missing or fails.

The numerical core is shared with the existing AURA fitter; its strict currency and receipt checks remain. Replay imports only the campaign's actual joint local output-MSE currency and emits no allocator payload or production qualification. Activation/recipe segments stay separate. The documented downstream joint-AURA and measured prefill selection work remains tracked in #237.

Separate fixes in this PR:

- `--anchors 1/2` can now reach the existing third-anchor bootstrap, subject to budget/round/rung limits.
- Fused/packed UCB retains a conservative bound for correlated AURA samples instead of assuming independence. Default candidate prices are unchanged; uncertainty metadata is corrected. Mixed-rung UCB support remains refused.
- Current pin/menu documentation and the scope of the diagonal activation approximation are corrected.

Validation:

- Shared fitter: 65 CPU checks passed; coefficients and shape outputs exactly matched the prior implementation across 60 comparison cases.
- Two-anchor scheduling: confirmed failing-before regression; 91 passed, 5 CUDA skips.
- Grouped uncertainty: confirmed failing-before regression; 111 passed without skips, including exact default-price checks.
- Replay: current campaign-main output was imported after a real tiny CPU encode; independent audit, identity, domain, monotonicity, PWL, deterministic replay and no-clobber cases passed. Root additionally reproduced and repaired extreme finite-cost PWL reporting overflow/underflow.
- Final combined integration selection: **306 passed, 5 CUDA skips**, exit 0, 233.54 seconds, 16 workers with native/Inductor threads one; includes all 24 final replay cases. Compile and executable-AST checks confirm the prose-only changes do not alter Python behavior.

Receipts and commands are retained under `/home/rob/tessera-runs/audit-pass4-2026-09-05/`. No new GPU/model-quality/serving-speed claim; old Gridbook and Tessera artifacts retain their historical scope. No PrismaBuild used.

Closes #236.
