### PR TITLE
fix: restore LFM checkpoint state and streamed source parity

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,15 @@
 As of: 2026-09-07 · `codex/campaign-batched-anchors`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-07, `fix/lfm-streamed-parity`) for **declared buffer
+precision in shared checkpoint loading**. Resident materialization and streamed
+cold/prefetch/cache paths cast parameters to the requested compute dtype while
+retaining each model buffer's declared dtype. This preserves FP32 LFM expert
+bias arithmetic when BF16 router scores are corrected before top-k selection;
+representable bias values alone do not make a BF16 buffer equivalent. The
+existing layer cache carries these tensors without a parallel residency path.
+Gate: `tests/test_streaming_buffer_precision.py`.
+
 Re-stamped (2026-09-07, `fix/lfm-streamed-parity`) for **checkpoint missing-state
 initialization**. The shared Transformers compatibility hook suppresses random
 initialization for from-config skeletons, but enables the genuine initializer

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,18 @@
 As of: 2026-09-07 · `codex/campaign-batched-anchors`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-07, `fix/lfm-streamed-parity`) for **checkpoint missing-state
+initialization**. The shared Transformers compatibility hook suppresses random
+initialization for from-config skeletons, but enables the genuine initializer
+inside ordinary checkpoint missing-state finalization. A context-local scope
+prevents exceptions or concurrent skeleton construction from leaking that
+permission. This restores nonpersistent buffers (including LFM rotary frequency
+buffers) rematerialized by Transformers with uninitialized storage. Successfully
+finalized models expose `prismaquant.pretrained_initialization.v1` through
+`pretrained_initialization_contract`; from-config models and malformed descriptors
+refuse. This descriptor records the checkpoint load phase, not later model
+mutations. Gate: `tests/test_pretrained_buffer_initialization.py`.
+
 Re-stamped (2026-09-07, `codex/campaign-batched-anchors`) for **bounded
 expert anchor batches** (§4.10; #300, #275; Tessera #385). The campaign's
 optional `--anchor-batch-size` groups pending expert anchors with equal shape,
@@ -33,6 +45,7 @@ squashing. Docker's ordinary PB shim retains CPU affinity and scope ownership.
 Host-interpreter specs remain supported. Census, anchor and materialization
 quanta share the same row builder; the adapter does no scheduling or fanout.
 Gate: `tests/test_tessera_campaign_container.py`.
+
 
 Re-stamped (2026-09-06, `fix/packed-plan-handoff`) for **the producer plan
 input for packed decisions** (§4.10; #293). Scoped preflight already resolved

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,16 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-07 · `codex/campaign-batched-anchors`. Stamps
+As of: 2026-09-07 · `fix/lfm-streamed-parity`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-07, `fix/lfm-streamed-parity`) for **AURA attention
+backend parity**. AURA explicitly requests eager attention in both resident
+checkpoint and streamed skeleton construction. The shared streaming builder
+passes an optional explicit `attn_implementation` through the auto-model and
+resolved-class construction routes; callers that omit it retain Transformers'
+backend selection. Together with checkpoint initialization and buffer precision,
+this makes the LFM BF16 source forward comparable on the same exact token draw;
+it does not loosen the full-vocabulary tolerance or quantization gates.
 
 Re-stamped (2026-09-07, `fix/lfm-streamed-parity`) for **declared buffer
 precision in shared checkpoint loading**. Resident materialization and streamed

--- a/docs/measurements/lfm-streamed-parity-2026-09-07.md
+++ b/docs/measurements/lfm-streamed-parity-2026-09-07.md
@@ -1,0 +1,111 @@
+# LFM source-forward correctness, 2026-09-07
+
+Issue [#310](https://github.com/RobTand/prismaquant/issues/310). The corrected
+normal resident and streamed paths produce bit-exact BF16 logits over the full
+128,000-token vocabulary for one frozen 512-token LFM input. All 24 decoder
+boundaries and all 24 isolated-layer outputs are also bit-exact. This is a
+source-forward correctness result, not quantized quality or a performance claim.
+
+## Three causal changes
+
+1. Ordinary Transformers checkpoint loading must initialize missing state.
+   Transformers 5.16.1 rematerializes nonpersistent buffers with `empty_like`;
+   PrismaQuant's global initialization suppression left the subsequent LFM
+   rotary initialization disabled. A poisoned-buffer regression deterministically
+   returned -777 instead of 3 before the fix. The shared hook now enables the
+   genuine initializer inside checkpoint missing-state finalization using a
+   `ContextVar`, and preserves from-config skeleton suppression outside that
+   phase. Tests cover loaded-weight preservation, exception cleanup and concurrent
+   skeleton isolation. Successful finalization emits the validated
+   `prismaquant.pretrained_initialization.v1` descriptor; it is evidence of that
+   load phase, not a certificate for subsequent model mutations.
+2. Shared materialization and streamed cold/prefetch/cache paths preserve
+   model-declared buffer dtype independently of parameter compute dtype. LFM's
+   FP32 expert bias remains FP32 when correcting BF16 router scores before top-k.
+   A bias value that is itself exactly representable in BF16 does not make BF16
+   addition equivalent to FP32 addition. Resident, cold and prefetched regressions
+   all failed before this change and pass afterward. The existing layer cache is
+   the sole residency mechanism.
+3. AURA's streamed builder explicitly selects eager attention, matching its
+   resident loader. The shared optional argument reaches both auto-model and
+   resolved-class construction; omitted arguments retain Transformers' selection.
+   Four CPU tests cover those routes and both explicit/default behavior.
+
+The original failed preflight had maximum absolute logit error 15.78125. After
+correct initialization and buffer precision, the diagnostic SDPA arm still
+had maximum absolute error 5.5625 against eager. The final normal-path gate uses
+no diagnostic initializer context, tensor substitutions or backend mutation.
+The original tolerance remains `atol=rtol=2^-6`; the observed error is zero.
+
+## Workload and immutable inputs
+
+- Model: `/mnt/shared/models/LFM2.5-8B-A1B-BF16`, BF16, 24 layers, 32 routed
+  experts per MoE layer and top-k 4. Source `model.safetensors` SHA256:
+  `c9b9e3c4b3be50b576e6da8c02de1b4223614ffe131d812abf92bb84421f6217`.
+- Input: the first row only of
+  `/mnt/shared/tessera-measurements/pq300-batch-20260907/capture/calibration_tokens.safetensors`.
+  File SHA256: `6b8fe5e0de9f509059f71d151f3e20c45a4fb57e391c8b06a502cefbcc94c98a`.
+  That file holds the retained WT2 train 32-by-512 draw, seed 0. This gate does
+  not certify every calibration sequence or expert coverage.
+- Known image:
+  `eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c`;
+  Transformers 5.16.1, PyTorch 2.13.0+cu130, GB10. PB preserves affinity;
+  four reserved CPU cores and native thread limits of one; 40 GiB host demand,
+  32 GiB GPU budget. Existing resident-prefetch cache is filled before comparison.
+
+## Validation and retained evidence
+
+All tests and GPU runs used PrismaBuild. Evidence root:
+`/mnt/shared/tessera-measurements/lfm-streamed-parity-20260907/`.
+The JSON captures contain per-layer comparisons, head/buffer comparisons, actual
+model-load descriptor, actual backend, toolchain and CPU affinity. `receipts/`
+retains terminal status, logs, cleanup and checked CAS result receipts. `harness/`
+retains the exact diagnostic and normal-path scripts and Docker wrappers.
+
+| Evidence | PB action | Result |
+|---|---|---|
+| Initial isolation | `0b7513a1ed51761af17d30e61db17b31a2425d7c0a8560e6123f56a6f1e458bd` | Diagnostic complete; dtype and attention boundary differences retained |
+| Canonical HF/rotary isolation | `c999ff211ab72d3655a38e67dcdc1c88c34c8616f1ab18375123ae487dbc76bd` | Diagnostic complete; eager plus valid buffers exact |
+| Five deterministic regressions | `fd39c08ea8929e7b81e8dd5fea553b4f598eed793841e1ffde6cff82fc255efd` | Five expected failures before changes |
+| Initializer plus existing initialization tests | `f3c60eb5f869a214d289c17f61f0cacb1a4ac1e81e36c15f7903ed7199cf221d` | 8 passed |
+| Buffer, scheduling and architecture gates | `734ca20bbc9f2c5083055fe88e990fddfe2d7958a77d000879fbdd4c7d4acfd4` | 34 passed |
+| Backend construction | `0355a3e02bf8faa80509243256273c344953be9616d4496845e3c784de8a093f` | 4 passed |
+| Normal paths on original integration base | `9a0c68830fbd23379d2988a2a2751afce36ff0fe756566ced878459acc06e319` | GPU rc0; all comparisons exact |
+| Normal paths after rebase to main | `8081e7376fed063a1ec1ffb7b7be7804d857d25e12c66209ee3c58c007fd8222` | GPU rc0; all comparisons exact |
+| Five touched production modules compiled | `e04b45dab4f121a135fefa72faa263712626a87fc2fe0080d2edc5a8eebbe2d1` | rc0, portable CPU worker |
+
+The final main-based GPU receipt is
+`4e7167cc18d171fb4a9cfbd5888374dbe954c1d49d9b7f6b7c34198b9333592c`.
+The separate supported CPU fanout covered streamed joint AURA, streamed cost
+checkpoints, calibration intake and wrapper construction: 52 passed, two
+skipped because Accelerate is absent; `final-cpu-tests.json` records each action.
+The final main-based CPU action
+`16362aea7693580b859479388c087b954caa97f005a726f983db639848f5a914`
+rechecked the changed contracts and architecture: 58 passed, the same two
+Accelerate-guarded wrapper tests skipped. Actual HF backend-construction tests
+and the real GPU streamed path still ran successfully. The calibration-intake seam
+was present on the original diagnostic base and belongs to its separate PR;
+it is not included in this parity delivery.
+
+Two early CPU submissions lacked pytest in the image and are tooling failures,
+not regression evidence. Scoped pytest 8.4.2 was then installed. One buffer test
+run (`64f06f410fd152bea36d850e81ef95eea0b4cc06416dc8ef0cfc82a8f74922dc`)
+reported 34 passing tests but failed CAS publication with `CASTamperError`;
+its failed terminal is retained and was reported to the PB owner. The stored
+blob subsequently matched its content hash. The replacement action above
+completed and published a verified receipt.
+
+Historical activation/Hessian captures produced under broken checkpoint
+initialization cannot support model-quality claims. They remain bounded
+performance evidence where both arms consumed identical inputs. New quality
+captures must record actual successful model initialization and be regenerated;
+this correction does not rewrite those historical files.
+
+A separate artifact-writing caller in compressed-tensors export still omits
+buffer precision metadata. It is recorded as
+[#311](https://github.com/RobTand/prismaquant/issues/311), with the missing
+artifact/stock-vLLM serving gate stated explicitly. It is outside this Tessera
+source-parity delivery.
+
+Evidence manifest: 26 retained files, SHA256
+`6c9b7f7c4c049eed779f5b06c986965afaffd0c68c2d8873b2ca83486971aea9`.

--- a/docs/measurements/tessera-campaign-batching-2026-09-07.md
+++ b/docs/measurements/tessera-campaign-batching-2026-09-07.md
@@ -246,3 +246,28 @@ has no untracked helper files. The original zero-route failed capture remains
 bounded negative evidence and does not qualify full-model calibration.
 
 Evidence manifest SHA-256: `8b144abda1b4a9933070146e9a54a1c5dcbd62c0159bae7428184a9bafdd11e5`.
+
+## Source-reference correction — 2026-09-07 05:25 UTC
+
+A later full-vocabulary LFM parity diagnosis found that PrismaQuant's global
+HF initialization no-op also suppresses Transformers 5.16.1's initialization
+of nonpersistent RoPE buffers during `from_pretrained`. The capture above used
+that ordinary loading path. Its activation rows, Hessians, route counts and
+maxima therefore cannot qualify canonical source-model quality or a new native
+operator panel. They must be regenerated after the shared loader correction.
+Token IDs and source checkpoint weight bytes are unaffected.
+
+The matched scalar/batch measurements remain evidence for the exact retained
+inputs, encoded-byte equality and measured throughput/energy deltas described
+above. They are not a canonical-model quality comparison. Original artifacts
+and their hashes are retained unchanged.
+
+Diagnosis action `c999ff211ab7` completed through PrismaBuild on GB10 using the
+same producer image. Its actual full-vocabulary first-sequence comparison is
+bit-exact between HF loaded with genuine initialization and the streamed model
+with FP32 routing buffers and eager attention. Injecting the old reference's
+invalid RoPE into that streamed path reproduces the old reference exactly;
+matching its attention mask alone does not. Detailed evidence is retained at
+`/mnt/shared/tessera-measurements/lfm-streamed-parity-20260907/diagnose-02/diagnosis.json`.
+This bounded diagnosis establishes the loading defect; it does not replace
+fresh full-calibration capture or final served quality validation.

--- a/prismaquant/__init__.py
+++ b/prismaquant/__init__.py
@@ -13,6 +13,10 @@ Older cross-layer allocators are archived under archive/cross_layer_2026-05-09
 for artifact replay and comparison.
 """
 import contextlib as _contextlib
+from contextvars import ContextVar as _ContextVar
+
+_checkpoint_initializing = _ContextVar("prismaquant_checkpoint_initializing", default=False)
+_INITIALIZATION_CONTRACT_ATTRIBUTE = "_prismaquant_pretrained_initialization_contract"
 
 from .format_registry import FormatSpec, REGISTRY, register_format
 
@@ -92,34 +96,44 @@ def _polyfill_transformers() -> None:
     except Exception:
         pass
     try:
-        # `_init_weights` is wasted work across every prismaquant
-        # model-load path: we build a meta skeleton via `from_config`
-        # then immediately overwrite every parameter from the
-        # checkpoint via `_materialize` / `_fast_install`. Running
-        # `_init_weights` in between costs bounded real time on small
-        # models and is a compatibility landmine on remote modeling
-        # files — transformers 5.x's `_init_weights` now expects
-        # rotary modules to expose `compute_default_rope_parameters`,
-        # which older remote modeling files (MiniMax M2/M2.7) don't
-        # provide. No-op it globally at import time.
-        #
-        # The no-op is only sound for callers that overwrite every
-        # parameter afterwards. A caller that *uses* a from-config model
-        # -- a test fixture, an eval harness building a random reference --
-        # gets whatever the allocator last left in the pages backing the
-        # parameters a modeling file allocates with a bare `torch.empty()`
-        # (transformers' own `nn.Linear`/`nn.Embedding` still self-init in
-        # their constructors; the raw `nn.Parameter(torch.empty(...))` ones
-        # do not). Keep the real method reachable so such a caller can
-        # restore it -- see `genuine_weight_initialization` below.
+        # From-config meta skeletons overwrite checkpoint parameters later,
+        # so they retain the existing no-init policy. Ordinary checkpoint
+        # loads must still initialize missing state, including nonpersistent
+        # buffers that Transformers rematerializes with empty_like.
         import transformers.modeling_utils as _mu
         if hasattr(_mu, "PreTrainedModel") and \
                 not getattr(_mu.PreTrainedModel, "_prismaquant_init_noop", False):
-            _mu.PreTrainedModel._prismaquant_real_initialize_weights = (
-                _mu.PreTrainedModel._initialize_weights)
-            _mu.PreTrainedModel._initialize_weights = (
-                lambda self, *a, **kw: None)
-            _mu.PreTrainedModel._prismaquant_init_noop = True
+            model_class = _mu.PreTrainedModel
+            real_initialize = model_class._initialize_weights
+            real_missing = model_class._initialize_missing_keys
+            model_class._prismaquant_real_initialize_weights = real_initialize
+
+            def _initialize_for_checkpoint(self, *args, **kwargs):
+                if _checkpoint_initializing.get():
+                    return real_initialize(self, *args, **kwargs)
+                return None
+
+            def _initialize_missing_checkpoint_state(self, *args, **kwargs):
+                import transformers
+                # An unsuccessful repeated finalization must not retain an
+                # earlier completion descriptor.
+                self.__dict__.pop(_INITIALIZATION_CONTRACT_ATTRIBUTE, None)
+                token = _checkpoint_initializing.set(True)
+                try:
+                    result = real_missing(self, *args, **kwargs)
+                finally:
+                    _checkpoint_initializing.reset(token)
+                setattr(self, _INITIALIZATION_CONTRACT_ATTRIBUTE, {
+                    "schema": "prismaquant.pretrained_initialization.v1",
+                    "scope": "checkpoint_missing_state",
+                    "status": "completed",
+                    "transformers_version": transformers.__version__,
+                })
+                return result
+
+            model_class._initialize_weights = _initialize_for_checkpoint
+            model_class._initialize_missing_keys = _initialize_missing_checkpoint_state
+            model_class._prismaquant_init_noop = True
     except Exception:
         pass
     try:
@@ -177,14 +191,36 @@ def _polyfill_transformers() -> None:
         pass
 
 
+def validate_pretrained_initialization_contract(value):
+    """Validate and copy a checkpoint initialization provenance descriptor."""
+    if not isinstance(value, dict) or set(value) != {
+        "schema", "scope", "status", "transformers_version"
+    } or value.get("schema") != "prismaquant.pretrained_initialization.v1" \
+            or value.get("scope") != "checkpoint_missing_state" \
+            or value.get("status") != "completed" \
+            or not isinstance(value.get("transformers_version"), str) \
+            or not value["transformers_version"].strip():
+        raise ValueError("Missing or invalid pretrained initialization contract")
+    return dict(value)
+
+
+def pretrained_initialization_contract(model):
+    """Require evidence that this model completed checkpoint initialization.
+
+    From-config skeletons have no such descriptor. This records the load
+    phase, not a general certification of subsequent model mutations.
+    """
+    return validate_pretrained_initialization_contract(
+        getattr(model, _INITIALIZATION_CONTRACT_ATTRIBUTE, None))
+
+
 @_contextlib.contextmanager
 def genuine_weight_initialization():
     """Build a model the way transformers would, inside a PrismaQuant process.
 
-    `_polyfill_transformers` no-ops `PreTrainedModel._initialize_weights`
-    for the whole process at import time, because every PrismaQuant load
-    path builds a `from_config` skeleton and then overwrites every
-    parameter from the checkpoint. That makes `from_config` construction
+    `_polyfill_transformers` suppresses `PreTrainedModel._initialize_weights`
+    outside checkpoint missing-state finalization, because streaming loads
+    build a `from_config` skeleton and overwrite checkpoint parameters. That makes `from_config` construction
     silently return **uninitialized** parameters for any tensor the
     modeling file allocates as a bare `nn.Parameter(torch.empty(...))` --
     routed-expert weights and hyper-connection tensors are the common

--- a/prismaquant/aura_cost.py
+++ b/prismaquant/aura_cost.py
@@ -3448,6 +3448,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             dtype=dt,
             offload_folder=offload_dir,
             profile=profile,
+            attn_implementation="eager",
         )
     else:
         load_kwargs = dict(

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -291,6 +291,7 @@ def build_streamed_causal_lm(
     prefetch_min_available_gb: float | str | None = None,
     prefetch_lookahead: int = 2,
     require_prefetched_residency: bool = False,
+    attn_implementation: str | None = None,
 ) -> StreamedCausalLM:
     """Build the repository's existing streaming context and wrap it."""
     from prismaquant.streaming_model import _build_streaming_context
@@ -305,6 +306,7 @@ def build_streamed_causal_lm(
         prefetch_workers=prefetch_workers,
         prefetch_min_available_gb=prefetch_min_available_gb,
         log_prefix="[cost-streaming]",
+        attn_implementation=attn_implementation,
     )
     effective_lookahead = max(0, int(prefetch_lookahead))
     if context.max_cache_slots is not None:

--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -793,7 +793,7 @@ def _materialize(model: nn.Module, prefixes: list[str],
                  fp8_scale_inv_map: dict[str, tuple[str, str]] | None = None,
                  ) -> int:
     """Load all tensors whose model-side name starts with any prefix in
-    `prefixes` onto `device` as `dtype`. Uses the checkpoint-side key to
+    `prefixes` onto `device`, with parameters as `dtype` and buffers in their declared dtype. Uses the checkpoint-side key to
     read from safetensors but assigns to the model-side name.
 
     When `fp8_scale_inv_map` is provided, fp8-sourced weights get their
@@ -802,6 +802,7 @@ def _materialize(model: nn.Module, prefixes: list[str],
     cast to bf16. See `_dequant_fp8_block_weight`.
 
     Returns count of tensors loaded."""
+    buffer_dtypes = {name: value.dtype for name, value in model.named_buffers(remove_duplicate=False)}
     by_shard: dict[str, list[tuple[str, str]]] = defaultdict(list)
     for model_name, shard in model_to_shard.items():
         if any(model_name.startswith(p) for p in prefixes):
@@ -823,7 +824,7 @@ def _materialize(model: nn.Module, prefixes: list[str],
                 if (t.is_floating_point()
                         and not _is_fp8_scaled_tensor(
                             model_name, fp8_scale_inv_map)):
-                    t = t.to(dtype)
+                    t = t.to(buffer_dtypes.get(model_name, dtype))
                 out[model_name] = t
     if fp8_scale_inv_map:
         _apply_fp8_dequant_inplace(out, fp8_scale_inv_map, device)
@@ -1321,9 +1322,13 @@ def _read_layer_to_device(prefix: str,
                               | None = None,
                           pack_experts=None,
                           merge_concat=None,
+                          buffer_dtypes: dict[str, torch.dtype] | None = None,
                           ) -> dict[str, torch.Tensor]:
     """Read all tensors under `prefix` from safetensors and place them
     on `device`. Returns {model_name: device_tensor}.
+
+    `buffer_dtypes` preserves model-declared buffer precision independently
+    of the requested parameter dtype (for example FP32 router bias).
 
     When `fp8_scale_inv_map` is provided, native-FP8 block-scaled
     weights are kept compressed through the host-side read and moved to
@@ -1362,7 +1367,7 @@ def _read_layer_to_device(prefix: str,
                 if (t.is_floating_point()
                         and not _is_fp8_scaled_tensor(
                             model_name, fp8_scale_inv_map)):
-                    t = t.to(dtype)
+                    t = t.to((buffer_dtypes or {}).get(model_name, dtype))
                 if not used_direct:
                     t = t.to(device, non_blocking=True)
                 if not t.is_contiguous():

--- a/prismaquant/streaming_model.py
+++ b/prismaquant/streaming_model.py
@@ -432,6 +432,8 @@ class StreamingContext:
         self.install_resolvers = install_resolvers
         self.weight_shard = weight_shard
         self.weight_ckpt = weight_ckpt
+        self.buffer_dtypes = {name: value.dtype for name, value in
+                              model.named_buffers(remove_duplicate=False)}
         self.layer_cache = layer_cache
         self.prefetch_pool = prefetch_pool
         self.device = device
@@ -528,7 +530,8 @@ class StreamingContext:
             prefix, self.weight_shard, self.weight_ckpt, self.dtype,
             self.device, fp8_scale_inv_map=self.fp8_scale_inv_map,
             pack_experts=self.expert_packer,
-            merge_concat=self.concat_merger)
+            merge_concat=self.concat_merger,
+            buffer_dtypes=self.buffer_dtypes)
         # The cache may still decline to RETAIN the layer under its dynamic
         # budget (or evict it as `pinned_until_read` before the consumer
         # arrives). That is a retention decision, not a delivery decision:
@@ -726,7 +729,8 @@ class StreamingContext:
             prefix, self.weight_shard, self.weight_ckpt, self.dtype,
             self.device, fp8_scale_inv_map=self.fp8_scale_inv_map,
             pack_experts=self.expert_packer,
-            merge_concat=self.concat_merger)
+            merge_concat=self.concat_merger,
+            buffer_dtypes=self.buffer_dtypes)
         self.layer_cache.put(L, tensors)
         return tensors, "cold"
 
@@ -1280,7 +1284,7 @@ def _build_streaming_context(model_path: str, *,
     # Constructor-derived NON-PERSISTENT head buffers (e.g. gemma4_unified's
     # `embed_scale = sqrt(hidden)`) are absent from the checkpoint, so
     # `_materialize` never assigns them and they stay on `meta` — and
-    # PrismaQuant globally no-ops `_initialize_weights` (prismaquant/__init__),
+    # PrismaQuant suppresses skeleton `_initialize_weights` (prismaquant/__init__),
     # so the modeling's `_init_weights` that would set them never runs. The
     # first forward op (`embed_tokens(ids)` multiplies by `embed_scale`) then
     # faults "Tensor on device meta". Re-create such buffers on `device` from
@@ -1328,7 +1332,9 @@ def _build_streaming_context(model_path: str, *,
             tensors = _read_layer_to_device(
                 visual_prefix + ".",
                 weight_shard, weight_ckpt, dtype, device,
-                fp8_scale_inv_map=fp8_scale_inv_map)
+                fp8_scale_inv_map=fp8_scale_inv_map,
+                buffer_dtypes={name: value.dtype for name, value in
+                               model.named_buffers(remove_duplicate=False)})
             print(f"{log_prefix} materializing visual tower: "
                   f"{len(tensors)}/{len(vis_keys)} tensors -> {device}", flush=True)
             if _module_has_meta_tensors(visual_module):
@@ -1341,7 +1347,7 @@ def _build_streaming_context(model_path: str, *,
             # the module constructor. Keep them colocated with checkpoint
             # tensors before the multimodal streaming probe calls visual
             # helpers such as get_image_features.
-            visual_module.to(device=device, dtype=dtype)
+            visual_module.to(device=device)
             if visual_requires_grad:
                 # Enable grad on every Linear's weight + bias so backward
                 # hooks fire on the reverse sweep. Embeddings and norms

--- a/prismaquant/streaming_model.py
+++ b/prismaquant/streaming_model.py
@@ -1143,6 +1143,7 @@ def _build_streaming_context(model_path: str, *,
                              log_prefix: str = "[streaming]",
                              multimodal: bool = False,
                              visual_requires_grad: bool = False,
+                             attn_implementation: str | None = None,
                              ) -> StreamingContext:
     """One-time setup: AutoConfig + empty skeleton, then manually
     materialize only the always-resident head pieces. Decoder layers
@@ -1209,13 +1210,15 @@ def _build_streaming_context(model_path: str, *,
     config, model_cls = _skeleton_config_and_class(
         config, multimodal=multimodal, log_prefix=log_prefix)
 
+    attention_kwargs = ({"attn_implementation": attn_implementation}
+                        if attn_implementation is not None else {})
     with _mask_cuda_queries_during_meta_init(log_prefix):
         with init_empty_weights():
             if model_cls is AutoModelForCausalLM:
                 skeleton = AutoModelForCausalLM.from_config(
-                    config, trust_remote_code=True)
+                    config, trust_remote_code=True, **attention_kwargs)
             else:
-                skeleton = model_cls._from_config(config)
+                skeleton = model_cls._from_config(config, **attention_kwargs)
     skel_base, skel_layers = _get_layer_list(skeleton)
     base_prefix = _resolve_base_prefix(skeleton, skel_base)
     num_layers = len(skel_layers)

--- a/tests/test_pretrained_buffer_initialization.py
+++ b/tests/test_pretrained_buffer_initialization.py
@@ -1,0 +1,94 @@
+"""Ordinary checkpoint loads must initialize tensors absent from the wire."""
+import pytest
+import torch
+from torch import nn
+from transformers import PretrainedConfig, PreTrainedModel
+
+from prismaquant import (genuine_weight_initialization,
+    pretrained_initialization_contract, validate_pretrained_initialization_contract)
+
+
+class _Config(PretrainedConfig):
+    model_type = 'pq_nonpersistent_buffer_probe'
+
+
+class _Model(PreTrainedModel):
+    config_class = _Config
+    base_model_prefix = 'probe'
+    def __init__(self, config):
+        super().__init__(config)
+        self.linear = nn.Linear(2, 2, bias=False)
+        self.register_buffer('derived_scale', torch.tensor([3.], dtype=torch.float32), persistent=False)
+        self.post_init()
+
+    def _init_weights(self, module):
+        if isinstance(module, _Model):
+            module.derived_scale.fill_(3.)
+        elif isinstance(module, nn.Linear):
+            module.weight.fill_(2.)
+
+
+def _checkpoint(tmp_path):
+    with genuine_weight_initialization():
+        source = _Model(_Config())
+    with torch.no_grad():
+        source.linear.weight.fill_(7.)
+    source.save_pretrained(tmp_path)
+
+
+def test_checkpoint_load_initializes_nonpersistent_buffers_without_replacing_weights(tmp_path, monkeypatch):
+    _checkpoint(tmp_path)
+    original = torch.empty_like
+    def poisoned_empty(value, *args, **kwargs):
+        result = original(value, *args, **kwargs)
+        if result.shape == (1,) and result.is_floating_point() and not result.is_meta:
+            result.fill_(-777.)
+        return result
+    monkeypatch.setattr(torch, 'empty_like', poisoned_empty)
+    loaded = _Model.from_pretrained(tmp_path, dtype=torch.bfloat16)
+    assert torch.equal(loaded.derived_scale, torch.tensor([3.]))
+    assert torch.equal(loaded.linear.weight, torch.full((2, 2), 7., dtype=torch.bfloat16))
+
+
+def test_checkpoint_initializer_failure_does_not_enable_later_skeleton_initialization(tmp_path, monkeypatch):
+    _checkpoint(tmp_path)
+    def fail(module_self, module):
+        raise RuntimeError('initialization sentinel')
+    monkeypatch.setattr(_Model, '_init_weights', fail)
+    with pytest.raises(RuntimeError, match='initialization sentinel'):
+        _Model.from_pretrained(tmp_path)
+    # The pre-existing no-init from-config contract remains scoped outside
+    # checkpoint finalization, including after an initializer exception.
+    _Model(_Config())
+
+
+def test_initialization_contract_is_emitted_only_by_completed_checkpoint_load(tmp_path):
+    _checkpoint(tmp_path)
+    with pytest.raises(ValueError, match='initialization contract'):
+        pretrained_initialization_contract(_Model(_Config()))
+    loaded = _Model.from_pretrained(tmp_path)
+    contract = pretrained_initialization_contract(loaded)
+    assert contract['scope'] == 'checkpoint_missing_state'
+    assert contract['status'] == 'completed'
+    assert contract['transformers_version']
+    contract['status'] = 'changed'
+    assert pretrained_initialization_contract(loaded)['status'] == 'completed'
+    with pytest.raises(ValueError, match='initialization contract'):
+        validate_pretrained_initialization_contract(contract)
+
+
+def test_checkpoint_initialization_does_not_enable_another_thread(tmp_path, monkeypatch):
+    from concurrent.futures import ThreadPoolExecutor
+    _checkpoint(tmp_path)
+    real_init = _Model._init_weights
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        def check_thread(self, module):
+            if isinstance(module, _Model):
+                # A global toggle would recursively enter this callback in
+                # the worker thread. Context-local permission leaves its
+                # ordinary from-config construction on the no-init path.
+                pool.submit(_Model, _Config()).result(timeout=10)
+            return real_init(self, module)
+        monkeypatch.setattr(_Model, '_init_weights', check_thread)
+        loaded = _Model.from_pretrained(tmp_path)
+    assert torch.equal(loaded.derived_scale, torch.tensor([3.]))

--- a/tests/test_streamed_prefetch_scheduling.py
+++ b/tests/test_streamed_prefetch_scheduling.py
@@ -57,6 +57,7 @@ def _make_ctx(
     ctx.num_layers = num_layers
     ctx.weight_shard = {}
     ctx.weight_ckpt = {}
+    ctx.buffer_dtypes = {}
     ctx.device = torch.device("cpu")
     ctx.dtype = torch.float32
     ctx.fp8_scale_inv_map = {}

--- a/tests/test_streaming_attention_backend.py
+++ b/tests/test_streaming_attention_backend.py
@@ -1,0 +1,35 @@
+"""Explicit streaming attention selection survives both HF construction routes."""
+import pytest
+import torch
+from transformers import AutoModelForCausalLM, Qwen2Config, Qwen2ForCausalLM
+
+import prismaquant.streaming_model as streaming
+
+
+@pytest.mark.parametrize('resolved_class', [False, True])
+@pytest.mark.parametrize('backend', [None, 'eager'])
+def test_streaming_skeleton_preserves_requested_or_default_backend(tmp_path, monkeypatch, resolved_class, backend):
+    config = Qwen2Config(hidden_size=32, intermediate_size=64, num_hidden_layers=1,
+        num_attention_heads=4, num_key_value_heads=2, vocab_size=64)
+    config.architectures = ['Qwen2ForCausalLM']
+    source = tmp_path / 'source'
+    config.save_pretrained(source)
+    stage = tmp_path / 'stage'
+    stage.mkdir()
+    monkeypatch.setenv('PRISMAQUANT_TMPDIR', str(stage))
+    expected = AutoModelForCausalLM.from_config(config).config._attn_implementation
+    if resolved_class:
+        monkeypatch.setattr(streaming, '_skeleton_config_and_class',
+            lambda cfg, **kwargs: (cfg, Qwen2ForCausalLM))
+    class BuiltSkeleton(Exception):
+        pass
+    observed = {}
+    def stop_after_build(model):
+        observed['backend'] = model.config._attn_implementation
+        raise BuiltSkeleton()
+    monkeypatch.setattr(streaming, '_get_layer_list', stop_after_build)
+    kwargs = {} if backend is None else {'attn_implementation': backend}
+    with pytest.raises(BuiltSkeleton):
+        streaming._build_streaming_context(str(source), device=torch.device('cpu'),
+            dtype=torch.bfloat16, offload_folder=str(tmp_path / 'offload'), **kwargs)
+    assert observed['backend'] == (backend if backend is not None else expected)

--- a/tests/test_streaming_buffer_precision.py
+++ b/tests/test_streaming_buffer_precision.py
@@ -1,0 +1,73 @@
+"""Checkpoint buffers retain their declared precision across source loads."""
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+import torch
+from torch import nn
+from safetensors.torch import save_file
+
+from prismaquant.layer_streaming import (
+    LayerCache, _build_install_resolver, _materialize,
+)
+from prismaquant.streaming_model import StreamingContext
+
+
+class _RoutingLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(2, 2, bias=False)
+        self.register_buffer('routing_bias', torch.tensor([0., 1 / 512], dtype=torch.float32))
+        self.register_buffer('route_count', torch.tensor([2], dtype=torch.int64))
+
+
+def _source(tmp_path):
+    model = nn.Module()
+    model.layers = nn.ModuleList([_RoutingLayer()])
+    with torch.no_grad():
+        model.layers[0].proj.weight.copy_(torch.eye(2))
+    path = tmp_path / 'source.safetensors'
+    save_file({name: value.contiguous() for name, value in model.state_dict().items()}, str(path))
+    names = list(model.state_dict())
+    model.to_empty(device='meta')
+    return model, {name: str(path) for name in names}, {name: name for name in names}
+
+
+def _assert_routing_precision(model):
+    layer = model.layers[0]
+    assert layer.proj.weight.dtype == torch.bfloat16
+    assert layer.routing_bias.dtype == torch.float32
+    assert layer.route_count.dtype == torch.int64
+    # All these values are exactly representable in BF16. Narrowing the
+    # BUFFER still changes arithmetic: the BF16 sum rounds away the bias.
+    scores = torch.tensor([[0.5, 0.5]], dtype=torch.bfloat16)
+    corrected = scores + layer.routing_bias
+    assert corrected[0, 1] > corrected[0, 0]
+    assert corrected.argmax(-1).item() == 1
+
+
+def test_resident_materialization_preserves_declared_buffer_precision(tmp_path):
+    model, shards, keys = _source(tmp_path)
+    assert _materialize(model, ['layers.0.'], shards, keys, torch.device('cpu'), torch.bfloat16) == 3
+    _assert_routing_precision(model)
+
+
+@pytest.mark.parametrize('prefetch', [False, True])
+def test_streaming_cache_preserves_declared_buffer_precision(tmp_path, prefetch):
+    model, shards, keys = _source(tmp_path)
+    pool = ThreadPoolExecutor(max_workers=1)
+    context = StreamingContext(model=model, base_model=model, layers=model.layers,
+        layers_prefix='layers.', num_layers=1,
+        install_resolvers=[_build_install_resolver(model, 'layers.0')],
+        weight_shard=shards, weight_ckpt=keys,
+        layer_cache=LayerCache(max_bytes=1024), prefetch_pool=pool,
+        device=torch.device('cpu'), dtype=torch.bfloat16, offload_folder=str(tmp_path))
+    try:
+        if prefetch:
+            context.schedule_prefetch(0)
+        context.install(0, require_prefetched=prefetch)
+        _assert_routing_precision(model)
+        context.unload(0)
+        context.install(0, require_prefetched=True)
+        _assert_routing_precision(model)
+    finally:
+        context.shutdown()


### PR DESCRIPTION
Ordinary LFM checkpoint loads could leave rotary buffers uninitialized, while streamed loading narrowed FP32 routing bias and selected a different attention backend. Three separate causal commits restore checkpoint missing-state initialization, preserve declared buffer precision, and make AURA request eager attention for both resident and streamed paths.

The normal paths now produce bit-exact BF16 logits over the full 128,000-token vocabulary on the frozen 512-token input; all 24 decoder boundaries and isolated layers are exact. The original full-vocabulary tolerance stays atol=rtol=2^-6. Checkpoint loads emit a validated initialization descriptor for downstream capture provenance; from-config initialization remains suppressed unless explicitly requested.

Validation through PrismaBuild: five demonstrated regressions before fixing; 98 distinct relevant CPU tests passed with two Accelerate-guarded skips across targeted/fanout runs; final main-based CPU check 58 passed/two same skips; five touched production modules compiled. Final GPU action `8081e7376fed063a1ec1ffb7b7be7804d857d25e12c66209ee3c58c007fd8222` completed rc0 with exact comparisons and verified CAS receipt `4e7167cc18d171fb4a9cfbd5888374dbe954c1d49d9b7f6b7c34198b9333592c`. Evidence, commands, tool failures and limits: `docs/measurements/lfm-streamed-parity-2026-09-07.md`.

Architecture reflects all three contracts. The earlier batching report now explicitly limits its invalid-source captures to matched performance evidence; fresh quality captures must be regenerated. Separate compressed-tensors artifact-writing caller finding is recorded in #311 and requires its artifact/serving gate.

Closes #310.
