### PR TITLE
Record canonical capture and matched reuse/maxima evidence

### DIFF
--- a/docs/reviews/2026-09-07/campaign-amax-residency.md
+++ b/docs/reviews/2026-09-07/campaign-amax-residency.md
@@ -31,3 +31,45 @@ and OMP/MKL/OpenBLAS threads bounded to one per worker:
 Initial submissions `be339e093292` and `4c1c3cdc5cd3` omitted the required
 Tessera import path and failed collection/imports. They are not behavioral
 results; the corrected invocations above supply that dependency explicitly.
+
+## Completed isolated canonical comparison
+
+The earlier profiling prerequisite is now satisfied by the seven-arm canonical
+measurement documented in [campaign-capture-reuse.md](campaign-capture-reuse.md).
+PB `0c4b585e8f43472a085435628bff68955d8bd6b546da2fe39a583dcb8d6ed821`
+exited 0; actual CAS payload
+`84b67475c6831a43c7b03f404e1827e81e051539ff87f0186d9ece2d46e7d349`
+and the broker's successful termination receipt were inspected. All arms
+preserve the finalized-buffer change, canonical initializer, eager attention,
+source checkpoint, 512 samples of 512 tokens, and the same 96 selected layer-10
+expert projections. The scalar-sync collector differs from the current
+collector only in the maxima hunk. Source bytes and `amax-only.diff` are
+retained under
+`/mnt/shared/tessera-measurements/first-model-20260907/capture-reuse/canonical-compare/frozen-source/`.
+No cached arm is included in the isolated maxima statistic.
+
+The ABBA order is device-max forward 3, scalar-sync forwards 4/5, device-max
+forward 6. Arm 3 is the shared endpoint with the separate reuse ABBA. Profiled
+scalar-sync times are **102.406 / 102.715 seconds**, versus device-max
+**101.423 / 100.154 seconds**. Medians are 102.561 and 100.789 seconds, a
+**1.73% observed reduction**. This is a small effect across only two repetitions
+per method; it does not establish a robust or general speedup, and it does not
+explain the much larger gain from skipping repeated forwards through reuse.
+Every arm exactly matches all 96 canonical X/H/count/max records.
+
+The before profiles have 1,938/2,023 samples; 195 samples in each fall at the
+per-batch scalar-read line. The after profiles have 2,076/1,976 samples, and
+the per-batch scalar-read site is absent by construction. Grouped-matmul frames
+remain the largest sampled Python location on both sides. These are sampled
+call locations, not CUDA event timing or a claim that every sampled scalar-read
+second becomes saved wall time.
+
+Both-host Netdata raw series and per-phase CPU/RAM/I/O/power summaries are
+retained alongside all four in-process profiles. Interpolated median GPU
+energy is **4,057.215 J scalar-sync versus 3,463.417 J device-max**, or 0.02366
+versus 0.02772 selected units per GPU joule (**1.17× observed work/J ratio**).
+Power uses ten-second sampling, with device-max means 31.821/36.938 W and
+scalar-sync 40.227/38.894 W; repeat variability and coarse telemetry limit the
+claim. This is GPU energy only, not whole-machine energy. Power is far below
+the approximate 140 W envelope, so these measurements do not establish GPU
+saturation. `derived-metrics.json` retains unrounded figures and limitations.

--- a/docs/reviews/2026-09-07/campaign-capture-reuse.md
+++ b/docs/reviews/2026-09-07/campaign-capture-reuse.md
@@ -61,3 +61,151 @@ regression. Failed-attempt artifacts are retained as bounded diagnosis under
 the broker's separate termination receipt confirms its scope stopped. The
 current fleet terminal JSON omits that cleanup field, so the separate receipt
 was inspected. This attempt provides no completed calibration or reuse result.
+
+## Completed canonical capture
+
+The native helper owner fixed the profile-property error, and replacement PB
+`13a85577915ce5349749e66bbab9b94e3d896f976e2689442a1e459d96eea4a6`
+completed on Sparklina with four assigned CPUs, 104 GiB aggregate memory and
+GPU measurement admission with no existing admitted members. Exit status, CAS stdout payload
+`ffd4a8a11b2ce6981c4456410b9573a79cc114ced07505bebac1bb1ad38038ed`, and the
+separate broker termination receipt were inspected. The known-good image was
+`sha256:9f9b9f05b17531399ba66dc6415b054cf5d68c82270626d0e9150e75c808435f`,
+with Torch 2.13.0+cu130, CUDA 13.0, canonical checkpoint initialization and
+explicit eager attention. All 2,142 units (30 dense projections and 2,112 expert
+projections) were persisted and sealed; the files total 41,938,210,454 bytes.
+The producer verified every entry; independent inspection checked the complete
+roster, file presence, three representative artifact hashes and the boundary
+hash. Each reuse quantum additionally rehashes its selected files.
+
+Evidence root:
+`/mnt/shared/tessera-measurements/first-model-20260907/capture-reuse/canonical/`.
+The completed `capture_manifest.json` SHA256 is
+`db3cd996ee8a3ac82d62c6e7e2f23cdb995874b831adcf9360acdae682654823`.
+`verified-receipt.json` links the terminal, CAS, token, profile and boundary
+receipts. The token safetensors file SHA256 is
+`a38312e3b1eeecc2a4363d2a91739ba535388036d4910bffa815d451dcb9a940`.
+The original layer-2 routed boundary is retained at
+`native-boundary/model__layers__2__feed_forward__experts.pt`, SHA256
+`1290dd0dcb4ebecd09aee9fd2427aae62cb9c09974a466c05dcbe1ff08c6874d`;
+it preserves BF16 inputs/weights, int64 route IDs and sample/token coordinates,
+and the actual float32 expert bias. Its separate consumer qualification is
+outside this capture-reuse change.
+
+The full collector took **553.835 seconds under py-spy**, with 10,289 samples;
+its profile SHA256 is
+`63f6e8a13ddf818819407e7baeebca8275e562e7ede42cc238233622c45df999`.
+Peak CUDA allocated/reserved bytes were 50,762,741,760 / 52,204,404,736;
+process peak RSS was 48,187,324 KiB. Sampled Python leaves included grouped
+matmul (4,446 samples) and per-expert route derivation (1,363); these are sample
+locations, not CUDA kernel timings. Setup, persistence (197.662 seconds) and
+sealing (46.793 seconds) have wall timers only, despite the harness's generic
+`kind=profile` phase label. No in-process profile is claimed for those phases.
+
+`netdata-both-hosts.json` retains raw series from both machines. During the
+collector, Sparklina sampled GPU power averaged 33.980 W, with a linearly
+interpolated integral of 18,819.128 J at 10-second sampling. Host CPU user/system
+means were 4.810% / 1.728%; CPU and RAM series bracket the phase without gaps.
+This power is about 24% of the GB10's approximate 140 W envelope; the run does
+not establish GPU saturation. Sparky averaged 4.163 W, but its CPU/RAM
+integrals were refused because the series had gaps. These are absolute capture
+measurements, not a before/after delta against the rejected initializer.
+
+## Clean delivery validation
+
+The four implementation commits were replayed onto current main after its
+canonical initializer fix, preserving separate finalization, maxima, census
+and reuse changes. PB
+`ace64b6c34994bebe6f08e95eae145ef3801430e9add66de1b0cafd8900c7e76`
+checked the clean delivery head with compile checks and **137 passing tests,
+no skips**, exit 0, 77.26 seconds. Inspected CAS payload:
+`a304b329bb7eb58200672bb26a9826ff5bbdb0e16b3992ce023fabd7919d0ce5`.
+The five touched production modules match the earlier integration-tested
+source byte for byte. The native helper is a separate committed dependency of
+the full-capture measurement harness and is not included in this PR.
+
+## Matched profiled reuse comparison
+
+PB `0c4b585e8f43472a085435628bff68955d8bd6b546da2fe39a583dcb8d6ed821`
+completed all seven arms with exit 0. The actual CAS payload was rehashed and
+read at
+`/mnt/shared/prismabuild-fleet/cas/blobs/84/84b67475c6831a43c7b03f404e1827e81e051539ff87f0186d9ece2d46e7d349`;
+the broker's separate termination receipt reports `result.ok=true`.
+The evidence root is
+`/mnt/shared/tessera-measurements/first-model-20260907/capture-reuse/canonical-compare/`.
+`verified-receipt.json` binds terminal/CAS, all seven profiles and derived
+results; `receipt.json`, `derived-metrics.json`, `netdata-both-hosts.json` and
+`frozen-source/` retain timings, raw telemetry, analysis code, exact harness
+sources, hashes and the maxima-only source diff. The PB campaign input is
+`frozen-source/canonical-compare-campaign.json`; its admitted command is
+`python3 -m tools.run_campaign_capture_baseline --module tools.campaign_capture_compare`.
+
+The workload selects the 96 projections of
+`model.layers.10.feed_forward.experts` from the same canonical 512-by-512 draw
+and full-model capture above. Source model, explicit eager attention, tokens,
+unit roster, full Hessians, scoring-prefix policy, device and container match.
+The model and tokens load once before all arms. Every forward arm completes the
+same full-model draw, collecting only those 96 units. Every cached arm rehashes
+source identity and selected capture artifacts, validates them and makes X/H
+resident. Both methods stop at the same resident-ready boundary; separate
+comparison/encoding and shared initial model/token setup are excluded.
+All seven arms include py-spy at 20 Hz. PB assigned Sparklina CPUs 5–8,
+50 GiB aggregate memory and measurement admission with no existing admitted
+GPU members. Native thread limits remained four. This is a preparation-stage
+comparison, not an end-to-end encoding or served-throughput benchmark.
+
+| Arm | Profiled seconds | Mean sampled GPU W | Interpolated GPU J |
+| --- | ---: | ---: | ---: |
+| 0 forward, device maxima | 103.144 | 31.480 | 3,247.026 |
+| 1 cached | 12.348 | 16.624 | 205.282 |
+| 2 cached | 12.315 | 15.747 | 193.915 |
+| 3 forward, device maxima | 101.423 | 31.821 | 3,227.401 |
+| 4 forward, scalar-sync maxima | 102.406 | 40.227 | 4,119.456 |
+| 5 forward, scalar-sync maxima | 102.715 | 38.894 | 3,994.973 |
+| 6 forward, device maxima | 100.154 | 36.938 | 3,699.434 |
+
+Reuse uses arms 0/1/2/3 in ABBA order. Median preparation time changes from
+**102.284 to 12.331 seconds: 8.295× throughput, 87.94% less elapsed time** on
+this selected scope. Median interpolated GPU energy changes from 3,237.213 to
+199.598 J, corresponding to 0.02966 versus 0.48097 selected units per GPU
+joule, a **16.22× sampled work-per-joule ratio**. GPU power is sampled every ten
+seconds, and each cached arm lasts only about twelve seconds; these integrals
+are coarse telemetry estimates, not precision energy measurements or whole-
+machine energy. Two repetitions on one scope/model/device do not establish a
+confidence interval or a general speedup across workloads. Persistence and the
+one-time full capture cost must also be amortized across reuse quanta.
+
+The in-process profiles explain the change. Forward arms 0/3 have 2,065/2,076
+samples; deepest Python grouped-matmul frames account for 1,353/1,382. Cached
+arms have 248/252 samples, of which 219/229 fall in `hashlib.file_digest`.
+The cached path has eliminated the repeated model forward, but its remaining
+preparation cost is dominated by content hashing and validation; GPU saturation
+is not established. This identifies remaining CPU preparation overhead without
+weakening source-content checks or inferring a further unmeasured speedup.
+
+Both hosts' CPU, RAM, I/O and GPU power series bracket all comparison phases
+without refused integrals. Sparklina host CPU user means range 4.568–4.936%,
+system 1.336–1.501%, and process peak RSS stays at 17,500,120 KiB. Peak CUDA
+allocated memory stays below 19.0 billion bytes and reserved below 19.1 billion
+bytes. Sparky's simultaneous sampled GPU power means range 4.0–13.011 W;
+its activity is preserved as external context and excluded from this GPU-energy
+ratio. Sparklina's 15.747–40.227 W range is about 11–29% of the approximate
+140 W GB10 envelope. GPU utilization percentages are not used to infer
+saturation or rank implementations.
+
+Every arm passed exact equality of all 96 scoring-input tensors, full Hessians,
+counts and maxima against the canonical per-unit files. Forward arm 0 and
+cached arm 1 also encoded expert 0's w1/w2/w3 using
+`TESSERA_E4M3_K1_R1024`; all three wire hashes, sizes and scored `dloss` values
+match exactly. The six output wire files were independently rehashed.
+The dloss values are 0.00011898282848830734, 0.0000005687553539246437 and
+0.00009622986960623945 respectively. This validates identical bytes and scored
+loss for those encodes; it adds no served-runtime, model-level KL or format-
+quality claim.
+
+The first comparison attempt `f3c07fbaa5e4` completed one 99.708-second forward
+and exact tensor comparisons, then failed because its measurement harness had
+not created the PWC output directory before encoding. The corrected harness
+creates that directory and records failed phase status explicitly. The failed
+attempt remains under `canonical-compare-harness-failed-f3c07fbaa5e4`; none of
+its timings enter the completed ABBA statistics.

--- a/tests/test_model_walk_export_gate.py
+++ b/tests/test_model_walk_export_gate.py
@@ -214,8 +214,9 @@ def test_save_load_roundtrip_preserves_the_result_payload(tmp_path):
 
 
 def test_load_walk_refuses_foreign_schema(tmp_path):
-    path = save_walk(_walked(), tmp_path / "walk.json",
-                     provenance=_walked().provenance)
+    result = _walked()
+    path = save_walk(result, tmp_path / "walk.json",
+                     provenance=result.provenance)
     payload = json.loads(path.read_text())
     payload["schema"] = "prismaquant.model_walk.v999"
     path.write_text(json.dumps(payload))


### PR DESCRIPTION
Records the completed canonical 2,142-unit capture and matched seven-arm profiled comparison after #315. On the fixed 96-unit scope, capture reuse changes median preparation from 102.284 to 12.331 seconds (8.295×); the separate maxima-only comparison changes 102.561 to 100.789 seconds (1.73%). The report states the two-repeat and sampled GPU-energy limits and identifies hashing as the remaining cached preparation cost.

All seven arms exactly match canonical X/H/count/max records, and three forward/cache native wire encodes have identical bytes and scored loss. PrismaBuild action `0c4b585e8f43` exited 0; actual CAS `84b67475c6831a43c7b03f404e1827e81e051539ff87f0186d9ece2d46e7d349`, all profiles, both-host raw Netdata, frozen source, six wire hashes and broker termination were independently inspected. The append-only report also retains failed-attempt dispositions. `git diff --check` passes. No extra tests were added for the prose update.

Separate incidental test fix: `test_load_walk_refuses_foreign_schema` now saves the result with provenance from that same walk. The previous fixture called the walker twice and failed whenever their timestamps crossed a second boundary, before reaching its schema-refusal assertion. CI run `34093110365` reproduced the failure (6,007 passed, 160 skipped, 3 xfailed). Targeted PrismaBuild action `034e8bdc47623817c8119ee9ea19bbfad24ddc0c43e507a2b2cb362dde587645` passed 50 tests with one skip (the unavailable DSv4 source config) across the model-walk and export-gate files on the CPU fleet, four workers and one native thread each, exit 0. Actual CAS `120e1a0e5e4021f124138a82120157bfcf8eb858aa07df33bb70bac8e391d3ec` was independently rehashed; the raw result is retained with the action.

Closes #305.

