### PR TITLE
Plan a packed-expert stack on a family the producer can route

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,16 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-06 · `main-campaign/pq278-attested-count`. Stamps
+As of: 2026-09-06 · `claude/pq280-projection-family-ladder`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-06, `claude/pq280-projection-family-ladder`) for **the
+nominal rung the campaign plans a packed-expert stack on** (§4.10;
+RobTand/prismaquant#280). The campaign asked the producer at the first menu
+rung, and the menu is ordered by rate, so on LFM2.5-8B-A1B it asked for an
+NVFP4 expert stack the pinned build has no route for and refused the whole
+population -- including the family that does have one. It now walks the menu's
+families in order and keeps the first the producer accepts, carrying every
+refusal.
 
 Re-stamped (2026-09-06, `main-campaign/pq278-attested-count`) for the
 Tessera menu width report (#278). `[alloc] Tessera menu: N of M priced rungs
@@ -6924,7 +6933,14 @@ Two properties make the numbers comparable with the rest of the menu:
   subprocess because the producer hashes the whole checkpoint), binds the
   answer exactly to the profile-declared units, reads each unit's source
   tensor from the shard the producer hashed and refuses, by name, a live view
-  that is not byte-for-byte that tensor. Expert anchors are grouped per
+  that is not byte-for-byte that tensor. The plan names a nominal rung per
+  stack, and the producer checks only that its *family* has an expert route on
+  its build; the menu is ordered by rate, so the campaign asks family by family
+  in menu order and keeps the first the producer accepts, carrying every
+  refusal in `plan_attempts` (PrismaQuant #280). At tessera `ba582d47` the LFM
+  expert stacks plan on `TESSERA_E4M3_K1` only -- `scheme.MOE_BUILDERS` names
+  `TESSERA_FP8` alone -- which is what the pinned contract's attested
+  `routed_moe` menu independently publishes. Expert anchors are grouped per
   producer stack (`_group_key` → `s:<stack>`) so every member measures the
   same rungs; their wire receipts are sealed with the producer's
   `unit_input_identity` (the projection record inside the identity, which is

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -1124,10 +1124,15 @@ def _project_expert_population(population: ExpertPopulation, *, weights, menus,
     import torch
 
     # The producer's plan asks for a nominal rung per stack; the unit records
-    # it returns do not depend on it.  The first menu rung of the stack's
-    # first member is the nominal one (every member has the same menu shape
-    # class, and the allocator picks the served rung later).
-    stacks: dict[str, tuple[str, int]] = {}
+    # it returns do not depend on it -- the producer checks only that the
+    # family has an expert route on its build.  The menu is ordered by rate,
+    # so its first rung's family is arbitrary with respect to the route, and
+    # asking on it refuses a stack whose OTHER families are routable.  Ask the
+    # producer family by family in menu order and keep the first it accepts;
+    # every refusal is carried, because "this build has no expert route for
+    # this family" is a measured fact the payload should record rather than
+    # lose in a traceback (PrismaQuant #280).
+    ladders: dict[str, list[tuple[str, int]]] = {}
     for stack, units in sorted(population.declared.items()):
         first = sorted(units)[0]
         menu = list(menus.get(first) or [])
@@ -1136,26 +1141,58 @@ def _project_expert_population(population: ExpertPopulation, *, weights, menus,
                 f"Tessera campaign has no menu for projected expert unit {first} "
                 f"(stack {stack}); refusing to price a stack the allocator could "
                 "not choose a rung for (PrismaQuant #183).")
-        parsed = parse_tessera_format_name(menu[0].format_name)
-        if parsed is None:
+        ladder: list[tuple[str, int]] = []
+        seen: set[str] = set()
+        for entry in menu:
+            parsed = parse_tessera_format_name(entry.format_name)
+            if parsed is None:
+                continue
+            family, rung = parsed
+            grid = family.payload_grid().name
+            if grid in seen:
+                continue
+            seen.add(grid)
+            ladder.append((grid, int(rung)))
+        if not ladder:
             raise RuntimeError(
-                f"Tessera campaign menu for projected expert unit {first} opens with a "
-                f"non-Tessera rung {menu[0].format_name!r}; the producer cannot plan it "
-                "(PrismaQuant #183).")
-        family, rung = parsed
-        stacks[stack] = (family.payload_grid().name, int(rung))
+                f"Tessera campaign menu for projected expert unit {first} names no "
+                "Tessera rung the producer could plan (PrismaQuant #183).")
+        ladders[stack] = ladder
     out_path = Path(cache_dir) / "expert_projection.json"
     try:
         tool = producer_plan_tool()
-        projection = request_expert_projection(model_path, stacks, out_path=out_path)
-        bound = bind_expert_projection(projection, declared=population.declared)
     except ExpertProjectionError as exc:
         raise RuntimeError(
+            "Tessera campaign cannot ask the producer for its expert projection; "
+            f"refusing to price it: {exc} (PrismaQuant #183).") from exc
+    attempts: list[dict] = []
+    stacks: dict[str, tuple[str, int]] = {}
+    projection = bound = None
+    for round_index in range(max(len(ladder) for ladder in ladders.values())):
+        asked = {stack: ladder[min(round_index, len(ladder) - 1)]
+                 for stack, ladder in ladders.items()}
+        if asked == stacks:
+            break                       # every ladder exhausted; nothing new to ask
+        stacks = asked
+        try:
+            projection = request_expert_projection(model_path, stacks, out_path=out_path)
+            bound = bind_expert_projection(projection, declared=population.declared)
+        except ExpertProjectionError as exc:
+            attempts.append({"request": stack_plan_request(stacks), "refused": str(exc)})
+            projection = bound = None
+            continue
+        attempts.append({"request": stack_plan_request(stacks), "refused": None})
+        break
+    if bound is None or projection is None:
+        raise RuntimeError(
             "Tessera campaign cannot bind the producer's expert projection to the "
-            f"profile-declared population; refusing to price it: {exc} (PrismaQuant #183)."
-        ) from exc
+            "profile-declared population on any family in the menu; refusing to "
+            "price it: "
+            + " || ".join(a["refused"] for a in attempts)
+            + " (PrismaQuant #183).")
     carried = carried_projection(projection, bound, request=stack_plan_request(stacks),
                                  tool=str(tool))
+    carried["plan_attempts"] = attempts
     projected: dict[str, dict] = {}
     mismatched: list[str] = []
     for stack, units in sorted(bound.items()):

--- a/tests/test_tessera_campaign_packed.py
+++ b/tests/test_tessera_campaign_packed.py
@@ -548,3 +548,41 @@ def test_wire_backed_units_keep_only_measured_rows():
     assert set(payload["costs"][dense]) == {f"{fam}_R{r}" for r in (128, 384, 512, 896)}
     assert set(payload["costs"][expert]) == {f"{fam}_R{r}" for r in (128, 512, 896)}
     assert all(row["output_mse_measured"] for row in payload["costs"][expert].values())
+
+
+def test_projection_walks_the_menu_to_a_family_with_an_expert_route(monkeypatch, tmp_path):
+    """The cheapest rung's family need not have an expert route (#280).
+
+    The menu is ordered by rate, so its first rung is NVFP4 here.  The pinned
+    producer refuses an NVFP4 expert stack -- ``scheme.MOE_BUILDERS`` names
+    only ``TESSERA_FP8`` on this build -- and the campaign must ask the next
+    family rather than refuse the whole population.  The refusal is the
+    producer's real one: nothing about the route is mocked.
+    """
+    from prismaquant.model_profiles.lfm2_moe import Lfm2MoeProfile
+
+    campaign, _argv, model, _encoded = _bridge_main_fixture(monkeypatch, tmp_path)
+    population = campaign._require_campaign_population(model, Lfm2MoeProfile(), 1)
+    assert population.declared, "fixture must declare a packed expert stack"
+    weights = {member.qname: member.weight.detach() for member in population.members}
+    ladder = [SimpleNamespace(format_name="TESSERA_E2M1_K2_R128", family="TESSERA_E2M1_K2",
+                              body_rate_q256=128, bpp=0.5),
+              SimpleNamespace(format_name=RUNG, family="TESSERA_E4M3_K1",
+                              body_rate_q256=1024, bpp=4.0)]
+    menus = {name: list(ladder) for name in weights}
+
+    carried, projected = campaign._project_expert_population(
+        population, weights=weights, menus=menus,
+        model_path=str(tmp_path / "source"), cache_dir=tmp_path / "cache")
+
+    assert projected, "the routable family must yield the projected units"
+    attempts = carried["plan_attempts"]
+    assert len(attempts) == 2, attempts
+    first = attempts[0]
+    assert first["refused"], "the producer must have refused the NVFP4 stack"
+    assert "no expert route" in first["refused"]
+    assert {entry["grid"] for entry in first["request"].values()} == {"E2M1x2"}
+    assert attempts[-1]["refused"] is None
+    grids = {entry["grid"] for entry in carried["request"].values()}
+    assert grids == {entry["grid"] for entry in attempts[-1]["request"].values()}
+    assert "E2M1" not in "".join(grids)


### PR DESCRIPTION
Closes #280

## The defect

The Tessera campaign asks the producer to project each in-scope packed-expert
stack at one nominal rung. The producer checks only that the rung's **family**
has an expert route on its build; the campaign took the rung from `menu[0]`,
and the menu is ordered by **rate**. On LFM2.5-8B-A1B the cheapest rung is
`TESSERA_E2M1_K2_R128`, so the campaign asked for an NVFP4 expert stack:

```
the plan gives the expert stack model.layers.18.feed_forward.experts grid
E2M1x2 (TESSERA_NVFP4): tessera target
'model.layers.18.feed_forward.experts': TESSERA_NVFP4 has no expert route in
this build (scheme.MOE_BUILDERS names ['TESSERA_FP8']). ... plan it on a
family with a route, or leave it out to pass it through as BF16.
```

and refused the entire packed population -- including `TESSERA_E4M3_K1`, the
family that does have a route. `stack_plan_request`'s own docstring already
says the campaign asks "at one **legal** rung"; the selection did not honour
that.

## The change

`_project_expert_population` builds a per-stack ladder of the menu's distinct
families in menu order and asks the producer round by round, keeping the first
family it accepts. Every refusal is carried verbatim in the projection block as
`plan_attempts`, so "this build has no expert route for this family" becomes a
fact the payload records rather than one lost in a traceback. A stack refused
on every family still refuses, and the refusal names each attempt. The producer
remains the sole authority on routes -- nothing here asserts anything about the
serving runtime.

Bounded cost: at most one producer call per distinct family (four), and the
producer hashes the checkpoint once per call.

## Cross-check (principle 14)

The pinned contract agrees with the producer independently. At tessera
`ba582d47`, `expand_tessera_menu` under `ServingContext(structure="routed_moe")`
returns exactly one attested rung at every LFM expert shape --
`TESSERA_E4M3_K1_R1024`, `route_status=backed_with_serve_flag` -- while the
dense attested menu is empty
(`/mnt/shared/tessera-measurements/pq275-2026-09-06/campaign-01/scope-03-routed-menu.json`,
PrismaBuild action `b7db174b169e` lineage).

## Receipts

| what | action | result |
|---|---|---|
| regression, unfixed tree + real producer | `2f0018a55639` | **1 failed** with the producer's own message |
| six Tessera campaign/projection suites, fixed tree | `260cc431e706` | **133 passed, 5 skipped** in 185.8s |

Both through PrismaBuild on the `gb10` tag with
`TESSERA_REPO=/mnt/shared/tessera-measurements/pq275-2026-09-06/inputs/tessera-ba582d47`.
The new test drives the real `_project_expert_population` against the real
producer tool; nothing about the route is mocked.

`docs/ARCHITECTURE.md` §4.10 records the nominal-plan rule and the measured
fact, and carries a new provenance stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFjMyTMLPGRSvn8i7eXhVB
