### PR TITLE
Recover completed helpers across process-exit races

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,6 +9,8 @@ read now rechecks process identity: disappearance or a zombie with the same
 start time means the helper ended, permitting exact receipt recovery. PID
 reuse, unreadable/malformed process state and live owner mismatch remain
 ambiguous and fail closed; they never authorize killing that process.
+The same refusal applies when ownership becomes ambiguous during recovery
+polling, before any receipt probe or retry.
 
 Re-stamped (2026-09-05, `codex/tessera-anchored-surface`) for opt-in,
 receipt-bound Tessera anchored-shape replay (§4.10). A declared shared pilot

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,14 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `codex/tessera-anchored-surface`. Stamps
+As of: 2026-09-05 · `codex/cluster-recovery-delivery`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-05, `codex/cluster-recovery-delivery`) for coordinator
+recovery across helper exit (PrismaQuant #239). A failed owner-environment
+read now rechecks process identity: disappearance or a zombie with the same
+start time means the helper ended, permitting exact receipt recovery. PID
+reuse, unreadable/malformed process state and live owner mismatch remain
+ambiguous and fail closed; they never authorize killing that process.
 
 Re-stamped (2026-09-05, `codex/tessera-anchored-surface`) for opt-in,
 receipt-bound Tessera anchored-shape replay (§4.10). A declared shared pilot

--- a/prismaquant/cluster_campaign.py
+++ b/prismaquant/cluster_campaign.py
@@ -1288,24 +1288,33 @@ def _helper_argv(host: Mapping[str, object]) -> list[str]:
     ]
 
 
-def _proc_snapshot(pid: int) -> tuple[int, str] | None:
+def _proc_snapshot(pid: int, *, strict: bool = False) -> tuple[int, str] | None:
+    """Read start time/state; strict checks distinguish missing from unreadable."""
     stat_path = Path(f"/proc/{int(pid)}/stat")
     try:
         text = stat_path.read_text(encoding="utf-8")
     except (FileNotFoundError, ProcessLookupError):
         return None
     except OSError:
+        if strict:
+            raise
         return None
     right = text.rfind(")")
     if right < 0:
+        if strict:
+            raise ValueError("malformed process stat")
         return None
     fields = text[right + 2 :].split()
     if len(fields) <= 19:
+        if strict:
+            raise ValueError("incomplete process stat")
         return None
     state = fields[0]
     try:
         ticks = int(fields[19])
     except ValueError:
+        if strict:
+            raise
         return None
     return ticks, state
 
@@ -1320,12 +1329,25 @@ def _proc_has_owner(pid: int, owner_token: str) -> bool:
 
 
 def _owned_process_state(pid: int, ticks: int, owner_token: str) -> str:
-    snapshot = _proc_snapshot(pid)
-    if snapshot is None or snapshot[1] == "Z":
-        return "gone"
-    if snapshot[0] != ticks or not _proc_has_owner(pid, owner_token):
+    try:
+        snapshot = _proc_snapshot(pid, strict=True)
+        if snapshot is None:
+            return "gone"
+        if snapshot[0] != ticks:
+            return "mismatch"
+        if snapshot[1] == "Z":
+            return "gone"
+        if _proc_has_owner(pid, owner_token):
+            return "owned"
+        # Exit can empty/remove environ after stat still showed a live helper.
+        # Only disappearance or a zombie with the same start time proves this
+        # attempt ended. PID reuse and unreadable state remain ambiguous.
+        snapshot = _proc_snapshot(pid, strict=True)
+    except (OSError, ValueError):
         return "mismatch"
-    return "owned"
+    if snapshot is None or snapshot == (ticks, "Z"):
+        return "gone"
+    return "mismatch"
 
 
 def _terminate_recorded_owned_process(pid: int, ticks: int, owner_token: str) -> bool:

--- a/prismaquant/cluster_campaign.py
+++ b/prismaquant/cluster_campaign.py
@@ -1615,6 +1615,14 @@ def _recover_running_stages(
         terminal = False
         if pid is not None and ticks is not None:
             process_state = _owned_process_state(int(pid), int(ticks), owner)
+            deadline_ns = int(attempt["started_unix_ns"]) + int(
+                stage["timeout_seconds"] + _RECOVERY_KILL_GRACE_SECONDS
+            ) * 1_000_000_000
+            while process_state == "owned" and time.time_ns() < deadline_ns:
+                time.sleep(max(0.01, float(poll_interval)))
+                process_state = _owned_process_state(int(pid), int(ticks), owner)
+            # Ownership may become ambiguous while monitoring, as well as on
+            # the initial read. Refuse before probing receipts or retrying.
             if process_state == "mismatch":
                 state = _finish_attempt(
                     state,
@@ -1626,12 +1634,6 @@ def _recover_running_stages(
                     detail="recorded PID ownership is ambiguous; process was not killed",
                 )
                 continue
-            deadline_ns = int(attempt["started_unix_ns"]) + int(
-                stage["timeout_seconds"] + _RECOVERY_KILL_GRACE_SECONDS
-            ) * 1_000_000_000
-            while process_state == "owned" and time.time_ns() < deadline_ns:
-                time.sleep(max(0.01, float(poll_interval)))
-                process_state = _owned_process_state(int(pid), int(ticks), owner)
             if process_state == "owned":
                 killed = _terminate_recorded_owned_process(
                     int(pid), int(ticks), owner

--- a/tests/test_cluster_campaign_runner.py
+++ b/tests/test_cluster_campaign_runner.py
@@ -1100,7 +1100,10 @@ def test_recorded_process_unreadable_stat_is_never_killed(monkeypatch, error):
     assert not campaign._terminate_recorded_owned_process(424242, 42, "owner")
 
 
-def test_ambiguous_recorded_pid_fails_closed_without_killing_it(tmp_path):
+@pytest.mark.parametrize("initially_owned", [False, True], ids=["on-resume", "during-monitoring"])
+def test_ambiguous_recorded_pid_fails_closed_without_killing_it(
+    tmp_path, monkeypatch, initially_owned
+):
     receipt_path = tmp_path / "never.json"
     receipt = _receipt(receipt_path, "never")
     stage = _stage(
@@ -1144,6 +1147,18 @@ def test_ambiguous_recorded_pid_fails_closed_without_killing_it(tmp_path):
     campaign.validate_campaign_state_v2(running, manifest)
     state_path = tmp_path / "ambiguous-state.json"
     state_path.write_text(json.dumps(running), encoding="utf-8")
+
+    if initially_owned:
+        # Start monitoring an owned helper, then deterministically lose its
+        # ownership on the next poll. Neither receipts nor retries may bypass
+        # the same refusal required when ownership is ambiguous on resume.
+        process_states = iter(["owned", "mismatch"])
+        monkeypatch.setattr(
+            campaign, "_owned_process_state", lambda *a: next(process_states)
+        )
+    monkeypatch.setattr(
+        os, "killpg", lambda *a: pytest.fail("ambiguous ownership must not be killed")
+    )
 
     with pytest.raises(campaign.CampaignTerminalFailure, match="ambiguous"):
         campaign.run_campaign_v2(manifest, state_path, poll_interval=0.01)

--- a/tests/test_cluster_campaign_runner.py
+++ b/tests/test_cluster_campaign_runner.py
@@ -1017,6 +1017,89 @@ def test_abrupt_worker_death_leaves_stage_lock_owned_by_child(tmp_path):
                 )
 
 
+@pytest.mark.parametrize(
+    "second_stat, expected",
+    [
+        ("42 Z", "gone"),
+        (FileNotFoundError(), "gone"),
+        (ProcessLookupError(), "gone"),
+        ("42 S", "mismatch"),
+        ("43 S", "mismatch"),
+        ("43 Z", "mismatch"),
+        (PermissionError(), "mismatch"),
+        (OSError("stat I/O failed"), "mismatch"),
+        ("malformed", "mismatch"),
+        ("invalid S", "mismatch"),
+    ],
+    ids=[
+        "zombie", "missing", "esrch", "live-owner-mismatch", "pid-reused",
+        "pid-reused-zombie", "permission-denied", "io-error", "malformed",
+        "invalid-ticks",
+    ],
+)
+@pytest.mark.parametrize("owner_read_error", [False, True], ids=["empty-env", "env-error"])
+def test_owned_process_state_rechecks_exit_after_failed_owner_read(
+    monkeypatch, second_stat, expected, owner_read_error
+):
+    # Force the exact exit window: stat reports our live helper, then environ
+    # loses its owner as the helper exits. No scheduling or sleep is involved.
+    snapshots = iter(["42 S", second_stat])
+
+    def read_stat(path, **kwargs):
+        assert str(path) == "/proc/424242/stat"
+        value = next(snapshots)
+        if isinstance(value, OSError):
+            raise value
+        if value == "malformed":
+            return value
+        ticks, state = value.split()
+        return "424242 (helper) " + " ".join([state] + ["0"] * 18 + [ticks])
+
+    def read_environ(path):
+        assert str(path) == "/proc/424242/environ"
+        if owner_read_error:
+            raise ProcessLookupError()
+        return b""
+
+    monkeypatch.setattr(Path, "read_text", read_stat)
+    monkeypatch.setattr(Path, "read_bytes", read_environ)
+    assert campaign._owned_process_state(424242, 42, "owner") == expected
+
+
+@pytest.mark.parametrize("owner_matches, expected", [(True, "owned"), (False, "mismatch")])
+def test_owned_process_state_live_identity(monkeypatch, owner_matches, expected):
+    monkeypatch.setattr(campaign, "_proc_snapshot", lambda *a, **kw: (42, "S"))
+    monkeypatch.setattr(campaign, "_proc_has_owner", lambda *a: owner_matches)
+    assert campaign._owned_process_state(424242, 42, "owner") == expected
+
+
+@pytest.mark.parametrize("state", ["S", "Z"])
+def test_recorded_process_pid_reuse_is_never_owned_or_killed(monkeypatch, state):
+    monkeypatch.setattr(campaign, "_proc_snapshot", lambda *a, **kw: (43, state))
+    monkeypatch.setattr(
+        campaign, "_proc_has_owner",
+        lambda *a: pytest.fail("a reused PID must not be checked for ownership"),
+    )
+    monkeypatch.setattr(
+        os, "killpg", lambda *a: pytest.fail("a reused PID must not be killed")
+    )
+    assert campaign._owned_process_state(424242, 42, "owner") == "mismatch"
+    assert not campaign._terminate_recorded_owned_process(424242, 42, "owner")
+
+
+@pytest.mark.parametrize("error", [PermissionError(), OSError("stat I/O failed")])
+def test_recorded_process_unreadable_stat_is_never_killed(monkeypatch, error):
+    def read_stat(*args, **kwargs):
+        raise error
+
+    monkeypatch.setattr(Path, "read_text", read_stat)
+    monkeypatch.setattr(
+        os, "killpg", lambda *a: pytest.fail("unreadable identity must not be killed")
+    )
+    assert campaign._owned_process_state(424242, 42, "owner") == "mismatch"
+    assert not campaign._terminate_recorded_owned_process(424242, 42, "owner")
+
+
 def test_ambiguous_recorded_pid_fails_closed_without_killing_it(tmp_path):
     receipt_path = tmp_path / "never.json"
     receipt = _receipt(receipt_path, "never")


### PR DESCRIPTION
Coordinator recovery could observe a live helper, then read an empty process environment after the helper exited, and terminal-fail completed work as an ownership mismatch. It now rechecks process state and identity after that read. Only disappearance or a zombie with the original start time permits receipt recovery; PID reuse and unreadable/malformed/live mismatches remain refused.

A separate commit applies the same refusal when ownership becomes ambiguous during polling, before receipt probing or retries. No ambiguous process is killed.

Both fixes have deterministic failing-before regressions. The full recovery test file passed **38 tests, zero skips**, including real coordinator death and worker/lock ownership cases (six CPU workers, native threads one). Root integration validation also passed **57 tests, zero skips**, including architecture and documentation checks (eight CPU workers, 15.59 seconds, exit 0) at `664b523cc871246d7bd3d93aa791ebd8ec519165`. Architecture is updated; checks and receipts are retained under `/home/rob/tessera-runs/audit-pass4-2026-09-05/`. No GPU, model-quality or performance claim. No PrismaBuild used.

Fixes #239.
