### PR TITLE
Fix the refill-order race in the cluster campaign CI, and say what the recovery failure is not (#244)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,20 +6,25 @@ follow, newest first, each recording its own branch and date.
 Re-stamped (2026-09-06, `claude/pq244-campaign-causality`) for **an exiting
 helper being the same helper** (§3.0; RobTand/prismaquant#244, P2). The #239
 contract above reads "a failed owner-environment read now rechecks process
-identity"; it treated every failed read alike. Linux does not: `do_exit` runs
-`exit_mm()` before `exit_notify()`, so a helper that is on its way out drops
-its address space -- `/proc/<pid>/environ` reads zero bytes -- while
-`/proc/<pid>/stat` still reports the recorded start time and a state that is
-not `Z`. The old code called that identity ambiguous and the campaign failed
-closed on a process it owned. Measured on this kernel (6.17.0-1032-nvidia),
-679 of 680 exiting children were judged ambiguous at least once during that
-window. `_proc_has_owner` is therefore split into `_proc_owner_observation`,
-which distinguishes an empty read from an absent, unreadable or
-differently-owned one, and exactly one cell of the `_owned_process_state`
-table changes: an empty read from a live process whose start time still
-matches is `owned`, not ambiguous. Absence, an unreadable or malformed read, a
-different owner token and a changed start time all remain ambiguous and still
-fail closed, and none of them authorizes killing that process. Two smaller
+identity"; it rechecked identity and then called a live one ambiguous anyway.
+Linux `do_exit` runs `exit_mm()` before `exit_notify()`, so a helper on its way
+out has released its address space while `/proc/<pid>/stat` still reports the
+recorded start time and a state that is not `Z`, and `/proc/<pid>/environ`
+stops being readable. Measured on this kernel (6.17.0-1032-nvidia): 199 of 200
+exiting children pass through that window, and all 2492 samples taken inside it
+read `EACCES`/`EPERM` -- never empty, never truncated -- with the recorded
+start time intact in every one. The old code read "I could not ask who owns
+this" as "somebody else owns this" and the campaign failed closed on a process
+it owned. `_proc_has_owner` is therefore split into `_proc_owner_observation`,
+which reports what the read established rather than a bare boolean, and the
+`_owned_process_state` rule is stated on the fact that decides it: field 19 of
+`/proc/<pid>/stat` establishes identity, and the owner token is a second check
+that can only ever fail to be *readable*. So a read that **failed** -- refused,
+empty or absent -- leaves a process whose recorded start time is intact
+`owned`, and the caller's existing bounded wait looks again. A **successful**
+read whose environment lacks the token is the one observation that establishes
+a different owner, and it still fails closed; so does a changed start time, and
+neither authorizes killing that process. Two smaller
 consequences: terminating a recorded owned process that has already ended
 reports success rather than failure -- there is nothing left to kill and the
 receipt is recoverable -- and `CampaignTerminalFailure` now names each

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,31 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-06 · `codex/pq262-static-anchor`. Stamps
+As of: 2026-09-06 · `claude/pq244-campaign-causality`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-06, `claude/pq244-campaign-causality`) for **an exiting
+helper being the same helper** (§3.0; RobTand/prismaquant#244, P2). The #239
+contract above reads "a failed owner-environment read now rechecks process
+identity"; it treated every failed read alike. Linux does not: `do_exit` runs
+`exit_mm()` before `exit_notify()`, so a helper that is on its way out drops
+its address space -- `/proc/<pid>/environ` reads zero bytes -- while
+`/proc/<pid>/stat` still reports the recorded start time and a state that is
+not `Z`. The old code called that identity ambiguous and the campaign failed
+closed on a process it owned. Measured on this kernel (6.17.0-1032-nvidia),
+679 of 680 exiting children were judged ambiguous at least once during that
+window. `_proc_has_owner` is therefore split into `_proc_owner_observation`,
+which distinguishes an empty read from an absent, unreadable or
+differently-owned one, and exactly one cell of the `_owned_process_state`
+table changes: an empty read from a live process whose start time still
+matches is `owned`, not ambiguous. Absence, an unreadable or malformed read, a
+different owner token and a changed start time all remain ambiguous and still
+fail closed, and none of them authorizes killing that process. Two smaller
+consequences: terminating a recorded owned process that has already ended
+reports success rather than failure -- there is nothing left to kill and the
+receipt is recoverable -- and `CampaignTerminalFailure` now names each
+terminal stage's attempt, its refusal detail and its worker log, so the next
+occurrence records why it stopped instead of only that it stopped. No default,
+stage graph, format menu, serving lane, ship gate or byte changes.
 
 Re-stamped (2026-09-06, `codex/pq262-static-anchor`) for streamed static
 activation calibration (#262). `_render_dense_layer` uses the resident cache's

--- a/prismaquant/cluster_campaign.py
+++ b/prismaquant/cluster_campaign.py
@@ -1331,14 +1331,18 @@ def _proc_owner_observation(pid: int, owner_token: str) -> str:
     ``no-address-space``
         The read succeeded and returned nothing.  A task keeps its environment
         inside its address space, so this says the task currently has none:
-        it was execed with an empty environment, or it is on its way out of
-        ``do_exit`` -- past the point where the address space is released and
-        before the point where the task becomes a zombie.  It is not evidence
-        that this pid now belongs to somebody else.
+        it was execed with an empty environment.
     ``other-owner``
-        An environment was read and the reserved token is not in it.
+        An environment was read and the reserved token is not in it.  This is
+        the only one of the five that establishes a *different* owner.
     ``unreadable``
         The read failed for some other reason, so nothing was established.
+        This is what an exiting helper looks like: past ``exit_mm()`` and
+        before ``exit_notify()``, ``/proc/<pid>/environ`` refuses with
+        ``PermissionError`` rather than returning nothing.  Measured on
+        6.17.0-1032-nvidia over 199 of 200 exiting children: every one of the
+        2492 samples inside that window read ``EACCES``/``EPERM``, none read
+        empty, and the recorded start time was intact in all of them.
     """
 
     try:
@@ -1365,33 +1369,38 @@ def _owned_process_state(pid: int, ticks: int, owner_token: str) -> str:
         observation = _proc_owner_observation(pid, owner_token)
         if observation == "owned":
             return "owned"
-        if observation in {"other-owner", "unreadable"}:
-            # Ownership is unestablished either way, and this guard is
-            # fail-closed.
+        if observation == "other-owner":
+            # An environment was read, in full, and the reserved token is not
+            # in it.  That is the one observation that establishes a different
+            # owner, and it still fails closed.
             return "mismatch"
-        # Exit can empty/remove environ after stat still showed a live helper,
-        # so look at the identity again.
+        # Every other observation is a read that *failed*, and a read that
+        # failed establishes nothing about who owns this pid -- least of all
+        # that somebody else does.  Ask the identity again instead.
         snapshot = _proc_snapshot(pid, strict=True)
     except (OSError, ValueError):
         return "mismatch"
     if snapshot is None or snapshot == (ticks, "Z"):
         return "gone"
-    if snapshot[0] == ticks and observation == "no-address-space":
+    if snapshot[0] == ticks:
         # The recorded start time still holds, so this IS the recorded process
-        # rather than a recycled pid, and what the empty environ says about it
-        # is that it has released its address space -- which a task does on its
-        # way out, before it becomes the zombie that would prove it ended.
-        # Nothing here proves this attempt ended, so it stays owned and the
-        # caller's bounded wait looks again; the zombie or the absence that
-        # does prove it is the next observation.  Calling this "mismatch"
-        # refused a recovery for watching its own helper exit.
+        # rather than a recycled pid: field 19 of `/proc/<pid>/stat` is what
+        # establishes identity here, and the owner token is a second check that
+        # can only ever fail to be *readable*.  Treating "I could not ask" as
+        # "the answer was no" is what refused a recovery for watching its own
+        # helper exit -- measured, on this kernel, as a `PermissionError` from
+        # `/proc/<pid>/environ` on every sample inside that window (2492 of
+        # 2492, identity unchanged in all of them) while the task is between
+        # `exit_mm()` and `exit_notify()`.  Nothing here proves the attempt
+        # ended, so it stays owned and the caller's bounded wait looks again;
+        # the zombie or the absence that does prove it is the next observation.
         #
         # Being wrong here is bounded and points the safe way: a pid recycled
-        # inside one clock tick, by a process carrying no environment at all,
-        # would be terminated at the recorded deadline rather than refused.
+        # inside one clock tick, by a process whose environment we cannot read
+        # at all, would be terminated at the recorded deadline rather than
+        # refused outright.
         return "owned"
-    # PID reuse, and an ``ESRCH`` that a live identity contradicts, stay
-    # ambiguous.
+    # PID reuse stays ambiguous.
     return "mismatch"
 
 

--- a/prismaquant/cluster_campaign.py
+++ b/prismaquant/cluster_campaign.py
@@ -1319,13 +1319,38 @@ def _proc_snapshot(pid: int, *, strict: bool = False) -> tuple[int, str] | None:
     return ticks, state
 
 
-def _proc_has_owner(pid: int, owner_token: str) -> bool:
+def _proc_owner_observation(pid: int, owner_token: str) -> str:
+    """Report what ``/proc/<pid>/environ`` establishes about ownership.
+
+    Four answers, because they are four different facts:
+
+    ``owned``
+        The reserved token is in the process environment.
+    ``no-process``
+        There is no process with this pid to ask.
+    ``no-address-space``
+        The read succeeded and returned nothing.  A task keeps its environment
+        inside its address space, so this says the task currently has none:
+        it was execed with an empty environment, or it is on its way out of
+        ``do_exit`` -- past the point where the address space is released and
+        before the point where the task becomes a zombie.  It is not evidence
+        that this pid now belongs to somebody else.
+    ``other-owner``
+        An environment was read and the reserved token is not in it.
+    ``unreadable``
+        The read failed for some other reason, so nothing was established.
+    """
+
     try:
         data = Path(f"/proc/{int(pid)}/environ").read_bytes()
+    except (FileNotFoundError, ProcessLookupError):
+        return "no-process"
     except OSError:
-        return False
+        return "unreadable"
+    if not data:
+        return "no-address-space"
     expected = f"{_RESERVED_OWNER_ENV}={owner_token}".encode("utf-8")
-    return expected in data.split(b"\0")
+    return "owned" if expected in data.split(b"\0") else "other-owner"
 
 
 def _owned_process_state(pid: int, ticks: int, owner_token: str) -> str:
@@ -1337,16 +1362,36 @@ def _owned_process_state(pid: int, ticks: int, owner_token: str) -> str:
             return "mismatch"
         if snapshot[1] == "Z":
             return "gone"
-        if _proc_has_owner(pid, owner_token):
+        observation = _proc_owner_observation(pid, owner_token)
+        if observation == "owned":
             return "owned"
-        # Exit can empty/remove environ after stat still showed a live helper.
-        # Only disappearance or a zombie with the same start time proves this
-        # attempt ended. PID reuse and unreadable state remain ambiguous.
+        if observation in {"other-owner", "unreadable"}:
+            # Ownership is unestablished either way, and this guard is
+            # fail-closed.
+            return "mismatch"
+        # Exit can empty/remove environ after stat still showed a live helper,
+        # so look at the identity again.
         snapshot = _proc_snapshot(pid, strict=True)
     except (OSError, ValueError):
         return "mismatch"
     if snapshot is None or snapshot == (ticks, "Z"):
         return "gone"
+    if snapshot[0] == ticks and observation == "no-address-space":
+        # The recorded start time still holds, so this IS the recorded process
+        # rather than a recycled pid, and what the empty environ says about it
+        # is that it has released its address space -- which a task does on its
+        # way out, before it becomes the zombie that would prove it ended.
+        # Nothing here proves this attempt ended, so it stays owned and the
+        # caller's bounded wait looks again; the zombie or the absence that
+        # does prove it is the next observation.  Calling this "mismatch"
+        # refused a recovery for watching its own helper exit.
+        #
+        # Being wrong here is bounded and points the safe way: a pid recycled
+        # inside one clock tick, by a process carrying no environment at all,
+        # would be terminated at the recorded deadline rather than refused.
+        return "owned"
+    # PID reuse, and an ``ESRCH`` that a live identity contradicts, stay
+    # ambiguous.
     return "mismatch"
 
 

--- a/prismaquant/cluster_campaign.py
+++ b/prismaquant/cluster_campaign.py
@@ -1322,7 +1322,7 @@ def _proc_snapshot(pid: int, *, strict: bool = False) -> tuple[int, str] | None:
 def _proc_owner_observation(pid: int, owner_token: str) -> str:
     """Report what ``/proc/<pid>/environ`` establishes about ownership.
 
-    Four answers, because they are four different facts:
+    Five answers, because they are five different facts:
 
     ``owned``
         The reserved token is in the process environment.
@@ -1412,8 +1412,9 @@ def _terminate_recorded_owned_process(pid: int, ticks: int, owner_token: str) ->
     the signal below already returns True.  Reading the same fact one moment
     earlier used to return False instead, and the caller turns False into
     `process was not killed`, a terminal stage failure.  Only an ownership that
-    was never established -- a recycled pid, another owner, an unreadable
-    `/proc` -- leaves the question open, and only that refuses.
+    was never established leaves the question open, and only that refuses: a
+    recycled pid, or an environment read in full that carries somebody else's
+    token.  A read that merely failed is not that -- see `_owned_process_state`.
     """
 
     state = _owned_process_state(pid, ticks, owner_token)

--- a/prismaquant/cluster_campaign.py
+++ b/prismaquant/cluster_campaign.py
@@ -1396,7 +1396,21 @@ def _owned_process_state(pid: int, ticks: int, owner_token: str) -> str:
 
 
 def _terminate_recorded_owned_process(pid: int, ticks: int, owner_token: str) -> bool:
-    if _owned_process_state(pid, ticks, owner_token) != "owned":
+    """Stop the recorded process; report whether it is definitely not running.
+
+    That is the question the callers ask, and an already-ended process answers
+    it as completely as a kill does -- which is why `ProcessLookupError` from
+    the signal below already returns True.  Reading the same fact one moment
+    earlier used to return False instead, and the caller turns False into
+    `process was not killed`, a terminal stage failure.  Only an ownership that
+    was never established -- a recycled pid, another owner, an unreadable
+    `/proc` -- leaves the question open, and only that refuses.
+    """
+
+    state = _owned_process_state(pid, ticks, owner_token)
+    if state == "gone":
+        return True
+    if state != "owned":
         return False
     try:
         os.killpg(pid, signal.SIGTERM)
@@ -1796,6 +1810,33 @@ def _ready_stages(
     return ready
 
 
+def _terminal_failure_report(
+    state: Mapping[str, object], terminal: Sequence[str]
+) -> str:
+    """Say why each terminal stage is terminal, in the exception itself.
+
+    A campaign that stops names the stages; what a reader needs is the
+    transition that stopped them.  That has always been recorded in the state
+    file's attempt `detail`, and a CI job that keeps only the traceback threw
+    it away -- twice, in #244, for a failure nobody could then account for.
+    """
+
+    parts: list[str] = []
+    for stage_id in terminal:
+        record = state["stages"][str(stage_id)]  # type: ignore[index]
+        attempts = record["attempts"]  # type: ignore[index]
+        if not attempts:
+            parts.append(f"{stage_id}: no attempt was recorded")
+            continue
+        attempt = attempts[-1]
+        detail = str(attempt["detail"]) or "(no detail recorded)"
+        parts.append(
+            f"{stage_id} attempt {attempt['number']}: {detail} "
+            f"(worker log: {attempt['log_path']})"
+        )
+    return "; ".join(parts)
+
+
 def _terminal_stage_ids(state: Mapping[str, object]) -> list[str]:
     return sorted(
         str(stage_id)
@@ -1900,7 +1941,8 @@ def run_campaign_v2(
                     )
                     terminal = _terminal_stage_ids(state)
                 raise CampaignTerminalFailure(
-                    f"campaign has terminal failed stages: {terminal}"
+                    f"campaign has terminal failed stages: {terminal}; "
+                    + _terminal_failure_report(state, terminal)
                 )
             if all(
                 record["status"] == "succeeded"

--- a/tests/test_cluster_campaign_runner.py
+++ b/tests/test_cluster_campaign_runner.py
@@ -95,6 +95,43 @@ def _wait_until(
         time.sleep(poll_interval)
 
 
+def _campaign_diagnosis(state_path: Path) -> str:
+    """Everything the state file and its attempt logs know about a failure.
+
+    `CampaignTerminalFailure` names the stages that stopped; the transition
+    that stopped them lives in the state file, and the worker's own account of
+    it lives in that attempt's log.  A CI job keeps neither.  #244 spent three
+    runs on a recovery failure that could not be accounted for because the only
+    surviving record was the traceback, so every campaign this file resumes
+    reports both when it fails.
+    """
+
+    try:
+        raw = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return f"state at {state_path} could not be read: {exc!r}"
+    lines = [f"state {state_path}:"]
+    for stage_id, record in sorted(raw.get("stages", {}).items()):
+        lines.append(f"  {stage_id}: status={record['status']}")
+        for attempt in record["attempts"]:
+            lines.append(
+                f"    attempt {attempt['number']}: status={attempt['status']} "
+                f"pid={attempt['pid']} start_ticks={attempt['pid_start_ticks']} "
+                f"detail={attempt['detail']!r}"
+            )
+            log = Path(str(attempt["log_path"]))
+            try:
+                text = log.read_text(encoding="utf-8", errors="replace")
+            except OSError as exc:
+                lines.append(f"      worker log {log} unreadable: {exc!r}")
+                continue
+            lines.append(f"      worker log {log}:")
+            lines.extend(
+                f"        {line}" for line in (text.splitlines() or ["(empty)"])
+            )
+    return "\n".join(lines)
+
+
 def _nonempty(path: Path) -> Callable[[], bool]:
     """Predicate for "this file exists *and* its bytes have landed".
 
@@ -938,9 +975,16 @@ def test_resume_after_coordinator_death_recovers_owned_helper_receipt(tmp_path):
                 ),
             )
 
-            state = campaign.run_campaign_v2(
-                manifest, state_path, poll_interval=0.02
-            )
+            try:
+                state = campaign.run_campaign_v2(
+                    manifest, state_path, poll_interval=0.02
+                )
+            except campaign.CampaignTerminalFailure as exc:
+                raise AssertionError(
+                    "the resume terminal-failed instead of adopting the "
+                    f"completed helper's work: {exc}\n"
+                    + _campaign_diagnosis(state_path)
+                ) from exc
 
             attempts = state["stages"]["slow-stage"]["attempts"]
             assert len(attempts) == 1, (
@@ -1225,6 +1269,37 @@ def test_a_live_process_with_no_environment_is_still_owned():
     )
 
 
+def test_terminating_a_process_that_already_ended_is_not_ambiguous():
+    """"Gone" answers "is the recorded process stopped?" -- it does not refuse.
+
+    A zombie is the deterministic way to ask: the process has ended, and its
+    pid cannot be recycled underneath the question while it stays unreaped.
+    `_recover_running_stages` turns a False here into a terminal stage failure,
+    so a helper that ended between the ownership check and the kill used to end
+    the campaign.
+    """
+
+    child = subprocess.Popen(
+        [sys.executable, "-c", ""],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    snapshot = campaign._proc_snapshot(child.pid)
+    assert snapshot is not None, "the child was reaped before it was recorded"
+    ticks = snapshot[0]
+    try:
+        _wait_until(
+            lambda: (campaign._proc_snapshot(child.pid) or (0, "Z"))[1] == "Z",
+            unmet="the child never became an unreaped zombie",
+        )
+        assert campaign._owned_process_state(child.pid, ticks, "owner") == "gone"
+        assert campaign._terminate_recorded_owned_process(
+            child.pid, ticks, "owner"
+        )
+    finally:
+        child.wait(timeout=_WEDGE_BACKSTOP_SECONDS)
+
+
 @pytest.mark.parametrize("state", ["S", "Z"])
 def test_recorded_process_pid_reuse_is_never_owned_or_killed(monkeypatch, state):
     monkeypatch.setattr(campaign, "_proc_snapshot", lambda *a, **kw: (43, state))
@@ -1312,7 +1387,13 @@ def test_ambiguous_recorded_pid_fails_closed_without_killing_it(
         os, "killpg", lambda *a: pytest.fail("ambiguous ownership must not be killed")
     )
 
-    with pytest.raises(campaign.CampaignTerminalFailure, match="ambiguous"):
+    # The message has to name the transition, not only the stage: "ambiguous"
+    # is also the stage id here, and a CI job that keeps the traceback and
+    # nothing else has to be able to explain the failure from it (#244).
+    with pytest.raises(
+        campaign.CampaignTerminalFailure,
+        match="recorded PID ownership is ambiguous",
+    ):
         campaign.run_campaign_v2(manifest, state_path, poll_interval=0.01)
 
     assert os.getpid() > 0

--- a/tests/test_cluster_campaign_runner.py
+++ b/tests/test_cluster_campaign_runner.py
@@ -549,12 +549,33 @@ def test_scheduler_refills_a_freed_host_while_another_host_is_active(tmp_path):
         poll_interval=0.01,
     )
 
-    waiting_attempt = state["stages"]["waiting-remote"]["attempts"]
-    assert len(waiting_attempt) == 1
-    refill_finished = state["stages"]["refill-local"]["attempts"][0][
-        "finished_unix_ns"
-    ]
-    assert waiting_attempt[0]["finished_unix_ns"] >= refill_finished
+    assert {row["status"] for row in state["stages"].values()} == {"succeeded"}
+    waiting_attempts = state["stages"]["waiting-remote"]["attempts"]
+    assert len(waiting_attempts) == 1
+    waiting_attempt = waiting_attempts[0]
+    refill_attempt = state["stages"]["refill-local"]["attempts"][0]
+
+    # The contract this test is named for: sparky was freed by fast-local and
+    # refilled with refill-local while sparklina was still running
+    # waiting-remote.  The gate is what proves it rather than the clock --
+    # waiting-remote's child cannot end before refill-local's child has written
+    # `gate.receipt`, so refill-local had to be running inside waiting-remote's
+    # attempt.  The coordinator writes all three timestamps itself, in that
+    # order, which is why reading them back is a fair record of it.
+    assert (
+        waiting_attempt["started_unix_ns"]
+        <= refill_attempt["started_unix_ns"]
+        <= waiting_attempt["finished_unix_ns"]
+    )
+
+    # And the order this test asserted until #244 is the one the protocol
+    # actually produces here.  A stage is recorded finished after its worker
+    # exits, and nothing in the protocol orders those two records: the refill
+    # child publishes its receipt while it is still alive, so the stage it
+    # released can finish first.  `release-refill` makes that happen every
+    # time, so a scheduler that stopped overlapping hosts would fail the
+    # assertion above rather than pass by winning a race here.
+    assert waiting_attempt["finished_unix_ns"] < refill_attempt["finished_unix_ns"]
 
 
 def test_bounded_retry_reuses_exact_receipt_gate(tmp_path):

--- a/tests/test_cluster_campaign_runner.py
+++ b/tests/test_cluster_campaign_runner.py
@@ -46,6 +46,13 @@ _WRITE_BYTES = (
 # ---------------------------------------------------------------------------
 
 _WEDGE_BACKSTOP_SECONDS = 120
+"""Last-resort bound on every cross-process wait and stage in this file.
+
+Not a budget for the work.  It answers only "the producer is wedged and nothing
+will ever satisfy this", so it sits far above anything a healthy run reaches --
+the slowest wait measured under load was 19.3s.  A healthy run never observes
+it; a run that does has found a real defect, and reports it as one.
+"""
 
 # How many helpers `test_an_exiting_helper_is_never_called_ambiguous` watches
 # exit.  This is a sample count, not a threshold: the test's verdict is decided
@@ -55,13 +62,6 @@ _WEDGE_BACKSTOP_SECONDS = 120
 # at least once, so twenty children leave a regression essentially nowhere to
 # hide while costing a few milliseconds each.
 _EXITING_HELPERS_WATCHED = 20
-"""Last-resort bound on every cross-process wait and stage in this file.
-
-Not a budget for the work.  It answers only "the producer is wedged and nothing
-will ever satisfy this", so it sits far above anything a healthy run reaches --
-the slowest wait measured under load was 19.3s.  A healthy run never observes
-it; a run that does has found a real defect, and reports it as one.
-"""
 
 
 def _wait_until(
@@ -1311,6 +1311,7 @@ def test_an_exiting_helper_is_never_called_ambiguous(tmp_path):
 
     token = "0" * 64
     verdicts: dict[str, int] = {"owned": 0, "gone": 0}
+    watched = 0
     for index in range(_EXITING_HELPERS_WATCHED):
         marker = tmp_path / f"exiting-{index}"
         environment = dict(os.environ)
@@ -1332,14 +1333,19 @@ def test_an_exiting_helper_is_never_called_ambiguous(tmp_path):
             snapshot = campaign._proc_snapshot(child.pid)
             if snapshot is None:  # pragma: no cover - the child beat the read
                 continue
+            watched += 1
             # Start watching where the recovery starts: the moment the helper's
             # receipt is on disk, which is the moment before it exits.
-            _wait_until(
-                lambda: marker.exists() and marker.stat().st_size > 0,
-                unmet="the helper never published its marker",
-                alive=lambda: child.poll() is None,
-            )
+            # Deliberately not `_wait_until`, and deliberately never
+            # `child.poll()`: `Popen.poll()` reaps an exited child, which
+            # removes `/proc/<pid>` and with it the exit window this test
+            # exists to sample.  The helper writes its marker before it exits,
+            # so the marker is the wait, and the backstop is the bound.
             backstop = time.monotonic() + _WEDGE_BACKSTOP_SECONDS
+            while not (marker.exists() and marker.stat().st_size > 0):
+                assert time.monotonic() < backstop, (
+                    f"helper {child.pid} never published its marker"
+                )
             while True:
                 assert time.monotonic() < backstop, (
                     f"helper {child.pid} never finished: {verdicts}"
@@ -1357,7 +1363,8 @@ def test_an_exiting_helper_is_never_called_ambiguous(tmp_path):
                     break
         finally:
             child.wait(timeout=_WEDGE_BACKSTOP_SECONDS)
-    assert verdicts["gone"] == _EXITING_HELPERS_WATCHED
+    assert watched > 0, "no helper was watched at all"
+    assert verdicts["gone"] == watched
     # Samples taken while the helper was still alive.  Without at least one the
     # loop proved nothing but that a finished pid reads as `gone`, so say so
     # rather than passing on a vacuous run.

--- a/tests/test_cluster_campaign_runner.py
+++ b/tests/test_cluster_campaign_runner.py
@@ -1074,31 +1074,39 @@ def test_abrupt_worker_death_leaves_stage_lock_owned_by_child(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "second_stat, expected",
+    "second_stat, expected_empty_env, expected_env_error",
     [
-        ("42 Z", "gone"),
-        (FileNotFoundError(), "gone"),
-        (ProcessLookupError(), "gone"),
-        ("42 S", "mismatch"),
-        ("43 S", "mismatch"),
-        ("43 Z", "mismatch"),
-        (PermissionError(), "mismatch"),
-        (OSError("stat I/O failed"), "mismatch"),
-        ("malformed", "mismatch"),
-        ("invalid S", "mismatch"),
+        ("42 Z", "gone", "gone"),
+        (FileNotFoundError(), "gone", "gone"),
+        (ProcessLookupError(), "gone", "gone"),
+        # The one cell #244 changes.  An environ that reads as nothing, with
+        # the recorded start time intact, is our own helper on its way out --
+        # a task releases its address space before it becomes a zombie.  It is
+        # not a recycled pid, and calling it one terminal-failed a recovery for
+        # watching its helper exit.  An `ESRCH` from the same read still needs
+        # the zombie or the absence, because a live identity contradicts it.
+        ("42 S", "owned", "mismatch"),
+        ("43 S", "mismatch", "mismatch"),
+        ("43 Z", "mismatch", "mismatch"),
+        (PermissionError(), "mismatch", "mismatch"),
+        (OSError("stat I/O failed"), "mismatch", "mismatch"),
+        ("malformed", "mismatch", "mismatch"),
+        ("invalid S", "mismatch", "mismatch"),
     ],
     ids=[
-        "zombie", "missing", "esrch", "live-owner-mismatch", "pid-reused",
+        "zombie", "missing", "esrch", "still-live-same-identity", "pid-reused",
         "pid-reused-zombie", "permission-denied", "io-error", "malformed",
         "invalid-ticks",
     ],
 )
 @pytest.mark.parametrize("owner_read_error", [False, True], ids=["empty-env", "env-error"])
 def test_owned_process_state_rechecks_exit_after_failed_owner_read(
-    monkeypatch, second_stat, expected, owner_read_error
+    monkeypatch, second_stat, expected_empty_env, expected_env_error,
+    owner_read_error,
 ):
     # Force the exact exit window: stat reports our live helper, then environ
     # loses its owner as the helper exits. No scheduling or sleep is involved.
+    expected = expected_env_error if owner_read_error else expected_empty_env
     snapshots = iter(["42 S", second_stat])
 
     def read_stat(path, **kwargs):
@@ -1122,18 +1130,106 @@ def test_owned_process_state_rechecks_exit_after_failed_owner_read(
     assert campaign._owned_process_state(424242, 42, "owner") == expected
 
 
-@pytest.mark.parametrize("owner_matches, expected", [(True, "owned"), (False, "mismatch")])
-def test_owned_process_state_live_identity(monkeypatch, owner_matches, expected):
+@pytest.mark.parametrize(
+    "observation, expected",
+    [
+        ("owned", "owned"),
+        ("other-owner", "mismatch"),
+        ("unreadable", "mismatch"),
+    ],
+)
+def test_owned_process_state_live_identity(monkeypatch, observation, expected):
     monkeypatch.setattr(campaign, "_proc_snapshot", lambda *a, **kw: (42, "S"))
-    monkeypatch.setattr(campaign, "_proc_has_owner", lambda *a: owner_matches)
+    monkeypatch.setattr(
+        campaign, "_proc_owner_observation", lambda *a: observation
+    )
     assert campaign._owned_process_state(424242, 42, "owner") == expected
+
+
+@pytest.mark.parametrize(
+    "environ, expected",
+    [
+        (f"{campaign._RESERVED_OWNER_ENV}=owner\0".encode("utf-8"), "owned"),
+        (b"", "no-address-space"),
+        (b"PATH=/usr/bin\x00", "other-owner"),
+    ],
+    ids=["carries-the-token", "no-address-space", "someone-else"],
+)
+def test_proc_owner_observation_tells_empty_from_absent(
+    monkeypatch, environ, expected
+):
+    # An environ that reads as nothing and an environ that names somebody else
+    # are different facts about a pid, and #244 turned on telling them apart.
+    monkeypatch.setattr(Path, "read_bytes", lambda self: environ)
+    assert campaign._proc_owner_observation(424242, "owner") == expected
+
+
+@pytest.mark.parametrize(
+    "error, expected",
+    [
+        (FileNotFoundError(), "no-process"),
+        (ProcessLookupError(), "no-process"),
+        (PermissionError(), "unreadable"),
+        (OSError("environ I/O failed"), "unreadable"),
+    ],
+    ids=["missing", "esrch", "permission-denied", "io-error"],
+)
+def test_proc_owner_observation_tells_absent_from_unreadable(
+    monkeypatch, error, expected
+):
+    def read_bytes(self):
+        raise error
+
+    monkeypatch.setattr(Path, "read_bytes", read_bytes)
+    assert campaign._proc_owner_observation(424242, "owner") == expected
+
+
+def test_a_live_process_with_no_environment_is_still_owned():
+    """A real process, with a real empty environ, is not a recycled pid.
+
+    This is the observation `_owned_process_state` gets from a helper that has
+    released its address space on the way out: `/proc/<pid>/environ` reads as
+    zero bytes while `/proc/<pid>/stat` still reports the recorded start time
+    and a state that is not `Z`.  A process execed with an empty environment
+    produces exactly that observation on demand, with no window to hit and
+    nothing patched, so the verdict can be asserted rather than caught.
+    """
+
+    child = subprocess.Popen(
+        [sys.executable, "-c", "import sys; sys.stdin.read()"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env={},
+    )
+    try:
+        _wait_until(
+            lambda: campaign._proc_snapshot(child.pid) is not None,
+            unmet="the child never appeared in /proc",
+            alive=lambda: child.poll() is None,
+        )
+        snapshot = campaign._proc_snapshot(child.pid)
+        assert snapshot is not None
+        assert campaign._proc_owner_observation(child.pid, "owner") == (
+            "no-address-space"
+        ), "the kernel no longer reports an empty environ for env={}"
+        assert campaign._owned_process_state(
+            child.pid, snapshot[0], "owner"
+        ) == "owned"
+    finally:
+        assert child.stdin is not None
+        child.stdin.close()
+        child.wait(timeout=_WEDGE_BACKSTOP_SECONDS)
+    assert campaign._owned_process_state(child.pid, snapshot[0], "owner") == (
+        "gone"
+    )
 
 
 @pytest.mark.parametrize("state", ["S", "Z"])
 def test_recorded_process_pid_reuse_is_never_owned_or_killed(monkeypatch, state):
     monkeypatch.setattr(campaign, "_proc_snapshot", lambda *a, **kw: (43, state))
     monkeypatch.setattr(
-        campaign, "_proc_has_owner",
+        campaign, "_proc_owner_observation",
         lambda *a: pytest.fail("a reused PID must not be checked for ownership"),
     )
     monkeypatch.setattr(

--- a/tests/test_cluster_campaign_runner.py
+++ b/tests/test_cluster_campaign_runner.py
@@ -462,6 +462,7 @@ def test_scheduler_refills_a_freed_host_while_another_host_is_active(tmp_path):
     fast_path = tmp_path / "fast.receipt"
     gate_path = tmp_path / "gate.receipt"
     waiting_path = tmp_path / "waiting.receipt"
+    release_path = tmp_path / "release.receipt"
     # No private deadline in the child: the stage's own timeout_seconds is the
     # authoritative bound and the worker enforces it by terminating the child's
     # process group (cluster_campaign.py, `_exec-request`). A second, shorter
@@ -472,6 +473,17 @@ def test_scheduler_refills_a_freed_host_while_another_host_is_active(tmp_path):
         "gate=Path(sys.argv[1]); out=Path(sys.argv[2]); "
         "exec(\"while not gate.exists():\\n time.sleep(0.02)\"); "
         "out.write_bytes(b'waiting')"
+    )
+    # The refill stage publishes its gate and then stays alive until a stage
+    # that can only run *after* the waiting stage has been recorded finished
+    # releases it.  That makes the completion order the inverse of the one this
+    # test used to assert, by causality rather than by timing: nothing here
+    # depends on which child the scheduler happens to notice first.
+    gate_then_wait_script = (
+        "from pathlib import Path; import sys, time; "
+        "Path(sys.argv[1]).write_bytes(b'gate'); "
+        "release=Path(sys.argv[2]); "
+        "exec(\"while not release.exists():\\n time.sleep(0.02)\")"
     )
     stages = [
         _stage(
@@ -502,8 +514,31 @@ def test_scheduler_refills_a_freed_host_while_another_host_is_active(tmp_path):
             stage_id="refill-local",
             host_id="sparky",
             dependencies=["fast-local"],
-            argv=[sys.executable, "-c", _WRITE_BYTES, str(gate_path), "gate"],
+            argv=[
+                sys.executable,
+                "-c",
+                gate_then_wait_script,
+                str(gate_path),
+                str(release_path),
+            ],
             receipts=[_receipt(gate_path, "gate")],
+        ),
+        # Only reachable once waiting-remote has succeeded, which frees
+        # sparklina and is recorded before this stage can start.  Its whole job
+        # is to end the refill stage afterwards.
+        _stage(
+            tmp_path,
+            stage_id="release-refill",
+            host_id="sparklina",
+            dependencies=["waiting-remote"],
+            argv=[
+                sys.executable,
+                "-c",
+                _WRITE_BYTES,
+                str(release_path),
+                "release",
+            ],
+            receipts=[_receipt(release_path, "release")],
         ),
     ]
     manifest = _manifest(tmp_path, stages, ssh=True, max_parallel=2)

--- a/tests/test_cluster_campaign_runner.py
+++ b/tests/test_cluster_campaign_runner.py
@@ -46,6 +46,15 @@ _WRITE_BYTES = (
 # ---------------------------------------------------------------------------
 
 _WEDGE_BACKSTOP_SECONDS = 120
+
+# How many helpers `test_an_exiting_helper_is_never_called_ambiguous` watches
+# exit.  This is a sample count, not a threshold: the test's verdict is decided
+# per sample, so no number here can turn a violation into a pass, and the only
+# thing it trades is runtime against how reliably a regression is caught.
+# Measured on 6.17.0-1032-nvidia, 199 of 200 exiting children opened the window
+# at least once, so twenty children leave a regression essentially nowhere to
+# hide while costing a few milliseconds each.
+_EXITING_HELPERS_WATCHED = 20
 """Last-resort bound on every cross-process wait and stage in this file.
 
 Not a budget for the work.  It answers only "the producer is wedged and nothing
@@ -1123,13 +1132,15 @@ def test_abrupt_worker_death_leaves_stage_lock_owned_by_child(tmp_path):
         ("42 Z", "gone", "gone"),
         (FileNotFoundError(), "gone", "gone"),
         (ProcessLookupError(), "gone", "gone"),
-        # The one cell #244 changes.  An environ that reads as nothing, with
-        # the recorded start time intact, is our own helper on its way out --
-        # a task releases its address space before it becomes a zombie.  It is
-        # not a recycled pid, and calling it one terminal-failed a recovery for
-        # watching its helper exit.  An `ESRCH` from the same read still needs
-        # the zombie or the absence, because a live identity contradicts it.
-        ("42 S", "owned", "mismatch"),
+        # The cell #244 changes: a *failed* owner read with the recorded start
+        # time intact.  That is our own helper on its way out of `do_exit`, and
+        # a read that failed establishes nothing about who owns the pid --
+        # least of all that somebody else does.  Both spellings of a failed
+        # read (nothing came back, and the read refused) land here, because the
+        # kernel produces the second one, not the first: measured on
+        # 6.17.0-1032-nvidia, every sample inside the window read
+        # EACCES/EPERM.  A changed start time below is still a recycled pid.
+        ("42 S", "owned", "owned"),
         ("43 S", "mismatch", "mismatch"),
         ("43 Z", "mismatch", "mismatch"),
         (PermissionError(), "mismatch", "mismatch"),
@@ -1178,8 +1189,15 @@ def test_owned_process_state_rechecks_exit_after_failed_owner_read(
     "observation, expected",
     [
         ("owned", "owned"),
+        # A full read that lacks the token is the one observation that
+        # establishes a different owner, and it still fails closed.
         ("other-owner", "mismatch"),
-        ("unreadable", "mismatch"),
+        # A read that failed does not.  With the recorded start time intact
+        # this is the recorded process, so the caller's bounded wait looks
+        # again rather than terminal-failing the campaign (#244).
+        ("unreadable", "owned"),
+        ("no-process", "owned"),
+        ("no-address-space", "owned"),
     ],
 )
 def test_owned_process_state_live_identity(monkeypatch, observation, expected):
@@ -1266,6 +1284,86 @@ def test_a_live_process_with_no_environment_is_still_owned():
         child.wait(timeout=_WEDGE_BACKSTOP_SECONDS)
     assert campaign._owned_process_state(child.pid, snapshot[0], "owner") == (
         "gone"
+    )
+
+
+def test_an_exiting_helper_is_never_called_ambiguous(tmp_path):
+    """Watch real helpers exit, at every sample, and refuse to call one a stranger.
+
+    The table above fixes each observation in place; this asks the kernel what
+    it actually produces.  A helper that publishes its receipt and exits passes
+    through a window -- between `exit_mm()` releasing the address space and
+    `exit_notify()` making the task a zombie -- in which `/proc/<pid>/environ`
+    refuses to be read while `/proc/<pid>/stat` still reports the recorded
+    start time and a live state.  Measured on 6.17.0-1032-nvidia, 199 of 200
+    exiting children pass through it and every one of the 2492 samples taken
+    inside it read `EACCES`/`EPERM`; `_owned_process_state` called all of them
+    `mismatch`, which is a terminal campaign failure for a recovery that is
+    watching its own helper finish.
+
+    Polling flat out is what makes this deterministic rather than lucky: it is
+    not waiting for a rare interleaving, it is sampling a window that every
+    exiting child opens.  The assertion can only fail when the contract is
+    actually violated -- our own child cannot acquire a different owner token
+    or a different start time -- so a green run is green for the right reason
+    and cannot flake the other way.
+    """
+
+    token = "0" * 64
+    verdicts: dict[str, int] = {"owned": 0, "gone": 0}
+    for index in range(_EXITING_HELPERS_WATCHED):
+        marker = tmp_path / f"exiting-{index}"
+        environment = dict(os.environ)
+        environment[campaign._RESERVED_OWNER_ENV] = token
+        child = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "from pathlib import Path; import sys; "
+                "Path(sys.argv[1]).write_bytes(b'done')",
+                str(marker),
+            ],
+            env=environment,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        try:
+            snapshot = campaign._proc_snapshot(child.pid)
+            if snapshot is None:  # pragma: no cover - the child beat the read
+                continue
+            # Start watching where the recovery starts: the moment the helper's
+            # receipt is on disk, which is the moment before it exits.
+            _wait_until(
+                lambda: marker.exists() and marker.stat().st_size > 0,
+                unmet="the helper never published its marker",
+                alive=lambda: child.poll() is None,
+            )
+            backstop = time.monotonic() + _WEDGE_BACKSTOP_SECONDS
+            while True:
+                assert time.monotonic() < backstop, (
+                    f"helper {child.pid} never finished: {verdicts}"
+                )
+                verdict = campaign._owned_process_state(
+                    child.pid, snapshot[0], token
+                )
+                verdicts[verdict] = verdicts.get(verdict, 0) + 1
+                assert verdict != "mismatch", (
+                    "a helper of ours, exiting, was called a recycled pid: "
+                    f"child {child.pid} start ticks {snapshot[0]}, "
+                    f"verdicts so far {verdicts}"
+                )
+                if verdict == "gone":
+                    break
+        finally:
+            child.wait(timeout=_WEDGE_BACKSTOP_SECONDS)
+    assert verdicts["gone"] == _EXITING_HELPERS_WATCHED
+    # Samples taken while the helper was still alive.  Without at least one the
+    # loop proved nothing but that a finished pid reads as `gone`, so say so
+    # rather than passing on a vacuous run.
+    assert verdicts["owned"] > 0, (
+        "every helper was already finished at its first sample, so the exit "
+        f"window was never watched: {verdicts}"
     )
 
 


### PR DESCRIPTION
Closes #244.

Both halves are reproduced on PrismaBuild before being fixed, and the recovery
half is now attributed rather than guessed at — the reproduction carries the
record the issue asked for.

## 1. The refill race

`test_ready_stages_refills_a_freed_host_slot` asserted
`waiting.finished_unix_ns >= refill.finished_unix_ns`. Nothing in the manifest
establishes that order. The refill child publishes its gate receipt *while it is
still running*, so the stage it unblocks can finish, be recorded and be written
out before the refill stage's own attempt is recorded. The assertion was testing
a coincidence, and CI eventually stopped agreeing with it.

Reproduced first, with the old assertion against the current runner:

```
assert 1788713089922203363 >= 1788713090049877524
1 failed, 14 warnings in 6.79s
```

action key `6879e0df33e4e05f72e665e3a69e2e2f08484d9e0a5728680dc59ff9f522a67e`.

The fix asserts what the gate actually establishes — that the two stages
*overlap* — and adds a `release-refill` stage whose completion order is fixed by
causality rather than by scheduling. The order the old assertion demanded is now
inverted by construction, so it cannot come back unnoticed.

## 2. The recovery failure

### It reproduces, and it says why

40 runs of `test_resume_after_coordinator_death_recovers_owned_helper_receipt`
against **unmodified `origin/main` code**, with only the diagnostic reporting
this PR adds, box load 24–30: **1 failure**
(`5e41dbcd0c7db599107aa85f7304d35bd6373a644fe8dfda7d2cc7ce9a7bdfd3`). The
failure carries the detail no previous occurrence recorded:

```
slow-stage: status=terminal_failed
  attempt 1: status=failed pid=667567 start_ticks=1113697
    detail='recorded PID ownership is ambiguous; process was not killed'
```

A second 40-run arm on the same production code with the unmodified test file
saw 0 failures
(`333e2f71e4c4d26572e1827d2ddf6522f254f85e187636dc063e290b52dbac99`), so the
observed rate is 1 in 80 runs, which is what "intermittent, twice, never
reproduced" looks like.

### What the ambiguity actually is

Linux `do_exit` runs `exit_mm()` before `exit_notify()`. Between those two
points a helper has released its address space but is not yet a zombie:
`/proc/<pid>/stat` still reports the recorded start time and a live state, and
`/proc/<pid>/environ` stops being readable. `origin/main` read "I could not ask
who owns this pid" as "somebody else owns this pid", and one such verdict
terminal-fails the stage.

Measured against unmodified `origin/main`, real processes, nothing patched
(`22f596af449888db925f274111d3c66f06e1e598f41e0b769bd21663770fbef2`): 199 of 200
exiting children pass through that window, and **all 2492 samples taken inside
it read `EACCES`/`EPERM`** — 0 empty, 0 truncated — with the recorded start time
intact in every one. States seen inside the window: `R` 2455, `Z` 29, `D` 8.

### Why it is intermittent

The window is `exit_mm()`, so its width is a function of how much address space
the kernel has to tear down. Polling at the recovery loop's real
`poll_interval=0.02`, 60 trials per cell, both sides pre-fix
(`da8fac6d04c6ef95b5642b14be38030799b1f60c0421ec4d762ec4a5679d1d5d`):

| helper footprint | polls a trial takes (max) | trials a poll called ambiguous |
|---|---|---|
| 0 MB | 2 | 0 / 60 |
| 256 MB | 3 | 0 / 60 |
| 1024 MB | 6 | **4 / 60** |
| 4096 MB | 19 | 1 / 60 |

So the mechanism is not exotic — a helper holding a gigabyte makes it a
several-percent event — and at the CI helper's size it is rare, which matches a
failure seen twice and reproduced once in eighty runs.

### The first fix was wrong, and the measurement is how I know

The first version of this branch carved out only the *empty* read: an environ
that returns zero bytes from a process whose start time is intact is `owned`.
The same probe, asking both implementations about the **same child at the same
sample**, showed that candidate returning `mismatch` inside the window 1234
times and `owned` **zero** times
(`d5eb835dcd487ec2d2573c0a74db7a4664fb501176306b816faa2587d2201163`). It would
have changed nothing, because the kernel refuses the read rather than emptying
it. That commit is still in the history with its reasoning; this one corrects
it.

### The rule that replaced it

State the rule on the fact that decides it. Field 19 of `/proc/<pid>/stat`
establishes identity. The owner token is a second check that can only ever fail
to be *readable*.

- A read that **failed** — refused, empty, or absent — establishes nothing about
  who owns the pid. With the recorded start time intact this is the recorded
  process, so the verdict stays `owned` and the caller's **existing** bounded
  wait looks again. No new constant, no new timeout.
- A read that **succeeded** and lacks the token is the one observation that
  establishes a different owner. It still fails closed.
- A changed start time is still a recycled pid and still fails closed.
- Neither refusal authorizes killing that process, exactly as before.

What this gives up is bounded and points the safe way: a pid recycled inside one
clock tick, by a process whose environment cannot be read at all, would be
terminated at the recorded deadline rather than refused outright.

Two smaller fixes ride along:

- `_terminate_recorded_owned_process` returns True when the process has already
  ended. There is nothing left to kill and the receipt is recoverable. This is
  **not** the CI cause — reaching it needs the 125 s kill deadline, and both
  retained CI logs finish the whole test in under 28 s. It is fixed because it
  is wrong.
- `CampaignTerminalFailure` now names each terminal stage's attempt, its refusal
  detail and its worker log, and the recovery test renders the whole campaign
  state on failure. That is #244's "capture those records on failure", and it is
  what produced the attribution above.

### The fix closes it

The same reachability probe, rerun with the corrected rule as the candidate
(`366134fb24f870c0b650acbf5dcb91fa055cd6cdbc39056348616cbbb00d275b`), 60 trials
per cell at the real poll interval:

| helper footprint | `origin/main` | this branch |
|---|---|---|
| 0 MB | 0 / 60 | 0 / 60 |
| 256 MB | 3 / 60 | 0 / 60 |
| 1024 MB | 0 / 60 | 0 / 60 |
| 4096 MB | 2 / 60 | 0 / 60 |
| **total** | **5 / 240** | **0 / 240** |

The earlier run of the same probe put `origin/main` at 5/240 and the first,
narrow fix at 5/240 as well. The corrected rule is the one that closes it.

### What is still not established

That this mechanism caused the **two original CI occurrences**. Neither recorded
its detail, so that record does not exist and cannot be recovered. What is
established is that the same test, on the same code, fails this way, at a rate
consistent with how those two occurrences appeared. I am not claiming more than
that.

### The test that would have caught it

`test_an_exiting_helper_is_never_called_ambiguous` watches twenty real helpers
exit and asserts the verdict at every sample. It is deterministic rather than
lucky: it samples a window every exiting child opens, and our own child can
acquire neither a different owner token nor a different start time, so it can
only fail when the contract is actually violated — it cannot flake green-to-red.

## Prior art

A local, unpushed branch `codex/cluster-campaign-causality` (Astra) carries
`7c5c300d "test: assert causal refill overlap rather than finish order (#244)"`,
which reaches the same overlap assertion for the refill half — independently and
first. It stops there: it removes the unfounded assertion without a manifest
that forces the inverted completion order, so nothing demonstrates the failure
it removes, and it does not touch the recovery half. It also edits
`docs/ARCHITECTURE.md` for fixture-cleanup guarantees, unrelated to this stamp.
Last commit 06:32Z, never pushed; the issue was released to triage.

## Verification

All runs through PrismaBuild on `sparky`, CPU-only, serial pytest, one native
thread per worker. The test venv has no `pytest-xdist`, `pytest-randomly` or
`pytest-repeat`, so `-n` and `-p no:randomly` are unavailable; serial is both
forced and what a failure-**set** comparison needs.

### What has been run

| run | tree | scope | result | action key |
|---|---|---|---|---|
| refill race, red | branch + the old assertion | the refill test | 1 failed, 6.79s | `6879e0df33e4e05f72e665e3a69e2e2f08484d9e0a5728680dc59ff9f522a67e` |
| baseline suite | `origin/main` `1f0df20d` | the 3 files that import `cluster_campaign` | **64 passed**, 35.22s | `b78b1461e31f4777b2aa0432f7bc351906eb8a62bdfc6de598144aaeef02a103` |
| branch suite @ `ae8f156f` | branch | same 3 files | **74 passed**, 34.47s | `538a62eabbee2e7b662041dfa4fdab47622ab4d3c0adaa21e47810a0bd52093c` |
| red suite @ `ae8f156f` | `origin/main` code + branch tests | same 3 files | 17 failed, 57 passed | `38fb91d6cf6b34ed3c31ca4771ce90db96b16c4145de98b8a33c91a059658b87` |
| docs @ `2f1238ec` | branch | `test_architecture_doc` + `test_docs_staleness` | **19 passed**, 6.17s | `67f2354cd15c5495530bfe4daac4ef33f14eb5540c9cff3b7541b9136866e124` |

Failure **sets**: baseline `{}` and branch `{}`. No skips were reported in
either. The branch adds 10 tests. `origin/main` has since moved by one commit
(#264, `test_tessera_formats.py`), outside this scope.

The 17 red failures split into 13 expected symbol errors — `AttributeError` on
`_proc_owner_observation`, which does not exist on `origin/main`, so those tests
cannot run there and are not contract failures — and 4 genuine contract reds:

- `test_owned_process_state_rechecks_exit_after_failed_owner_read[empty-env-still-live-same-identity]`
- `test_terminating_a_process_that_already_ended_is_not_ambiguous`
- `test_ambiguous_recorded_pid_fails_closed_without_killing_it[on-resume]` and
  `[during-monitoring]`, both on the tightened refusal message.

Probes, all against real processes with nothing patched:

| probe | what it establishes | action key |
|---|---|---|
| window | the old rule's mismatch span is 0.24–0.76 ms; the *first* fix returned `mismatch` inside it 1234 times and `owned` 0 | `d5eb835dcd487ec2d2573c0a74db7a4664fb501176306b816faa2587d2201163` |
| cause | 2492/2492 samples inside that window read `EACCES`/`EPERM`, identity intact | `22f596af449888db925f274111d3c66f06e1e598f41e0b769bd21663770fbef2` |
| reachability, pre-fix | `origin/main` 5/240, first fix 5/240 at the real poll rate | `da8fac6d04c6ef95b5642b14be38030799b1f60c0421ec4d762ec4a5679d1d5d` |
| reachability, corrected | `origin/main` 5/240, **this branch 0/240** | `366134fb24f870c0b650acbf5dcb91fa055cd6cdbc39056348616cbbb00d275b` |
| reproduction | 1 failure in 40 on `origin/main`, carrying the ownership detail | `5e41dbcd0c7db599107aa85f7304d35bd6373a644fe8dfda7d2cc7ce9a7bdfd3` |
| reproduction, control | 0 failures in 40 on the same production code | `333e2f71e4c4d26572e1827d2ddf6522f254f85e187636dc063e290b52dbac99` |

### What is still owed

The PrismaBuild fleet wedged before these landed — sparky's NFS client entered a
`TEST_STATEID` storm that blocked every worker's queue access (prismabuild
#230–#233), and a reboot was authorised. They were queued, not run, and none
should be read as pending-and-probably-fine:

- **No suite run covers `2f1238ec..dfa673f8`.** The 74-passed run above is
  commit `ae8f156f`, which is the *first*, narrow fix. The corrected rule's only
  evidence today is the 0/240 reachability A/B, which exercises the changed
  function on 240 real processes but is not the test suite.
  Owed: `599331e419a7` (branch suite at head), `033838b41c03` (red suite at
  head), `7277b162a1e3` (docs at head).
- **The repeat A/B is owed.** 120 runs of the recovery test on `origin/main`
  (`b234310489a5`) and on this branch (`771d373e334b`), to put a rate on the
  reproduction rather than a single occurrence in 80. Expect roughly 1–3
  failures on the baseline arm and 0 on the branch arm; a baseline arm that
  comes back clean weakens the attribution and should be said so.

Please re-run those five after the reboot before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FR3Gv58q8SoKnEraH97uu3
