### PR TITLE
Drop the three tracked absolute symlinks under calibration/

### DIFF
--- a/calibration/diverse-v1.jsonl
+++ b/calibration/diverse-v1.jsonl
@@ -1,1 +1,0 @@
-/home/rob/dq-runs/calibration/diverse-v1.jsonl

--- a/calibration/xdom-fit-v1.jsonl
+++ b/calibration/xdom-fit-v1.jsonl
@@ -1,1 +1,0 @@
-/home/rob/dq-runs/calibration/xdom-fit-v1.jsonl

--- a/calibration/xdom-gate-v1.jsonl
+++ b/calibration/xdom-gate-v1.jsonl
@@ -1,1 +1,0 @@
-/home/rob/dq-runs/calibration/xdom-gate-v1.jsonl


### PR DESCRIPTION
Closes #268.

`calibration/{diverse-v1,xdom-fit-v1,xdom-gate-v1}.jsonl` were tracked symlinks into `/home/rob/dq-runs/calibration/` (from the 2026-08-26 wip tree import). The published PrismaBuild `pbrun` now refuses to seal a checkout whose link graph leaves the repository (`require_contained_snapshot_links`), so every PrismaQuant submission failed before admission. No module or test reads the repo-relative paths; the docs cite the absolute files directly, and the corpora stay where they are.

Verification: the same change rides the PR #265 run branch (`d4753373`), and with it the #253 GPU serving action `9a8ed64994787c825f7e0ee746cedbbd49c4d438e32c3b430e215284b2d5b9f5` was admitted by `pbrun` (queued, tags gb10/sparky). No test exercises these paths, so no test change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U62uoo3Nuxzsd4mMPHsmn