### PR TITLE
Validate paired joint AURA assignment diagnostics

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,21 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-05 · `codex/pq183-tessera-reader`. Stamps
+As of: 2026-09-06 · `codex/237-paired-diagnostics`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-06, `codex/237-paired-diagnostics`) for validated paired
+assignment diagnostics (#257, research groundwork for #237). The shared joint
+AURA row contract establishes probe/calibration/source/currency and actual
+operator bindings before covariance is reported as aligned. Legacy equal-length
+arrays retain an explicitly unverified diagnostic. Assignment comparisons
+declare additive unary loss or the quadratic of summed signed projections;
+unchanged units remain in the latter's cross terms. Empirical probe uncertainty
+conditional on fixed calibration and caller-supplied held-out sequence
+uncertainty stay separate. The existing additivity report CLI exposes the
+comparison without allocator refinement or serving admission. Gates:
+`tests/test_joint_aura_assignment_diagnostics.py`,
+`tests/test_aura_additivity_identity.py`. See
+`docs/design/joint_aura_runtime_allocation.md`.
 
 Re-stamped (2026-09-06, `codex/lfm-mixed-preparation`) for the opt-in
 LFM full-body mixed-family sanity input preparation (#253). The producer's

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,7 +11,9 @@ arrays retain an explicitly unverified diagnostic. Assignment comparisons
 declare additive unary loss or the quadratic of summed signed projections;
 unchanged units remain in the latter's cross terms. Empirical probe uncertainty
 conditional on fixed calibration and caller-supplied held-out sequence
-uncertainty stay separate. The existing additivity report CLI exposes the
+uncertainty stay separate. Measured KL must be finite, and its supplied standard
+error must be finite and nonnegative; finite negative sample KL estimates remain
+valid. The existing additivity report CLI exposes the
 comparison without allocator refinement or serving admission. Gates:
 `tests/test_joint_aura_assignment_diagnostics.py`,
 `tests/test_aura_additivity_identity.py`. See

--- a/docs/design/joint_aura_runtime_allocation.md
+++ b/docs/design/joint_aura_runtime_allocation.md
@@ -39,6 +39,45 @@ not uncertainty over new calibration data or evidence of generalization.
 The additive sum of local quadratic prices is still a model approximation;
 it does not establish the quality of every joint assignment.
 
+## Assignment diagnostics
+
+`joint_aura.assignment_probe_summary` and `paired_assignment_difference`
+consume complete joint rows keyed by unit. The paired helper requires the
+same nonempty unit roster in both arms, including unchanged units. Every row
+must pass the producer's identity and sample validator. Probe IDs and the full
+probe identity (source model, calibration, producer source and arithmetic)
+must agree. Each unit retains its source weight; different formats carry
+their own validated render and activation identities. The same unit/format
+cannot silently change operator binding between arms.
+
+The explicit `objective` determines the per-probe quantity:
+
+- `additive` (default): `0.5 sum_i(a_i[k] ** 2)`, the allocator's unary sum.
+- `joint_quadratic`: `0.5 (sum_i a_i[k]) ** 2`, the baseline local
+  linearization with cross-unit terms retained.
+
+Pairing reports A minus B on common samples and its empirical standard error,
+conditional on the fixed calibration. Unchanged units cancel from additive
+differences, but remain in the cross terms of `joint_quadratic`. Neither
+objective measures a new background forward pass or fixes background-dependent
+unary ordering. There is no automatic allocator refinement or admission from
+these diagnostics.
+
+The existing `aura_additivity_gate` CLI accepts `--comparison-assignment` and
+`--paired-objective` to append this paired report. Its additivity prediction
+always remains additive. Complete aligned joint rows use
+`stderr_method=per_probe_aligned_empirical`. Historical bare arrays retain
+their previous numeric estimate as `per_probe_unverified`; equal lengths are
+not proof of alignment. Without arrays the independence estimate is labeled
+`independence_assumed`, not a covariance lower bound. Old bare-list screen
+receipts remain unverified by this identity contract.
+
+The existing `measured_kl_stderr` is caller-supplied held-out sequence
+uncertainty and stays separate from the probe standard error. The residual
+z-score is descriptive and assumes independent probe and sequence errors;
+this helper does not certify the supplied held-out dataset or estimate
+generalization from probe variance.
+
 ## Runtime input and search
 
 `--measured-runtime-table` opts the allocator into measured-resource search.

--- a/docs/design/joint_aura_runtime_allocation.md
+++ b/docs/design/joint_aura_runtime_allocation.md
@@ -72,6 +72,8 @@ not proof of alignment. Without arrays the independence estimate is labeled
 `independence_assumed`, not a covariance lower bound. Old bare-list screen
 receipts remain unverified by this identity contract.
 
+Measured KL must be finite; a finite negative sample estimate is allowed.
+Its supplied standard error must be finite and nonnegative.
 The existing `measured_kl_stderr` is caller-supplied held-out sequence
 uncertainty and stays separate from the probe standard error. The residual
 z-score is descriptive and assumes independent probe and sequence errors;

--- a/docs/measurements/pq257-paired-diagnostics-2026-09-06.md
+++ b/docs/measurements/pq257-paired-diagnostics-2026-09-06.md
@@ -1,0 +1,54 @@
+# Paired AURA diagnostic validation, 2026-09-06
+
+Scope: #257, diagnostic groundwork for #237. These are CPU scalar and
+small-module regression results, not model-quality or serving measurements.
+The additive unary objective and quadratic of summed signed projections
+remain explicitly distinct. Probe SE is conditional on fixed calibration;
+held-out sequence uncertainty is not inferred from it.
+
+Implementation started from main `6f3044019a7f64c027d7a3f15bee53d20b28db80`
+in an isolated no-local clone. All execution used the published PrismaBuild
+tools. PB selected placement and file shards; no manual host test jobs ran.
+The successful CPU actions used the existing
+`/home/rob/dq-runs/venvs/prismaquant-cu130/bin/python` dependency environment,
+tag `gb10`, CUDA hidden, one CPU and 4 GiB per test shard, native threads
+bounded to one. The first x86 attempt failed collection because its `pb-cpu`
+environment lacked `compressed_tensors`; that was not counted as a regression.
+
+The snapshotter initially refused three unused tracked calibration symlinks
+whose targets escape the repository. They were temporarily moved aside in
+the isolated clone for all test snapshots, then restored before commit.
+Synthetic inputs only were used. No calibration data, production cache,
+allocator assignment, or serving artifact was generated or changed.
+
+| Phase | Actual result | PB action(s) |
+|---|---|---|
+| Initial RED | 37 failed: five existing gate regressions and 32 absent-API cases; pytest exit 1 | `ff4b4d8d6a68` |
+| First focused GREEN | 100 passed, no skips, six exit-0 shards | `7466c541786d`, `f00a731729b4`, `ac82b5f6109e`, `bbe0c94bf877`, `27da068611b7`, `ec8d51c615e9` |
+| Review RED | Six intended failures: canonical JSON identity and small residual cancellation; 33 deselected, pytest exit 1 | `9c8673e2ede7` |
+| Final affected-file GREEN | 66 passed, no skips, three exit-0 shards | `f0458ad5006e`, `0cfb8e52415e`, `ca9e8a9350d8` |
+| Final compile | Both source modules compiled, exit 0 | `3ae6862321db` |
+
+The first green covered `test_aura_additivity_identity.py`,
+`test_joint_aura_assignment_diagnostics.py`, `test_aura_cost.py`,
+`test_joint_aura_streamed.py`, `test_architecture_doc.py` and
+`test_docs_staleness.py`. The final green repeated the two new diagnostic
+files and streamed integration file after the review fixes; the other 40
+checks were unaffected. Runs emitted existing torch JIT deprecation warnings.
+Terminal records, actual stdout, resource cleanup and CAS result hashes were
+checked; a submission acknowledgement was not counted as a pass.
+
+Exact commands, logs, full action keys and CAS receipts are retained at
+`/home/rob/tessera-runs/pq237-paired-diagnostics-receipts-2026-09-06/` in
+`commands.md`, `red.log`, `red-receipt.json`, `review-red.log`,
+`green-results.json` and `final-green-results.json`. PB terminal records are
+under `/mnt/shared/prismabuild-fleet/pb-queue/{done,failed}/` by full action key.
+
+The mathematical tests exercise one-unit reduction, common-probe covariance,
+cross-unit cancellation, unchanged-background cross terms, large cancelling
+terms, full rosters, and mismatched probe/source/calibration/currency/operator
+identities. The report CLI consumes complete rows and preserves separate
+probe and supplied sequence standard errors. Historical bare-list screens
+remain unverified by this identity contract. These results do not qualify
+background-dependent unary ordering, sparse-anchor generalization, runtime
+admission, or positive quality gains; #237 remains open.

--- a/docs/measurements/pq257-paired-diagnostics-2026-09-06.md
+++ b/docs/measurements/pq257-paired-diagnostics-2026-09-06.md
@@ -52,3 +52,26 @@ probe and supplied sequence standard errors. Historical bare-list screens
 remain unverified by this identity contract. These results do not qualify
 background-dependent unary ordering, sparse-anchor generalization, runtime
 admission, or positive quality gains; #237 remains open.
+
+## Integration review, 2026-09-06
+
+Rebased onto main `3cb0d35933c614c61df79be25d478ebf7d43e859`, retaining
+the preparation and row-count provenance stamps. Review found the existing
+gate accepted NaN/infinite measured KL and negative/nonfinite supplied standard
+errors. Five new cases failed before the guard; the finite negative sample-KL
+control passed. RED action
+`3849fc643867792bc014b89de2b248bf773404e5136c73c7ab3a4db28fba226c`
+returned 1: five failed, one passed, 13 deselected.
+
+After finite-domain validation and overflow-resistant `math.hypot` combination,
+`tests/test_aura_additivity_identity.py` and `tests/test_aura_cost.py` passed
+40 tests, no skips, in 6.52 seconds using two xdist workers, two CPUs and
+4 GiB total on PB-selected Sparky, CUDA hidden and native threads bounded to one.
+GREEN action
+`3b99832b56d056196d0d01f109f9f3072a9dc0e4af686d6e0d20eaf2b76146a5`
+returned 0 with complete scope cleanup and no OOM. Receipt SHA256
+`402bbfe73506fbed0aa0cbf5abbda56079f0a6f60fccbf68988589c90cae83c7`
+binds the actual 651-byte test log, independently read and rehashed as
+`35a2267abef3a135aa893f629b640c69e7b78a905e51ba26c781566adbe6da87`.
+The final three agent-produced GREEN payloads above were also independently
+read and rehashed during integration. Original failure records are retained.

--- a/prismaquant/aura_additivity_gate.py
+++ b/prismaquant/aura_additivity_gate.py
@@ -42,6 +42,12 @@ def additivity_gate(
     Uncovered members (assignment entries with no cost row) are LISTED, never
     silently dropped — a large uncovered set invalidates the comparison.
     """
+    measured_kl = float(measured_kl)
+    measured_kl_stderr = float(measured_kl_stderr)
+    if not math.isfinite(measured_kl):
+        raise ValueError("measured KL estimate must be finite")
+    if not math.isfinite(measured_kl_stderr) or measured_kl_stderr < 0:
+        raise ValueError("measured KL standard error must be finite and nonnegative")
     costs = cost_payload["costs"]
     covered: list[tuple[str, str]] = []
     uncovered: list[str] = []
@@ -105,7 +111,7 @@ def additivity_gate(
         stderr_method = "independence_assumed"
 
     residual = float(measured_kl) - predicted_sum
-    denom = math.sqrt(predicted_stderr ** 2 + float(measured_kl_stderr) ** 2)
+    denom = math.hypot(predicted_stderr, measured_kl_stderr)
     z = residual / denom if denom > 0 else float("inf") if residual else 0.0
 
     return {

--- a/prismaquant/aura_additivity_gate.py
+++ b/prismaquant/aura_additivity_gate.py
@@ -1,24 +1,15 @@
-"""AURA additivity gate: observe the cross-layer residual, per artifact.
+"""AURA assignment diagnostics with explicit covariance and identity scope.
 
-AURA's one structural assumption is that per-Linear KL contributions add.
-The 2026-06-09 measurements say that assumption is sound but has a boundary:
-the fp32 residual is +5–12% of full KL on 0.6B (growing with total distortion)
-and is a DIFFUSE sum of micro-couplings — only 3/1180 pairs significant — so
-the single assignment-level residual
+The additivity residual compares measured end-KL with the sum of unary
+quadratic prices. Complete joint rows establish common probe/calibration,
+source, currency and per-candidate operator bindings before the empirical
+standard error includes covariance. Bare legacy arrays retain their numeric
+diagnostic with unverified alignment; equal lengths cannot establish pairing.
 
-    residual = measured_end_KL(assignment) − Σ_i predicted_dloss_i
-
-is the entire cross-layer story worth measuring. This module computes it with
-an honest stderr and turns the trust-region question ("are we somewhere AURA's
-assumptions hold?") into a per-run, recorded diagnostic instead of a
-paper-level claim. A residual that blows out flags a regime departure
-(low bpp, routing, new arch) before anyone trusts the allocation.
-
-Stderr correctness: cost rows share the same K probes, so row errors are
-correlated and √Σσ² understates the sum's noise. When the cost rows carry
-``x2_per_probe`` (probe-aligned raw samples), the gate forms the per-probe
-sums S_k = Σ_i x²_{i,k} and takes the exact stderr of 0.5·mean_k(S_k);
-otherwise it falls back to the independence approximation and says so.
+Probe sampling error is conditional on fixed calibration. Supplied held-out
+sequence uncertainty remains a separate quantity. These diagnostics neither
+admit an allocation nor establish generalization or background-independent
+unary rankings.
 """
 from __future__ import annotations
 
@@ -28,6 +19,11 @@ import math
 import pickle
 from pathlib import Path
 from typing import Mapping, Sequence
+
+from prismaquant.joint_aura import (
+    ASSIGNMENT_OBJECTIVES, PROBE_UNCERTAINTY_SCOPE, assignment_probe_summary,
+    paired_assignment_difference, validate_joint_aura_entry,
+)
 
 ZERO_COST_SOURCES = {"aura_passthrough_zero"}
 
@@ -41,8 +37,8 @@ def additivity_gate(
 ) -> dict:
     """Compare an assignment's measured end-KL to AURA's additive prediction.
 
-    Returns a dict with the predicted sum, its stderr (exact per-probe when
-    available), the residual, the residual's z-score, and coverage accounting.
+    Returns the predicted sum, empirical stderr, residual, descriptive
+    z-score, identity/uncertainty scope, and coverage accounting.
     Uncovered members (assignment entries with no cost row) are LISTED, never
     silently dropped — a large uncovered set invalidates the comparison.
     """
@@ -51,6 +47,7 @@ def additivity_gate(
     uncovered: list[str] = []
     zero_rows = 0
     per_probe_ok = True
+    joint_rows = {}
     n_probes = int(cost_payload.get("n_probes", 0))
 
     for name, fmt in assignment.items():
@@ -59,6 +56,11 @@ def additivity_gate(
         if row is None:
             uncovered.append(f"{name}|{fmt}")
             continue
+        # Validate joint claims before any zero-cost shortcut or sample use.
+        if validate_joint_aura_entry(row):
+            if row["joint_operator_identity"]["format"] != fmt:
+                raise ValueError(f"joint AURA assignment format identity mismatch: {name}")
+            joint_rows[name] = row
         if row.get("cost_source") in ZERO_COST_SOURCES or (
                 row.get("predicted_dloss", 0.0) == 0.0
                 and "x2_per_probe" not in row):
@@ -71,8 +73,21 @@ def additivity_gate(
     predicted_sum = sum(
         float(costs[n][f]["predicted_dloss"]) for n, f in covered)
 
-    if covered and per_probe_ok and n_probes >= 2:
-        # Exact correlated-sum stderr: per-probe totals across all rows.
+    alignment_verified = False
+    probe_identity = None
+    if joint_rows:
+        if len(joint_rows) != len(covered) or zero_rows:
+            raise ValueError("joint AURA diagnostic refuses mixed or unmeasured zero rows")
+        summary = assignment_probe_summary(joint_rows, objective="additive")
+        if n_probes != len(summary["probe_ids"]):
+            raise ValueError("joint AURA payload probe count alignment mismatch")
+        predicted_sum = summary["mean"]
+        predicted_stderr = summary["standard_error"]
+        stderr_method = "per_probe_aligned_empirical"
+        alignment_verified = True
+        probe_identity = summary["probe_identity_sha256"]
+    elif covered and per_probe_ok and n_probes >= 2:
+        # Preserve historical arithmetic without certifying a common draw.
         s = [0.0] * n_probes
         for n, f in covered:
             for k, x2 in enumerate(costs[n][f]["x2_per_probe"]):
@@ -80,12 +95,14 @@ def additivity_gate(
         mean_s = sum(s) / n_probes
         var_s = sum((v - mean_s) ** 2 for v in s) / (n_probes - 1)
         predicted_stderr = 0.5 * math.sqrt(var_s / n_probes)
-        stderr_method = "per_probe_exact"
+        stderr_method = "per_probe_unverified"
     else:
         predicted_stderr = math.sqrt(sum(
             float(costs[n][f].get("predicted_dloss_stderr", 0.0)) ** 2
             for n, f in covered))
-        stderr_method = "independence_lower_bound"
+        # Ignoring covariance is not generally a lower bound: covariance can
+        # be negative. This remains only the historical independence estimate.
+        stderr_method = "independence_assumed"
 
     residual = float(measured_kl) - predicted_sum
     denom = math.sqrt(predicted_stderr ** 2 + float(measured_kl_stderr) ** 2)
@@ -98,6 +115,14 @@ def additivity_gate(
         "predicted_sum": predicted_sum,
         "predicted_stderr": predicted_stderr,
         "stderr_method": stderr_method,
+        "probe_alignment_verified": alignment_verified,
+        "probe_identity_sha256": probe_identity,
+        "objective": "additive",
+        "predicted_uncertainty_scope": (
+            PROBE_UNCERTAINTY_SCOPE if alignment_verified
+            else "unverified_probe_alignment"),
+        "measured_uncertainty_scope": "caller_supplied_heldout_sequence_standard_error",
+        "residual_z_scope": "descriptive_independent_probe_and_sequence_errors_assumed",
         "residual": residual,
         "residual_over_measured": (
             residual / measured_kl if measured_kl else 0.0),
@@ -109,6 +134,36 @@ def additivity_gate(
     }
 
 
+def paired_assignment_report(
+    cost_payload: Mapping, assignment_a: Mapping[str, str],
+    assignment_b: Mapping[str, str], *, objective: str = "additive",
+) -> dict:
+    """Compare two complete assignments from one cost artifact, A minus B.
+
+    The signed-probe helper owns numerical/identity validation. Missing units
+    and unmeasured BF16 placeholders cannot be invented as zeros for a pair.
+    No held-out sequence standard error is inferred from these probe draws.
+    """
+    def select(assignment):
+        rows = {}
+        for name, fmt in assignment.items():
+            fmt = str(fmt).strip().upper()
+            row = cost_payload["costs"].get(name, {}).get(fmt)
+            if row is None:
+                raise ValueError(f"paired joint AURA missing assignment row: {name}|{fmt}")
+            if not validate_joint_aura_entry(row):
+                raise ValueError("paired joint AURA requires complete joint rows")
+            if row["joint_operator_identity"]["format"] != fmt:
+                raise ValueError(f"paired joint AURA format identity mismatch: {name}")
+            rows[name] = row
+        return rows
+
+    result = paired_assignment_difference(select(assignment_a), select(assignment_b), objective=objective)
+    if cost_payload.get("n_probes") != len(result["probe_ids"]):
+        raise ValueError("paired joint AURA payload probe count alignment mismatch")
+    return result
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     p = argparse.ArgumentParser(
         description="AURA additivity gate: measured vs Σ predicted end-KL")
@@ -117,6 +172,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                    help="layer_config.json (format-name or AutoRound dicts)")
     p.add_argument("--measured-kl", required=True, type=float)
     p.add_argument("--measured-kl-stderr", type=float, default=0.0)
+    p.add_argument("--comparison-assignment", help="optional complete assignment B; report A minus B")
+    p.add_argument("--paired-objective", choices=ASSIGNMENT_OBJECTIVES, default="additive",
+                   help="paired diagnostic only; additivity prediction remains additive")
     p.add_argument("--output", default=None)
     args = p.parse_args(argv)
 
@@ -127,6 +185,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     result = additivity_gate(
         payload, assignment, args.measured_kl,
         measured_kl_stderr=args.measured_kl_stderr)
+    if args.comparison_assignment:
+        result["paired_assignment"] = paired_assignment_report(
+            payload, assignment, load_assignment(args.comparison_assignment),
+            objective=args.paired_objective)
     text = json.dumps(result, indent=1)
     if args.output:
         Path(args.output).write_text(text)

--- a/prismaquant/joint_aura.py
+++ b/prismaquant/joint_aura.py
@@ -25,6 +25,8 @@ from prismaquant.memory_management import env_truthy
 JOINT_CURRENCY = "joint_aura_predicted_dloss"
 JOINT_AURA_COST_CURRENCY = JOINT_CURRENCY
 JOINT_AURA_COST_SOURCE = "joint_aura"
+PROBE_UNCERTAINTY_SCOPE = "probe_sampling_conditional_on_fixed_calibration"
+ASSIGNMENT_OBJECTIVES = ("additive", "joint_quadratic")
 
 
 def identity_sha256(value) -> str:
@@ -347,7 +349,7 @@ def paired_candidate_difference(entry_a: Mapping, entry_b: Mapping) -> dict:
     """A minus B with common-probe covariance retained, conditional on calibration."""
     if not validate_joint_aura_entry(entry_a) or not validate_joint_aura_entry(entry_b):
         raise ValueError("paired joint AURA requires joint rows")
-    if entry_a["probe_identity"] != entry_b["probe_identity"] or entry_a["probe_ids"] != entry_b["probe_ids"]:
+    if not _same_probe_identity(entry_a, entry_b):
         raise ValueError("paired joint AURA probe alignment mismatch")
     values = [0.5 * (a - b) for a, b in zip(entry_a["x2_per_probe"], entry_b["x2_per_probe"])]
     n = len(values)
@@ -357,3 +359,132 @@ def paired_candidate_difference(entry_a: Mapping, entry_b: Mapping) -> dict:
             "difference_per_probe": values, "probe_ids": list(entry_a["probe_ids"]),
             "probe_identity_sha256": entry_a["probe_identity_sha256"],
             "uncertainty_scope": "probe_sampling_conditional_on_fixed_calibration"}
+
+
+def _same_probe_identity(left: Mapping, right: Mapping) -> bool:
+    # Hashes have already been checked against canonical JSON by the row
+    # validator. Python equality would conflate distinct JSON true/1/1.0.
+    return (left["probe_identity_sha256"] == right["probe_identity_sha256"]
+            and identity_sha256(left["probe_ids"]) == identity_sha256(right["probe_ids"]))
+
+
+def _validated_assignment(rows: Mapping, objective: str) -> dict:
+    if objective not in ASSIGNMENT_OBJECTIVES:
+        raise ValueError(f"unsupported joint AURA assignment objective: {objective!r}")
+    if not isinstance(rows, Mapping) or not rows:
+        raise ValueError("joint AURA assignment requires a nonempty unit roster")
+    if any(not isinstance(name, str) or not name for name in rows):
+        raise ValueError("joint AURA assignment requires named units")
+    ordered = {name: rows[name] for name in sorted(rows)}
+    reference = None
+    for name, row in ordered.items():
+        if not isinstance(row, Mapping) or not validate_joint_aura_entry(row):
+            raise ValueError("joint AURA assignment requires complete joint rows")
+        if row["joint_operator_identity"]["qname"] != name:
+            raise ValueError(f"joint AURA assignment operator coordinate mismatch: {name}")
+        if reference is None:
+            reference = row
+        elif not _same_probe_identity(row, reference):
+            raise ValueError("joint AURA assignment probe alignment mismatch")
+    return ordered
+
+
+def _probe_moments(values: list[float]) -> tuple[float, float]:
+    """Empirical sample SE; the measured calibration remains fixed."""
+    if len(values) < 2 or any(not math.isfinite(value) for value in values):
+        raise ValueError("joint AURA diagnostic requires finite aligned samples")
+    mean = math.fsum(value / len(values) for value in values)
+    # hypot avoids overflow in the sum of squared deviations.
+    stderr = math.hypot(*(value - mean for value in values)) / math.sqrt(
+        len(values) * (len(values) - 1))
+    if not math.isfinite(mean) or not math.isfinite(stderr):
+        raise ValueError("joint AURA diagnostic sample moments overflow")
+    return mean, stderr
+
+
+def _assignment_metadata(rows: Mapping, objective: str) -> dict:
+    reference = next(iter(rows.values()))
+    identities = {name: row["joint_operator_identity_sha256"]
+                  for name, row in rows.items()}
+    return {
+        "objective": objective, "cost_currency": JOINT_CURRENCY,
+        "probe_ids": list(reference["probe_ids"]),
+        "probe_identity_sha256": reference["probe_identity_sha256"],
+        "operator_identity_sha256_by_unit": identities,
+        "assignment_identity_sha256": identity_sha256(identities),
+        "uncertainty_scope": PROBE_UNCERTAINTY_SCOPE,
+        "measurement_status": "research",
+    }
+
+
+def assignment_probe_summary(rows: Mapping, *, objective: str = "additive") -> dict:
+    """Summarize one complete assignment on validated, common signed probes.
+
+    ``additive`` is the allocator's sum of local quadratic prices:
+    0.5 sum_i(a_i[k]**2). ``joint_quadratic`` is 0.5 (sum_i a_i[k])**2,
+    retaining cross-unit terms in the baseline's local linearization. Neither
+    updates the background model nor measures held-out assignment quality.
+    """
+    rows = _validated_assignment(rows, objective)
+    samples = zip(*(row["signed_per_probe"] for row in rows.values()))
+    values = [0.5 * (math.fsum(x * x for x in sample) if objective == "additive"
+                     else math.fsum(sample) ** 2) for sample in samples]
+    mean, stderr = _probe_moments(values)
+    return {"schema": "prismaquant.joint_aura.assignment_summary.v1",
+            **_assignment_metadata(rows, objective),
+            "mean": mean, "standard_error": stderr, "per_probe": values}
+
+
+def paired_assignment_difference(
+    rows_a: Mapping, rows_b: Mapping, *, objective: str = "additive",
+) -> dict:
+    """A minus B, retaining common-probe covariance conditional on calibration.
+
+    Both arms must name the complete same unit roster, including unchanged
+    units (which still contribute cross terms to ``joint_quadratic``). Each
+    candidate binds its own actual render/activation operator. Different
+    formats may differ there, but the same candidate cannot silently change
+    operator identity, and each unit must retain the same source weight.
+    """
+    a, b = _validated_assignment(rows_a, objective), _validated_assignment(rows_b, objective)
+    if a.keys() != b.keys():
+        raise ValueError("paired joint AURA requires the same complete unit roster")
+    pairs = []
+    for name in a:
+        left, right = a[name], b[name]
+        operator_a, operator_b = left["joint_operator_identity"], right["joint_operator_identity"]
+        if not _same_probe_identity(left, right):
+            raise ValueError("paired joint AURA assignment probe alignment mismatch")
+        if identity_sha256(operator_a["source_weight"]) != identity_sha256(operator_b["source_weight"]):
+            raise ValueError(f"paired joint AURA source weight identity mismatch: {name}")
+        if (operator_a["format"] == operator_b["format"]
+                and left["joint_operator_identity_sha256"] != right["joint_operator_identity_sha256"]):
+            raise ValueError(f"paired joint AURA changed operator identity for the same candidate: {name}")
+        pairs.append((left, right))
+    if objective == "additive":
+        # The candidate-difference algebra, with every signed squared term
+        # retained until fsum: neither rounded assignment totals nor rounded
+        # per-unit differences may erase a small residual across unit changes.
+        values = [math.fsum(sign * 0.5 * row["x2_per_probe"][k]
+                            for pair in pairs for sign, row in zip((1, -1), pair))
+                  for k in range(len(pairs[0][0]["probe_ids"]))]
+    else:
+        values = []
+        for k in range(len(pairs[0][0]["probe_ids"])):
+            # Difference of squares, factored before summing the background.
+            delta = math.fsum(sign * row["signed_per_probe"][k]
+                              for pair in pairs for sign, row in zip((1, -1), pair))
+            total = math.fsum(row["signed_per_probe"][k]
+                              for pair in pairs for row in pair)
+            values.append(0.5 * delta * total)
+    mean, stderr = _probe_moments(values)
+    metadata_a, metadata_b = _assignment_metadata(a, objective), _assignment_metadata(b, objective)
+    return {
+        "schema": "prismaquant.joint_aura.paired_assignment_difference.v1",
+        "objective": objective, "cost_currency": JOINT_CURRENCY,
+        "mean_difference": mean, "paired_standard_error": stderr,
+        "difference_per_probe": values, "probe_ids": metadata_a["probe_ids"],
+        "probe_identity_sha256": metadata_a["probe_identity_sha256"],
+        "assignment_a": metadata_a, "assignment_b": metadata_b,
+        "uncertainty_scope": PROBE_UNCERTAINTY_SCOPE, "measurement_status": "research",
+    }

--- a/tests/test_aura_additivity_identity.py
+++ b/tests/test_aura_additivity_identity.py
@@ -1,0 +1,113 @@
+"""Identity regressions for the existing pipeline diagnostic (CPU only)."""
+from __future__ import annotations
+
+import copy
+import json
+import math
+import pickle
+
+import pytest
+
+from prismaquant.aura_additivity_gate import additivity_gate, main, paired_assignment_report
+from test_joint_aura_assignment_diagnostics import UNIT_A, UNIT_B, _rebuild, _row
+
+
+def _payload(a, b):
+    return {"n_probes": 3, "costs": {
+        UNIT_A: {"FP8_E4M3": a}, UNIT_B: {"FP8_E4M3": b}}}
+
+
+ASSIGNMENT = {UNIT_A: "FP8_E4M3", UNIT_B: "FP8_E4M3"}
+
+
+@pytest.mark.parametrize("field", ["seed_base", "calibration_sha256", "producer_source_sha256"])
+def test_equal_length_joint_rows_from_different_measurements_refuse(field):
+    a, b = _row(UNIT_A, [1, 2, 3]), _row(UNIT_B, [3, 2, 1])
+    replacement = 237001 if field == "seed_base" else "f" * 64
+    b = _rebuild(b, probe_change=lambda probe: probe.update({field: replacement}))
+    # Both rows are complete and internally valid; only their alignment differs.
+    with pytest.raises(ValueError, match="probe|alignment"):
+        additivity_gate(_payload(a, b), ASSIGNMENT, measured_kl=0.1)
+
+
+def test_gate_validates_render_binding_before_sampling_claim():
+    a, b = _row(UNIT_A, [1, 2, 3]), _row(UNIT_B, [3, 2, 1])
+    b["joint_operator_identity"]["rendered_weight"]["content_sha256"] = "f" * 64
+    with pytest.raises(ValueError, match="identity"):
+        additivity_gate(_payload(a, b), ASSIGNMENT, measured_kl=0.1)
+
+
+def test_bare_arrays_never_claim_verified_probe_alignment():
+    a = {"predicted_dloss": 7 / 3, "predicted_dloss_stderr": 7 / 6,
+         "x2_per_probe": [1.0, 4.0, 9.0]}
+    b = copy.deepcopy(a)
+    result = additivity_gate(_payload(a, b), ASSIGNMENT, measured_kl=0.1)
+    assert result["stderr_method"] == "per_probe_unverified"
+    assert result["probe_alignment_verified"] is False
+
+
+def test_gate_verified_joint_covariance_keeps_sequence_uncertainty_separate():
+    a, b = _row(UNIT_A, [2, -4, 6]), _row(UNIT_B, [-2, 4, -6])
+    result = additivity_gate(_payload(a, b), ASSIGNMENT, measured_kl=20,
+                             measured_kl_stderr=0.25)
+    assert result["predicted_sum"] == pytest.approx(56 / 3)
+    assert result["predicted_stderr"] == pytest.approx(28 / 3)
+    assert result["measured_kl_stderr"] == 0.25
+    assert result["stderr_method"] == "per_probe_aligned_empirical"
+    assert result["probe_alignment_verified"] is True
+    assert result["probe_identity_sha256"] == a["probe_identity_sha256"]
+    assert result["predicted_uncertainty_scope"] == "probe_sampling_conditional_on_fixed_calibration"
+    assert result["measured_uncertainty_scope"] == "caller_supplied_heldout_sequence_standard_error"
+    assert result["residual_z"] == pytest.approx((20 - 56 / 3) / math.hypot(28 / 3, 0.25))
+
+
+@pytest.mark.parametrize("mutation", ["format", "qname", "n_probes", "mixed_currency", "zero_shortcut"])
+def test_gate_refuses_incompatible_payload_coordinates_and_legacy_rows(mutation):
+    a, b = _row(UNIT_A, [1, 2, 3]), _row(UNIT_B, [3, 2, 1])
+    payload = _payload(a, b)
+    if mutation in ("format", "qname"):
+        b = _rebuild(b, operator_change=lambda op: op.update(
+            {mutation: "NVFP4A16" if mutation == "format" else UNIT_A}))
+        payload["costs"][UNIT_B]["FP8_E4M3"] = b
+    elif mutation == "n_probes":
+        payload["n_probes"] = 4
+    else:
+        payload["costs"][UNIT_B]["FP8_E4M3"] = {
+            "predicted_dloss": 0.0 if mutation == "zero_shortcut" else 1.0}
+    with pytest.raises(ValueError):
+        additivity_gate(payload, ASSIGNMENT, measured_kl=0.1)
+
+
+def test_report_cli_emits_explicit_paired_objective_from_validated_rows(tmp_path, capsys):
+    a, b = _row(UNIT_A, [-1, 0, 1]), _row(UNIT_B, [10, 10, 10])
+    payload = _payload(a, b)
+    payload["costs"][UNIT_A]["FP8_E5M2"] = _row(UNIT_A, [1, 0, -1], fmt="FP8_E5M2")
+    comparison = {**ASSIGNMENT, UNIT_A: "FP8_E5M2"}
+    cost_path, assignment_path, comparison_path, output_path = [
+        tmp_path / name for name in ("cost.pkl", "a.json", "b.json", "report.json")]
+    cost_path.write_bytes(pickle.dumps(payload))
+    assignment_path.write_text(json.dumps(ASSIGNMENT))
+    comparison_path.write_text(json.dumps(comparison))
+    assert main(["--costs", str(cost_path), "--assignment", str(assignment_path),
+                 "--measured-kl", "0.1", "--measured-kl-stderr", "0.002",
+                 "--comparison-assignment", str(comparison_path),
+                 "--paired-objective", "joint_quadratic", "--output", str(output_path)]) == 0
+    report = json.loads(output_path.read_text())
+    assert json.loads(capsys.readouterr().out) == report
+    assert report["objective"] == "additive"
+    assert report["measured_kl_stderr"] == 0.002
+    paired = report["paired_assignment"]
+    assert paired["objective"] == "joint_quadratic"
+    assert paired["difference_per_probe"] == [-20.0, 0.0, 20.0]
+    assert paired["paired_standard_error"] == pytest.approx(20 / math.sqrt(3))
+    assert "measured_kl_stderr" not in paired
+
+
+def test_paired_report_requires_measured_rows_for_the_whole_roster():
+    a, b = _row(UNIT_A, [1, 2, 3]), _row(UNIT_B, [3, 2, 1])
+    payload = _payload(a, b)
+    with pytest.raises(ValueError, match="missing"):
+        paired_assignment_report(payload, ASSIGNMENT, {**ASSIGNMENT, UNIT_A: "BF16"})
+    payload["costs"][UNIT_A]["BF16"] = {"predicted_dloss": 0.0}
+    with pytest.raises(ValueError, match="complete joint"):
+        paired_assignment_report(payload, ASSIGNMENT, {**ASSIGNMENT, UNIT_A: "BF16"})

--- a/tests/test_aura_additivity_identity.py
+++ b/tests/test_aura_additivity_identity.py
@@ -20,6 +20,24 @@ def _payload(a, b):
 ASSIGNMENT = {UNIT_A: "FP8_E4M3", UNIT_B: "FP8_E4M3"}
 
 
+@pytest.mark.parametrize("measured,stderr", [
+    (0.1, -0.1), (0.1, float("nan")), (0.1, float("inf")),
+    (float("nan"), 0.1), (float("inf"), 0.1),
+])
+def test_gate_refuses_invalid_measured_uncertainty(measured, stderr):
+    a, b = _row(UNIT_A, [1, 2, 3]), _row(UNIT_B, [3, 2, 1])
+    with pytest.raises(ValueError, match="measured"):
+        additivity_gate(_payload(a, b), ASSIGNMENT, measured,
+                        measured_kl_stderr=stderr)
+
+
+def test_gate_retains_finite_negative_kl_estimates():
+    a, b = _row(UNIT_A, [1, 2, 3]), _row(UNIT_B, [3, 2, 1])
+    result = additivity_gate(_payload(a, b), ASSIGNMENT, -0.1,
+                             measured_kl_stderr=0.25)
+    assert result["measured_kl"] == -0.1
+
+
 @pytest.mark.parametrize("field", ["seed_base", "calibration_sha256", "producer_source_sha256"])
 def test_equal_length_joint_rows_from_different_measurements_refuse(field):
     a, b = _row(UNIT_A, [1, 2, 3]), _row(UNIT_B, [3, 2, 1])

--- a/tests/test_aura_cost.py
+++ b/tests/test_aura_cost.py
@@ -252,7 +252,7 @@ def test_per_probe_samples_align_and_reproduce_mean():
         assert abs(0.5 * sum(xs) / 6 - row["predicted_dloss"]) < 1e-12
 
 
-def test_additivity_gate_exact_correlated_stderr():
+def test_additivity_gate_legacy_correlated_stderr_has_unverified_alignment():
     import math
     from prismaquant.aura_additivity_gate import additivity_gate
 
@@ -262,7 +262,7 @@ def test_additivity_gate_exact_correlated_stderr():
         n_probes=8, min_free_gib=0.0, n_linear_chunks=1,
     )
     assignment = {n: "NVFP4" for n in payload["costs"]}
-    # Exact stderr must equal the std-of-per-probe-sums computed by hand.
+    # Preserve the legacy arithmetic, but array lengths are not probe identity.
     K = 8
     sums = [0.0] * K
     for n in payload["costs"]:
@@ -274,7 +274,8 @@ def test_additivity_gate_exact_correlated_stderr():
     expected_sum = 0.5 * mean_s
 
     out = additivity_gate(payload, assignment, measured_kl=expected_sum * 1.1)
-    assert out["stderr_method"] == "per_probe_exact"
+    assert out["stderr_method"] == "per_probe_unverified"
+    assert out["probe_alignment_verified"] is False
     assert abs(out["predicted_sum"] - expected_sum) < 1e-12
     assert abs(out["predicted_stderr"] - expected_stderr) < 1e-12
     assert abs(out["residual"] - 0.1 * expected_sum) < 1e-9

--- a/tests/test_joint_aura_assignment_diagnostics.py
+++ b/tests/test_joint_aura_assignment_diagnostics.py
@@ -1,0 +1,328 @@
+"""CPU scalar oracles for fixed-calibration assignment diagnostics.
+
+Synthetic complete rows exercise identity admission and paired arithmetic;
+these tests make no model-quality or serving-runtime claim.
+"""
+from __future__ import annotations
+
+import copy
+import math
+
+import pytest
+import torch
+
+from prismaquant import format_registry as fr
+from prismaquant import joint_aura as joint
+from prismaquant.cost_streaming import STREAMED_MODEL_IDENTITY_SCHEMA
+
+
+UNIT_A = "model.layers.0.mlp.down_proj"
+UNIT_B = "model.layers.7.mlp.down_proj"
+SCOPE = "probe_sampling_conditional_on_fixed_calibration"
+OBJECTIVES = ("additive", "joint_quadratic")
+
+
+def _row(name, signed, *, fmt="FP8_E4M3"):
+    # The allocator currency fixture runs a model to build rows. These scalar
+    # oracles instead use the same complete row builder and identity contract.
+    source_content = {
+        "config": {"fixture": "assignment diagnostics"},
+        "weight_map": {"fixture.weight": "fixture.safetensors"},
+        "shards": [{"path": "/fixture/fixture.safetensors", "size": 1,
+                    "sha256": "a" * 64}],
+    }
+    source_model = {
+        "schema": STREAMED_MODEL_IDENTITY_SCHEMA, "source": "synthetic",
+        "resolved_commit": None, **source_content,
+        "content_sha256": joint.identity_sha256(source_content),
+    }
+    arithmetic = joint.arithmetic_identity(torch.float32)
+    probe = {
+        "schema": "prismaquant.joint_aura.probes.v1", "seed_base": 237000,
+        "n_probes": len(signed), "calibration_sha256": "c" * 64,
+        "producer_source_sha256": "d" * 64, "source_model": source_model,
+        "distribution": "rademacher", "normalization": "global_kl_fisher",
+        "temperature": 1.0, "arithmetic": arithmetic,
+    }
+    operator = {
+        "schema": "prismaquant.joint_aura.operator.v1", "qname": name,
+        "format": fmt, "probe_identity_sha256": joint.identity_sha256(probe),
+        "source_weight": {
+            "content_sha256": joint.identity_sha256({"source": name}),
+            "shape": [2, 2], "dtype": "torch.float32", "logical_bytes": 16,
+        },
+        "rendered_weight": {
+            "content_sha256": joint.identity_sha256({"render": name, "format": fmt}),
+            "shape": [2, 2], "dtype": "torch.float32", "logical_bytes": 16,
+        },
+        "activation": joint.activation_identity(fr.get_format(fmt), {}, name),
+        "arithmetic": arithmetic,
+    }
+    return joint.make_joint_aura_entry(
+        operator_identity=operator, probe_identity=probe,
+        signed_components=[dict(weight=float(x), activation=0.0, mixed=0.0,
+                                total=float(x)) for x in signed],
+    )
+
+
+def _rebuild(row, *, operator_change=None, probe_change=None):
+    """Re-sign changed identities so pairing, not a stale digest, must refuse."""
+    operator = copy.deepcopy(row["joint_operator_identity"])
+    probe = copy.deepcopy(row["probe_identity"])
+    if operator_change:
+        operator_change(operator)
+    if probe_change:
+        probe_change(probe)
+    operator["probe_identity_sha256"] = joint.identity_sha256(probe)
+    operator["arithmetic"] = copy.deepcopy(probe["arithmetic"])
+    return joint.make_joint_aura_entry(
+        operator_identity=operator, probe_identity=probe,
+        signed_components=copy.deepcopy(row["signed_components_per_probe"]),
+    )
+
+
+@pytest.mark.parametrize("objective", OBJECTIVES)
+def test_single_unit_summary_and_pair_match_independent_samples(objective):
+    a = _row(UNIT_A, [2, 4, -6])
+    b = _row(UNIT_A, [1, -3, 5], fmt="FP8_E5M2")
+    summary = joint.assignment_probe_summary({UNIT_A: a}, objective=objective)
+    assert summary["per_probe"] == [2.0, 8.0, 18.0]
+    assert summary["mean"] == pytest.approx(28 / 3)
+    assert summary["standard_error"] == pytest.approx(14 / 3)
+    assert summary["probe_ids"] == [237000, 237001, 237002]
+    assert summary["probe_identity_sha256"] == a["probe_identity_sha256"]
+    paired = joint.paired_assignment_difference({UNIT_A: a}, {UNIT_A: b},
+                                              objective=objective)
+    legacy = joint.paired_candidate_difference(a, b)
+    for field in ("mean_difference", "paired_standard_error", "difference_per_probe"):
+        assert paired[field] == pytest.approx(legacy[field])
+    assert paired["difference_per_probe"] == [1.5, 3.5, 5.5]
+    assert paired["paired_standard_error"] == pytest.approx(2 / math.sqrt(3))
+    assert paired["uncertainty_scope"] == SCOPE
+
+
+@pytest.mark.parametrize("objective", OBJECTIVES)
+def test_pair_preserves_common_probe_covariance(objective):
+    a = _row(UNIT_A, [5, 4, -5, -4])
+    b = _row(UNIT_A, [3, 0, 3, 0], fmt="FP8_E5M2")
+    assert a["predicted_dloss_stderr"] > 0
+    assert b["predicted_dloss_stderr"] > 0
+    result = joint.paired_assignment_difference({UNIT_A: a}, {UNIT_A: b},
+                                              objective=objective)
+    assert result["difference_per_probe"] == [8.0] * 4
+    assert result["mean_difference"] == 8.0
+    assert result["paired_standard_error"] == 0.0
+
+
+def test_interunit_cancellation_keeps_objectives_distinct():
+    rows = {UNIT_A: _row(UNIT_A, [2, -4, 6]),
+            UNIT_B: _row(UNIT_B, [-2, 4, -6])}
+    additive = joint.assignment_probe_summary(rows, objective="additive")
+    quadratic = joint.assignment_probe_summary(rows, objective="joint_quadratic")
+    assert additive["per_probe"] == [4.0, 16.0, 36.0]
+    assert additive["mean"] == pytest.approx(56 / 3)
+    assert additive["standard_error"] == pytest.approx(28 / 3)
+    assert quadratic["per_probe"] == [0.0] * 3
+    assert quadratic["mean"] == quadratic["standard_error"] == 0.0
+    assert joint.assignment_probe_summary(rows) == additive
+
+
+def test_unchanged_unit_remains_in_joint_quadratic_cross_terms():
+    background = _row(UNIT_B, [10, 10, 10])
+    a = {UNIT_A: _row(UNIT_A, [-1, 0, 1]), UNIT_B: background}
+    b = {UNIT_A: _row(UNIT_A, [1, 0, -1], fmt="FP8_E5M2"),
+         UNIT_B: copy.deepcopy(background)}
+    additive = joint.paired_assignment_difference(a, b, objective="additive")
+    quadratic = joint.paired_assignment_difference(a, b, objective="joint_quadratic")
+    assert additive["difference_per_probe"] == [0.0] * 3
+    assert quadratic["difference_per_probe"] == [-20.0, 0.0, 20.0]
+    assert quadratic["mean_difference"] == 0.0
+    assert quadratic["paired_standard_error"] == pytest.approx(20 / math.sqrt(3))
+    assert joint.paired_assignment_difference(a, b) == additive
+
+
+def test_close_swap_is_not_erased_by_rounding_large_background_totals():
+    background = _row(UNIT_B, [1e16, 1e16, 1e16])
+    a = {UNIT_A: _row(UNIT_A, [1, 2, 3]), UNIT_B: background}
+    b = {UNIT_A: _row(UNIT_A, [0, 0, 0], fmt="FP8_E5M2"), UNIT_B: background}
+    # Rounded full-assignment totals coincide; subtract local contributions
+    # before the background sum to preserve the actual close-swap samples.
+    assert joint.paired_assignment_difference(a, b)["difference_per_probe"] == [0.5, 2.0, 4.5]
+    quadratic = joint.paired_assignment_difference(a, b, objective="joint_quadratic")
+    assert quadratic["difference_per_probe"] == pytest.approx([1e16, 2e16, 3e16])
+
+
+@pytest.mark.parametrize("objective", OBJECTIVES)
+def test_unchanged_assignment_has_zero_paired_uncertainty(objective):
+    rows = {UNIT_A: _row(UNIT_A, [-2, 3, 5]), UNIT_B: _row(UNIT_B, [1, 4, -6])}
+    result = joint.paired_assignment_difference(rows, copy.deepcopy(rows), objective=objective)
+    assert result["difference_per_probe"] == [0.0] * 3
+    assert result["mean_difference"] == result["paired_standard_error"] == 0.0
+    assert result["uncertainty_scope"] == SCOPE
+
+
+@pytest.mark.parametrize("objective", OBJECTIVES)
+def test_mapping_order_is_irrelevant_and_inputs_are_not_mutated(objective):
+    a = {UNIT_A: _row(UNIT_A, [-2, 3, 5]), UNIT_B: _row(UNIT_B, [1, 4, -6])}
+    b = {UNIT_A: _row(UNIT_A, [2, 1, 4], fmt="FP8_E5M2"),
+         UNIT_B: _row(UNIT_B, [-3, 2, 1], fmt="FP8_E5M2")}
+    before = copy.deepcopy((a, b))
+    reversed_a, reversed_b = dict(reversed(a.items())), dict(reversed(b.items()))
+    assert joint.assignment_probe_summary(a, objective=objective) == joint.assignment_probe_summary(
+        reversed_a, objective=objective)
+    assert joint.paired_assignment_difference(a, b, objective=objective) == joint.paired_assignment_difference(
+        reversed_a, reversed_b, objective=objective)
+    assert (a, b) == before
+
+
+@pytest.mark.parametrize("objective", OBJECTIVES)
+def test_paired_assignments_require_same_complete_unit_roster(objective):
+    a = {UNIT_A: _row(UNIT_A, [1, 2, 3]), UNIT_B: _row(UNIT_B, [4, 5, 6])}
+    with pytest.raises(ValueError):
+        joint.paired_assignment_difference(a, {UNIT_A: a[UNIT_A]}, objective=objective)
+
+
+@pytest.mark.parametrize("mutation", ["source", "render", "activation"])
+def test_rehashed_unchanged_format_identity_changes_are_refused(mutation):
+    a = _row(UNIT_A, [1, 2, 3])
+    def change(operator):
+        if mutation == "activation":
+            operator["activation"]["activation_max_abs"] = 7.0
+        else:
+            operator["source_weight" if mutation == "source" else "rendered_weight"]["content_sha256"] = "e" * 64
+    b = _rebuild(a, operator_change=change)
+    assert joint.validate_joint_aura_entry(b)
+    with pytest.raises(ValueError):
+        joint.paired_assignment_difference({UNIT_A: a}, {UNIT_A: b})
+
+
+def test_changed_format_does_not_allow_different_source_weight():
+    a = _row(UNIT_A, [1, 2, 3])
+    b = _rebuild(_row(UNIT_A, [3, 2, 1], fmt="FP8_E5M2"),
+                 operator_change=lambda op: op["source_weight"].update(content_sha256="e" * 64))
+    assert joint.validate_joint_aura_entry(b)
+    with pytest.raises(ValueError):
+        joint.paired_assignment_difference({UNIT_A: a}, {UNIT_A: b})
+
+
+@pytest.mark.parametrize("mutation", ["seed", "calibration", "arithmetic", "source_model"])
+def test_rehashed_probe_contract_mismatches_fail_within_and_between_assignments(mutation):
+    def change(probe):
+        if mutation == "seed":
+            probe["seed_base"] += 1
+        elif mutation == "calibration":
+            probe["calibration_sha256"] = "e" * 64
+        elif mutation == "arithmetic":
+            probe["arithmetic"]["measurement_dtype"] = "torch.bfloat16"
+        else:
+            model = probe["source_model"]
+            model["config"]["revision"] = "different"
+            model["content_sha256"] = joint.identity_sha256(
+                {key: model[key] for key in ("config", "weight_map", "shards")})
+    a = _row(UNIT_A, [1, 2, 3])
+    b = _rebuild(_row(UNIT_B, [4, 5, 6]), probe_change=change)
+    assert joint.validate_joint_aura_entry(b)
+    with pytest.raises(ValueError):
+        joint.assignment_probe_summary({UNIT_A: a, UNIT_B: b})
+    changed_a = _rebuild(_row(UNIT_A, [3, 2, 1], fmt="FP8_E5M2"), probe_change=change)
+    with pytest.raises(ValueError):
+        joint.paired_assignment_difference({UNIT_A: a}, {UNIT_A: changed_a})
+
+
+@pytest.mark.parametrize("mutation", ["missing_probe", "permuted_probes", "duplicate_probe",
+                                     "currency", "signed_component", "loss", "operator_digest"])
+def test_both_diagnostics_apply_complete_joint_row_validation(mutation):
+    good = _row(UNIT_A, [1, 2, 3])
+    bad = copy.deepcopy(good)
+    if mutation == "missing_probe":
+        bad["probe_ids"].pop()
+    elif mutation == "permuted_probes":
+        bad["probe_ids"].reverse()
+    elif mutation == "duplicate_probe":
+        bad["probe_ids"][1] = bad["probe_ids"][0]
+    elif mutation == "currency":
+        bad["cost_currency"] = "output_mse"
+    elif mutation == "signed_component":
+        bad["signed_components_per_probe"][0]["mixed"] = 1.0
+    elif mutation == "loss":
+        bad["predicted_dloss"] += 1.0
+    else:
+        bad["joint_operator_identity_sha256"] = "f" * 64
+    with pytest.raises(ValueError):
+        joint.assignment_probe_summary({UNIT_A: bad})
+    with pytest.raises(ValueError):
+        joint.paired_assignment_difference({UNIT_A: good}, {UNIT_A: bad})
+
+
+def test_mapping_coordinates_must_match_operator_qname():
+    row = _row(UNIT_A, [1, 2, 3])
+    with pytest.raises(ValueError):
+        joint.assignment_probe_summary({UNIT_B: row})
+    with pytest.raises(ValueError):
+        joint.paired_assignment_difference({UNIT_B: row}, {UNIT_B: copy.deepcopy(row)})
+
+
+def test_empty_assignments_cannot_publish_zero_uncertainty():
+    with pytest.raises(ValueError):
+        joint.assignment_probe_summary({})
+    with pytest.raises(ValueError):
+        joint.paired_assignment_difference({}, {})
+
+
+@pytest.mark.parametrize("objective", ["weight_only", "", None])
+def test_unsupported_objective_refuses_instead_of_silently_mixing_costs(objective):
+    rows = {UNIT_A: _row(UNIT_A, [1, 2, 3])}
+    with pytest.raises(ValueError):
+        joint.assignment_probe_summary(rows, objective=objective)
+    with pytest.raises(ValueError):
+        joint.paired_assignment_difference(rows, rows, objective=objective)
+
+
+@pytest.mark.parametrize("consumer", ["summary", "assignment_pair", "candidate_pair"])
+def test_probe_pairing_requires_canonical_identity_not_python_numeric_equality(consumer):
+    a = _row(UNIT_A, [1, 2, 3])
+    name = UNIT_B if consumer == "summary" else UNIT_A
+    b = _rebuild(_row(name, [3, 2, 1], fmt="FP8_E5M2"),
+                 probe_change=lambda probe: probe.update(temperature=True))
+    # JSON true and 1.0 are distinct recorded identities, although Python's
+    # nested equality treats them as equal. Both rows pass local validation.
+    assert joint.validate_joint_aura_entry(b)
+    assert a["probe_identity"] == b["probe_identity"]
+    assert a["probe_identity_sha256"] != b["probe_identity_sha256"]
+    with pytest.raises(ValueError):
+        if consumer == "summary":
+            joint.assignment_probe_summary({UNIT_A: a, UNIT_B: b})
+        elif consumer == "assignment_pair":
+            joint.paired_assignment_difference({UNIT_A: a}, {UNIT_A: b})
+        else:
+            joint.paired_candidate_difference(a, b)
+
+
+def test_same_candidate_requires_canonical_operator_identity():
+    a = _rebuild(_row(UNIT_A, [1, 2, 3]), operator_change=lambda op:
+                 op["activation"].update(clip_enabled=True))
+    b = _rebuild(a, operator_change=lambda op: op["activation"].update(clip_enabled=1))
+    assert joint.validate_joint_aura_entry(a)
+    assert joint.validate_joint_aura_entry(b)
+    assert a["probe_identity_sha256"] == b["probe_identity_sha256"]
+    assert a["joint_operator_identity"] == b["joint_operator_identity"]
+    assert a["joint_operator_identity_sha256"] != b["joint_operator_identity_sha256"]
+    with pytest.raises(ValueError):
+        joint.paired_assignment_difference({UNIT_A: a}, {UNIT_A: b})
+
+
+@pytest.mark.parametrize("objective", OBJECTIVES)
+def test_pair_retains_small_residual_across_large_cancelling_unit_changes(objective):
+    unit_c = "model.layers.21.mlp.down_proj"
+    names = [UNIT_A, UNIT_B, unit_c]
+    a = {name: _row(name, [value] * 3)
+         for name, value in zip(names, [1e16, -1e16, 1.0])}
+    b = {name: _row(name, [value] * 3, fmt="FP8_E5M2")
+         for name, value in zip(names, [0.0, -1e16, 1e16])}
+    # Additive: .5 * (1e32 + 1e32 + 1 - 0 - 1e32 - 1e32) = .5.
+    # Joint quadratic: .5 * (1**2 - 0**2) = .5. Subtracting
+    # rounded unit totals first loses the 1 in either expression.
+    result = joint.paired_assignment_difference(a, b, objective=objective)
+    assert result["difference_per_probe"] == [0.5] * 3
+    assert result["mean_difference"] == 0.5
+    assert result["paired_standard_error"] == 0.0


### PR DESCRIPTION
## Tracked issue

Closes #257. References #237; #237 remains open.

## Change

The additivity report previously labeled equal-length arrays `per_probe_exact` even when they came from different probes, calibration, source or rendered operators. Complete joint rows now pass the shared row validator and canonical identity checks before covariance is reported as aligned. Legacy arrays retain their numeric diagnostic with an explicit unverified label; the independence estimate is no longer called a lower bound.

Add validated assignment summaries and paired A-minus-B diagnostics to the existing joint AURA module and additivity report CLI. The objective explicitly distinguishes additive unary loss from the quadratic of summed signed projections. Both arms retain the same unit roster and source weights while each format binds its own actual render and activation operator. Signed summation preserves small residuals across large cancelling changes. Probe SE conditional on fixed calibration stays separate from supplied held-out sequence uncertainty.

This adds no allocator refinement, cache, model experiment, quality-gain claim or serving admission. Historical bare-list screens remain unverified by this contract.

## Validation

All execution went through published PrismaBuild, CPU only with CUDA hidden, one CPU / 4 GiB per test shard and native threads bounded to one. PB owned sharding and placement on the existing GB10 dependency environment.

- Genuine RED: 37 failures, including five behavioral gate regressions (`ff4b4d8d6a68`).
- First focused GREEN: 100 passed across six files, no skips.
- Review RED: six intended canonical-identity and numerical-cancellation failures (`9c8673e2ede7`).
- Final affected-file GREEN: 66 passed across the two new diagnostic files and streamed integration tests; the earlier 40 legacy/docs checks were unaffected. Both source modules compiled successfully (`3ae6862321db`).

Terminal exits, stdout, resource cleanup and actual CAS hashes were checked. The first x86 attempt failed collection for missing `compressed_tensors` and was not counted as RED. Three unused external calibration symlinks were temporarily omitted from isolated snapshots and restored before commit. Rebased onto main `3cb0d359`; architecture provenance insertions retain the preparation and row-count changes. Integration review also rejects nonfinite measured KL and negative/nonfinite supplied standard errors while retaining finite negative sample estimates. Five invalid-domain tests reproduced the original bug; the affected gate and legacy AURA files then passed 40 tests, no skips, using two PB-admitted CPU workers (action `3b99832b56d0`). Actual payloads were independently read and rehashed. Broad GitHub CPU CI has not completed and is not claimed green.

Exact commands and receipts: `docs/measurements/pq257-paired-diagnostics-2026-09-06.md`, backed by `/home/rob/tessera-runs/pq237-paired-diagnostics-receipts-2026-09-06/`.
