### PR TITLE
Reuse canonical calibration across campaign quanta

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,29 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-07 · `codex/canonical-campaign-census-20260907`. Stamps
+As of: 2026-09-07 · `codex/capture-delivery-20260907`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-07, `codex/campaign-capture-reuse-20260907`) for
+**reusable campaign calibration** (§4.10; #305). With an existing full census,
+`--capture-calibration-out` captures once and exits before encoding. The shared
+PB driver exposes this dependency as `capture`; `plan --calibration-cache`
+hash-binds the completed manifest into each ordinary fanout row. The
+existing activation-cache writer stores each unit's first scoring rows in
+float32, uncapped float32 Hessian, full row count and maximum; ordinary
+perturbed-cache precision and row selection remain unchanged. The existing
+cost-stage journal binds per-unit file hashes to a versioned complete manifest,
+the exact census/draw, source checkpoint bytes and full unit geometry. Its v2
+contract requires the actual checkpoint-initialization descriptor, explicit
+attention backend and matching Torch/CUDA/Transformers versions in both the
+census producer and the capture. Legacy unqualified v1 captures are refused.
+`--calibration-cache` verifies that identity and hashes source files anew, then
+loads only selected artifacts and makes X/H resident before encoding. Missing,
+corrupt or mismatched selected inputs refuse reuse. Completed full captures
+validate on resume without another forward. Cost provenance binds the manifest
+path and hash; merged rows must agree, and selected-wire materialization derives
+its cache from those priced bytes. Legacy campaigns without a capture continue
+with explicit model calibration. This changes no format, serving gate or wire
+recipe. Gate: `tests/test_tessera_calibration_cache.py`.
 
 Re-stamped (2026-09-07, `codex/canonical-campaign-census-20260907`) for
 **canonical census provenance** (§4.10; #305). Census production now requires
@@ -13,9 +35,6 @@ An uninitialized model or backend mismatch refuses before calibration. Ordinary
 campaigns retain their library attention default unless explicitly configured.
 First-model calibration uses explicit eager attention. Gate:
 `tests/test_tessera_canonical_census.py`.
-
-As of: 2026-09-07 · `fix/lfm-streamed-parity`. Stamps
-follow, newest first, each recording its own branch and date.
 
 Re-stamped (2026-09-07, `codex/campaign-amax-residency-20260907`) for
 **resident calibration maxima**. Campaign collection keeps each unit's running
@@ -7207,9 +7226,24 @@ row computes them once. `--census-out` runs the prologue over the whole scope
 and writes `prismaquant.tessera_campaign_census.v1`: the per-unit calibration
 row counts, the per-unit activation maxima, the anchor grouping, the unit
 shapes, the draw's own `text_sha256`/`fit_ids_sha256`, and the producer's
-expert projection of every declared stack. `--calibration-census` reads it
-back, refuses a census of another draw or scope, checks every unit the run
-hooked against it, and only then stamps the scope's values.
+expert projection of every declared stack. Census production requires explicit
+`--attention-implementation` and records the actual loaded model's checkpoint
+initialization descriptor, attention backend, and Torch/CUDA/Transformers
+versions. `--calibration-census` reads it back, refuses a census of another
+draw or scope, checks every observed unit against it, and only then stamps the
+scope's values.
+
+An optional dependent `capture` action (`--capture-calibration-out`) computes
+all uncapped Hessians and first-row float32 scoring inputs once using the same
+census and exits before encoding. The existing activation-cache writer and
+cost-stage journal seal a complete `prismaquant.tessera_calibration_cache.v2`
+manifest. `plan --calibration-cache` binds that manifest path and SHA256 into
+each anchor action. The action verifies its actual initializer, backend,
+runtime, complete source bytes, calibration and geometry, then prefetches only
+its selected X/H artifacts before encoding. Cost provenance retains the same
+manifest; selected-wire materialization derives reuse from that provenance.
+Legacy unqualified capture manifests refuse. Without a cache, each row still
+performs its own selected-unit calibration over the exact draw.
 
 * **`fit_tokens` is a maximum over the scope**, and Tessera seals it into every
   H-aware wire receipt (`cached_unit.encoding_input_identity`), so a shard
@@ -7223,8 +7257,8 @@ hooked against it, and only then stamps the scope's values.
   side no module executes. Taking the scope's maxima removes the dependence.
 * **The producer's expert projection is rebound at allocation** against every
   stack the carried block names (`carried_units`), so a block trimmed to one
-  shard's stacks is refused there; and the request hashes the whole checkpoint,
-  which must not land on every row.
+  shard's stacks is refused there. Reuse readers verify complete checkpoint
+  bytes anew even though projection and calibration outputs are shared.
 
 `--seed-checkpoint` offers another campaign's stored anchors to this run's own
 row gates rather than resuming its journal: a journal binds the run identity

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,19 @@
 # PrismaQuant Architecture
 
+As of: 2026-09-07 · `codex/canonical-campaign-census-20260907`. Stamps
+follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-07, `codex/canonical-campaign-census-20260907`) for
+**canonical census provenance** (§4.10; #305). Census production now requires
+an explicit `--attention-implementation eager|sdpa`. After checkpoint loading,
+the campaign obtains the shared initialization descriptor from the actual model
+and checks its resolved attention backend against the request. The census
+records that descriptor, actual backend, and Torch/CUDA/Transformers versions.
+An uninitialized model or backend mismatch refuses before calibration. Ordinary
+campaigns retain their library attention default unless explicitly configured.
+First-model calibration uses explicit eager attention. Gate:
+`tests/test_tessera_canonical_census.py`.
+
 As of: 2026-09-07 · `fix/lfm-streamed-parity`. Stamps
 follow, newest first, each recording its own branch and date.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,12 @@
 As of: 2026-09-07 · `fix/lfm-streamed-parity`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-07, `codex/campaign-amax-residency-20260907`) for
+**resident calibration maxima**. Campaign collection keeps each unit's running
+maximum on the model device and reads it once after the full draw. The full-row
+scope and Python-max NaN behavior remain unchanged. Gate:
+`tests/test_campaign_amax_residency.py`. This changes no format or serving gate.
+
 Re-stamped (2026-09-07, `fix/lfm-streamed-parity`) for **AURA attention
 backend parity**. AURA explicitly requests eager attention in both resident
 checkpoint and streamed skeleton construction. The shared streaming builder

--- a/docs/reviews/2026-09-07/campaign-amax-residency.md
+++ b/docs/reviews/2026-09-07/campaign-amax-residency.md
@@ -1,0 +1,33 @@
+# Campaign maxima residency — 2026-09-07
+
+The campaign previously called `.item()` for each observed unit in each
+calibration batch. The full-capture profile at
+`/mnt/shared/tessera-measurements/first-model-20260907/capture-reuse/baseline/collector.speedscope.json`
+identified this scalar-read site as a hotspot. That earlier capture used the
+subsequently rejected checkpoint initializer; its artifacts remain invalid for
+calibration reuse or quality claims. It is bounded profiling evidence only.
+
+The collector now keeps each maximum as a device float32 scalar, combines
+batches with `torch.fmax`, and converts once per unit after all forwards.
+`fmax(previous, NaN)` retains the previous value, matching the existing Python
+`max` policy. Full-row coverage, score-prefix selection and Hessians are
+unchanged. No GPU speedup or energy delta is claimed here; canonical matched
+profiling is a separate measurement prerequisite.
+
+Validation ran through PrismaBuild on the x86 CPU worker with
+`/home/rob/venvs/pq-cpu312/bin/python`, the pinned Tessera source on PYTHONPATH,
+and OMP/MKL/OpenBLAS threads bounded to one per worker:
+
+- Before: `pytest -q tests/test_campaign_amax_residency.py --tb=short`, action
+  `74706a628738f7065b1b8708c70ae70e14ba62167396fab6082d868b9ebda40b`, expected
+  exit 1. The two-unit, three-nonempty-batch fixture observed six scalar reads,
+  while maximum values and counts already matched.
+- After: eight-worker pytest over that regression, `test_tessera_campaign.py`,
+  `test_tessera_campaign_packed.py`, and `test_architecture_doc.py`, action
+  `5048a5c104a7751674f9fd99fb07945ef1ab2cfca2c450860db8a81d06e95ac9`, exit 0,
+  **76 passed, 5 CUDA-required skips**, 171.39 seconds. Actual CAS payload:
+  `/mnt/shared/prismabuild-fleet/cas/blobs/5f/5fc9ee47f6a06cff5dbd78a971d4015091ce1574a2959a7ef30ec0c9aa8432df`.
+
+Initial submissions `be339e093292` and `4c1c3cdc5cd3` omitted the required
+Tessera import path and failed collection/imports. They are not behavioral
+results; the corrected invocations above supply that dependency explicitly.

--- a/docs/reviews/2026-09-07/campaign-capture-finalization.md
+++ b/docs/reviews/2026-09-07/campaign-capture-finalization.md
@@ -1,0 +1,32 @@
+# Campaign capture finalization
+
+The collector retained every scoring chunk while concatenating the complete
+scoring-row output, then retained every GPU Hessian while copying the complete
+Hessian output to CPU. On shared-memory GB10, both copies consume physical DRAM.
+The finalizer now releases each consumed chunk list and each transferred GPU
+Hessian. It returns freed CUDA allocator blocks after each 256 MiB of transfers
+and after the remainder. The forward, accumulation, row order, dtype, counts
+and activation maxima are unchanged.
+
+Static sizing from the frozen 512 × 512 first-model census is 15.773 GiB of
+checkpoint files, 31.242 GiB of Hessians and 7.749 GiB of scoring rows. The old
+finalization tensor floor was 93.756 GiB, excluding runtime, allocator and
+workspace overhead. This is source-derived sizing, not a measured process peak.
+The sizing artifact is
+`/mnt/shared/tessera-measurements/first-model-20260907/capture-reuse/baseline-sizing.json`.
+
+The live-reference regression failed on the original collector in PrismaBuild
+`69ef257b14aa398dffeaf804e19dd3d769290cab566eabf9aca0a325918ff48c`:
+the next concatenation still observed the preceding unit's source chunks.
+After the change, CPU tests for finalization, campaign and packed capture passed
+63 tests, with 5 CUDA-required skips, in 176.40 seconds on DL380g10 (4 workers,
+10 GiB reservation, native threads 1). The regression also checks exact prefix
+rows, uncapped Hessians, full counts and maxima.
+
+PrismaBuild action:
+`053484ff72926578c1efcb48b6c560eb4c0e569f815ab117f201912aafb0d5c2`.
+Verified action exit status 0; CAS payload:
+`/mnt/shared/prismabuild-fleet/cas/blobs/47/4780f69596394c81f56d4ba8ebb4ff12dd225894ecf50329141eb500582d66c1`.
+
+Full-model GPU before/after profiling and both-host Netdata validation are
+pending; no runtime speed or measured peak-memory improvement is claimed here.

--- a/docs/reviews/2026-09-07/campaign-capture-reuse.md
+++ b/docs/reviews/2026-09-07/campaign-capture-reuse.md
@@ -1,0 +1,63 @@
+# Canonical campaign capture reuse — 2026-09-07
+
+Issue: https://github.com/RobTand/prismaquant/issues/305
+
+The campaign can capture the whole census once, store exact float32 scoring
+prefixes and uncapped Hessians through the existing activation-cache writer,
+and reuse selected units in each anchor or materialization quantum. The
+existing cost-stage journal seals per-unit file receipts. The manifest is
+`prismaquant.tessera_calibration_cache.v2`, with a complete unit roster and
+identity bound to canonical checkpoint initialization, actual attention
+backend, Torch/CUDA/Transformers runtime, census, complete source checkpoint
+bytes, exact calibration draw and per-unit geometry.
+
+The public flow is `dispatch_tessera_campaign capture`, followed by
+`plan --calibration-cache <capture_manifest.json>`. Each row carries the exact
+manifest SHA256 and verifies selected artifacts before making X/H resident.
+Missing, stale or incomplete captures fail closed. Selected-wire materialization
+derives its cache and hash from the priced cost provenance and loads the same
+explicit attention backend. Merging requires every row to agree on the capture.
+The optional packed-collector boundary consumer preserves original positional
+and keyword arguments before dtype conversion or sampling, with original
+sample/token coordinates from the calibration loop. It does not add a second
+forward or alter default reservoir sampling.
+
+CPU and compile validation passed through PrismaBuild action
+`b2b5bac37cc59636019d06897ae99f6b945d3a467535f74b80e8d71e89c8beee` on dl380g10:
+**176 passed, no skips**, exit 0, 70.58 seconds. Eight pytest workers used the
+scoped `pq-cpu312` environment with pinned Tessera producer imports and one
+OMP/MKL/OpenBLAS thread each; aggregate demand was eight CPUs and 20 GiB.
+Compile checks covered all touched production modules and measurement harnesses.
+The tests cover exact X/H precision, selective prefetch, source/draw/scope/
+geometry/artifact drift, legacy initialization refusal, complete-journal
+resume, CLI reuse without a second forward, automatic materializer binding,
+raw argument identity, keyword routes, calibration coordinates, unchanged
+reservoir sampling, and native input contracts. Actual inspected CAS payload:
+`/mnt/shared/prismabuild-fleet/cas/blobs/46/4605bb918e52c1ed53800a40813b9b852d2500fabba8ee48c2a6726c9e2bd119`.
+
+The canonical full-model census is
+`/mnt/shared/tessera-measurements/first-model-20260907/canonical-census-512/census.json`,
+SHA256 `62d41825f84edd280de46bbb89893676fae8203563834dc95d8ad29c05bad04d`.
+The draw is 512 samples of 512 tokens; its int32 token digest is
+`ed77a9890e02ae0b6bac2cbaa8fab4dd27617d7b57635976b689badaf8d5a8e4`.
+The prior no-op-initializer capture remains quarantined under
+`capture-reuse/baseline/INVALID_FOR_CALIBRATION_REUSE.json`; no quality or
+reuse claim derives from those X/H bytes. Canonical full capture and profiled
+ABBA reuse measurements are tracked below as separate evidence, not inferred
+from the CPU suite.
+
+Initial validation attempts `a8a78fab56ed`, `c30ca448df8a`, and `791a51c9c833`
+used the PB infrastructure Python instead of the scoped project Python and
+failed on missing Torch or compressed-tensors. The corrected project-runtime
+run `3f5a504cf1d3` passed 133 tests and exposed two synthetic producer-hash
+fixtures. Those fixtures now declare their actual source hashes; the final
+176-test run above passed. No runtime input guard was weakened.
+
+The first canonical GPU attempt `35ab901ece41` stopped before writing a routed
+boundary: the native helper called the LFM profile's `name` property as a
+method. The owner is fixing the three affected sites with a real-profile
+regression. Failed-attempt artifacts are retained as bounded diagnosis under
+`capture-reuse/canonical-helper-failed-35ab901ece41`; the worker exit was 1 and
+the broker's separate termination receipt confirms its scope stopped. The
+current fleet terminal JSON omits that cleanup field, so the separate receipt
+was inspected. This attempt provides no completed calibration or reuse result.

--- a/prismaquant/perturbed_x_cache.py
+++ b/prismaquant/perturbed_x_cache.py
@@ -177,6 +177,29 @@ def activation_cache_filename(name: str) -> str:
     return _FNAME_SUB.sub("__", name) + ".pt"
 
 
+def write_activation_cache_entry(cache_dir, name, inputs, *, source="perturbed_x",
+                                 durable=False, **metadata):
+    """Atomically store already-selected rows without changing their precision."""
+    import os
+    path = Path(cache_dir) / activation_cache_filename(name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(".pt.tmp")
+    with temporary.open("wb") as handle:
+        torch.save({**metadata, "inputs": inputs.contiguous(), "name": name,
+                    "source": source}, handle)
+        if durable:
+            handle.flush()
+            os.fsync(handle.fileno())
+    os.replace(temporary, path)
+    if durable:
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    return path
+
+
 def _tensor_hash_update(h: "hashlib._Hash", tensor: torch.Tensor) -> None:
     t = tensor.detach().to("cpu").contiguous()
     h.update(str(tuple(t.shape)).encode())
@@ -1397,10 +1420,7 @@ class PerturbedActivationCache:
             if rows is None or rows.size(0) == 0:
                 continue
             x = rows[:self.input_rows].to(torch.bfloat16).contiguous()
-            torch.save(
-                {"inputs": x, "name": name, "source": "perturbed_x"},
-                self.cache_dir / activation_cache_filename(name),
-            )
+            write_activation_cache_entry(self.cache_dir, name, x)
             written.append(name)
         return {
             "cache_dir": str(self.cache_dir),

--- a/prismaquant/production_weight_cache.py
+++ b/prismaquant/production_weight_cache.py
@@ -7818,7 +7818,10 @@ class _PackedExpertActivationCollector:
     An optional ``row_consumer(qname, X)`` observes each full, live input before
     storage selection. It must consume synchronously rather than retain X;
     campaigns use it to accumulate full-calibration Hessians without creating
-    a second module-input cache. The default leaves reservoir sampling intact.
+    a second module-input cache. An optional boundary_consumer receives the
+    original module, positional and keyword arguments before row selection or
+    dtype conversion, preserving actual routing tensors for native validation.
+    The default leaves reservoir sampling intact.
     """
 
     def __init__(
@@ -7832,10 +7835,12 @@ class _PackedExpertActivationCollector:
         profile=None,
         store_qnames: set[str] | None = None,
         row_consumer=None,
+        boundary_consumer=None,
     ):
         self.model = model
         self.profile = profile
         self.row_consumer = row_consumer
+        self.boundary_consumer = boundary_consumer
         # #145: ``experts_qnames`` is the enumeration the collector HOOKS --
         # the full visible module set -- and ``store_qnames`` narrows only
         # which modules keep full activation tensors. One shared generator
@@ -7871,12 +7876,16 @@ class _PackedExpertActivationCollector:
 
     def install(self) -> None:
         for qname, mod in self._modules_by_qname.items():
-            self._handles.append(
-                mod.register_forward_pre_hook(self._make_hook(qname))
-            )
+            if self.boundary_consumer is None:
+                handle = mod.register_forward_pre_hook(self._make_hook(qname))
+            else:
+                handle = mod.register_forward_pre_hook(self._make_hook(qname), with_kwargs=True)
+            self._handles.append(handle)
 
     def _make_hook(self, qname: str):
-        def hook(module, args):
+        def hook(module, args, kwargs=None):
+            if self.boundary_consumer is not None:
+                self.boundary_consumer(qname, module, args, kwargs or {})
             if not args or not isinstance(args[0], torch.Tensor):
                 return
             x = args[0]

--- a/prismaquant/tessera_calibration_cache.py
+++ b/prismaquant/tessera_calibration_cache.py
@@ -1,0 +1,208 @@
+"""Campaign capture receipts over the existing per-unit activation cache storage.
+
+Scoring inputs retain the campaign's first rows in float32, while Hessians,
+counts and maxima cover the entire draw. No row sampling or runtime scheduling
+lives here. Readers verify inputs and prefetch their selected scope before use.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from pathlib import Path
+
+from .cost_stage_checkpoint import atomic_write_bytes, prepare_journal, write_unit
+
+SCHEMA = 'prismaquant.tessera_calibration_cache.v2'
+STAGE = 'tessera_calibration_capture'
+SOURCE = 'tessera_campaign_prefix_f32_v1'
+
+
+def sha256(path):
+    with Path(path).open('rb') as handle:
+        return hashlib.file_digest(handle, 'sha256').hexdigest()
+
+
+def _json(path, value):
+    atomic_write_bytes(Path(path), (json.dumps(value, sort_keys=True, indent=2,
+                                              allow_nan=False) + '\n').encode())
+
+
+def capture_identity(census_path, *, calibration, max_act_rows,
+                     model_load_contract, attention_implementation):
+    """Hash source bytes on every invocation; mtimes never authorize reuse."""
+    import importlib.metadata
+    import torch
+    census_path = Path(census_path)
+    census = json.loads(census_path.read_text())
+    if type(max_act_rows) is not int or max_act_rows < 1:
+        raise ValueError('capture scoring prefix must have positive max_act_rows')
+    from prismaquant import validate_pretrained_initialization_contract
+    contract = validate_pretrained_initialization_contract(model_load_contract)
+    recorded = validate_pretrained_initialization_contract(census.get('model_load_contract'))
+    runtime = dict(torch=torch.__version__,cuda=torch.version.cuda,
+                   transformers=importlib.metadata.version('transformers'))
+    if (contract != recorded or census.get('capture_runtime') != runtime or
+            attention_implementation not in ('eager','sdpa') or
+            census.get('attention_implementation') != attention_implementation):
+        raise RuntimeError('canonical model initialization, runtime or attention differs from census')
+    root = Path(census['model'])
+    files = sorted({*root.glob('*.safetensors'), *root.glob('*.json'),
+                    *root.glob('*.model'), *root.glob('*.txt')})
+    if not files or not (root / 'config.json').is_file():
+        raise RuntimeError('calibration capture needs a complete local source checkpoint')
+    source = {p.name:sha256(p) for p in files if p.is_file()}
+    # The census already seals the producer's complete source/auxiliary
+    # roster (including non-JSON tokenizer assets such as chat_template.jinja).
+    # Check those bytes too, without inventing another producer identity.
+    producer = (census.get('expert_projection') or {}).get('producer') or {}
+    declared = producer.get('source') or {}
+    expected = {**declared.get('files',{}),**declared.get('auxiliary_sha256',{})}
+    if declared.get('config_sha256'):
+        expected['config.json'] = declared['config_sha256']
+    for name,digest in expected.items():
+        actual = source[name] if name in source else sha256(root/name)
+        if actual != digest:
+            raise RuntimeError(f'calibration source differs from census producer: {name}')
+    if not any(name.endswith('.safetensors') for name in source):
+        raise RuntimeError('calibration capture source has no safetensors weights')
+    return dict(schema=SCHEMA, model_load_contract=contract,
+                attention_implementation=attention_implementation,
+                census_sha256=sha256(census_path),capture_runtime=runtime,
+                source_files=source, calibration=dict(calibration),
+                max_act_rows=int(max_act_rows), storage_source=SOURCE,
+                units={name:list(shape) for name,shape in sorted(census['unit_shapes'].items())})
+
+
+def _validate_tensors(name, payload, census, max_rows):
+    import torch
+    columns = int(census['unit_shapes'][name][1])
+    count = int(census['counts'][name])
+    x, h = payload.get('inputs'), payload.get('hessian')
+    if (payload.get('name') != name or payload.get('source') != SOURCE or
+            payload.get('count') != count or count <= 0 or
+            payload.get('max_abs') != census['max_abs'][name] or
+            not math.isfinite(float(payload['max_abs']))):
+        raise RuntimeError(f'{name}: calibration capture metadata disagrees with census')
+    if (not isinstance(x, torch.Tensor) or x.dtype != torch.float32 or
+            list(x.shape) != [min(count, max_rows), columns] or
+            not isinstance(h, torch.Tensor) or h.dtype != torch.float32 or
+            list(h.shape) != [columns, columns]):
+        raise RuntimeError(f'{name}: calibration capture tensor geometry or precision changed')
+    if not torch.isfinite(x).all() or not torch.isfinite(h).all():
+        raise RuntimeError(f'{name}: calibration capture contains nonfinite tensors')
+    return x, h
+
+
+def publish_capture(root, *, census_path, identity, acts=None, hessians=None,
+                    counts=None, maxima=None, existing_entries=None):
+    """Seal a complete capture, journalling per-unit file receipts atomically.
+
+    ``existing_entries`` seals a previously measured raw capture without another
+    model forward. Its bytes receive exactly the ordinary writer's validation.
+    """
+    import torch
+    from .perturbed_x_cache import activation_cache_filename, write_activation_cache_entry
+    root = Path(root).resolve()
+    census = json.loads(Path(census_path).read_text())
+    names = sorted(identity['units'])
+    if len({activation_cache_filename(n) for n in names}) != len(names):
+        raise RuntimeError('calibration unit filenames collide')
+    if set(names) != set(census['counts']):
+        raise RuntimeError('calibration capture must cover the full census scope')
+    if existing_entries is None and any(set(values or {}) != set(names)
+                                       for values in (acts,hessians,counts,maxima)):
+        raise RuntimeError('calibration capture arrays must cover the complete census')
+    if existing_entries is not None and set(existing_entries) != set(names):
+        raise RuntimeError('raw capture does not cover the full census')
+    journal, digest, completed = prepare_journal(root/'journal', stage=STAGE,
+        resume=True, identity=identity, qnames=names)
+    records = {}
+    for name in names:
+        expected_path = Path('inputs') / activation_cache_filename(name)
+        record = completed.get(name) or (existing_entries or {}).get(name)
+        if record is None:
+            payload = dict(inputs=acts[name],hessian=hessians[name],count=counts[name],
+                           max_abs=maxima[name],name=name,source=SOURCE)
+            _validate_tensors(name,payload,census,identity['max_act_rows'])
+            path = write_activation_cache_entry(root/'inputs',name,acts[name],
+                source=SOURCE,durable=True,hessian=hessians[name],count=counts[name],max_abs=maxima[name])
+            record = dict(path=str(expected_path),sha256=sha256(path))
+        else:
+            if record.get('path') != str(expected_path):
+                raise RuntimeError(f'{name}: capture file is outside its canonical location')
+            path = root/expected_path
+            if sha256(path) != record['sha256']:
+                raise RuntimeError(f'{name}: capture artifact checksum mismatch')
+            _validate_tensors(name,torch.load(path,map_location='cpu',weights_only=True),
+                              census,identity['max_act_rows'])
+        if name not in completed:
+            write_unit(journal,stage=STAGE,qname=name,identity_sha256=digest,state=record)
+        records[name] = record
+    manifest = dict(schema=SCHEMA,status='complete',identity=identity,entries=records)
+    path = root/'capture_manifest.json'
+    if path.exists() and json.loads(path.read_text()) != manifest:
+        raise RuntimeError('existing complete calibration capture changed')
+    _json(path,manifest)
+    return dict(path=str(path),sha256=sha256(path))
+
+
+def require_capture_contract(path, expected_sha256=None):
+    """Validate a complete canonical capture before downstream preparation."""
+    from prismaquant import validate_pretrained_initialization_contract
+    path = Path(path)
+    if expected_sha256 is not None and sha256(path) != expected_sha256:
+        raise RuntimeError('priced calibration capture manifest changed')
+    manifest = json.loads(path.read_text())
+    identity = manifest.get('identity') or {}
+    if manifest.get('schema') != SCHEMA or manifest.get('status') != 'complete':
+        raise RuntimeError('not a complete canonical calibration capture v2')
+    contract = validate_pretrained_initialization_contract(identity.get('model_load_contract'))
+    runtime = identity.get('capture_runtime')
+    if (not isinstance(runtime,dict) or set(runtime) != {'torch','cuda','transformers'} or
+            not isinstance(runtime.get('torch'),str) or not runtime['torch'] or
+            (runtime.get('cuda') is not None and not isinstance(runtime['cuda'],str))):
+        raise RuntimeError('canonical capture runtime identity is incomplete')
+    if (identity.get('schema') != SCHEMA or
+            identity.get('attention_implementation') not in ('eager','sdpa') or
+            (identity.get('capture_runtime') or {}).get('transformers') != contract['transformers_version'] or
+            not identity.get('source_files') or not identity.get('units') or
+            set(manifest.get('entries',{})) != set(identity['units'])):
+        raise RuntimeError('canonical capture runtime, source or completeness is invalid')
+    return manifest
+
+
+def prefetch_capture(path, *, expected_identity, census, names, device,
+                     expected_sha256=None):
+    """Verify selected files and make all selected X/H resident before encoding."""
+    import torch
+    from .perturbed_x_cache import activation_cache_filename
+    path = Path(path)
+    digest = sha256(path)
+    if expected_sha256 is not None and digest != expected_sha256:
+        raise RuntimeError('priced calibration capture manifest changed')
+    manifest = require_capture_contract(path, expected_sha256=expected_sha256)
+    names = sorted(names)
+    if (manifest.get('schema') != SCHEMA or manifest.get('status') != 'complete' or
+            manifest.get('identity') != expected_identity or
+            set(manifest.get('entries',{})) != set(expected_identity['units']) or
+            not set(names) <= set(expected_identity['units'])):
+        raise RuntimeError('calibration capture identity, completeness or scope mismatch')
+    acts, hessians, counts, maxima = {}, {}, {}, {}
+    for name in names:
+        record = manifest['entries'][name]
+        relative = str(Path('inputs') / activation_cache_filename(name))
+        if record.get('path') != relative:
+            raise RuntimeError(f'{name}: noncanonical capture artifact path')
+        artifact = path.parent/relative
+        if sha256(artifact) != record.get('sha256'):
+            raise RuntimeError(f'{name}: capture artifact checksum mismatch')
+        payload = torch.load(artifact,map_location='cpu',weights_only=True)
+        x,h = _validate_tensors(name,payload,census,expected_identity['max_act_rows'])
+        acts[name],hessians[name] = x.to(device),h.to(device)
+        counts[name],maxima[name] = payload['count'],payload['max_abs']
+    if str(device).startswith('cuda'):
+        torch.cuda.synchronize(device)
+    resident = sum(t.numel()*t.element_size() for t in (*acts.values(),*hessians.values()))
+    print(f'[campaign] calibration prefetched: {len(names)} units, {resident} resident bytes, 0 misses',flush=True)
+    return (acts,hessians,counts,maxima),dict(path=str(path.resolve()),sha256=digest)

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -1809,14 +1809,30 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
         raise RuntimeError(
             "packed campaign units have no routed calibration rows: "
             f"{sorted(unobserved)}; refusing a shared-Hessian or weight-only fallback")
-    rows = {
-        name: (torch.cat(chunks, dim=0) if chunks else None)
-        for name, chunks in store.items()
-    }
-    hessians = {
-        name: (None if h is None else h.to(device="cpu"))
-        for name, h in hess.items()
-    } if want_hessian else {}
+    # Do not retain both the original chunks and their concatenated outputs
+    # for the whole scope. Full-model captures can hold GiB of scoring rows.
+    rows = {}
+    for name in list(store):
+        chunks = store.pop(name)
+        rows[name] = torch.cat(chunks, dim=0) if chunks else None
+        del chunks
+    hessians = {}
+    if want_hessian:
+        # GB10 shares physical DRAM with CPU tensors. Releasing Python tensor
+        # references alone leaves the CUDA allocator's cached blocks resident,
+        # so periodically return those blocks while transferring the full H.
+        released_cuda_bytes = 0
+        for name in list(hess):
+            h = hess.pop(name)
+            hessians[name] = None if h is None else h.to(device="cpu")
+            if h is not None and h.is_cuda:
+                released_cuda_bytes += h.numel() * h.element_size()
+            del h
+            if released_cuda_bytes >= 256 * 1024**2:
+                torch.cuda.empty_cache()
+                released_cuda_bytes = 0
+        if released_cuda_bytes:
+            torch.cuda.empty_cache()
     return rows, hessians, dict(seen), dict(amax)
 
 

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -1711,8 +1711,13 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
             return
         if name in routed_seen:
             routed_seen[name] += int(flat.shape[0])
-        amax[name] = max(
-            amax[name], float(flat.abs().amax().float().item()))
+        batch_max = flat.abs().amax().float()
+        previous_max = amax[name]
+        if not isinstance(previous_max, torch.Tensor):
+            previous_max = torch.zeros((), dtype=torch.float32, device=batch_max.device)
+        # Python max(previous, NaN) preserves previous. fmax keeps that exact
+        # policy while avoiding a device-to-host scalar read on every batch.
+        amax[name] = torch.fmax(previous_max, batch_max)
         seen[name] += int(flat.shape[0])
         if want_hessian:
             # Every row, before any cap: see the docstring.
@@ -1809,6 +1814,9 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
         raise RuntimeError(
             "packed campaign units have no routed calibration rows: "
             f"{sorted(unobserved)}; refusing a shared-Hessian or weight-only fallback")
+    # All forwards are complete: materialize each unit's maximum only once.
+    amax = {name: float(value.item()) if isinstance(value, torch.Tensor) else value
+            for name, value in amax.items()}
     # Do not retain both the original chunks and their concatenated outputs
     # for the whole scope. Full-model captures can hold GiB of scoring rows.
     rows = {}

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -2387,7 +2387,8 @@ def select_anchor_groups(selection: Mapping, resolved: Mapping[str, list[str]],
 def calibration_census(counts: Mapping[str, int], max_abs: Mapping[str, float], *,
                        args, groups: Mapping, dense_targets: Sequence[str],
                        expert_targets: Sequence[str], shapes: Mapping,
-                       identity: Mapping, expert_projection=None) -> dict:
+                       identity: Mapping, expert_projection=None, model_load_contract=None,
+                       attention_implementation=None, capture_runtime=None) -> dict:
     """The whole priced scope, as one run that loaded the model saw it.
 
     Everything here is scope-wide and selection-independent, and it is here
@@ -2399,6 +2400,9 @@ def calibration_census(counts: Mapping[str, int], max_abs: Mapping[str, float], 
     """
     return {
         "schema": CENSUS_SCHEMA,
+        **({"model_load_contract": model_load_contract,
+            "attention_implementation": attention_implementation,
+            "capture_runtime": capture_runtime} if model_load_contract is not None else {}),
         "model": str(args.model),
         "nsamples": int(args.nsamples),
         "seqlen": int(args.seqlen),
@@ -3158,7 +3162,11 @@ def main(argv: "Sequence[str] | None" = None) -> int:
                     help="collect the calibration census over the whole scope, "
                          "write it here and exit. No Hessians, no retained "
                          "scoring rows, no encodes.")
+    ap.add_argument("--attention-implementation", choices=("eager", "sdpa"), default=None,
+                    help="Explicit HF attention backend required for canonical census.")
     args = ap.parse_args(argv)
+    if args.census_out and not args.attention_implementation:
+        ap.error("canonical census requires explicit --attention-implementation")
     if args.anchor_batch_size < 1:
         ap.error("--anchor-batch-size must be positive")
     if args.anchor_batch_size > 1:
@@ -3193,8 +3201,22 @@ def main(argv: "Sequence[str] | None" = None) -> int:
 
     model = AutoModelForCausalLM.from_pretrained(
         args.model, dtype=torch.bfloat16, device_map=device,
+        **({"attn_implementation": args.attention_implementation}
+           if args.attention_implementation is not None else {}),
     )
     model.eval()
+    model_load_contract = None
+    attention_implementation = None
+    capture_runtime = None
+    if args.census_out:
+        import importlib.metadata
+        from prismaquant import pretrained_initialization_contract
+        model_load_contract = pretrained_initialization_contract(model)
+        attention_implementation = model.config._attn_implementation
+        if attention_implementation != args.attention_implementation:
+            raise RuntimeError("loaded model attention backend differs from explicit request")
+        capture_runtime = dict(torch=torch.__version__,cuda=torch.version.cuda,
+            transformers=importlib.metadata.version("transformers"))
 
     from .model_profiles import detect_profile
 
@@ -3443,7 +3465,9 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             dense_targets=census_dense_targets,
             expert_targets=census_expert_targets,
             shapes={name: tuple(weight.shape) for name, weight in weights.items()},
-            identity=hessian_identity, expert_projection=expert_projection)
+            identity=hessian_identity, expert_projection=expert_projection,
+            model_load_contract=model_load_contract,
+            attention_implementation=attention_implementation,capture_runtime=capture_runtime)
         if set(payload["counts"]) != set(census_targets):
             raise RuntimeError(
                 "the census did not observe every unit in scope: missing "

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -1432,6 +1432,7 @@ def _campaign_checkpoint_identity(*, weights, acts, hessians, menus, args,
     # ``--seed-checkpoint``, one verified row at a time.
     for name in ("out", "cache_dir", "checkpoint", "deadline_seconds",
                  "units", "calibration_census", "census_out",
+                 "capture_calibration_out", "calibration_cache", "calibration_cache_sha256",
                  "seed_checkpoint", "seed_wire_dir", "anchor_batch_size"):
         settings.pop(name, None)
     return {
@@ -1650,7 +1651,8 @@ def _link_seed_wire(seed_wire: Path, wire_dir: Path, filename) -> None:
 
 
 def _collect_activations(model, targets, tokens, max_rows: int, device,
-                         *, want_hessian: bool = False, profile=None):
+                         *, want_hessian: bool = False, profile=None,
+                         boundary_consumer=None):
     """One model forward per batch, for dense and declared packed projections.
 
     Returns ``(rows, hessians, token_counts, max_abs)``. Counts describe every
@@ -1697,6 +1699,10 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
     routed_seen: dict[str, int] = {}
     handles = []
     packed_collector = None
+    calibration_coordinates = None
+
+    def consume_boundary(qname, module, args, kwargs):
+        boundary_consumer(qname, module, args, kwargs, calibration_coordinates)
 
     def accumulate(name, x):
         # ONE accumulator for both populations: a dense Linear's pre-hook and
@@ -1794,6 +1800,7 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
             model, {member.module_qname for member in inventory},
             module_token_budget=0, store_device=device, store_qnames=set(),
             profile=profile, row_consumer=consume_packed,
+            boundary_consumer=(consume_boundary if boundary_consumer is not None else None),
         )
     try:
         for name in targets:
@@ -1802,7 +1809,15 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
         if packed_collector is not None:
             packed_collector.install()
         with torch.no_grad():
+            sample_offset = 0
             for batch in tokens:
+                if boundary_consumer is not None:
+                    if batch.ndim != 2:
+                        raise RuntimeError("boundary capture requires [sample, token] calibration IDs")
+                    sample_ids = torch.arange(sample_offset, sample_offset + batch.shape[0], dtype=torch.int64)
+                    positions = torch.arange(batch.shape[1], dtype=torch.int64)
+                    calibration_coordinates = torch.cartesian_prod(sample_ids, positions)
+                    sample_offset += batch.shape[0]
                 model(batch.to(device))
     finally:
         for handle in handles:
@@ -3163,10 +3178,25 @@ def main(argv: "Sequence[str] | None" = None) -> int:
                          "write it here and exit. No Hessians, no retained "
                          "scoring rows, no encodes.")
     ap.add_argument("--attention-implementation", choices=("eager", "sdpa"), default=None,
-                    help="Explicit HF attention backend required for canonical census.")
+                    help="Explicit HF attention backend required for canonical census/capture.")
+    ap.add_argument("--capture-calibration-out", default=None,
+                    help="Capture full-census float32 prefix X and uncapped H once, then exit.")
+    ap.add_argument("--calibration-cache", default=None,
+                    help="Verified capture manifest; prefetch selected X/H before encoding.")
+    ap.add_argument("--calibration-cache-sha256", default=None,
+                    help="Expected capture manifest hash, sealed by the campaign planner.")
     args = ap.parse_args(argv)
-    if args.census_out and not args.attention_implementation:
-        ap.error("canonical census requires explicit --attention-implementation")
+    if (args.census_out or args.capture_calibration_out or args.calibration_cache) and not args.attention_implementation:
+        ap.error("canonical census/capture requires explicit --attention-implementation")
+    if args.calibration_cache_sha256 and not args.calibration_cache:
+        ap.error("--calibration-cache-sha256 requires --calibration-cache")
+    if args.capture_calibration_out or args.calibration_cache:
+        if not args.calibration_census or args.census_out or args.hessian != "require":
+            ap.error("capture/reuse requires --calibration-census and --hessian require")
+        if args.capture_calibration_out and (args.units or args.calibration_cache):
+            ap.error("--capture-calibration-out requires the full scope and cannot also reuse")
+        if args.max_act_rows < 1:
+            ap.error("capture/reuse requires positive --max-act-rows")
     if args.anchor_batch_size < 1:
         ap.error("--anchor-batch-size must be positive")
     if args.anchor_batch_size > 1:
@@ -3208,7 +3238,7 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     model_load_contract = None
     attention_implementation = None
     capture_runtime = None
-    if args.census_out:
+    if args.census_out or args.capture_calibration_out or args.calibration_cache:
         import importlib.metadata
         from prismaquant import pretrained_initialization_contract
         model_load_contract = pretrained_initialization_contract(model)
@@ -3326,42 +3356,71 @@ def main(argv: "Sequence[str] | None" = None) -> int:
 
     tokens, corpus_text = _calibration_tokens(
         args.model, args.nsamples, args.seqlen, args.seed)
-    # A census run needs the counts and the maxima, which every hook produces
-    # unconditionally; it needs neither the Hessians nor the retained scoring
-    # rows, because it encodes nothing.
-    want_h = args.hessian == "require" and not census_only
-    acts, hessians, hessian_rows, act_max_abs = _collect_activations(
-        model, targets, tokens, 0 if census_only else args.max_act_rows, device,
-        want_hessian=want_h, profile=profile)
-    # For the log line and the run-level provenance only; every encode is
-    # given its own Linear's count.
     census = (None if not args.calibration_census
               else load_calibration_census(args.calibration_census, args=args))
-    hessian_token_count, hessian_token_min = census_token_counts(
-        census, hessian_rows)
-    print(f"[campaign] activations collected "
-          f"(hessian={args.hessian}, rows/Linear "
-          f"{hessian_token_min}..{hessian_token_count})",
-          flush=True)
-
-    # The draw's identity, in Tessera's own required vocabulary and built by
-    # the function the production render also calls. An ActivationSource
-    # refuses a provenance missing any of the three, which is what makes
-    # "cost.pkl and the production cache are the same draw" a checkable claim.
+    want_h = args.hessian == "require" and not census_only
+    calibration_cache = None
+    capture_identity = None
+    if census is not None:
+        # Validate the whole scope before a selected unit's artifact is read.
+        if (set(census["counts"]) != set(census_targets) or
+                census["anchor_groups"] != scope_groups):
+            raise RuntimeError("calibration census scope differs from the loaded model")
+        scope_shapes = {name: list(dict(model.named_modules())[name].weight.shape)
+                        for name in census_dense_targets}
+        scope_shapes.update({member.qname: list(member.weight.shape)
+                             for member in population.members})
+        if census["unit_shapes"] != scope_shapes:
+            raise RuntimeError("calibration census geometry differs from the loaded model")
+    if args.capture_calibration_out or args.calibration_cache:
+        from . import tessera_calibration_cache as calibration_store
+        hi, lo = census_token_counts(census, {})
+        bound_calibration = th.calibration_identity(
+            corpus_text, tokens, fit_tokens=hi,
+            source="wikitext-2-raw-v1/train", split_role="calibration",
+            model=str(args.model), seed=int(args.seed), nsamples=int(args.nsamples),
+            seqlen=int(args.seqlen), fit_tokens_min=lo)
+        require_census_draw(census, bound_calibration, where="calibration capture")
+        capture_identity = calibration_store.capture_identity(
+            args.calibration_census, calibration=bound_calibration,
+            max_act_rows=args.max_act_rows, model_load_contract=model_load_contract,
+            attention_implementation=attention_implementation)
+    if args.capture_calibration_out:
+        completed_capture = Path(args.capture_calibration_out) / "capture_manifest.json"
+        if completed_capture.exists():
+            _values, record = calibration_store.prefetch_capture(
+                completed_capture, expected_identity=capture_identity,
+                census=census, names=census_targets, device="cpu")
+            print(f"[campaign] complete calibration capture reused: {record}", flush=True)
+            return 0
+    if args.calibration_cache:
+        values, calibration_cache = calibration_store.prefetch_capture(
+            args.calibration_cache, expected_identity=capture_identity,
+            census=census, names=targets, device=device,
+            expected_sha256=args.calibration_cache_sha256)
+        acts, hessians, hessian_rows, act_max_abs = values
+    else:
+        acts, hessians, hessian_rows, act_max_abs = _collect_activations(
+            model, targets, tokens, 0 if census_only else args.max_act_rows, device,
+            want_hessian=want_h, profile=profile)
+    hessian_token_count, hessian_token_min = census_token_counts(census, hessian_rows)
     hessian_identity = th.calibration_identity(
-        corpus_text, tokens,
-        fit_tokens=int(hessian_token_count),
-        source="wikitext-2-raw-v1/train",
-        split_role="calibration",
-        model=str(args.model),
-        seed=int(args.seed),
-        nsamples=int(args.nsamples),
-        seqlen=int(args.seqlen),
-        fit_tokens_min=int(hessian_token_min),
-    )
+        corpus_text, tokens, fit_tokens=int(hessian_token_count),
+        source="wikitext-2-raw-v1/train", split_role="calibration",
+        model=str(args.model), seed=int(args.seed), nsamples=int(args.nsamples),
+        seqlen=int(args.seqlen), fit_tokens_min=int(hessian_token_min))
     if census is not None:
         require_census_draw(census, hessian_identity,
                             where=f"--calibration-census {args.calibration_census}")
+    if args.capture_calibration_out:
+        calibration_cache = calibration_store.publish_capture(
+            args.capture_calibration_out, census_path=args.calibration_census,
+            identity=capture_identity, acts=acts, hessians=hessians,
+            counts=hessian_rows, maxima=act_max_abs)
+        print(f"[campaign] complete calibration capture: {calibration_cache}", flush=True)
+        return 0
+    print(f"[campaign] activations ready (hessian={args.hessian}, rows/Linear "
+          f"{hessian_token_min}..{hessian_token_count})", flush=True)
 
     # The static A-side calibration, from the same forward passes: one
     # input_global_scale per unit under the resolved contract policy, fused
@@ -4038,6 +4097,7 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             # unified. The served contract reads exactly one such scalar per
             # module (trellis_input_global_scale), so this block is what makes
             # "the priced A side is the served A side" checkable downstream.
+            "calibration_cache": calibration_cache,
             "activation_static_scales": {
                 "policy": str(static_scale_policy),
                 "source": "campaign_calibration_amax_fused_unified",

--- a/prismaquant/tessera_materialization.py
+++ b/prismaquant/tessera_materialization.py
@@ -221,7 +221,10 @@ def run(plan_path, group_index, *, anchor_batch_size=1):
     _verify_source(model_path, source)
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     profile = detect_profile(model_path)
-    model = AutoModelForCausalLM.from_pretrained(model_path, dtype=torch.bfloat16, device_map=device)
+    cache_record = provenance.get('calibration_cache')
+    attention_implementation = census.get('attention_implementation') if cache_record else None
+    model = AutoModelForCausalLM.from_pretrained(model_path, dtype=torch.bfloat16, device_map=device,
+        **({'attn_implementation':attention_implementation} if attention_implementation else {}))
     model.eval()
     population = tc._require_campaign_population(model, profile, provenance['layer_stride'])
     members = {member.qname: member for member in population.members}
@@ -230,9 +233,21 @@ def run(plan_path, group_index, *, anchor_batch_size=1):
     tokens, corpus = tc._calibration_tokens(model_path, provenance['nsamples'],
                                            provenance['seqlen'], provenance['seed'])
     want_h = provenance['hessian']['supplied']
-    acts, hessians, counts, maxima = tc._collect_activations(
-        model, names, tokens, provenance['max_act_rows'], device,
-        want_hessian=want_h, profile=profile)
+    if cache_record is not None:
+        from prismaquant import pretrained_initialization_contract
+        from . import tessera_calibration_cache as calibration_store
+        cache_identity = calibration_store.capture_identity(
+            data['census_path'], calibration=provenance['hessian']['calibration_identity'],
+            max_act_rows=provenance['max_act_rows'],
+            model_load_contract=pretrained_initialization_contract(model),
+            attention_implementation=model.config._attn_implementation)
+        (acts,hessians,counts,maxima), _record = calibration_store.prefetch_capture(
+            cache_record['path'],expected_sha256=cache_record['sha256'],
+            expected_identity=cache_identity,census=census,names=names,device=device)
+    else:
+        acts, hessians, counts, maxima = tc._collect_activations(
+            model, names, tokens, provenance['max_act_rows'], device,
+            want_hessian=want_h, profile=profile)
     hi, lo = tc.census_token_counts(census, counts)
     calibration = th.calibration_identity(corpus, tokens, fit_tokens=hi,
         source='wikitext-2-raw-v1/train', split_role='calibration', model=str(model_path),

--- a/tests/test_campaign_amax_residency.py
+++ b/tests/test_campaign_amax_residency.py
@@ -1,0 +1,27 @@
+"""Calibration maxima stay on device until the complete draw has run."""
+import torch
+from prismaquant.tessera_campaign import _collect_activations
+
+
+def test_maxima_convert_to_host_once_per_unit_and_keep_python_nan_semantics(monkeypatch):
+    class Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.first = torch.nn.Linear(2,2,bias=False)
+            self.second = torch.nn.Linear(2,2,bias=False)
+        def forward(self,x):
+            return self.first(x)+self.second(x)
+    model = Model()
+    batches = [torch.tensor([[1.,2.]]),torch.tensor([[float('nan'),99.]]),
+               torch.empty(0,2),torch.tensor([[-4.,3.]])]
+    scalar_reads = []
+    original = torch.Tensor.item
+    def item(value,*args,**kwargs):
+        scalar_reads.append(value.shape)
+        return original(value,*args,**kwargs)
+    monkeypatch.setattr(torch.Tensor,'item',item)
+    _x,_h,counts,maxima = _collect_activations(model,['first','second'],batches,1,'cpu',want_hessian=False)
+    # Python max(0, NaN) ignores the NaN batch, including its finite 99.
+    assert maxima == {'first':4.,'second':4.}
+    assert counts == {'first':3,'second':3}
+    assert scalar_reads == [torch.Size([]),torch.Size([])]

--- a/tests/test_tessera_calibration_cache.py
+++ b/tests/test_tessera_calibration_cache.py
@@ -1,0 +1,228 @@
+"""A reusable calibration keeps full-H/prefix-X bytes and refuses stale inputs."""
+import copy
+import importlib.metadata
+import prismaquant
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from prismaquant import tessera_calibration_cache as cc
+
+
+def canonical_fields():
+    return dict(model_load_contract=dict(schema='prismaquant.pretrained_initialization.v1',
+        scope='checkpoint_missing_state',status='completed',
+        transformers_version=importlib.metadata.version('transformers')),
+        attention_implementation='eager',capture_runtime=dict(torch=torch.__version__,
+        cuda=torch.version.cuda,transformers=importlib.metadata.version('transformers')))
+
+
+def identity(path,calibration,max_act_rows):
+    fields = canonical_fields()
+    return cc.capture_identity(path,calibration=calibration,max_act_rows=max_act_rows,
+        model_load_contract=fields['model_load_contract'],attention_implementation='eager')
+
+
+@pytest.fixture
+def capture(tmp_path):
+    source = tmp_path/'source'
+    source.mkdir()
+    (source/'config.json').write_text('{}')
+    (source/'model.safetensors').write_bytes(b'bounded source fixture')
+    census = dict(model=str(source),counts={'a':5,'b':7},max_abs={'a':4.,'b':8.},
+                  unit_shapes={'a':[3,2],'b':[3,2]},layer_stride=1,
+                  anchor_groups={'u:a':['a'],'u:b':['b']},**canonical_fields())
+    path = tmp_path/'census.json'
+    path.write_text(json.dumps(census))
+    capture_id = identity(path,calibration={'fit_ids_sha256':'draw'},max_act_rows=2)
+    acts = {'a':torch.tensor([[1.,2.],[3.,4.]]),'b':torch.ones(2,2)}
+    hessians = {'a':torch.eye(2)*13,'b':torch.eye(2)*25}
+    root = tmp_path/'capture'
+    record = cc.publish_capture(root,census_path=path,identity=capture_id,acts=acts,
+        hessians=hessians,counts=census['counts'],maxima=census['max_abs'])
+    return root,path,census,capture_id,acts,hessians,record
+
+
+def test_prefetch_only_selected_and_preserves_full_h_and_prefix_precision(capture):
+    root,path,census,identity,acts,hessians,record = capture
+    (root/'inputs/b.pt').unlink()  # unrelated units are not transferred by this quantum
+    values,_ = cc.prefetch_capture(record['path'],expected_identity=identity,
+        census=census,names=['a'],device='cpu',expected_sha256=record['sha256'])
+    assert set(values[0]) == {'a'}
+    assert torch.equal(values[0]['a'],acts['a'])
+    assert torch.equal(values[1]['a'],hessians['a'])
+    assert values[2] == {'a':5}
+
+
+@pytest.mark.parametrize('change',['artifact','manifest','source','draw','geometry','scope'])
+def test_prefetch_refuses_drift(capture,change):
+    root,path,census,identity,acts,hessians,record = capture
+    expected = copy.deepcopy(identity)
+    if change == 'artifact':
+        with (root/'inputs/a.pt').open('ab') as f:
+            f.write(b'changed')
+    elif change == 'manifest':
+        with open(record['path'],'a') as f:
+            f.write(' ')
+    elif change == 'source':
+        (path.parent/'source/model.safetensors').write_bytes(b'changed')
+        expected = globals()['identity'](path,calibration=identity['calibration'],max_act_rows=2)
+    elif change == 'draw':
+        expected['calibration']['fit_ids_sha256'] = 'other'
+    elif change == 'geometry':
+        expected['units']['a'] = [4,2]
+    else:
+        expected['units'].pop('b')
+    with pytest.raises(RuntimeError,match='checksum|identity|manifest changed'):
+        cc.prefetch_capture(record['path'],expected_identity=expected,census=census,
+            names=['a'],device='cpu',expected_sha256=record['sha256'])
+
+
+def test_completed_journal_revalidates_artifacts(capture):
+    root,path,census,identity,acts,hessians,record = capture
+    again = cc.publish_capture(root,census_path=path,identity=identity,acts=acts,
+        hessians=hessians,counts=census['counts'],maxima=census['max_abs'])
+    assert again == record
+    (root/'inputs/a.pt').unlink()
+    with pytest.raises(FileNotFoundError):
+        cc.publish_capture(root,census_path=path,identity=identity,acts=acts,
+            hessians=hessians,counts=census['counts'],maxima=census['max_abs'])
+
+
+def test_cli_capture_then_reuse_never_repeats_forward(monkeypatch,tmp_path):
+    from test_tessera_campaign_resume import _main_fixture,UNIT
+    tc,_,argv,model,inputs = _main_fixture(monkeypatch,tmp_path)
+    model.config = SimpleNamespace(_attn_implementation='eager')
+    monkeypatch.setattr(prismaquant,'pretrained_initialization_contract',lambda model:canonical_fields()['model_load_contract'])
+    argv += ['--attention-implementation','eager']
+    source = tmp_path/'source'
+    source.mkdir()
+    (source/'config.json').write_text('{}')
+    (source/'model.safetensors').write_bytes(b'fixture')
+    argv[argv.index('--model')+1] = str(source)
+    argv[argv.index('--hessian')+1] = 'require'
+    calibration = tc.th.calibration_identity(inputs['text'],inputs['tokens'],fit_tokens=4,
+        source='wikitext-2-raw-v1/train',split_role='calibration',model=str(source),
+        seed=0,nsamples=32,seqlen=512,fit_tokens_min=4)
+    census = tc.calibration_census({UNIT:4},{UNIT:3.},args=SimpleNamespace(model=str(source),
+        nsamples=32,seqlen=512,seed=0,layer_stride=1),groups={'u:'+UNIT:[UNIT]},
+        dense_targets=[UNIT],expert_targets=[],shapes={UNIT:[32,256]},identity=calibration,**canonical_fields())
+    census_path = tmp_path/'census.json'
+    census_path.write_text(json.dumps(census))
+    argv += ['--nsamples','32','--seqlen','512','--layer-stride','1',
+             '--calibration-census',str(census_path)]
+    root = tmp_path/'full-capture'
+    assert tc.main([*argv,'--capture-calibration-out',str(root)]) == 0
+    monkeypatch.setattr(tc,'_collect_activations',lambda *a,**k: pytest.fail('repeated forward'))
+    assert tc.main([*argv,'--capture-calibration-out',str(root)]) == 0
+    assert tc.main([*argv,'--calibration-cache',str(root/'capture_manifest.json')]) == tc.EXIT_EMPTY_MENU
+
+
+def test_driver_capture_and_plan_bind_one_complete_capture(capture):
+    from tools import dispatch_tessera_campaign as dispatch
+    root,path,census,identity,acts,hessians,record = capture
+    spec = path.parent/'spec.json'
+    spec.write_text(json.dumps(dict(model=census['model'],campaign_argv=[],
+        cwd=str(path.parent),python='python3',env={},cpus=1,headroom_gb=2)))
+    common = ['--spec',str(spec),'--workspace',str(path.parent)]
+    assert dispatch.main(['capture',*common]) == 0
+    quantum = json.loads((path.parent/'capture-manifest.json').read_text())
+    assert len(quantum) == 1
+    assert '--capture-calibration-out' in quantum[0]['argv']
+    assert '--units' not in quantum[0]['argv']
+    assert dispatch.main(['plan',*common,'--calibration-cache',record['path']]) == 0
+    rows = json.loads((path.parent/'manifest.json').read_text())
+    for row in rows:
+        argv = row['argv']
+        assert argv[argv.index('--calibration-cache')+1] == record['path']
+        assert argv[argv.index('--calibration-cache-sha256')+1] == record['sha256']
+    manifest = json.loads(Path(record['path']).read_text())
+    manifest['status'] = 'partial'
+    Path(record['path']).write_text(json.dumps(manifest))
+    with pytest.raises(RuntimeError,match='complete.*capture'):
+        dispatch.main(['plan',*common,'--calibration-cache',record['path']])
+
+
+def test_merge_refuses_disagreeing_capture_bindings():
+    from test_tessera_campaign_fanout import _payloads
+    from tools import dispatch_tessera_campaign as dispatch
+    payloads = _payloads()
+    for index,payload in enumerate(payloads.values()):
+        payload['provenance']['calibration_cache'] = dict(path='/capture.json',sha256=str(index))
+    with pytest.raises(dispatch.MergeRefused,match='calibration_cache'):
+        dispatch.merge_payloads(payloads,census={'counts':{'a':16384,'b':16384}},capture_sha256='merged')
+
+
+@pytest.mark.parametrize('field',['model_load_contract','attention_implementation','capture_runtime'])
+def test_identity_refuses_legacy_or_changed_census(capture,field):
+    root,path,census,capture_id,acts,hessians,record = capture
+    census.pop(field)
+    path.write_text(json.dumps(census))
+    with pytest.raises((RuntimeError,ValueError),match='initialization|runtime|attention'):
+        identity(path,calibration=capture_id['calibration'],max_act_rows=2)
+
+
+@pytest.mark.parametrize('field',['model_load_contract','attention_implementation','capture_runtime','schema'])
+def test_downstream_contract_refuses_unqualified_identity(capture,field):
+    root,path,census,capture_id,acts,hessians,record = capture
+    manifest = json.loads(Path(record['path']).read_text())
+    manifest['identity'].pop(field)
+    Path(record['path']).write_text(json.dumps(manifest))
+    with pytest.raises((RuntimeError,ValueError),match='initialization|runtime'):
+        cc.require_capture_contract(record['path'])
+
+
+@pytest.mark.parametrize('kwargs_route',[False,True])
+def test_boundary_callback_preserves_raw_arguments_and_reservoir(kwargs_route):
+    from test_tessera_campaign_packed import _RoutedModel,EXPERT_PREFIX
+    from prismaquant.production_weight_cache import _PackedExpertActivationCollector
+    model = _RoutedModel().to(torch.bfloat16)
+    module = model.model.layers[2].feed_forward.experts
+    x = torch.arange(32,dtype=torch.bfloat16).reshape(8,4)/32
+    indices = torch.arange(8).remainder(2).reshape(8,1)
+    weights = torch.ones(8,1,dtype=torch.bfloat16)
+    snapshots = []
+    for callback in (None,lambda name,actual,args,kwargs:snapshots.append((name,actual,args,kwargs))):
+        collector = _PackedExpertActivationCollector(model,{EXPERT_PREFIX},module_token_budget=3,
+            store_device='cpu',boundary_consumer=callback)
+        collector.install()
+        try:
+            if kwargs_route:
+                module(x,indices=indices,weights=weights)
+            else:
+                module(x,indices,weights)
+        finally:
+            collector.remove()
+        sampled = torch.cat(collector.activations[EXPERT_PREFIX])
+        if callback is None:
+            original = sampled
+        else:
+            assert torch.equal(original,sampled)
+    name,actual,args,kwargs = snapshots[0]
+    assert name == EXPERT_PREFIX and actual is module and args[0] is x
+    assert (kwargs['indices'] if kwargs_route else args[1]) is indices
+    assert (kwargs['weights'] if kwargs_route else args[2]) is weights
+    assert not module._forward_pre_hooks
+
+
+def test_campaign_boundary_coordinates_follow_batched_calibration_ids():
+    from test_tessera_campaign_packed import _RoutedModel,EXPERT_PREFIX
+    from prismaquant import tessera_campaign as tc
+    class TokenModel(_RoutedModel):
+        def forward(self,ids):
+            hidden = torch.stack((ids.float()*2-1,ids.float(),ids.float()+1,ids.float()-1),dim=-1)
+            return super().forward(hidden)
+    model = TokenModel()
+    tokens = [torch.tensor([[0,1],[1,0]]),torch.tensor([[0,1]])]
+    captures = []
+    values = tc._collect_activations(model,[EXPERT_PREFIX+'.0.w1',EXPERT_PREFIX+'.1.w1'],
+        tokens,2,'cpu',want_hessian=True,
+        boundary_consumer=lambda name,module,args,kwargs,coords:captures.append((args[0].clone(),coords.clone())))
+    assert len(captures) == 2
+    assert captures[0][1].tolist() == [[0,0],[0,1],[1,0],[1,1]]
+    assert captures[1][1].tolist() == [[2,0],[2,1]]
+    assert captures[0][0][:,0].tolist() == [-1,1,1,-1]
+    assert all(count == 3 for count in values[2].values())

--- a/tests/test_tessera_campaign_packed.py
+++ b/tests/test_tessera_campaign_packed.py
@@ -346,6 +346,14 @@ def _bridge_main_fixture(monkeypatch, tmp_path, *, perturb=None):
         pytest.skip(f"producer projection tool unavailable: {exc}")
 
     model = _WideRoutedModel().to(dtype=torch.bfloat16)
+    # The fixture substitutes HF loading; checkpoint-initialization behavior
+    # is separately exercised with real HF modules in its own contract tests.
+    import prismaquant
+    import importlib.metadata
+    model.config._attn_implementation = "eager"
+    monkeypatch.setattr(prismaquant, "pretrained_initialization_contract", lambda model: dict(
+        schema="prismaquant.pretrained_initialization.v1",scope="checkpoint_missing_state",
+        status="completed",transformers_version=importlib.metadata.version("transformers")))
     source = tmp_path / "source"
     _write_source_checkpoint(model, source, perturb=perturb)
     transformers = ModuleType("transformers")
@@ -387,7 +395,8 @@ def _bridge_main_fixture(monkeypatch, tmp_path, *, perturb=None):
     monkeypatch.setattr(tessera_campaign, "_measure_anchor", measure_without_route_admission)
     argv = ["--model", str(source), "--out", str(tmp_path / "cost.pkl"),
             "--cache-dir", str(tmp_path / "cache"), "--hessian", "off",
-            "--menu-mode", "research", "--max-rounds", "1"]
+            "--menu-mode", "research", "--max-rounds", "1",
+            "--attention-implementation", "eager"]
     return tessera_campaign, argv, model, encoded
 
 

--- a/tests/test_tessera_canonical_census.py
+++ b/tests/test_tessera_canonical_census.py
@@ -1,0 +1,57 @@
+"""Canonical census provenance comes from the loaded model, not CLI labels."""
+import importlib.metadata
+import json
+from types import SimpleNamespace
+
+import pytest
+import torch
+import prismaquant
+
+
+def fixture(monkeypatch,tmp_path):
+    from test_tessera_campaign_resume import _main_fixture
+    tc,_,argv,model,inputs = _main_fixture(monkeypatch,tmp_path)
+    model.config = SimpleNamespace(_attn_implementation='eager')
+    contract = dict(schema='prismaquant.pretrained_initialization.v1',
+        scope='checkpoint_missing_state',status='completed',
+        transformers_version=importlib.metadata.version('transformers'))
+    calls = []
+    def getter(actual):
+        assert actual is model
+        calls.append(actual)
+        return dict(contract)
+    monkeypatch.setattr(prismaquant,'pretrained_initialization_contract',getter)
+    path = tmp_path/'census.json'
+    return tc,argv+['--census-out',str(path)],model,contract,calls,path
+
+
+def test_census_binds_actual_model_initialization_and_backend(monkeypatch,tmp_path):
+    tc,argv,model,contract,calls,path = fixture(monkeypatch,tmp_path)
+    assert tc.main([*argv,'--attention-implementation','eager']) == 0
+    census = json.loads(path.read_text())
+    assert calls == [model]
+    assert census['model_load_contract'] == contract
+    assert census['attention_implementation'] == 'eager'
+    assert census['capture_runtime'] == dict(torch=torch.__version__,cuda=torch.version.cuda,
+        transformers=importlib.metadata.version('transformers'))
+
+
+def test_census_refuses_unrequested_backend(monkeypatch,tmp_path):
+    tc,argv,model,contract,calls,path = fixture(monkeypatch,tmp_path)
+    with pytest.raises(SystemExit,match='2'):
+        tc.main(argv)
+    assert not calls and not path.exists()
+    model.config._attn_implementation = 'sdpa'
+    with pytest.raises(RuntimeError,match='backend differs'):
+        tc.main([*argv,'--attention-implementation','eager'])
+    assert not path.exists()
+
+
+def test_census_refuses_model_without_initialization_evidence(monkeypatch,tmp_path):
+    tc,argv,model,contract,calls,path = fixture(monkeypatch,tmp_path)
+    def refuse(model):
+        raise ValueError('Missing or invalid pretrained initialization contract')
+    monkeypatch.setattr(prismaquant,'pretrained_initialization_contract',refuse)
+    with pytest.raises(ValueError,match='initialization contract'):
+        tc.main([*argv,'--attention-implementation','eager'])
+    assert not path.exists()

--- a/tests/test_tessera_capture_finalization.py
+++ b/tests/test_tessera_capture_finalization.py
@@ -1,0 +1,25 @@
+"""The collector must release obsolete capture buffers during finalization."""
+import weakref
+import torch
+from prismaquant import tessera_campaign as tc
+
+
+def test_scoring_chunks_are_released_between_units(monkeypatch):
+    model = torch.nn.Sequential(torch.nn.Linear(4,4,bias=False),
+                                torch.nn.Linear(4,4,bias=False)).to(torch.bfloat16)
+    tokens = [torch.arange(12).reshape(3,4).to(torch.bfloat16)]
+    original_cat = torch.cat
+    previous = []
+    def concatenate(chunks, *args, **kwargs):
+        assert all(ref() is None for ref in previous), 'previous unit scoring chunks retained'
+        previous[:] = [weakref.ref(value) for value in chunks]
+        return original_cat(chunks, *args, **kwargs)
+    monkeypatch.setattr(torch, 'cat', concatenate)
+    rows, hessians, counts, maxima = tc._collect_activations(
+        model,['0','1'],tokens,2,'cpu',want_hessian=True)
+    x = tokens[0].float()
+    y = model[0](tokens[0]).float()
+    assert torch.equal(rows['0'],x[:2]) and torch.equal(rows['1'],y[:2])
+    assert torch.equal(hessians['0'],x.T@x) and torch.equal(hessians['1'],y.T@y)
+    assert counts == {'0':3,'1':3}
+    assert maxima == {'0':float(x.abs().max()),'1':float(y.abs().max())}

--- a/tests/test_tessera_materialization.py
+++ b/tests/test_tessera_materialization.py
@@ -20,6 +20,10 @@ from test_tessera_export_projection import case, _meta, _units, FMT, STACK, N, D
 @pytest.fixture
 def selection(case, tmp_path):
     _pack(case)
+    # This materialization fixture checks actual source bytes as well as headers.
+    source = case.payload['__prismaquant__'][tep.PROJECTION_KEY]['producer']['source']
+    source['files'] = {name:tm._sha(case.model/name) for name in source['files']}
+    source['config_sha256'] = tm._sha(case.model/'config.json')
     config = copy.deepcopy(case.payload)
     assignment = canonicalize_assignment(config)
     meta = config['__prismaquant__']
@@ -250,7 +254,8 @@ def test_complete_selected_stack_needs_no_materialization_quantum(selection, mon
 
 
 @pytest.mark.parametrize('batch_size', [1, 2])
-def test_run_encodes_only_missing_selection_and_resume_verifies_existing_bytes(selection, monkeypatch, batch_size):
+@pytest.mark.parametrize('reuse', [False, True])
+def test_run_encodes_only_missing_selection_and_resume_verifies_existing_bytes(selection, monkeypatch, batch_size, reuse):
     from transformers import AutoModelForCausalLM
     from prismaquant import tessera_hessian as th
     s = selection
@@ -261,6 +266,24 @@ def test_run_encodes_only_missing_selection_and_resume_verifies_existing_bytes(s
         s.cost_path.write_bytes(pickle.dumps(s.cost))
         tm.write_selection_request(s.request, layer_config=s.config, assignment=s.assignment,
             cost_path=s.cost_path, cost_payload=s.cost, output_path=s.output)
+    if reuse:
+        from prismaquant import tessera_calibration_cache as cc
+        census = json.loads(s.census.read_text())
+        from test_tessera_calibration_cache import canonical_fields
+        import prismaquant
+        census.update(canonical_fields())
+        s.census.write_text(json.dumps(census))
+        monkeypatch.setattr(prismaquant,'pretrained_initialization_contract',lambda model:canonical_fields()['model_load_contract'])
+        cache_identity = cc.capture_identity(s.census,
+            calibration=s.cost['provenance']['hessian']['calibration_identity'],max_act_rows=4,
+            model_load_contract=canonical_fields()['model_load_contract'],attention_implementation='eager')
+        record = cc.publish_capture(s.workspace/'capture',census_path=s.census,
+            identity=cache_identity,acts={n:torch.ones(4,N) for n in _units()},
+            hessians={n:torch.eye(N) for n in _units()},counts=census['counts'],maxima=census['max_abs'])
+        s.cost['provenance']['calibration_cache'] = record
+        s.cost_path.write_bytes(pickle.dumps(s.cost))
+        tm.write_selection_request(s.request,layer_config=s.config,assignment=s.assignment,
+            cost_path=s.cost_path,cost_payload=s.cost,output_path=s.output)
     path, _data, _calls = _plan(s, monkeypatch)
     api = ReceiptAPI()
     api.make_unit_record = lambda blob, identity, filename: dict(file=filename,
@@ -271,7 +294,7 @@ def test_run_encodes_only_missing_selection_and_resume_verifies_existing_bytes(s
     weight = torch.ones(N,N)
     monkeypatch.setattr(tep, 'source_unit_weight', lambda *args:weight)
     monkeypatch.setattr(AutoModelForCausalLM, 'from_pretrained',
-                        lambda *args, **kwargs:SimpleNamespace(eval=lambda:None))
+                        lambda *args, **kwargs:SimpleNamespace(eval=lambda:None,config=SimpleNamespace(_attn_implementation="eager")))
     monkeypatch.setattr(tc, '_require_campaign_population', lambda *args:SimpleNamespace(
         members=[SimpleNamespace(qname=n, weight=weight) for n in _units()]))
     monkeypatch.setattr(tc, '_calibration_tokens', lambda *args:(torch.ones(2,4), 'fixture'))
@@ -279,6 +302,7 @@ def test_run_encodes_only_missing_selection_and_resume_verifies_existing_bytes(s
     monkeypatch.setattr(th, 'calibration_identity', lambda *args, **kwargs:calibration)
     captures = []
     def collect(model, targets, tokens, max_rows, device, **kwargs):
+        assert not reuse, 'materialization repeated the calibration forward'
         captures.append((list(targets), max_rows))
         return ({n:torch.ones(4,N) for n in targets}, {}, {n:8 for n in targets}, {n:1.0 for n in targets})
     monkeypatch.setattr(tc, '_collect_activations', collect)
@@ -306,13 +330,19 @@ def test_run_encodes_only_missing_selection_and_resume_verifies_existing_bytes(s
     tm.run(path, 0, anchor_batch_size=batch_size)
     assert measured == [(n,FMT) for n in expected_missing]
     assert batches == ([] if batch_size == 1 else [expected_missing])
-    assert captures == [(sorted(_units()),4)]
+    assert captures == ([] if reuse else [(sorted(_units()),4)])
     assert not s.output.exists()
     tm.run(path, 0, anchor_batch_size=1)
     assert measured == [(n,FMT) for n in expected_missing]
     report = tm.finalize(path)
     assert report['verified_source_units'] == len(_units())
 
+
+    if reuse:
+        with open(record['path'],'a') as handle:
+            handle.write(' ')
+        with pytest.raises(RuntimeError,match='priced calibration capture manifest changed'):
+            tm.run(path,0)
 
 def test_real_producer_wire_materialization_and_translator_handoff(tmp_path, monkeypatch):
     """Real source/capture/encoder/receipt/translator; no served-route scoring."""

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -83,7 +83,7 @@ PLAN_SCHEMA = "prismaquant.tessera_campaign_plan.v1"
 SHARED_PROVENANCE = (
     "menu_mode", "tp_degree", "model", "nsamples", "seqlen", "max_act_rows",
     "layer_stride", "anchors_round_one", "max_rounds", "anchor_budget",
-    "loo_gate", "max_artifact_bpp", "cost_mode", "rate_band",
+    "loo_gate", "max_artifact_bpp", "cost_mode", "rate_band", "calibration_cache",
 )
 
 #: Hessian identity fields every row must already agree on.  ``capture_sha256``
@@ -115,7 +115,8 @@ def load_spec(path: Path) -> dict:
             raise RuntimeError(f"{path}: spec has no {field!r}")
     forbidden = {"--model", "--out", "--cache-dir", "--checkpoint", "--units",
                  "--calibration-census", "--census-out", "--seed-checkpoint",
-                 "--seed-wire-dir"}
+                 "--seed-wire-dir", "--capture-calibration-out",
+                 "--calibration-cache", "--calibration-cache-sha256"}
     named = forbidden.intersection(spec["campaign_argv"])
     if named:
         raise RuntimeError(
@@ -237,6 +238,41 @@ def cmd_census(args) -> int:
         return _pbcampaign(manifest, wait_s=args.wait_s,
                            receipts=workspace / "census-receipts.json")
     return 0
+
+
+def cmd_capture(args) -> int:
+    """Submit one dependent full-scope capture through the existing PB adapter."""
+    spec = load_spec(Path(args.spec))
+    workspace = Path(args.workspace)
+    census_path = workspace / "census.json"
+    census = json.loads(census_path.read_text())
+    if census.get("model") != spec["model"]:
+        raise RuntimeError("capture census and spec name different models")
+    manifest = workspace / "capture-manifest.json"
+    row = _row(spec, ["--model", spec["model"],
+        "--out", str(workspace / "capture-unused.pkl"),
+        "--cache-dir", str(workspace / "capture-cache"),
+        "--calibration-census", str(census_path),
+        "--capture-calibration-out", str(workspace / "calibration-cache"),
+        *spec["campaign_argv"]],
+        mem_gb=_row_memory_gb(spec, sorted(census["counts"]), census),
+        timeout_s=int(args.timeout_s))
+    manifest.write_text(json.dumps([row], indent=2) + "\n")
+    if args.submit:
+        return _pbcampaign(manifest, wait_s=args.wait_s,
+                           receipts=workspace / "capture-receipts.json")
+    return 0
+
+
+def _calibration_cache_binding(path, census_path):
+    from prismaquant.tessera_calibration_cache import require_capture_contract, sha256
+    if not path:
+        return None
+    path = Path(path).resolve()
+    capture = require_capture_contract(path)
+    if capture["identity"].get("census_sha256") != sha256(census_path):
+        raise RuntimeError("planning requires a complete capture bound to this census")
+    return dict(path=str(path), sha256=sha256(path))
 
 
 def _pbcampaign(manifest: Path, *, wait_s: int, receipts: Path | None = None) -> int:
@@ -396,6 +432,8 @@ def cmd_plan(args) -> int:
         raise RuntimeError(
             f"census was taken on {census.get('model')!r}, the spec names "
             f"{spec['model']!r}")
+    calibration_cache = _calibration_cache_binding(
+        getattr(args, "calibration_cache", None), workspace / "census.json")
     groups = census["anchor_groups"]
     if not groups:
         raise RuntimeError("census reports no anchor group to price")
@@ -455,6 +493,9 @@ def cmd_plan(args) -> int:
             "--calibration-census", str(workspace / "census.json"),
             *spec["campaign_argv"],
         ]
+        if calibration_cache:
+            argv += ["--calibration-cache", calibration_cache["path"],
+                     "--calibration-cache-sha256", calibration_cache["sha256"]]
         if args.seed_checkpoint:
             argv += ["--seed-checkpoint", str(args.seed_checkpoint)]
             if args.seed_wire_dir:
@@ -478,6 +519,7 @@ def cmd_plan(args) -> int:
         "schema": PLAN_SCHEMA,
         "model": spec["model"],
         "census": str(workspace / "census.json"),
+        "calibration_cache": calibration_cache,
         "manifest": str(manifest),
         "groups_per_row": int(args.groups_per_row),
         "rows_per_box": per_box,
@@ -1095,9 +1137,19 @@ def main(argv=None) -> int:
     census.add_argument("--submit", action="store_true")
     census.set_defaults(func=cmd_census)
 
+    capture = sub.add_parser("capture", help="capture full-census X/H once before planning rows")
+    capture.add_argument("--spec", required=True)
+    capture.add_argument("--workspace", required=True)
+    capture.add_argument("--timeout-s", type=int, default=7200)
+    capture.add_argument("--wait-s", type=int, default=14400)
+    capture.add_argument("--submit", action="store_true")
+    capture.set_defaults(func=cmd_capture)
+
     plan = sub.add_parser("plan", help="lay the campaign out as pbcampaign rows")
     plan.add_argument("--spec", required=True)
     plan.add_argument("--workspace", required=True)
+    plan.add_argument("--calibration-cache", default=None,
+                      help="complete capture manifest to hash-bind into every row")
     plan.add_argument("--groups-per-row", type=int, default=1)
     plan.add_argument("--rows-per-box", type=int, default=1,
                       help="how many of these rows one box is meant to run at "


### PR DESCRIPTION
Anchor and selected-wire quanta currently repeat the full calibration forward. This adds one canonical capture dependency and reuses verified per-unit scoring inputs and full Hessians through the existing activation-cache writer, journal and prefetch path. Capture v2 refuses stale source bytes, changed draws, incomplete scope, unqualified initialization, attention mismatches and runtime drift; materialization derives the capture binding from the priced cost.

Separate commits release finalized capture buffers, keep maxima resident until the draw completes, require canonical census provenance, and add capture reuse. The optional packed boundary callback preserves original routed arguments and calibration coordinates for native validation. No format, serving gate or wire recipe changes.

Validation: integration compile checks and 176 CPU tests passed through PB `b2b5bac37cc5` with no skips; the amax regression failed before and passed after (76 passed, 5 CUDA-required skips). This clean delivery head passed compile checks and 137 targeted tests with no skips through PB `ace64b6c3499` (CAS `a304b329bb7eb58200672bb26a9826ff5bbdb0e16b3992ce023fabd7919d0ce5`). Canonical GPU capture and matched profiled comparisons remain in progress; no speedup is claimed yet. Evidence and commands are in `docs/reviews/2026-09-07/campaign-capture-reuse.md`, `campaign-capture-finalization.md`, and `campaign-amax-residency.md`.

Closes #305.
