### PR TITLE
Name an LFM2.5 conv layer by asking its mixer child

### DIFF
--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -2042,19 +2042,27 @@ def _embed_prefix(base_model: nn.Module, full_path: str) -> str:
     return f"{full_path}.embed_tokens." if full_path else "embed_tokens."
 
 
+#: Names a hybrid decoder layer gives its mixer child. The mixer is where a
+#: layer that carries no ``layer_type`` of its own keeps the two facts that
+#: name it: its ``layer_idx`` and the ``config`` whose ``layer_types`` the
+#: index reads. ``linear_attn`` is Qwen3.5/3.6's DeltaNet child; ``conv`` is
+#: LFM2.5's ``Lfm2MoeShortConv``, whose layers expose no attention module at
+#: all -- omitting it left every LFM conv layer unnamed, and
+#: ``_call_layer`` failing closed on a mask dict that already held its entry
+#: (RobTand/prismaquant#276).
+_MIXER_CHILD_NAMES = ("self_attn", "attention", "linear_attn", "conv")
+
+
 def _layer_attention_type(layer: nn.Module):
     # `.block_type` is the transformers>=5.13 name for what `.layer_type`
-    # was on hybrid decoder layers up to 5.12; `.linear_attn` is the
-    # recurrent child module on Qwen3.5/3.6 DeltaNet hybrid layers, which
-    # carries its own `layer_type`/`layer_idx` (the outer layer has no
-    # `self_attn`/`attention` on those layers).
-    lt = (
-        getattr(layer, "layer_type", None)
-        or getattr(layer, "block_type", None)
-        or getattr(getattr(layer, "self_attn", None), "layer_type", None)
-        or getattr(getattr(layer, "attention", None), "layer_type", None)
-        or getattr(getattr(layer, "linear_attn", None), "layer_type", None)
-    )
+    # was on hybrid decoder layers up to 5.12; the mixer children above
+    # carry their own `layer_type`/`layer_idx` on architectures whose outer
+    # layer has none (Qwen3.5/3.6 DeltaNet, LFM2.5 short-conv).
+    lt = getattr(layer, "layer_type", None) or getattr(layer, "block_type", None)
+    for child_name in _MIXER_CHILD_NAMES:
+        if lt is not None:
+            break
+        lt = getattr(getattr(layer, child_name, None), "layer_type", None)
     if lt is not None:
         return lt
     # Laguna/Gemma2/Cohere2 convention: the attention module carries a
@@ -2066,13 +2074,17 @@ def _layer_attention_type(layer: nn.Module):
                     else "full_attention")
     # Generic fallback: config.layer_types[layer_idx] when both exist.
     idx = getattr(layer, "layer_idx", None)
-    if idx is None:
-        for attn_name in ("self_attn", "attention", "linear_attn"):
-            idx = getattr(getattr(layer, attn_name, None), "layer_idx", None)
-            if idx is not None:
-                break
-    cfg = getattr(layer, "config", None) or getattr(
-        getattr(layer, "self_attn", None), "config", None)
+    cfg = getattr(layer, "config", None)
+    for child_name in _MIXER_CHILD_NAMES:
+        if idx is not None and cfg is not None:
+            break
+        child = getattr(layer, child_name, None)
+        if child is None:
+            continue
+        if idx is None:
+            idx = getattr(child, "layer_idx", None)
+        if cfg is None:
+            cfg = getattr(child, "config", None)
     lts = getattr(cfg, "layer_types", None) if cfg is not None else None
     if idx is not None and lts is not None and 0 <= int(idx) < len(lts):
         return lts[int(idx)]

--- a/tests/test_linear_attention_mask_routing.py
+++ b/tests/test_linear_attention_mask_routing.py
@@ -96,6 +96,49 @@ def test_linear_attn_child_layer_idx_config_resolves():
     assert _layer_attention_type(layer) == "linear_attention"
 
 
+def _lfm_cfg():
+    # LFM2.5's schedule: a short-convolution mixer on most layers, GQA on the
+    # rest. `_compute_attention_mask` already keys its dict on these strings.
+    cfg = PreTrainedConfig()
+    cfg.is_causal = True
+    cfg.layer_types = ["conv", "full_attention"]
+    cfg._attn_implementation = "eager"
+    return cfg
+
+
+def test_conv_mixer_child_names_an_lfm_layer():
+    # RobTand/prismaquant#276: Lfm2MoeDecoderLayer carries no layer_type and
+    # no attention module on a conv layer -- only `self.conv`, which holds
+    # the layer_idx and the config the generic fallback needs.
+    layer = nn.Module()
+    layer.conv = nn.Module()
+    layer.conv.layer_idx = 0
+    layer.conv.config = _lfm_cfg()
+    assert _layer_attention_type(layer) == "conv"
+
+
+def test_lfm_conv_and_attention_layers_get_different_mask_entries():
+    # The whole point of naming the layer: the conv layer must receive the
+    # recurrent padding entry and the attention layer the dense causal one.
+    cfg = _lfm_cfg()
+    conv_layer = _RecorderLayer()
+    conv_layer.conv = nn.Module()
+    conv_layer.conv.layer_idx = 0
+    conv_layer.conv.config = cfg
+    attn_layer = _RecorderLayer()
+    attn_layer.self_attn = nn.Module()
+    attn_layer.self_attn.layer_idx = 1
+    attn_layer.self_attn.config = cfg
+    masks = {"full_attention": torch.zeros(1, 1, 2, 2), "conv": torch.ones(1, 2)}
+    hidden = torch.zeros(1, 2, 4)
+    _call_layer(conv_layer, hidden, position_embeddings=None,
+                attention_mask=masks, position_ids=None)
+    _call_layer(attn_layer, hidden, position_embeddings=None,
+                attention_mask=masks, position_ids=None)
+    assert conv_layer.received_mask is masks["conv"]
+    assert attn_layer.received_mask is masks["full_attention"]
+
+
 def test_unknown_self_attn_layer_fails_closed():
     # A layer whose type cannot be resolved must stay unresolved (None) and
     # make _call_layer raise — never silently assume full_attention.


### PR DESCRIPTION
Closes #276

## The defect

`incremental_probe` refused LFM2.5-8B-A1B before its first backward:

```
RuntimeError: per-layer attention mask requires a known layer_type; got None for Lfm2MoeDecoderLayer
```

`_compute_attention_mask` already builds LFM's per-type mask dict -- `"conv"
in config.layer_types` is one of the conditions that selects that path
(`layer_streaming.py`, "conv shares the recurrent-mask contract upstream")
-- so the dict was correct and held a `conv` entry. What failed was naming
the layer it belonged to. On a `Lfm2MoeDecoderLayer` conv layer there is no
`layer_type`, no `block_type` and no attention module at all: the
`layer_idx` and the `config` that the generic `config.layer_types[idx]`
fallback needs both live on `self.conv` (`Lfm2MoeShortConv`), and the
resolver looked only at `self_attn`, `attention` and `linear_attn`.

## The change

The mixer child names are one tuple, consulted for the child `layer_type`,
for the `layer_idx`, and for the `config`. The value returned is the string
the model's own config declares -- the same key `_compute_attention_mask`
used to build the dict -- so nothing is guessed, and the fail-closed `None`
for a genuinely unresolvable layer is unchanged. The added lookups run only
after the existing ones return `None`, so every layer that resolved before
resolves identically.

## Receipts

The regression is demonstrated before it is fixed, on the driver rather
than the fixture:

* without the change, tests-only checkout `/home/rob/tessera-runs/pq276-nofix`,
  PrismaBuild action `fd9b03e3b145`: **2 failed, 19 passed** --
  `test_conv_mixer_child_names_an_lfm_layer` and
  `test_lfm_conv_and_attention_layers_get_different_mask_entries`.
* with the change, `pbtest` over
  `test_linear_attention_mask_routing.py`, `test_qwen35_linear_attention_integration.py`,
  `test_multilayer_rope_forward.py`, `test_docs_staleness.py` on `gb10`:
  **2/2 shards green, 46 passed, 2 skipped**
  (`/home/rob/tmp/pq275/pq276-tests.json`).

The failing probe this unblocks is PrismaBuild action `27d56655e3f8`
(sparklina, exit 1 in 9 s), the allocation leg of the #275 Tessera ladder
campaign.

`docs/ARCHITECTURE.md` is unchanged: this alters no default, stage, format,
lane or ship gate -- it repairs a resolver so an architecture the tree
already declares can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFjMyTMLPGRSvn8i7eXhVB