### PR TITLE
Count a Tessera rung as attested only when the admission predicate says so

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,22 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-06 · `claude/pq244-campaign-causality`. Stamps
+As of: 2026-09-06 · `main-campaign/pq278-attested-count`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-06, `main-campaign/pq278-attested-count`) for the
+Tessera menu width report (#278). `[alloc] Tessera menu: N of M priced rungs
+are attested` counted the caller's explicit `--formats` list, and the token
+expansion's `dropped` is empty by construction when the `TESSERA` token is
+absent, so an explicit unattested menu printed "3 of 3 attested" one line
+before the eligibility gate refused all three -- a producer-side attestation
+with no contract read (principle 14). `tessera_menu.partition_attested` now
+applies the same `format_is_producer_eligible` predicate the gate applies to
+every explicit Tessera name, `menu_width_report` builds the provenance widths
+and the line from that partition (new fields `explicit_unattested_rungs`,
+`research_admitted_rungs`, `menu_mode`; `attested_rungs` is 0 under
+`PRISMAQUANT_TESSERA_MENU=research`, whose line says "admitted under research
+mode, not attested"). No default, stage graph, format menu, serving lane, ship
+gate or byte changes. Gate: `tests/test_tessera_menu_attested_count.py`.
 
 Re-stamped (2026-09-06, `claude/pq244-campaign-causality`) for **an exiting
 helper being the same helper** (§3.0; RobTand/prismaquant#244, P2). The #239

--- a/prismaquant/allocator.py
+++ b/prismaquant/allocator.py
@@ -96,6 +96,9 @@ from pathlib import Path
 from . import format_registry as fr
 from .tessera_menu import (
     expand_menu_tokens_report,
+    menu_mode,
+    menu_width_report,
+    partition_attested,
     surrogate_selection_caveat,
 )
 from .allocator_solver import (
@@ -2561,19 +2564,17 @@ def main():
     tessera_menu_widths: dict = {}
     if priced_tessera:
         kept = [n for n in fmt_names if n.startswith("TESSERA_")]
+        # The count is the admission predicate's, not the caller's: an
+        # explicitly named rung stays on the menu so the eligibility gate can
+        # refuse it out loud, and it is not "attested" until then (#278).
+        admitted, explicit_unattested = partition_attested(
+            kept, **({"context_by_unit": tessera_context_by_unit}
+                     if tessera_context_by_unit is not None else {}))
+        widths, line = menu_width_report(
+            priced_tessera, admitted, unattested, explicit_unattested, menu_mode())
         if kept:
-            tessera_menu_widths = {
-                "priced_rungs": len(priced_tessera),
-                "attested_rungs": len(kept),
-                "dropped_unattested_rungs": len(unattested),
-            }
-        print(
-            f"[alloc] Tessera menu: {len(kept)} of {len(priced_tessera)} priced "
-            f"rungs are attested by the pinned runtime"
-            + (f" ({len(unattested)} dropped as unattested)" if unattested else "")
-            + (f"; sample: {kept[:4]}" if kept else ""),
-            flush=True,
-        )
+            tessera_menu_widths = widths
+        print(line, flush=True)
         # The measured status of the ranking this DP is about to do. Printed
         # here rather than at the end because it governs how the whole run's
         # output is to be read, and stamped into provenance below because a

--- a/prismaquant/tessera_menu.py
+++ b/prismaquant/tessera_menu.py
@@ -1446,6 +1446,62 @@ def expand_menu_tokens_report(names, priced_formats=(), *, context_by_unit=None)
     return out, ([] if not any(str(n) == MENU_TOKEN for n in names) else dropped)
 
 
+def partition_attested(names, *, context_by_unit=None) -> tuple[list[str], list[str]]:
+    """``(admitted, refused)`` over the Tessera names actually on a menu.
+
+    The menu token narrows itself through ``format_is_producer_eligible``
+    (above). An explicitly named rung is kept on the menu on purpose so the
+    eligibility gate refuses it out loud -- but counting it as attested before
+    that gate runs was a producer-side claim with no contract read behind it
+    (#278): the allocator printed "3 of 3 priced rungs are attested" one line
+    before refusing all three. Same predicate, third use; nothing here reads
+    the contract a second way.
+    """
+    from . import format_registry as fr
+
+    if context_by_unit is not None:
+        context_by_unit = {context.key(): context for context in context_by_unit.values()
+                           if context is not None}
+    admitted: list[str] = []
+    refused: list[str] = []
+    for name in names:
+        name = str(name)
+        if not name.startswith("TESSERA_"):
+            continue
+        eligible = fr.format_is_producer_eligible(name, **(
+            {"context_by_unit": context_by_unit} if context_by_unit is not None else {}))
+        (admitted if eligible else refused).append(name)
+    return admitted, refused
+
+
+def menu_width_report(priced, admitted, dropped, explicit_refused, mode) -> tuple[dict, str]:
+    """The provenance widths and the one log line for a Tessera menu.
+
+    ``attested_rungs`` counts what the admission predicate admitted, not what
+    the caller named. Under research mode the predicate admits unattested
+    rungs by design, so the line says "admitted under research mode" rather
+    than "attested by the pinned runtime": the count is honest either way,
+    the label says which question it answers.
+    """
+    research = mode == MENU_RESEARCH
+    widths = {
+        "priced_rungs": len(priced),
+        "attested_rungs": 0 if research else len(admitted),
+        "research_admitted_rungs": len(admitted) if research else 0,
+        "dropped_unattested_rungs": len(dropped),
+        "explicit_unattested_rungs": len(explicit_refused),
+        "menu_mode": mode,
+    }
+    label = ("admitted under PRISMAQUANT_TESSERA_MENU=research (not attested by the "
+             "pinned runtime)" if research else "attested by the pinned runtime")
+    line = (f"[alloc] Tessera menu: {len(admitted)} of {len(priced)} priced rungs are {label}"
+            + (f" ({len(dropped)} dropped as unattested)" if dropped else "")
+            + (f" ({len(explicit_refused)} explicitly named rungs are unattested; "
+               "the eligibility gate refuses them below)" if explicit_refused else "")
+            + (f"; sample: {list(admitted)[:4]}" if admitted else ""))
+    return widths, line
+
+
 #: How a family's rungs are priced. Today every family answers the same way,
 #: and the value of naming it per family is that the answer is a property OF
 #: the family rather than a global assumption -- Tessera's embedded axis is a

--- a/tests/test_tessera_menu_attested_count.py
+++ b/tests/test_tessera_menu_attested_count.py
@@ -1,0 +1,51 @@
+"""An explicitly named Tessera rung is not "attested" until the predicate says so (#278)."""
+from prismaquant import format_registry as fr
+from prismaquant import tessera_menu as menu
+
+ATTESTED = "TESSERA_E4M3_K1_R1024"
+UNATTESTED = "TESSERA_E4M3_K1_R896"
+
+
+def _admits_only_r1024(monkeypatch):
+    monkeypatch.setattr(fr, "format_is_producer_eligible",
+                        lambda name, **_kw: str(name).endswith("R1024"))
+
+
+def test_explicit_unattested_rung_is_partitioned_out(monkeypatch):
+    _admits_only_r1024(monkeypatch)
+    admitted, refused = menu.partition_attested([ATTESTED, UNATTESTED, "NVFP4"])
+    assert admitted == [ATTESTED]
+    assert refused == [UNATTESTED]
+
+
+def test_explicit_menu_report_counts_the_predicate_not_the_caller(monkeypatch):
+    _admits_only_r1024(monkeypatch)
+    kept = [ATTESTED, UNATTESTED]
+    admitted, refused = menu.partition_attested(kept)
+    widths, line = menu.menu_width_report(kept, admitted, [], refused, menu.MENU_ATTESTED)
+    assert widths["attested_rungs"] == 1
+    assert widths["explicit_unattested_rungs"] == 1
+    assert widths["menu_mode"] == menu.MENU_ATTESTED
+    assert line.startswith("[alloc] Tessera menu: 1 of 2 priced rungs are attested by the pinned runtime")
+    assert "1 explicitly named rungs are unattested" in line
+
+
+def test_all_explicit_rungs_unattested_reads_zero_not_all(monkeypatch):
+    monkeypatch.setattr(fr, "format_is_producer_eligible", lambda name, **_kw: False)
+    kept = [ATTESTED, UNATTESTED, "TESSERA_BF16_K1_R896"]
+    admitted, refused = menu.partition_attested(kept)
+    widths, line = menu.menu_width_report(kept, admitted, [], refused, menu.MENU_ATTESTED)
+    assert widths["attested_rungs"] == 0 and refused == kept
+    assert line.startswith("[alloc] Tessera menu: 0 of 3 priced rungs are attested")
+    assert "sample" not in line
+
+
+def test_research_mode_is_labelled_admitted_not_attested(monkeypatch):
+    monkeypatch.setattr(fr, "format_is_producer_eligible", lambda name, **_kw: True)
+    kept = [ATTESTED, UNATTESTED]
+    admitted, refused = menu.partition_attested(kept)
+    widths, line = menu.menu_width_report(kept, admitted, [], refused, menu.MENU_RESEARCH)
+    assert widths["attested_rungs"] == 0
+    assert widths["research_admitted_rungs"] == 2
+    assert "PRISMAQUANT_TESSERA_MENU=research" in line
+    assert "attested by the pinned runtime" not in line.split("(not attested")[0]


### PR DESCRIPTION
Closes #278.

The allocator printed `[alloc] Tessera menu: 3 of 3 priced rungs are attested by the pinned runtime` for an explicit unattested `--formats` list, one line before the eligibility gate refused all three (found by the #261 run-03 CPU solve, `/mnt/shared/tessera-measurements/pq261-2026-09-06/regret-cpu-01/`). The count was `len(kept)` over the caller's list, and `expand_menu_tokens_report` returns `dropped == []` by construction when the `TESSERA` token is absent.

- `tessera_menu.partition_attested`: the same `format_is_producer_eligible` predicate the gate applies, over every explicit Tessera name.
- `tessera_menu.menu_width_report`: provenance widths + the log line from that partition. New fields `explicit_unattested_rungs`, `research_admitted_rungs`, `menu_mode`; under `PRISMAQUANT_TESSERA_MENU=research` the line says "admitted under research mode (not attested by the pinned runtime)" and `attested_rungs` is 0.
- Explicit rungs stay on the menu so the gate still refuses them out loud; only the count and its label change. No default, menu, lane or byte change. ARCHITECTURE stamped.

Pool receipt: pbtest shard on gb10, `tests/test_tessera_menu_attested_count.py tests/test_tessera_menu.py tests/test_docs_staleness.py tests/test_architecture_doc.py` — 85 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFjMyTMLPGRSvn8i7eXhVB