### PR TITLE
Declare exact treatment stacks for paired quantized validation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,22 @@
 As of: 2026-09-05 · `codex/pq208-preflight-receipts`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-05, `measurement/pq208-2026-09-05`) for the opt-in paired
+stack treatment contract: validation manifest v2 declares one immutable image
+and the exact artifact identity and resident-extension set for each role.
+Boundary-control receipt v2 retains the raw observed manifest and recomputes
+its full fingerprint before projecting only the declared extension coordinate
+out of paired comparison. Every other stack payload field uses canonical JSON
+digest equality, including JSON types. Extra/missing extensions, wrong roles,
+artifacts, images or unreadable residency refuse. The identical declaration,
+existing same-campaign binding and candidate's exact control hash compose
+through offline replay; a declaration may be reused, receipts cannot be mixed.
+Legacy v1 remains strict and cannot silently consume v2 proof. Per-arm full
+pre/post residency checks and general serving/gold guards remain unchanged.
+Gates: `tests/test_boundary_stack_contract.py`, boundary/controller/identity
+tests and architecture/doc staleness tests. This enables an explicit experiment,
+not a shipping-policy promotion or a candidate measurement claim.
+
 Re-stamped (2026-09-05, `measurement/pq208-2026-09-05`) for retained
 paired-client preflight evidence and the opt-in `--stack-preflight` diagnostic
 (#208). The client writes its raw observed server manifest before any

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `codex/pq208-preflight-receipts`. Stamps
+As of: 2026-09-05 · `codex/pq208-stack-contract`. Stamps
 follow, newest first, each recording its own branch and date.
 
 Re-stamped (2026-09-05, `measurement/pq208-2026-09-05`) for the opt-in paired

--- a/docs/experiments/pq87_quantized_validation.md
+++ b/docs/experiments/pq87_quantized_validation.md
@@ -41,6 +41,26 @@ manifests. It skips all policy and PPL clients and ends with
 `status: preflight_completed`; this is never a completed quantized campaign.
 Keep the full fingerprints and all their fields when diagnosing a mismatch.
 
+The #208 diagnostic observed exactly one stack-payload difference: BF16
+resident extensions were `sampling.so`, while native NVFP4 additionally
+loaded `trtllm_utils.so`. Validation manifest v2 therefore opts into
+`prismaquant.boundary_stack_contract/1`, fixed before any candidate policy
+observation. It binds the immutable image and exact content artifact IDs to
+the two declared roles and exact extension sets. This is not an extension
+wildcard: missing or additional extensions refuse. Every other existing stack
+payload field must have an identical canonical JSON digest, preserving types.
+The original raw manifests and full fingerprints remain in boundary-control
+v2 receipts and are recomputed during pairing and offline replay. Full per-arm
+pre/post residency and content checks still apply.
+
+Both receipts must contain the identical immutable declaration, have the same
+campaign ID and satisfy the existing tokenization/producer/host contracts;
+the candidate binds the exact control receipt hash. These checks allow a
+declaration to be reused in a new campaign without allowing receipt swapping
+between campaigns. Legacy v1 pairing keeps full-fingerprint equality. A v1
+receipt with added proof, or v2 with missing proof, refuses; old replay code
+rejects the new receipt schema. The production shipping policy is unchanged.
+
 The BF16 serve derives an uncensored schedule separately for the existing
 30-pair screen and a disjoint 30-pair heldout set. Both prompt sets and seeds
 are committed before either model is observed; no candidate outcome selects
@@ -100,7 +120,25 @@ and required evidence are complete.
 
 ## Controller verification, not served validation
 
-All controller checks used deployed PrismaBuild `aa6d3cfa2f77`, Sparky with
+The declared-stack correction was qualified on 2026-09-05 through PrismaBuild
+runtime `d8f82f3a48f6`. Before the correction, action `1b65696d241e8882`
+produced 6 failed / 17 passed contract regressions. The additional canonical
+type regression `4b7629a98cb42083` failed because rehashed `gpu_count: true`
+was accepted against `gpu_count: 1`. After correction, `b7ae4af16c86c2c9`
+passed all 161 tests in nine files (the eight below plus
+`tests/test_boundary_stack_contract.py`), with no skips or collection errors.
+It used two admitted Sparklina CPUs, 8 GiB, pytest `-n 2`, disabled CUDA
+visibility and OMP/MKL/OpenBLAS thread limits of one with the existing
+`/home/rob/dq-runs/venvs/prismaquant-cu130/bin/python`. Compile action
+`e33b8cd1d7ec6d47` completed with rc0 for the four touched Python files.
+Exact commands, exclusions, terminal records, CAS receipts and rehashed result
+payloads are under
+`/mnt/shared/tessera-runs/measurement-208-183-2026-09-05/pq208-stack-*`.
+Green CAS receipt: `5d2fa2ee4c956bbd0b12a35a17d1bc7cf12bd2cf42f04c3b8ac452198833cb29`;
+812-byte result: `900b9439b7c7e462cf158ef7f4644c3148580ffb76b6f5fa335cc464782de436`.
+These CPU checks do not constitute a candidate policy observation.
+
+The original controller checks below used deployed PrismaBuild `aa6d3cfa2f77`, Sparky with
 one CPU/4 GiB, `CUDA_VISIBLE_DEVICES=''`, and all three BLAS/OMP thread limits
 set to one. The serial eight-file population collected every selected module,
 with zero skips or collection errors. No master baseline or full suite ran.

--- a/experiments/pq87_paired_validation.py
+++ b/experiments/pq87_paired_validation.py
@@ -29,12 +29,20 @@ import pq87_physical_ab as instrument
 
 def validate_manifest(value):
     from prismaquant import boundary_control as bc
-    if not isinstance(value, dict) or set(value) != {
+    fields = {
         "schema", "image", "models", "contracts", "deadline_seconds", "netdata_urls"
-    } or value["schema"] != "prismaquant.boundary_validation/1":
+    }
+    if isinstance(value, dict) and value.get("schema") == "prismaquant.boundary_validation/2":
+        fields.add("stack_contract")
+    if (not isinstance(value, dict) or set(value) != fields
+            or value["schema"] not in {"prismaquant.boundary_validation/1", "prismaquant.boundary_validation/2"}):
         raise ValueError("validation manifest fields differ from schema")
     if not isinstance(value["image"], str) or not re.fullmatch(r"[^\s@]+@sha256:[0-9a-f]{64}", value["image"]):
         raise ValueError("validation image must be an immutable digest")
+    if "stack_contract" in value:
+        bc.validate_stack_contract(value["stack_contract"])
+        if value["stack_contract"]["image"] != value["image"]:
+            raise ValueError("stack contract image differs from campaign image")
     models = value["models"]
     if (not isinstance(models, dict) or set(models) != {"control", "candidate"}
             or any(not isinstance(path, str) or not Path(path).is_absolute() for path in models.values())
@@ -219,6 +227,8 @@ def client_phase(args):
                 "--out", prefix + ".json"]
         argv += (["--contract", f"/run/{args.population}-contract.json"] if args.role == "control" else
                  ["--control", f"/run/control-{args.population}.json", "--decision-policy", "no-new-failures"])
+        if "stack_contract" in manifest:
+            argv += ["--stack-contract", "/run/stack-contract.json"]
         return client.main(argv)
 
 
@@ -368,6 +378,10 @@ def host(args):
             elif (config.get("quantization_config") or {}).get("quant_method") != "compressed-tensors":
                 raise ValueError("this first validation manifest requires a native compressed-tensors candidate")
             before, stats = client._capture_artifact(model)
+            if "stack_contract" in manifest:
+                role_key = "bf16_control" if role == "control" else "candidate"
+                if bc.artifact_content_id(before) != manifest["stack_contract"]["roles"][role_key]["artifact_id"]:
+                    raise ValueError(f"{role} artifact_id differs from stack treatment declaration")
             frozen = out / "models" / role
             shutil.copytree(model, frozen)
             content, _ = client._capture_artifact(frozen)
@@ -382,6 +396,8 @@ def host(args):
             frozen.chmod(0o555)
         for population, contract in manifest["contracts"].items():
             instrument.dump(out / f"{population}-contract.json", contract)
+        if "stack_contract" in manifest:
+            instrument.dump(out / "stack-contract.json", manifest["stack_contract"])
         for directory in ("tmp", "triton", "inductor", "vllm-cache"):
             (out / directory).mkdir()
         threading.Thread(target=telemetry, daemon=True).start()

--- a/experiments/pq87_validation_manifest.json
+++ b/experiments/pq87_validation_manifest.json
@@ -1,6 +1,20 @@
 {
-  "schema": "prismaquant.boundary_validation/1",
+  "schema": "prismaquant.boundary_validation/2",
   "image": "eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c",
+  "stack_contract": {
+    "schema": "prismaquant.boundary_stack_contract/1",
+    "image": "eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c",
+    "roles": {
+      "bf16_control": {
+        "artifact_id": "24e9b66a00b4495068efc88c4450677912057b33b27caae40d6eaf909dca06bc",
+        "resident_extensions": ["sampling.so"]
+      },
+      "candidate": {
+        "artifact_id": "0c87a90020e39d62fcf1fd560c22cc9d6ccf01d190ac9248a07825bd54f29a80",
+        "resident_extensions": ["sampling.so", "trtllm_utils.so"]
+      }
+    }
+  },
   "models": {
     "control": "/mnt/shared/tessera-runs/ts113-fresh-sparklina-aa6-r1/inputs/bf16",
     "candidate": "/mnt/shared/tessera-runs/bf16/refs/qwen3-0.6b-nvfp4"

--- a/prismaquant/boundary_control.py
+++ b/prismaquant/boundary_control.py
@@ -18,6 +18,7 @@ import re
 from prismaquant import validate_quantized_model as vqm
 
 SCHEMA = "prismaquant.boundary_control/1"
+DECLARED_STACK_SCHEMA = "prismaquant.boundary_control/2"
 SCORER = "prismaquant.boundary_close_count/1"
 DECISION_SCHEMA = "prismaquant.boundary_decision/1"
 NO_NEW_FAILURES_POLICY = "prismaquant.no_new_boundary_failures/1"
@@ -40,6 +41,70 @@ def artifact_content_id(content):
     _closed_weight_content_manifest(content["weight_content_manifest"],
                                     where="boundary artifact_content")
     return digest(content)
+
+
+def validate_stack_contract(contract):
+    """An explicit image/artifact/role declaration, never a residency wildcard."""
+    if (not isinstance(contract, dict) or set(contract) != {"schema", "image", "roles"}
+            or contract["schema"] != "prismaquant.boundary_stack_contract/1"
+            or not isinstance(contract["image"], str)
+            or not re.fullmatch(r"[^\s@]+@sha256:[0-9a-f]{64}", contract["image"])):
+        raise ValueError("invalid paired stack contract")
+    roles = contract["roles"]
+    if not isinstance(roles, dict) or set(roles) != {"bf16_control", "candidate"}:
+        raise ValueError("paired stack contract requires both treatment roles")
+    for row in roles.values():
+        if (not isinstance(row, dict) or set(row) != {"artifact_id", "resident_extensions"}
+                or not isinstance(row["artifact_id"], str)
+                or not re.fullmatch(r"[0-9a-f]{64}", row["artifact_id"])):
+            raise ValueError("paired stack contract requires exact artifact_id")
+        extensions = row["resident_extensions"]
+        if (not isinstance(extensions, list)
+                or any(not isinstance(name, str) or not re.fullmatch(
+                    r"[A-Za-z0-9_+.-]+\.so(?:\.[0-9]+)*", name) for name in extensions)
+                or extensions != sorted(set(extensions))):
+            raise ValueError("paired resident_extensions must be exact sorted unique basenames")
+    if roles["bf16_control"]["artifact_id"] == roles["candidate"]["artifact_id"]:
+        raise ValueError("paired stack contract requires distinct treatment artifacts")
+    return contract
+
+
+def _paired_stack_payload(binding, role):
+    from tools import serve_fingerprint as sf
+
+    proof = binding.get("paired_stack")
+    if (not isinstance(proof, dict) or set(proof) != {"schema", "role", "contract", "manifest"}
+            or proof["schema"] != "prismaquant.boundary_stack_binding/1"
+            or proof["role"] != role or role not in {"bf16_control", "candidate"}):
+        raise ValueError("paired stack binding role or schema differs")
+    contract = validate_stack_contract(proof["contract"])
+    expected = contract["roles"][role]
+    if binding["artifact_id"] != expected["artifact_id"]:
+        raise ValueError("paired stack treatment artifact_id differs")
+    manifest = proof["manifest"]
+    if not isinstance(manifest, dict) or manifest.get("residency_readable") is not True:
+        raise ValueError("paired stack requires readable residency")
+    raw = sf.performance_stack_fingerprint(manifest)
+    if raw != binding["serve_fingerprint"] or raw != manifest.get("performance_stack_fingerprint"):
+        raise ValueError("paired raw serve fingerprint differs from observed manifest")
+    if (manifest.get("serve_session_id") != binding["serve_session_id"]
+            or (manifest.get("host_identity") or {}).get("boot_id") != binding["host_boot_id"]):
+        raise ValueError("paired stack live session or host binding differs")
+    payload = sf.performance_stack_payload(manifest)
+    if payload["image"] != contract["image"]:
+        raise ValueError("paired stack image differs from treatment declaration")
+    if payload["resident_extensions"] != expected["resident_extensions"]:
+        raise ValueError("paired resident_extensions differ from exact role declaration")
+    # The complete raw fingerprint remains in the binding. Only this explicitly
+    # declared treatment coordinate is projected out of the paired comparison.
+    return {key: value for key, value in payload.items() if key != "resident_extensions"}
+
+
+def bind_stack_contract(binding, contract, manifest, role):
+    proof = {"schema": "prismaquant.boundary_stack_binding/1", "role": role,
+             "contract": copy.deepcopy(contract), "manifest": copy.deepcopy(manifest)}
+    _paired_stack_payload({**binding, "paired_stack": proof}, role)
+    return proof
 
 
 def _positive(value, field):
@@ -183,7 +248,9 @@ def measure_step(base_url, model_name, contract, max_tokens, *, raw=False):
 
 
 def _receipt(contract, binding, role):
-    return {"schema": SCHEMA, "scorer": SCORER,
+    if "paired_stack" in binding:
+        _paired_stack_payload(binding, role)
+    return {"schema": DECLARED_STACK_SCHEMA if "paired_stack" in binding else SCHEMA, "scorer": SCORER,
             "request_schema": vqm.BOUNDARY_REQUEST_SCHEMA,
             "response_schema": vqm.BOUNDARY_RESPONSE_SCHEMA,
             "promptset_sha256": digest(contract["prompts"]),
@@ -232,7 +299,8 @@ def _replay_step(step, contract, cap):
 
 
 def _replay_header(receipt):
-    expected = {"schema": SCHEMA, "scorer": SCORER,
+    declared = "paired_stack" in receipt.get("binding", {})
+    expected = {"schema": DECLARED_STACK_SCHEMA if declared else SCHEMA, "scorer": SCORER,
                 "request_schema": vqm.BOUNDARY_REQUEST_SCHEMA,
                 "response_schema": vqm.BOUNDARY_RESPONSE_SCHEMA,
                 "advisory_only": True}
@@ -241,6 +309,8 @@ def _replay_header(receipt):
             raise ValueError(f"receipt {field} differs from measurement contract")
     contract, binding = receipt["contract"], receipt["binding"]
     bound = _validate(contract, binding)
+    if declared:
+        _paired_stack_payload(binding, receipt.get("role"))
     if receipt.get("promptset_sha256") != digest(contract["prompts"]):
         raise ValueError("promptset_sha256 does not bind measured prompts")
     return contract, bound
@@ -275,7 +345,19 @@ def _paired(control, binding):
     if not control["fixed_point"]:
         raise ValueError("BF16 control did not reach a finishing fixed point")
     _validate(control["contract"], binding)
-    for field in ("campaign_id", "host_boot_id", "serve_fingerprint",
+    reference = control["binding"]
+    declared = "paired_stack" in reference or "paired_stack" in binding
+    if declared:
+        control_payload = _paired_stack_payload(reference, "bf16_control")
+        candidate_payload = _paired_stack_payload(binding, "candidate")
+        if reference["paired_stack"]["contract"] != binding["paired_stack"]["contract"]:
+            raise ValueError("paired stack treatment declaration differs")
+        for field in control_payload:
+            if digest(control_payload[field]) != digest(candidate_payload[field]):
+                raise ValueError(f"paired serve stack {field} differs")
+    elif binding["serve_fingerprint"] != reference["serve_fingerprint"]:
+        raise ValueError("paired serve_fingerprint differs")
+    for field in ("campaign_id", "host_boot_id",
                   "model_context_tokens", "prompt_tokens", "prompt_token_ids",
                   "producer_source_sha256"):
         if binding[field] != control["binding"][field]:

--- a/tests/test_boundary_stack_contract.py
+++ b/tests/test_boundary_stack_contract.py
@@ -1,0 +1,152 @@
+"""A declared native treatment changes only its exact extension residency."""
+import copy
+
+import pytest
+
+from prismaquant import boundary_control as bc
+from tools import serve_fingerprint as sf
+from test_boundary_control import _binding, _contract, _response
+
+
+IMAGE = "fixture@sha256:" + "d" * 64
+
+
+def _declared_pair():
+    bindings = {"bf16_control": _binding(), "candidate": _binding("quant")}
+    extensions = {"bf16_control": ["sampling.so"],
+                  "candidate": ["sampling.so", "trtllm_utils.so"]}
+    contract = {"schema": "prismaquant.boundary_stack_contract/1", "image": IMAGE,
+                "roles": {role: {"artifact_id": bound["artifact_id"],
+                                  "resident_extensions": extensions[role]}
+                          for role, bound in bindings.items()}}
+    for role, bound in bindings.items():
+        manifest = {
+            "image": IMAGE, "gpu_name": "GB10", "gpu_uuid": "gpu-1", "gpu_count": 1,
+            "driver_version": "595.84", "compute_capability": "12.1",
+            "gpu_compute_capabilities": ["12.1"], "package_versions": {"vllm": "pinned"},
+            "vllm_compilation_provenance": {"source": "pinned"},
+            "resident_extensions": extensions[role], "residency_readable": True,
+            "normalized_performance_argv": ["vllm", "serve", "<arm>", "--enforce-eager"],
+            "server_process_environment": {"values": {"OMP_NUM_THREADS": "2"}},
+            "listener_binding": {"base_url": "http://server", "launch_host": "127.0.0.1",
+                                 "launch_port": "8187"},
+            "serve_session_id": bound["serve_session_id"],
+            "host_identity": {"boot_id": bound["host_boot_id"]},
+        }
+        manifest["performance_stack_fingerprint"] = sf.performance_stack_fingerprint(manifest)
+        bound["serve_fingerprint"] = manifest["performance_stack_fingerprint"]
+        bound["paired_stack"] = {"schema": "prismaquant.boundary_stack_binding/1",
+                                 "role": role, "contract": copy.deepcopy(contract),
+                                 "manifest": manifest}
+    return bindings
+
+
+def _control(monkeypatch, bindings):
+    monkeypatch.setattr(bc.vqm, "_post_json", lambda _url, body: _response(body["max_tokens"]))
+    return bc.measure_control("http://server", "control", _contract(), bindings["bf16_control"])
+
+
+def _rehash(binding):
+    manifest = binding["paired_stack"]["manifest"]
+    manifest["performance_stack_fingerprint"] = sf.performance_stack_fingerprint(manifest)
+    binding["serve_fingerprint"] = manifest["performance_stack_fingerprint"]
+
+
+def test_declared_native_treatment_pairs_with_raw_fingerprints_retained(monkeypatch):
+    bindings = _declared_pair()
+    assert bindings["bf16_control"]["serve_fingerprint"] != bindings["candidate"]["serve_fingerprint"]
+    control = _control(monkeypatch, bindings)
+    candidate = bc.measure_candidate("http://server", "candidate", control, bindings["candidate"])
+    decision = bc.decide_no_new_failures(control, candidate)
+    assert decision["verdict"] == "accepted"
+    assert bc.replay_no_new_failures(decision, control, candidate) == decision
+    assert control["schema"] == candidate["schema"] == "prismaquant.boundary_control/2"
+    assert control["binding"]["serve_fingerprint"] != candidate["binding"]["serve_fingerprint"]
+
+
+@pytest.mark.parametrize("field,value", [
+    ("image", "other@sha256:" + "e" * 64), ("gpu_name", "other"),
+    ("gpu_uuid", "gpu-2"), ("gpu_count", 2), ("driver_version", "other"),
+    ("compute_capability", "9.0"), ("gpu_compute_capabilities", ["9.0"]),
+    ("package_versions", {"vllm": "other"}),
+    ("vllm_compilation_provenance", {"source": "other"}),
+    ("normalized_performance_argv", ["vllm", "serve", "<arm>"]),
+    ("server_process_environment", {"values": {"OMP_NUM_THREADS": "4"}}),
+    ("listener_binding", {"base_url": "http://other", "launch_host": "127.0.0.1", "launch_port": "8187"}),
+])
+def test_declared_residency_never_waives_other_stack_fields(monkeypatch, field, value):
+    bindings = _declared_pair()
+    control = _control(monkeypatch, bindings)
+    candidate = bindings["candidate"]
+    candidate["paired_stack"]["manifest"][field] = value
+    _rehash(candidate)
+    monkeypatch.setattr(bc.vqm, "_post_json", lambda *_args: pytest.fail("unpaired stack reached server"))
+    with pytest.raises(ValueError):
+        bc.measure_candidate("http://server", "candidate", control, candidate)
+
+
+@pytest.mark.parametrize("extensions", [["sampling.so"], ["sampling.so", "trtllm_utils.so", "extra.so"]])
+def test_exact_role_residency_refuses_missing_and_extra_extensions(monkeypatch, extensions):
+    bindings = _declared_pair()
+    control = _control(monkeypatch, bindings)
+    candidate = bindings["candidate"]
+    candidate["paired_stack"]["manifest"]["resident_extensions"] = extensions
+    _rehash(candidate)
+    with pytest.raises(ValueError, match="resident_extensions"):
+        bc.measure_candidate("http://server", "candidate", control, candidate)
+
+
+def test_raw_fingerprint_is_recomputed_not_taken_from_binding(monkeypatch):
+    bindings = _declared_pair()
+    control = _control(monkeypatch, bindings)
+    candidate = bindings["candidate"]
+    candidate["serve_fingerprint"] = control["binding"]["serve_fingerprint"]
+    with pytest.raises(ValueError, match="raw.*fingerprint"):
+        bc.measure_candidate("http://server", "candidate", control, candidate)
+
+
+@pytest.mark.parametrize("mutation", ["role", "artifact", "declaration", "missing", "unreadable", "campaign"])
+def test_stack_proof_cannot_be_swapped_or_dropped(monkeypatch, mutation):
+    bindings = _declared_pair()
+    control = _control(monkeypatch, bindings)
+    candidate = bindings["candidate"]
+    proof = candidate["paired_stack"]
+    if mutation == "role":
+        proof["role"] = "bf16_control"
+    elif mutation == "artifact":
+        proof["contract"]["roles"]["candidate"]["artifact_id"] = "a" * 64
+    elif mutation == "declaration":
+        proof["contract"]["roles"]["bf16_control"]["resident_extensions"] = []
+    elif mutation == "missing":
+        del candidate["paired_stack"]
+    elif mutation == "campaign":
+        candidate["campaign_id"] = "another-campaign"
+    else:
+        proof["manifest"]["residency_readable"] = False
+        _rehash(candidate)
+    with pytest.raises(ValueError):
+        bc.measure_candidate("http://server", "candidate", control, candidate)
+
+
+def test_declared_receipt_cannot_be_downgraded_to_legacy_schema(monkeypatch):
+    control = _control(monkeypatch, _declared_pair())
+    control["schema"] = "prismaquant.boundary_control/1"
+    with pytest.raises(ValueError, match="schema"):
+        bc.replay_control(control)
+
+
+def test_declared_control_cannot_erase_proof_under_new_schema(monkeypatch):
+    control = _control(monkeypatch, _declared_pair())
+    del control["binding"]["paired_stack"]
+    with pytest.raises(ValueError, match="schema"):
+        bc.replay_control(control)
+
+
+def test_projected_stack_comparison_preserves_json_types(monkeypatch):
+    bindings = _declared_pair()
+    control = _control(monkeypatch, bindings)
+    candidate = bindings["candidate"]
+    candidate["paired_stack"]["manifest"]["gpu_count"] = True
+    _rehash(candidate)
+    with pytest.raises(ValueError, match="gpu_count"):
+        bc.measure_candidate("http://server", "candidate", control, candidate)

--- a/tools/measure_boundary_control.py
+++ b/tools/measure_boundary_control.py
@@ -45,6 +45,7 @@ def main(argv=None):
     parser.add_argument("--image", required=True, help="immutable repository@sha256 digest")
     parser.add_argument("--contract", help="frozen prompt/seed/cap contract JSON (control)")
     parser.add_argument("--control", help="completed BF16 control receipt (candidate)")
+    parser.add_argument("--stack-contract", help="explicit image/artifact/role extension declaration")
     parser.add_argument("--campaign-id", required=True)
     parser.add_argument("--out", required=True)
     parser.add_argument("--legacy-ab", action="store_true",
@@ -124,6 +125,10 @@ def main(argv=None):
         "prompt_token_ids": token_ids,
         "producer_source_sha256": bc.digest(source_hashes),
     }
+    if args.stack_contract:
+        binding["paired_stack"] = bc.bind_stack_contract(binding,
+            json.loads(Path(args.stack_contract).read_text()), before,
+            "bf16_control" if args.role == "control" else "candidate")
     context_bound = bc._validate(contract, binding)
     started = time.time()
     historical = None


### PR DESCRIPTION
A paired BF16/native-NVFP4 campaign could not start candidate generation because NVFP4 necessarily loaded `trtllm_utils.so` in addition to the control’s `sampling.so`. The bounded same-image diagnostic measured that exact difference; every other performance-stack field agreed.

Add an opt-in, versioned treatment declaration binding the exact serving image, both artifact content IDs, and each role’s exact extension set. Declared receipts use boundary_control/2, retain and recompute their full raw fingerprints, and compare all remaining stack fields canonically. Missing/extra extensions, altered declarations, wrong image/artifact/session/campaign, and other stack changes refuse. Legacy receipts retain strict full-fingerprint comparison. Offline replay checks the same declaration and complete control receipt binding.

The Qwen3-0.6B experiment now declares the observed treatment before a fresh full campaign. Issue #208 remains pending its actual policy and PPL results. This changes an explicit experiment comparison contract; it is not a quality/speed promotion. Architecture and the runbook document the boundary.

PrismaBuild validation: regression coverage includes exact role residency, raw fingerprint recomputation, artifact/image/session identity, declaration stripping/swapping, replay, legacy strictness, and campaign mismatch. An independent reviewer found a Python bool/int equality gap; its new regression failed before canonical comparison fixed it. Final nine-file CPU qualification passed161 tests, zero skips, plus compile checks. Root independently verified the actual812-byte CAS result `900b9439b7c7e462cf158ef7f4644c3148580ffb76b6f5fa335cc464782de436` (action `b7ae4af16c86c2c9bf403008e6c8b2b299f845b153968d22a0a4f3020aad063f`, sparklina2CPU8GiB). Executable/test files match tested worker commit4888f033 exactly after integration with main. Separate broader CI failures remain tracked in #244.
