### PR TITLE
Bind native operator panels to exact calibration and joint AURA inputs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,16 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-06 · `fix/packed-plan-handoff`. Stamps
+As of: 2026-09-07 · `integration/native-panel-267`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-07, `integration/native-panel-267`) for **exact calibration
+draw intake** (#267, #237). The shared AURA CLI accepts an independently hashed
+safetensors token draw through `--calibration-input` plus
+`--calibration-input-sha256`, preserving its IDs instead of invoking a sampler.
+The shared calibration loader checks sample/sequence geometry, int64 token
+storage, the campaign's int32 draw digest and its provenance. Joint AURA keeps
+its existing int64 tensor digest; both identities are recorded explicitly.
+Dataset sampling remains the default. Gate: `tests/test_native_panel_calibration.py`.
 
 Re-stamped (2026-09-06, `fix/packed-plan-handoff`) for **the producer plan
 input for packed decisions** (§4.10; #293). Scoped preflight already resolved

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,6 +12,16 @@ storage, the campaign's int32 draw digest and its provenance. Joint AURA keeps
 its existing int64 tensor digest; both identities are recorded explicitly.
 Dataset sampling remains the default. Gate: `tests/test_native_panel_calibration.py`.
 
+The same research integration adds a native operator panel/receipt boundary
+(`#267`, `#237`) in `prismaquant.native_operator_panel`. Frozen PWC renders,
+source wire and shared activation QDQ provide the independent references;
+actual joint rows bind the same calibration and predeclared probes. Tessera's
+separate producer owns native preparation/execution. PQ consumes exact
+panel/runtime/route/tensor and resource-trace identities while retaining
+unknown fixed/full-model resources. Operator observations alone cannot become
+a measured-runtime table, and no pin, format default or serving gate changes.
+Gate: `tests/test_native_operator_panel.py`.
+
 Re-stamped (2026-09-06, `fix/packed-plan-handoff`) for **the producer plan
 input for packed decisions** (§4.10; #293). Scoped preflight already resolved
 packed allocations against per-expert wire receipts, but the producer's

--- a/docs/design/joint_aura_runtime_allocation.md
+++ b/docs/design/joint_aura_runtime_allocation.md
@@ -187,3 +187,23 @@ and sequence counts must match. This path bypasses dataset sampling and refuses
 the int64 token hash used by joint AURA, with the original seed retained in
 provenance. A WT2 train 32 × 512 torch-randint draw and the retained diverse
 32 × 1024 Fisher draw are different calibrations even when both name seed zero.
+
+The research native bridge in `prismaquant.native_operator_panel` prepares
+reference inputs through the existing PWC, shared activation QDQ, and decoded
+producer wire. `experiments/pq267_native_panel.py` transports those immutable
+artifacts to Tessera's separate `bench_native_operator.py`; PQ imports no
+Tessera serving runtime. A preparation plan freezes the source checkpoint,
+calibration draw, probe seed/count, input row counts, and numerical tolerance
+before native output is observed. Actual joint cost rows must match those
+inputs before the independent panel is frozen. Native preparation facts never
+substitute for numerical references.
+
+Receipt intake verifies the exact panel/runtime/tensor/route bindings, both
+prefill and decode numerical results at the frozen tolerance, and repeated
+single-apply measurements. Native allocation bounds require the accompanying
+memory trace and matching collector identity. The bridge preserves unknown
+native scratch as unknown, and always leaves fixed/full-model resources
+unknown. It produces operator evidence, not a complete runtime table: complete
+table admission still needs independently measured fixed/KV work and the
+serving-unit coverage required above. A readable research rung or a local
+operator parity result does not change the runtime pin or serving gates.

--- a/docs/design/joint_aura_runtime_allocation.md
+++ b/docs/design/joint_aura_runtime_allocation.md
@@ -176,3 +176,14 @@ wrapper does not infer these experimental inputs or enable this mode.
 The [current-model screen](../measurements/pq237-joint-aura-screen-2026-09-05.md)
 verifies numerical decomposition but shows no selection-quality gain.
 Qualification remains open in #237.
+
+An existing draw can be passed unchanged with `--calibration-input` and its
+independently held `--calibration-input-sha256`. The safetensors artifact contains
+only `calibration_ids` (int64, samples × sequence length); its
+`calibration_provenance` metadata records the original draw, including
+`fit_ids_sha256`, `fit_tokens`, `nsamples`, and `seqlen`. The explicit CLI sample
+and sequence counts must match. This path bypasses dataset sampling and refuses
+`--dataset`. It checks the campaign's int32 token hash and separately records
+the int64 token hash used by joint AURA, with the original seed retained in
+provenance. A WT2 train 32 × 512 torch-randint draw and the retained diverse
+32 × 1024 Fisher draw are different calibrations even when both name seed zero.

--- a/docs/research/native_panel_267_2026-09-07.md
+++ b/docs/research/native_panel_267_2026-09-07.md
@@ -90,3 +90,42 @@ with four pytest workers and native threads bounded to one, CPU-only, no skips:
 PB `c15c02b7ff50fc29181a1d5dd6706e846f5a5bcf60f827b7a8f9aee708168acc`,
 exit 0; verified receipt
 `1eb6a46a751e09cdf268ebfa815094ce15e945f442f3d6d0a43f85aff35a018c`.
+
+## Correction: the earlier resident reference was not canonical
+
+Subsequent diagnosis by the streaming owner (PB
+`c999ff211ab7`, retained by that owner) established that PrismaQuant's global
+no-init patch suppressed Transformers' checkpoint-finalization initialization
+of nonpersistent rotary buffers. The ordinary HF arm used by `joint-02` was
+therefore not a valid source-quality reference. Its recorded mismatch is a
+real difference between those two executed paths, but cannot attribute the
+whole difference to streaming. The source-quality interpretation above is
+superseded by this correction; the raw failed artifact remains unchanged.
+
+The helper now brackets its HF reference load with the existing
+`genuine_weight_initialization()` context. The streaming owner also identified
+FP32-buffer preservation and explicit eager attention as required for source
+parity. That owner's corrected canonical HF/streaming diagnostic is bit-exact
+across all logits and layers. These findings require fresh canonical captures
+before any actual joint/native qualification: the earlier captures and their
+PWC/native inputs are historical preparation/integrity evidence only, not
+qualified source-quality inputs. The pending native panel must use regenerated
+captures and costs, not a metadata revision of the old tensors.
+
+Fresh preparation now requires `prismaquant.native_dense_preparation.v2` with
+an independently hashed shared `prismaquant.tessera_calibration_cache.v2`
+manifest, its canonical census path, and an exact calibration input path/hash.
+The shared capture reader validates actual initialization/runtime provenance;
+the helper prefetches the selected X/H entry through that existing mechanism.
+The historical protocol JSON is refused. Both GPU wrappers require explicit
+CLI input/hash/output arguments and contain no implicit old-capture defaults.
+This adapter depends on the shared capture-v2 implementation; it fails closed
+before any quality use when that implementation or a fresh capture is absent.
+
+The canonical-capture adapter and quarantine regressions passed 48 checks on
+DL380g10, CPU-only, four pytest workers, native threads bounded to one, no
+skips: PB `7ced034e2c72df41a32f2b0104af0b7f931163ebb724f48dd283988f9a06bd02`,
+exit 0; receipt
+`53475fa74d4518957099ec3a31bec359c842be470b857ab33ce57008dbcfe3de`.
+The CAS payload hash was independently recomputed. This validates the helper
+guards and existing panel contracts; fresh GPU qualification remains pending.

--- a/docs/research/native_panel_267_2026-09-07.md
+++ b/docs/research/native_panel_267_2026-09-07.md
@@ -1,0 +1,92 @@
+# Native operator panel bridge: 2026-09-07 qualification
+
+This record covers one dense LFM2.5-8B-A1B unit,
+`model.layers.0.feed_forward.w1`, source shape `[7168, 2048]`, using
+`TESSERA_BF16_K1_R1792`. It does not establish full-model cost coverage, an
+allocator runtime table, or a serving gate. The preparation uses the existing
+ProductionWeightCache and shared activation QDQ. Tessera's separate producer
+owns native operator preparation, measurement, and memory-trace analysis; PQ
+checks the immutable panel and receipt bindings, without importing that runtime.
+
+The exact retained calibration is WT2 train, seed zero, 32 × 512 tokens. Its
+int32 draw digest is `809883cb91e1359d0b7e7829f4a7ab3ddeacd7eee75a66dd6866aa671a4f935d`.
+The retained dense Hessian uses all 16,384 token rows. Native input shapes use
+512 actual retained activation rows for prefill and the first row for decode;
+these are operator shape checks, not an autoregressive engine workload. The
+separate full 512 × 512 census is a different calibration and cannot consume
+these costs as its own.
+
+Artifacts are retained under
+`/mnt/shared/tessera-measurements/pq267-native-20260907/`. The source protocol is
+`experiments/protocols/pq267-lfm-dense-20260907.json`; wrappers
+`experiments/pq267_native_prepare.sh` and `experiments/pq267_joint_probe.sh`
+record executable preparation/probe commands. Run them through PrismaBuild.
+Both native numerical tolerances were frozen before output at
+`atol=rtol=0.015625`; source/render/wire identities remain exact.
+
+## Completed preparation and CPU qualification
+
+PB `c5c402fc2de38d7dcbc4b428e928b668342a52ab661b3b13da1c848de77ffdb4`
+completed on Sparky with exit 0; CAS receipt
+`9218f721a77ba1a635cda809ecac372f2c4e05f2a9a76bc92a66be0843947b1b`
+and payload hash were checked. `dense-r1792-01` retains a real resident PWC
+entry of 29,360,128 bytes, zero prefetch misses, and a 12,892,880-byte producer
+wire whose decoded values match the PWC exactly. Artifact file hashes were
+recomputed against `inputs.json`. No timing improvement is claimed.
+
+The initial image label contained only a digest. Versioned transport metadata
+corrected it to the actual immutable RepoDigest
+`eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c`.
+`inputs.v2.json` has SHA256
+`c9d9f5a886a2ca3ff4e919349d005356b46d231eee04640af3abb3dfb862a756`;
+`request.v2.json` has SHA256
+`98191514a952658a8be856aad16cf243a82d58df2106852c7868d4659e754143`.
+Original metadata remains alongside it; tensors, PWC, wire, calibration and
+numerical policy did not change. Native preflight is untimed preparation only:
+`native-preflight.json`, SHA256
+`5cb86100285f6e20e1b52ef8fc6529cd2c76203984d9cfb94e30571e9e592575`.
+
+PB `9579e2f0c1e866c9892a27bdeb700a069ca323354cd0e0087e32e050165b8cda`
+ran compile checks for the experiment and 46 targeted tests on Sparky, CPU
+mode, one worker and native threads bounded to one, exit 0, no skips:
+`tests/test_native_operator_panel.py`,
+`tests/test_native_panel_calibration.py`, `tests/test_docs_staleness.py`, and
+`tests/test_architecture_doc.py`. Receipt
+`4e994836a50c8232f15c00171875b6fe6a3112e48d3c3bd36febaa344b99f3f6`
+and CAS payload were checked. Negative cases reject altered probe seeds,
+source bytes, source/render/activation/calibration identities, image/runtime
+bindings, route shapes, tolerances, timing granularity, missing native memory
+traces, and inconsistent peak composition. This establishes boundary behavior;
+it does not substitute for a measured real joint row or native receipt.
+
+## Preserved failures and practical consequences
+
+The first PWC preparation failed before rendering because root inside Docker
+could not read the UID-owned calibration file on the root-squashed shared
+mount. Running the known image as the invoking UID/GID fixed that transport
+failure. An earlier queued preparation was withdrawn before admission after
+strengthening source/probe binding; it produced no measurement.
+
+Joint attempt
+`3a71db3cf672b9c0820df4feb011eb23f172cd86725f4d8cd7b4738537bca896`
+failed before weights loaded: the reference helper passed `device_map` to a
+container without Accelerate. The helper now performs ordinary HF loading and
+`.to("cuda")`, as supported by the shared CLI's existing fallback.
+
+Joint attempt
+`d95cf7b5cc9730fbcfc7621feb1ed9b07d71cb77aa453460d42c164e59f0d7e4`
+then failed with exit 1 at the full-vocabulary forward check, before cost
+probes. The resident HF model and prefetched streamed model saw the same first
+calibration sequence, both BF16. Their `[1, 512, 128000]` logits had maximum
+absolute error 15.78125 and maximum tolerance-normalized error
+833.1246948242188. The frozen tolerance was not relaxed. Raw result:
+`joint-02/streamed-forward-parity.json`; request and source identity are retained
+beside it. The streaming integration owner is correcting this defect before
+any cost rerun. No successful joint panel, native price, or full-model resource
+claim follows from the failed check.
+
+The final edited helper and report also passed the same 46 checks on DL380g10
+with four pytest workers and native threads bounded to one, CPU-only, no skips:
+PB `c15c02b7ff50fc29181a1d5dd6706e846f5a5bcf60f827b7a8f9aee708168acc`,
+exit 0; verified receipt
+`1eb6a46a751e09cdf268ebfa815094ce15e945f442f3d6d0a43f85aff35a018c`.

--- a/experiments/pq267_joint_probe.sh
+++ b/experiments/pq267_joint_probe.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+image=eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
+input_root=/mnt/shared/tessera-measurements/first-model-20260907/inputs
+prisma_snapshot_commit=$(git rev-parse HEAD)
+docker run --rm --gpus all --ipc=host --network=host --user "$(id -u):$(id -g)" \
+  -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared -w /workspace --entrypoint python3 \
+  -e PYTHONDONTWRITEBYTECODE=1 -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
+  -e XDG_CACHE_HOME=/tmp/pq267-cache -e TORCH_EXTENSIONS_DIR=/tmp/pq267-extensions \
+  -e HF_HOME=/tmp/pq267-hf -e HF_MODULES_CACHE=/tmp/pq267-modules \
+  -e "PRISMAQUANT_IDENTITY_GIT_COMMIT=$prisma_snapshot_commit" \
+  -e "PYTHONPATH=/workspace:$input_root/tessera-382a1a97/src:$input_root/container-compatible-deps" \
+  "$image" -m experiments.pq267_native_panel probe \
+  --inputs /mnt/shared/tessera-measurements/pq267-native-20260907/dense-r1792-01/inputs.v2.json \
+  --inputs-sha256 c9d9f5a886a2ca3ff4e919349d005356b46d231eee04640af3abb3dfb862a756 \
+  --out /mnt/shared/tessera-measurements/pq267-native-20260907/joint-02

--- a/experiments/pq267_joint_probe.sh
+++ b/experiments/pq267_joint_probe.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# All input artifacts, hashes and output paths must be explicit. The original
+# 2026-09-07 capture is quarantined because its HF rotary buffer was uninitialized.
 image=eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
 input_root=/mnt/shared/tessera-measurements/first-model-20260907/inputs
 prisma_snapshot_commit=$(git rev-parse HEAD)
@@ -10,7 +12,4 @@ docker run --rm --gpus all --ipc=host --network=host --user "$(id -u):$(id -g)" 
   -e HF_HOME=/tmp/pq267-hf -e HF_MODULES_CACHE=/tmp/pq267-modules \
   -e "PRISMAQUANT_IDENTITY_GIT_COMMIT=$prisma_snapshot_commit" \
   -e "PYTHONPATH=/workspace:$input_root/tessera-382a1a97/src:$input_root/container-compatible-deps" \
-  "$image" -m experiments.pq267_native_panel probe \
-  --inputs /mnt/shared/tessera-measurements/pq267-native-20260907/dense-r1792-01/inputs.v2.json \
-  --inputs-sha256 c9d9f5a886a2ca3ff4e919349d005356b46d231eee04640af3abb3dfb862a756 \
-  --out /mnt/shared/tessera-measurements/pq267-native-20260907/joint-02
+  "$image" -m experiments.pq267_native_panel probe "$@"

--- a/experiments/pq267_native_panel.py
+++ b/experiments/pq267_native_panel.py
@@ -33,74 +33,70 @@ def dump(path, value):
     Path(path).write_text(json.dumps(value, sort_keys=True, indent=2, allow_nan=False) + "\n")
 
 
+def load_canonical_capture(plan):
+    # The shared v2 contract is emitted only after actual checkpoint missing-state
+    # initialization and binds the census/runtime. Old captures are quarantined.
+    if plan.get("schema") != "prismaquant.native_dense_preparation.v2":
+        raise ValueError("native preparation requires a new canonical capture plan v2")
+    raw = json.loads(checked(plan["capture"], plan["capture_sha256"]).read_text())
+    if raw.get("schema") != "prismaquant.tessera_calibration_cache.v2":
+        raise ValueError("native preparation refuses historical unqualified calibration captures")
+    from prismaquant.tessera_calibration_cache import require_capture_contract
+    capture = require_capture_contract(plan["capture"], expected_sha256=plan["capture_sha256"])
+    if capture["identity"]["attention_implementation"] != "eager":
+        raise ValueError("native preparation requires the actual eager source capture")
+    census = json.loads(checked(plan["census"], capture["identity"]["census_sha256"]).read_text())
+    from prismaquant.calibration_data import load_calibration_input
+    identity = capture["identity"]["calibration"]
+    tokens, calibration = load_calibration_input(plan["calibration_input"],
+        expected_sha256=plan["calibration_input_sha256"], n_samples=identity["nsamples"], seqlen=identity["seqlen"])
+    for key in ("fit_ids_sha256", "text_sha256", "source", "seed", "nsamples", "seqlen"):
+        if calibration["provenance"][key] != identity[key]:
+            raise ValueError(f"canonical capture and exact token draw disagree: {key}")
+    return capture, census, identity, tokens, calibration
+
+
 def prepare(args):
     import torch
     from safetensors import safe_open
     from safetensors.torch import save_file
     from tessera import cached_unit
-    from prismaquant.calibration_data import load_calibration_input
     from prismaquant.native_operator_panel import EXECUTION, prepare_native_inputs
     from prismaquant.production_weight_cache import ProductionWeightCache
-    from prismaquant.tessera_export_lane import hessian_capture_sha256
+    from prismaquant.tessera_calibration_cache import prefetch_capture
     from prismaquant.tessera_formats import parse_tessera_format_name
     from prismaquant.tessera_hessian import activation_source, encoder_kwargs
     from prismaquant.tessera_render import encode_tessera_unit, rung_accepts_hessian, tessera_wire_recipe
 
     plan = json.loads(checked(args.plan, args.plan_sha256).read_text())
-    if plan["schema"] != "prismaquant.native_dense_preparation.v1":
-        raise ValueError("unsupported native preparation plan")
     if re.fullmatch(r"[^\s@]+@sha256:[0-9a-f]{64}", plan["runtime_image"]) is None:
         raise ValueError("native preparation needs a full immutable image RepoDigest reference")
-    unit, fmt = plan["unit"], plan["format"]
-    capture = json.loads(checked(plan["capture"], plan["capture_sha256"]).read_text())
-    root = Path(plan["capture"]).parent
-    identity = capture["identity"]
-    tokens, calibration = load_calibration_input(capture["tokens_file"],
-        expected_sha256=capture["tokens_file_sha256"], n_samples=identity["nsamples"], seqlen=identity["seqlen"])
-    if calibration["provenance"] != identity:
-        raise ValueError("token provenance differs from capture")
+    capture, census, identity, tokens, calibration = load_canonical_capture(plan)
     del tokens
-    if unit not in capture["captured_units"] or unit in capture.get("excluded_units", []):
-        raise ValueError("native panel unit was not captured")
-    checked(root / "activations.safetensors", capture["activation_sha256"])
-    checked(plan["units"], capture["units_safetensors_sha256"])
-    with safe_open(plan["units"], framework="pt", device="cpu") as source:
-        weight = source.get_tensor("weight/" + unit).to("cuda")
-    with safe_open(str(root / "activations.safetensors"), framework="pt", device="cpu") as source:
-        rows = source.get_tensor("activation/" + unit).to(device="cuda", dtype=torch.bfloat16)
-    hessians = torch.load(capture["hessian_capture"], map_location="cpu", mmap=True, weights_only=True)
-    if hessian_capture_sha256(hessians["H"], hessians["provenance"]) != capture["hessian_capture_sha256"]:
-        raise ValueError("captured Hessian values/provenance changed")
-    # The input scale is reconstructed from the capture's actual calibrated G
-    # by the SAME contract used by QDQ, not from a prefix maximum.
+    unit, fmt = plan["unit"], plan["format"]
+    source = census["expert_projection"]["producer"]["source"]
+    if plan["probe_request"]["source_model"] != census["model"] or plan["probe_request"]["source_shards"] != source["files"]:
+        raise ValueError("native preparation source differs from its canonical census")
+    tensor_name = unit + ".weight"
+    shard = Path(census["model"]) / source["tensors"][tensor_name]
+    checked(shard, source["files"][shard.name])
+    with safe_open(str(shard), framework="pt", device="cpu") as stored:
+        weight = stored.get_tensor(tensor_name).to("cuda")
+    (acts, hessians, counts, maxima), _ = prefetch_capture(plan["capture"], expected_sha256=plan["capture_sha256"],
+        expected_identity=capture["identity"], census=census, names=[unit], device="cuda")
+    rows = acts[unit].to(torch.bfloat16)
     from prismaquant import format_registry as fr
     spec = fr.get_format(fmt)
-    amax = None
-    if spec.static_activation_contract is not None:
-        from safetensors.torch import load_file
-        scales = load_file(capture["static_scales"])
-        key = unit + ".input_global_scale"
-        if key not in scales:
-            raise ValueError("captured static activation scale missing")
-        # The capture receipt carries the actual maxima separately. A reciprocal
-        # convention cannot be inferred from a scale artifact alone.
-        maxima = capture.get("activation_max_abs", {})
-        if unit not in maxima:
-            raise ValueError("capture must retain actual activation_max_abs for a static native route")
-        amax = float(maxima[unit])
-        actual_g = spec.static_activation_contract.require_input_global_scale(amax, qname=unit, consumer="native panel")
-        if actual_g != float(scales[key].reshape(())):
-            raise ValueError("captured scale differs from current activation contract")
+    amax = float(maxima[unit]) if spec.static_activation_contract is not None else None
     cache = ProductionWeightCache(weights={}, levers={"tessera_hessian_identity": identity},
                                   activation_max_abs={unit: amax} if amax is not None else {})
     family, rung = parse_tessera_format_name(fmt)
     recipe = tessera_wire_recipe(family, rung)
     uses_hessian = rung_accepts_hessian(fmt, recipe)
-    activation = activation_source({unit: hessians["H"][unit]}, identity) if uses_hessian else None
+    activation = activation_source(hessians, identity) if uses_hessian else None
     kwargs = (encoder_kwargs(activation, unit, weight.shape[1], weight.device, scale_plane=recipe.scale_plane)
               if activation is not None else None)
     args.out.mkdir(parents=True, exist_ok=False)
-    # The numerical policy is persisted before any native preparation/output.
     dump(args.out / "preparation-plan.json", plan)
     with torch.inference_mode():
         rendered, blob = encode_tessera_unit(weight, fmt, activation_kwargs=kwargs,
@@ -114,7 +110,6 @@ def prepare(args):
         max_resident_bytes=plan["max_resident_bytes"])
     (args.out / "weight.tessera").write_bytes(blob)
     dump(args.out / "wire-record.json", record)
-    # Clone aliases because A16 QDQ may deliberately return the original input.
     save_file({key: tensor.detach().cpu().contiguous().clone() for key, tensor in tensors.items()},
               str(args.out / "tensors.safetensors"))
     cache.weights[unit, fmt] = rendered.detach().cpu()
@@ -124,6 +119,8 @@ def prepare(args):
         ("weight.tessera", "wire-record.json", "tensors.safetensors", "production.pkl")}
     inputs["preparation_plan_sha256"] = args.plan_sha256
     inputs["preparation_plan_file"] = "preparation-plan.json"
+    inputs["source_capture"] = {"manifest_sha256": plan["capture_sha256"], "identity": capture["identity"],
+                                "member_entry": capture["entries"][unit], "member_count": counts[unit]}
     inputs["runtime_image"] = plan["runtime_image"]
     inputs["probe_request"] = plan["probe_request"]
     dump(args.out / "inputs.json", inputs)
@@ -155,7 +152,7 @@ def probe(args):
     import gc
     import torch
     from transformers import AutoModelForCausalLM
-    from prismaquant import aura_cost
+    from prismaquant import aura_cost, genuine_weight_initialization
     from prismaquant.calibration_data import load_calibration_input
     from prismaquant.joint_aura import validate_joint_aura_entry
     from prismaquant.model_profiles import detect_profile
@@ -163,12 +160,11 @@ def probe(args):
     inputs = json.loads(checked(args.inputs, args.inputs_sha256).read_text())
     root = args.inputs.parent
     plan = json.loads(checked(root / inputs["preparation_plan_file"], inputs["preparation_plan_sha256"]).read_text())
-    capture = json.loads(checked(plan["capture"], plan["capture_sha256"]).read_text())
+    capture, _census, capture_identity, calibration, _calibration_receipt = load_canonical_capture(plan)
+    if inputs.get("source_capture", {}).get("manifest_sha256") != plan["capture_sha256"]:
+        raise ValueError("native PWC inputs are not bound to this canonical capture")
     request = inputs["probe_request"]
     checked(root / "production.pkl", inputs["artifacts"]["production.pkl"])
-    calibration, _ = load_calibration_input(capture["tokens_file"],
-        expected_sha256=capture["tokens_file_sha256"], n_samples=capture["identity"]["nsamples"],
-        seqlen=capture["identity"]["seqlen"])
     if args.out.exists():
         raise ValueError("refuse overwriting joint probe output")
     args.out.mkdir(parents=True)
@@ -176,9 +172,12 @@ def probe(args):
     # A new model architecture must agree with its ordinary HF forward before
     # its streamed cotangents can qualify this panel. This is one bounded
     # first-sequence check, not a model-wide parity or performance claim.
-    reference_model = AutoModelForCausalLM.from_pretrained(request["source_model"],
-        dtype=torch.bfloat16, trust_remote_code=True,
-        local_files_only=True, attn_implementation="eager").to("cuda").eval()
+    # Transformers rebuilds nonpersistent buffers while finalizing a checkpoint.
+    # The ordinary reference needs their genuine initializers (not probe no-init).
+    with genuine_weight_initialization():
+        reference_model = AutoModelForCausalLM.from_pretrained(request["source_model"],
+            dtype=torch.bfloat16, trust_remote_code=True,
+            local_files_only=True, attn_implementation="eager").to("cuda").eval()
     with torch.inference_mode():
         reference = reference_model(calibration[:1].cuda(), use_cache=False).logits.detach().cpu()
     del reference_model
@@ -212,9 +211,9 @@ def probe(args):
             "--allow-packed-expert-omission", "--n-probes", str(request["n_probes"]),
             "--seed-base", str(request["seed_base"]), "--token-scope", request["token_scope"],
             "--temperature", str(request["temperature"]), "--min-free-gib", "2",
-            "--calibration-input", capture["tokens_file"], "--calibration-input-sha256", capture["tokens_file_sha256"],
-            "--n-calib-samples", str(capture["identity"]["nsamples"]),
-            "--calib-seqlen", str(capture["identity"]["seqlen"]),
+            "--calibration-input", plan["calibration_input"], "--calibration-input-sha256", plan["calibration_input_sha256"],
+            "--n-calib-samples", str(capture_identity["nsamples"]),
+            "--calib-seqlen", str(capture_identity["seqlen"]),
             "--checkpoint-dir", str(args.out / "checkpoints"),
             "--streaming-offload-dir", str(args.out / "streaming"), "--output", str(args.out / "joint.pkl")]
     dump(args.out / "probe-request.json", {"inputs_sha256": args.inputs_sha256, "argv": argv,

--- a/experiments/pq267_native_panel.py
+++ b/experiments/pq267_native_panel.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Deterministic artifact preparation/consumption for one real native panel.
+
+Run GPU preparation through PrismaBuild. This uses the existing source/Hessian
+capture and one ProductionWeightCache entry; Tessera's separate producer owns
+native runtime preparation and measurement. No allocator prices are invented.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import pickle
+import re
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for block in iter(lambda: stream.read(8 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def checked(path, expected):
+    if sha256(path) != expected:
+        raise ValueError(f"input artifact SHA256 mismatch: {path}")
+    return Path(path)
+
+
+def dump(path, value):
+    Path(path).write_text(json.dumps(value, sort_keys=True, indent=2, allow_nan=False) + "\n")
+
+
+def prepare(args):
+    import torch
+    from safetensors import safe_open
+    from safetensors.torch import save_file
+    from tessera import cached_unit
+    from prismaquant.calibration_data import load_calibration_input
+    from prismaquant.native_operator_panel import EXECUTION, prepare_native_inputs
+    from prismaquant.production_weight_cache import ProductionWeightCache
+    from prismaquant.tessera_export_lane import hessian_capture_sha256
+    from prismaquant.tessera_formats import parse_tessera_format_name
+    from prismaquant.tessera_hessian import activation_source, encoder_kwargs
+    from prismaquant.tessera_render import encode_tessera_unit, rung_accepts_hessian, tessera_wire_recipe
+
+    plan = json.loads(checked(args.plan, args.plan_sha256).read_text())
+    if plan["schema"] != "prismaquant.native_dense_preparation.v1":
+        raise ValueError("unsupported native preparation plan")
+    if re.fullmatch(r"[^\s@]+@sha256:[0-9a-f]{64}", plan["runtime_image"]) is None:
+        raise ValueError("native preparation needs a full immutable image RepoDigest reference")
+    unit, fmt = plan["unit"], plan["format"]
+    capture = json.loads(checked(plan["capture"], plan["capture_sha256"]).read_text())
+    root = Path(plan["capture"]).parent
+    identity = capture["identity"]
+    tokens, calibration = load_calibration_input(capture["tokens_file"],
+        expected_sha256=capture["tokens_file_sha256"], n_samples=identity["nsamples"], seqlen=identity["seqlen"])
+    if calibration["provenance"] != identity:
+        raise ValueError("token provenance differs from capture")
+    del tokens
+    if unit not in capture["captured_units"] or unit in capture.get("excluded_units", []):
+        raise ValueError("native panel unit was not captured")
+    checked(root / "activations.safetensors", capture["activation_sha256"])
+    checked(plan["units"], capture["units_safetensors_sha256"])
+    with safe_open(plan["units"], framework="pt", device="cpu") as source:
+        weight = source.get_tensor("weight/" + unit).to("cuda")
+    with safe_open(str(root / "activations.safetensors"), framework="pt", device="cpu") as source:
+        rows = source.get_tensor("activation/" + unit).to(device="cuda", dtype=torch.bfloat16)
+    hessians = torch.load(capture["hessian_capture"], map_location="cpu", mmap=True, weights_only=True)
+    if hessian_capture_sha256(hessians["H"], hessians["provenance"]) != capture["hessian_capture_sha256"]:
+        raise ValueError("captured Hessian values/provenance changed")
+    # The input scale is reconstructed from the capture's actual calibrated G
+    # by the SAME contract used by QDQ, not from a prefix maximum.
+    from prismaquant import format_registry as fr
+    spec = fr.get_format(fmt)
+    amax = None
+    if spec.static_activation_contract is not None:
+        from safetensors.torch import load_file
+        scales = load_file(capture["static_scales"])
+        key = unit + ".input_global_scale"
+        if key not in scales:
+            raise ValueError("captured static activation scale missing")
+        # The capture receipt carries the actual maxima separately. A reciprocal
+        # convention cannot be inferred from a scale artifact alone.
+        maxima = capture.get("activation_max_abs", {})
+        if unit not in maxima:
+            raise ValueError("capture must retain actual activation_max_abs for a static native route")
+        amax = float(maxima[unit])
+        actual_g = spec.static_activation_contract.require_input_global_scale(amax, qname=unit, consumer="native panel")
+        if actual_g != float(scales[key].reshape(())):
+            raise ValueError("captured scale differs from current activation contract")
+    cache = ProductionWeightCache(weights={}, levers={"tessera_hessian_identity": identity},
+                                  activation_max_abs={unit: amax} if amax is not None else {})
+    family, rung = parse_tessera_format_name(fmt)
+    recipe = tessera_wire_recipe(family, rung)
+    uses_hessian = rung_accepts_hessian(fmt, recipe)
+    activation = activation_source({unit: hessians["H"][unit]}, identity) if uses_hessian else None
+    kwargs = (encoder_kwargs(activation, unit, weight.shape[1], weight.device, scale_plane=recipe.scale_plane)
+              if activation is not None else None)
+    args.out.mkdir(parents=True, exist_ok=False)
+    # The numerical policy is persisted before any native preparation/output.
+    dump(args.out / "preparation-plan.json", plan)
+    with torch.inference_mode():
+        rendered, blob = encode_tessera_unit(weight, fmt, activation_kwargs=kwargs,
+            hessian_required=uses_hessian, recipe=recipe, verify=True)
+    cache.weights[unit, fmt] = rendered
+    encoding = cached_unit.encoding_input_identity(weight, unit, family.payload_grid(), int(rung), activation=activation)
+    record = cached_unit.make_unit_record(blob, encoding, filename="weight.tessera")
+    inputs, tensors = prepare_native_inputs(cache, weight, rows, unit=unit, format_name=fmt,
+        calibration_receipt=calibration, wire_blob=blob, wire_record=record, encoding_identity=encoding,
+        numerics=plan["numerics"], prefill_rows=plan["prefill_rows"], decode_rows=plan["decode_rows"],
+        max_resident_bytes=plan["max_resident_bytes"])
+    (args.out / "weight.tessera").write_bytes(blob)
+    dump(args.out / "wire-record.json", record)
+    # Clone aliases because A16 QDQ may deliberately return the original input.
+    save_file({key: tensor.detach().cpu().contiguous().clone() for key, tensor in tensors.items()},
+              str(args.out / "tensors.safetensors"))
+    cache.weights[unit, fmt] = rendered.detach().cpu()
+    with (args.out / "production.pkl").open("wb") as stream:
+        pickle.dump(cache, stream)
+    inputs["artifacts"] = {name: sha256(args.out / name) for name in
+        ("weight.tessera", "wire-record.json", "tensors.safetensors", "production.pkl")}
+    inputs["preparation_plan_sha256"] = args.plan_sha256
+    inputs["preparation_plan_file"] = "preparation-plan.json"
+    inputs["runtime_image"] = plan["runtime_image"]
+    inputs["probe_request"] = plan["probe_request"]
+    dump(args.out / "inputs.json", inputs)
+    dump(args.out / "request.json", {"schema": "tessera.native_dense_request.v1", "unit": unit,
+        "format": fmt, "wire_path": "weight.tessera", "wire_record_path": "wire-record.json",
+        "tensors_path": "tensors.safetensors", "runtime_image": plan["runtime_image"],
+        "input_global_scale": inputs["activation"]["input_global_scale"], "execution": dict(EXECUTION)})
+    print(json.dumps({"status": "prepared", "unit": unit, "format": fmt, "shape": inputs["shape"],
+        "inputs_sha256": sha256(args.out / "inputs.json"), "request_sha256": sha256(args.out / "request.json"),
+        "prefetch": inputs["prefetch"], "hessian_applied": uses_hessian}, sort_keys=True))
+
+
+def freeze(args):
+    from prismaquant.native_operator_panel import freeze_native_panel
+    inputs = json.loads(checked(args.inputs, args.inputs_sha256).read_text())
+    preflight = json.loads(checked(args.preflight, args.preflight_sha256).read_text())
+    with checked(args.cost, args.cost_sha256).open("rb") as stream:
+        cost = pickle.load(stream)
+    row = cost["costs"][inputs["unit"]][inputs["format"]]
+    panel = freeze_native_panel(inputs, preflight, row, cost_sha256=args.cost_sha256)
+    if args.out.exists():
+        raise ValueError("refuse overwriting frozen native panel")
+    dump(args.out, panel)
+    print(json.dumps({"status": "frozen", "panel_sha256": sha256(args.out)}, sort_keys=True))
+
+
+def probe(args):
+    """Run the shared CLI on exact inputs after one resident/streamed check."""
+    import gc
+    import torch
+    from transformers import AutoModelForCausalLM
+    from prismaquant import aura_cost
+    from prismaquant.calibration_data import load_calibration_input
+    from prismaquant.joint_aura import validate_joint_aura_entry
+    from prismaquant.model_profiles import detect_profile
+
+    inputs = json.loads(checked(args.inputs, args.inputs_sha256).read_text())
+    root = args.inputs.parent
+    plan = json.loads(checked(root / inputs["preparation_plan_file"], inputs["preparation_plan_sha256"]).read_text())
+    capture = json.loads(checked(plan["capture"], plan["capture_sha256"]).read_text())
+    request = inputs["probe_request"]
+    checked(root / "production.pkl", inputs["artifacts"]["production.pkl"])
+    calibration, _ = load_calibration_input(capture["tokens_file"],
+        expected_sha256=capture["tokens_file_sha256"], n_samples=capture["identity"]["nsamples"],
+        seqlen=capture["identity"]["seqlen"])
+    if args.out.exists():
+        raise ValueError("refuse overwriting joint probe output")
+    args.out.mkdir(parents=True)
+    detect_profile(request["source_model"])
+    # A new model architecture must agree with its ordinary HF forward before
+    # its streamed cotangents can qualify this panel. This is one bounded
+    # first-sequence check, not a model-wide parity or performance claim.
+    reference_model = AutoModelForCausalLM.from_pretrained(request["source_model"],
+        dtype=torch.bfloat16, trust_remote_code=True,
+        local_files_only=True, attn_implementation="eager").to("cuda").eval()
+    with torch.inference_mode():
+        reference = reference_model(calibration[:1].cuda(), use_cache=False).logits.detach().cpu()
+    del reference_model
+    gc.collect()
+    torch.cuda.empty_cache()
+    actual_compute = aura_cost.compute_aura_cost_streamed
+
+    def checked_compute(runner, calib, formats, **kwargs):
+        runner.require_prefetched_residency = True
+        with torch.inference_mode():
+            observed = runner(calib[:1]).logits.detach()
+        expected = reference.to(device=observed.device)
+        delta = (observed.float() - expected.float()).abs()
+        limit = plan["numerics"]["atol"] + plan["numerics"]["rtol"] * expected.float().abs()
+        finite = bool(torch.isfinite(observed).all() and torch.isfinite(expected).all())
+        passed = finite and bool((delta <= limit).all())
+        dump(args.out / "streamed-forward-parity.json", {
+            "status": "passed" if passed else "failed", "scope": "first calibration sequence only",
+            "shape": list(reference.shape), "numerics": plan["numerics"],
+            "max_abs_error": float(delta.max()) if finite else None,
+            "max_normalized_error": float((delta / limit).max()) if finite else None,
+            "require_prefetched_residency": True})
+        if not passed:
+            raise ValueError("streamed LFM forward differs from resident source reference")
+        del observed, expected, delta, limit
+        return actual_compute(runner, calib, formats, **kwargs)
+
+    argv = ["--model", request["source_model"], "--dtype", "bfloat16", "--streaming", "--joint-activation",
+            "--production-cache", str(root / "production.pkl"), "--require-production-cache",
+            "--formats", inputs["format"], "--unit-filter", "^" + re.escape(inputs["unit"]) + "$",
+            "--allow-packed-expert-omission", "--n-probes", str(request["n_probes"]),
+            "--seed-base", str(request["seed_base"]), "--token-scope", request["token_scope"],
+            "--temperature", str(request["temperature"]), "--min-free-gib", "2",
+            "--calibration-input", capture["tokens_file"], "--calibration-input-sha256", capture["tokens_file_sha256"],
+            "--n-calib-samples", str(capture["identity"]["nsamples"]),
+            "--calib-seqlen", str(capture["identity"]["seqlen"]),
+            "--checkpoint-dir", str(args.out / "checkpoints"),
+            "--streaming-offload-dir", str(args.out / "streaming"), "--output", str(args.out / "joint.pkl")]
+    dump(args.out / "probe-request.json", {"inputs_sha256": args.inputs_sha256, "argv": argv,
+                                           "probe_request": request, "scope": "one dense unit; no model-wide cost coverage"})
+    aura_cost.compute_aura_cost_streamed = checked_compute
+    try:
+        code = aura_cost.main(argv)
+    finally:
+        aura_cost.compute_aura_cost_streamed = actual_compute
+    if code != 0:
+        raise RuntimeError(f"shared joint probe failed with exit status {code}")
+    with (args.out / "joint.pkl").open("rb") as stream:
+        result = pickle.load(stream)
+    row = result["costs"][inputs["unit"]][inputs["format"]]
+    if not validate_joint_aura_entry(row):
+        raise ValueError("shared probe did not return actual joint currency")
+    print(json.dumps({"status": "measured_joint_row", "unit": inputs["unit"], "format": inputs["format"],
+        "cost_sha256": sha256(args.out / "joint.pkl"), "predicted_dloss": row["predicted_dloss"],
+        "predicted_dloss_stderr": row["predicted_dloss_stderr"], "probe_identity_sha256": row["probe_identity_sha256"],
+        "joint_operator_identity_sha256": row["joint_operator_identity_sha256"]}, sort_keys=True))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    prep = sub.add_parser("prepare")
+    prep.add_argument("--plan", required=True, type=Path)
+    prep.add_argument("--plan-sha256", required=True)
+    prep.add_argument("--out", required=True, type=Path)
+    probed = sub.add_parser("probe")
+    probed.add_argument("--inputs", required=True, type=Path)
+    probed.add_argument("--inputs-sha256", required=True)
+    probed.add_argument("--out", required=True, type=Path)
+    frozen = sub.add_parser("freeze")
+    for name in ("inputs", "preflight", "cost"):
+        frozen.add_argument("--" + name, required=True, type=Path)
+        frozen.add_argument("--" + name + "-sha256", required=True)
+    frozen.add_argument("--out", required=True, type=Path)
+    consumed = sub.add_parser("consume")
+    for name in ("receipt", "panel"):
+        consumed.add_argument("--" + name, required=True, type=Path)
+        consumed.add_argument("--" + name + "-sha256", required=True)
+    consumed.add_argument("--memory-trace", type=Path)
+    consumed.add_argument("--out", required=True, type=Path)
+    args = parser.parse_args()
+    if args.command == "prepare":
+        prepare(args)
+    elif args.command == "probe":
+        probe(args)
+    elif args.command == "freeze":
+        freeze(args)
+    else:
+        from prismaquant.native_operator_panel import consume_native_receipt
+        panel = json.loads(checked(args.panel, args.panel_sha256).read_text())
+        result = consume_native_receipt(args.receipt, expected_sha256=args.receipt_sha256,
+            expected_panel=panel, memory_trace_path=args.memory_trace)
+        if args.out.exists():
+            raise ValueError("refuse overwriting native observation")
+        dump(args.out, result)
+        print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/pq267_native_prepare.sh
+++ b/experiments/pq267_native_prepare.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-image=sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
+# All input artifacts, hashes and output paths must be explicit. The original
+# 2026-09-07 capture is quarantined because its HF rotary buffer was uninitialized.
+image=eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
 input_root=/mnt/shared/tessera-measurements/first-model-20260907/inputs
 # This image is currently present only on Sparky; PB submission declares --here.
 docker run --rm --gpus all --ipc=host --network=host --user "$(id -u):$(id -g)" \
@@ -9,7 +11,4 @@ docker run --rm --gpus all --ipc=host --network=host --user "$(id -u):$(id -g)" 
   -e PYTHONDONTWRITEBYTECODE=1 -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
   -e XDG_CACHE_HOME=/tmp/pq267-cache -e TORCH_EXTENSIONS_DIR=/tmp/pq267-extensions \
   -e "PYTHONPATH=/workspace:$input_root/tessera-382a1a97/src:$input_root/container-compatible-deps" \
-  "$image" -m experiments.pq267_native_panel prepare \
-  --plan experiments/protocols/pq267-lfm-dense-20260907.json \
-  --plan-sha256 5884af5c07be34ae37d8fef42aa580f098aa427dcadf261c6b9c2a92df0f6ace \
-  --out /mnt/shared/tessera-measurements/pq267-native-20260907/dense-r1792-01
+  "$image" -m experiments.pq267_native_panel prepare "$@"

--- a/experiments/pq267_native_prepare.sh
+++ b/experiments/pq267_native_prepare.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+image=sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
+input_root=/mnt/shared/tessera-measurements/first-model-20260907/inputs
+# This image is currently present only on Sparky; PB submission declares --here.
+docker run --rm --gpus all --ipc=host --network=host --user "$(id -u):$(id -g)" \
+  -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared \
+  -w /workspace --entrypoint python3 \
+  -e PYTHONDONTWRITEBYTECODE=1 -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
+  -e XDG_CACHE_HOME=/tmp/pq267-cache -e TORCH_EXTENSIONS_DIR=/tmp/pq267-extensions \
+  -e "PYTHONPATH=/workspace:$input_root/tessera-382a1a97/src:$input_root/container-compatible-deps" \
+  "$image" -m experiments.pq267_native_panel prepare \
+  --plan experiments/protocols/pq267-lfm-dense-20260907.json \
+  --plan-sha256 5884af5c07be34ae37d8fef42aa580f098aa427dcadf261c6b9c2a92df0f6ace \
+  --out /mnt/shared/tessera-measurements/pq267-native-20260907/dense-r1792-01

--- a/experiments/protocols/pq267-lfm-dense-20260907.json
+++ b/experiments/protocols/pq267-lfm-dense-20260907.json
@@ -1,0 +1,28 @@
+{
+  "capture": "/mnt/shared/tessera-measurements/pq300-batch-20260907/capture/capture.json",
+  "capture_sha256": "5977ad6df1b606e65e006418c6feaa4d4e9826f3c69001a6d407011e4aeeb2ad",
+  "decode_rows": 1,
+  "format": "TESSERA_BF16_K1_R1792",
+  "max_resident_bytes": 1073741824,
+  "numerics": {
+    "atol": 0.015625,
+    "rtol": 0.015625
+  },
+  "prefill_rows": 512,
+  "probe_request": {
+    "distribution": "rademacher",
+    "n_probes": 2,
+    "normalization": "global_kl_fisher",
+    "seed_base": 267000,
+    "source_model": "/mnt/shared/models/LFM2.5-8B-A1B-BF16",
+    "source_shards": {
+      "model.safetensors": "c9b9e3c4b3be50b576e6da8c02de1b4223614ffe131d812abf92bb84421f6217"
+    },
+    "temperature": 1.0,
+    "token_scope": "causal"
+  },
+  "runtime_image": "eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c",
+  "schema": "prismaquant.native_dense_preparation.v1",
+  "unit": "model.layers.0.feed_forward.w1",
+  "units": "/mnt/shared/tessera-measurements/tessera385-2026-09-06/units/units.safetensors"
+}

--- a/prismaquant/aura_cost.py
+++ b/prismaquant/aura_cost.py
@@ -3305,6 +3305,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                         "the cost draws from the same corpus as the pipeline "
                         "probe/render. Default keeps the historical WikiText "
                         "windowed loader (--calib-split/--calib-seed).")
+    p.add_argument("--calibration-input", default=None,
+                   help="Exact safetensors calibration_ids draw; bypasses dataset sampling. "
+                        "Requires --calibration-input-sha256 and matching sample/sequence counts.")
+    p.add_argument("--calibration-input-sha256", default=None,
+                   help="Independent SHA256 of --calibration-input.")
     p.add_argument("--token-scope", default="all")
     p.add_argument("--temperature", type=float, default=1.0)
     p.add_argument(
@@ -3403,6 +3408,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                    help="Pipeline COST_MODE stamped into "
                         "provenance['cost_mode'] (re-vet R2).")
     args = p.parse_args(argv)
+    if bool(args.calibration_input) != bool(args.calibration_input_sha256):
+        p.error("--calibration-input and --calibration-input-sha256 are required together")
+    if args.calibration_input and args.dataset:
+        p.error("--calibration-input and --dataset are mutually exclusive")
     if args.joint_activation and not args.streaming:
         p.error("--joint-activation requires --streaming")
     if args.resume and not args.checkpoint_dir:
@@ -3489,7 +3498,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         model.train()
         _log("gradient checkpointing ON (non-reentrant, train-mode armed, "
              "no active dropout/batchnorm)")
-    if args.dataset:
+    calibration_input_receipt = None
+    if args.calibration_input:
+        from prismaquant.calibration_data import load_calibration_input
+        calib, calibration_input_receipt = load_calibration_input(
+            args.calibration_input, expected_sha256=args.calibration_input_sha256,
+            n_samples=args.n_calib_samples, seqlen=args.calib_seqlen,
+        )
+        calib = calib.to(args.device)
+    elif args.dataset:
         from prismaquant.sensitivity_probe import load_calibration
         calib = load_calibration(
             tok, args.dataset, args.n_calib_samples, args.calib_seqlen,
@@ -3612,15 +3629,18 @@ def main(argv: Sequence[str] | None = None) -> int:
         "model": str(args.model),
         "dtype": str(args.dtype),
         "calib_source": (
-            str(args.dataset) if args.dataset
+            str(args.calibration_input) if args.calibration_input else str(args.dataset) if args.dataset
             else f"wikitext:{args.calib_split}"),
         "n_calib_samples": int(args.n_calib_samples),
         "calib_seqlen": int(args.calib_seqlen),
-        "calib_seed": int(args.calib_seed),
+        "calib_seed": (calibration_input_receipt["provenance"].get("seed")
+                       if calibration_input_receipt is not None else int(args.calib_seed)),
         "production_cache": str(args.production_cache or ""),
         # re-vet R2 precondition (i): which pipeline COST_MODE produced this.
         "cost_mode": str(args.cost_mode or ""),
     })
+    if calibration_input_receipt is not None:
+        payload["provenance"]["calibration_input"] = calibration_input_receipt
     Path(args.output).parent.mkdir(parents=True, exist_ok=True)
     with open(args.output, "wb") as fh:
         pickle.dump(payload, fh)

--- a/prismaquant/calibration_data.py
+++ b/prismaquant/calibration_data.py
@@ -2,8 +2,57 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+import hashlib
+import json
+from pathlib import Path
+import re
 
 import torch
+
+
+def load_calibration_input(path, *, expected_sha256, n_samples, seqlen):
+    """Load an independently pinned token draw without invoking a sampler.
+
+    The campaign's ``fit_ids_sha256`` hashes int32 token bytes; joint AURA
+    hashes the actual int64 tensor. Preserve and check both conventions.
+    This is explicit artifact preparation, outside the measurement hot path.
+    """
+    from safetensors import safe_open
+
+    if not isinstance(expected_sha256, str) or re.fullmatch(r"[0-9a-f]{64}", expected_sha256) is None:
+        raise ValueError("exact calibration input requires its independent SHA256")
+    path = Path(path)
+    artifact_sha256 = hashlib.sha256(path.read_bytes()).hexdigest()
+    if artifact_sha256 != expected_sha256:
+        raise ValueError("exact calibration input artifact SHA256 mismatch")
+    with safe_open(str(path), framework="pt", device="cpu") as stream:
+        if set(stream.keys()) != {"calibration_ids"}:
+            raise ValueError("exact calibration input requires only calibration_ids")
+        try:
+            provenance = json.loads(stream.metadata()["calibration_provenance"])
+        except (TypeError, KeyError, ValueError) as exc:
+            raise ValueError("exact calibration input requires calibration_provenance JSON") from exc
+        ids = stream.get_tensor("calibration_ids")
+    if ids.dtype != torch.int64 or list(ids.shape) != [n_samples, seqlen] or ids.numel() == 0:
+        raise ValueError("exact calibration input dtype/shape differs from requested draw")
+    if bool((ids < 0).any()) or bool((ids > torch.iinfo(torch.int32).max).any()):
+        raise ValueError("exact calibration token IDs exceed the nonnegative int32 identity domain")
+    if not isinstance(provenance, dict):
+        raise ValueError("exact calibration provenance must be an object")
+    draw_sha256 = hashlib.sha256(ids.to(torch.int32).numpy().tobytes()).hexdigest()
+    if (provenance.get("fit_ids_sha256") != draw_sha256
+            or provenance.get("fit_tokens") != ids.numel()
+            or provenance.get("nsamples") != n_samples
+            or provenance.get("seqlen") != seqlen):
+        raise ValueError("exact calibration input differs from declared draw provenance")
+    # Refuse a file replacement between its digest check and tensor loading.
+    if hashlib.sha256(path.read_bytes()).hexdigest() != artifact_sha256:
+        raise ValueError("exact calibration input changed while loading")
+    return ids, {
+        "schema": "prismaquant.calibration_input.v1", "artifact_sha256": artifact_sha256,
+        "calibration_sha256": hashlib.sha256(ids.contiguous().numpy().tobytes()).hexdigest(),
+        "shape": list(ids.shape), "dtype": str(ids.dtype), "provenance": provenance,
+    }
 
 
 def _sample_token_windows_from_texts(

--- a/prismaquant/native_operator_panel.py
+++ b/prismaquant/native_operator_panel.py
@@ -1,0 +1,261 @@
+"""Frozen PWC inputs and a narrow native operator receipt bridge.
+
+No serving runtime is imported here. Tessera owns native preparation/execution;
+PQ supplies the actual production render, shared activation QDQ and joint-cost
+identity. An operator observation never invents fixed/full-model resources or
+becomes a complete measured-runtime allocation table by itself.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from pathlib import Path
+
+from .joint_aura import identity_sha256, validate_joint_aura_entry
+from .measured_runtime_prices import OperatorMeasurement
+
+INPUT_SCHEMA = "prismaquant.native_dense_inputs.v1"
+PANEL_SCHEMA = "tessera.native_dense_panel.v1"
+EXECUTION = {"owner_kind": "single_dense", "mode": "resident",
+             "execution_mode": "eager", "tensor_parallel": 1, "bias": False}
+PHASES = ("prefill", "decode")
+
+
+def _sha(value, name):
+    if not isinstance(value, str) or len(value) != 64 or any(c not in "0123456789abcdef" for c in value):
+        raise ValueError(f"{name}: lowercase SHA256 required")
+    return value
+
+
+def _equal(actual, expected, name):
+    if identity_sha256(actual) != identity_sha256(expected):
+        raise ValueError(f"native panel {name} differs from independently frozen input")
+
+
+def _number(value, name):
+    if type(value) not in (int, float) or not math.isfinite(value) or value < 0:
+        raise ValueError(f"{name}: finite nonnegative number required")
+    return value
+
+
+def _bytes(value, name):
+    if type(value) is not int or value < 0:
+        raise ValueError(f"{name}: nonnegative integer bytes required")
+    return value
+
+
+def prepare_native_inputs(cache, source_weight, activation_rows, *, unit, format_name,
+                          calibration_receipt, wire_blob, wire_record, encoding_identity,
+                          numerics, prefill_rows, decode_rows, max_resident_bytes):
+    """Prepare independent references from existing resident PWC/activation data.
+
+    ``encoding_identity`` must be derived by the producer from the actual
+    source/Hessian/calibration settings, not copied from the wire record. The
+    caller pins that preparation input artifact before executing this function.
+    Artifact transport and tensor hashing occur outside any timed native apply.
+    """
+    import torch
+    from tessera.cached_unit import verify_cached_unit
+    from tessera.unit_artifact import read_unit_artifact
+    from . import format_registry as fr
+    from .joint_aura import activation_identity, prefetch_joint_cache
+    from .perturbed_x_cache import _activation_qdq
+    from .production_weight_cache import ProductionWeightCache, _cb_cache_tensor_identity
+
+    if not isinstance(cache, ProductionWeightCache):
+        raise TypeError("native panel requires the actual ProductionWeightCache")
+    for value, name in ((source_weight, "source"), (activation_rows, "activation rows")):
+        if value.ndim != 2 or value.dtype != torch.bfloat16 or value.device.type != "cuda":
+            raise ValueError(f"native panel {name} requires resident 2-D CUDA BF16")
+        if not bool(torch.isfinite(value).all()):
+            raise ValueError(f"native panel {name} is nonfinite")
+    if activation_rows.shape[1] != source_weight.shape[1]:
+        raise ValueError("native panel activation/source width differs")
+    for rows in (prefill_rows, decode_rows):
+        if type(rows) is not int or rows < 1 or rows > activation_rows.shape[0]:
+            raise ValueError("native panel phase rows exceed retained calibration activations")
+    if set(numerics) != {"atol", "rtol"}:
+        raise ValueError("native panel requires explicit predeclared atol and rtol")
+    for key, value in numerics.items():
+        _number(value, key)
+    if calibration_receipt.get("schema") != "prismaquant.calibration_input.v1":
+        raise ValueError("native panel requires an exact calibration input receipt")
+    _sha(calibration_receipt["calibration_sha256"], "calibration")
+    prefetch = prefetch_joint_cache(cache, [unit], {unit: [format_name]},
+                                   max_resident_bytes=max_resident_bytes)
+    rendered = cache.get(unit, format_name).to(device=source_weight.device)
+    if rendered.shape != source_weight.shape or rendered.dtype != torch.bfloat16:
+        raise ValueError("native panel PWC source/render dtype or shape differs")
+    verify_cached_unit(wire_blob, wire_record, encoding_identity)
+    decoded = read_unit_artifact(wire_blob, device=str(rendered.device)).to(rendered.dtype)
+    _equal(_cb_cache_tensor_identity(decoded), _cb_cache_tensor_identity(rendered), "wire/PWC decode")
+    del decoded
+    spec = fr.get_format(format_name)
+    activation = activation_identity(spec, cache.activation_max_abs or {}, unit)
+    if activation["clip_enabled"]:
+        raise ValueError("native operator does not implement PQ's optional activation preclip")
+    tensors = {"source_weight": source_weight, "rendered_weight": rendered}
+    phases = {}
+    with torch.inference_mode():
+        for phase, count in (("prefill", prefill_rows), ("decode", decode_rows)):
+            x = activation_rows[:count].contiguous()
+            qx = (_activation_qdq(x, spec, cache.activation_max_abs or {}, unit)
+                  if spec.act_quant_changes_input else x)
+            output = torch.nn.functional.linear(qx, rendered)
+            for name, value in (("input", x), ("reference_qdq", qx), ("reference_output", output)):
+                tensors[f"{phase}.{name}"] = value
+            phases[phase] = {"m": count, **{name: _cb_cache_tensor_identity(tensors[f"{phase}.{name}"])
+                for name in ("input", "reference_qdq", "reference_output")}}
+    return {
+        "schema": INPUT_SCHEMA, "unit": unit, "format": format_name,
+        "shape": list(source_weight.shape), "source_weight": _cb_cache_tensor_identity(source_weight),
+        "rendered_weight": _cb_cache_tensor_identity(rendered), "activation": activation,
+        "calibration": calibration_receipt, "activation_rows": _cb_cache_tensor_identity(activation_rows),
+        "wire": {"blob_sha256": hashlib.sha256(wire_blob).hexdigest(), "blob_bytes": len(wire_blob),
+                 "record": wire_record}, "numerics": dict(numerics), "execution": dict(EXECUTION),
+        "phases": phases, "prefetch": prefetch,
+    }, tensors
+
+
+def freeze_native_panel(inputs, preflight, cost_row, *, cost_sha256):
+    """Join independently frozen PWC references to untimed native facts and cost.
+
+    A legacy MSE row is refused; only actual validated joint AURA rows can bind
+    this panel. Native facts are declarations for subsequent measurement, not
+    substituted numerical references or evidence of successful execution.
+    """
+    _sha(cost_sha256, "cost payload")
+    if inputs.get("schema") != INPUT_SCHEMA:
+        raise ValueError("native panel input schema unsupported")
+    if (preflight.get("schema") != "tessera.native_dense_preflight.v1"
+            or preflight.get("status") != "untimed_preparation"):
+        raise ValueError("native panel requires untimed producer preparation")
+    if not validate_joint_aura_entry(cost_row):
+        raise ValueError("native panel requires an actual joint AURA cost row")
+    joint = cost_row["joint_operator_identity"]
+    operator = preflight["operator"]
+    probe = cost_row["probe_identity"]
+    request = inputs["probe_request"]
+    for key in ("n_probes", "seed_base", "token_scope", "temperature", "distribution", "normalization"):
+        _equal(probe[key], request[key], f"predeclared probe {key}")
+    _equal(probe["source_model"]["source"], request["source_model"], "probe source model")
+    _equal({Path(item["path"]).name: item["sha256"] for item in probe["source_model"]["shards"]},
+           request["source_shards"], "probe source checkpoint bytes")
+    for key, expected in (("qname", inputs["unit"]), ("format", inputs["format"]),
+                          ("source_weight", inputs["source_weight"]),
+                          ("rendered_weight", inputs["rendered_weight"]),
+                          ("activation", inputs["activation"])):
+        _equal(joint[key], expected, f"joint {key}")
+    _equal(probe["calibration_sha256"], inputs["calibration"]["calibration_sha256"], "joint calibration")
+    _equal(probe["calibration_shape"], inputs["calibration"]["shape"], "joint calibration shape")
+    _equal(probe["calibration_dtype"], inputs["calibration"]["dtype"], "joint calibration dtype")
+    for key in ("source_weight", "rendered_weight"):
+        _equal(operator[key], inputs[key], f"native {key}")
+    _equal(operator["input_global_scale"], joint["activation"]["input_global_scale"], "native input scale")
+    _equal(operator["clip_enabled"], False, "native clip")
+    _equal(operator["wire_sha256"], inputs["wire"]["blob_sha256"], "native wire")
+    _equal(operator["wire_record_sha256"], identity_sha256(inputs["wire"]["record"]), "native wire record")
+    _equal(preflight["runtime_sha256"], identity_sha256(preflight["runtime"]), "runtime digest")
+    _equal(preflight["native_tensors_sha256"], identity_sha256(operator["native_tensors"]), "native tensors")
+    _equal(preflight["scheme_sha256"], identity_sha256(operator["scheme"]), "native scheme")
+    _equal(preflight["runtime"]["execution"], EXECUTION, "native execution")
+    _equal(preflight["runtime"]["image"], inputs["runtime_image"], "native image reference")
+    route = operator["declared_route"]
+    _equal(route["contract"], operator["activation_contract"], "activation route")
+    panel = {
+        "schema": PANEL_SCHEMA, "unit": inputs["unit"], "format": inputs["format"],
+        "shape": inputs["shape"], "source_sha256": probe["source_model"]["content_sha256"],
+        "calibration_sha256": probe["calibration_sha256"], "cost_sha256": cost_sha256,
+        "probe_identity_sha256": cost_row["probe_identity_sha256"],
+        "joint_operator_identity_sha256": cost_row["joint_operator_identity_sha256"],
+        "joint_operator_identity": joint, "wire": inputs["wire"], "execution": dict(EXECUTION),
+        "runtime": preflight["runtime"], "native_tensors_sha256": preflight["native_tensors_sha256"],
+        "scheme_sha256": preflight["scheme_sha256"], "numerics": inputs["numerics"],
+        "phases": {phase: {**inputs["phases"][phase], "expected_route": route} for phase in PHASES},
+    }
+    return json.loads(json.dumps(panel, allow_nan=False))
+
+
+def consume_native_receipt(path, *, expected_sha256, expected_panel, memory_trace_path=None):
+    """Validate an exact receipt and retain unknown full-model resource fields.
+
+    Returns warmed operator evidence only. The existing runtime table still
+    needs independently measured fixed work/KV resources and whole-unit/fused
+    coverage; this bridge does not fabricate that table or its missing prices.
+    """
+    raw = Path(path).read_bytes()
+    _equal(hashlib.sha256(raw).hexdigest(), _sha(expected_sha256, "receipt"), "receipt file")
+    receipt = json.loads(raw)
+    if receipt.get("schema") != "tessera.native_dense_operator_receipt.v1" or receipt.get("status") != "timing_admissible":
+        raise ValueError("native receipt has no admitted numerical/timing observation")
+    _equal(receipt["panel"], expected_panel, "receipt panel")
+    _equal(receipt["panel_sha256"], identity_sha256(expected_panel), "receipt panel digest")
+    _equal(receipt["runtime"], expected_panel["runtime"], "receipt runtime")
+    _equal(receipt["runtime_sha256"], identity_sha256(expected_panel["runtime"]), "receipt runtime digest")
+    operator = receipt["operator"]
+    joint = expected_panel["joint_operator_identity"]
+    for key in ("source_weight", "rendered_weight"):
+        _equal(operator[key], joint[key], f"receipt {key}")
+    _equal(operator["input_global_scale"], joint["activation"]["input_global_scale"], "receipt activation scale")
+    _equal(operator["clip_enabled"], False, "receipt activation clip")
+    _equal(operator["wire_sha256"], expected_panel["wire"]["blob_sha256"], "receipt wire")
+    _equal(operator["wire_record_sha256"], identity_sha256(expected_panel["wire"]["record"]), "receipt wire record")
+    _equal(identity_sha256(operator["native_tensors"]), expected_panel["native_tensors_sha256"], "receipt native tensors")
+    _equal(identity_sha256(operator["scheme"]), expected_panel["scheme_sha256"], "receipt scheme")
+    resources = receipt["resources"]
+    complete = resources.get("status") == "complete_operator_bound"
+    if complete:
+        if memory_trace_path is None:
+            raise ValueError("complete native resource bound requires its actual memory trace")
+        trace = json.loads(Path(memory_trace_path).read_text())
+        _equal(identity_sha256(trace), resources["trace_sha256"], "memory trace")
+        _equal(trace["capture"]["collector_library_sha256"],
+               expected_panel["runtime"]["resource_collector"]["library_sha256"], "resource collector")
+    observations = {}
+    for phase in PHASES:
+        observed, expected = receipt["phases"][phase], expected_panel["phases"][phase]
+        for name in ("input", "reference_qdq", "reference_output"):
+            _equal(observed[name], expected[name], f"{phase} {name}")
+        route = observed["route"]
+        _equal({key: route[key] for key in expected["expected_route"]}, expected["expected_route"], f"{phase} route")
+        if (route.get("state") != "served" or route.get("reason") is not None
+                or route.get("shape") != f"M{expected['m']}:N{expected_panel['shape'][0]}:K{expected_panel['shape'][1]}"):
+            raise ValueError(f"{phase}: native route state/shape differs")
+        for kind in ("numerics", "qdq_numerics"):
+            error = observed[kind]
+            if error.get("status") != "passed" or error.get("finite") is not True:
+                raise ValueError(f"{phase}: refused native numerical comparison")
+            _equal({key: error[key] for key in ("atol", "rtol")}, expected_panel["numerics"], f"{phase} tolerance")
+            if _number(error["max_normalized_error"], "normalized numerical error") > 1:
+                raise ValueError(f"{phase}: numerical error exceeds frozen tolerance")
+        timing = observed["measurement"]
+        if timing.get("sample_unit") != "single_apply":
+            raise ValueError("native timing is not repeated individual operator invocations")
+        measurement = OperatorMeasurement.from_dict({key: timing[key] for key in
+            ("method", "samples_ms", "warmup_iterations")} | {
+                "receipt_path": str(path), "receipt_sha256": expected_sha256})
+        bound = resources["phases"][phase].get("bound")
+        scratch = None
+        if complete:
+            if (bound.get("status") != "complete_operator_bound"
+                    or bound.get("full_model_fixed_resources_complete") is not False
+                    or bound.get("composition") != "sum_of_independent_peaks_including_output"):
+                raise ValueError(f"{phase}: native resource scope/bound mismatch")
+            native = _bytes(bound["external_native_peak_bytes"], "external native peak")
+            torch_peak = _bytes(bound["torch_peak_increment_bytes"], "torch peak")
+            scratch = _bytes(bound["peak_scratch_bytes"], "scratch")
+            if scratch != native + torch_peak:
+                raise ValueError(f"{phase}: resource peaks do not compose to the declared bound")
+        observations[phase] = {"measurement": measurement.as_dict(), "median_ms": measurement.median_ms,
+                               "peak_scratch_bytes": scratch, "resource_bound": bound,
+                               "input_bytes": expected["input"]["logical_bytes"],
+                               "output_bytes": expected["reference_output"]["logical_bytes"]}
+    return {"schema": "prismaquant.native_dense_observation.v1", "status": "operator_evidence",
+            "panel_sha256": identity_sha256(expected_panel), "receipt_sha256": expected_sha256,
+            "unit": expected_panel["unit"], "format": expected_panel["format"],
+            "cost_sha256": expected_panel["cost_sha256"], "phases": observations,
+            "serialized_unit_bytes": expected_panel["wire"]["blob_bytes"],
+            "resident_bytes": _bytes(resources["resident_bytes"], "resident"),
+            "full_model_resources": None, "runtime_table_admissible": False,
+            "unknown": ["fixed_and_full_model_resources"] + ([] if complete else ["native_operator_scratch"])}

--- a/tests/test_native_capture_quarantine.py
+++ b/tests/test_native_capture_quarantine.py
@@ -1,0 +1,21 @@
+"""Old source captures remain reproducible history, never fresh preparation."""
+import hashlib
+import json
+
+import pytest
+
+from experiments.pq267_native_panel import load_canonical_capture
+
+
+def test_original_preparation_plan_cannot_reuse_quarantined_source():
+    with pytest.raises(ValueError, match="canonical capture plan v2"):
+        load_canonical_capture({"schema": "prismaquant.native_dense_preparation.v1"})
+
+
+def test_renaming_plan_cannot_promote_old_capture(tmp_path):
+    capture = tmp_path / "capture.json"
+    capture.write_text(json.dumps({"schema": "prismaquant.tessera_calibration_cache.v1",
+                                  "status": "complete", "canonical": True}))
+    with pytest.raises(ValueError, match="historical unqualified"):
+        load_canonical_capture({"schema": "prismaquant.native_dense_preparation.v2", "capture": str(capture),
+                                "capture_sha256": hashlib.sha256(capture.read_bytes()).hexdigest()})

--- a/tests/test_native_operator_panel.py
+++ b/tests/test_native_operator_panel.py
@@ -1,0 +1,171 @@
+"""Boundary fixtures for frozen inputs, real joint currency and unknown resources.
+
+Synthetic receipt records below test intake only; they are never measurements.
+The actual producer/GPU qualification is a separate recorded action.
+"""
+import copy
+import hashlib
+import json
+
+import pytest
+import torch
+
+from prismaquant.joint_aura import arithmetic_identity, identity_sha256, make_joint_aura_entry
+from prismaquant.native_operator_panel import (EXECUTION, INPUT_SCHEMA, consume_native_receipt,
+                                               freeze_native_panel)
+from prismaquant.production_weight_cache import _cb_cache_tensor_identity
+from test_streamed_cost_checkpoints import _model_identity
+
+
+@pytest.fixture
+def joined():
+    unit, fmt = "fixture.dense", "TESSERA_BF16_K1_R1792"
+    weight = _cb_cache_tensor_identity(torch.arange(16, dtype=torch.bfloat16).reshape(4, 4))
+    activation = {"schema": "prismaquant.joint_aura.activation.v1", "quantizes_input": False,
+                  "activation_max_abs": None, "input_global_scale": None, "clip_enabled": False}
+    arithmetic = arithmetic_identity(torch.bfloat16)
+    probe = {"schema": "prismaquant.joint_aura.probes.v1", "source_model": _model_identity("panel-fixture"),
+             "calibration_sha256": "1" * 64, "calibration_shape": [1, 4], "calibration_dtype": "torch.int64",
+             "producer_source_sha256": "2" * 64, "n_probes": 3, "seed_base": 7,
+             "token_scope": "causal",
+             "distribution": "rademacher", "normalization": "global_kl_fisher", "temperature": 1.0,
+             "arithmetic": arithmetic}
+    joint = {"schema": "prismaquant.joint_aura.operator.v1", "qname": unit, "format": fmt,
+             "source_weight": weight, "rendered_weight": weight, "activation": activation,
+             "arithmetic": arithmetic, "probe_identity_sha256": identity_sha256(probe)}
+    row = make_joint_aura_entry(operator_identity=joint, probe_identity=probe, signed_components=[
+        {"weight": v, "activation": 0., "mixed": 0., "total": v} for v in (.1, -.2, .3)])
+    tensor = _cb_cache_tensor_identity(torch.ones(1, 4, dtype=torch.bfloat16))
+    wire = {"blob_sha256": "3" * 64, "blob_bytes": 42, "record": {"fixture": "wire-record"}}
+    route = {"kind": "dense", "policy": "TESSERA_BF16:resident", "symbol": "torch.mm",
+             "decoder": "fixture-window", "contract": "bf16_unquantized"}
+    inputs = {"schema": INPUT_SCHEMA, "unit": unit, "format": fmt, "shape": [4, 4],
+              "source_weight": weight, "rendered_weight": weight, "activation": activation,
+              "calibration": {"calibration_sha256": "1" * 64, "shape": [1, 4], "dtype": "torch.int64"},
+              "wire": wire, "numerics": {"atol": .015625, "rtol": .015625},
+              "runtime_image": "fixture/image@sha256:" + "9" * 64,
+              "probe_request": {**{key: probe[key] for key in ("n_probes", "seed_base", "token_scope",
+                                  "temperature", "distribution", "normalization")},
+                                "source_model": "panel-fixture", "source_shards": {
+                                    "panel-fixture.safetensors": probe["source_model"]["shards"][0]["sha256"]}},
+              "phases": {p: {"m": 1, "input": tensor, "reference_qdq": tensor, "reference_output": tensor}
+                         for p in ("prefill", "decode")}}
+    native = {"source_weight": weight, "rendered_weight": weight, "input_global_scale": None,
+              "clip_enabled": False, "wire_sha256": wire["blob_sha256"],
+              "wire_record_sha256": identity_sha256(wire["record"]), "native_tensors": {"fixture": weight},
+              "scheme": {"fixture": True}, "declared_route": route, "activation_contract": "bf16_unquantized"}
+    runtime = {"schema": "tessera.native_dense_runtime.v1", "execution": dict(EXECUTION),
+               "image": inputs["runtime_image"],
+               "resource_collector": {"library_sha256": "5" * 64}}
+    preflight = {"schema": "tessera.native_dense_preflight.v1", "status": "untimed_preparation",
+                 "operator": native, "runtime": runtime, "runtime_sha256": identity_sha256(runtime),
+                 "native_tensors_sha256": identity_sha256(native["native_tensors"]),
+                 "scheme_sha256": identity_sha256(native["scheme"])}
+    return inputs, preflight, row
+
+
+def test_freeze_joins_joint_operator_and_predeclared_tolerance(joined):
+    inputs, preflight, row = joined
+    panel = freeze_native_panel(*joined, cost_sha256="4" * 64)
+    assert panel["joint_operator_identity_sha256"] == row["joint_operator_identity_sha256"]
+    assert panel["numerics"] == inputs["numerics"]
+    assert panel["phases"]["decode"]["expected_route"] == preflight["operator"]["declared_route"]
+
+
+@pytest.mark.parametrize("coordinate", ["calibration", "rendered_weight", "wire", "scale", "runtime", "probe_seed", "source_bytes", "image"])
+def test_self_consistent_native_facts_cannot_replace_independent_inputs(joined, coordinate):
+    inputs, preflight, row = joined
+    if coordinate == "calibration":
+        inputs["calibration"]["calibration_sha256"] = "0" * 64
+    elif coordinate == "rendered_weight":
+        inputs["rendered_weight"] = dict(inputs["rendered_weight"], content_sha256="0" * 64)
+    elif coordinate == "wire":
+        preflight["operator"]["wire_sha256"] = "0" * 64
+    elif coordinate == "scale":
+        preflight["operator"]["input_global_scale"] = 1.0
+    elif coordinate == "runtime":
+        preflight["runtime"]["execution"]["tensor_parallel"] = 2
+        preflight["runtime_sha256"] = identity_sha256(preflight["runtime"])
+    elif coordinate == "probe_seed":
+        inputs["probe_request"]["seed_base"] += 1
+    elif coordinate == "source_bytes":
+        inputs["probe_request"]["source_shards"]["panel-fixture.safetensors"] = "0" * 64
+    else:
+        preflight["runtime"]["image"] = "another/image@sha256:" + "8" * 64
+        preflight["runtime_sha256"] = identity_sha256(preflight["runtime"])
+    with pytest.raises(ValueError):
+        freeze_native_panel(inputs, preflight, row, cost_sha256="4" * 64)
+
+
+def test_legacy_cost_never_becomes_joint_currency(joined):
+    inputs, preflight, _ = joined
+    with pytest.raises(ValueError, match="actual joint"):
+        freeze_native_panel(inputs, preflight, {"output_mse": .1}, cost_sha256="4" * 64)
+
+
+def receipt_fixture(joined, complete=False):
+    inputs, preflight, _ = joined
+    panel = freeze_native_panel(*joined, cost_sha256="4" * 64)
+    numerics = {"status": "passed", "finite": True, "max_normalized_error": .5, **inputs["numerics"]}
+    phases = {p: {**inputs["phases"][p], "route": {**preflight["operator"]["declared_route"],
+                                                "state": "served", "reason": None, "shape": "M1:N4:K4"},
+                  "numerics": dict(numerics), "qdq_numerics": dict(numerics),
+                  "measurement": {"method": "cuda_events", "sample_unit": "single_apply",
+                                  "samples_ms": [3., 1., 2.], "warmup_iterations": 4}}
+              for p in ("prefill", "decode")}
+    trace = {"fixture": "trace", "capture": {"collector_library_sha256": "5" * 64}}
+    bound = {"status": "complete_operator_bound", "composition": "sum_of_independent_peaks_including_output",
+             "full_model_fixed_resources_complete": False, "peak_scratch_bytes": 128,
+             "external_native_peak_bytes": 64, "torch_peak_increment_bytes": 64}
+    receipt = {"schema": "tessera.native_dense_operator_receipt.v1", "status": "timing_admissible",
+               "panel": panel, "panel_sha256": identity_sha256(panel), "operator": preflight["operator"],
+               "runtime": preflight["runtime"], "runtime_sha256": preflight["runtime_sha256"], "phases": phases,
+               "resources": {"status": "complete_operator_bound" if complete else "incomplete", "resident_bytes": 64,
+                             "trace_sha256": identity_sha256(trace),
+                             "phases": {p: {"bound": copy.deepcopy(bound)} if complete else {}
+                                        for p in ("prefill", "decode")}}}
+    return panel, receipt, trace
+
+
+def write(path, value):
+    path.write_text(json.dumps(value))
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+@pytest.mark.parametrize("complete", [False, True])
+def test_observation_keeps_unmeasured_full_model_resources_unknown(joined, tmp_path, complete):
+    panel, receipt, trace = receipt_fixture(joined, complete)
+    path = tmp_path / "receipt.json"
+    digest = write(path, receipt)
+    trace_path = tmp_path / "trace.json"
+    write(trace_path, trace)
+    observation = consume_native_receipt(path, expected_sha256=digest, expected_panel=panel,
+                                         memory_trace_path=trace_path if complete else None)
+    assert observation["full_model_resources"] is None
+    assert observation["runtime_table_admissible"] is False
+    assert observation["phases"]["prefill"]["median_ms"] == 2.
+    assert observation["phases"]["prefill"]["peak_scratch_bytes"] == (128 if complete else None)
+
+
+@pytest.mark.parametrize("mutation", ["tolerance", "panel", "native_unknown", "composed_bound", "receipt_hash", "trace"])
+def test_receipt_rejects_altered_binding_or_unproved_resource_claim(joined, tmp_path, mutation):
+    panel, receipt, trace = receipt_fixture(joined, complete=True)
+    if mutation == "tolerance":
+        receipt["phases"]["decode"]["numerics"]["atol"] *= 2
+    elif mutation == "panel":
+        receipt["panel"] = copy.deepcopy(panel)
+        receipt["panel"]["cost_sha256"] = "0" * 64
+        receipt["panel_sha256"] = identity_sha256(receipt["panel"])
+    elif mutation == "native_unknown":
+        receipt["resources"]["phases"]["decode"]["bound"]["external_native_peak_bytes"] = None
+    elif mutation == "composed_bound":
+        receipt["resources"]["phases"]["decode"]["bound"]["peak_scratch_bytes"] = 0
+    elif mutation == "trace":
+        trace["capture"]["collector_library_sha256"] = "0" * 64
+        receipt["resources"]["trace_sha256"] = identity_sha256(trace)
+    path, trace_path = tmp_path / "receipt.json", tmp_path / "trace.json"
+    digest = write(path, receipt)
+    write(trace_path, trace)
+    with pytest.raises(ValueError):
+        consume_native_receipt(path, expected_sha256="0" * 64 if mutation == "receipt_hash" else digest,
+                               expected_panel=panel, memory_trace_path=trace_path)

--- a/tests/test_native_panel_calibration.py
+++ b/tests/test_native_panel_calibration.py
@@ -1,0 +1,52 @@
+"""Exact token artifacts preserve the draw rather than re-running a sampler."""
+import hashlib
+import json
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+
+def artifact(tmp_path, *, dtype=torch.int64, provenance=None):
+    ids = torch.arange(32).reshape(4, 8).to(dtype)
+    identity = {"source": "fixture", "fit_tokens": 32, "nsamples": 4, "seqlen": 8,
+                "fit_ids_sha256": hashlib.sha256(ids.int().numpy().tobytes()).hexdigest()}
+    identity.update(provenance or {})
+    path = tmp_path / "tokens.safetensors"
+    save_file({"calibration_ids": ids}, str(path),
+              metadata={"calibration_provenance": json.dumps(identity)})
+    return path, hashlib.sha256(path.read_bytes()).hexdigest(), ids
+
+
+def test_exact_calibration_preserves_ids_and_both_hash_conventions(tmp_path):
+    from prismaquant.calibration_data import load_calibration_input
+    path, sha, ids = artifact(tmp_path)
+    actual, receipt = load_calibration_input(path, expected_sha256=sha, n_samples=4, seqlen=8)
+    assert torch.equal(actual, ids)
+    assert receipt["artifact_sha256"] == sha
+    assert receipt["calibration_sha256"] == hashlib.sha256(ids.numpy().tobytes()).hexdigest()
+    assert receipt["provenance"]["fit_ids_sha256"] != receipt["calibration_sha256"]
+
+
+@pytest.mark.parametrize("change", ["file_hash", "shape", "draw_hash", "dtype", "missing_hash"])
+def test_exact_calibration_refuses_different_contract(tmp_path, change):
+    from prismaquant.calibration_data import load_calibration_input
+    path, sha, _ = artifact(tmp_path, dtype=torch.int32 if change == "dtype" else torch.int64,
+                            provenance={"fit_ids_sha256": "0" * 64} if change == "draw_hash" else None)
+    with pytest.raises(ValueError):
+        load_calibration_input(path, expected_sha256=None if change == "missing_hash" else
+                               "0" * 64 if change == "file_hash" else sha,
+                               n_samples=3 if change == "shape" else 4, seqlen=8)
+
+
+@pytest.mark.parametrize("extra", [
+    ["--calibration-input", "tokens.safetensors"],
+    ["--calibration-input-sha256", "a" * 64],
+    ["--calibration-input", "tokens.safetensors", "--calibration-input-sha256", "a" * 64,
+     "--dataset", "wikitext"],
+])
+def test_calibration_cli_refuses_ambiguous_inputs_before_model_loading(extra):
+    from prismaquant.aura_cost import main
+    with pytest.raises(SystemExit) as failure:
+        main(["--model", "/nonexistent", "--output", "/unused", *extra])
+    assert failure.value.code == 2


### PR DESCRIPTION
Bind a native operator observation to the actual ProductionWeightCache render, shared activation QDQ, independently pinned source/calibration/probe inputs, and a validated joint AURA row. Tessera owns native execution and memory-trace analysis; PQ verifies runtime/tensor/route/numerical identities and preserves unknown full-model costs. This includes exact calibration-token intake and a research preparation/freeze/consume CLI.

Fresh preparation requires a canonical shared capture-v2 manifest and its pinned census and token draw. Historical captures produced with suppressed checkpoint-finalization initialization are rejected, including when an old capture is placed in a renamed plan. The reference loader enables genuine initialization, and wrappers require explicit input/output arguments.

Closes #308. Supports #267 and #237 without closing their end-to-end scope. No runtime pin, format default, serving gate, or complete allocator runtime table changes. The shared capture-v2 and canonical source initialization dependencies are integrated from main (#315 and #312).

Validation: 48 targeted CPU tests passed on DL380g10 through PrismaBuild with four pytest workers, native threads bounded to one, and no skips; terminal exit and CAS payload hash verified. Earlier GPU preparation remains historical integrity evidence only: subsequent diagnosis invalidated its source-quality reference. Fresh canonical joint/native qualification is pending. Receipts and the explicit correction are retained in `docs/research/native_panel_267_2026-09-07.md`.

Refreshed against main at 332f5c76: 69 targeted native/calibration/capture/docs tests passed via PrismaBuild, no skips, exit 0, terminal and CAS verified (80b8390eb41d). Only the architecture stamp block conflicted; both contracts were preserved.
