### PR TITLE
Fix expert projection fallback across differently ordered stack menus

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,17 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-06 · `main-campaign/pq290-stack-payload`. Stamps
+As of: 2026-09-06 · `review/pq-joint-evidence-20260906`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-06, `review/pq-joint-evidence-20260906`) for **expert
+projection retries across different stack menus** (RobTand/prismaquant#295).
+The campaign preserves its existing nominal plan attempts and also asks the
+producer at each family shared by every stack, matched by family name rather
+than menu position. Each request covers the whole population and retains the
+producer's exact projection and source-byte checks. Attempts remain bounded
+by twice the maximum number of distinct families in a stack menu; this is not
+an exhaustive search of arbitrary mixed-family plans. No format menu, serving
+admission, numerical pricing or exported bytes change.
 
 Re-stamped (2026-09-06, `main-campaign/pq282-campaign-fanout`) for **what a
 campaign quantum measures: the expert sample, the rate band, and the refusal
@@ -7158,16 +7168,20 @@ Two properties make the numbers comparable with the rest of the menu:
   projections *and* for which the producer's projection tool is declared and
   present; anything else in scope is refused by name before calibration, and
   the stride's leftovers are recorded as omitted. After the menus exist the
-  campaign asks the producer ONCE (`_project_expert_population`:
-  `experiments/tessera_producer_plan.py` over every in-scope stack, one
-  subprocess because the producer hashes the whole checkpoint), binds the
+  campaign asks the producer over every in-scope stack in each nominal-plan
+  attempt (`_project_expert_population`:
+  `experiments/tessera_producer_plan.py`, never a subprocess per stack because
+  the producer hashes the whole checkpoint), binds the
   answer exactly to the profile-declared units, reads each unit's source
   tensor from the shard the producer hashed and refuses, by name, a live view
   that is not byte-for-byte that tensor. The plan names a nominal rung per
   stack, and the producer checks only that its *family* has an expert route on
   its build; the menu is ordered by rate, so the campaign asks family by family
   in menu order and keeps the first the producer accepts, carrying every
-  refusal in `plan_attempts` (PrismaQuant #280). At tessera `ba582d47` the LFM
+  refusal in `plan_attempts` (PrismaQuant #280). When stack menus differ,
+  additional requests align their shared families by name, preserving the
+  existing mixed nominal plans and admitting a common routed family at
+  different menu positions (#295). At tessera `ba582d47` the LFM
   expert stacks plan on `TESSERA_E4M3_K1` only -- `scheme.MOE_BUILDERS` names
   `TESSERA_FP8` alone -- which is what the pinned contract's attested
   `routed_moe` menu independently publishes. Expert anchors are grouped per

--- a/docs/measurements/pq295-projection-family-review-2026-09-06.md
+++ b/docs/measurements/pq295-projection-family-review-2026-09-06.md
@@ -1,0 +1,58 @@
+# Expert projection family alignment review
+
+Reviewed base: PrismaQuant `c488b592` (2026-09-06 changes). Issue #295.
+
+The existing retry sequence applied the same family-menu index to every expert
+stack. Two legal, different menus `[E2M1x2, E4M3]` and `[E4M3, BF16]` never
+produced the all-E4M3 request accepted by the current producer. The new
+regression creates two real small unpacked BF16-source stacks, calls the
+actual producer plan tool, binds all projected units, and compares their
+source bytes with the live weights. Producer routes and projection results
+are not mocked.
+
+The repair preserves the existing nominal request sequence and adds any
+missing request for a family shared by all stacks, matched by family name.
+The request count is at most twice the largest distinct-family menu. No
+per-stack subprocesses or Cartesian enumeration are introduced. It does not
+claim exhaustive search for arbitrary mixed-family plans on a hypothetical
+producer with different route support per stack. The current producer's
+routed family support is build-wide and E4M3-only.
+
+All execution below used published PrismaBuild. CPU tests reserved one CPU
+and 4 GiB, hid CUDA, and bounded OMP/MKL/OpenBLAS threads to one. The producer
+and test dependencies were the existing GB10 environment:
+`/home/rob/dq-runs/venvs/prismaquant-cu130/bin/python`,
+`TESSERA_REPO=/home/rob/tessera`. These are small source/projection regressions,
+not a full-model quantization, serving or performance qualification.
+
+| Check | PB action | Actual result |
+| --- | --- | --- |
+| Before fix, new two-stack regression | `11355529964ff001fda25c2096465b85ff84f75144a927a91b711a5b8d04b703` | sparky, exit 1; 1 failed, 15 deselected, no skips. Producer refuses NVFP4 on the first stack, then BF16 on the second. |
+| After fix, existing one-stack and new two-stack projection regressions | `72ae634c60923445547eb68a37267cdad780d8876051295961660727852ce672` | sparklina, exit 0; 2 passed, 33 deselected, no skips. The `-k` selector also deselected the initially supplied documentation tests; their separate action is below. |
+| Architecture/staleness | `bdd55f472f52c60172d69b7500ded5b04c2bd4419762a776dcb54f236419bcda` | sparklina, exit 0; 19 passed, no skips. |
+| Compile touched production/test modules | `304c94bedbe9c618d49c03d628ba4a8349000e0dd4319c53a95ca30684f8d06e` | sparklina, exit 0; 2 modules compiled. Portable standard Python, one CPU/1 GiB. |
+
+Commands after the common `pbrun.py --cwd <review-checkout>` prefix:
+
+```bash
+--tag gb10 --cpus 1 --demand mem_gb=4 \
+ --env OMP_NUM_THREADS=1 --env MKL_NUM_THREADS=1 --env OPENBLAS_NUM_THREADS=1 \
+ --env TESSERA_REPO=/home/rob/tessera --timeout-s 300 -- \
+ /home/rob/dq-runs/venvs/prismaquant-cu130/bin/python -m pytest -q \
+ tests/test_tessera_campaign_packed.py -k projection_matches_family_names
+
+# Green projection action used -k 'projection_walks or projection_matches'.
+# Documentation action used these paths without -k:
+# tests/test_docs_staleness.py tests/test_architecture_doc.py
+```
+
+Terminal records and actual worker stdout were read. Successful CAS payloads
+were read and SHA-256 checked independently:
+
+| Action prefix | Receipt SHA-256 | Result SHA-256 |
+| --- | --- | --- |
+| `72ae634c6092` | `5cb0fb820fd852aa34dd77fcb478ab3da325c605e22b1b0f723fe2efcc870265` | `25213a684e5082fcf035ced399ed9f936506b00b2cbb11c3ed079addc4350e61` |
+| `bdd55f472f52` | `a06a4e65243c379220b1e965ad86a01869750d61ed86d76b087e40ec59c90141` | `f04563fb40fd4b2b7d98fc2a0655558c112d653da161467187a739528a051cb0` |
+| `304c94bedbe9` | `16c0fd9e3a31f8c020afce3fc19c02105612d81d0b6ca4405e2feddd30a8adc3` | `79cf46efdbff419748bb1683bba58a6c76cb507f0616a846b8de990491ba62c8` |
+
+Terminal files live in `/mnt/shared/prismabuild-fleet/pb-queue/{done,failed}/<action>.json`; worker logs are under `attempts/<action>/`; result payloads are `/mnt/shared/prismabuild-fleet/cas/blobs/<first-two>/<result-sha256>`. No successful CAS receipt is claimed for the intentional RED. No GPU, quality, latency or work-per-joule delta is claimed.

--- a/experiments/pq237_joint_aura_streamed.md
+++ b/experiments/pq237_joint_aura_streamed.md
@@ -192,8 +192,9 @@ The 48 GiB reservation/container limit retains the prior small-model screen's
 known working envelope; it is not a measured peak-memory claim.
 
 After committing the reviewed source, run from this checkout. This Python
-submission wrapper temporarily omits only the three unused external
-calibration symlinks while PB seals the checkout, restoring them in `finally`.
+submission wrapper temporarily omits any remaining legacy external calibration
+symlinks while PB seals the checkout, restoring them in `finally`. Main removed
+these tracked links in #269; a checkout without them also passes this step.
 The experiment reads only its own frozen inputs. The source manifest records
 that omission; no deleted symlink belongs in the delivered commit.
 
@@ -206,7 +207,7 @@ root = Path.cwd()
 run = Path('/mnt/shared/tessera-measurements/mixed-lfm-237-2026-09-06')
 links = {root / 'calibration' / (name + '.jsonl'): None
          for name in ('diverse-v1', 'xdom-fit-v1', 'xdom-gate-v1')}
-links = {path: path.readlink() for path in links}
+links = {path: path.readlink() for path in links if path.is_symlink()}
 try:
     for path in links:
         path.unlink()

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -2419,8 +2419,9 @@ def _project_expert_population(population: ExpertPopulation, *, weights, menus,
                                projection=None) -> tuple[dict, dict]:
     """Ask the producer to project every in-scope stack; bind it; check the bytes.
 
-    One subprocess for the whole campaign (the producer hashes the checkpoint
-    to identify its source).  The answer is bound exactly to the
+    Each request covers the whole campaign (the producer hashes the checkpoint
+    to identify its source); family retries never request one stack at a time.
+    The answer is bound exactly to the
     profile-declared units -- no name outside the profile's declaration, no
     2-D slice PrismaQuant chose -- and each unit's source tensor is read from
     the shard the producer hashed and compared byte-for-byte with the live
@@ -2505,14 +2506,26 @@ def _project_expert_population(population: ExpertPopulation, *, weights, menus,
         raise RuntimeError(
             "Tessera campaign cannot ask the producer for its expert projection; "
             f"refusing to price it: {exc} (PrismaQuant #183).") from exc
+    # Keep every previously attempted mixed nominal plan. Also ask at each
+    # common family by NAME: different stack menus can place E4M3 at different
+    # indices, so moving all ladders together can miss the one routed family
+    # even when every stack offers it (#295). At most two plans per distinct
+    # family count, never the Cartesian product of stack assignments and never
+    # one checkpoint-hashing producer call per stack.
+    plans = [{stack: ladder[min(index, len(ladder) - 1)]
+              for stack, ladder in ladders.items()}
+             for index in range(max(map(len, ladders.values())))]
+    by_family = {stack: dict(ladder) for stack, ladder in ladders.items()}
+    common_families = set.intersection(*(set(rows) for rows in by_family.values()))
+    for grid in next(iter(by_family.values())):
+        if grid in common_families:
+            asked = {stack: (grid, rows[grid]) for stack, rows in by_family.items()}
+            if asked not in plans:
+                plans.append(asked)
     attempts: list[dict] = []
     stacks: dict[str, tuple[str, int]] = {}
     answer = bound = None
-    for round_index in range(max(len(ladder) for ladder in ladders.values())):
-        asked = {stack: ladder[min(round_index, len(ladder) - 1)]
-                 for stack, ladder in ladders.items()}
-        if asked == stacks:
-            break                       # every ladder exhausted; nothing new to ask
+    for asked in plans:
         stacks = asked
         try:
             answer = request_expert_projection(model_path, stacks, out_path=out_path)
@@ -2526,7 +2539,7 @@ def _project_expert_population(population: ExpertPopulation, *, weights, menus,
     if bound is None or answer is None:
         raise RuntimeError(
             "Tessera campaign cannot bind the producer's expert projection to the "
-            "profile-declared population on any family in the menu; refusing to "
+            "profile-declared population on the attempted nominal family plans; refusing to "
             "price it: "
             + " || ".join(a["refused"] for a in attempts)
             + " (PrismaQuant #183).")

--- a/tests/test_tessera_campaign_packed.py
+++ b/tests/test_tessera_campaign_packed.py
@@ -586,3 +586,41 @@ def test_projection_walks_the_menu_to_a_family_with_an_expert_route(monkeypatch,
     grids = {entry["grid"] for entry in carried["request"].values()}
     assert grids == {entry["grid"] for entry in attempts[-1]["request"].values()}
     assert "E2M1" not in "".join(grids)
+
+
+def test_projection_matches_family_names_across_different_stack_menus(monkeypatch, tmp_path):
+    """Different menu positions must not hide a common routable family."""
+    from safetensors.torch import load_file, save_file
+    from prismaquant.model_profiles.lfm2_moe import Lfm2MoeProfile
+
+    campaign, _argv, model, _encoded = _bridge_main_fixture(monkeypatch, tmp_path)
+    second_stack = STACK.replace("layers.2", "layers.3")
+    layer = torch.nn.Module()
+    layer.feed_forward = _RoutedBlock()
+    layer.feed_forward.experts = _WideExperts().to(dtype=torch.bfloat16)
+    model.model.layers.append(layer)
+    source = tmp_path / "source"
+    tensors = load_file(str(source / "model.safetensors"))
+    tensors.update({name.replace(STACK, second_stack): value.clone()
+                    for name, value in list(tensors.items()) if name.startswith(STACK)})
+    save_file(tensors, str(source / "model.safetensors"))
+    config = json.loads((source / "config.json").read_text())
+    config["num_hidden_layers"] = 4
+    (source / "config.json").write_text(json.dumps(config))
+
+    population = campaign._require_campaign_population(model, Lfm2MoeProfile(), 1)
+    assert set(population.declared) == {STACK, second_stack}
+    weights = {member.qname: member.weight.detach() for member in population.members}
+    first = ["TESSERA_E2M1_K2_R128", RUNG]
+    second = [RUNG, "TESSERA_BF16_K1_R1792"]
+    menus = {name: [SimpleNamespace(format_name=fmt) for fmt in
+                   (first if name.startswith(STACK + ".") else second)]
+             for name in weights}
+
+    carried, projected = campaign._project_expert_population(
+        population, weights=weights, menus=menus,
+        model_path=str(source), cache_dir=tmp_path / "cache")
+
+    assert set(projected) == set(weights)
+    assert {row["grid"] for row in carried["request"].values()} == {"E4M3"}
+    assert carried["plan_attempts"][-1]["refused"] is None


### PR DESCRIPTION
A campaign with stack menus `[E2M1x2, E4M3]` and `[E4M3, BF16] refused even though both stacks had a legal E4M3 route: the fallback advanced each menu by the same index. Preserve the existing nominal plans and add missing requests matching common families by name. Every request still covers the full population, validates the producer projection and compares source bytes; attempts are bounded by twice the maximum distinct-family menu rather than enumerating stack combinations. Architecture and scope are documented in the same commit.

PrismaBuild reproduced the refusal with two real small BF16-source expert stacks and the actual producer. The fix passed both the existing one-stack regression and the new heterogeneous-menu regression (2 passed), architecture/staleness checks (19 passed), and compile checks (2 modules). No skips; CPU only, native threads bounded to one. Terminal exits, worker logs and actual CAS payload hashes were verified. Exact commands and receipts: `docs/measurements/pq295-projection-family-review-2026-09-06.md`. No full-model, GPU, quality or performance claim.

A separate documentation commit also makes the existing streamed qualification launch example tolerate the calibration symlinks already removed by #269; its unconditional `readlink()` otherwise stops the example before submission. No inference rerun was needed for that correction.

Closes #295.
