### PR TITLE
Preserve static activation scales in transient Tessera anchors

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,16 @@
 As of: 2026-09-05 · `codex/pq183-tessera-reader`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-06, `codex/pq262-static-anchor`) for streamed static
+activation calibration (#262). `_render_dense_layer` uses the resident cache's
+resolved-format predicate `_formats_need_static_activation_max`, including
+Tessera-only A4 plans. Native NVFP4 weight-global derivation remains separate.
+Sparse transient requests calibrate the complete planned layer scope and unify
+fused-sibling maxima before scoring any member, so render batching/order cannot
+change the activation identity consumed by joint AURA. Existing calibration,
+source, render-lever and transient-consumer bindings remain required; no new
+cache, serving route, numerical promotion or production default is introduced.
+
 Re-stamped (2026-09-06, `codex/lfm-mixed-preparation`) for the opt-in
 LFM full-body mixed-family sanity input preparation (#253). The producer's
 source classification and fusion roster define 22 E4M3 routed stacks, six

--- a/docs/measurements/static-anchor-scales-2026-09-06.md
+++ b/docs/measurements/static-anchor-scales-2026-09-06.md
@@ -66,3 +66,27 @@ Both use the known producer container image
 with four CPUs, one GPU and 16 GiB reserved through PB; actual terminal results
 must be checked separately. At this record's creation neither had completed.
 No GPU correctness, served quality, performance or promotion result is claimed.
+
+## Follow-up: GPU fixture provenance and documentation checks
+
+The GPU baseline action
+`d06916b9c894f63d2f167af216d0ca0f471dacf8540a23e5a389782debd28cfd`
+finished with exit 1: four failures, no skips. Its two CPU failures reproduce
+missing static activation maxima. Its two CUDA cases instead stopped earlier:
+`HessianContractError`: activation rows were supplied without the
+`tessera_hessian_identity` lever. This is a missing input in the new test fixture,
+not evidence of the activation-scale defect on the real GPU renderer.
+The fixture now supplies provenance through the existing `calibration_identity`
+helper for its synthetic four-row capture. Hessian-aware rendering remains on.
+The corrected container regression action is
+`a8430eb1534c8648a7339a7ad5faf7089cf67f6c1e2af39738d1fb119148748c`;
+its result remains pending. The earlier container action60172 is retained as
+an attempt using the incomplete fixture, not substituted as corrected evidence.
+
+Documentation checks on the implementation commit, action
+`2c8fa21586f804eea450cf8da5400c5a0c6d2afcbbc739163f32b1486d31b6bf`,
+finished exit 0: **19 passed, zero skips**, 4.55 seconds pytest time, four workers,
+CPU-only on sparky. Files: `tests/test_docs_staleness.py` and
+`tests/test_architecture_doc.py`. No collection errors. Same host dependency
+warnings noted above. Independently verified output CAS SHA-256:
+`6008ddc2d64c7bfbbe8e5f8aff433406991ebe36997eb442ed98dca7899a4f28`.

--- a/docs/measurements/static-anchor-scales-2026-09-06.md
+++ b/docs/measurements/static-anchor-scales-2026-09-06.md
@@ -1,0 +1,68 @@
+# Static activation scales in transient anchors — CPU regression evidence
+
+Issue: #262. Source base: `3cb0d359`. Tessera development pin:
+`ba582d476a3b6db9057ebd1385dc52926f171451` (unchanged).
+
+A Tessera-only static A4 plan previously reached production scoring without a
+calibrated activation maximum. The shared streamed renderer now asks the existing
+resolved-format predicate whether static maxima are required, and gathers them
+across the planned layer's fused siblings even for one-sibling transient requests.
+Native NVFP4 weight-global computation keeps its independent native-format guard.
+
+## Verified CPU evidence
+
+PrismaBuild ran four pytest-xdist workers with `--dist worksteal --durations=15
+-ra`, native math threads bounded to one, four CPUs and 12 GiB reserved. Worker:
+`sparky`, aarch64, Python 3.12, cu130 environment with CUDA hidden by CPU admission.
+
+Before the fix, action
+`584abc9a2d6f755c48540d3d5ef901c9a319dec1036dc8dce55b661f760cc419`
+exited 1: **2 failed, 2 skipped**. Both batched and one-sibling cases failed with:
+
+```text
+ActivationScaleContractError: production cache render score @ TESSERA_E2M1_K1_R768:
+'model.layers.0.self_attn.q_proj' is served under the static
+e2m1_group16_ue4m3_static activation contract but has no calibrated activation
+maximum (got None); refusing to price it under a dynamic quantiser the runtime
+never executes.
+```
+
+After the fix, action
+`558d5bfb93ff975bd3324491dadc4aa912cb989e1da39af372ce8d0c490400e3`
+exited 0: **19 passed, 2 skipped**, 8.38 seconds pytest time. Files:
+`tests/test_streaming_static_activations.py` and
+`tests/test_streamed_cost_checkpoints.py`. No collection errors were reported.
+Both skips: `real Tessera anchor render needs CUDA`.
+The CPU cases stub weight rendering only; static activation quantization,
+production scoring and joint identity use their real implementations. Existing
+checkpoint tests cover replay and identity refusal.
+
+The output CAS payload was independently SHA-256 verified:
+`37fbf2d78c375b02571b1c1bd51dcf8ef9239302e439be768cf761b13db4c678`.
+Logs and receipts are retained under
+`/mnt/shared/tessera-runs/issue-queue-receipts/<action-key>.{log,receipt.json}`.
+The scoped test-plugin installation reported existing llmcompressor dependency
+conflicts with host Torch 2.11.0+cu130 and Transformers 5.6.0; this result is the
+bounded CPU regression population, not qualification of that host environment.
+
+PB snapshots materialized the three tracked external calibration symlinks with
+identical verified target bytes, then restored the original symlinks. None of
+those materializations is committed. Their snapshot hashes are:
+
+| Calibration file | SHA-256 |
+| --- | --- |
+| diverse-v1.jsonl | e09a138a4903c4af66a3bf2f9367185f3432224391f1dfe8c94ccc29d99315ba |
+| xdom-fit-v1.jsonl | 8425e172ee00a85c92795c6350c862de5c0c6f0b9d16b323c1fd4551d8b11058 |
+| xdom-gate-v1.jsonl | d44ce5d5f8f263cd37c3c028528c08f5ca8a6960aaa698e225d6e56f18ccbc05 |
+
+## Pending GPU evidence
+
+Corrected regression/checkpoint action:
+`60172adc2c4d5f5efc126db42df1786aab4a8b2d61cdf626df7ddff0ceb51ddc`.
+Existing streaming/resident parity action:
+`367511b949336a23b9f239c5c683ae64be47d114b21236f2b7629a834fe69dc7`.
+Both use the known producer container image
+`sha256:cf3f7f83e6820fa75aae249393e8fa4840af4562192203a1aed3f2082f3ea2f9`,
+with four CPUs, one GPU and 16 GiB reserved through PB; actual terminal results
+must be checked separately. At this record's creation neither had completed.
+No GPU correctness, served quality, performance or promotion result is claimed.

--- a/prismaquant/streaming_production_cache.py
+++ b/prismaquant/streaming_production_cache.py
@@ -54,6 +54,7 @@ from prismaquant.production_weight_cache import (
     _canonical_rendered_weight_tensor,
     _cb_cache_tensor_identity,
     _fused_sibling_leaf_mapping_from_profile,
+    _formats_need_static_activation_max,
     _render_base_format,
     _render_score_record,
     _render_score_record_key,
@@ -334,17 +335,18 @@ def _render_dense_layer(
         for f in fmts
     }
     needs_nvfp4 = "NVFP4" in render_base_fmts
+    needs_static_activation_max = _formats_need_static_activation_max(render_base_fmts)
+    joint_scope = (
+        dict(joint_scale_modules)
+        if joint_scale_modules is not None
+        else qname_to_module
+    )
 
     # Joint fused-sibling NVFP4 global (max across q/k/v or gate/up). Restricted
     # to this layer's non-BF16 dense qnames; siblings are co-resident. The
     # synthetic all-NVFP4 assignment matches the resident derivation.
     joint_globals: dict[str, torch.Tensor] = {}
     if needs_nvfp4:
-        joint_scope = (
-            dict(joint_scale_modules)
-            if joint_scale_modules is not None
-            else qname_to_module
-        )
         joint_globals = _compute_nvfp4_joint_global(
             model,
             {q: "NVFP4" for q in joint_scope},
@@ -352,11 +354,13 @@ def _render_dense_layer(
         )
 
     # Per-Linear calibrated max_abs, unified (max) across fused sibling groups
-    # — reproduces the resident block; the value drives only the export
-    # activation scale (metadata), never the rendered weight.
-    if needs_nvfp4:
+    # — the resolved static activation contract owns this requirement, even
+    # when no native NVFP4 weight is requested (#262). A transient request may
+    # render one sibling at a time; calibrate the complete planned layer scope
+    # so its scale identity does not depend on request order or batching.
+    if needs_static_activation_max:
         per_qname_max_abs: dict[str, float] = {}
-        for qname in qname_to_module:
+        for qname in joint_scope:
             canonical = resolve_cost_target_name(qname, act_index, profile)
             if canonical not in act_index:
                 continue

--- a/tests/test_streaming_static_activations.py
+++ b/tests/test_streaming_static_activations.py
@@ -1,0 +1,87 @@
+"""Static activation identity survives sparse, transient production renders."""
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from prismaquant import format_registry as fr
+from prismaquant.joint_aura import activation_identity
+from prismaquant.model_profiles.default import DefaultProfile
+from prismaquant.streaming_production_cache import StreamedProductionAnchorRenderer
+from test_streamed_cost_checkpoints import _model_identity
+
+
+@pytest.mark.parametrize('one_at_a_time', [False, True])
+@pytest.mark.parametrize('device', ['cpu', pytest.param('cuda', marks=pytest.mark.skipif(
+    not torch.cuda.is_available(), reason='real Tessera anchor render needs CUDA'))])
+def test_tessera_only_transient_anchor_keeps_fused_static_identity(
+        monkeypatch, one_at_a_time, device):
+    import prismaquant.streaming_production_cache as streaming
+    import prismaquant.export_native_compressed as export
+
+    fmt = 'TESSERA_E2M1_K1_R768'
+    spec = fr.get_format(fmt)
+    assert spec.static_activation_contract.measured_as_served
+    model = nn.Module()
+    model.model = nn.Module()
+    model.model.config = SimpleNamespace(layer_types=())
+    layer = nn.Module()
+    layer.self_attn = nn.Module()
+    model.model.layers = nn.ModuleList([layer])
+    modules = {}
+    maxima = {}
+    for leaf, maximum in [('q_proj', 2.0), ('k_proj', 8.0), ('v_proj', 4.0)]:
+        module = nn.Linear(256, 16, bias=False, device=device)
+        setattr(layer.self_attn, leaf, module)
+        name = 'model.layers.0.self_attn.' + leaf
+        modules[name] = module
+        maxima[name] = maximum
+    profile = DefaultProfile()
+    assert len({profile.fused_sibling_group(name) for name in modules}) == 1
+
+    class Activations:
+        def __contains__(self, name):
+            return name in maxima
+
+        def load_with_row_indices(self, name):
+            return torch.full((4, 256), maxima[name]), None
+
+    # The CPU arm isolates activation plumbing; the GPU arm uses the actual
+    # Tessera weight renderer and the same static activation scoring oracle.
+    if device == 'cpu':
+        monkeypatch.setattr(streaming, 'render_production_weight',
+                            lambda weight, *_args, **_kwargs: weight.detach().clone())
+    def refuse_native_weight_globals(*_args, **_kwargs):
+        raise AssertionError('Tessera-only plan requested native NVFP4 weight globals')
+    monkeypatch.setattr(export, '_compute_nvfp4_joint_global', refuse_native_weight_globals)
+    consumer = {'schema': 'test.static-anchor-consumer.v1'}
+    plan = {name: (fmt,) for name in modules}
+    renderer = StreamedProductionAnchorRenderer(
+        model, act_index=Activations(), formats_by_qname=plan,
+        levers={'gptq': False, 'joint_scale_opt': False}, profile=profile,
+        device=device, col_weights={}, cb_serialization_context=None,
+        calibration_hash='c' * 64, arm_identity={'arm': 'static-anchor-regression'},
+        model_identity=_model_identity('static-anchor-source'), max_act_rows=4,
+        transient_consumer_identity=consumer,
+    )
+    expected_max = max(maxima.values())
+    expected_scale = spec.static_activation_contract.require_input_global_scale(
+        expected_max, qname=next(iter(modules)), consumer='test oracle')
+    identities = {}
+    def consume(**kwargs):
+        name = kwargs['qname']
+        identity = activation_identity(spec, renderer.cache.activation_max_abs, name)
+        assert identity['activation_max_abs'] == expected_max
+        assert identity['input_global_scale'] == expected_scale
+        assert kwargs['render_score']['activation_max_abs'] == expected_max
+        assert kwargs['render_score']['input_global_scale'] == expected_scale
+        identities[name] = identity
+        return {'consumed': True}
+    requests = [{name: plan[name]} for name in modules] if one_at_a_time else [plan]
+    for requested in requests:
+        renderer.render_layer_transient(
+            layer=0, modules=modules, formats_by_qname=requested,
+            consume_render=consume, consumer_identity=consumer)
+        assert renderer.cache.weights == {}
+    assert set(identities) == set(modules)

--- a/tests/test_streaming_static_activations.py
+++ b/tests/test_streaming_static_activations.py
@@ -7,6 +7,7 @@ from torch import nn
 
 from prismaquant import format_registry as fr
 from prismaquant.joint_aura import activation_identity
+from prismaquant.tessera_hessian import calibration_identity
 from prismaquant.model_profiles.default import DefaultProfile
 from prismaquant.streaming_production_cache import StreamedProductionAnchorRenderer
 from test_streamed_cost_checkpoints import _model_identity
@@ -59,7 +60,12 @@ def test_tessera_only_transient_anchor_keeps_fused_static_identity(
     plan = {name: (fmt,) for name in modules}
     renderer = StreamedProductionAnchorRenderer(
         model, act_index=Activations(), formats_by_qname=plan,
-        levers={'gptq': False, 'joint_scale_opt': False}, profile=profile,
+        levers={
+            'gptq': False, 'joint_scale_opt': False,
+            'tessera_hessian_identity': calibration_identity(
+                'synthetic four-row fused-static-scale fixture',
+                [torch.arange(4)], fit_tokens=4),
+        }, profile=profile,
         device=device, col_weights={}, cb_serialization_context=None,
         calibration_hash='c' * 64, arm_identity={'arm': 'static-anchor-regression'},
         model_identity=_model_identity('static-anchor-source'), max_act_rows=4,


### PR DESCRIPTION
Tessera-only static A4 transient anchors previously reached scoring without a calibrated activation maximum and were refused. Reuse the shared resolved-format predicate and gather maxima across the complete planned fused-sibling group, so batched and one-sibling requests produce the same static scale identity. Native NVFP4 weight globals retain their separate guard.

PrismaBuild reproduced both regression cases failing before the fix. Corrected CPU validation passed 19 tests with two explicit CUDA skips, covering real static activation scoring/identity and existing streamed checkpoint behavior. The CPU arm substitutes only weight rendering; its CAS payload was independently verified. Exact actions, environment limitations and snapshot provenance are recorded in `docs/measurements/static-anchor-scales-2026-09-06.md`.

Keep draft: real Tessera GPU regression and existing streaming/resident parity runs are pending through PrismaBuild in the known producer container. No served quality, performance or promotion claim is made. The Tessera pin is unchanged.

Closes #262
