### PR TITLE
Retain the unit's own activation source in the streamed harness (#261)

### DIFF
--- a/experiments/pq237_joint_aura_streamed.py
+++ b/experiments/pq237_joint_aura_streamed.py
@@ -118,6 +118,24 @@ def _probe_summary(values):
             "uncertainty_scope": "probe_sampling_conditional_on_fixed_calibration"}
 
 
+def unit_activation_source_recorder(captured_source, activation_source):
+    """Record only the activation source built for ``captured_source["unit"]``.
+
+    The encoder also builds unit-less sources while encoding (an empty one and
+    an identity probe, ``tessera_render._encoder_kwargs_for_plane``), AFTER
+    the renderer built the unit's own source. Keeping the last source handed
+    the probe to the wire receipt, which then refused for lack of an exact
+    Hessian key (PQ #261). Only the source carrying THIS unit's Hessian is the
+    production activation source the receipt must name.
+    """
+    def record(hessians, *args, **kwargs):
+        source = activation_source(hessians, *args, **kwargs)
+        if captured_source.get("unit") in hessians:
+            captured_source["value"] = source
+        return source
+    return record
+
+
 def retain_production_wire(weight, rendered, blob, *, qname, fmt, activation_source, wire_dir):
     """Retain the original bytes using the existing campaign/producer grammar."""
     from prismaquant.production_weight_cache import _cb_cache_tensor_identity
@@ -223,10 +241,7 @@ def _capture_and_render(model, calibration, plan, out, *, calibration_text):
     encode = render_owner.encode_tessera_unit
     activation_source = hessian_owner.activation_source
 
-    def record_activation_source(*args, **kwargs):
-        source = activation_source(*args, **kwargs)
-        captured_source["value"] = source
-        return source
+    record_activation_source = unit_activation_source_recorder(captured_source, activation_source)
 
     def record_encode(weight, fmt, **kwargs):
         rendered, blob = encode(weight, fmt, **kwargs)
@@ -246,6 +261,7 @@ def _capture_and_render(model, calibration, plan, out, *, calibration_text):
             for fmt in formats:
                 emitted.clear()
                 captured_source.clear()
+                captured_source["unit"] = name
                 with torch.no_grad():
                     rendered = render_production_weight(source, fmt, qname=name,
                                                         activations=activations, levers=levers)

--- a/tests/test_pq261_unit_activation_source.py
+++ b/tests/test_pq261_unit_activation_source.py
@@ -1,0 +1,57 @@
+"""PQ #261: the streamed harness must retain the unit's own activation source.
+
+``tessera_render._encoder_kwargs_for_plane`` builds an empty source and an
+identity-probe source during ``encode_tessera_unit`` -- after the renderer
+built the unit's Hessian source -- so a "last source wins" recorder handed the
+probe to ``retain_production_wire`` and Tessera refused ("cached unit has no
+exact Hessian key").
+"""
+import importlib.util
+from pathlib import Path
+
+
+def _harness():
+    path = Path(__file__).resolve().parents[1] / "experiments" / "pq237_joint_aura_streamed.py"
+    spec = importlib.util.spec_from_file_location("pq237_joint_aura_streamed", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fake_activation_source(hessians, identity, **overrides):
+    return {"hessians": dict(hessians), "identity": identity}
+
+
+def test_recorder_keeps_the_unit_source_over_later_unit_less_sources():
+    recorder = _harness().unit_activation_source_recorder
+    captured = {"unit": "model.layers.0.mlp.down_proj"}
+    record = recorder(captured, _fake_activation_source)
+    unit = record({"model.layers.0.mlp.down_proj": "H"}, "id")
+    record({}, "id")                      # _encoder_kwargs_for_plane: width query
+    record({"probe": "eye"}, "id")        # _encoder_kwargs_for_plane: identity probe
+    assert captured["value"] is unit
+    assert set(captured["value"]["hessians"]) == {"model.layers.0.mlp.down_proj"}
+
+
+def test_recorder_records_nothing_without_the_unit_hessian():
+    recorder = _harness().unit_activation_source_recorder
+    captured = {"unit": "model.layers.0.mlp.down_proj"}
+    record = recorder(captured, _fake_activation_source)
+    record({}, "id")
+    record({"probe": "eye"}, "id")
+    record({"model.layers.1.mlp.down_proj": "H"}, "id")
+    assert "value" not in captured
+
+
+def test_recorder_returns_the_real_source_every_call():
+    recorder = _harness().unit_activation_source_recorder
+    calls = []
+
+    def source(hessians, identity, **overrides):
+        calls.append((dict(hessians), identity, overrides))
+        return len(calls)
+
+    record = recorder({"unit": "u"}, source)
+    assert record({"u": 1}, "id", ldlq_block=4) == 1
+    assert record({}, "id") == 2
+    assert calls[0] == ({"u": 1}, "id", {"ldlq_block": 4})


### PR DESCRIPTION
Fixes the harness defect behind the joint-streamed-run-01 refusal in #261: `record_activation_source` kept the LAST source built during a render, and `tessera_render._encoder_kwargs_for_plane` builds an empty source and an identity-probe source during `encode_tessera_unit`, after the unit's Hessian source. The wire receipt then named the probe source and Tessera refused ("cached unit has no exact Hessian key").

The recorder now keeps only the source whose Hessians carry the unit being rendered. Extracted as `unit_activation_source_recorder` so the regression test runs on CPU.

Receipts:
- red: `origin/main` has no recorder seam; the last-source recorder is the observed failure in `/mnt/shared/tessera-measurements/pq261-2026-09-06/joint-streamed-run-01/`
- green: pbrun `5451888b6585` (sparky, CPU): 48 passed (`tests/test_pq261_unit_activation_source.py` + the four `test_pq237_streamed_*` / `test_joint_aura_streamed` suites)

The run itself (joint-streamed-run-02) is relaunched after merge and reported on #261.

Closes #272
Refs #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFjMyTMLPGRSvn8i7eXhVB