### PR TITLE
Complete sampled allocations through selected-wire materialization

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,28 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-07 · `codex/campaign-batched-anchors`. Stamps
+As of: 2026-09-07 · `codex/selected-wire-materialization-20260907`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-07, `codex/selected-wire-materialization-20260907`) for
+**selected expert-wire materialization** (§4.10; #301). The allocator's opt-in
+`--tessera-materialization-plan` writes a versioned, non-exportable selection
+request before the existing complete-wire allocation gate. The request binds
+the original cost bytes and preserves packed decisions and sampled estimates.
+`tessera_materialization plan` turns census anchor stacks with missing selected
+wires into ordinary PrismaBuild rows; complete stacks require no new quantum.
+Each row captures only its selected source units on the same calibration draw,
+uses the campaign encoder and `ProductionWeightCache` (including its opt-in
+`--anchor-batch-size` adapter), verifies existing
+producer receipts, and journals only the selected missing renders. Finalization
+verifies source bytes, producer recipe, every selected wire, and exact equality
+of overlapping Hessians before binding the verified capture union and publishing
+the packed allocation through the existing receipt and priced-input gates.
+Static-scale preflight expands the explicit member map and checks each source
+scalar; unequal expert scales cannot be replaced by a packed scalar. The
+producer's source-unit plan view remains a downstream export product. No
+format, pricing estimate, production default or serving admission changes.
+Gates: `tests/test_tessera_materialization.py`,
+`tests/test_tessera_packed_export_scope.py`.
 
 Re-stamped (2026-09-07, `codex/campaign-batched-anchors`) for **bounded
 expert anchor batches** (§4.10; #300, #275; Tessera #385). The campaign's
@@ -19,6 +40,7 @@ batch width and identify equally apportioned batch encoding time; that is
 accounting, not independently measured per-unit latency. Default width remains
 one pending performance qualification. No serving pin, wire recipe, cost
 currency or format menu changes. Gate: `tests/test_tessera_campaign_batch.py`.
+
 
 Re-stamped (2026-09-07, `codex/first-model-integration-20260907`) for
 **campaign quanta in the declared Docker runtime** (§4.10). The shared fanout
@@ -6259,6 +6281,32 @@ twin of anything live — it is the only one of the two left, and §4.10 is its
 seam.
 
 ### 4.10 The Tessera continuous menu — `FORMATS=TESSERA` (2026-09-02)
+
+For a sampled allocation that selects source wires not yet encoded, the opt-in
+completion path is:
+
+```mermaid
+flowchart LR
+  costs[Sampled campaign costs] --> selection[Non-exportable packed selection request]
+  census[Calibration census] --> plan[Selected-wire PB manifest]
+  selection --> plan
+  plan --> groups[Census stack quanta: capture, verify, encode missing selected wires]
+  groups --> finalize[Verify receipts and Hessian union]
+  finalize --> gate[Existing strict allocation and priced-input gates]
+  gate --> allocation[Final packed allocation]
+```
+
+Run `python -m prismaquant.tessera_materialization plan --request REQUEST
+--census CENSUS --workspace WORKSPACE --spec CAMPAIGN_SPEC`, submit its
+`WORKSPACE/manifest.json` through PrismaBuild's published `pbcampaign.py`, and
+run `python -m prismaquant.tessera_materialization finalize --plan
+WORKSPACE/plan.json` inside an admitted action. `final/result.json` names the
+final allocation, capture, scales and wire directory for the export leg.
+The request itself is never an exporter input. Interrupted groups resume through
+the existing identity-bound journal; contradictory or unjournaled wire bytes
+refuse instead of being replaced. These selected wire measurements do not
+re-solve the allocation or turn sampled stack estimates into census prices.
+
 
 **Fan-out journal integrity.** Each source journal must pass the same
 manifest, unit identity and payload checksum checks as ordinary resume.

--- a/docs/reviews/2026-09-07/selected-wire-materialization.md
+++ b/docs/reviews/2026-09-07/selected-wire-materialization.md
@@ -89,3 +89,20 @@ inside an admitted action. `WORKSPACE/final/result.json` names the exact final
 allocation, Hessian capture, scale file and wire directory. This opt-in step
 requires the dispatcher/container adapter and shared batch adapter commits;
 no format default or serving gate changes.
+
+## Integration review
+
+The root reviewer read the final materializer and packed-scale gate, verified
+both original PB payload hashes, and checked the real producer 2-of-3 fixture.
+The combined materializer, batch, container, projection and documentation suite
+then passed on the CPU fleet worker `dl380g10`: **135 passed, 2 expected skips**,
+PB `70538e0ed5bde8b8226b11206891b8b757ed6a9bb2d6db5e07e86613bd705170`,
+receipt `3f4612f36ba32ce074c600c40f765321c12f2cdf4c440f6ee83f4496bbd8324a`,
+payload `997efe6d45ea7d9d16f0154b45e0bde9fc81568b60a59c22a4a78768d09d61ea`.
+The skipped cases are the obsolete absent-producer-seal case and the separate
+CUDA-only batch CLI case; the batch PR supplies that CUDA qualification.
+This run used Python 3.12.11, Torch 2.10.0 CPU, Transformers 5.16.1,
+compressed-tensors 0.15.0, eight pytest workers, native threads of one and a
+20 GiB aggregate reservation. An earlier attempt stopped at collection because
+`psutil` was absent; scoped dependency installation preceded the passing retry.
+No GPU or full-model quality claim follows from this CPU integration run.

--- a/docs/reviews/2026-09-07/selected-wire-materialization.md
+++ b/docs/reviews/2026-09-07/selected-wire-materialization.md
@@ -1,0 +1,91 @@
+# Selected expert-wire materialization — PrismaQuant #301
+
+The sampled allocator can now write an explicit non-exportable selected-wire
+request. Its canonical packed decisions and original cost digest remain fixed.
+The new module turns only census stacks with missing selected wires into PB
+rows; complete selected stacks reuse their original evidence. Each row uses
+campaign calibration and the shared scalar/batch encoder, ProductionWeightCache,
+producer input identities and cost-stage journal. It encodes only missing
+selected unit/rung pairs and verifies existing receipts before reuse.
+
+Finalization verifies the original source files, producer source/recipe, exact
+census identity, every selected wire and the union of captures. Overlapping
+Hessians and counts must agree exactly. The original sampled prices are not
+rewritten or promoted to census measurements. Final allocation publication uses
+the existing strict expert-receipt and priced-input gates. The latter now
+expands the explicit packed-member map before checking each source unit's
+static scalar, so unequal expert scalars are checked individually.
+
+## Validation
+
+All execution used PrismaBuild with GPU visibility disabled for CPU tests,
+OMP/MKL/OpenBLAS threads bounded to one, and aggregate CPU/memory reservations.
+No full-model GPU materialization, serving quality, throughput or residency
+claim is made by these tests. The production path still pays the existing
+whole-model forward cost once per selected census stack. No before/after
+performance comparison was made.
+
+- Pre-fix PB `5cdfb77dd2e2`: the new unequal-source-scale case failed because
+  preflight searched packed keys. The two defective-scale variants also failed
+  at that earlier wrong boundary. All three now exercise the source-key gate:
+  valid unequal values pass, missing and altered values refuse.
+- PB `707ecc774ed770da8838da52433486a20c6bc500fab8cea2069f63c92f3f2f8e`:
+  **127 passed, 2 skipped**, rc 0, CPU on sparklina. The skips are the legacy
+  absent-Hessian-seal case (the producer publishes a seal) and the separate
+  CUDA-only batch CLI test. This used the frozen first-model producer
+  `tessera-382a1a97`, including the real producer encoder/receipt/translator.
+  Receipt: `/mnt/shared/prismabuild-fleet/cas/actions/v3/70/707ecc774ed770da8838da52433486a20c6bc500fab8cea2069f63c92f3f2f8e.json`.
+  Actual pytest output: `/mnt/shared/prismabuild-fleet/cas/blobs/28/28f995706e71969c1c9dbb6174b80b832040e680f2eedf1c31f33b34080f53e0`.
+- Final materializer PB `0bcf755f5d17d4549877a4d6305146f28f4f2110b0f77855b40f24b9e9976985`:
+  **24 passed, no skips**, rc 0. This includes the strengthened packed
+  two-of-three native producer fixture, source/census geometry checks,
+  unbound-producer refusal and original-capture count checks added after the
+  wider run. It used the same command/environment, restricted to
+  `tests/test_tessera_materialization.py`.
+  Receipt: `/mnt/shared/prismabuild-fleet/cas/actions/v3/0b/0bcf755f5d17d4549877a4d6305146f28f4f2110b0f77855b40f24b9e9976985.json`.
+  Actual pytest output: `/mnt/shared/prismabuild-fleet/cas/blobs/54/54541db33208cf6266aece113f35e32c7a7e275b0ff8df59b275084a6b26182d`.
+- PB `d40318e6d6ac7af10f7bc3cfd0dd33470f70afe92329d54632f73fad8dea8e9e`:
+  compileall of the four touched modules, rc 0. Receipt:
+  `/mnt/shared/prismabuild-fleet/cas/actions/v3/d4/d40318e6d6ac7af10f7bc3cfd0dd33470f70afe92329d54632f73fad8dea8e9e.json`.
+
+The final materialization fixture additionally checks a packed 2-of-3 expert
+sample using real producer bytes: only the third expert's three wires are
+encoded, its original reference receipt is reproduced exactly, the packed
+allocation stays packed, and the existing source-view handoff reaches the
+producer's actual translator. It uses synthetic routed activations and omits
+served-route scoring; it is a protocol and byte-integrity test, not a served
+measurement. The sample needs at least two non-certainty experts: an attempted
+one-of-two fixture correctly hit the estimator's variance refusal and was
+replaced with the valid two-of-three frame.
+
+A wider intermediate run against the old host producer also found three batch
+test stubs that assumed `encode_linears` existed. Their owner fixed the test
+portability in `87af2f94`; production materialization still refuses an explicitly
+requested batch when the actual producer has no batch API.
+
+## Commands
+
+```bash
+python3 /mnt/shared/prismabuild-fleet/repo/tools/pbrun.py \
+  --cwd /home/rob/tmp/pq-selected-wire-materialization \
+  --cpus 2 --demand mem_gb=6 --tag gb10 \
+  --env OMP_NUM_THREADS=1 --env MKL_NUM_THREADS=1 --env OPENBLAS_NUM_THREADS=1 \
+  --env TESSERA_REPO=/mnt/shared/tessera-measurements/first-model-20260907/inputs/tessera-382a1a97 \
+  --env PYTHONPATH=/mnt/shared/tessera-measurements/first-model-20260907/inputs/tessera-382a1a97/src \
+  -- /home/rob/dq-runs/venvs/prismaquant-cu130/bin/python -m pytest -q -rs -n 2 \
+  tests/test_tessera_materialization.py tests/test_tessera_packed_export_scope.py \
+  tests/test_tessera_expert_projection.py tests/test_tessera_priced_export_inputs.py \
+  tests/test_architecture_doc.py tests/test_docs_staleness.py \
+  tests/test_tessera_packed_plan_handoff.py tests/test_tessera_stack_driver_integration.py \
+  tests/test_tessera_campaign_batch.py --tb=short
+```
+
+For the application workflow, add `--tessera-materialization-plan REQUEST` to
+the ordinary allocator invocation while retaining its intended `--layer-config`
+output. Run the new module's `plan` command with the same cost-derived census
+and existing campaign spec, optionally `--anchor-batch-size N`, submit
+`WORKSPACE/manifest.json` with the published `pbcampaign.py`, and run `finalize`
+inside an admitted action. `WORKSPACE/final/result.json` names the exact final
+allocation, Hessian capture, scale file and wire directory. This opt-in step
+requires the dispatcher/container adapter and shared batch adapter commits;
+no format default or serving gate changes.

--- a/prismaquant/allocator.py
+++ b/prismaquant/allocator.py
@@ -1916,6 +1916,9 @@ def main():
     ap.add_argument("--layer-config", required=True,
                     help="Output AutoRound layer_config JSON")
     ap.add_argument("--pareto-csv", required=True, help="Output Pareto CSV")
+    ap.add_argument("--tessera-materialization-plan", default=None,
+                    help="Write a non-exportable selected-wire request here instead of layer-config; "
+                         "finalize through prismaquant.tessera_materialization after selected wires exist")
     ap.add_argument("--knee-refine-tol", type=float, default=0.03,
                     help="Golden-section knee refinement tolerance in bpp "
                          "(default 0.03). The coarse Pareto grid only lands the "
@@ -5748,6 +5751,13 @@ def main():
     # before the layer config is written.  Additive: a stock cost table adds
     # no keys, and a table carrying a population but no projection carries
     # only the population.
+    if args.tessera_materialization_plan:
+        from .tessera_materialization import write_selection_request
+        write_selection_request(args.tessera_materialization_plan,
+            layer_config=layer_cfg, assignment=assignment_expanded,
+            cost_path=args.costs, cost_payload=cost_data, output_path=args.layer_config)
+        print(f"[alloc] non-exportable selected-wire request → {args.tessera_materialization_plan}")
+        return
     try:
         layer_cfg[LAYER_CONFIG_META_KEY].update(
             allocation_expert_projection_block(cost_data, assignment_expanded))

--- a/prismaquant/tessera_expert_projection.py
+++ b/prismaquant/tessera_expert_projection.py
@@ -558,6 +558,23 @@ def expand_stack_decision_assignment(assignment: Mapping[str, Any], population: 
 
 def allocation_expert_projection_block(payload: Mapping[str, Any],
                                        assignment: Mapping[str, Any]) -> dict:
+    """Carry population/projection only after every selected receipt is present."""
+    return _allocation_expert_projection_block(payload, assignment, require_wires=True)
+
+
+def selection_expert_projection_block(payload: Mapping[str, Any],
+                                      assignment: Mapping[str, Any]) -> dict:
+    """Validate selection structure without claiming selected bytes exist.
+
+    This is only for a non-exportable materialization request. The public
+    allocation gate always requires every selected receipt.
+    """
+    return _allocation_expert_projection_block(payload, assignment, require_wires=False)
+
+
+def _allocation_expert_projection_block(payload: Mapping[str, Any],
+                                        assignment: Mapping[str, Any], *,
+                                        require_wires: bool) -> dict:
     """What an allocation carries about the expert population it selected from.
 
     A stock table (no population statement, no projection, no wires) adds no
@@ -663,6 +680,8 @@ def allocation_expert_projection_block(payload: Mapping[str, Any],
     if not isinstance(wire_dir, str) or not wire_dir:
         raise ExpertProjectionError(
             "cost table names no wire_dir for its priced expert wires")
+    if wires is None and not require_wires:
+        wires = {}
     if not isinstance(wires, Mapping):
         raise ExpertProjectionError(
             "cost table carries a producer projection but no priced expert wires")
@@ -674,6 +693,8 @@ def allocation_expert_projection_block(payload: Mapping[str, Any],
         family, q256 = parsed
         per_unit = wires.get(name)
         record = per_unit.get(fmt) if isinstance(per_unit, Mapping) else None
+        if record is None and not require_wires:
+            continue
         if record is None:
             raise ExpertProjectionError(
                 f"{name}: selected {fmt} has no priced wire receipt in the cost table; "

--- a/prismaquant/tessera_export_lane.py
+++ b/prismaquant/tessera_export_lane.py
@@ -1139,7 +1139,21 @@ def require_priced_export_inputs(
         tessera_serving_route, tessera_wire_recipe,
     )
 
-    selected = {name: fmt for name, fmt in load_assignment(assignment_path).items()
+    from .tessera_expert_projection import (
+        POPULATION_KEY, PROJECTION_KEY, ExpertProjectionError,
+        carried_units, expand_stack_decision_assignment,
+    )
+    assignment = load_assignment(assignment_path)
+    metadata = read_layer_config_metadata(assignment_path)
+    population = metadata.get(POPULATION_KEY)
+    if isinstance(population, Mapping) and population.get("stack_decisions"):
+        try:
+            _source, units, stack_of = carried_units(metadata.get(PROJECTION_KEY))
+            assignment, _owners = expand_stack_decision_assignment(
+                assignment, population, units=units, stack_of=stack_of)
+        except ExpertProjectionError as exc:
+            raise TesseraExportLaneError(f"expert projection: {exc}") from exc
+    selected = {name: fmt for name, fmt in assignment.items()
                 if fmt.startswith("TESSERA_")}
     report = {
         "hessian_required": False, "hessian": None,

--- a/prismaquant/tessera_materialization.py
+++ b/prismaquant/tessera_materialization.py
@@ -1,0 +1,480 @@
+"""Materialize selected expert wires between sampled allocation and export.
+
+A selection request is deliberately not a layer config. Each census anchor
+stack is one independent PB action, using campaign calibration, render cache,
+producer identities and the shared journal. Only finalization can publish the
+packed allocation, after the ordinary receipt and priced-input gates pass.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import pickle
+from pathlib import Path
+from types import SimpleNamespace
+
+from . import tessera_expert_projection as tep
+from .cost_stage_checkpoint import atomic_write_bytes
+
+REQUEST_SCHEMA = "prismaquant.tessera_selected_wire_request.v1"
+PLAN_SCHEMA = "prismaquant.tessera_selected_wire_plan.v1"
+STAGE = "tessera_selected_wire"
+
+
+def _sha(path):
+    with Path(path).open('rb') as handle:
+        return hashlib.file_digest(handle, 'sha256').hexdigest()
+
+
+def _json(path, value):
+    atomic_write_bytes(Path(path), (json.dumps(value, indent=2, sort_keys=True,
+                                             allow_nan=False) + '\n').encode())
+
+
+def write_selection_request(path, *, layer_config, assignment, cost_path,
+                            cost_payload, output_path):
+    """Persist decisions and existing evidence without claiming export readiness."""
+    from .layer_config import canonicalize_assignment
+    if canonicalize_assignment(layer_config) != dict(assignment):
+        raise RuntimeError('selection layer config disagrees with resolved assignment')
+    block = tep.selection_expert_projection_block(cost_payload, assignment)
+    if not block.get(tep.PROJECTION_KEY):
+        raise RuntimeError('selected-wire materialization requires a producer projection')
+    config = copy.deepcopy(layer_config)
+    config['__prismaquant__'].update(block)
+    request = dict(schema=REQUEST_SCHEMA, status='selection_only_nonexportable',
+                   layer_config=config, assignment=dict(assignment),
+                   cost_path=str(Path(cost_path).resolve()), cost_sha256=_sha(cost_path),
+                   output_path=str(Path(output_path).resolve()))
+    _json(path, request)
+    return request
+
+
+def _request(path):
+    from .layer_config import canonicalize_assignment
+    request = json.loads(Path(path).read_text())
+    if (request.get('schema') != REQUEST_SCHEMA or
+            request.get('status') != 'selection_only_nonexportable'):
+        raise RuntimeError('not a non-exportable selected-wire request')
+    if _sha(request['cost_path']) != request['cost_sha256']:
+        raise RuntimeError('selected-wire cost input changed')
+    with Path(request['cost_path']).open('rb') as handle:
+        cost = pickle.load(handle)
+    assignment = canonicalize_assignment(request['layer_config'])
+    if assignment != request['assignment']:
+        raise RuntimeError('selected-wire assignment changed')
+    block = tep.selection_expert_projection_block(cost, assignment)
+    for key, value in block.items():
+        if request['layer_config']['__prismaquant__'].get(key) != value:
+            raise RuntimeError(f'selected-wire request changed carried {key}')
+    source, units, stacks = tep.carried_units(block[tep.PROJECTION_KEY])
+    expanded, _owners = tep.expand_stack_decision_assignment(
+        assignment, block.get(tep.POPULATION_KEY), units=units, stack_of=stacks,
+        costs=cost.get('costs', {}))
+    return request, cost, source, units, expanded
+
+
+def _check_census(path, cost, source, units):
+    from . import tessera_campaign as tc
+    provenance = {**cost['provenance']['hessian']['calibration_identity'], **cost['provenance']}
+    args = SimpleNamespace(**{field:provenance[field]
+        for field in ('model', 'nsamples', 'seqlen', 'seed', 'layer_stride')})
+    census = tc.load_calibration_census(path, args=args)
+    tc.require_census_draw(census, provenance['hessian']['calibration_identity'],
+                           where='selected-wire planning')
+    census_source, census_units, _stacks = tep.carried_units(census.get('expert_projection'))
+    if census_source != source or census_units != units:
+        raise RuntimeError('materialization census producer projection differs from priced projection')
+    for name, unit in units.items():
+        if census.get('unit_shapes', {}).get(name) != [unit['rows'], unit['cols']]:
+            raise RuntimeError(f'{name}: census shape does not match projected geometry')
+    return census
+
+
+def _planned_groups(census, selected, cost):
+    groups, covered = [], set()
+    for key, members in sorted(census['anchor_groups'].items()):
+        names = sorted(set(members) & set(selected))
+        if covered.intersection(names):
+            raise RuntimeError('census groups overlap selected units')
+        covered.update(names)
+        if names and any(cost.get(tep.EXPERT_WIRES_KEY, {}).get(n, {}).get(selected[n]) is None
+                         for n in names):
+            groups.append(dict(key=key, assignment={n:selected[n] for n in names}))
+    if covered != set(selected):
+        raise RuntimeError('census groups do not cover selected source units')
+    return groups
+
+
+def plan(request_path, census_path, workspace, spec_path, *, anchor_batch_size=1):
+    from tools import dispatch_tessera_campaign as dispatcher
+    if anchor_batch_size < 1:
+        raise ValueError('anchor batch size must be positive')
+    request, cost, source, units, expanded = _request(request_path)
+    provenance = cost['provenance']
+    census = _check_census(census_path, cost, source, units)
+    workspace = Path(workspace).resolve()
+    workspace.mkdir(parents=True, exist_ok=True)
+    spec = dispatcher.load_spec(Path(spec_path))
+    if spec['model'] != provenance['model']:
+        raise RuntimeError('materialization spec model differs from priced model')
+    selected = {n: expanded[n] for n in units if expanded[n].startswith('TESSERA_')}
+    groups = _planned_groups(census, selected, cost)
+    result = dict(schema=PLAN_SCHEMA, request_path=str(Path(request_path).resolve()),
+                  request_sha256=_sha(request_path), census_path=str(Path(census_path).resolve()),
+                  census_sha256=_sha(census_path), workspace=str(workspace), groups=groups)
+    plan_path = workspace / 'plan.json'
+    _json(plan_path, result)
+    rows = []
+    for index, group in enumerate(groups):
+        row = dispatcher._row(spec, ['run', '--plan', str(plan_path), '--group', str(index),
+                                     '--anchor-batch-size', str(anchor_batch_size)],
+            mem_gb=dispatcher._row_memory_gb({**spec, 'max_act_rows':provenance['max_act_rows']},
+                                            list(group['assignment']), census),
+            timeout_s=int(spec.get('timeout_s', 86400)), module='prismaquant.tessera_materialization')
+        rows.append(row)
+    _json(workspace / 'manifest.json', rows)
+    return result
+
+
+def _inputs(plan_path, group_index=None):
+    from . import tessera_campaign as tc
+    plan_data = json.loads(Path(plan_path).read_text())
+    if plan_data.get('schema') != PLAN_SCHEMA:
+        raise RuntimeError('not a selected-wire plan')
+    for field in ('request', 'census'):
+        if _sha(plan_data[field + '_path']) != plan_data[field + '_sha256']:
+            raise RuntimeError(f'selected-wire {field} changed after planning')
+    request, cost, source, units, expanded = _request(plan_data['request_path'])
+    expected = {n: expanded[n] for n in units if expanded[n].startswith('TESSERA_')}
+    census = _check_census(plan_data['census_path'], cost, source, units)
+    if plan_data['groups'] != _planned_groups(census, expected, cost):
+        raise RuntimeError('materialization plan differs from selected census groups')
+    api = tc._checkpoint_identity_api()
+    source_sha = api.encoder_source_sha256()
+    # Every measured receipt must describe the same producer source.
+    priced_receipts = 0
+    for name, rows in cost.get(tep.EXPERT_WIRES_KEY, {}).items():
+        for record in rows.values():
+            priced_receipts += 1
+            if record['identity'].get('encoder_source_sha256') != source_sha:
+                raise RuntimeError(f'{name}: priced wire producer source changed')
+    if expected and not priced_receipts:
+        raise RuntimeError('selected-wire request has no priced producer receipt to bind encoder source')
+    if tc.th.encoder_recipe() != cost['provenance']['hessian']['recipe']:
+        raise RuntimeError('selected-wire encoder recipe differs from priced recipe')
+    from .production_weight_cache import _production_cache_source_sha256
+    identity = dict(plan_sha256=_sha(plan_path), encoder_source_sha256=source_sha,
+                    prismaquant_source_sha256=_production_cache_source_sha256(),
+                    recipe=tc.th.encoder_recipe())
+    if group_index is not None and not 0 <= group_index < len(plan_data['groups']):
+        raise ValueError('materialization group index is outside the plan')
+    group = None if group_index is None else plan_data['groups'][group_index]
+    return plan_data, request, cost, source, units, expanded, census, identity, group
+
+
+def _verify_source(model, source):
+    for filename, expected in source['files'].items():
+        if _sha(Path(model) / filename) != expected:
+            raise RuntimeError(f'selected-wire source checkpoint changed: {filename}')
+    if _sha(Path(model) / 'config.json') != source['config_sha256']:
+        raise RuntimeError('selected-wire source model config changed')
+    for filename, expected in source.get('auxiliary_sha256', {}).items():
+        if _sha(Path(model) / filename) != expected:
+            raise RuntimeError(f'selected-wire auxiliary source changed: {filename}')
+
+
+def _journal(plan_data, identity, index, names):
+    from .cost_stage_checkpoint import prepare_journal
+    root = Path(plan_data['workspace']) / 'groups' / str(index)
+    root.mkdir(parents=True, exist_ok=True)
+    return root, prepare_journal(root / 'journal', stage=STAGE, resume=True,
+        identity={**identity, 'group': index}, qnames=names)
+
+
+def run(plan_path, group_index, *, anchor_batch_size=1):
+    """Execute inside one admitted action; never submit recursively."""
+    import functools
+    from dataclasses import asdict
+    import torch
+    from transformers import AutoModelForCausalLM
+    from . import tessera_campaign as tc
+    from . import tessera_hessian as th
+    from .cost_stage_checkpoint import write_unit
+    from .model_profiles import detect_profile
+    from .production_weight_cache import ProductionWeightCache
+    from .tessera_formats import parse_tessera_format_name, tessera_wire_recipe
+    from .tessera_render import rung_accepts_hessian
+
+    if anchor_batch_size < 1:
+        raise ValueError('anchor batch size must be positive')
+    if anchor_batch_size > 1:
+        from .tessera_render import require_tessera_batch_encoder
+        require_tessera_batch_encoder()
+    data, request, cost, source, units, _expanded, census, identity, group = _inputs(plan_path, group_index)
+    names = sorted(group['assignment'])
+    root, (journal, journal_sha, completed) = _journal(data, identity, group_index, names)
+    provenance = {**cost['provenance']['hessian']['calibration_identity'], **cost['provenance']}
+    model_path = provenance['model']
+    _verify_source(model_path, source)
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    profile = detect_profile(model_path)
+    model = AutoModelForCausalLM.from_pretrained(model_path, dtype=torch.bfloat16, device_map=device)
+    model.eval()
+    population = tc._require_campaign_population(model, profile, provenance['layer_stride'])
+    members = {member.qname: member for member in population.members}
+    if set(names) - set(members):
+        raise RuntimeError('selected source units absent from profile population')
+    tokens, corpus = tc._calibration_tokens(model_path, provenance['nsamples'],
+                                           provenance['seqlen'], provenance['seed'])
+    want_h = provenance['hessian']['supplied']
+    acts, hessians, counts, maxima = tc._collect_activations(
+        model, names, tokens, provenance['max_act_rows'], device,
+        want_hessian=want_h, profile=profile)
+    hi, lo = tc.census_token_counts(census, counts)
+    calibration = th.calibration_identity(corpus, tokens, fit_tokens=hi,
+        source='wikitext-2-raw-v1/train', split_role='calibration', model=str(model_path),
+        seed=provenance['seed'], nsamples=provenance['nsamples'],
+        seqlen=provenance['seqlen'], fit_tokens_min=lo)
+    tc.require_census_draw(census, calibration, where='selected-wire capture')
+    if calibration != provenance['hessian']['calibration_identity']:
+        raise RuntimeError('selected-wire capture calibration differs from priced capture')
+    scales, scale_policy = tc._static_input_scales(tc.census_max_abs(census, maxima), profile=profile)
+    stamped_scales = provenance['activation_static_scales']
+    if scale_policy != stamped_scales['policy'] or scales != stamped_scales['units']:
+        raise RuntimeError('selected-wire static scales differ from priced census scales')
+    weights = {name: members[name].weight.detach() for name in names}
+    for name, weight in weights.items():
+        original = tep.source_unit_weight(model_path, source, units[name])
+        if not torch.equal(original, weight.cpu()):
+            raise RuntimeError(f'{name}: live projection differs from source checkpoint')
+    del model, members, population
+    if device == 'cuda':
+        torch.cuda.empty_cache()
+    activation = th.activation_source(hessians, calibration) if want_h else None
+    @functools.lru_cache(maxsize=None)
+    def kwargs(name, plane):
+        return th.encoder_kwargs(activation, name, weights[name].shape[1], device, scale_plane=plane)
+    wire_dir = root / 'wire'
+    wire_dir.mkdir(exist_ok=True)
+    cache = ProductionWeightCache(weights={}, levers={'tessera_campaign': True},
+        cache_dir=str(root), metadata={'schema': REQUEST_SCHEMA})
+    api = tc._checkpoint_identity_api()
+    missing, expected_by_name = [], {}
+    for name in names:
+        fmt = group['assignment'][name]
+        family, rung = parse_tessera_format_name(fmt)
+        active = (activation if activation is not None and
+                  rung_accepts_hessian(fmt, tessera_wire_recipe(family, rung)) else None)
+        expected = api.unit_input_identity(weights[name], units[name], family.payload_grid(), rung,
+                                           activation=active)
+        wire_path = tc._wire_path(wire_dir, name, fmt)
+        state = completed.get(name)
+        record = None if state is None else state['record']
+        if record is None:
+            record = cost.get(tep.EXPERT_WIRES_KEY, {}).get(name, {}).get(fmt)
+            if record is not None:
+                tc._link_seed_wire(Path(provenance['wire_dir']), wire_dir, record['file'])
+        if record is not None:
+            tep.verify_expert_wire_record(record, name=name, unit=units[name], q256=rung,
+                grid=family.payload_grid().name, wire_dir=wire_dir)
+            api.verify_cached_unit(wire_path.read_bytes(), record, expected)
+            if record['file'] != wire_path.name:
+                raise RuntimeError(f'{name}: wire filename differs from selected rung')
+            anchor = None if state is None else state.get('anchor')
+        else:
+            if wire_path.exists():
+                raise RuntimeError(f'{name}: unjournaled wire exists; refusing overwrite')
+            missing.append((name, family.name, rung))
+            expected_by_name[name] = expected
+            continue
+        write_unit(journal, stage=STAGE, qname=name, identity_sha256=journal_sha,
+            state=dict(format=fmt, record=record, anchor=anchor))
+    for batch in tc._anchor_batches(missing, weights=weights, expert_members=units,
+                                    batch_size=anchor_batch_size):
+        batch_names = [item[0] for item in batch]
+        fmt = group['assignment'][batch_names[0]]
+        common = dict(format_name=fmt, cache=cache, wire_dir=wire_dir,
+                      activation_kwargs_for=kwargs, hessian_required=want_h)
+        if len(batch) == 1:
+            name = batch_names[0]
+            anchors = [tc._measure_anchor(qname=name, weight=weights[name].to(device),
+                activations=acts[name].to(device), static_input_scale=scales.get(name), **common)]
+        else:
+            anchors = tc._measure_anchor_batch(qnames=batch_names,
+                weights=[weights[name].to(device) for name in batch_names],
+                activations=[acts[name].to(device) for name in batch_names],
+                static_input_scales=scales, **common)
+        for anchor in anchors:
+            name = anchor.qname
+            record = tc._checkpoint_wire_record(anchor, wire_dir, expected_by_name[name])
+            write_unit(journal, stage=STAGE, qname=name, identity_sha256=journal_sha,
+                state=dict(format=anchor.format_name, record=record, anchor=asdict(anchor)))
+    capture, scale_file, digest = tc.write_export_inputs(root, hessians=hessians if want_h else None,
+        hessian_rows=counts, hessian_identity=calibration, static_scales=scales,
+        static_scale_policy=scale_policy)
+    _json(root / 'complete.json', dict(identity=identity, group=group_index,
+        capture_path=None if capture is None else str(capture), capture_sha256=digest,
+        input_scales_path=None if scale_file is None else str(scale_file),
+        units=names, calibration_identity=calibration))
+
+
+def finalize(plan_path):
+    """Publish only a fully verified packed allocation and its exact export inputs."""
+    import torch
+    from . import tessera_campaign as tc
+    from . import tessera_hessian as th
+    from . import tessera_export_lane as export
+    from .tessera_formats import parse_tessera_format_name, tessera_wire_recipe
+    from .tessera_render import rung_accepts_hessian
+
+    data, request, cost, source, units, expanded, census, identity, _group = _inputs(plan_path)
+    provenance = {**cost['provenance']['hessian']['calibration_identity'], **cost['provenance']}
+    _verify_source(provenance['model'], source)
+    root = Path(data['workspace']) / 'final'
+    root.mkdir(parents=True, exist_ok=True)
+    wire_dir = root / 'wire'
+    wire_dir.mkdir(exist_ok=True)
+    want_h = provenance['hessian']['supplied']
+    calibration = provenance['hessian']['calibration_identity']
+    hessians, counts = {}, {}
+    if want_h:
+        original_path = Path(provenance['hessian']['capture_path'])
+        hessians, original_identity, digest = export._bound_hessian_capture(original_path)
+        if (digest != provenance['hessian']['capture_sha256'] or
+                original_identity != {**calibration, 'hessian_role': 'fit'}):
+            raise RuntimeError('original priced capture changed before materialization')
+        counts = dict(torch.load(original_path, map_location='cpu', weights_only=False)['counts'])
+        tc.census_token_counts(census, counts)
+        if set(counts) != set(hessians):
+            raise RuntimeError('original priced capture counts do not cover its Hessians')
+    receipts = copy.deepcopy(cost.get(tep.EXPERT_WIRES_KEY, {}))
+    api = tc._checkpoint_identity_api()
+    completed_names = set()
+    for index, group in enumerate(data['groups']):
+        names = sorted(group['assignment'])
+        group_root, (_journal_root, _digest, completed) = _journal(data, identity, index, names)
+        completion = json.loads((group_root / 'complete.json').read_text())
+        if (completion['identity'] != identity or completion['group'] != index or
+                completion['units'] != names or completion['calibration_identity'] != calibration or
+                set(completed) != set(names)):
+            raise RuntimeError(f'materialization group {index} is incomplete or changed')
+        group_h = {}
+        if want_h:
+            capture = group_root / 'hessian_capture.pt'
+            group_h, capture_identity, digest = export._bound_hessian_capture(capture)
+            if (digest != completion['capture_sha256'] or
+                    capture_identity != {**calibration, 'hessian_role': 'fit'} or
+                    set(group_h) != set(names)):
+                raise RuntimeError(f'materialization group {index} capture changed')
+            group_counts = torch.load(capture, map_location='cpu', weights_only=False)['counts']
+            tc.census_token_counts(census, group_counts)
+            if set(group_counts) != set(names):
+                raise RuntimeError('materialization capture counts do not cover exactly its selected units')
+            for name, hessian in group_h.items():
+                if name in hessians and (not torch.equal(hessians[name], hessian) or
+                                        counts[name] != group_counts[name]):
+                    raise RuntimeError(f'{name}: materialized Hessian disagrees with priced overlap')
+                hessians[name], counts[name] = hessian, group_counts[name]
+        for name in names:
+            fmt = group['assignment'][name]
+            state = completed[name]
+            if state['format'] != fmt:
+                raise RuntimeError(f'{name}: materialization changed selected format')
+            record = state['record']
+            previous = receipts.setdefault(name, {}).get(fmt)
+            if previous is not None and previous != record:
+                raise RuntimeError(f'{name}: materialization replaced an existing selected receipt')
+            receipts[name][fmt] = record
+            completed_names.add(name)
+    # Existing complete stacks need no new calibration quantum. Verify their
+    # receipts under the original capture, alongside every completed group.
+    activation = th.activation_source(hessians, calibration) if want_h else None
+    for name in sorted(units):
+        fmt = expanded[name]
+        if not fmt.startswith('TESSERA_'):
+            continue
+        record = receipts.get(name, {}).get(fmt)
+        if record is None:
+            raise RuntimeError(f'{name}: selected wire is still missing')
+        source_dir = Path(provenance['wire_dir'])
+        for index, group in enumerate(data['groups']):
+            if name in group['assignment']:
+                source_dir = Path(data['workspace']) / 'groups' / str(index) / 'wire'
+                break
+        family, rung = parse_tessera_format_name(fmt)
+        active = (activation if activation is not None and
+                  rung_accepts_hessian(fmt, tessera_wire_recipe(family, rung)) else None)
+        weight = tep.source_unit_weight(provenance['model'], source, units[name])
+        expected = api.unit_input_identity(weight, units[name], family.payload_grid(), rung,
+                                           activation=active)
+        checked = tep.verify_expert_wire_record(record, name=name, unit=units[name], q256=rung,
+            grid=family.payload_grid().name, wire_dir=source_dir)
+        api.verify_cached_unit((source_dir / checked['file']).read_bytes(), checked, expected)
+        tc._link_seed_wire(source_dir, wire_dir, checked['file'])
+        api.verify_cached_unit((wire_dir / checked['file']).read_bytes(), checked, expected)
+        completed_names.add(name)
+    scales = provenance['activation_static_scales']
+    capture, scale_path, digest = tc.write_export_inputs(root,
+        hessians=hessians if want_h else None, hessian_rows=counts,
+        hessian_identity=calibration, static_scales=scales['units'],
+        static_scale_policy=scales['policy'])
+    completed_cost = {**cost, tep.EXPERT_WIRES_KEY: receipts,
+                      'provenance': {**provenance, 'wire_dir': str(wire_dir)}}
+    config = copy.deepcopy(request['layer_config'])
+    meta = config['__prismaquant__']
+    meta.update(tep.allocation_expert_projection_block(completed_cost, request['assignment']))
+    meta['tessera_activation_static_scales'] = dict(schema=export.PRICED_STATIC_SCALES_SCHEMA,
+                                                   units=dict(scales['units']))
+    if want_h:
+        meta['tessera_hessian'] = {**meta['tessera_hessian'], 'capture_sha256': digest,
+                                   'capture_path': str(capture)}
+    meta['tessera_selected_wire_materialization'] = dict(
+        schema='prismaquant.tessera_selected_wire_completion.v1',
+        request_sha256=data['request_sha256'], plan_sha256=_sha(plan_path),
+        original_cost_sha256=request['cost_sha256'],
+        original_capture_sha256=provenance['hessian'].get('capture_sha256'),
+        capture_sha256=digest, verified_source_units=sorted(completed_names),
+        selection_prices='unchanged_sampled_stack_estimates')
+    candidate = root / 'verified-layer-config.json'
+    _json(candidate, config)
+    export.require_priced_export_inputs(candidate, hessian_path=capture,
+                                       input_scales_path=scale_path)
+    atomic_write_bytes(Path(request['output_path']), candidate.read_bytes())
+    report = dict(layer_config=request['output_path'], hessian=None if capture is None else str(capture),
+                  input_scales=None if scale_path is None else str(scale_path),
+                  wire_dir=str(wire_dir), verified_source_units=len(completed_names))
+    _json(root / 'result.json', report)
+    return report
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest='command', required=True)
+    planning = commands.add_parser('plan')
+    planning.add_argument('--request', required=True)
+    planning.add_argument('--census', required=True)
+    planning.add_argument('--workspace', required=True)
+    planning.add_argument('--spec', required=True)
+    planning.add_argument('--anchor-batch-size', type=int, default=1)
+    running = commands.add_parser('run')
+    running.add_argument('--plan', required=True)
+    running.add_argument('--group', type=int, required=True)
+    running.add_argument('--anchor-batch-size', type=int, default=1)
+    finalizing = commands.add_parser('finalize')
+    finalizing.add_argument('--plan', required=True)
+    args = parser.parse_args(argv)
+    if args.command == 'plan':
+        result = plan(args.request, args.census, args.workspace, args.spec,
+                      anchor_batch_size=args.anchor_batch_size)
+    elif args.command == 'run':
+        result = run(args.plan, args.group, anchor_batch_size=args.anchor_batch_size)
+    else:
+        result = finalize(args.plan)
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_architecture_doc.py
+++ b/tests/test_architecture_doc.py
@@ -609,8 +609,8 @@ def test_tail_veto_default_on_with_kl_max_is_documented():
 # and a doc/driver agreement test with no driver is theatre.
 
 
-def test_three_diagrams_present():
-    assert _doc().count("```mermaid") == 3
+def test_four_diagrams_present():
+    assert _doc().count("```mermaid") == 4
 
 
 def test_docs_index_leads_with_architecture():

--- a/tests/test_tessera_materialization.py
+++ b/tests/test_tessera_materialization.py
@@ -1,0 +1,474 @@
+"""Selection is non-exportable; materialization preserves chosen prices and bytes."""
+import copy
+import hashlib
+import json
+import pickle
+from types import SimpleNamespace
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from prismaquant import tessera_materialization as tm
+from prismaquant import tessera_campaign as tc
+from prismaquant import tessera_expert_projection as tep
+from prismaquant.layer_config import canonicalize_assignment, load_assignment
+from test_tessera_packed_export_scope import _pack
+from test_tessera_export_projection import case, _meta, _units, FMT, STACK, N, DENSE
+
+
+@pytest.fixture
+def selection(case, tmp_path):
+    _pack(case)
+    config = copy.deepcopy(case.payload)
+    assignment = canonicalize_assignment(config)
+    meta = config['__prismaquant__']
+    for record in case.receipts.values():
+        record['identity']['encoder_source_sha256'] = 'producer-source'
+    census_identity = dict(text_sha256='a'*64, fit_ids_sha256='b'*64, fit_tokens=8,
+        model=str(case.model), seed=0, nsamples=2, seqlen=4, fit_tokens_min=8,
+        source='wikitext-2-raw-v1/train', split_role='calibration')
+    costs = {name: {FMT: {'output_mse': 0.123}} for name in meta[tep.POPULATION_KEY]['priced']['dense']
+             + meta[tep.POPULATION_KEY]['priced']['routed_experts']}
+    provenance = dict(model=str(case.model), nsamples=2, seqlen=4, layer_stride=1, max_act_rows=4,
+        wire_dir=str(case.wire_dir),
+        hessian=dict(supplied=False, calibration_identity=census_identity, recipe={'fixture': True}),
+        activation_static_scales=dict(policy='fixture', units={n: float(i+1) for i,n in enumerate(_units())}))
+    provenance.update({key: meta[key] for key in (tep.POPULATION_KEY, tep.PROJECTION_KEY)})
+    cost = dict(costs=costs, provenance=provenance,
+                tessera_expert_wires={n: {FMT: r} for n,r in case.receipts.items()})
+    # One missing unsampled expert demonstrates the actual selection/finalization gap.
+    missing = f'{STACK}.1.w2'
+    del cost[tep.EXPERT_WIRES_KEY][missing]
+    packed = f'{STACK}.down_proj'
+    cost['provenance'][tep.POPULATION_KEY]['stack_decisions'][packed]['sampled_members'] = [f'{STACK}.0.w2']
+    cost_path = tmp_path / 'cost.pkl'
+    cost_path.write_bytes(pickle.dumps(cost))
+    request_path = tmp_path / 'request.json'
+    output = tmp_path / 'final-layer-config.json'
+    tm.write_selection_request(request_path, layer_config=config, assignment=assignment,
+                               cost_path=cost_path, cost_payload=cost, output_path=output)
+    census = dict(schema=tc.CENSUS_SCHEMA, model=str(case.model), nsamples=2, seqlen=4, seed=0,
+        layer_stride=1, text_sha256='a'*64, fit_ids_sha256='b'*64,
+        counts={n:8 for n in _units()}, max_abs={n:1.0 for n in _units()},
+        anchor_groups={'s:'+STACK: _units()}, unit_shapes={n:[N,N] for n in _units()},
+        expert_projection=cost['provenance'][tep.PROJECTION_KEY])
+    census_path = tmp_path / 'census.json'
+    census_path.write_text(json.dumps(census))
+    spec = tmp_path / 'spec.json'
+    spec.write_text(json.dumps(dict(model=str(case.model), campaign_argv=[], cwd=str(tmp_path),
+        python='python', env={}, cpus=1, headroom_gb=3)))
+    return SimpleNamespace(case=case, config=config, assignment=assignment, cost=cost,
+        cost_path=cost_path, request=request_path, output=output, missing=missing,
+        census=census_path, spec=spec, workspace=tmp_path/'materialization')
+
+
+def test_selection_does_not_publish_allocation_or_invent_missing_receipts(selection):
+    s = selection
+    assert not s.output.exists()
+    request, cost, _source, _units, expanded = tm._request(s.request)
+    assert request['status'] == 'selection_only_nonexportable'
+    assert s.missing not in request['layer_config']['__prismaquant__'][tep.EXPERT_WIRES_KEY]
+    assert expanded[s.missing] == FMT
+    with pytest.raises(tep.ExpertProjectionError, match='no priced wire receipt'):
+        tep.allocation_expert_projection_block(cost, s.assignment)
+    with pytest.raises(ValueError):
+        load_assignment(s.request)
+
+
+@pytest.mark.parametrize('defect', ['cost', 'assignment', 'projection'])
+def test_request_refuses_input_drift(selection, defect):
+    s = selection
+    if defect == 'cost':
+        s.cost_path.write_bytes(s.cost_path.read_bytes() + b'changed')
+    else:
+        request = json.loads(s.request.read_text())
+        if defect == 'assignment':
+            request['assignment'][DENSE] = 'BF16'
+        else:
+            request['layer_config']['__prismaquant__'][tep.PROJECTION_KEY]['tool'] = 'changed'
+        s.request.write_text(json.dumps(request))
+    with pytest.raises(RuntimeError, match='changed'):
+        tm._request(s.request)
+
+
+def _plan(selection, monkeypatch):
+    from tools import dispatch_tessera_campaign as dispatcher
+    calls = []
+    def row(spec, argv, **kwargs):
+        calls.append((argv, kwargs))
+        return dict(argv=argv, **kwargs)
+    monkeypatch.setattr(dispatcher, '_row', row)
+    result = tm.plan(selection.request, selection.census, selection.workspace, selection.spec)
+    return selection.workspace / 'plan.json', result, calls
+
+
+def test_plan_uses_census_quanta_and_pb_row_sizing(selection, monkeypatch):
+    path, result, calls = _plan(selection, monkeypatch)
+    assert len(result['groups']) == len(calls) == 1
+    assert result['groups'][0]['assignment'] == {n:FMT for n in _units()}
+    assert calls[0][1]['module'] == 'prismaquant.tessera_materialization'
+    assert calls[0][1]['mem_gb'] >= 3
+    assert (selection.workspace / 'manifest.json').is_file()
+    assert not selection.output.exists()
+
+
+def test_plan_refuses_different_calibration(selection, monkeypatch):
+    census = json.loads(selection.census.read_text())
+    census['fit_ids_sha256'] = 'different'
+    selection.census.write_text(json.dumps(census))
+    with pytest.raises(RuntimeError, match='different draws'):
+        _plan(selection, monkeypatch)
+
+
+class ReceiptAPI:
+    def encoder_source_sha256(self):
+        return 'producer-source'
+
+    def unit_input_identity(self, weight, unit, grid, rung, activation=None):
+        return dict(schema='tessera.cached_unit_inputs.v1', unit=unit['tensor'][:-7],
+            encoder_source_sha256=self.encoder_source_sha256(),
+            recipe=dict(grid=grid.name, q256=rung),
+            projection={key:unit[key] for key in tep.UNIT_IDENTITY_KEYS})
+
+    def verify_cached_unit(self, blob, record, identity):
+        assert record['identity'] == identity
+        assert hashlib.sha256(blob).hexdigest() == record['blob_sha256']
+        assert len(blob) == record['blob_bytes']
+
+
+def _completed(selection, monkeypatch, *, hessian=False):
+    from prismaquant.cost_stage_checkpoint import write_unit
+    from prismaquant import tessera_hessian as th
+    if hessian:
+        s = selection
+        calibration = s.cost['provenance']['hessian']['calibration_identity']
+        original = s.workspace / 'original'
+        original.mkdir(parents=True)
+        capture, _scales, digest = tc.write_export_inputs(original,
+            hessians={s.missing:torch.eye(N)}, hessian_rows={s.missing:8},
+            hessian_identity=calibration, static_scales={}, static_scale_policy='fixture')
+        s.cost['provenance']['hessian'].update(supplied=True, capture_path=str(capture), capture_sha256=digest)
+        s.config['__prismaquant__']['tessera_hessian'].update(supplied=True,
+            **calibration, capture_sha256=digest)
+        s.cost_path.write_bytes(pickle.dumps(s.cost))
+        tm.write_selection_request(s.request, layer_config=s.config, assignment=s.assignment,
+            cost_path=s.cost_path, cost_payload=s.cost, output_path=s.output)
+    path, data, _calls = _plan(selection, monkeypatch)
+    monkeypatch.setattr(tc, '_checkpoint_identity_api', lambda:ReceiptAPI())
+    monkeypatch.setattr(th, 'encoder_recipe', lambda:{'fixture':True})
+    monkeypatch.setattr(tm, '_verify_source', lambda *args:None)
+    monkeypatch.setattr(tep, 'source_unit_weight', lambda *args:torch.ones(N,N))
+    monkeypatch.setattr(th, 'activation_source', lambda *args:None)
+    from prismaquant import tessera_render
+    monkeypatch.setattr(tessera_render, 'rung_accepts_hessian', lambda *args:True)
+    *_, identity, group = tm._inputs(path, 0)
+    root, (journal, digest, _completed) = tm._journal(data, identity, 0, sorted(_units()))
+    wires = root/'wire'
+    wires.mkdir()
+    for name, record in selection.case.receipts.items():
+        (wires/record['file']).write_bytes((selection.case.wire_dir/record['file']).read_bytes())
+        write_unit(journal, stage=tm.STAGE, qname=name, identity_sha256=digest,
+                   state=dict(format=FMT, record=record, anchor=None))
+    calibration = selection.cost['provenance']['hessian']['calibration_identity']
+    capture_digest = None
+    if hessian:
+        _capture, _scales, capture_digest = tc.write_export_inputs(root,
+            hessians={n:torch.eye(N) for n in _units()}, hessian_rows={n:8 for n in _units()},
+            hessian_identity=calibration, static_scales={}, static_scale_policy='fixture')
+    tm._json(root/'complete.json', dict(identity=identity, group=0, units=sorted(_units()),
+        calibration_identity=calibration, capture_sha256=capture_digest))
+    return path, root
+
+
+def test_finalize_preserves_packed_decisions_and_reuses_selected_wire_bytes(selection, monkeypatch):
+    path, root = _completed(selection, monkeypatch)
+    report = tm.finalize(path)
+    assert report['verified_source_units'] == len(_units())
+    assert load_assignment(selection.output) == selection.assignment
+    meta = json.loads(selection.output.read_text())['__prismaquant__']
+    assert set(meta[tep.EXPERT_WIRES_KEY]) == set(_units())
+    assert meta['tessera_selected_wire_materialization']['selection_prices'] == 'unchanged_sampled_stack_estimates'
+    assert pickle.loads(selection.cost_path.read_bytes()) == selection.cost
+    for name, record in selection.case.receipts.items():
+        assert (selection.workspace/'final'/'wire'/record['file']).read_bytes() == (
+            selection.case.wire_dir/record['file']).read_bytes()
+    assert tm.finalize(path) == report
+
+
+@pytest.mark.parametrize('defect', ['wire', 'completion', 'producer', 'recipe', 'missing_unit'])
+def test_finalize_refuses_incomplete_or_contradictory_evidence(selection, monkeypatch, defect):
+    from prismaquant.cost_stage_checkpoint import unit_path
+    path, root = _completed(selection, monkeypatch)
+    if defect == 'wire':
+        record = selection.case.receipts[selection.missing]
+        (root/'wire'/record['file']).write_bytes(b'corrupt')
+    elif defect == 'completion':
+        data = json.loads((root/'complete.json').read_text())
+        data['units'].remove(selection.missing)
+        tm._json(root/'complete.json', data)
+    elif defect == 'producer':
+        monkeypatch.setattr(ReceiptAPI, 'encoder_source_sha256', lambda self:'changed')
+    elif defect == 'recipe':
+        monkeypatch.setattr(tc.th, 'encoder_recipe', lambda:{'fixture':False})
+    else:
+        unit_path(root/'journal', selection.missing).unlink()
+    with pytest.raises((RuntimeError, AssertionError), match='changed|incomplete|match|recipe'):
+        tm.finalize(path)
+    assert not selection.output.exists()
+
+
+def test_finalize_unions_hessians_and_requires_exact_priced_overlap(selection, monkeypatch):
+    path, root = _completed(selection, monkeypatch, hessian=True)
+    result = tm.finalize(path)
+    capture = torch.load(result['hessian'], map_location='cpu', weights_only=False)
+    assert set(capture['H']) == set(_units())
+    assert set(capture['counts']) == set(_units())
+    selection.output.unlink()
+    group_capture = root/'hessian_capture.pt'
+    payload = torch.load(group_capture, weights_only=False)
+    payload['H'][selection.missing] += 1
+    _capture, _scales, digest = tc.write_export_inputs(root, hessians=payload['H'],
+        hessian_rows=payload['counts'], hessian_identity=payload['provenance'],
+        static_scales={}, static_scale_policy='fixture')
+    complete = json.loads((root/'complete.json').read_text())
+    complete['capture_sha256'] = digest
+    tm._json(root/'complete.json', complete)
+    with pytest.raises(RuntimeError, match='disagrees with priced overlap'):
+        tm.finalize(path)
+    assert not selection.output.exists()
+
+
+def test_complete_selected_stack_needs_no_materialization_quantum(selection, monkeypatch):
+    s = selection
+    s.cost[tep.EXPERT_WIRES_KEY][s.missing] = {FMT:s.case.receipts[s.missing]}
+    s.cost_path.write_bytes(pickle.dumps(s.cost))
+    tm.write_selection_request(s.request, layer_config=s.config, assignment=s.assignment,
+        cost_path=s.cost_path, cost_payload=s.cost, output_path=s.output)
+    _path, result, calls = _plan(s, monkeypatch)
+    assert result['groups'] == calls == []
+
+
+@pytest.mark.parametrize('batch_size', [1, 2])
+def test_run_encodes_only_missing_selection_and_resume_verifies_existing_bytes(selection, monkeypatch, batch_size):
+    from transformers import AutoModelForCausalLM
+    from prismaquant import tessera_hessian as th
+    s = selection
+    expected_missing = [s.missing]
+    if batch_size == 2:
+        expected_missing.append(f'{STACK}.1.w3')
+        del s.cost[tep.EXPERT_WIRES_KEY][expected_missing[-1]]
+        s.cost_path.write_bytes(pickle.dumps(s.cost))
+        tm.write_selection_request(s.request, layer_config=s.config, assignment=s.assignment,
+            cost_path=s.cost_path, cost_payload=s.cost, output_path=s.output)
+    path, _data, _calls = _plan(s, monkeypatch)
+    api = ReceiptAPI()
+    api.make_unit_record = lambda blob, identity, filename: dict(file=filename,
+        blob_bytes=len(blob), blob_sha256=hashlib.sha256(blob).hexdigest(), identity=identity)
+    monkeypatch.setattr(tc, '_checkpoint_identity_api', lambda:api)
+    monkeypatch.setattr(th, 'encoder_recipe', lambda:{'fixture':True})
+    monkeypatch.setattr(tm, '_verify_source', lambda *args:None)
+    weight = torch.ones(N,N)
+    monkeypatch.setattr(tep, 'source_unit_weight', lambda *args:weight)
+    monkeypatch.setattr(AutoModelForCausalLM, 'from_pretrained',
+                        lambda *args, **kwargs:SimpleNamespace(eval=lambda:None))
+    monkeypatch.setattr(tc, '_require_campaign_population', lambda *args:SimpleNamespace(
+        members=[SimpleNamespace(qname=n, weight=weight) for n in _units()]))
+    monkeypatch.setattr(tc, '_calibration_tokens', lambda *args:(torch.ones(2,4), 'fixture'))
+    calibration = s.cost['provenance']['hessian']['calibration_identity']
+    monkeypatch.setattr(th, 'calibration_identity', lambda *args, **kwargs:calibration)
+    captures = []
+    def collect(model, targets, tokens, max_rows, device, **kwargs):
+        captures.append((list(targets), max_rows))
+        return ({n:torch.ones(4,N) for n in targets}, {}, {n:8 for n in targets}, {n:1.0 for n in targets})
+    monkeypatch.setattr(tc, '_collect_activations', collect)
+    monkeypatch.setattr(tc, '_static_input_scales', lambda *args, **kwargs:(
+        s.cost['provenance']['activation_static_scales']['units'], 'fixture'))
+    measured = []
+    def measure(**kwargs):
+        name = kwargs['qname']
+        measured.append((name, kwargs['format_name']))
+        record = s.case.receipts[name]
+        (kwargs['wire_dir']/record['file']).write_bytes((s.case.wire_dir/record['file']).read_bytes())
+        return tc.CampaignAnchor(qname=name, family='TESSERA_E4M3_K1', format_name=FMT,
+            body_rate_q256=1024, dloss=0.1, dloss_stderr=0.0, memory_bytes=128,
+            bits_per_param=4, activation_contract='fixture', activation_quantized=True,
+            wire_bytes=record['blob_bytes'], seconds=0.0)
+    monkeypatch.setattr(tc, '_measure_anchor', measure)
+    batches = []
+    def batch(**kwargs):
+        batches.append(kwargs['qnames'])
+        return [measure(qname=n, format_name=kwargs['format_name'], wire_dir=kwargs['wire_dir'])
+                for n in kwargs['qnames']]
+    monkeypatch.setattr(tc, '_measure_anchor_batch', batch)
+    from prismaquant import tessera_render
+    monkeypatch.setattr(tessera_render, 'require_tessera_batch_encoder', lambda:None)
+    tm.run(path, 0, anchor_batch_size=batch_size)
+    assert measured == [(n,FMT) for n in expected_missing]
+    assert batches == ([] if batch_size == 1 else [expected_missing])
+    assert captures == [(sorted(_units()),4)]
+    assert not s.output.exists()
+    tm.run(path, 0, anchor_batch_size=1)
+    assert measured == [(n,FMT) for n in expected_missing]
+    report = tm.finalize(path)
+    assert report['verified_source_units'] == len(_units())
+
+
+def test_real_producer_wire_materialization_and_translator_handoff(tmp_path, monkeypatch):
+    """Real source/capture/encoder/receipt/translator; no served-route scoring."""
+    import test_tessera_campaign_packed as packed_fixture
+    from test_tessera_campaign_packed import _bridge_main_fixture, RUNG, STACK as REAL_STACK
+    monkeypatch.setattr(packed_fixture, 'EXPERTS', 3)
+    monkeypatch.setattr(packed_fixture._Router, 'forward', lambda self, hidden:
+        torch.nn.functional.one_hot(torch.arange(len(hidden)) % 3, 3).to(hidden.dtype))
+    from prismaquant import tessera_export_lane as export
+    from prismaquant import tessera_hessian as th
+    campaign, argv, model, encoded = _bridge_main_fixture(monkeypatch, tmp_path)
+    measured_anchors = {}
+    real_measure = campaign._measure_anchor
+    def remember(**kwargs):
+        anchor = real_measure(**kwargs)
+        measured_anchors.setdefault(anchor.qname, {}).setdefault(anchor.family, []).append(anchor)
+        return anchor
+    monkeypatch.setattr(campaign, '_measure_anchor', remember)
+    assert campaign.main(argv) == 0
+    census_path = tmp_path/'census.json'
+    assert campaign.main([*argv, '--census-out', str(census_path)]) == 0
+    cost_path = tmp_path/'cost.pkl'
+    cost = pickle.loads(cost_path.read_bytes())
+    # The existing CPU bridge fixture replaces only the hessian-status report.
+    cost['provenance']['hessian']['recipe'] = th.encoder_recipe()
+    from test_tessera_stack_sample_cost import _packed_probe_row
+    from prismaquant.model_profiles.lfm2_moe import Lfm2MoeProfile
+    profile = Lfm2MoeProfile()
+    population = campaign._require_campaign_population(model, profile, 1)
+    samples = {}
+    for packed, shape in population.packed_in_scope.items():
+        stats = _packed_probe_row(shape[0], [1.0]*shape[0],
+            packed_param=packed.rsplit('.',1)[-1], out_features=shape[1], in_features=shape[2])
+        stats['_packed_experts_module'] = REAL_STACK
+        samples[packed] = campaign.stack_sample_from_probe(packed, stats, profile,
+            sampled_experts=[0,1], inclusion_prob={0:2/3, 1:2/3, 2:2/3}, seed=0)
+    retained = {n for sample in samples.values() for members in sample.members.values() for n in members}
+    dense = 'model.layers.0.attention'
+    measured = {n:rows for n,rows in measured_anchors.items() if n == dense or n in retained}
+    prices = campaign.campaign_cost_payload(measured, {}, loo={},
+        provenance={'provenance':cost['provenance']}, stack_samples=samples)
+    prices['provenance'][tep.POPULATION_KEY] = campaign.campaign_population_block(
+        dense_targets=[dense], expert_targets=population.qnames, dense_all=[dense], pinned=[],
+        population=population, layer_stride=1, costs=prices['costs'],
+        menus={n:[RUNG] for n in prices['costs']}, stack_samples=samples, profile=profile)
+    missing = f'{REAL_STACK}.2.w2'
+    original_record = cost[tep.EXPERT_WIRES_KEY][missing][RUNG]
+    missing_names = set(cost[tep.EXPERT_WIRES_KEY]) - retained
+    prices[tep.EXPERT_WIRES_KEY] = {n:rows for n,rows in cost[tep.EXPERT_WIRES_KEY].items() if n in retained}
+    cost = prices
+    cost_path.write_bytes(pickle.dumps(cost))
+    assignment = {name:RUNG for name in cost['costs']}
+    config = {name:dict(data_type='tessera', bits=4, tessera_format=fmt)
+              for name,fmt in assignment.items()}
+    config['__prismaquant__'] = {'tessera_hessian':{'supplied':False}}
+    request = tmp_path/'request.json'
+    output = tmp_path/'allocation.json'
+    tm.write_selection_request(request, layer_config=config, assignment=assignment,
+        cost_path=cost_path, cost_payload=cost, output_path=output)
+    spec = tmp_path/'spec.json'
+    spec.write_text(json.dumps(dict(model=argv[1], campaign_argv=[], cwd=str(tmp_path),
+        python='python', env={}, cpus=1, headroom_gb=3)))
+    workspace = tmp_path/'materialization'
+    tm.plan(request, census_path, workspace, spec)
+    before = len(encoded)
+    tm.run(workspace/'plan.json', 0)
+    assert len(encoded) == before+len(missing_names)
+    assert {row[0] for row in encoded[before:]} == missing_names
+    tm.finalize(workspace/'plan.json')
+    metadata = json.loads(output.read_text())['__prismaquant__']
+    assert metadata[tep.EXPERT_WIRES_KEY][missing] == original_record
+    assert load_assignment(output) == assignment
+    import os
+    import runpy
+    from pathlib import Path
+    from safetensors import safe_open
+    shapes = {}
+    for shard in Path(argv[1]).glob('*.safetensors'):
+        with safe_open(str(shard), framework='pt', device='cpu') as handle:
+            shapes.update({name:tuple(handle.get_slice(name).get_shape()) for name in handle.keys()})
+    producer = runpy.run_path(str(Path(os.environ['TESSERA_REPO']) / 'experiments/plan_from_layer_config.py'))
+    derived = export._write_plan_assignment(output, expected_sha256=tm._sha(output))
+    assert load_assignment(output) == assignment
+    producer_config = json.loads(Path(derived['plan_assignment']).read_text())
+    translated, _provenance = producer['build'](producer_config, shapes,
+        cover='as-allocated', allow_disagreement=False, prismaquant=None, with_control=False)
+    assert translated[missing + '.weight'] == {'grid':'E4M3', 'q256':1024}
+
+
+def test_real_allocator_routes_opt_in_request_before_strict_wire_gate(tmp_path, monkeypatch):
+    """Use the established scoped packed solve to exercise the CLI branch."""
+    import sys
+    from pathlib import Path
+    from prismaquant import allocator
+    from test_tessera_stack_driver_integration import test_a_stack_payload_allocates_through_the_real_allocator
+    original_main = allocator.main
+    seen = []
+    def record(path, **kwargs):
+        assert canonicalize_assignment(kwargs['layer_config']) == kwargs['assignment']
+        assert Path(kwargs['cost_path']).is_file()
+        assert not Path(kwargs['output_path']).exists()
+        seen.append((path, kwargs))
+    monkeypatch.setattr(tm, 'write_selection_request', record)
+    def both_paths():
+        original_argv = list(sys.argv)
+        sys.argv += ['--tessera-materialization-plan', str(tmp_path/'selection-request.json')]
+        original_main()
+        assert len(seen) == 1
+        assert not (tmp_path/'layer.json').exists()
+        sys.argv[:] = original_argv
+        original_main()
+    monkeypatch.setattr(allocator, 'main', both_paths)
+    test_a_stack_payload_allocates_through_the_real_allocator(tmp_path, monkeypatch)
+    assert seen[0][0] == str(tmp_path/'selection-request.json')
+
+
+@pytest.mark.parametrize('field', ['model.safetensors', 'config.json', 'tokenizer.json'])
+def test_source_verification_refuses_changed_checkpoint_files(tmp_path, field):
+    source = {'files':{}, 'config_sha256':'', 'auxiliary_sha256':{}}
+    for name in ('model.safetensors', 'config.json', 'tokenizer.json'):
+        (tmp_path/name).write_bytes(name.encode())
+    source['files']['model.safetensors'] = tm._sha(tmp_path/'model.safetensors')
+    source['config_sha256'] = tm._sha(tmp_path/'config.json')
+    source['auxiliary_sha256']['tokenizer.json'] = tm._sha(tmp_path/'tokenizer.json')
+    tm._verify_source(tmp_path, source)
+    (tmp_path/field).write_bytes(b'changed')
+    with pytest.raises(RuntimeError, match='changed'):
+        tm._verify_source(tmp_path, source)
+
+
+def test_plan_refuses_missing_geometry_before_pb_memory_sizing(selection, monkeypatch):
+    census = json.loads(selection.census.read_text())
+    del census['unit_shapes'][selection.missing]
+    selection.census.write_text(json.dumps(census))
+    with pytest.raises(RuntimeError, match='shape does not match'):
+        _plan(selection, monkeypatch)
+
+
+def test_finalize_refuses_original_capture_count_drift(selection, monkeypatch):
+    path, _root = _completed(selection, monkeypatch, hessian=True)
+    original = selection.cost['provenance']['hessian']['capture_path']
+    capture = torch.load(original, weights_only=False)
+    capture['counts'][selection.missing] += 1
+    torch.save(capture, original)
+    with pytest.raises(RuntimeError, match='census disagrees'):
+        tm.finalize(path)
+    assert not selection.output.exists()
+
+
+def test_materialization_refuses_unbound_producer_source(selection, monkeypatch):
+    s = selection
+    s.cost[tep.EXPERT_WIRES_KEY] = {}
+    s.cost_path.write_bytes(pickle.dumps(s.cost))
+    tm.write_selection_request(s.request, layer_config=s.config, assignment=s.assignment,
+        cost_path=s.cost_path, cost_payload=s.cost, output_path=s.output)
+    path, _data, _calls = _plan(s, monkeypatch)
+    monkeypatch.setattr(tc, '_checkpoint_identity_api', lambda:ReceiptAPI())
+    with pytest.raises(RuntimeError, match='no priced producer receipt'):
+        tm._inputs(path)

--- a/tests/test_tessera_packed_export_scope.py
+++ b/tests/test_tessera_packed_export_scope.py
@@ -105,3 +105,32 @@ def test_packed_static_route_still_requires_its_priced_scales(case):
     _save(case)
     with pytest.raises(export.TesseraExportLaneError, match='static activation contract.*no --input-scales'):
         export.require_priced_export_inputs(case.assignment)
+
+
+@pytest.mark.parametrize('defect', [None, 'missing', 'mismatch'])
+def test_packed_static_scales_bind_each_source_member(case, tmp_path, defect):
+    import torch
+    from safetensors.torch import save_file
+    parameters = _pack(case)
+    for name in parameters:
+        case.payload[name]['tessera_format'] = 'TESSERA_E2M1_K2_R896'
+    values = {name: float(i + 1) for i, name in enumerate(sorted(_units()))}
+    _meta(case)['tessera_activation_static_scales'] = {
+        'schema': export.PRICED_STATIC_SCALES_SCHEMA, 'units': values}
+    _save(case)
+    tensors = {name + '.input_global_scale': torch.tensor(value)
+               for name, value in values.items()}
+    key = sorted(tensors)[-1]
+    if defect == 'missing':
+        del tensors[key]
+    elif defect == 'mismatch':
+        tensors[key] = tensors[key] + 1
+    scales = tmp_path / 'scales.safetensors'
+    save_file(tensors, str(scales))
+    if defect:
+        with pytest.raises(export.TesseraExportLaneError, match='carries no input_global_scale|but the allocation priced'):
+            export.require_priced_export_inputs(case.assignment, input_scales_path=scales)
+    else:
+        report = export.require_priced_export_inputs(case.assignment, input_scales_path=scales)
+        assert report['input_scales_bound_units'] == len(values)
+        assert report['input_global_scales'] == {n + '.input_global_scale': v for n, v in values.items()}


### PR DESCRIPTION
Sampled packed allocations can select expert wires that were never encoded. The opt-in `--tessera-materialization-plan` now writes a non-exportable selection request; deterministic PrismaBuild rows encode only missing selected wires, and finalization verifies source bytes, producer identities, census geometry, receipts and the Hessian union before publishing the original packed decisions. Static-scale checks expand the bound member map and validate each expert's scalar independently.

The original sampled prices stay explicitly sampled. Missing or conflicting evidence still refuses export. Architecture and workflow documentation are included.

Validation: 24 materializer tests pass, including a real producer 2-of-3 packed sample that encodes exactly the three missing expert wires and reaches the actual translator. The combined integration suite passes 135 tests on the CPU fleet, with two documented skips; the batch dependency supplies its separate CUDA CLI qualification. PB receipts, payload hashes and source changes were independently reviewed. No full-model quality or serving claim is made.

Closes #301. Uses the shared batch adapter merged in #304.
