### PR TITLE
Retain refused pairing evidence and add bounded stack diagnostics

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,17 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `codex/pq183-coverage`. Stamps
+As of: 2026-09-05 · `codex/pq208-preflight-receipts`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-05, `measurement/pq208-2026-09-05`) for retained
+paired-client preflight evidence and the opt-in `--stack-preflight` diagnostic
+(#208). The client writes its raw observed server manifest before any
+identity refusal. The paired controller's diagnostic reuses the same frozen
+inputs, sequential servers, warmups and owned-container cleanup, but runs no
+policy/PPL clients and ends as `preflight_completed`, never a completed
+validation. Raw full performance fingerprints and all pairing guards remain
+unchanged. This diagnoses cross-arm stack differences without repeating
+the control's cap search.
 
 Re-stamped (2026-09-05, `codex/pq183-measurement`) for Tessera campaign
 population v2 (#183). Enumerated targets and emitted prices are distinct:

--- a/docs/experiments/pq87_quantized_validation.md
+++ b/docs/experiments/pq87_quantized_validation.md
@@ -33,6 +33,14 @@ Docker bind mounts, then archive receipts to shared storage after safe
 cleanup: the first #208 action's new NFS parent was mode 0700 and Docker
 could not traverse it. Retain both infrastructure-inconclusive attempts.
 
+The client now retains `<arm>-serve-pre.json` before any pairing refusal,
+so the observed stack is available even when no completed arm receipt is
+written. A bounded `--stack-preflight` diagnostic reuses the full controller's
+freeze, sequential servers, warmups and cleanup to capture both raw stack
+manifests. It skips all policy and PPL clients and ends with
+`status: preflight_completed`; this is never a completed quantized campaign.
+Keep the full fingerprints and all their fields when diagnosing a mismatch.
+
 The BF16 serve derives an uncensored schedule separately for the existing
 30-pair screen and a disjoint 30-pair heldout set. Both prompt sets and seeds
 are committed before either model is observed; no candidate outcome selects

--- a/experiments/pq87_paired_validation.py
+++ b/experiments/pq87_paired_validation.py
@@ -226,6 +226,7 @@ def inside(args):
     _root, _client, _bc = instrument.bootstrap()
     import serve_fingerprint as sf
     manifest = validate_manifest(json.loads(Path("/run/manifest.json").read_text()))
+    stack_preflight = getattr(args, "stack_preflight", False)
     deadline = time.monotonic() + args.seconds
     signal.signal(signal.SIGTERM, _interrupt)
     status = {"status": "inconclusive", "advisory_only": True, "started": time.time(), "phases": {}}
@@ -267,7 +268,12 @@ def inside(args):
                     endpoint = "completions" if raw else "chat/completions"
                     instrument.dump(Path(f"/run/warm-{role}-{raw}.json"), instrument._http(
                         "http://127.0.0.1:8187/v1/" + endpoint, body, timeout=min(60, instrument.remaining(deadline))))
-                for population in ("screen", "heldout", "ppl"):
+                if stack_preflight:
+                    observed = sf.collect_manifest(image=manifest["image"],
+                        base_url="http://127.0.0.1:8187", attestation_phase="pre")
+                    instrument.dump(Path(f"/run/{role}-stack-preflight.json"), observed)
+                    role_status["stack_preflight"] = observed["performance_stack_fingerprint"]
+                for population in (() if stack_preflight else ("screen", "heldout", "ppl")):
                     instrument.dump(Path("/run/inside-status.json"), status)
                     with open(f"/run/{role}-{population}-client.log", "x") as client_log:
                         result = subprocess.run([sys.executable, "-P", __file__, "--client", "--role", role,
@@ -293,7 +299,7 @@ def inside(args):
                 # The subsequent arm must not coexist with an orphaned engine.
                 if sf.find_server_pids():
                     raise ValueError(f"{role} left a serving process after shutdown")
-        status["status"] = "completed"
+        status["status"] = "preflight_completed" if stack_preflight else "completed"
     except BaseException as exc:
         status["error"] = repr(exc)
     finally:
@@ -393,6 +399,8 @@ def host(args):
             "--entrypoint", "/usr/bin/env", manifest["image"], "-u", "PYTHONPATH", "python3", "-P",
             "/repo/experiments/pq87_paired_validation.py", "--inside", "--seconds",
             str(max(1, int(instrument.remaining(deadline)) - 30)), "--nonce", out.name]
+        if getattr(args, "stack_preflight", False):
+            command.append("--stack-preflight")
         status["docker_argv"] = command
         instrument.dump(out / "campaign.json", status)
         with (out / "container.log").open("x") as log:
@@ -425,6 +433,8 @@ def main():
     parser.add_argument("--population", choices=("screen", "heldout", "ppl"))
     parser.add_argument("--nonce")
     parser.add_argument("--seconds", type=int)
+    parser.add_argument("--stack-preflight", action="store_true",
+                        help="warm both servers and retain stack manifests; no policy or PPL measurement")
     args = parser.parse_args()
     if args.client:
         return client_phase(args)

--- a/tests/test_measure_boundary_control_identity.py
+++ b/tests/test_measure_boundary_control_identity.py
@@ -124,3 +124,25 @@ def test_offline_replay_refuses_content_manifest_inconsistent_with_identity(camp
     manifest["files"][weight.name]["sha256"] = "b" * 64
     with pytest.raises(ValueError, match="artifact_id"):
         bc.replay_control(measurement)
+
+
+def test_pairing_refusal_preserves_the_observed_candidate_preflight(campaign, monkeypatch):
+    model, _weight, run, _post, requests = campaign
+    control = run("control.json")
+    observed = copy.deepcopy(control["serve_pre"])
+    observed["performance_stack_fingerprint"] = "b" * 64
+    monkeypatch.setattr(sf, "collect_manifest", lambda **_kwargs: copy.deepcopy(observed))
+    requests.clear()
+    output = model.parent / "candidate.json"
+    with pytest.raises(ValueError, match="paired serve_fingerprint differs"):
+        tool.main([
+            "candidate", "--base-url", "http://fixture", "--model-name", "nonce",
+            "--model-dir", str(model), "--image", "fixture@sha256:" + "a" * 64,
+            "--control", str(model.parent / "control.json"),
+            "--campaign-id", "same-campaign", "--out", str(output),
+        ])
+    assert not output.exists()
+    assert not any(url.endswith("/chat/completions") for url in requests)
+    retained = output.with_name("candidate-serve-pre.json")
+    assert retained.exists(), "pairing refusal lost its observed server manifest"
+    assert json.loads(retained.read_text()) == observed

--- a/tools/measure_boundary_control.py
+++ b/tools/measure_boundary_control.py
@@ -78,6 +78,12 @@ def main(argv=None):
     artifact_pre, weight_stats_pre = _capture_artifact(args.model_dir)
     before = sf.collect_manifest(image=args.image, base_url=args.base_url,
                                  attestation_phase="pre")
+    # A refused pairing still needs the actual observed stack for diagnosis.
+    # This raw preflight is not a completed measurement receipt, and a fresh
+    # exclusive file prevents a new attempt from overwriting old evidence.
+    with output.with_name(output.stem + "-serve-pre.json").open("x") as stream:
+        json.dump(before, stream, indent=2, ensure_ascii=False, allow_nan=False)
+        stream.write("\n")
     if not before["residency_readable"] or not before.get("serve_session_id"):
         raise ValueError("serve process/residency attestation is incomplete")
     model = before["models_endpoint_binding"]["model"]


### PR DESCRIPTION
Pairing refusal discarded the observed candidate stack, leaving no raw evidence to diagnose why the full fingerprints differed. The measurement client now writes its preflight manifest before identity guards, using an exclusive output file. The existing paired controller also gains an opt-in `--stack-preflight` mode that warms both frozen models sequentially, records their stacks, and finishes as `preflight_completed`; it runs no policy/PPL clients.

All existing comparison guards and full fingerprints are preserved. Issue #208 remains pending actual paired quantized validation. Architecture and the experiment runbook describe the diagnostic boundary.

Validation through PrismaBuild: the lost-manifest regression failed before the fix;136 targeted CPU tests passed with zero skips on sparklina (two workers, native threads1), plus compile checks. The coordinator independently hashed actual732-byte CAS result `34e8ab54bc9a5e8b2a9f354b476e584c7b99d5f94404772b0ff2479f689d378b`, action `dd7594ff2895839829dd3923045adfd507d7221db36f7805f01512b71e99b342`. Integration with merged #243 required only combining architecture history;19 architecture/staleness tests then passed, zero skips (action `6b407166b7e3fd27ee29c86e6781d7daed1bf38a03eae9d1317c9c8285f2fd24`). The changed executable/test files match the tested worker commit exactly.

Broader GitHub CI has separate cluster-runner failures recorded in #244; these are not claimed resolved by this diagnostic change. Receipts: `/mnt/shared/tessera-runs/measurement-208-183-2026-09-05/pq208-preflight-green-*` and `/home/rob/tessera-runs/measurement-208-183-2026-09-05/preflight208-integration-*`.
