### PR TITLE
Bound paired validation server startup memory

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,17 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `claude/pq-227`. Stamps
+As of: 2026-09-05 · `measurement/pq208-2026-09-05`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-05, `measurement/pq208-2026-09-05`) for the opt-in
+paired Qwen3-0.6B campaign's explicit vLLM startup memory budget (#208).
+Both native BF16 and NVFP4 servers pass `--gpu-memory-utilization 0.2`,
+about 24.3 GiB on the campaign's 121.63 GiB GB10, inside its 28 GiB
+container and 32 GiB PrismaBuild reservation. Fixed 1 GiB KV bytes alone
+do not bypass the pinned image's startup fraction check; its inherited
+0.92 default refused before any prompt ran. The sequential servers,
+numerical contracts and production shipping defaults are unchanged.
+Gate: `tests/test_pq87_paired_validation.py`.
 
 Re-stamped (2026-09-05, `claude/pq-227`) for integration of the cache
 activation-scale policy guard with joint AURA and the current producer pin.

--- a/docs/experiments/pq87_quantized_validation.md
+++ b/docs/experiments/pq87_quantized_validation.md
@@ -22,6 +22,17 @@ The manifest's 2400-second wall deadline is an inconclusive backstop, not a
 predicted completion time. An enclosing `timeout` must retain cleanup grace.
 No GPU action may be submitted without the coordinator allocating that box.
 
+Resource correction for #208 (2026-09-05): both paired servers explicitly
+pass `--gpu-memory-utilization 0.2`. This is about 24.3 GiB on the 121.63 GiB
+GB10, within the existing 28 GiB container envelope. The pinned image's
+inherited 0.92 startup check requested 111.9 GiB despite the explicit 1 GiB
+KV allocation and refused with 111.87 GiB free before any model observation.
+The KV, sequence, prompt, seed, cap, PPL and candidate-decision contracts
+remain unchanged. Use a fresh task-owned local output directory for the
+Docker bind mounts, then archive receipts to shared storage after safe
+cleanup: the first #208 action's new NFS parent was mode 0700 and Docker
+could not traverse it. Retain both infrastructure-inconclusive attempts.
+
 The BF16 serve derives an uncensored schedule separately for the existing
 30-pair screen and a disjoint 30-pair heldout set. Both prompt sets and seeds
 are committed before either model is observed; no candidate outcome selects

--- a/experiments/pq87_paired_validation.py
+++ b/experiments/pq87_paired_validation.py
@@ -63,6 +63,10 @@ def validate_manifest(value):
 def server_argv(nonce, model):
     argv = instrument.server_argv(nonce)
     argv[argv.index("serve") + 1] = model
+    # Explicit KV bytes do not bypass vLLM's startup memory-fraction check.
+    # On this GB10 campaign, 20% is ~24.3 GiB within the 28 GiB container;
+    # inheriting the image's 92% default requests ~111.9 GiB instead.
+    argv += ["--gpu-memory-utilization", "0.2"]
     return argv
 
 

--- a/tests/test_pq87_paired_validation.py
+++ b/tests/test_pq87_paired_validation.py
@@ -57,6 +57,19 @@ def test_both_model_arms_reuse_the_existing_bounded_server_configuration():
     assert "--quantization" not in control + candidate
 
 
+@pytest.mark.parametrize("role", ["control", "candidate"])
+def test_paired_server_startup_budget_fits_the_reserved_container(role):
+    # A fixed 1 GiB KV cache does not bypass vLLM's device-startup fraction
+    # check. The image's 0.92 default requests 111.9 GiB on our GB10, far
+    # outside this campaign's 28 GiB container and 32 GiB fleet reservation.
+    argv = _driver().server_argv("nonce", f"/models/{role}")
+    flag = "--gpu-memory-utilization"
+    assert argv.count(flag) == 1, "paired server must declare its startup memory budget"
+    fraction = float(argv[argv.index(flag) + 1])
+    assert fraction == 0.2
+    assert (1 << 30) < fraction * 121.63 * (1 << 30) < 28 * (1 << 30)
+
+
 def _arm_receipts(monkeypatch, *, control_texts=None, candidate_texts):
     """The two `prismaquant.boundary_campaign_arm/1` files the driver reads back."""
     from prismaquant import boundary_control as bc


### PR DESCRIPTION
The paired BF16/NVFP4 validation server inherited the pinned vLLM image’s 92% startup memory request, despite an explicit 1 GiB KV cache and 28 GiB container limit. On GB10 this requested 111.9 GiB and refused startup before measurement.

Both arms now explicitly request 20% (~24.3 GiB on the declared GB10), within the existing envelope. Model, prompt, seed, paired-cap and PPL contracts are unchanged; this is an experiment launch correction. The architecture and runbook record the resource contract.

PrismaBuild regression: two missing-budget failures before the change; **135 tests passed, zero skips** after it (eight controller/policy/docs files, two CPU workers, one native thread each, 9.60s). Compile passed. Root verified the CAS payload hash/size and actual output; green action `3347f6736ee3d2e31ae599b63ba57c3de1802773a7e345943273dda9674f2139`, receipt `e4ee23974bbfb59d1aadc867eea6e409b793b8cc6dd809a22175aaaf0e874bf1`.

Refs #208. Earlier attempts are retained as startup-inconclusive; no quality or serving outcome is inferred from these tests. The corrected actual campaign is tracked separately in #208.
