### PR TITLE
Require PRs to link repository issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Tracked issue
+
+Closes #<!-- same-repository issue number -->
+
+Every change to `main` must arrive through a pull request that closes at least
+one issue in this repository. Keep a supported closing keyword (`Closes`,
+`Fixes`, or `Resolves`) and the issue number in this description; a plain
+mention, a pull request number, or a cross-repository issue does not satisfy the
+`linked issue` check.
+
+## Change
+
+<!-- What changes, and why? -->
+
+## Validation
+
+<!-- Commands, results, receipts, and any skips or unmeasured claims. -->

--- a/.github/scripts/linked_issue.cjs
+++ b/.github/scripts/linked_issue.cjs
@@ -1,0 +1,214 @@
+"use strict";
+
+const CHECK_NAME = "linked issue";
+const TARGET_BRANCH = "main";
+
+const CLOSING_ISSUES_QUERY = `
+  query ClosingIssues($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        number
+        closingIssuesReferences(first: 100) {
+          nodes {
+            __typename
+            number
+            state
+            url
+            repository {
+              nameWithOwner
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} is missing or malformed`);
+  }
+  return value;
+}
+
+function evaluateClosingIssues(response, expectedRepository, expectedPullNumber) {
+  const root = requireObject(response, "GraphQL response");
+  const repository = requireObject(root.repository, "GraphQL repository");
+  const pullRequest = requireObject(
+    repository.pullRequest,
+    `pull request #${expectedPullNumber}`,
+  );
+
+  if (pullRequest.number !== expectedPullNumber) {
+    throw new Error(
+      `GraphQL returned pull request #${String(pullRequest.number)} instead of #${expectedPullNumber}`,
+    );
+  }
+
+  const connection = requireObject(
+    pullRequest.closingIssuesReferences,
+    "closingIssuesReferences",
+  );
+  if (!Array.isArray(connection.nodes)) {
+    throw new Error("closingIssuesReferences.nodes is missing or malformed");
+  }
+
+  const issues = [];
+  for (const rawNode of connection.nodes) {
+    const node = requireObject(rawNode, "closing issue node");
+    const nodeRepository = requireObject(
+      node.repository,
+      "closing issue repository",
+    );
+    if (
+      node.__typename === "Issue" &&
+      nodeRepository.nameWithOwner === expectedRepository &&
+      Number.isInteger(node.number) &&
+      node.number > 0 &&
+      typeof node.url === "string" &&
+      node.url.length > 0
+    ) {
+      issues.push({
+        number: node.number,
+        state: node.state,
+        url: node.url,
+      });
+    }
+  }
+
+  return {
+    ok: issues.length > 0,
+    issues,
+    totalClosingReferences: connection.nodes.length,
+  };
+}
+
+function pullRequestIdentity(context) {
+  const pullRequest = requireObject(
+    context && context.payload && context.payload.pull_request,
+    "pull_request event payload",
+  );
+  const base = requireObject(pullRequest.base, "pull request base");
+  const baseRepository = requireObject(base.repo, "pull request base repository");
+  const head = requireObject(pullRequest.head, "pull request head");
+  const headSha = head.sha;
+  const expectedRepository = `${context.repo.owner}/${context.repo.repo}`;
+
+  if (base.ref !== TARGET_BRANCH) {
+    throw new Error(
+      `refusing to evaluate base branch ${String(base.ref)}; expected ${TARGET_BRANCH}`,
+    );
+  }
+  if (baseRepository.full_name !== expectedRepository) {
+    throw new Error(
+      `base repository ${String(baseRepository.full_name)} does not match ${expectedRepository}`,
+    );
+  }
+  if (!Number.isInteger(pullRequest.number) || pullRequest.number <= 0) {
+    throw new Error("pull request number is missing or malformed");
+  }
+  if (typeof headSha !== "string" || !/^[0-9a-f]{40}$/.test(headSha)) {
+    throw new Error("pull request head SHA is missing or malformed");
+  }
+
+  return {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    repository: expectedRepository,
+    pullNumber: pullRequest.number,
+    headSha,
+  };
+}
+
+async function publishStatus(github, identity, targetUrl, state, description) {
+  await github.rest.repos.createCommitStatus({
+    owner: identity.owner,
+    repo: identity.repo,
+    sha: identity.headSha,
+    state,
+    context: CHECK_NAME,
+    description,
+    target_url: targetUrl,
+  });
+}
+
+async function run({ github, context, core }) {
+  let identity;
+  let targetUrl;
+  try {
+    identity = pullRequestIdentity(context);
+    targetUrl = `${context.serverUrl}/${identity.repository}/actions/runs/${context.runId}`;
+    await publishStatus(
+      github,
+      identity,
+      targetUrl,
+      "pending",
+      "Resolving GitHub closing-issue references",
+    );
+
+    const response = await github.graphql(CLOSING_ISSUES_QUERY, {
+      owner: identity.owner,
+      repo: identity.repo,
+      number: identity.pullNumber,
+    });
+    const result = evaluateClosingIssues(
+      response,
+      identity.repository,
+      identity.pullNumber,
+    );
+
+    if (!result.ok) {
+      await publishStatus(
+        github,
+        identity,
+        targetUrl,
+        "failure",
+        "No same-repository closing issue is linked",
+      );
+      core.setFailed(
+        `pull request #${identity.pullNumber} has no same-repository closing issue reference`,
+      );
+      return;
+    }
+
+    const linked = result.issues
+      .map((issue) => `#${issue.number} (${String(issue.state).toLowerCase()})`)
+      .join(", ");
+    await publishStatus(
+      github,
+      identity,
+      targetUrl,
+      "success",
+      `Closes same-repository issue #${result.issues[0].number}`,
+    );
+    core.info(`accepted closing issue reference(s): ${linked}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (identity && targetUrl) {
+      try {
+        await publishStatus(
+          github,
+          identity,
+          targetUrl,
+          "failure",
+          "Could not verify a linked issue; gate failed closed",
+        );
+      } catch (publishError) {
+        core.error(
+          `could not publish the failure to pull request head ${identity.headSha}: ${String(publishError)}`,
+        );
+      }
+    }
+    core.setFailed(`linked-issue verification failed closed: ${message}`);
+  }
+}
+
+module.exports = {
+  CHECK_NAME,
+  CLOSING_ISSUES_QUERY,
+  TARGET_BRANCH,
+  evaluateClosingIssues,
+  publishStatus,
+  pullRequestIdentity,
+  run,
+};

--- a/.github/scripts/linked_issue.test.cjs
+++ b/.github/scripts/linked_issue.test.cjs
@@ -1,0 +1,170 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  CHECK_NAME,
+  evaluateClosingIssues,
+  pullRequestIdentity,
+  run,
+} = require("./linked_issue.cjs");
+
+const REPOSITORY = "RobTand/prismaquant";
+const HEAD_SHA = "a".repeat(40);
+
+function issue(number, repository = REPOSITORY) {
+  return {
+    __typename: "Issue",
+    number,
+    state: "OPEN",
+    url: `https://github.com/${repository}/issues/${number}`,
+    repository: { nameWithOwner: repository },
+  };
+}
+
+function response(nodes, number = 253) {
+  return {
+    repository: {
+      pullRequest: {
+        number,
+        closingIssuesReferences: { nodes },
+      },
+    },
+  };
+}
+
+function context() {
+  return {
+    repo: { owner: "RobTand", repo: "prismaquant" },
+    payload: {
+      pull_request: {
+        number: 253,
+        base: { ref: "main", repo: { full_name: REPOSITORY } },
+        head: { sha: HEAD_SHA },
+      },
+    },
+    runId: 1234,
+    serverUrl: "https://github.com",
+  };
+}
+
+test("accepts a real same-repository issue", () => {
+  assert.deepEqual(evaluateClosingIssues(response([issue(252)]), REPOSITORY, 253), {
+    ok: true,
+    issues: [
+      {
+        number: 252,
+        state: "OPEN",
+        url: "https://github.com/RobTand/prismaquant/issues/252",
+      },
+    ],
+    totalClosingReferences: 1,
+  });
+});
+
+test("rejects missing, cross-repository, and pull-request references", () => {
+  const pullRequest = {
+    ...issue(251),
+    __typename: "PullRequest",
+    url: "https://github.com/RobTand/prismaquant/pull/251",
+  };
+  const result = evaluateClosingIssues(
+    response([issue(9, "RobTand/tessera"), pullRequest]),
+    REPOSITORY,
+    253,
+  );
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.issues, []);
+  assert.equal(result.totalClosingReferences, 2);
+  assert.equal(evaluateClosingIssues(response([]), REPOSITORY, 253).ok, false);
+});
+
+test("fails closed on malformed or mismatched API responses", () => {
+  assert.throws(
+    () => evaluateClosingIssues({}, REPOSITORY, 253),
+    /GraphQL repository is missing or malformed/,
+  );
+  assert.throws(
+    () => evaluateClosingIssues(response([issue(252)], 999), REPOSITORY, 253),
+    /instead of #253/,
+  );
+  assert.throws(
+    () =>
+      evaluateClosingIssues(
+        { repository: { pullRequest: { number: 253, closingIssuesReferences: {} } } },
+        REPOSITORY,
+        253,
+      ),
+    /nodes is missing or malformed/,
+  );
+});
+
+test("takes the check SHA from the pull request head", () => {
+  assert.deepEqual(pullRequestIdentity(context()), {
+    owner: "RobTand",
+    repo: "prismaquant",
+    repository: REPOSITORY,
+    pullNumber: 253,
+    headSha: HEAD_SHA,
+  });
+});
+
+test("an API error completes the actual-head check as failure", async () => {
+  const statuses = [];
+  const github = {
+    graphql: async () => {
+      throw new Error("GraphQL unavailable");
+    },
+    rest: {
+      repos: {
+        createCommitStatus: async (input) => statuses.push(input),
+      },
+    },
+  };
+  const failures = [];
+  await run({
+    github,
+    context: context(),
+    core: {
+      error: () => {},
+      info: () => {},
+      setFailed: (message) => failures.push(message),
+    },
+  });
+
+  assert.equal(statuses[0].sha, HEAD_SHA);
+  assert.equal(statuses[0].context, CHECK_NAME);
+  assert.equal(statuses[0].state, "pending");
+  assert.equal(statuses.at(-1).sha, HEAD_SHA);
+  assert.equal(statuses.at(-1).state, "failure");
+  assert.match(failures.at(-1), /failed closed/);
+});
+
+test("a valid issue completes the actual-head check as success", async () => {
+  const statuses = [];
+  const github = {
+    graphql: async () => response([issue(252)]),
+    rest: {
+      repos: {
+        createCommitStatus: async (input) => statuses.push(input),
+      },
+    },
+  };
+  const failures = [];
+  await run({
+    github,
+    context: context(),
+    core: {
+      error: () => {},
+      info: () => {},
+      setFailed: (message) => failures.push(message),
+    },
+  });
+
+  assert.deepEqual(failures, []);
+  assert.equal(statuses.at(-1).sha, HEAD_SHA);
+  assert.equal(statuses.at(-1).context, CHECK_NAME);
+  assert.equal(statuses.at(-1).state, "success");
+  assert.match(statuses.at(-1).description, /#252/);
+});

--- a/.github/workflows/linked-issue.yml
+++ b/.github/workflows/linked-issue.yml
@@ -1,0 +1,39 @@
+name: Linked issue policy
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+# The workflow is loaded from the default branch and only reads PR metadata.
+# It checks out the trusted base commit so the validator is never sourced from
+# the pull request head. No repository code or contributor-supplied command is
+# executed.
+permissions:
+  contents: read
+  statuses: write
+  pull-requests: read
+  issues: read
+
+concurrency:
+  group: linked-issue-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate:
+    name: publish linked-issue policy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check out trusted base policy
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Evaluate and publish check on pull request head
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        with:
+          script: |
+            const policy = require("./.github/scripts/linked_issue.cjs");
+            await policy.run({ github, context, core });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,15 @@ These rules are mandatory for coding agents working in this repository.
 Before implementing new functionality, read this file,
 `docs/design/design_guidelines.md`, and `docs/ARCHITECTURE.md`.
 
+## Repository change delivery
+
+Every change to `main` must start with an issue in this repository and arrive
+through a pull request. Never push commits directly to `main`. Put a supported
+closing reference such as `Closes #123` in the pull request description so
+GitHub links the issue through its native closing-issue relationship. A plain
+mention, a pull request number, a nonexistent number, or an issue in another
+repository does not satisfy the required `linked issue` check.
+
 ## Core Principles
 
 1. **GPU-bound by default.** Production probes, cache fills, recache,


### PR DESCRIPTION
## Problem and result

Pull requests to `main` currently have no machine-enforced connection to the issue tracker. This adds a metadata-only `pull_request_target` workflow that resolves GitHub's native `closingIssuesReferences`, requires at least one real issue in `RobTand/prismaquant`, and publishes the stable `linked issue` status on the pull request's actual head SHA.

The validator fails for missing, cross-repository, pull-request, and malformed references, and for GraphQL/API errors. The workflow checks out only `github.event.pull_request.base.sha`, uses exact action commit pins, and never executes pull-request head code. `AGENTS.md` and the pull request template document `Closes #<issue>` / `Fixes` / `Resolves` as the supported process.

Closes #252

## Validation

- PrismaBuild `node --test .github/scripts/linked_issue.test.cjs`: 6 passed, 0 failed; exit 0. Action `882419528a85f66c3ca8c5ffb68dd5a11135fa2a88c9f4778587c975ecc2cea0`; CAS receipt `8a3bf6fe53ff42f6913cb7e28567306ae6f0903ecadf48426e33c3eb508934d6`; payload `/mnt/shared/prismabuild-fleet/cas/blobs/99/992e366734ac10a925ce7c6fde90ca7f1d2949add6cc1d0f4736c5d898b8e2f1`.
- PrismaBuild actionlint v1.7.12 (release checksum verified): exit 0. Action `358d85aaebfdc4092ff1b1b387c8d5a0f69883d0648c21ccbacd33d13e71731d`; CAS receipt `ebf9218fe28fa426e8f28fe642ca3e15d9d2ec7cbcc6297529a89254314f98cc`; payload `/mnt/shared/prismabuild-fleet/cas/blobs/6d/6d9eb0479e61ea2df0448bb106a1e839b4dcf311fb68837317128eb4afdc3402`.
- Live GitHub GraphQL schema reports `PullRequest.closingIssuesReferences` as `IssueConnection`; PR #250 resolves same-repository issue #183 through it.

The main checkout contains a tracked absolute calibration symlink, so PrismaBuild's full-repository snapshot correctly refused it. The two exact changed artifacts and their test were copied byte-for-byte into a minimal Git staging checkout for fleet execution; SHA-256 equality was checked before submission.

## Bootstrap after merge

This workflow does not exist on the default branch yet, so GitHub cannot run it for this governance PR. Merge this PR under the current no-required-status bootstrap, then require context `linked issue` from the GitHub Actions app (`app_id: 15368`) in `main` branch protection. Future PR open/edit/synchronize/reopen/ready-for-review events will refresh that status on the PR head.
