### PR TITLE
Run Tessera campaign quanta in declared Docker environments

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,21 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-06 · `fix/packed-plan-handoff`. Stamps
+As of: 2026-09-07 · `codex/first-model-integration-20260907`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-07, `codex/first-model-integration-20260907`) for
+**campaign quanta in the declared Docker runtime** (§4.10). The shared fanout
+spec accepts an optional `container` block with `image` and explicit absolute
+`mounts` (`source`, `target`, optional `readonly`). The worker resolves the image
+once, logs its immutable ID and executes that ID; use a digest in versioned
+specs when retries must retain the same runtime. The existing environment is
+passed into the container. Its source is the PB worker's sealed checkout at
+`/workspace`, read-only; data mounts cannot hide that source. The container
+runs with the worker's UID/GID so shared output remains writable under NFS root
+squashing. Docker's ordinary PB shim retains CPU affinity and scope ownership.
+Host-interpreter specs remain supported. Census, anchor and materialization
+quanta share the same row builder; the adapter does no scheduling or fanout.
+Gate: `tests/test_tessera_campaign_container.py`.
 
 Re-stamped (2026-09-06, `fix/packed-plan-handoff`) for **the producer plan
 input for packed decisions** (§4.10; #293). Scoped preflight already resolved

--- a/docs/reviews/2026-09-07/container-campaign.md
+++ b/docs/reviews/2026-09-07/container-campaign.md
@@ -1,0 +1,31 @@
+# Campaign container execution
+
+The campaign dispatcher now carries its explicitly selected Docker runtime
+through census, anchor and selected-wire materialization rows. The worker
+mounts its sealed checkout, runs as its own UID/GID, forwards the declared
+environment and data mounts, and executes the resolved immutable image ID.
+PrismaBuild continues to own placement, resource reservations and containment.
+
+Validation through the published PrismaBuild runtime `67a44bb72cf7`:
+
+| Action | Mode and result |
+| --- | --- |
+| `68e0d76bfb7571bcbcf5d955eaff924400c92eb0b3c95e7afacb7aef5c97304c` | Before: base `70e5f7a8` plus new tests; Docker, CPU only; 6 failed, 1 passed. The old dispatcher ignored the container configuration. |
+| `2c81ad059dec1226a14a2b30a5d15308385edb16f9ad5ba5dbc2b5003b986b15` | After: Docker, CPU only; 7 passed, no skips. |
+| `3ca70ffd7bec71ca66004687b02848c05acb7cf23b239ad6db49c86fcf945143` | Container, existing fanout, architecture and documentation tests; qualified GB10 interpreter, CPU only, 4 pytest workers/native threads 1; 59 passed, no skips. |
+| `6d4412cc3afb7c02752b643135255874b70e593d5132439e03656508b01978e6` | Python compilation of both tools and the new test module; exit 0. |
+
+Terminal records, successful CAS payload hashes and logs were checked. Evidence:
+`/mnt/shared/tessera-measurements/first-model-20260907/validation/container/receipts.json`.
+The Docker tests used `prismaquant-qwen38-producer:20260827-tf516-hf128`;
+the broader checks used `/home/rob/dq-runs/venvs/prismaquant-cu130/bin/python`.
+
+Two setup failures are excluded from those results: `b5a87d76997b` had no Torch
+in the CPU test interpreter, and `1114fe5d737f` had no pytest-xdist in the
+producer image. Both were replaced by the qualified environments above.
+
+The initial full-model census attempt `5c9d294c707d` independently exposed
+the shared-output problem: container root failed to create its cache directory
+on the NFS mount. Using the worker UID/GID passed that point and loaded all
+30 dense and 2,112 projected expert units. Calibration and final-model
+quality/performance are separate work; these tests do not qualify a model.

--- a/tests/test_tessera_campaign_container.py
+++ b/tests/test_tessera_campaign_container.py
@@ -1,0 +1,67 @@
+"""The fanout must execute the sealed source in its declared Docker runtime."""
+import importlib
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+import dispatch_tessera_campaign as dispatch
+
+
+def spec():
+    return {
+        "model": "/mnt/shared/model", "cwd": "/original/checkout",
+        "python": "python3", "campaign_argv": [],
+        "env": {"PYTHONPATH": ".:/producer/src", "OMP_NUM_THREADS": "4"},
+        "container": {"image": "qualified:fixed", "mounts": [
+            {"source": "/mnt/shared", "target": "/mnt/shared"},
+            {"source": "/producer", "target": "/producer", "readonly": True},
+        ]},
+    }
+
+
+def test_container_row_keeps_row_arguments_and_declared_runtime():
+    row = dispatch._row(spec(), ["--units", "/mnt/shared/units.json"],
+                        mem_gb=48, timeout_s=600)
+    assert row["argv"][:3] == ["python3", "-m", "tools.tessera_campaign_container"]
+    cut = row["argv"].index("--")
+    assert row["argv"][cut + 1:] == [
+        "python3", "-u", "-m", "prismaquant.tessera_campaign",
+        "--units", "/mnt/shared/units.json"]
+    assert json.loads(row["argv"][4])["container"] == spec()["container"]
+    assert row["demand"] == {"gpu": 1, "cpu": 4, "mem_gb": 48}
+    assert row["retry_safe"] is True
+
+
+def test_container_uses_worker_snapshot_and_host_user_without_shell():
+    runner = importlib.import_module("tools.tessera_campaign_container")
+    argv = runner.docker_command(spec(), ["python3", "a path;$(touch bad)"],
+                                 cwd="/worker/snapshot", uid=1000, gid=1001,
+                                 image_id="sha256:resolved")
+    assert argv[:3] == ["docker", "run", "--rm"]
+    assert argv[argv.index("--user") + 1] == "1000:1001"
+    assert "type=bind,src=/worker/snapshot,dst=/workspace,readonly" in argv
+    assert not any("/original/checkout" in arg for arg in argv)
+    assert "PYTHONPATH=.:/producer/src" in argv
+    assert "type=bind,src=/producer,dst=/producer,readonly" in argv
+    assert argv[-3:] == ["sha256:resolved", "python3", "a path;$(touch bad)"]
+    assert not any(arg.startswith("--cpuset") or arg == "--cgroup-parent" for arg in argv)
+
+
+@pytest.mark.parametrize("target", ["/", "/workspace", "/workspace/tools", "/mnt/../workspace"])
+def test_spec_refuses_mounts_that_hide_the_sealed_source(tmp_path, target):
+    data = spec()
+    data["container"]["mounts"][0]["target"] = target
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps(data))
+    with pytest.raises(RuntimeError, match="workspace|canonical"):
+        dispatch.load_spec(path)
+
+
+def test_host_rows_remain_direct():
+    data = spec()
+    del data["container"]
+    assert dispatch._row(data, [], mem_gb=40, timeout_s=60)["argv"] == [
+        "python3", "-u", "-m", "prismaquant.tessera_campaign"]

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -66,6 +66,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+if __package__:
+    from .tessera_campaign_container import validate_container
+else:
+    from tessera_campaign_container import validate_container
+
 PBCAMPAIGN = Path("/mnt/shared/prismabuild-fleet/repo/tools/pbcampaign.py")
 
 #: What ``plan`` writes beside the manifest, so ``merge`` reads the row layout
@@ -125,6 +130,8 @@ def load_spec(path: Path) -> dict:
         raise RuntimeError(
             f"{path}: campaign_argv sets --deadline-seconds; a fanned-out row "
             "takes its deadline from the fleet, not from inside the round loop")
+    if "container" in spec:
+        validate_container(spec)
     return spec
 
 
@@ -180,9 +187,16 @@ def require_rows_fit(mem_gb: "list[int]", per_box: int, budget) -> int:
     return widest
 
 
-def _row(spec: dict, argv: list[str], *, mem_gb: int, timeout_s: int) -> dict:
+def _row(spec: dict, argv: list[str], *, mem_gb: int, timeout_s: int,
+         module: str = "prismaquant.tessera_campaign") -> dict:
+    command = [spec["python"], "-u", "-m", module, *argv]
+    if "container" in spec:
+        validate_container(spec)
+        command = ["python3", "-m", "tools.tessera_campaign_container", "--spec",
+                   json.dumps({"container": spec["container"], "env": spec["env"]},
+                              sort_keys=True), "--", *command]
     row = {
-        "argv": [spec["python"], "-u", "-m", "prismaquant.tessera_campaign", *argv],
+        "argv": command,
         "cwd": spec["cwd"],
         "demand": {"gpu": 1, "cpu": int(spec.get("cpus", 4)), "mem_gb": int(mem_gb)},
         "env": dict(spec["env"]),

--- a/tools/tessera_campaign_container.py
+++ b/tools/tessera_campaign_container.py
@@ -1,0 +1,93 @@
+"""Run an admitted campaign quantum in its declared Docker environment.
+
+PB owns placement, CPU affinity and container containment. This adapter only
+maps the worker's sealed checkout and explicit data mounts into the container.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path, PurePosixPath
+import subprocess
+
+
+def validate_container(spec: dict) -> None:
+    container = spec.get("container")
+    if not isinstance(container, dict) or set(container) - {"image", "mounts"}:
+        raise RuntimeError("container must declare image and optional mounts only")
+    image = container.get("image")
+    if not isinstance(image, str) or not image or image.startswith("-"):
+        raise RuntimeError("container.image must name a Docker image")
+    mounts = container.get("mounts", [])
+    if not isinstance(mounts, list):
+        raise RuntimeError("container.mounts must be a list")
+    targets = set()
+    for mount in mounts:
+        if not isinstance(mount, dict) or set(mount) - {"source", "target", "readonly"}:
+            raise RuntimeError("container mount must declare source, target and optional readonly")
+        for field in ("source", "target"):
+            value = mount.get(field)
+            if (not isinstance(value, str) or not value.startswith("/")
+                    or "," in value or "\x00" in value
+                    or str(PurePosixPath(value)) != value or ".." in PurePosixPath(value).parts):
+                raise RuntimeError(f"container mount {field} must be a canonical absolute path")
+        target = PurePosixPath(mount["target"])
+        workspace = PurePosixPath("/workspace")
+        if target == workspace or target in workspace.parents or workspace in target.parents:
+            raise RuntimeError("container mount cannot hide /workspace sealed source")
+        if str(target) in targets:
+            raise RuntimeError(f"duplicate container mount target: {target}")
+        targets.add(str(target))
+        if not isinstance(mount.get("readonly", False), bool):
+            raise RuntimeError("container mount readonly must be boolean")
+    env = spec.get("env", {})
+    if not isinstance(env, dict) or any(
+            not isinstance(k, str) or not k or "=" in k or "\x00" in k
+            or not isinstance(v, str) or "\x00" in v for k, v in env.items()):
+        raise RuntimeError("container env must map environment names to strings")
+
+
+def docker_command(spec: dict, command: list[str], *, cwd: str,
+                   uid: int, gid: int, image_id: str) -> list[str]:
+    validate_container(spec)
+    argv = ["docker", "run", "--rm", "--gpus", "all", "--ipc=host",
+            "--user", f"{uid}:{gid}", "--workdir", "/workspace",
+            "--entrypoint", "", "--mount",
+            f"type=bind,src={cwd},dst=/workspace,readonly"]
+    for mount in spec["container"].get("mounts", []):
+        value = f"type=bind,src={mount['source']},dst={mount['target']}"
+        if mount.get("readonly", False):
+            value += ",readonly"
+        argv += ["--mount", value]
+    for key, value in sorted(spec.get("env", {}).items()):
+        argv += ["--env", f"{key}={value}"]
+    return [*argv, image_id, *command]
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spec", required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    spec = json.loads(args.spec)
+    validate_container(spec)
+    command = args.command[1:] if args.command[:1] == ["--"] else args.command
+    if not command:
+        parser.error("a container command is required")
+    requested = spec["container"]["image"]
+    image_id = subprocess.check_output(
+        ["docker", "image", "inspect", requested, "--format", "{{.Id}}"], text=True).strip()
+    if not image_id.startswith("sha256:") or len(image_id) != 71:
+        raise RuntimeError("Docker returned no immutable image ID")
+    print(json.dumps({"schema": "prismaquant.tessera_campaign_container.v1",
+                      "requested_image": requested, "image_id": image_id,
+                      "uid": os.getuid(), "gid": os.getgid()}), flush=True)
+    docker = docker_command(spec, command, cwd=str(Path.cwd()),
+                            uid=os.getuid(), gid=os.getgid(), image_id=image_id)
+    os.execvp(docker[0], docker)
+    return 1  # exec never returns
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Campaign specs now carry an optional Docker runtime and explicit data mounts into every PrismaBuild quantum. The worker mounts its sealed source, uses its own UID/GID for shared output, forwards declared environment, and executes the resolved image ID while PB retains placement and containment. This also supplies the shared row adapter used by selected-wire materialization.

Closes #303. Refs #275. Architecture and receipt notes are updated. Validation through PB: before 6 failed/1 passed; after 7 Docker tests passed; broader fanout/architecture/docs 59 passed, no skips; Python compilation passed. Actual LFM census passed container startup/model loading and reached the existing zero-routed-row refusal, which remains strict. This PR does not qualify first-model calibration or serving.
