### PR TITLE
Count observed calibration rows without Hessians

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,14 @@
 As of: 2026-09-05 · `codex/pq183-tessera-reader`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-06, `codex/tessera-row-count-255`) for truthful calibration
+row counts without Hessians (#255). The shared Tessera campaign collector
+counts all observed dense or routed input rows independently of the Hessian
+flag and scoring-row cap. Disabling H retains an empty Hessian result; it no
+longer reports zero observed rows after a real static-scale capture. Existing
+H-mode Gram accumulation and row counts are unchanged. Gate:
+`tests/test_tessera_capture_row_counts.py` (actual CPU torch tensors).
+
 Re-stamped (2026-09-05, `codex/pq183-tessera-reader`) for saved Tessera
 campaign assignment intake (#183). The shared torch-free layer-config reader
 accepts a Tessera rung name as a shorthand string as well as the existing

--- a/docs/measurements/tessera-capture-row-counts-2026-09-06.md
+++ b/docs/measurements/tessera-capture-row-counts-2026-09-06.md
@@ -1,0 +1,33 @@
+# Calibration row counts without Hessians (#255)
+
+The shared `_collect_activations` returned zero `token_counts` whenever
+`want_hessian=False`, although it had observed inputs and calibrated maxima.
+The increment was inside the Hessian branch. This blocked the mixed-family
+sanity preparation's truthful six-input scale receipt with `max_rows=0`.
+That preparation remains tracked separately in #253.
+
+PB red `c69b6445f40408be4d672c5778f2363fc2c6681da2dd506c0b7f1649a6ec18d0`
+ran a genuine small CPU torch dense model with six observed input rows. Both
+no-H subcases (`max_rows=0` and `2`) returned zero instead of six; the full-Gram
+H-mode control passed. This was the intended regression, not a dependency or
+collection failure. Overall exit 1, no successful CAS claimed.
+
+The count now increments for every nonempty input before either the H branch
+or scoring-row cap. H-mode Gram computation is unchanged. No-H mode still
+returns no Hessians; its returned counts and campaign calibration provenance
+now report actual observed rows. Export-input writing only serializes Hessian
+counts when real Hessians exist. No inferred expert rows are introduced.
+
+PB green `862727591e5ccd98238eb82c0041418d698b21bd841e5d888bb99c822b42a038`
+passed both real-tensor tests, zero skips, on the qualified GB10 CPU interpreter
+with GPU visibility disabled, one CPU/4 GiB and native threads bounded to one.
+Terminal exit zero and resource cleanup complete. The actual 458-byte CAS
+payload was read and rehashed to
+`e981fd25570c1542cbbd27c90e5be910bc1d29b87eb6e187d40c8dae56feeb69`;
+receipt `3733e49559350c19e47bf4a23cd2b9bb186a8e45cbab77bf131f55c4b6e71c54`.
+Full private receipts are retained under
+`/home/rob/tessera-runs/mixed-lfm-237-2026-09-06/preparation-evidence/`.
+The command was the qualified Python interpreter running
+`-m unittest discover -s tests -p test_tessera_capture_row_counts.py -v`
+through the published `pbrun.py` client, with a `gb10` environment dependency
+and PB selecting the eligible worker. No GPU measurement was performed here.

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -745,7 +745,9 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
                          *, want_hessian: bool = False, profile=None):
     """One model forward per batch, for dense and declared packed projections.
 
-    Returns ``(rows, hessians, token_counts, max_abs)``.
+    Returns ``(rows, hessians, token_counts, max_abs)``. Counts describe every
+    observed input row, including when Hessians and retained scoring rows are
+    disabled; they are calibration provenance, not a Hessian-computation flag.
 
     Three different things come out of the same hook, and they have different
     row budgets on purpose:
@@ -803,6 +805,7 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
             routed_seen[name] += int(flat.shape[0])
         amax[name] = max(
             amax[name], float(flat.abs().amax().float().item()))
+        seen[name] += int(flat.shape[0])
         if want_hessian:
             # Every row, before any cap: see the docstring.
             f32 = flat.to(dtype=torch.float32)
@@ -811,7 +814,6 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
                 hess[name] = gram
             else:
                 hess[name] += gram
-            seen[name] += int(f32.shape[0])
         room = max_rows - kept[name]
         if room <= 0:
             return

--- a/tests/test_tessera_capture_row_counts.py
+++ b/tests/test_tessera_capture_row_counts.py
@@ -1,0 +1,32 @@
+"""Actual CPU tensor regression for calibration counts independent of H/score rows."""
+import unittest
+import torch
+from prismaquant.tessera_campaign import _collect_activations
+
+
+class CaptureCountTests(unittest.TestCase):
+    def test_dense_capture_counts_all_rows_without_hessian_or_retained_rows(self):
+        net = torch.nn.Sequential(torch.nn.Linear(4, 3, bias=False)).eval()
+        batches = [torch.arange(12, dtype=torch.float32).reshape(3, 4),
+                   torch.arange(12, 24, dtype=torch.float32).reshape(3, 4)]
+        for cap in (0, 2):
+            with self.subTest(max_rows=cap):
+                rows, hess, counts, maxima = _collect_activations(
+                    net, ['0'], batches, max_rows=cap, device='cpu', want_hessian=False)
+                self.assertEqual(counts, {'0': 6})
+                self.assertEqual(hess, {})
+                self.assertEqual(maxima, {'0': 23.0})
+                self.assertEqual(None if rows['0'] is None else rows['0'].shape[0], None if cap == 0 else cap)
+
+    def test_hessian_mode_keeps_full_gram_and_same_row_count(self):
+        net = torch.nn.Sequential(torch.nn.Linear(4, 3, bias=False)).eval()
+        batches = [torch.arange(24, dtype=torch.float32).reshape(6, 4)]
+        rows, hess, counts, maxima = _collect_activations(
+            net, ['0'], batches, max_rows=0, device='cpu', want_hessian=True)
+        self.assertEqual(counts, {'0': 6})
+        self.assertIsNone(rows['0'])
+        torch.testing.assert_close(hess['0'], batches[0].T @ batches[0])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem and result

With `want_hessian=False`, the shared Tessera capture hook observed real calibration inputs and maxima but reported zero `token_counts` because the counter increment lived inside the Hessian branch. The collector now counts every nonempty observed input before the independent Hessian and retained-scoring-row decisions. No-H results still contain no Hessians, while H mode retains its full Gram and existing count.

Closes #255

Context: issue #253 tracks the mixed-family preparation and remains open. This PR addresses only the reusable collector defect found during that work.

## Validation

No test was rerun after rebasing onto governance-only `main`: the implementation and actual-tensor test are byte-identical to the already tested PrismaBuild snapshot.

- Green sealed snapshot commit: `be0703cb3f1f9d7adbc94a864b31e6e90fc97e52`; snapshot Git bundle SHA-256: `bb2804c9ce48a3409f1c2bafd7e12c494ab6d6da4e01a806e7f70de0b90d93fa`.
- `prismaquant/tessera_campaign.py`: Git blob `47b532ff9beac7dd1a94686941fdb78b02ac4f32`, content SHA-256 `77f50df9baf0aa71952ca2de2cd5a3cf7acfddb5a7fdb10cbd7c1a80550adcf4` in both the sealed snapshot and this PR.
- `tests/test_tessera_capture_row_counts.py`: Git blob `51d56eea1a316a51c697d0a339d7e84c33600bc5`, content SHA-256 `3a0ab4ea3f153c7176c5a6fd1e2f68b90e221cbd75734538bf1081b4a227cc2c` in both the sealed snapshot and this PR.
- PrismaBuild red action `c69b6445f40408be4d672c5778f2363fc2c6681da2dd506c0b7f1649a6ec18d0`: exit 1, both no-H cases returned `{'0': 0}` instead of `{'0': 6}`; H-mode control passed. No successful CAS was claimed.
- PrismaBuild green action `862727591e5ccd98238eb82c0041418d698b21bd841e5d888bb99c822b42a038`: 2 passed, zero skips, exit 0. Receipt `3733e49559350c19e47bf4a23cd2b9bb186a8e45cbab77bf131f55c4b6e71c54` records a 458-byte result with SHA-256 `e981fd25570c1542cbbd27c90e5be910bc1d29b87eb6e187d40c8dae56feeb69` at `/mnt/shared/prismabuild-fleet/cas/blobs/e9/e981fd25570c1542cbbd27c90e5be910bc1d29b87eb6e187d40c8dae56feeb69`; that actual payload was read and rehashed successfully.

The architecture conflict with the preparation branch retained only this row-count stamp. It does not carry the unrelated mixed-preparation stamp.
