### PR TITLE
Square joint AURA probe samples identically at both sites (#273)

### DIFF
--- a/prismaquant/aura_cost.py
+++ b/prismaquant/aura_cost.py
@@ -2038,7 +2038,7 @@ def compute_aura_cost_streamed(
         from prismaquant.cost_streaming import validate_streamed_model_identity
         from prismaquant.joint_aura import (
             SignedJointProjectionLease, activation_identity, arithmetic_identity,
-            identity_sha256, make_joint_aura_entry, prefetch_joint_cache,
+            identity_sha256, make_joint_aura_entry, prefetch_joint_cache, squared_signed,
             validate_joint_aura_entry,
         )
         from prismaquant.production_weight_cache import _cb_cache_tensor_identity
@@ -2900,7 +2900,9 @@ def compute_aura_cost_streamed(
                     if joint_lease is not None:
                         for key, terms in joint_lease.finish_probe().items():
                             joint_components[key].append(terms)
-                            value = terms["total"] ** 2
+                            # Same squaring as make_joint_aura_entry: the
+                            # checkpoint reload compares both lists exactly.
+                            value = squared_signed(terms["total"])
                             s2[key] += value
                             s4[key] += value * value
                             x2_probe[key].append(value)

--- a/prismaquant/joint_aura.py
+++ b/prismaquant/joint_aura.py
@@ -317,10 +317,23 @@ def validate_joint_aura_entry(entry: Mapping) -> bool:
     return True
 
 
+def squared_signed(total) -> float:
+    """The one squaring of a signed joint projection.
+
+    ``x ** 2`` goes through C ``pow`` and ``x * x`` is a correctly rounded
+    multiply; on glibc they differ by one ulp for some inputs. The streamed
+    accumulator and this row must square identically, because checkpoint
+    reload compares the two sample lists exactly (PQ #261, run-02: 9 of 128
+    samples of ``model.layers.0.mlp.down_proj@TESSERA_E4M3_K1_R896`` differed).
+    """
+    total = float(total)
+    return total * total
+
+
 def make_joint_aura_entry(*, operator_identity, probe_identity, signed_components) -> dict:
     """Publish one complete, aligned cost row, also used by checkpoint replay."""
     signed = [float(value["total"]) for value in signed_components]
-    squared = [value * value for value in signed]
+    squared = [squared_signed(value) for value in signed]
     n = len(squared)
     if not n:
         raise ValueError("joint AURA needs at least one signed probe")

--- a/tests/test_joint_aura_one_squaring.py
+++ b/tests/test_joint_aura_one_squaring.py
@@ -1,0 +1,65 @@
+"""PQ #261 run-02: the streamed accumulator squared a signed projection with
+``x ** 2`` (C ``pow``) while ``make_joint_aura_entry`` used ``x * x``; on glibc
+they differ by one ulp for some inputs, and the exact checkpoint-reload
+comparison of the two sample lists refused ("legacy/joint sample alignment
+mismatch"). Both sites now call ``squared_signed``.
+"""
+import ast
+from pathlib import Path
+
+import torch
+
+from prismaquant import format_registry as fr
+from prismaquant.cost_stage_checkpoint import canonical_json_sha256
+from prismaquant.cost_streaming import STREAMED_MODEL_IDENTITY_SCHEMA
+from prismaquant.joint_aura import (activation_identity, arithmetic_identity, identity_sha256,
+                                    make_joint_aura_entry, squared_signed)
+
+# Two signed totals recorded in joint-streamed-run-02 whose pow/mul squares
+# differ by one ulp on this platform.
+RECORDED = [0.09054819587618113, -0.022860320983454585]
+
+
+def test_squared_signed_is_the_correctly_rounded_multiply():
+    for total in RECORDED:
+        assert squared_signed(total) == total * total
+
+
+def test_row_squares_with_squared_signed():
+    components = [{"weight": t, "activation": 0.0, "mixed": 0.0, "total": t} for t in RECORDED]
+    arithmetic = arithmetic_identity(torch.float32)
+    source_content = {"config": {"fixture": True}, "weight_map": {"fixture.weight": "fixture.weight"},
+                      "shards": [{"path": "/fixture/synthetic.safetensors", "size": 1, "sha256": "a" * 64}]}
+    source_model = {"schema": STREAMED_MODEL_IDENTITY_SCHEMA, "source": "synthetic", "resolved_commit": None,
+                    "content_sha256": canonical_json_sha256(source_content, where="one-squaring fixture"),
+                    **source_content}
+    probe = {"schema": "prismaquant.joint_aura.probes.v1", "seed_base": 0,
+             "n_probes": len(RECORDED), "calibration_sha256": "c" * 64,
+             "producer_source_sha256": "d" * 64, "source_model": source_model,
+             "distribution": "rademacher", "normalization": "global_kl_fisher",
+             "temperature": 1.0, "arithmetic": arithmetic}
+    name, fmt = "model.layers.0.mlp.down_proj", "NVFP4"
+    operator = {"schema": "prismaquant.joint_aura.operator.v1", "qname": name, "format": fmt,
+                "probe_identity_sha256": identity_sha256(probe),
+                "source_weight": {"content_sha256": "a" * 64, "shape": [64, 64],
+                                  "dtype": "torch.float32", "logical_bytes": 16384},
+                "rendered_weight": {"content_sha256": "b" * 64, "shape": [64, 64],
+                                    "dtype": "torch.float32", "logical_bytes": 16384},
+                "activation": activation_identity(fr.get_format(fmt), {}, name),
+                "arithmetic": arithmetic}
+    row = make_joint_aura_entry(operator_identity=operator, probe_identity=probe,
+                                signed_components=components)
+    assert row["x2_per_probe"] == [squared_signed(t) for t in RECORDED]
+    assert row["x2_per_probe"] == [t * t for t in RECORDED]
+
+
+def test_streamed_accumulator_uses_the_shared_squaring():
+    source = (Path(__file__).resolve().parents[1] / "prismaquant" / "aura_cost.py").read_text()
+    tree = ast.parse(source)
+    pow_squares = [node.lineno for node in ast.walk(tree)
+                   if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Pow)
+                   and isinstance(node.right, ast.Constant) and node.right.value == 2
+                   and isinstance(node.left, ast.Subscript)
+                   and isinstance(node.left.slice, ast.Constant) and node.left.slice.value == "total"]
+    assert pow_squares == [], f"joint total squared with ** at lines {pow_squares}"
+    assert "squared_signed(terms[\"total\"])" in source


### PR DESCRIPTION
`compute_aura_cost_streamed` accumulated each joint probe's sample as `total ** 2` (C `pow`) while `make_joint_aura_entry` published `x2_per_probe` as `total * total`. On glibc they differ by one ulp for some inputs, so the exact checkpoint-reload comparison refused and the #261 qualification could not complete (joint-streamed-run-02: 9/128 and 3/128 samples differed; legacy == `s**2`, joint == `s*s` for every differing sample).

One shared squaring, `squared_signed` (the correctly rounded multiply), at both sites. The non-joint legacy accumulator is untouched.

Receipts:
- red: `origin/main` squares with `**` at `aura_cost.py:2903` and has no `squared_signed` (the new AST test fails there)
- green: pbrun `c364f0d64033` (sparky, CPU): 143 passed across `tests/test_joint_aura_one_squaring.py`, the joint-AURA suites, the streamed-harness suites and `test_allocator_measured_runtime_cli.py`

joint-streamed-run-03 is relaunched after merge and reported on #261.

Closes #273
Refs #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFjMyTMLPGRSvn8i7eXhVB
