### PR TITLE
Batch compatible Tessera campaign expert anchors

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,25 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-06 · `fix/packed-plan-handoff`. Stamps
+As of: 2026-09-07 · `codex/campaign-batched-anchors`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-07, `codex/campaign-batched-anchors`) for **bounded
+expert anchor batches** (§4.10; #300, #275; Tessera #385). The campaign's
+optional `--anchor-batch-size` groups pending expert anchors with equal shape,
+dtype, device, family and rung inside the existing admitted action. The
+adaptive schedule still chooses every anchor; PrismaBuild still assigns the
+actions. `tessera_render.encode_tessera_units` reuses the scalar input guard
+and calls Tessera's `encode_linears` with each unit's own ActivationSource
+mapping. Each result uses the scalar path's served activation scale, wire
+decoder, production scorer and cache writer. Per-unit wire identity and
+journal envelopes remain unchanged; each completed batch is journalled before
+the next starts. Batch width is excluded from input identity, so a resume can
+change execution width without repricing completed rows. Measured rows record
+batch width and identify equally apportioned batch encoding time; that is
+accounting, not independently measured per-unit latency. Default width remains
+one pending performance qualification. No serving pin, wire recipe, cost
+currency or format menu changes. Gate: `tests/test_tessera_campaign_batch.py`.
+
 
 Re-stamped (2026-09-06, `fix/packed-plan-handoff`) for **the producer plan
 input for packed decisions** (§4.10; #293). Scoped preflight already resolved

--- a/docs/measurements/tessera-campaign-batching-2026-09-07.md
+++ b/docs/measurements/tessera-campaign-batching-2026-09-07.md
@@ -1,0 +1,80 @@
+# Campaign batching: input and journal qualification
+
+PrismaQuant #300 consumes Tessera #386 (`382a1a97`) for the #275 campaign.
+`--anchor-batch-size` is opt-in; the scalar default remains one. The campaign
+keeps its adaptive pending-anchor schedule and groups compatible expert units
+inside each admitted PrismaBuild action. It uses the existing resident source
+weights, captured scoring rows, ActivationSource memo, production scorer and
+ProductionWeightCache. Tessera owns batch encoding. No serving release pin or
+wire recipe changes.
+
+The scalar and batch adapters share one input guard. Batch calls carry separate
+per-unit Hessian mappings, retain the scalar artifact name, and decode each
+result through the existing wire reader. The campaign scores each unit with its
+own served activation scale, then writes its normal cache/wire entries and
+journal receipt. Batch width is an execution setting excluded from checkpoint
+input identity; batch timing is explicitly apportioned among its units. Missing
+batch API support refuses before model load. A width-one run keeps the previous
+ten-anchor journal flush cadence.
+
+## Correctness evidence
+
+All execution used PrismaBuild. The initial three adapter/grouping regressions
+failed on main `70e5f7a8` because the batch seam did not exist. The final new suite
+passed all six tests on CUDA in the known producer image
+`prismaquant-qwen38-producer:20260827-tf516-hf128`, Python 3.12 / Torch 2.13+cu130:
+
+- Action `a25b803d46b5b611292a00d724bd7c7353d374f1b6b98f6daf2f50069ced6599`,
+  Sparky, exit 0, six passes, no skips, 21.63 seconds.
+- CAS receipt `0b811bd4d82ed8ce2a800101d92c10a951a5d8f8ab71eed9ffb66b632bdcb10e`.
+- Actual `campaign.main()` on a routed fixture encodes seven source units with
+  each unit's own Hessian. Batches of four and two reach the real producer.
+  Wire bytes and numerical cost rows equal the scalar run. Resuming with width
+  two performs no encode, and a tampered wire refuses resume.
+- Separate tests retain distinct static activation scales, refuse missing H,
+  split incompatible shapes/rungs, and refuse an old producer before loading.
+
+The relevant distinct coverage totals 150 tests: the existing campaign suite
+(46 CPU plus five CUDA), new batch suite (six CUDA), packed campaign (16),
+fanout (33), journal merge (10), architecture (13), document staleness (six),
+and stack sample costs (15). CPU runs explicitly skipped CUDA cases; all those
+cases were subsequently executed on CUDA. The first combined GPU run's sole
+failure was a new fixture replacing every registry row; restricting the fixture
+to its target format corrected it. The initial real CLI fixture used 64-wide
+weights, which the normal pricing contract correctly refused; it was widened
+to 256 before qualification. An expensive CPU encode rerun was withdrawn through
+PB and moved to the GPU. None of those attempts is performance evidence.
+
+Receipts/logs for the final GPU gate are retained under
+`/mnt/shared/tessera-measurements/pq300-batch-20260907/`.
+The CPU reports are `/home/rob/tmp/pq-batch-contracts.json` and
+`/home/rob/tmp/pq-batch-finalcpu.json`; their CAS receipts remain authoritative.
+
+## Calibration preparation and its limit
+
+Retained input: `/mnt/shared/tessera-measurements/tessera385-2026-09-06/units/`,
+WikiText-2 train, 32 samples of length 512, seed zero. Both exact corpus and token
+hashes matched before the new forward:
+
+- text: `aee724fa58bfbdeb3fc6803297fb6bab27b203d7c40b39ddef9b9770e5d52fe5`
+- IDs: `809883cb91e1359d0b7e7829f4a7ab3ddeacd7eee75a66dd6866aa671a4f935d`
+
+The current container forward routed no rows to layer-18 expert 6; the collector
+refused, as it must (action `ba0a368758de697b`, exit 1). This is not a complete
+campaign calibration. An explicitly bounded validation recapture excluded that
+one unit and retained the other 31 expert w1 units plus dense layer-0 w1, using
+the same collector and exact tokens. It saved 512 scoring rows per unit where
+available, the existing export H/scales files, the token tensor and corpus text.
+
+Action `539fa6315350c4182922d091f2faa33afca5a3b58f25973c87a0a99ee80d77d4`
+completed on Sparklina with exit 0; receipt
+`0134db4fd8b9574554164c8b84f0d3beef9f398896a991df4c9a7fe5b9ddc952`.
+Files are in `/mnt/shared/tessera-measurements/pq300-batch-20260907/capture/`.
+Dense H equals the retained H exactly. All 31 expert H tensors differ, despite
+identical tokens and source weights; the largest absolute H-entry difference is
+777.96484375. This establishes a forward difference, not its cause. Every count
+and comparison is in `capture.json`. No old expert cost is relabelled as a
+measurement on this new capture.
+
+The real cost-row A/B and paired in-process/host profiles are pending. No
+throughput or energy improvement is claimed by this correctness record.

--- a/docs/measurements/tessera-campaign-batching-2026-09-07.md
+++ b/docs/measurements/tessera-campaign-batching-2026-09-07.md
@@ -76,5 +76,69 @@ identical tokens and source weights; the largest absolute H-entry difference is
 and comparison is in `capture.json`. No old expert cost is relabelled as a
 measurement on this new capture.
 
-The real cost-row A/B and paired in-process/host profiles are pending. No
-throughput or energy improvement is claimed by this correctness record.
+The original capture inherited the source identity's `fit_tokens_min=1`.
+Its observed selected-scope minimum is 84; individual counts were recorded
+correctly. `capture-scope-correction-v2.json` records that correction without
+mutating files already consumed by measurements. The retained harness now
+computes this field from fresh counts. This narrow scope does not demonstrate
+full-model routing coverage.
+
+## Real cost-row BF16 A/B
+
+On Sparklina GB10, producer `382a1a97`, the same known Docker image,
+Python 3.12.3 / Torch 2.13.0+cu130 / Triton 3.7.1, four PB-assigned CPU cores
+and 16 GiB aggregate reservation, eight `[1792,2048]` positive-route expert
+w1 units were measured at `TESSERA_BF16_K1_R1792`. Each arm used exactly the
+same source weight, freshly captured Hessian and scored activation rows.
+Inputs and activation factorizations were resident before timing. Each phase
+executes real encode, decode, production cost scoring, ProductionWeightCache
+write and wire persistence; calibration, model loading and journal publication
+are outside this timing. CLI/journal behavior is separately covered above.
+
+Both arms warmed up, followed by scalar / batch-eight / batch-eight / scalar.
+All wire SHA-256 values, measured dloss, memory costs, scales and H-applied flags
+were identical in every phase. Batch phases reached one eight-unit producer
+call. This is a layer-local cost-row comparison, not an end-to-end KL or served
+benchmark, and no serving gate is qualified by it.
+
+| Arm/order | Seconds for 8 rows | Rows/s | GPU joules | Rows/J |
+|---|---:|---:|---:|---:|
+| Scalar / 1 | 31.54958 | 0.253569 | 2501.66 | 0.003198 |
+| Batch 8 / 2 | 31.33940 | 0.255270 | 1979.42 | 0.004042 |
+| Batch 8 / 3 | 31.32566 | 0.255382 | 2483.03 | 0.003222 |
+| Scalar / 4 | 31.53244 | 0.253707 | 2569.75 | 0.003113 |
+
+Throughput is essentially flat: approximately 0.6% separates these two-arm
+means. GPU energy is integrated from Netdata's ten-second power samples,
+linearly interpolated at phase boundaries. The series brackets each interval
+without gaps, but each 31-second phase spans few power samples and batch-arm
+energy itself varies substantially. The aggregate work/J ordering favors
+batching in this run; this does **not** establish a repeatable energy gain.
+Power averaged 63.2–81.5 W against GB10's approximately 140 W envelope.
+Sparklina CPU activity averaged about 6.0% machine-wide, with 0.7–0.9% iowait.
+Both boxes' CPU, memory, I/O and GPU power series are retained; the other box's
+independent work is not charged to this action. GPU utilization is not used.
+
+The measured action is
+`3b12d6fa3f4c42d72d301e511661b87bd104845204b3bdb1254a6af3d384d7de`,
+exit zero; CAS receipt
+`fbcf392528ce1cfac35878e5d8d12481bc293eb3b5dee21126442f78fd317b6d`.
+`BF16/results.json` contains every phase, environment, source hashes and wire
+fingerprint; `BF16/netdata-both-hosts.json` contains raw series and integrals.
+
+Initial paired cProfile passes are retained as a diagnostic limitation:
+scalar accounts for 32.57 seconds of a 32.86-second wall interval, while batch
+accounts for only 3.57 seconds of a 32.64-second wall interval. The incomplete
+batch accounting cannot explain total wall time. Full native sampled profiles
+and the second format's A/B are being finalized; no acceleration claim follows
+from the incomplete profile.
+
+All artifact-relative paths above are beneath
+`/mnt/shared/tessera-measurements/pq300-batch-20260907/`. The `harness/` directory
+retains exact reproduction helpers and their SHA-256 manifest; PB receipts
+also identify the actual submitted checkout snapshot. `campaign.json` holds
+the two isolated measurement actions and `native-profile-campaign.json` the
+follow-up sampled-profile actions. Submit with the published `pbcampaign.py`
+from the measurement host; use new output directories because the harness
+refuses to overwrite an existing result.
+

--- a/docs/measurements/tessera-campaign-batching-2026-09-07.md
+++ b/docs/measurements/tessera-campaign-batching-2026-09-07.md
@@ -129,9 +129,8 @@ fingerprint; `BF16/netdata-both-hosts.json` contains raw series and integrals.
 Initial paired cProfile passes are retained as a diagnostic limitation:
 scalar accounts for 32.57 seconds of a 32.86-second wall interval, while batch
 accounts for only 3.57 seconds of a 32.64-second wall interval. The incomplete
-batch accounting cannot explain total wall time. Full native sampled profiles
-and the second format's A/B are being finalized; no acceleration claim follows
-from the incomplete profile.
+batch accounting cannot explain total wall time. Full native sampled profiles were collected separately (below); no
+acceleration claim follows from the incomplete cProfile accounting.
 
 All artifact-relative paths above are beneath
 `/mnt/shared/tessera-measurements/pq300-batch-20260907/`. The `harness/` directory
@@ -142,3 +141,79 @@ follow-up sampled-profile actions. Submit with the published `pbcampaign.py`
 from the measurement host; use new output directories because the harness
 refuses to overwrite an existing result.
 
+
+## Real cost-row E2M1 A/B
+
+The same eight-unit input, resident preparation, environment, four-core
+reservation and cost-row timing scope were then measured at
+`TESSERA_E2M1_K2_R896`. Wire bytes and all numerical cost fields again matched
+exactly in both warmups, all four measured phases and both cProfile phases.
+The first call warmed scalar for 102.83 seconds and batch-eight for 24.53
+seconds; these are excluded from the table.
+
+| Arm/order | Seconds for 8 rows | Rows/s | GPU joules | Rows/J |
+|---|---:|---:|---:|---:|
+| Scalar / 1 | 98.83112 | 0.080946 | 1973.32 | 0.004054 |
+| Batch 8 / 2 | 23.77231 | 0.336526 | 467.66 | 0.017106 |
+| Batch 8 / 3 | 23.74366 | 0.336932 | 536.65 | 0.014907 |
+| Scalar / 4 | 98.83196 | 0.080945 | 1680.14 | 0.004761 |
+
+The aggregate comparison is **4.1599× rows/s and 3.6378× rows/J** on this
+workload. Scalar and batch arms each measured 16 total rows: 197.6631 versus
+47.5160 seconds, and 3653.46 versus 1004.31 GPU joules. Energy uses the same
+bracket-checked ten-second Netdata interpolation as BF16 and includes device
+baseline power. It is GPU energy, not wall-plug system energy. The short batch
+phases limit its precision; both batch observations nevertheless exceed both
+scalar observations in work/J in this run.
+
+Average GPU power was only 17.0–22.6 W; machine-wide CPU activity was about
+6.0–6.1%, with 0.7–0.8% iowait. These measurements establish a family-specific
+latency and energy benefit and substantial unused GPU power headroom. They do
+not establish GPU saturation or identify its cause. The default remains one.
+
+Action `c4c08a329ba4cbb86d299ee2d91382e467c724d60001159b5af332e8afafb7b9`
+completed on Sparklina, exit zero, 509.72 seconds; CAS receipt
+`e0ec6b724209b7744909cdc57d21269f99700314041c7f48e77747b01357fe5c`.
+The raw measurements, paired cProfile files and both-host telemetry are under
+`E2M1/`. Sampled native profiles remain a separate pair of admitted actions.
+
+
+## Full-call native profile follow-up
+
+A separate admitted profile action warmed both complete eight-unit arms and
+sampled one scalar and one batch call at 100 Hz using py-spy native/Python
+stacks. These profiled wall times are excluded from the throughput comparison.
+Each profile receipt verifies its binary, output and log SHA-256 values and
+positive sample count. This bounds memory without retaining an unbounded CUDA
+event table. Native categories are inclusive and may overlap; they are sampled
+host stacks, not GPU kernel durations. Per-thread coverage is explicit in
+`profile-summary.json`.
+
+BF16 produced 3,463 scalar and 3,242 batch main-thread samples, representing
+34.63 and 32.42 sampled thread-seconds; timed cost-row walls were 34.19 and
+32.66 seconds. The small window difference includes sampling/phase bookkeeping
+and sampling resolution. Inclusive CUDA stream synchronization occupied 22.26
+versus 21.25 sampled seconds. The dominant source callsite is
+Tessera `window_viterbi.py:771`, `sse += float(final.sum())`, with 22.19 versus
+21.16 sampled seconds. Inclusive `viterbi_window_fused` occupies 30.77 versus
+29.01 sampled seconds. This broadly unchanged full-call profile supports the
+flat throughput finding and replaces the incomplete batch cProfile account.
+A synchronization wait includes outstanding GPU work; its duration alone is
+not a promise of removable latency.
+
+BF16 native action
+`d9cacad92f402405ba1cdd0413e92bed4fc8eab0eaa0785710267e457df59534`
+completed on Sparklina, exit zero, 145.57 seconds; CAS receipt
+`551d095978f5d2a55c5eed1849df6b8770251487d2c30733c9dc188f7d5cb349`.
+Raw profiles, verified profile receipts and both-host Netdata series are under
+`BF16-native-profile/`.
+
+The E2M1 cProfile already accounts for 100.40 of 100.54 scalar wall seconds
+and 25.00 of 25.34 batch wall seconds. `viterbi_columns` calls fall from
+2,048 to 256, with cumulative time 89.56 to 14.46 seconds. Its
+`_TCQPlan.sse` host scalar read (`encode.py:573`) accounts for 89.10 to
+14.38 seconds; unit-local refit work remains near 6.9 seconds. The producer's
+`_run_joined` discards the returned scalar SSE. That is an attributable
+follow-up seam for Tessera #385, reported to its owner; this integration does
+not change the producer, and further speedup from suppressing the readback is
+unmeasured. The full native E2M1 pair is still pending.

--- a/docs/measurements/tessera-campaign-batching-2026-09-07.md
+++ b/docs/measurements/tessera-campaign-batching-2026-09-07.md
@@ -216,4 +216,33 @@ and 25.00 of 25.34 batch wall seconds. `viterbi_columns` calls fall from
 `_run_joined` discards the returned scalar SSE. That is an attributable
 follow-up seam for Tessera #385, reported to its owner; this integration does
 not change the producer, and further speedup from suppressing the readback is
-unmeasured. The full native E2M1 pair is still pending.
+unmeasured. The full native E2M1 pair below confirms the reduction.
+
+
+E2M1 native sampling produced 10,608 scalar and 2,814 batch main-thread
+samples, representing 106.08 and 28.14 sampled seconds; profiled walls were
+105.45 and 27.85 seconds. Inclusive `sse` time is 90.43 versus 14.98 sampled
+seconds. CUDA stream synchronization totals 71.58 versus 16.38 sampled seconds;
+the `sse` readback at `encode.py:574` is responsible for 66.24 versus 11.20
+of those seconds. The next largest synchronization site, `_fit_lut:1522`,
+remains 4.68 versus 4.63 seconds. This localizes the observed batching gain to
+the joined trellis/readback path while showing that independent refit waits
+persist. It does not measure the effect of a future asynchronous SSE change.
+
+E2M1 native action
+`192ab33b80faa3a251dab65fad7a5fda92834340bf308025c1ea31b9f2c867a9`
+completed on Sparklina, exit zero, 272.18 seconds; CAS receipt
+`2626f7830802671e6351d240eff23988543f94f75e5124f4bfa1e7834a1ac922`.
+Raw profiles, verified profile receipts and both-host Netdata series are under
+`E2M1-native-profile/`. Both hosts' telemetry brackets every measured and
+profiled interval in both formats, without missing-series or gap errors.
+
+All four performance actions and the CUDA correctness gate have terminal
+exit-zero records and CAS receipts. The 48-file `evidence-manifest.json` binds
+the capture correction, reproduction helpers, action receipts, results,
+profiles and telemetry by SHA-256. Temporary checkout helpers were retired
+after byte-identical copies were retained in `harness/`; the production branch
+has no untracked helper files. The original zero-route failed capture remains
+bounded negative evidence and does not qualify full-model calibration.
+
+Evidence manifest SHA-256: `8b144abda1b4a9933070146e9a54a1c5dcbd62c0159bae7428184a9bafdd11e5`.

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -39,7 +39,8 @@ to the dynamic quantiser.
 Rendering identity, and the wire
 --------------------------------
 The render is not ``render_tessera_weight``'s reconstruction; it is
-``read_unit_artifact(encode_linear(...).blob)`` -- **the bytes, decoded**.  So the
+``read_unit_artifact(encode_linear(...).blob)`` (or the equivalent batch
+entry) -- **the bytes, decoded**.  So the
 cache entry holds the wire beside the dequantised render. Checkpoint resume
 verifies those bytes against their producer input receipt. That proves the
 cached wire is the priced wire. The packed producer-plan/cached-wire bridge
@@ -140,6 +141,7 @@ class CampaignAnchor:
     activation_contract: str
     activation_quantized: bool
     wire_bytes: int
+    #: Encoding wall time; joined batches apportion it equally among units.
     seconds: float
     #: Was a Hessian actually applied to these bytes? Admission comes from the
     #: producer's ActivationSource settings for this rung's scale plane, via
@@ -151,6 +153,7 @@ class CampaignAnchor:
     #: on every other route.  Carried per row so the price's activation
     #: identity survives into the cost table beside the Hessian identity.
     input_global_scale: "float | None" = None
+    encoding_batch_size: int = 1
 
 
 def anchor_schedule(lo: int, hi: int, count: int) -> list[int]:
@@ -313,7 +316,7 @@ def _encode_and_render(weight, format_name: str, *, activation_kwargs=None,
     """``(render, blob)`` for one rung: the bytes, and what they decode to.
 
     A thin adapter over ``tessera_render.encode_tessera_unit``, which is the
-    **one** function in this tree that calls Tessera's byte path.  Everything
+    shared scalar/batch adapter that calls Tessera's byte path.  Everything
     that made this function worth having -- the render is
     ``read_unit_artifact(blob)``, i.e. the bytes decoded rather than a second
     reconstruction (principle 8), and ``verify=False`` because the tensor
@@ -362,12 +365,24 @@ def _measure_anchor(
     of a rung whose shipping bytes are H-aware is exactly that bug with
     different bytes.
     """
-    import torch
+    prepared = _prepare_anchor(
+        qname=qname, format_name=format_name,
+        activation_kwargs_for=activation_kwargs_for,
+        hessian_required=hessian_required, static_input_scale=static_input_scale)
+    started = time.time()
+    render, blob = _encode_and_render(
+        weight, format_name, recipe=prepared["wire"],
+        activation_kwargs=prepared["activation_kwargs"],
+        hessian_required=prepared["hessian_required"])
+    return _finish_anchor(qname=qname, weight=weight, activations=activations,
+        format_name=format_name, cache=cache, wire_dir=wire_dir,
+        prepared=prepared, render=render, blob=blob, elapsed=time.time() - started)
 
+
+def _prepare_anchor(*, qname, format_name, activation_kwargs_for,
+                    hessian_required, static_input_scale):
+    """Admit each unit's Hessian and served activation contract before encode."""
     from . import format_registry as fr
-    from .production_weight_cache import (
-        _local_forward_render_score, _store_rendered_weight_entry,
-    )
     from .tessera_formats import (
         parse_tessera_format_name, tessera_serving_route, tessera_wire_recipe,
     )
@@ -432,13 +447,22 @@ def _measure_anchor(
             raise HessianContractError(
                 f"{qname}: no Hessian for this Linear. A lookup that misses "
                 "must not fall through to a weights-only encode.")
-    started = time.time()
-    render, blob = _encode_and_render(
-        weight, format_name, recipe=wire, activation_kwargs=activation_kwargs,
-        hessian_required=hessian_required,
-    )
-    elapsed = time.time() - started
+    return dict(spec=spec, family=family, rung=rung, wire=wire,
+                activation_qdq=activation_qdq, input_scale=input_scale,
+                activation_kwargs=activation_kwargs,
+                hessian_required=hessian_required)
 
+
+def _finish_anchor(*, qname, weight, activations, format_name, cache, wire_dir,
+                   prepared, render, blob, elapsed, encoding_batch_size=1):
+    """Score decoded bytes and publish the existing cache/wire entries."""
+    import torch
+    from .production_weight_cache import (
+        _local_forward_render_score, _store_rendered_weight_entry)
+
+    spec, family, rung = (prepared[key] for key in ("spec", "family", "rung"))
+    activation_qdq, input_scale = (prepared[key] for key in (
+        "activation_qdq", "input_scale"))
     score, metric, quantized, _clipped = _local_forward_render_score(
         reference_weight=weight,
         rendered_weight=render,
@@ -451,7 +475,7 @@ def _measure_anchor(
     )
     if metric != "output_mse":
         raise RuntimeError(f"unexpected render-score metric {metric!r}")
-    hessian_applied = bool(activation_kwargs)
+    hessian_applied = bool(prepared["activation_kwargs"])
 
     _store_rendered_weight_entry(
         weights=cache.weights,
@@ -488,7 +512,55 @@ def _measure_anchor(
         seconds=elapsed,
         hessian_applied=hessian_applied,
         input_global_scale=input_scale,
+        encoding_batch_size=encoding_batch_size,
     )
+
+
+def _measure_anchor_batch(*, qnames, weights, activations, format_name,
+                          cache, wire_dir, activation_kwargs_for=None,
+                          hessian_required=True, static_input_scales=None):
+    """One producer batch, with the scalar path's per-unit gates and storage."""
+    from .tessera_render import encode_tessera_units
+
+    if not qnames or len(set(qnames)) != len(qnames):
+        raise ValueError("anchor batch needs distinct nonempty unit names")
+    if len(weights) != len(qnames) or len(activations) != len(qnames):
+        raise ValueError("anchor batch needs one weight and activation input per unit")
+    prepared = [_prepare_anchor(
+        qname=name, format_name=format_name,
+        activation_kwargs_for=activation_kwargs_for,
+        hessian_required=hessian_required,
+        static_input_scale=(static_input_scales or {}).get(name)) for name in qnames]
+    started = time.time()
+    encoded = encode_tessera_units(
+        weights, format_name, recipe=prepared[0]["wire"],
+        activation_kwargs=[entry["activation_kwargs"] for entry in prepared],
+        hessian_required=prepared[0]["hessian_required"])
+    # Batch wall time is apportioned, not attributed as a measured per-unit
+    # duration. Summing anchor.seconds still reports the actual encoding time.
+    elapsed = (time.time() - started) / len(qnames)
+    return [_finish_anchor(qname=name, weight=weight, activations=acts,
+        format_name=format_name, cache=cache, wire_dir=wire_dir, prepared=entry,
+        render=render, blob=blob, elapsed=elapsed, encoding_batch_size=len(qnames))
+        for name, weight, acts, entry, (render, blob) in zip(
+            qnames, weights, activations, prepared, encoded)]
+
+
+def _anchor_batches(pending, *, weights, expert_members, batch_size):
+    """Bound compatible expert encodes inside this action; never assign hosts."""
+    if batch_size < 1:
+        raise ValueError("anchor batch size must be positive")
+    if batch_size == 1:
+        return [[item] for item in pending]
+    groups = {}
+    for item in pending:
+        name, family, rung = item
+        weight = weights[name]
+        key = ((family, rung, tuple(weight.shape), weight.dtype, weight.device)
+               if name in expert_members else (name, family, rung))
+        groups.setdefault(key, []).append(item)
+    return [group[start:start + batch_size] for group in groups.values()
+            for start in range(0, len(group), batch_size)]
 
 
 # ---------------------------------------------------------------------------
@@ -500,8 +572,8 @@ def _measure_anchor(
 # serving-unit promotion already enforces that (``allocator_solver.
 # _packed_groups_by_profile`` keys ``...experts.gate_up_proj`` and
 # ``...experts.down_proj`` into the same ``__packed_format__`` group).  The
-# campaign, however, measures ONE EXPERT AT A TIME -- an encode is per Linear
-# -- and on a 32-expert stack a full census of every rung is 32x the GPU.
+# campaign measures separate expert Linears, optionally encoding compatible
+# units together. A full census still requires every expert's wire and score.
 #
 # So the campaign may measure a SAMPLE of experts and this module estimates the
 # stack from it.  Two things have to be right for that to be honest:
@@ -1196,6 +1268,9 @@ def campaign_cost_payload(
                     "activation_contract": anchor.activation_contract,
                     "wire_bytes": anchor.wire_bytes,
                     "encode_seconds": anchor.seconds,
+                    "encode_seconds_accounting": ("unit" if anchor.encoding_batch_size == 1
+                        else "batch_wall_time_divided_by_batch_size"),
+                    "encoding_batch_size": anchor.encoding_batch_size,
                     # The static A-side scale this row was scored under, when
                     # its route executes the static NVFP4 contract; the value
                     # identity the export's scale file must reproduce.
@@ -1339,8 +1414,8 @@ def _campaign_checkpoint_identity(*, weights, acts, hessians, menus, args,
 
     api = _checkpoint_identity_api()
     settings = vars(args).copy()
-    # Locations and a wall-clock interruption limit are not encoding/scoring
-    # inputs. All other explicit campaign settings remain bound by default.
+    # Locations, batch width and a wall-clock interruption limit are not
+    # encoding/scoring inputs. All other explicit campaign settings remain bound by default.
     #
     # ``units``, ``calibration_census`` and ``census_out`` are locations too,
     # and each one's load-bearing content is already bound by value somewhere
@@ -1357,7 +1432,7 @@ def _campaign_checkpoint_identity(*, weights, acts, hessians, menus, args,
     # ``--seed-checkpoint``, one verified row at a time.
     for name in ("out", "cache_dir", "checkpoint", "deadline_seconds",
                  "units", "calibration_census", "census_out",
-                 "seed_checkpoint", "seed_wire_dir"):
+                 "seed_checkpoint", "seed_wire_dir", "anchor_batch_size"):
         settings.pop(name, None)
     return {
         **({"stack_sampling_identity": stack_sampling_identity}
@@ -2979,6 +3054,10 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     ap.add_argument("--layer-stride", type=int, default=1,
                     help="price every Nth decoder layer (1 = every Linear)")
     ap.add_argument("--anchors", type=int, default=ROUND_ONE_ANCHORS)
+    ap.add_argument("--anchor-batch-size", type=int, default=1,
+                    help="maximum compatible expert anchors in one producer "
+                         "batch within this action (1 = scalar). Does not "
+                         "change the anchor schedule or PB placement.")
     ap.add_argument("--max-rounds", type=int, default=0,
                     help="hard stop on adaptive rounds (0 = governed by "
                          "--anchor-budget instead). Rounds are not the "
@@ -3056,6 +3135,11 @@ def main(argv: "Sequence[str] | None" = None) -> int:
                          "write it here and exit. No Hessians, no retained "
                          "scoring rows, no encodes.")
     args = ap.parse_args(argv)
+    if args.anchor_batch_size < 1:
+        ap.error("--anchor-batch-size must be positive")
+    if args.anchor_batch_size > 1:
+        from .tessera_render import require_tessera_batch_encoder
+        require_tessera_batch_encoder()
     serving_target = serving_target_from_args(args)
 
     mode = menu_mode(args.menu_mode)
@@ -3707,45 +3791,59 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             break
         print(f"[campaign] round {round_index}: {len(pending)} anchors",
               flush=True)
-        for index, (name, family, rung) in enumerate(pending):
+        batches = _anchor_batches(
+            [item for item in pending if acts.get(item[0]) is not None],
+            weights=weights, expert_members=expert_members,
+            batch_size=args.anchor_batch_size)
+        completed = 0
+        for batch in batches:
             if out_of_time():
                 stopped_early = True
                 print("[campaign] deadline reached; stopping", flush=True)
                 break
+            names = [item[0] for item in batch]
+            family, rung = batch[0][1:]
             fmt = f"{family}_R{rung}"
-            activations = acts.get(name)
-            if activations is None:
-                continue
             try:
-                anchor = _measure_anchor(
-                    qname=name, weight=weights[name].to(device),
-                    activations=activations.to(device),
-                    format_name=fmt, cache=cache, wire_dir=wire_dir,
+                common = dict(format_name=fmt, cache=cache, wire_dir=wire_dir,
                     activation_kwargs_for=(
                         _activation_kwargs_for if want_h else None),
-                    hessian_required=want_h,
-                    static_input_scale=static_scales.get(name),
-                )
+                    hessian_required=want_h)
+                if len(batch) == 1:
+                    name = names[0]
+                    anchors = [_measure_anchor(
+                        qname=name, weight=weights[name].to(device),
+                        activations=acts[name].to(device),
+                        static_input_scale=static_scales.get(name), **common)]
+                else:
+                    anchors = _measure_anchor_batch(
+                        qnames=names,
+                        weights=[weights[name].to(device) for name in names],
+                        activations=[acts[name].to(device) for name in names],
+                        static_input_scales=static_scales, **common)
             except (HessianContractError, ActivationScaleContractError):
-                # Never absorbed into "one anchor failed": a contract refusal
-                # is about every row this run would write, not this one.
                 raise
             except Exception as exc:
-                print(f"[campaign] {name} {fmt}: FAILED {type(exc).__name__}: "
+                print(f"[campaign] {names} {fmt}: FAILED {type(exc).__name__}: "
                       f"{exc}", flush=True)
                 continue
-            identity = _checkpoint_anchor_identity(
-                anchor, weights=weights, menus=menus,
-                calibration_source=calibration_source, static_scales=static_scales,
-                projected_units=projected_units)
-            wire_records[name][fmt] = _checkpoint_wire_record(anchor, wire_dir, identity)
-            measured.setdefault(name, {}).setdefault(family, []).append(anchor)
-            dirty_checkpoint_units.add(name)
-            if index % 10 == 0:
+            for anchor in anchors:
+                name = anchor.qname
+                identity = _checkpoint_anchor_identity(
+                    anchor, weights=weights, menus=menus,
+                    calibration_source=calibration_source, static_scales=static_scales,
+                    projected_units=projected_units)
+                wire_records[name][fmt] = _checkpoint_wire_record(anchor, wire_dir, identity)
+                measured.setdefault(name, {}).setdefault(family, []).append(anchor)
+                dirty_checkpoint_units.add(name)
+            completed += len(anchors)
+            # Commit every joined quantum before advancing. The scalar mode
+            # keeps its existing ten-anchor flush cadence.
+            if args.anchor_batch_size > 1 or (completed - 1) % 10 == 0:
                 flush_checkpoint()
-                print(f"[campaign] r{round_index} {index}/{len(pending)} "
-                      f"{name} {fmt} mse={anchor.dloss:.6g} "
-                      f"{anchor.seconds:.1f}s", flush=True)
+                print(f"[campaign] r{round_index} {completed}/{len(pending)} "
+                      f"batch={len(anchors)} {fmt} "
+                      f"encode_seconds={sum(a.seconds for a in anchors):.3f}", flush=True)
         flush_checkpoint()
         if stopped_early:
             break

--- a/prismaquant/tessera_render.py
+++ b/prismaquant/tessera_render.py
@@ -1053,7 +1053,7 @@ def synthesize_tessera_spec(
 
 
 # ---------------------------------------------------------------------------
-# The encoder seam: one function owns the call into Tessera's byte path.
+# The encoder seam: scalar and batch entries share one input guard.
 # ---------------------------------------------------------------------------
 
 class HessianContractError(RuntimeError):
@@ -1273,6 +1273,17 @@ def encode_tessera_unit(
     """
     from tessera.unit_artifact import read_unit_artifact
 
+    kwargs = _tessera_unit_encode_kwargs(
+        format_name, activation_kwargs=activation_kwargs,
+        hessian_required=hessian_required, verify=verify, recipe=recipe)
+    unit = _tessera_export.encode_linear(weight, **kwargs)
+    render = read_unit_artifact(unit.blob, device=str(weight.device))
+    return render.to(dtype=weight.dtype, device=weight.device), unit.blob
+
+
+def _tessera_unit_encode_kwargs(format_name, *, activation_kwargs,
+                                hessian_required, verify, recipe):
+    """The shared single/batch admission and producer keyword contract."""
     from .tessera_formats import parse_tessera_format_name
 
     parsed = parse_tessera_format_name(format_name)
@@ -1341,14 +1352,63 @@ def encode_tessera_unit(
                 "object's output and nothing else."
             )
         kwargs.update(activation_kwargs)
-    unit = _tessera_export.encode_linear(weight, **kwargs)
-    render = read_unit_artifact(unit.blob, device=str(weight.device))
-    return render.to(dtype=weight.dtype, device=weight.device), unit.blob
+    return kwargs
+
+
+def require_tessera_batch_encoder():
+    """Refuse an explicitly requested batch before any campaign work starts."""
+    encoder = getattr(_tessera_export, "encode_linears", None)
+    if not callable(encoder):
+        raise RuntimeError(
+            "Tessera producer has no encode_linears API; anchor batching requires "
+            "a producer with Tessera #386 (382a1a97 or later).")
+    return encoder
+
+
+def encode_tessera_units(weights, format_name: str, *, activation_kwargs=None,
+                         hessian_required: bool = True, verify: bool = False,
+                         recipe=None):
+    """Encode compatible units at one rung with their own activation inputs.
+
+    Each wire retains the scalar adapter's artifact name and is decoded by the
+    same reader. All unit inputs pass the scalar guard before the producer runs;
+    Tessera owns the joined trellis and validation of shared encoder settings.
+    """
+    from tessera.unit_artifact import read_unit_artifact
+
+    weights = list(weights)
+    if not weights:
+        raise ValueError("encode_tessera_units needs at least one weight")
+    per_unit = ([None] * len(weights) if activation_kwargs is None
+                else list(activation_kwargs))
+    if len(per_unit) != len(weights):
+        raise ValueError("one activation input is required per batch weight")
+    first = weights[0]
+    if any((w.shape, w.dtype, w.device) !=
+           (first.shape, first.dtype, first.device) for w in weights):
+        raise ValueError("batch weights must share shape, dtype and device")
+    admitted = [_tessera_unit_encode_kwargs(
+        format_name, activation_kwargs=inputs,
+        hessian_required=hessian_required, verify=verify, recipe=recipe)
+        for inputs in per_unit]
+    common = {key: admitted[0][key] for key in ("grid", "q256", "verify")}
+    units = require_tessera_batch_encoder()(
+        weights, names=[entry["name"] for entry in admitted],
+        per_unit=[{key: value for key, value in entry.items()
+                   if key not in {"grid", "q256", "verify", "name"}}
+                  for entry in admitted], **common)
+    if len(units) != len(weights):
+        raise RuntimeError("Tessera batch returned the wrong number of units")
+    return [(read_unit_artifact(unit.blob, device=str(weight.device)).to(
+                dtype=weight.dtype, device=weight.device), unit.blob)
+            for weight, unit in zip(weights, units)]
 
 
 __all__ += [
     "HessianContractError",
     "encode_tessera_unit",
+    "encode_tessera_units",
+    "require_tessera_batch_encoder",
     "rung_accepts_hessian",
     "tessera_encoder_hessian_status",
 ]

--- a/tests/test_tessera_campaign_batch.py
+++ b/tests/test_tessera_campaign_batch.py
@@ -1,0 +1,157 @@
+"""Batch admission preserves per-unit inputs, prices, wire bytes and retries."""
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from prismaquant import tessera_campaign as campaign
+from prismaquant import tessera_render as render
+
+
+FMT = "TESSERA_E4M3_K1_R1024"
+
+
+def test_pending_batches_keep_each_anchor_once_and_split_incompatible_units():
+    weights = {name: torch.empty(shape) for name, shape in {
+        "a": (16, 256), "b": (16, 256), "c": (32, 256),
+        "dense": (16, 256), "d": (16, 256),
+    }.items()}
+    pending = [("a", "family", 100), ("a", "family", 200),
+               ("b", "family", 100), ("c", "family", 100),
+               ("dense", "family", 100), ("d", "family", 100)]
+    batches = campaign._anchor_batches(
+        pending, weights=weights, expert_members={"a", "b", "c", "d"},
+        batch_size=2)
+    assert sorted(item for batch in batches for item in batch) == sorted(pending)
+    assert [("a", "family", 100), ("b", "family", 100)] in batches
+    assert [("dense", "family", 100)] in batches
+    assert max(map(len, batches)) == 2
+    assert campaign._anchor_batches(pending, weights=weights,
+        expert_members=set(weights), batch_size=1) == [[item] for item in pending]
+
+
+def test_batch_adapter_calls_producer_once_with_separate_activation_inputs(monkeypatch):
+    seen = []
+    weights = [torch.full((16, 256), float(i)) for i in (1, 2)]
+    hessians = [{"ldl": torch.eye(256) * i, "ldl_block": 128} for i in (1, 2)]
+    monkeypatch.setattr(render, "_encoder_accepts_hessian",
+                        lambda: (True, {"ldl", "ldl_block"}, {}))
+    monkeypatch.setattr(render, "rung_accepts_hessian", lambda *_args: True)
+
+    def encode(values, **kwargs):
+        seen.append((values, kwargs))
+        return [SimpleNamespace(blob=bytes([i])) for i in range(len(values))]
+
+    monkeypatch.setattr(render._tessera_export, "encode_linears", encode)
+    from tessera import unit_artifact
+    monkeypatch.setattr(unit_artifact, "read_unit_artifact",
+                        lambda blob, **_kwargs: weights[blob[0]])
+    out = render.encode_tessera_units(weights, FMT, activation_kwargs=hessians)
+    assert len(seen) == 1
+    assert seen[0][1]["names"] == [FMT, FMT]
+    assert seen[0][1]["per_unit"] == hessians
+    assert all(torch.equal(actual[0], expected) for actual, expected in zip(out, weights))
+
+
+def test_batch_missing_hessian_refuses_before_any_producer_call(monkeypatch):
+    monkeypatch.setattr(render._tessera_export, "encode_linears",
+                        lambda *_args, **_kwargs: pytest.fail("encoded invalid inputs"))
+    with pytest.raises(render.HessianContractError, match="no Hessian"):
+        render.encode_tessera_units([torch.ones(16, 256)] * 2, FMT,
+                                    activation_kwargs=[{"ldl": torch.eye(256)}, None])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="real encoder CLI requires CUDA")
+def test_real_cli_batch_wire_prices_and_resume_equal_scalar(monkeypatch, tmp_path):
+    import pickle
+    import test_tessera_campaign_packed as fixture
+    monkeypatch.setattr(fixture, "HIDDEN", 256)
+    monkeypatch.setattr(fixture, "INTER", 256)
+    _bridge_main_fixture = fixture._bridge_main_fixture
+
+    scalar_measure = campaign._measure_anchor
+    instance, argv, model, _ = _bridge_main_fixture(monkeypatch, tmp_path)
+    model.to("cuda")
+    monkeypatch.setattr(instance, "_measure_anchor", scalar_measure)
+    argv[argv.index("--hessian") + 1] = "require"
+    real_batch = render._tessera_export.encode_linears
+    seen = []
+
+    def tracked(weights, **kwargs):
+        seen.append(len(weights))
+        return real_batch(weights, **kwargs)
+
+    monkeypatch.setattr(render._tessera_export, "encode_linears", tracked)
+    assert instance.main(argv) == 0
+    baseline = pickle.loads((tmp_path / "cost.pkl").read_bytes())
+    baseline_wires = {path.name: path.read_bytes()
+                      for path in (tmp_path / "cache" / "wire").glob("*.tessera")}
+    batch_args = list(argv)
+    batch_args[batch_args.index("--out") + 1] = str(tmp_path / "batch.pkl")
+    batch_args[batch_args.index("--cache-dir") + 1] = str(tmp_path / "batch-cache")
+    batch_args += ["--anchor-batch-size", "4"]
+    seen.clear()
+    assert instance.main(batch_args) == 0
+    assert 4 in seen
+    candidate = pickle.loads((tmp_path / "batch.pkl").read_bytes())
+    def numerical_costs(costs):
+        return {name: {fmt: {key: value for key, value in row.items()
+                            if key not in {"encode_seconds", "encode_seconds_accounting", "encoding_batch_size"}}
+                       for fmt, row in rows.items()}
+                for name, rows in costs.items()}
+    assert numerical_costs(candidate["costs"]) == numerical_costs(baseline["costs"])
+    batch_wires = {path.name: path.read_bytes()
+                   for path in (tmp_path / "batch-cache" / "wire").glob("*.tessera")}
+    assert batch_wires == baseline_wires and batch_wires
+    monkeypatch.setattr(render._tessera_export, "encode_linears",
+                        lambda *_args, **_kwargs: pytest.fail("resume encoded again"))
+    monkeypatch.setattr(render._tessera_export, "encode_linear",
+                        lambda *_args, **_kwargs: pytest.fail("resume encoded again"))
+    # Batch width is an execution setting, so changing it resumes the same rows.
+    batch_args[-1] = "2"
+    assert instance.main(batch_args) == 0
+    wire = next((tmp_path / "batch-cache" / "wire").glob("*.tessera"))
+    blob = bytearray(wire.read_bytes())
+    blob[-1] ^= 1
+    wire.write_bytes(blob)
+    with pytest.raises(RuntimeError, match="cached wire identity refused"):
+        instance.main(batch_args)
+
+
+def test_batch_scoring_keeps_each_units_static_activation_scale(monkeypatch, tmp_path):
+    from prismaquant import format_registry as fr
+    weights = [torch.ones(16, 256), torch.full((16, 256), 2.0)]
+    acts = [torch.ones(2, 256), torch.full((2, 256), 3.0)]
+    scales = {"a": 0.5, "b": 2.0}
+    spec = SimpleNamespace(
+        static_activation_contract=SimpleNamespace(execution="fixture-static",
+            quantize_dequantize=lambda x, scale: x * scale),
+        bits_for_shape=lambda shape: 8 * shape[0] * shape[1],
+        memory_bytes_for_shape=lambda shape: shape[0] * shape[1], act_dtype_name="a8")
+    get_format = fr.get_format
+    monkeypatch.setattr(fr, "get_format", lambda fmt: spec if fmt == FMT else get_format(fmt))
+    monkeypatch.setattr(render, "encode_tessera_units",
+        lambda values, *_args, **_kwargs: [(w * 0.75, b"wire") for w in values])
+    monkeypatch.setattr(campaign, "_encode_and_render",
+        lambda w, *_args, **_kwargs: (w * 0.75, b"wire"))
+    cache = SimpleNamespace(weights={}, cache_dir=None)
+    wire_dir = tmp_path / "wire"
+    wire_dir.mkdir()
+    batch = campaign._measure_anchor_batch(qnames=["a", "b"], weights=weights,
+        activations=acts, format_name=FMT, cache=cache, wire_dir=wire_dir,
+        hessian_required=False, static_input_scales=scales)
+    scalar = [campaign._measure_anchor(qname=name, weight=w, activations=x,
+        format_name=FMT, cache=cache, wire_dir=wire_dir, hessian_required=False,
+        static_input_scale=scales[name]) for name, w, x in zip(scales, weights, acts)]
+    assert [row.input_global_scale for row in batch] == [0.5, 2.0]
+    assert [row.dloss for row in batch] == [row.dloss for row in scalar]
+    assert batch[0].dloss != batch[1].dloss
+    assert all(row.encoding_batch_size == 2 for row in batch)
+
+
+def test_requested_batch_refuses_old_producer_before_loading_model(monkeypatch, tmp_path):
+    monkeypatch.setattr(render._tessera_export, "encode_linears", None)
+    with pytest.raises(RuntimeError, match="no encode_linears API"):
+        campaign.main(["--model", "must-not-load", "--out", str(tmp_path / "cost.pkl"),
+                       "--cache-dir", str(tmp_path / "cache"), "--anchor-batch-size", "4"])

--- a/tests/test_tessera_campaign_batch.py
+++ b/tests/test_tessera_campaign_batch.py
@@ -43,7 +43,7 @@ def test_batch_adapter_calls_producer_once_with_separate_activation_inputs(monke
         seen.append((values, kwargs))
         return [SimpleNamespace(blob=bytes([i])) for i in range(len(values))]
 
-    monkeypatch.setattr(render._tessera_export, "encode_linears", encode)
+    monkeypatch.setattr(render._tessera_export, "encode_linears", encode, raising=False)
     from tessera import unit_artifact
     monkeypatch.setattr(unit_artifact, "read_unit_artifact",
                         lambda blob, **_kwargs: weights[blob[0]])
@@ -56,7 +56,7 @@ def test_batch_adapter_calls_producer_once_with_separate_activation_inputs(monke
 
 def test_batch_missing_hessian_refuses_before_any_producer_call(monkeypatch):
     monkeypatch.setattr(render._tessera_export, "encode_linears",
-                        lambda *_args, **_kwargs: pytest.fail("encoded invalid inputs"))
+                        lambda *_args, **_kwargs: pytest.fail("encoded invalid inputs"), raising=False)
     with pytest.raises(render.HessianContractError, match="no Hessian"):
         render.encode_tessera_units([torch.ones(16, 256)] * 2, FMT,
                                     activation_kwargs=[{"ldl": torch.eye(256)}, None])
@@ -151,7 +151,7 @@ def test_batch_scoring_keeps_each_units_static_activation_scale(monkeypatch, tmp
 
 
 def test_requested_batch_refuses_old_producer_before_loading_model(monkeypatch, tmp_path):
-    monkeypatch.setattr(render._tessera_export, "encode_linears", None)
+    monkeypatch.setattr(render._tessera_export, "encode_linears", None, raising=False)
     with pytest.raises(RuntimeError, match="no encode_linears API"):
         campaign.main(["--model", "must-not-load", "--out", str(tmp_path / "cost.pkl"),
                        "--cache-dir", str(tmp_path / "cache"), "--anchor-batch-size", "4"])


### PR DESCRIPTION
Compatible Tessera campaign expert anchors can now share one producer `encode_linears` call with `--anchor-batch-size N`. Every unit retains its own Hessian, static scale, byte-identical wire, measured cost row and resume receipt; changing width does not invalidate the journal. The default stays scalar, and a producer missing the batch API refuses before model load.

PrismaBuild validation covers 150 distinct relevant tests, including six new CUDA cases exercising the real campaign CLI and producer, exact scalar/batch outputs, resume without encoding and tampered-wire refusal. Old-producer CPU fixture coverage also passes. Architecture describes the contract; the latest main's container support is integrated.

On eight retained LFM expert w1 units, `[1792,2048]`, fresh matched Hessians/scoring rows and the same calibration identity, isolated Sparklina GB10 ABBA measurements show E2M1 R896 at **4.16× rows/s and 3.64× GPU rows/J**. BF16 R1792 is essentially flat (~0.6%). Full paired native profiles and both-host Netdata are recorded; the E2M1 gain localizes to the joined trellis/readback path. All wires and numerical costs match exactly. This bounded cost-row measurement excludes model loading/calibration and does not qualify full-model KL or serving. One zero-route expert was explicitly excluded from the capture; coverage and scope metadata are documented.

The dated measurement record contains exact commands, source identities, four completed performance-action receipts, profile counts, energy limitations and a SHA-256 evidence manifest. No serving pin, default, format menu or producer recipe changes.

Closes #300. Supports #275 and RobTand/tessera#385; consumes the development API from RobTand/tessera#386.
