### PR TITLE
Preserve parent-owned LFM expert bias during packed routing

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,18 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `codex/pq208-stack-contract`. Stamps
+As of: 2026-09-05 · `codex/pq183-parent-router-bias`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-05, `codex/pq183-router-bias`) for packed LFM routing
+compatibility (#183). Activation capture, packed-cost replay and empirical
+down-input statistics pass the parent MoE block's `expert_bias` to routers
+whose forward signature declares it, alongside existing HYV3
+`e_score_correction_bias` handling. A bias-enabled router without its required
+parent buffer fails before routing; explicitly bias-disabled LFM routers remain
+valid. Capture follows actual biased expert selection and gate weights rather
+than recomputing an uncorrected assignment. Gate:
+`tests/test_lfm_parent_router_bias.py`, including the real Transformers 5.15.1
+router and derived input rows.
 
 Re-stamped (2026-09-05, `measurement/pq208-2026-09-05`) for the opt-in paired
 stack treatment contract: validation manifest v2 declares one immutable image

--- a/prismaquant/expert_empirical_cost.py
+++ b/prismaquant/expert_empirical_cost.py
@@ -202,7 +202,8 @@ def _replay_down_proj_col_weights(
     else:
         top_k_index, _tw = _packed_router_topk(
             router, Xd, e_score_correction_bias=getattr(
-                parent_mod, "e_score_correction_bias", None))
+                parent_mod, "e_score_correction_bias", None),
+            expert_bias=getattr(parent_mod, "expert_bias", None))
     out = torch.zeros(E, inter, dtype=torch.float32, device=dev)
     hit = torch.zeros(E, dtype=torch.bool)
     for e in range(E):

--- a/prismaquant/measure_quant_cost.py
+++ b/prismaquant/measure_quant_cost.py
@@ -1513,12 +1513,16 @@ def _packed_router_topk(
     router: nn.Module,
     hidden_states: torch.Tensor,
     e_score_correction_bias: torch.Tensor | None = None,
+    *,
+    expert_bias: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Return (top_k_index, top_k_weights) for a Qwen/DeepSeek-style router.
 
     Some routers (HYV3TopKRouter) take the parent MoE block's
-    e_score_correction_bias buffer as a required positional — callers pass
-    it from ``parent_mod`` so routing matches the model's real forward."""
+    e_score_correction_bias buffer as a required positional. Newer LFM routers
+    similarly take the parent's expert_bias. Callers supply the original
+    buffer so capture and replay follow the model's real token assignments.
+    """
     import inspect
     try:
         fwd_params = inspect.signature(router.forward).parameters
@@ -1533,6 +1537,13 @@ def _packed_router_topk(
             hidden_states,
             e_score_correction_bias.to(hidden_states.device),
         )
+    elif "expert_bias" in fwd_params:
+        if expert_bias is None and getattr(router, "use_expert_bias", True):
+            raise ValueError(
+                f"{type(router).__name__}.forward requires expert_bias; "
+                "the parent module must supply it")
+        out = router(hidden_states, expert_bias=(
+            expert_bias.to(hidden_states.device) if expert_bias is not None else None))
     else:
         out = router(hidden_states)
     if isinstance(out, (tuple, list)):
@@ -1689,6 +1700,7 @@ def derive_per_expert_activations(
                 router, Xf,
                 e_score_correction_bias=getattr(
                     parent_mod, "e_score_correction_bias", None),
+                expert_bias=getattr(parent_mod, "expert_bias", None),
             )
         expert_mask = F.one_hot(
             top_k_index.to(torch.long), num_classes=num_experts).permute(2, 1, 0)
@@ -1835,6 +1847,7 @@ def _measure_packed_experts(
                             router, X,
                             e_score_correction_bias=getattr(
                                 parent_mod, "e_score_correction_bias", None),
+                            expert_bias=getattr(parent_mod, "expert_bias", None),
                         )
                     y_ref = _packed_experts_forward_with_weights(
                         experts_mod,

--- a/tests/test_lfm_parent_router_bias.py
+++ b/tests/test_lfm_parent_router_bias.py
@@ -1,0 +1,79 @@
+"""Packed capture must follow the real parent-owned LFM router bias."""
+import pytest
+import torch
+from torch import nn
+
+from prismaquant.measure_quant_cost import derive_per_expert_activations, _packed_router_topk
+
+
+def _real_block(use_bias=True):
+    from transformers import Lfm2MoeConfig
+    from transformers.models.lfm2_moe import modeling_lfm2_moe as module
+    if not hasattr(module, 'Lfm2MoeTopKRouter'):
+        pytest.skip('requires Transformers parent-owned LFM router API (5.15.1 qualified)')
+    config = Lfm2MoeConfig(hidden_size=8, moe_intermediate_size=4, num_experts=2,
+                          num_experts_per_tok=1, use_expert_bias=use_bias)
+    block = module.Lfm2MoeSparseMoeBlock(config).eval()
+    with torch.no_grad():
+        block.gate.weight.zero_()
+        block.gate.weight[0].fill_(1)
+        if use_bias:
+            block.expert_bias.copy_(torch.tensor([-2., 2.]))
+        block.experts.gate_up_proj.fill_(0.1)
+        block.experts.down_proj.fill_(0.2)
+    return block
+
+
+def test_real_lfm_parent_bias_capture_matches_forward():
+    block = _real_block()
+    x = torch.arange(24, dtype=torch.float32).reshape(3, 8) / 24
+    _, weights, indices = block.gate(x, block.expert_bias)
+    _, _, no_bias_indices = block.gate(x, torch.zeros_like(block.expert_bias))
+    assert torch.equal(indices, torch.ones(3, 1, dtype=torch.long))
+    assert torch.equal(no_bias_indices, torch.zeros(3, 1, dtype=torch.long))
+    seen = []
+    handle = block.experts.register_forward_pre_hook(lambda _module, args: seen.append(args))
+    try:
+        block(x.unsqueeze(0))
+    finally:
+        handle.remove()
+    assert torch.equal(seen[0][1], indices)
+    assert torch.equal(seen[0][2], weights)
+    got = derive_per_expert_activations(block.experts, x, block)
+    assert got['row_counts'] == [0, 3]
+    assert torch.equal(got['gate_up'][1], x)
+    assert torch.equal(got['gate_weights'][1], weights[:, 0])
+    gate, up = torch.nn.functional.linear(x, block.experts.gate_up_proj[1]).chunk(2, -1)
+    torch.testing.assert_close(got['down'][1], block.experts.act_fn(gate) * up)
+    from prismaquant.expert_empirical_cost import _replay_down_proj_col_weights
+    col_weights = _replay_down_proj_col_weights(block.experts, block, block.gate, x)
+    torch.testing.assert_close(col_weights[1, 0], got['down'][1].square().mean(0))
+
+
+def test_real_lfm_disabled_parent_bias_still_captures():
+    block = _real_block(False)
+    x = torch.ones(3, 8)
+    got = derive_per_expert_activations(block.experts, x, block)
+    assert got['row_counts'] == [3, 0]
+
+
+def test_external_bias_router_without_parent_bias_fails_clearly():
+    class ExternalBiasRouter(nn.Module):
+        use_expert_bias = True
+        def forward(self, hidden_states, expert_bias=None):
+            raise AssertionError('must reject missing parent bias before router execution')
+    with pytest.raises(ValueError, match='expert_bias.*parent'):
+        _packed_router_topk(ExternalBiasRouter(), torch.ones(3, 8))
+
+
+def test_existing_correction_bias_router_remains_supported():
+    class CorrectionRouter(nn.Module):
+        def forward(self, hidden_states, e_score_correction_bias):
+            logits = hidden_states[:, :2] + e_score_correction_bias
+            weights, indices = logits.softmax(-1).topk(1, -1)
+            return logits, weights, indices
+    x = torch.tensor([[2., 0.], [3., 1.]])
+    bias = torch.tensor([-10., 10.])
+    indices, weights = _packed_router_topk(CorrectionRouter(), x, bias)
+    assert torch.equal(indices, torch.ones(2, 1, dtype=torch.long))
+    torch.testing.assert_close(weights, (x + bias).softmax(-1)[:, 1:])


### PR DESCRIPTION
The actual LFM campaign reached calibration and then failed in packed activation capture: Transformers5.15.1 stores expert routing bias on the parent MoE block, while PrismaQuant invoked its gate without that bias. The shared router adapter now passes the parent-owned `expert_bias` through activation capture, packed-cost replay, and empirical down-input statistics. Missing enabled bias refuses explicitly; bias-disabled LFM and the existing correction-bias router path remain supported.

The regression uses the real LFM router with a nonzero bias that changes every selected expert, checks the model’s actual forward routing, and compares derived gate/up/down rows, routing weights, and empirical statistics. This fixes the demonstrated capture boundary for issue #183; the actual GPU campaign/export/serve acceptance remains pending. Architecture describes the contract.

PrismaBuild: baseline reproduced two intended failures and one pass in the qualified producer image. After the fix,32 tests passed with zero skips against real Transformers5.15.1 and existing packed/empirical suites, followed by compile checks and19 documentation tests. Root independently verified the actual546-byte CAS result `c04707642fbca02bb534ad6879b09603eeb325ef56920d1a2135ae220a0a64f8`, action `c6f5d1ff7694a576078497966c1538b14c579f16153adc5ef71fa2acaf089c00` (sparklina2CPU8GiB, no GPU). Integration with current main retained the tested production/test files exactly;19 architecture/staleness checks passed again after combining the history (action `70667c52be760b5b4b2adaafccc48f53e2c5ff34e1c5f63f3cc6e7164ceb2444`, zero skips, actual CAS independently hashed).

The original GPU failure is preserved at `/home/rob/tessera-runs/measurement-208-183-2026-09-05/run183-02` on sparklina; exact-container cleanup passed, and no cost/export output existed. Broader CI’s separate cluster-runner failures are tracked in #244.
