### PR TITLE
Report actual priced coverage in Tessera campaigns

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,21 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `measurement/pq208-2026-09-05`. Stamps
+As of: 2026-09-05 · `codex/pq183-coverage`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-05, `codex/pq183-measurement`) for Tessera campaign
+population v2 (#183). Enumerated targets and emitted prices are distinct:
+empty admitted menus and targets without a successful anchor are recorded
+as in-scope unpriced units, with their reason. Only nonempty emitted cost
+rows establish priced coverage; a packed stack is priced whole only when
+every projected unit has a price. Stride and profile omissions remain
+separate. An allocation consuming v2 must explicitly retain each unpriced
+unit at BF16, records those retained names, and refuses missing or quantized
+choices. Intake checks priced names against nonempty cost rows and refuses
+overlapping priced/unpriced declarations or an enumerated target without
+either disposition. Legacy v1 receipts remain readable.
+This preserves partial
+campaign evidence without certifying coverage from attempted work.
 
 Re-stamped (2026-09-05, `measurement/pq208-2026-09-05`) for the opt-in
 paired Qwen3-0.6B campaign's explicit vLLM startup memory budget (#208).
@@ -60,6 +74,7 @@ existing cache directory's `render_identity.json` has no
 `levers.nvfp4_input_global_scale_policy`, so the first fill that resumes it
 refuses with that field named; the shards themselves are policy-independent,
 but the fix for a resume is a fresh `--cache-dir`.
+
 
 Re-stamped (2026-09-05, `codex/237-integration`) for the joint probe-count
 contract: joint harvesting and row admission require at least two probes.
@@ -6747,9 +6762,13 @@ Two properties make the numbers comparable with the rest of the menu:
   cost rows are **measured only** (`campaign_cost_payload(...,
   wire_backed=)`), because an interpolated rung on a wire-backed unit would
   be a price with no bytes behind it. The payload says what it priced:
-  `provenance.population` (`prismaquant.tessera_campaign_population.v1`:
-  priced dense / routed experts / packed parameters / stacks; omitted
-  dense-outside-stride, packed-outside-stride, pinned; counts),
+  `provenance.population` (`prismaquant.tessera_campaign_population.v2`:
+  enumerated dense / routed experts / packed parameters / stacks; priced
+  units with emitted rows and completely priced stacks; in-scope unpriced
+  units with reasons; omitted dense-outside-stride, packed-outside-stride,
+  pinned; counts). Allocation retains every unpriced unit explicitly at
+  BF16 and records `retained_bf16`; a missing or quantized choice refuses.
+  The other carried records are
   `provenance.tessera_expert_projection` (the producer's answer verbatim
   beside the request and the exact binding) and top-level
   `tessera_expert_wires` (`{unit: {rung: receipt}}`). The checkpoint identity

--- a/docs/measurements/pq183-campaign-population-2026-09-05.md
+++ b/docs/measurements/pq183-campaign-population-2026-09-05.md
@@ -75,3 +75,25 @@ dense FFN units in layer 0 and 96 expert projections in layer 12. A real
 producer projection must verify that population during the admitted run.
 No actual-model, GPU or served measurement is claimed by this correction;
 #183 acceptance item 4 remains a separate measurement obligation.
+
+## Integration on the delivered main branch
+
+The final code was integrated with merged PRs #230 and #242 (main
+`015b67b19f21db2497f2fedc13c2777a4ac4676f`). PrismaBuild action
+`97858e8ae052447622994737c1b5f53506040d945bb86019e533aee42f4d7ce1` tested
+source `379e2f21c99e265771b3c6febf9ad72ae80f1ff5` on sparklina with CUDA
+hidden, four pytest workers, native threads bounded to one, and a 24 GiB
+reservation. The six files covering campaign population, allocator projection,
+export projection, activation policy, architecture, and documentation staleness
+passed: **95 passed, zero skips**, 100.69 seconds. Measured action memory peak
+was 16,034,717,696 bytes; there were no OOM events.
+
+The coordinator inspected the terminal exit status and independently hashed the
+actual 743-byte result payload
+`9faf232c5b24153dba979b2aceffe73e0af3a0695d8e68321c55fce5f96f1f96`;
+receipt SHA-256 is
+`1034b506db5e8e6a4dd3609284de0c425ab7aa8a41fa33cfe45da636b14f94fd`.
+Submission, terminal, receipt, and result are retained under
+`/home/rob/tessera-runs/measurement-208-183-2026-09-05/coverage-integration-*`.
+Only this evidence paragraph was added after that code validation. Actual GPU
+campaign/export/serve measurement for #183 remains separate and pending.

--- a/docs/measurements/pq183-campaign-population-2026-09-05.md
+++ b/docs/measurements/pq183-campaign-population-2026-09-05.md
@@ -1,0 +1,77 @@
+# Tessera campaign population coverage, 2026-09-05
+
+PrismaQuant #183's actual-model preparation found that campaign targets were
+reported as priced even when no admitted menu or successful anchor produced
+a cost row. At PrismaQuant `729972255a71a8cba4b99a7213e8af29e7e311e5`,
+`tessera_campaign.main()` passed its target lists directly into
+`provenance.population.priced` before constructing the emitted cost table.
+
+Population v2 now separates enumerated targets, units with emitted prices,
+in-scope unpriced units and stride/profile omissions. A packed stack counts
+as completely priced only when every projected member has rows. Allocation
+requires explicit BF16 retention for unpriced units, verifies emitted-row
+agreement and disjoint dispositions, and refuses an enumerated unit whose
+disposition disappeared. Legacy v1 receipts remain readable.
+
+## CPU regression evidence
+
+All execution used PrismaBuild on `dl380g10`, Python 3.14.4, Torch
+2.11.0+cpu, two pytest workers, and OMP/MKL/OpenBLAS threads set to one.
+CUDA visibility was empty. A test-only snapshot supplied Tessera
+`ba582d476a3b6db9057ebd1385dc52926f171451`; action-scoped dependencies used
+Transformers 5.6.0, Accelerate 1.12.0 and the known-good pure-Python
+compressed-tensors 0.15.1a20260414 sources. Dependency inventories and
+per-file hashes are retained with the submission inputs.
+
+| PrismaBuild action | Result | Scope |
+|---|---|---|
+| `110a3a962e3bbbfb35707e9bb3d693c6941bc135e999ea9dc216f7e2df7a74d9` | 7 expected failures, exit 1 | New mixed-main empty-menu/failed-anchor/failed-expert cases and missing/quantized/BF16-retention cases against the original source modules |
+| `6ad031429a0183f0236f737d54e9dc718c2e13c81b3a95ec7dc14eaf0d376a23` | 137 passed, 5 skipped, 7 failures | Campaign, packed campaign, resume, allocator projection, export projection and architecture/docs files |
+| `c2b36821a29d15820be4b1aaefabd03b6b5b12417ab11fca158440a7d782c690` | 61 passed, exit 0 | Final allocator/export/docs files, touched-module compile checks and the two remaining failed resume/dependency cases |
+
+The broader run's seven failures were resolved: five export CLI cases had
+an incomplete synthetic fixture that did not isolate the producer-repository
+pin gate when `TESSERA_REPO` was set; one resume fixture discarded the
+payload's provenance; one subprocess deliberately reset `PYTHONPATH` and
+therefore lost the staged compressed-tensors dependency. The pin isolation
+is a separate test-only fix. The dependency was made visible through the
+action-scoped environment's site path. Production pin gates are unchanged.
+The five skips explicitly require CUDA; this CPU screen does not qualify
+GPU scoring, export or serving.
+
+Red peak memory was 9,960,148,992 bytes under a 24-GiB reservation;
+the broader screen peaked at 10,112,835,584 bytes. The final follow-up
+reserved 8 GiB and peaked at 1,480,130,560 bytes. An earlier 6-GiB attempt
+(`d9fafc6ae5529100d8a63768fd0a0229d44476e835bbc7b59dde587d6bff4c8b`)
+hit its exact cgroup cap and exited 137; it is an undersized attempt,
+not regression evidence. Earlier collection/setup failures are likewise
+not counted as red tests.
+
+The final CAS receipt is
+`da8fd946d3d10e49b3a7162543ab6f554e8ed110267e8781ae0fdde57a339862`.
+Its 11,948-byte payload was read and independently SHA-256 checked as
+`e522618fd2e5b99804178f627fd3745299088f0b3081754740a455e4ca63513e`.
+Terminal records, full logs and receipt JSON are retained under
+`/home/rob/tessera-runs/measurement-208-183-2026-09-05/pq183-evidence/`.
+The admitted command is recorded in each terminal's source request; its
+common submission shape was:
+
+```sh
+python3 /mnt/shared/prismabuild-fleet/repo/tools/pbrun.py \
+  --cwd CHECKOUT --anywhere --cpus 2 --demand mem_gb=8 \
+  --env OMP_NUM_THREADS=1 --env MKL_NUM_THREADS=1 \
+  --env OPENBLAS_NUM_THREADS=1 --timeout-s 600 --detach -- \
+  bash pb183-inputs/cpu-tests.sh consumers
+```
+
+## Actual-model boundary
+
+The pinned contract admits routed E4M3/q1024 on the EUGR image and dense
+cells on a different stock vLLM image. A bounded LFM2.5 campaign may
+therefore price its selected routed stack while retaining unpriced dense
+units explicitly at BF16. The shared model and reference ts5 directories
+were inspected read-only; source-derived scope for layer stride 12 is three
+dense FFN units in layer 0 and 96 expert projections in layer 12. A real
+producer projection must verify that population during the admitted run.
+No actual-model, GPU or served measurement is claimed by this correction;
+#183 acceptance item 4 remains a separate measurement obligation.

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -1181,23 +1181,43 @@ def _project_expert_population(population: ExpertPopulation, *, weights, menus,
     return carried, projected
 
 
-def _population_block(*, dense_priced, expert_priced, dense_all, pinned,
-                      population: ExpertPopulation, layer_stride: int) -> dict:
-    """Which population the payload prices and which it omits, by name."""
+def _population_block(*, dense_targets, expert_targets, dense_all, pinned,
+                      population: ExpertPopulation, layer_stride: int,
+                      costs, menus) -> dict:
+    """Distinguish selected targets from units with actual emitted prices."""
     from .tessera_expert_projection import POPULATION_SCHEMA
 
-    dense_omitted = sorted(set(dense_all) - set(dense_priced))
+    dense_omitted = sorted(set(dense_all) - set(dense_targets))
+    priced = {name for name, rows in costs.items() if rows}
+    dense_priced = sorted(set(dense_targets) & priced)
+    expert_priced = sorted(set(expert_targets) & priced)
+    unpriced = {
+        kind: {name: ("no_admitted_menu" if not menus.get(name)
+                      else "no_successful_anchor")
+               for name in sorted(set(targets) - priced)}
+        for kind, targets in (("dense", dense_targets),
+                              ("routed_experts", expert_targets))
+    }
+    complete_stacks = sorted(stack for stack, units in population.declared.items()
+                             if set(units) <= priced)
+    packed = {name: list(shape) for name, shape
+              in sorted(population.packed_in_scope.items())}
     packed_omitted = {name: list(shape) for name, shape
                       in sorted(population.omitted_outside_layer_stride.items())}
     return {
         "schema": POPULATION_SCHEMA,
         "layer_stride": int(layer_stride),
+        "enumerated": {"dense": sorted(dense_targets),
+                       "routed_experts": sorted(expert_targets),
+                       "packed_parameters": packed,
+                       "stacks": sorted(population.declared)},
+        "unpriced": unpriced,
         "priced": {
-            "dense": sorted(dense_priced),
-            "routed_experts": sorted(expert_priced),
-            "packed_parameters": {name: list(shape) for name, shape
-                                  in sorted(population.packed_in_scope.items())},
-            "stacks": sorted(population.declared),
+            "dense": dense_priced,
+            "routed_experts": expert_priced,
+            "packed_parameters": {name: shape for name, shape in packed.items()
+                                  if name.rsplit(".", 1)[0] in complete_stacks},
+            "stacks": complete_stacks,
         },
         "omitted": {
             "dense_outside_layer_stride": dense_omitted,
@@ -1207,6 +1227,8 @@ def _population_block(*, dense_priced, expert_priced, dense_all, pinned,
         "counts": {
             "dense_priced": len(dense_priced),
             "routed_experts_priced": len(expert_priced),
+            "dense_unpriced": len(unpriced["dense"]),
+            "routed_experts_unpriced": len(unpriced["routed_experts"]),
             "dense_omitted": len(dense_omitted),
             "packed_omitted": len(packed_omitted),
             "pinned": len(pinned),
@@ -1909,15 +1931,6 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             "seqlen": int(args.seqlen),
             "max_act_rows": int(args.max_act_rows),
             "layer_stride": int(args.layer_stride),
-            # Which population this table prices and which it omits, by name
-            # (PrismaQuant #183).  ``priced`` is what reached the anchor loop;
-            # ``omitted`` is what the stride left out or the profile pins.
-            # A reader of the payload does not have to infer coverage from
-            # the row keys.
-            POPULATION_KEY: _population_block(
-                dense_priced=dense_targets, expert_priced=expert_targets,
-                dense_all=all_dense, pinned=pinned, population=population,
-                layer_stride=int(args.layer_stride)),
             **({PROJECTION_KEY: expert_projection}
                if expert_projection is not None else {}),
             "anchors_round_one": int(args.anchors),
@@ -2022,6 +2035,12 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     payload = campaign_cost_payload(
         measured, menus, loo=loo, provenance=provenance,
         wire_backed=frozenset(projected_units))
+    # Empty menus, failed anchors and interrupted work do not establish a
+    # price. Publish coverage only after the cost rows have been constructed.
+    payload["provenance"][POPULATION_KEY] = _population_block(
+        dense_targets=dense_targets, expert_targets=expert_targets,
+        dense_all=all_dense, pinned=pinned, population=population,
+        layer_stride=int(args.layer_stride), costs=payload["costs"], menus=menus)
     if projected_units:
         # The producer's receipts for every priced expert wire, keyed by unit
         # then rung; the allocator carries the selected rung's receipt into

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -42,9 +42,9 @@ The render is not ``render_tessera_weight``'s reconstruction; it is
 ``read_unit_artifact(encode_linear(...).blob)`` -- **the bytes, decoded**.  So the
 cache entry holds the wire beside the dequantised render. Checkpoint resume
 verifies those bytes against their producer input receipt. That proves the
-cached wire is the priced wire; export reuse and served qualification still
-owe their own receipts. The packed producer-plan/cached-wire bridge remains
-the separate work tracked by PrismaQuant #183 (principle 8).
+cached wire is the priced wire. The packed producer-plan/cached-wire bridge
+carries those receipts through allocation and export; actual export/serve
+qualification remains the measurement tracked by PrismaQuant #183.
 
 What this stage does NOT do
 ---------------------------
@@ -772,11 +772,10 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
     so there is one notion of "what the campaign captured" for either
     population, and ``write_export_inputs`` has one input to write.  The
     score-row cap never caps routed rows before the Hessian or the maximum.
-    This capture API does not open the main-entry packed-population/export
-    gate: :func:`_require_campaign_population` still refuses a live packed
-    population before calibration, so nothing here reaches a cost payload or
-    the export inputs until the producer's projection bridge exists
-    (PrismaQuant #183).
+    The main-entry gate requires profile-declared projections and the
+    producer's planning tool before calibration. The campaign later binds
+    that producer projection to these live views before pricing the units
+    and carrying their wire receipts into export (PrismaQuant #183).
     """
     import torch
 

--- a/prismaquant/tessera_expert_projection.py
+++ b/prismaquant/tessera_expert_projection.py
@@ -72,7 +72,8 @@ PROJECTION_KEY = "tessera_expert_projection"
 EXPERT_WIRES_KEY = "tessera_expert_wires"
 #: Where the campaign payload says which population it priced and omitted.
 POPULATION_KEY = "population"
-POPULATION_SCHEMA = "prismaquant.tessera_campaign_population.v1"
+POPULATION_SCHEMA = "prismaquant.tessera_campaign_population.v2"
+LEGACY_POPULATION_SCHEMA = "prismaquant.tessera_campaign_population.v1"
 #: The projection block's own envelope schema inside PrismaQuant artifacts.
 CARRIED_PROJECTION_SCHEMA = "prismaquant.tessera_expert_projection.v1"
 
@@ -531,11 +532,63 @@ def allocation_expert_projection_block(payload: Mapping[str, Any],
         return {}
     block: dict[str, Any] = {}
     if population is not None:
-        if not isinstance(population, Mapping) or population.get("schema") != POPULATION_SCHEMA:
+        if not isinstance(population, Mapping) or population.get("schema") not in {
+                POPULATION_SCHEMA, LEGACY_POPULATION_SCHEMA}:
             raise ExpertProjectionError(
                 f"cost table population block is not {POPULATION_SCHEMA}; the allocation "
                 "cannot say which population was priced")
         block[POPULATION_KEY] = json.loads(json.dumps(population, sort_keys=True))
+        if population.get("schema") == POPULATION_SCHEMA:
+            unpriced = population.get("unpriced")
+            if not isinstance(unpriced, Mapping) or set(unpriced) != {"dense", "routed_experts"}:
+                raise ExpertProjectionError("cost table population needs explicit unpriced units")
+            priced = population.get("priced")
+            if not isinstance(priced, Mapping):
+                raise ExpertProjectionError("cost table population needs explicit priced units")
+            enumerated = population.get("enumerated")
+            if not isinstance(enumerated, Mapping):
+                raise ExpertProjectionError("cost table population needs explicit enumerated units")
+            priced_names = set()
+            for kind in ("dense", "routed_experts"):
+                names = priced.get(kind)
+                if (not isinstance(names, list) or
+                        any(not isinstance(name, str) or not name for name in names) or
+                        len(set(names)) != len(names) or priced_names.intersection(names)):
+                    raise ExpertProjectionError("population priced units must be unique names")
+                priced_names.update(names)
+            costs = payload.get("costs", {})
+            if not isinstance(costs, Mapping):
+                raise ExpertProjectionError("campaign cost rows must be an object")
+            actual_priced = {name for name, rows in costs.items()
+                             if isinstance(rows, Mapping) and rows}
+            if priced_names != actual_priced:
+                raise ExpertProjectionError(
+                    "population priced units disagree with nonempty campaign cost rows")
+            retained = []
+            for kind in ("dense", "routed_experts"):
+                if not isinstance(unpriced[kind], Mapping):
+                    raise ExpertProjectionError(f"population unpriced.{kind} must name units")
+                targets = enumerated.get(kind)
+                if (not isinstance(targets, list) or
+                        any(not isinstance(name, str) or not name for name in targets) or
+                        len(set(targets)) != len(targets) or
+                        set(targets) != set(priced[kind]) | set(unpriced[kind])):
+                    raise ExpertProjectionError(
+                        f"population enumerated.{kind} must equal its priced and unpriced units")
+                for name, reason in sorted(unpriced[kind].items()):
+                    if (not isinstance(name, str) or not name or reason not in
+                            {"no_admitted_menu", "no_successful_anchor"}):
+                        raise ExpertProjectionError("population has an invalid unpriced unit")
+                    if name in priced_names or name in retained:
+                        raise ExpertProjectionError(
+                            f"population priced/unpriced units must be disjoint: {name}")
+                    if assignment.get(name) != "BF16":
+                        raise ExpertProjectionError(
+                            f"unpriced campaign unit {name} ({reason}) must be explicitly "
+                            "retained at BF16; absent or quantized assignments have no price")
+                    retained.append(name)
+            if retained:
+                block[POPULATION_KEY]["retained_bf16"] = sorted(retained)
     if carried is None:
         if wires:
             raise ExpertProjectionError(

--- a/tests/test_allocator_expert_projection.py
+++ b/tests/test_allocator_expert_projection.py
@@ -99,6 +99,8 @@ def _receipt(name: str, unit: dict, fmt: str = FMT) -> dict:
 def _population() -> dict:
     return {
         "schema": POPULATION_SCHEMA, "layer_stride": 1,
+        "enumerated": {"dense": [DENSE], "routed_experts": _units()},
+        "unpriced": {"dense": {}, "routed_experts": {}},
         "priced": {"dense": [DENSE], "routed_experts": _units(),
                    "packed_parameters": {f"{STACK}.gate_up_proj": [2, 2 * N, N],
                                          f"{STACK}.down_proj": [2, N, N]},
@@ -229,6 +231,75 @@ def test_main_carries_projection_population_and_selected_receipts(tmp_path, monk
                                       for name in _units()}
     assert meta["tessera_expert_stack_formats"] == {STACK: FMT}
     assert meta["tessera_expert_wire_dir"] == str(tmp_path / "wire")
+
+
+@pytest.mark.parametrize("selected", [None, FMT, "NVFP4"])
+def test_allocation_requires_explicit_bf16_for_unpriced_campaign_unit(selected):
+    payload = {"provenance": {POPULATION_KEY: _unpriced_population()}}
+    assignment = {} if selected is None else {DENSE: selected}
+    with pytest.raises(ExpertProjectionError, match="unpriced.*BF16"):
+        allocation_expert_projection_block(payload, assignment)
+
+
+def test_allocation_records_explicit_bf16_retention_for_unpriced_campaign_unit():
+    population = _unpriced_population()
+    payload = {"provenance": {POPULATION_KEY: population}}
+    block = allocation_expert_projection_block(payload, {DENSE: "BF16"})
+    assert block[POPULATION_KEY]["retained_bf16"] == [DENSE]
+    assert "retained_bf16" not in population
+
+
+def _unpriced_population():
+    return {"schema": POPULATION_SCHEMA, "layer_stride": 1,
+            "enumerated": {"dense": [DENSE], "routed_experts": [],
+                           "packed_parameters": {}, "stacks": []},
+            "priced": {"dense": [], "routed_experts": [],
+                       "packed_parameters": {}, "stacks": []},
+            "unpriced": {"dense": {DENSE: "no_admitted_menu"}, "routed_experts": {}},
+            "omitted": {"dense_outside_layer_stride": [],
+                        "packed_outside_layer_stride": {}, "pinned": []},
+            "counts": {"dense_priced": 0, "routed_experts_priced": 0,
+                       "dense_unpriced": 1, "routed_experts_unpriced": 0,
+                       "dense_omitted": 0, "packed_omitted": 0, "pinned": 0}}
+
+
+def test_allocation_refuses_claimed_prices_without_rows():
+    population = _unpriced_population()
+    population["priced"]["dense"] = [DENSE]
+    population["unpriced"]["dense"] = {}
+    with pytest.raises(ExpertProjectionError, match="disagree.*cost rows"):
+        allocation_expert_projection_block({"provenance": {POPULATION_KEY: population}}, {})
+
+
+def test_allocation_refuses_overlapping_priced_and_unpriced_units():
+    population = _unpriced_population()
+    population["priced"]["dense"] = [DENSE]
+    payload = {"provenance": {POPULATION_KEY: population},
+               "costs": {DENSE: {FMT: {"output_mse": 0.1}}}}
+    with pytest.raises(ExpertProjectionError, match="must be disjoint"):
+        allocation_expert_projection_block(payload, {DENSE: "BF16"})
+
+
+def test_allocation_refuses_stripped_unpriced_disposition():
+    population = _unpriced_population()
+    population["unpriced"]["dense"] = {}
+    with pytest.raises(ExpertProjectionError, match="enumerated.dense.*priced and unpriced"):
+        allocation_expert_projection_block({"provenance": {POPULATION_KEY: population}}, {})
+
+
+def test_allocation_preserves_legacy_population_receipts():
+    population = _population()
+    population["schema"] = tep.LEGACY_POPULATION_SCHEMA
+    population.pop("unpriced")
+    payload = {"provenance": {POPULATION_KEY: population}}
+    assert allocation_expert_projection_block(payload, {}) == {POPULATION_KEY: population}
+
+
+def test_allocation_refuses_v2_without_unpriced_disposition():
+    population = _population()
+    population.pop("unpriced")
+    with pytest.raises(ExpertProjectionError, match="explicit unpriced"):
+        allocation_expert_projection_block({"provenance": {POPULATION_KEY: population}}, {})
 
 
 def test_main_refuses_a_selected_rung_with_no_priced_wire(tmp_path, monkeypatch):

--- a/tests/test_tessera_campaign_packed.py
+++ b/tests/test_tessera_campaign_packed.py
@@ -327,10 +327,9 @@ def _bridge_main_fixture(monkeypatch, tmp_path, *, perturb=None):
     """main() with a real capture, projection, encode and receipt; no route scoring.
 
     ``_measure_anchor`` is replaced by the producer's real encode without its
-    served-route admission, and by name: on this branch the campaign cannot
-    score a rung against either producer checkout (the pinned Tessera lacks
-    ``tessera.cached_unit``; the release publishes lane eligibility v8, which
-    PrismaQuant #192 admits).  Everything the bridge adds -- the population
+    served-route admission: this CPU fixture exercises the bridge, while
+    runtime-scoped GPU pricing requires its own measurement. Everything the
+    bridge adds -- the population
     gate, the producer request, the binding, the source-byte check, the real
     Tessera bytes under ``unit_input_identity`` receipts and the payload's
     population/projection/wire blocks -- runs for real.

--- a/tests/test_tessera_campaign_packed.py
+++ b/tests/test_tessera_campaign_packed.py
@@ -473,6 +473,50 @@ def test_main_refuses_a_live_view_that_disagrees_with_the_producer_source(monkey
     assert not (tmp_path / "cost.pkl").exists()
 
 
+@pytest.mark.parametrize("failure", ["empty_menu", "failed_anchor", "failed_expert"])
+def test_main_reports_unpriced_targets_without_claiming_coverage(monkeypatch, tmp_path, failure):
+    campaign, argv, _model, _encoded = _bridge_main_fixture(monkeypatch, tmp_path)
+    dense = "model.layers.0.attention"
+    target = _expert_unit_names()[0] if failure == "failed_expert" else dense
+    if failure == "empty_menu":
+        expand = campaign.expand_menus_for_targets
+
+        def menus(*args, **kwargs):
+            result = expand(*args, **kwargs)
+            result[dense] = []
+            return result
+
+        monkeypatch.setattr(campaign, "expand_menus_for_targets", menus)
+    else:
+        measure = campaign._measure_anchor
+
+        def failing_measure(**kwargs):
+            if kwargs["qname"] == target:
+                raise RuntimeError("synthetic encode failure")
+            return measure(**kwargs)
+
+        monkeypatch.setattr(campaign, "_measure_anchor", failing_measure)
+    assert campaign.main(argv) == 0
+    payload = pickle.loads((tmp_path / "cost.pkl").read_bytes())
+    population = payload["provenance"]["population"]
+    assert target not in payload["costs"]
+    if failure == "failed_expert":
+        assert target not in population["priced"]["routed_experts"]
+        assert population["enumerated"]["routed_experts"] == sorted(_expert_unit_names())
+        assert population["unpriced"]["routed_experts"] == {target: "no_successful_anchor"}
+        assert population["priced"]["stacks"] == []
+        assert population["priced"]["packed_parameters"] == {}
+        assert population["counts"]["routed_experts_priced"] == len(_expert_unit_names()) - 1
+        return
+    assert population["priced"]["dense"] == []
+    assert population["enumerated"]["dense"] == [dense]
+    assert population["unpriced"]["dense"] == {
+        dense: "no_admitted_menu" if failure == "empty_menu" else "no_successful_anchor"}
+    assert population["counts"]["dense_priced"] == 0
+    assert population["counts"]["dense_unpriced"] == 1
+    assert population["priced"]["routed_experts"] == sorted(_expert_unit_names())
+
+
 def test_wire_backed_units_keep_only_measured_rows():
     """A priced expert wire IS the exported wire, so no rung without bytes is offered.
 

--- a/tests/test_tessera_campaign_resume.py
+++ b/tests/test_tessera_campaign_resume.py
@@ -59,7 +59,7 @@ def _main_fixture(monkeypatch, tmp_path, *, priced=False):
 
     def unverified_anchors_reached_payload(anchors, *_args, **_kwargs):
         assert not anchors, "unverified checkpoint anchors reached the current cost payload"
-        return {"costs": {}, "formats": []}
+        return {**_kwargs["provenance"], "costs": {}, "formats": []}
 
     if not priced:
         monkeypatch.setattr(tessera_campaign, "campaign_cost_payload",

--- a/tests/test_tessera_campaign_resume.py
+++ b/tests/test_tessera_campaign_resume.py
@@ -244,11 +244,10 @@ def test_refused_resume_leaves_the_surviving_tables_export_inputs(monkeypatch, t
     ``hessian_capture.pt``, its sidecar and ``input_scales.safetensors`` are
     the export leg's half of the same surviving table: destroy them and the
     table that survived cannot be exported at all (#211).  The pytest form of
-    ``pq-audit-caches/pq-204/proofs/rejected_resume_postfix.py``; it needs the
-    release Tessera's ``cached_unit`` receipt API to reach ``main()``'s resume
-    at all, so it skips at the development pin.  The menu is left empty (the
-    ``priced=False`` fixture) so the refusal is the run-level identity's and
-    not the released contract's lane-eligibility schema.
+    ``pq-audit-caches/pq-204/proofs/rejected_resume_postfix.py``; it needs
+    Tessera's ``cached_unit`` receipt API to reach ``main()``'s resume.
+    The menu is left empty (the ``priced=False`` fixture) so the refusal
+    exercises run-level identity independently of route admission.
     """
     pytest.importorskip("tessera.cached_unit")
     campaign, checkpoint, argv, _model, inputs = _main_fixture(monkeypatch, tmp_path)

--- a/tests/test_tessera_export_projection.py
+++ b/tests/test_tessera_export_projection.py
@@ -147,6 +147,8 @@ def _receipt(name: str, unit: dict, fmt: str = FMT) -> dict:
 def _population() -> dict:
     return {
         "schema": POPULATION_SCHEMA, "layer_stride": 1,
+        "enumerated": {"dense": [DENSE], "routed_experts": _units()},
+        "unpriced": {"dense": {}, "routed_experts": {}},
         "priced": {"dense": [DENSE], "routed_experts": _units(),
                    "packed_parameters": {f"{STACK}.gate_up_proj": [2, 2 * N, N],
                                          f"{STACK}.down_proj": [2, N, N]},
@@ -477,6 +479,8 @@ def _allocator_metadata(case, assignment):
     """
     meta = _meta(case)
     payload = {
+        "costs": {name: {FMT: {"output_mse": 1e-4}}
+                  for name in [DENSE, *_units()]},
         "provenance": {
             POPULATION_KEY: meta[POPULATION_KEY],
             PROJECTION_KEY: meta[PROJECTION_KEY],

--- a/tests/test_tessera_export_projection.py
+++ b/tests/test_tessera_export_projection.py
@@ -407,6 +407,7 @@ def _isolate_other_gates(monkeypatch):
     monkeypatch.setattr(export, "require_declared_structure", lambda model: "routed_moe")
     monkeypatch.setattr(export, "require_executes_derived_from_contract", lambda: ())
     monkeypatch.setattr(export, "require_producer_tools", lambda: ())
+    monkeypatch.setattr(export, "require_producer_repo_is_pinned", lambda: ())
     monkeypatch.setattr(export, "require_release_pin", lambda: None)
     monkeypatch.setattr(pin, "load_tessera_serving_runtime_pin",
                         lambda: SimpleNamespace(version="fixture", commit="f" * 40))


### PR DESCRIPTION
Campaigns reported enumerated targets as priced even when no menu cell or successful anchor produced a cost row. Population schema v2 now distinguishes enumerated, priced, unpriced, and omitted units; partially measured expert stacks do not count as fully priced. Allocation validates that coverage against actual costs and requires explicit BF16 retention for unpriced units. Legacy v1 records remain readable.

This extends the packed-MoE bridge for #183 and preserves cached-wire and producer-pin gates. The real bounded GPU measurement remains pending under issue #183; that issue stays open. Architecture and dated evidence are updated.

Validation: seven regression failures demonstrated on the baseline through PrismaBuild. Follow-up CPU checks passed61 tests. Final integration with merged #230/#242 passed95 tests with zero skips on sparklina (four workers, native threads1, CUDA hidden); terminal exit and actual CAS payload independently verified. The broader earlier run had five CUDA-only skips and seven fixture/environment failures, all addressed as documented. See `docs/measurements/pq183-campaign-population-2026-09-05.md` for commands and receipts.
