### PR TITLE
Read saved Tessera rung strings in export assignments

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,17 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `codex/pq183-parent-router-bias`. Stamps
+As of: 2026-09-05 · `codex/pq183-tessera-reader`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-05, `codex/pq183-tessera-reader`) for saved Tessera
+campaign assignment intake (#183). The shared torch-free layer-config reader
+accepts a Tessera rung name as a shorthand string as well as the existing
+`data_type=tessera` dictionary representation. Both preserve the family,
+arity and body-rate identity; malformed or group-only names, including trailing
+newlines in either representation, refuse. Parsing
+does not import the numerical runtime, establish rung legality, or certify
+target admission: the existing producer and serving gates still own those
+checks. Gate: `tests/test_layer_config_tessera_strings.py`.
 
 Re-stamped (2026-09-05, `codex/pq183-router-bias`) for packed LFM routing
 compatibility (#183). Activation capture, packed-cost replay and empirical

--- a/prismaquant/layer_config.py
+++ b/prismaquant/layer_config.py
@@ -120,7 +120,7 @@ def canonicalize_format(entry: dict | str | int) -> str:
             # and for legality by ``get_format`` (which parses the rung and
             # refuses an illegal one); this module stays a mapper.
             name = str(entry.get("tessera_format", ""))
-            if not _TESSERA_FORMAT_NAME.match(name):
+            if not _TESSERA_FORMAT_NAME.fullmatch(name):
                 raise ValueError(f"unsupported tessera scheme: {entry!r}")
             return name
         if dt == "nv_fp" and bits == 4:
@@ -181,6 +181,10 @@ def canonicalize_format(entry: dict | str | int) -> str:
         raise ValueError(f"unsupported scheme: {entry!r}")
     if isinstance(entry, str):
         value = entry.lower()
+        if _TESSERA_FORMAT_NAME.fullmatch(value.upper()):
+            # Saved campaign strings and dictionary recipes name the same
+            # rung. Legality and target admission remain downstream gates.
+            return value.upper()
         if value.upper() in _GGUF_FORMAT_NAMES:
             return value.upper()
         if value.upper() in _NVFP4_CB_FORMAT_NAMES:

--- a/tests/test_layer_config_tessera_strings.py
+++ b/tests/test_layer_config_tessera_strings.py
@@ -1,0 +1,78 @@
+"""Saved Tessera strings survive the shared reader in a fresh process.
+
+Isolate the documented torch-free modules from the package initializer, which
+imports the numerical runtime. The real export CLI is qualified separately.
+"""
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+_REPO = Path(__file__).resolve().parents[1]
+_BOOTSTRAP = """import sys, types
+from pathlib import Path
+package = types.ModuleType('prismaquant')
+package.__path__ = [str(Path(sys.argv[1]) / 'prismaquant')]
+sys.modules['prismaquant'] = package
+from prismaquant.layer_config import canonicalize_format, load_assignment
+"""
+
+
+class TesseraStringAssignmentTests(unittest.TestCase):
+    def run_reader(self, code, *args):
+        result = subprocess.run([sys.executable, '-c', _BOOTSTRAP + code,
+                                 str(_REPO), *map(str, args)],
+                                capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_string_matches_existing_dictionary_entry(self):
+        self.run_reader("""name = 'TESSERA_E4M3_K1_R1024'
+expected = canonicalize_format({'data_type': 'tessera', 'tessera_format': name})
+assert canonicalize_format(name) == expected
+assert canonicalize_format(name.lower()) == expected
+assert 'torch' not in sys.modules and 'tessera' not in sys.modules
+""")
+
+    def test_fresh_reader_loads_campaign_assignment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'assignment.json'
+            path.write_text(json.dumps({
+                'model.layers.13.feed_forward.experts.0.w1': 'TESSERA_E4M3_K1_R1024',
+                'model.layers.0.feed_forward.w1': 'BF16'}))
+            self.run_reader("""assignment = load_assignment(sys.argv[2])
+assert assignment['model.layers.13.feed_forward.experts.0.w1'] == 'TESSERA_E4M3_K1_R1024'
+assert assignment['model.layers.0.feed_forward.w1'] == 'BF16'
+assert 'torch' not in sys.modules and 'tessera' not in sys.modules
+""", path)
+
+    def test_malformed_or_group_names_are_not_rungs(self):
+        names = ['TESSERA_E4M3_K1_G1024', 'TESSERA_E4M3_K1_R1024_extra',
+                 'prefix_TESSERA_E4M3_K1_R1024', 'TESSERA_E4M3_K1_R1024\n',
+                 'TESSERA_E4M3_Kx_R1024']
+        self.run_reader("""import json
+for name in json.loads(sys.argv[2]):
+    try:
+        canonicalize_format(name)
+    except ValueError:
+        continue
+    raise AssertionError('malformed rung accepted: ' + repr(name))
+""", json.dumps(names))
+
+    def test_malformed_dictionary_names_are_rejected(self):
+        names = ['TESSERA_E4M3_K1_R1024\n', 'TESSERA_E4M3_K1_R1024_extra',
+                 'TESSERA_E4M3_K1_G1024', 'tessera_e4m3_k1_r1024']
+        self.run_reader("""import json
+for name in json.loads(sys.argv[2]):
+    try:
+        canonicalize_format({'data_type': 'tessera', 'tessera_format': name})
+    except ValueError:
+        continue
+    raise AssertionError('malformed dictionary rung accepted: ' + repr(name))
+""", json.dumps(names))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
A real Tessera campaign produced a valid 96-unit assignment containing `TESSERA_E4M3_K1_R1024`, but the export process rejected that shorthand string. The shared layer-config reader now accepts Tessera rung strings using its existing grammar, matching dictionary recipes. Both representations reject malformed names, including a trailing newline previously accepted by the dictionary path. Numerical legality and serving admission remain with the existing downstream gates.

Validation: fresh-process regressions reproduced the shorthand failure and dictionary newline acceptance before each fix; all four focused tests then passed. PrismaBuild independently partitioned five integration files and chose workers: 50 tests passed, zero skips, covering the existing layer-config/export preflight paths plus architecture/staleness checks. Root verified each terminal, cleanup and actual CAS payload. Initial integration submission hit a Git alternates-depth limit before admission; the self-contained checkout passed unchanged code. This does not yet establish the actual artifact's export/serving result.

Refs #183. The real campaign's 96 priced wires are preserved for deterministic export continuation; issue #183 remains open pending that validation. Existing unrelated broad CI scheduling failures remain tracked in #244.
