### PR TITLE
Price packed source Linears with streamed joint AURA

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,7 +13,9 @@ logical projections. The signed residual lease observes the unchanged packed
 expert row offsets, splits fused outputs according to the profile, and restores
 its taps on success or failure. An unobserved packed implementation refuses.
 Each source Linear receives its own aligned joint row, source/render identities
-and activation policy; repeated calls and the three local residual terms sum
+and activation policy. Probe identities also seal each module's resolved attention
+and expert backend; a changed backend refuses checkpoint resume, and mutation
+during measurement refuses before that layer's rows are written. Repeated calls and the three local residual terms sum
 while signed within that Linear before squaring. The allocator's additive
 per-Linear objective is unchanged. Original decoded `ProductionWeightCache`
 entries are required; the dense-only on-demand renderer refuses before the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,24 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-07 · `integration/native-panel-267`. Stamps
+As of: 2026-09-07 · `feat/packed-joint-aura`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-07, `feat/packed-joint-aura`) for **joint costs for
+profile-declared packed source Linears** (#313). Opt-in streamed joint AURA
+with routed experts extends `PackedExpertProjection` views over the original
+packed Parameters. Views refresh after each shared streaming install/unload;
+one gradient hook per physical leaf distributes the existing gradient into its
+logical projections. The signed residual lease observes the unchanged packed
+`F.linear` calls, splits fused outputs according to the profile, and restores
+its taps on success or failure. An unobserved packed implementation refuses.
+Each source Linear receives its own aligned joint row, source/render identities
+and activation policy; repeated calls and the three local residual terms sum
+while signed within that Linear before squaring. The allocator's additive
+per-Linear objective is unchanged. Original decoded `ProductionWeightCache`
+entries are required; the dense-only on-demand renderer refuses before the
+source forward. LFM exposes 96 w1/w3/w2 source rows per 32-expert block, while
+native runtime binding still assigns one whole-block measurement to that roster.
+Gates: `tests/test_joint_aura_packed.py`, `tests/test_joint_aura_lease_lifetime.py`.
 
 Re-stamped (2026-09-07, `integration/native-panel-267`) for **exact calibration
 draw intake** (#267, #237). The shared AURA CLI accepts an independently hashed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,7 +9,8 @@ with routed experts extends `PackedExpertProjection` views over the original
 packed Parameters. Views refresh after each shared streaming install/unload;
 one gradient hook per physical leaf distributes the existing gradient into its
 logical projections. The signed residual lease observes the unchanged packed
-`F.linear` calls, splits fused outputs according to the profile, and restores
+`F.linear` or `F.grouped_mm` calls, validates packed transposes and cumulative
+expert row offsets, splits fused outputs according to the profile, and restores
 its taps on success or failure. An unobserved packed implementation refuses.
 Each source Linear receives its own aligned joint row, source/render identities
 and activation policy; repeated calls and the three local residual terms sum

--- a/docs/design/joint_aura_runtime_allocation.md
+++ b/docs/design/joint_aura_runtime_allocation.md
@@ -43,8 +43,9 @@ it does not establish the quality of every joint assignment.
 
 `--include-routed-experts` with streamed joint AURA also accepts the existing
 profile-declared `PackedExpertProjection` views. A packed source is observed
-through its actual per-expert `F.linear` slices; its model, routing and source
-arithmetic remain intact. Fused gate/up output gradients are split using those
+through its actual per-expert `F.linear` slices or `F.grouped_mm` packed
+transposes and cumulative expert row offsets. Its model, expert backend, routing
+and source arithmetic remain intact. Fused gate/up output gradients are split using those
 exact views. Source views refresh at each streaming install and unload, and a
 single hook on each packed leaf serves its logical members. An implementation
 that bypasses the declared Linear boundaries refuses instead of emitting an

--- a/docs/design/joint_aura_runtime_allocation.md
+++ b/docs/design/joint_aura_runtime_allocation.md
@@ -39,6 +39,27 @@ not uncertainty over new calibration data or evidence of generalization.
 The additive sum of local quadratic prices is still a model approximation;
 it does not establish the quality of every joint assignment.
 
+### Packed source projections
+
+`--include-routed-experts` with streamed joint AURA also accepts the existing
+profile-declared `PackedExpertProjection` views. A packed source is observed
+through its actual per-expert `F.linear` slices; its model, routing and source
+arithmetic remain intact. Fused gate/up output gradients are split using those
+exact views. Source views refresh at each streaming install and unload, and a
+single hook on each packed leaf serves its logical members. An implementation
+that bypasses the declared Linear boundaries refuses instead of emitting an
+unobserved zero price. A genuinely unrouted member still receives aligned zero
+samples.
+
+The LFM packed block produces 96 source-Linear rows (32 experts times w1/w3/w2),
+with each member's actual rendered weight and activation policy. These require
+original decoded production-cache entries; the on-demand dense renderer is not
+an adapter for packed sources and refuses early. All repeated uses of the SAME
+logical Linear sum while signed before squaring. Different members remain
+separate unary prices under the existing additive objective. A whole-block
+runtime measurement binds the complete roster without inventing a group quality
+price; the explicitly requested diagnostics below remain available.
+
 ## Assignment diagnostics
 
 `joint_aura.assignment_probe_summary` and `paired_assignment_difference`

--- a/docs/measurements/lfm-packed-joint-aura-2026-09-07.json
+++ b/docs/measurements/lfm-packed-joint-aura-2026-09-07.json
@@ -1,0 +1,458 @@
+{
+  "schema": "prismaquant.packed_joint_screen.evidence.v1",
+  "scope": "canonical_row0_operator_screen",
+  "final_cost": "cost-02/joint-cost.json",
+  "source_proof": "source-03/results.json",
+  "superseded": {
+    "source-01": "fail-closed grouped source before observer support",
+    "source-02": "explicit eager diagnostic; not the canonical source backend",
+    "cost-01": "numeric pass before source-backend identity sealing"
+  },
+  "artifacts": [
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/cost-01/joint-cost.json",
+      "bytes": 53753019,
+      "sha256": "9e9072b0eaa3e4f1b9b53bea295dd9ac366b11054f4b78f802ff121199e378a5"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/cost-01/model_identity.json",
+      "bytes": 252894,
+      "sha256": "7df54e965502049485b352d2201a2a5eb319c71ffce456bf8952c4e626b57ee6"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/cost-01/netdata-both-hosts.json",
+      "bytes": 54230,
+      "sha256": "dadae36ea933ee12f01b132a1ea013800fb8712a670fc3797213c63aa7aa244d"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/cost-01/results.json",
+      "bytes": 259199,
+      "sha256": "9962ad1f847e516b9560c448425a5abf19b221f88662c79af1ac9e40e0044171"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/cost-01/streamed_packed_joint.pstats",
+      "bytes": 414467,
+      "sha256": "a1ac6246214a65209e3d7560827d772195c1779130f032293f871c4ea0227928"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/cost-02/joint-cost.json",
+      "bytes": 55126885,
+      "sha256": "fcf48abdb0e0b1d8bc324c5c938b9b68ebb821f1c5b0591aefffb4b7c3c45462"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/cost-02/model_identity.json",
+      "bytes": 252894,
+      "sha256": "7df54e965502049485b352d2201a2a5eb319c71ffce456bf8952c4e626b57ee6"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/cost-02/netdata-both-hosts.json",
+      "bytes": 50064,
+      "sha256": "964bb56ec55dc9a6056b73ee2b17372a3006f4866b2e355d822808eeb3442997"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/cost-02/results.json",
+      "bytes": 259197,
+      "sha256": "d4732454841403fe79554a5fe1b6166fda1795ae410378bbe43b216c541a2e95"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/cost-02/streamed_packed_joint.pstats",
+      "bytes": 420546,
+      "sha256": "e96a8d131dc52acd9a60b1cf4eb9c8e00c05cfb473f0d6f86a756783f036c742"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/harness/lfm_packed_joint_screen.py",
+      "bytes": 14531,
+      "sha256": "60e8c15ef49085e8c9730bc877a64e35a44b7849fcd249dc741b1ad8bf43e87d"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/harness/lfm_packed_joint_screen.sh",
+      "bytes": 897,
+      "sha256": "6d1ceeab69427b0c674dfe7e525e5d9178ae5f63014052e977d79740172c8530"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/harness/lfm_stream_cpu_pytest.sh",
+      "bytes": 894,
+      "sha256": "a74a309609d296f8e8bb12f45e3434b0036f4e29dc115e996d4d488a0186aefb"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/operator-subset/calibration_tokens.safetensors",
+      "bytes": 4928,
+      "sha256": "ba4482b67fa9256ce48579182504a94cfc5d29f8d0057337b22ca303373c7cc7"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/1b8d78e28352.stderr.log",
+      "bytes": 788,
+      "sha256": "4bcc954ff4293459740438ab5d34f9d2f8aa3afb18a706d32862d1d51d4ef578"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/1b8d78e28352.stdout.log",
+      "bytes": 8191,
+      "sha256": "7a9afc06bbfaa902ff4b45b1330a29630389c86c991bc621a2a57299e773c263"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/1b8d78e28352.terminal.json",
+      "bytes": 1512,
+      "sha256": "5a9ece02b7abeed24c1a2e35b5cc4170d5fe7d3d02abe72bc28dab357b94b6a8"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/3398c8e2b688.cas.json",
+      "bytes": 2625,
+      "sha256": "72f78a86d723003a8cc39df6793d1393b3a5c8d73d9fa6ed41bfad257879b416"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/3398c8e2b688.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/3398c8e2b688.stdout.log",
+      "bytes": 3811,
+      "sha256": "22dfc60ef4812c58c1e29d8243cb7b3556b8e1aaecef55372b66ddfb0deb95dd"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/3398c8e2b688.terminal.json",
+      "bytes": 2306,
+      "sha256": "4dfa1bf1060cf948fd8edfe58755c9d22d49ec78a47cd61ae73838aba6f78519"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/39c37cd27620.stderr.log",
+      "bytes": 788,
+      "sha256": "4bcc954ff4293459740438ab5d34f9d2f8aa3afb18a706d32862d1d51d4ef578"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/39c37cd27620.stdout.log",
+      "bytes": 6622,
+      "sha256": "a31ddef3d958ff3e0f3e305aecdef62fb385c1a3d604dc1bb0c58e3227a7c68c"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/39c37cd27620.terminal.json",
+      "bytes": 2124,
+      "sha256": "cbfb9620ba6afc59e6c45ba5cd191615296d7bff5efb72ab6becfc65a7e5a750"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/4dfe87cc2196.cas.json",
+      "bytes": 2625,
+      "sha256": "c60769da7577b11189b41f7b28d8e8fe1b2c3486db51e8c861ea15a0334b327e"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/4dfe87cc2196.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/4dfe87cc2196.stdout.log",
+      "bytes": 3811,
+      "sha256": "e35166711fa7a4534c02f122af0d812bfca216ff1a69a6b0930cd0cc598e7ddb"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/4dfe87cc2196.terminal.json",
+      "bytes": 2308,
+      "sha256": "7e7207a179d29714814cb14e0b147f0dbb20199f51d9c8322ef354b380c53475"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/4f66c9b25ccb.stderr.log",
+      "bytes": 788,
+      "sha256": "e7a99d88c97eaca6f70d8c37214c8f1c0c44f21ef0983ef41356eb13203c7c4c"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/4f66c9b25ccb.stdout.log",
+      "bytes": 173,
+      "sha256": "48c3d3ace182f667e94473127c2901ededd9876c09c252c9dffda3cfcc07d664"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/4f66c9b25ccb.terminal.json",
+      "bytes": 1506,
+      "sha256": "cc941eae929e388afed035f6a3a04c89426f5b71b651513b0980c2bb6f89f15b"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/567ebd4a94a9.stderr.log",
+      "bytes": 788,
+      "sha256": "4bcc954ff4293459740438ab5d34f9d2f8aa3afb18a706d32862d1d51d4ef578"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/567ebd4a94a9.stdout.log",
+      "bytes": 14442,
+      "sha256": "552f51e9a87781ea5d0537f319a919cd667991a21c5dedc964e462973fa5b6d9"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/567ebd4a94a9.terminal.json",
+      "bytes": 1511,
+      "sha256": "122f37e0536570166eb74697bc7cbdcb59026c20069858c557f6937719f80779"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/584254592eb3.cas.json",
+      "bytes": 2625,
+      "sha256": "bdb45b73405572f3ef02f04058a0ae50f11f332cdb9fb7c82d0609adcf28d2cc"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/584254592eb3.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/584254592eb3.stdout.log",
+      "bytes": 3596,
+      "sha256": "9649a19328b36bd66d02ae67e10cb24ba0ba9b3bc60f29e6cb3dc0f704626d36"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/584254592eb3.terminal.json",
+      "bytes": 1699,
+      "sha256": "3eb22ea2e5c4cfdb4a065d7690977a23ff63b0e8c4fc59ef6274d50c8cdaf268"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/6139a113829a.cas.json",
+      "bytes": 2624,
+      "sha256": "25baf656483607daba6b516914666290d0ab5c9caa421cd7720725642be8bb14"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/6139a113829a.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/6139a113829a.stdout.log",
+      "bytes": 3107,
+      "sha256": "045320a5ef444f8521b1f877f4cff031509df7fe175fda9e1274773b70ae3e45"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/6139a113829a.terminal.json",
+      "bytes": 1697,
+      "sha256": "955c9e42f48abd1dd8d2a3fa53d92ec69969cd144337be7b3e75a8ae99ac47c6"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/6c48859f61f9.cas.json",
+      "bytes": 2624,
+      "sha256": "c89f2d60695f962f34d8774d433bc2f92944ee717f26ea6b3e90d3522952645a"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/6c48859f61f9.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/6c48859f61f9.stdout.log",
+      "bytes": 3108,
+      "sha256": "13ff289a2d01f8d1b344c00fcf344aa5951e3005d28629a860dfc0d249365f72"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/6c48859f61f9.terminal.json",
+      "bytes": 1699,
+      "sha256": "1029f891ef20d199ede1402ccda95a4d58054831d195e303f8eb6d077655f1fa"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/8f08b0728520.stderr.log",
+      "bytes": 788,
+      "sha256": "4bcc954ff4293459740438ab5d34f9d2f8aa3afb18a706d32862d1d51d4ef578"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/8f08b0728520.stdout.log",
+      "bytes": 5097,
+      "sha256": "d2074c97f0cbf99fd0fb750ef1b352594c23e2b17663a14151a05d198251fa75"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/8f08b0728520.terminal.json",
+      "bytes": 1518,
+      "sha256": "1bcf33e0dc33d666fc11bfba0734283c933d4e6dc2ffc3e042c8fe936480cf64"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/910381a7f145.cas.json",
+      "bytes": 2624,
+      "sha256": "30d51c63e13b47db2f031010be962217dea23e8aa49f0abbd1151f17b74c0a75"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/910381a7f145.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/910381a7f145.stdout.log",
+      "bytes": 3107,
+      "sha256": "2e60846228874f1e07a1d10b0f22712ec31c3d1e75aec1756cd630f4179ce15a"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/910381a7f145.terminal.json",
+      "bytes": 1696,
+      "sha256": "9b69479355031be00e9bee20f021dfa0d11104f956f66b46f997ff1f705ec142"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/92d4c7353b5a.cas.json",
+      "bytes": 2631,
+      "sha256": "a29c33b64579cd2519e66826cde037e25f67615e71403ffe72128cdad4a1fd91"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/92d4c7353b5a.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/92d4c7353b5a.stdout.log",
+      "bytes": 3601,
+      "sha256": "b9e7e5ee0f8141b1350687687360bc6ea4c6d3b19939c89707767dd3661b18aa"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/92d4c7353b5a.terminal.json",
+      "bytes": 1706,
+      "sha256": "f12406d8a429b08907d28bc52922304748a165e0d14cb0902374d2558866a42e"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/9c91cb5cf200.cas.json",
+      "bytes": 2625,
+      "sha256": "48cc54db48a819a396fac80fd45ea43c56898ebce0d1819d4ad157ecb33ad925"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/9c91cb5cf200.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/9c91cb5cf200.stdout.log",
+      "bytes": 5150,
+      "sha256": "42516698c1e4b173d92905bb4f02789e24b1ebcc5b4a58623437e2df8a3ed2d0"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/9c91cb5cf200.terminal.json",
+      "bytes": 2304,
+      "sha256": "b4ab48b3864b6d43044e67c31c400433f7355ca884d8f0466985c1b280da267e"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/a9a456a0c731.cas.json",
+      "bytes": 2625,
+      "sha256": "ff46abb05ec2339c8c71af55b7ab1a74e67290b866d92bbf6cb111e30f5b63a4"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/a9a456a0c731.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/a9a456a0c731.stdout.log",
+      "bytes": 3596,
+      "sha256": "33ba3727e4abd47c9b9c880a15a8f668a47191a3d7081389cd1b7be0047f2cdd"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/a9a456a0c731.terminal.json",
+      "bytes": 1700,
+      "sha256": "aa125dc28cb9718dab96dfcf44b186616e02a1b6e15b55abc42a6ca23319ce2d"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/d74f632a40ce.stderr.log",
+      "bytes": 788,
+      "sha256": "e7a99d88c97eaca6f70d8c37214c8f1c0c44f21ef0983ef41356eb13203c7c4c"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/d74f632a40ce.stdout.log",
+      "bytes": 173,
+      "sha256": "48c3d3ace182f667e94473127c2901ededd9876c09c252c9dffda3cfcc07d664"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/d74f632a40ce.terminal.json",
+      "bytes": 1505,
+      "sha256": "fd59d015753fe99c9a30e9ccd0b87729d29516b6a3b904876f24c0bd50f33e6f"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/f45f37939d43.cas.json",
+      "bytes": 2631,
+      "sha256": "098d07163499f84fd6ae2bb63c95dec732631b103de5fdc15085533950a72359"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/f45f37939d43.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/f45f37939d43.stdout.log",
+      "bytes": 5007,
+      "sha256": "3e73023fd3cfe4d29576e2053e297a0366b92a9ef948790c8a8dfc7d0d28fb1e"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/f45f37939d43.terminal.json",
+      "bytes": 2313,
+      "sha256": "745e404566b24689b5fd709b95d1cb34c5b441dd797407c953924957ce76f131"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-01/model_identity.json",
+      "bytes": 252894,
+      "sha256": "fa7a85734252375df0d01fe5003efc065688348c3c535535305bc9f64d47d339"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-01/resident_reference_forward_backward.pstats",
+      "bytes": 197198,
+      "sha256": "95ff401d3a1c1bbee116862bcccc33c61aa4871777341335b9f74d447546ab31"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-01/results.json",
+      "bytes": 258979,
+      "sha256": "1d5d2d1758f60fb11eb673001bc3ea3c8469573740097008a42929cc93c90fd4"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-01/streamed_packed_joint.pstats",
+      "bytes": 127318,
+      "sha256": "2f8da9af233766bb43eddd305b637bb38decf581c98d51de43377ce921db1739"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-02/calibration_subset.safetensors",
+      "bytes": 4184,
+      "sha256": "3bfed5390950e170914c54116d8e0d8f7a122c22f23b6225e5b4f4147c767d90"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-02/joint-cost.json",
+      "bytes": 27115224,
+      "sha256": "c27639e7dc9d92c8d8ec14ba1d16a78168b0ce5159d47bd7a7a8a77b16619e5d"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-02/model_identity.json",
+      "bytes": 252894,
+      "sha256": "fa7a85734252375df0d01fe5003efc065688348c3c535535305bc9f64d47d339"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-02/resident_reference_forward_backward.pstats",
+      "bytes": 195879,
+      "sha256": "2dff499d7dc408f0369348fdcdb2812d72c7b2ee75cd8bba826fa041ac7de529"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-02/results.json",
+      "bytes": 262307,
+      "sha256": "94386032024ced25bcd416ef39e2b5f6d30fb02251df595a0fdf165046e57ae4"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-02/streamed_packed_joint.pstats",
+      "bytes": 152195,
+      "sha256": "9f1713b341a1478aaad4704cf63ec6f55e4943c58c8b5e74a0d93e6cff437961"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-03/calibration_subset.safetensors",
+      "bytes": 4184,
+      "sha256": "3bfed5390950e170914c54116d8e0d8f7a122c22f23b6225e5b4f4147c767d90"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-03/joint-cost.json",
+      "bytes": 27115235,
+      "sha256": "ff640ffb7a0cf3ddf022331fd18b7f6273bb7846acc547944529e7e5e9410094"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-03/model_identity.json",
+      "bytes": 252894,
+      "sha256": "7df54e965502049485b352d2201a2a5eb319c71ffce456bf8952c4e626b57ee6"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-03/netdata-both-hosts.json",
+      "bytes": 62803,
+      "sha256": "a5e7e8100df2280dca5e17fe01df6023c06014f45224b4ddc92fa3323a6ebd71"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-03/resident_reference_forward_backward.pstats",
+      "bytes": 202374,
+      "sha256": "377bacdc1d941f9dc75074a1ded21dd3b76d82002568d50775518242b9b5efcd"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-03/results.json",
+      "bytes": 262759,
+      "sha256": "f9f586b721bbdcfa1c261d8566507ba95d8b66138f43ef91124f40c89a13db9a"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-03/streamed_packed_joint.pstats",
+      "bytes": 153670,
+      "sha256": "0f7cb43b230ebfe7e9a4b11f3a6c770a85d28a9f7f53a32f90ead200aef462a6"
+    }
+  ]
+}

--- a/docs/measurements/lfm-packed-joint-aura-2026-09-07.json
+++ b/docs/measurements/lfm-packed-joint-aura-2026-09-07.json
@@ -2,7 +2,7 @@
   "schema": "prismaquant.packed_joint_screen.evidence.v1",
   "scope": "canonical_row0_operator_screen",
   "final_cost": "cost-02/joint-cost.json",
-  "source_proof": "source-03/results.json",
+  "source_proof": "source-04/results.json",
   "superseded": {
     "source-01": "fail-closed grouped source before observer support",
     "source-02": "explicit eager diagnostic; not the canonical source backend",
@@ -61,8 +61,8 @@
     },
     {
       "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/harness/lfm_packed_joint_screen.py",
-      "bytes": 14531,
-      "sha256": "60e8c15ef49085e8c9730bc877a64e35a44b7849fcd249dc741b1ad8bf43e87d"
+      "bytes": 17168,
+      "sha256": "c4dd617894467c9abe5d6a3004330123041d043c1af92363fd1d77bc3a806a9c"
     },
     {
       "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/harness/lfm_packed_joint_screen.sh",
@@ -350,6 +350,26 @@
       "sha256": "fd59d015753fe99c9a30e9ccd0b87729d29516b6a3b904876f24c0bd50f33e6f"
     },
     {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/e46ba7cf0b4f.cas.json",
+      "bytes": 2631,
+      "sha256": "ba466beb96da86ecc54f56524f3672da1308dcd2337ea8969be1c7d521c65038"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/e46ba7cf0b4f.stderr.log",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/e46ba7cf0b4f.stdout.log",
+      "bytes": 5320,
+      "sha256": "3c8704b583ddbe14e16ac72df8cccee6ab777e5ecea6c8c286788845364aea04"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/e46ba7cf0b4f.terminal.json",
+      "bytes": 2312,
+      "sha256": "9d2d7ffe72e5b8b570efffe976aa55984a29d311f0388f0ad8fab386cdf45d03"
+    },
+    {
       "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/receipts/f45f37939d43.cas.json",
       "bytes": 2631,
       "sha256": "098d07163499f84fd6ae2bb63c95dec732631b103de5fdc15085533950a72359"
@@ -453,6 +473,36 @@
       "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-03/streamed_packed_joint.pstats",
       "bytes": 153670,
       "sha256": "0f7cb43b230ebfe7e9a4b11f3a6c770a85d28a9f7f53a32f90ead200aef462a6"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-04/joint-cost.json",
+      "bytes": 27808659,
+      "sha256": "a36ef223bc3c529129c3b4ff62e0ba12919a54750ca2b6c92a8a04259024454c"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-04/model_identity.json",
+      "bytes": 252894,
+      "sha256": "fa7a85734252375df0d01fe5003efc065688348c3c535535305bc9f64d47d339"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-04/netdata-both-hosts.json",
+      "bytes": 64676,
+      "sha256": "1e2cef57235ec0bdab8f0a265f7c00f9071d28db0651dae2e8d36a1eabf76cf5"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-04/resident_reference_forward_backward.pstats",
+      "bytes": 202897,
+      "sha256": "06455f495cb6bd4b00ec104dff6c40b2daf9c451e2197b6b7608960757f3db43"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-04/results.json",
+      "bytes": 742114,
+      "sha256": "f308e7f6fbf563884d9625721523f4247322e0bfa95876e04798438553ce8558"
+    },
+    {
+      "path": "/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-04/streamed_packed_joint.pstats",
+      "bytes": 152388,
+      "sha256": "2e2cd761b066b61987388f8482e5d3d146a30a8bc54ca34cdd425fcfb2e621dc"
     }
   ]
 }

--- a/docs/measurements/lfm-packed-joint-aura-2026-09-07.md
+++ b/docs/measurements/lfm-packed-joint-aura-2026-09-07.md
@@ -137,3 +137,30 @@ per-Linear signed accumulation across partitions before squaring. Whole-draw
 logits and Fisher tensors must not be materialized at once. Native whole-MoE
 runtime measurements bind the 96-row roster separately; this cost result alone
 does not qualify a serving lane or change any ship gate.
+
+## Independent retained-boundary qualification
+
+A subsequent source-only run qualifies the retained first canonical MoE boundary
+without changing or recapturing it. PB action
+`e46ba7cf0b4fd2f38ed6a127bee4a3fb78010b73b223f54756eec66b1626e1fe`
+finished rc0. The proof at
+`/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/source-04/results.json`
+has SHA256 `f308e7f6fbf563884d9625721523f4247322e0bfa95876e04798438553ce8558`.
+It binds the original raw boundary artifact SHA256
+`1290dd0dcb4ebecd09aee9fd2427aae62cb9c09974a466c05dcbe1ff08c6874d`,
+retains that artifact's original metadata, and independently compares new source
+input activations, top-k IDs, top-k weights, FP32 expert bias, and token
+coordinates. Every tensor is bit-exact with matching dtype and hash. The
+reference descriptor is captured before its first forward; all 49 resolved
+module backend descriptors match the streamed model. The run also repeats and
+passes full-vocabulary forward, all eight packed gradient comparisons, and
+the shared-derived versus actual grouped down-input comparison.
+
+The retained cProfile files have an attribution limitation discovered during
+separate inspection: some call edges contradict the source call graph, including
+an apparent recursive `assignment_keys` edge. These files must not support
+function-level timing or bottleneck claims. The failure mechanism is not
+established. Future performance comparisons require reliable per-thread
+instrumentation or an independent sampler alongside both hosts' telemetry.
+The tensor comparisons, terminal outcomes, CAS results and Netdata artifacts
+remain separately attributable; this screen makes no speed claim.

--- a/docs/measurements/lfm-packed-joint-aura-2026-09-07.md
+++ b/docs/measurements/lfm-packed-joint-aura-2026-09-07.md
@@ -1,0 +1,139 @@
+# LFM packed joint AURA screen, 2026-09-07
+
+Issue [#313](https://github.com/RobTand/prismaquant/issues/313). Streamed joint
+AURA now observes the original packed expert source operators and emits the
+existing per-Linear currency for all 96 w1/w3/w2 projections in LFM layer 2.
+This measurement covers **only canonical calibration row 0, 512 tokens, four
+Rademacher probes**. It does not establish full-calibration quality, measured
+KL, serving quality, or a performance improvement.
+
+## Source and projection contracts
+
+The implementation extends `PackedExpertProjection`, the existing streamed
+runner, and `SignedJointProjectionLease`. It refreshes 2D views after each
+source install and unload, harvests one gradient per physical packed leaf,
+and observes original `F.linear` slices or `F.grouped_mm` transposes and expert
+row offsets. It preserves the source model, expert dispatch, routing, and
+forward outputs. Unsupported boundaries fail closed. Output cotangents split
+both expert rows and fused gate/up columns before applying each logical
+Linear's weight, activation, and mixed residual terms. Repeated invocations
+sum while signed within that Linear before squaring. Different Linears remain
+separate unary prices under the existing additive objective.
+
+A separate lifetime fix releases the completed joint lease and delta tensors
+before the next layer install. A separate identity fix binds each module's
+resolved attention/expert backend, including private Transformers selectors
+omitted by `config.to_dict()`. Backend changes reject checkpoint resume before
+source installation; changes during measurement reject the layer before its
+checkpoint rows are written.
+
+## Frozen inputs
+
+- BF16 source: `/mnt/shared/models/LFM2.5-8B-A1B-BF16`, 24 layers, 32 experts,
+  top-k 4. Checkpoint SHA256:
+  `c9b9e3c4b3be50b576e6da8c02de1b4223614ffe131d812abf92bb84421f6217`.
+- Parent calibration: canonical int64 `[512,512]` artifact at
+  `/mnt/shared/tessera-measurements/first-model-20260907/capture-reuse/canonical/calibration_tokens.safetensors`,
+  SHA256 `a38312e3b1eeecc2a4363d2a91739ba535388036d4910bffa815d451dcb9a940`.
+  WT2 train corpus SHA256:
+  `aee724fa58bfbdeb3fc6803297fb6bab27b203d7c40b39ddef9b9770e5d52fe5`.
+- Actual operator subset: sole int64 `[1,512]` row 0 at
+  `/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/operator-subset/calibration_tokens.safetensors`,
+  file SHA256 `ba4482b67fa9256ce48579182504a94cfc5d29f8d0057337b22ca303373c7cc7`;
+  raw int64 bytes SHA256
+  `24b78ebefe086cc05dd11849766a543db3e23569a679cd201fa55a16221b3017`.
+  The subset metadata retains parent corpus/source/seed and explicitly sets
+  `nsamples=1`, `fit_tokens=512`, parent file/hash/row and screen scope.
+  Its int32 fit-token hash is
+  `b1622ee77efe13444af2d8f0dff5d156176ce8395a954fabb65a1334bc28f4af`.
+- Original decoded production cache:
+  `/mnt/shared/tessera-measurements/first-model-20260907/native-moe-wires-r1024/production.pkl`,
+  SHA256 `6a07cb3431476dd41a2a12a55a999cef866afddec9b1e69d3d9664eaacec9127`.
+  These are the 96 existing projected E4M3 K1 R1024 wire renders fitted using
+  the full canonical Hessian contract. This screen does not re-encode them.
+- Probe seeds 7000–7003, all-token scope, temperature 1, Rademacher distribution,
+  global KL Fisher normalization. Attention is eager; experts remain the
+  canonical Transformers `grouped_mm` backend. `PRISMAQUANT_PROD_ACT_SCALES=0`
+  matches the explicit native comparison protocol.
+
+## Actual results
+
+The ordinary Hugging Face reference and streamed source agree bit for bit on
+all `[1,512,128000]` BF16 logits. For each of four probes, both full packed
+leaf gradients agree bit for bit: gate/up `[32,3584,2048]` and down
+`[32,2048,1792]`; all eight comparisons have maximum absolute error zero.
+The shared `derive_per_expert_activations` down inputs also agree bit for bit
+with actual grouped source inputs after aligning token/top-k-slot order:
+`[2048,1792]`, zero differing elements, SHA256
+`29050e797f37e4aca7c43ef50ee110dc13d8e17f517ed1018c34bcd95e8046bb`.
+This last comparison is scoped to the actual row-0 layer-2 operator inputs.
+
+The final cost payload contains 96 E4M3 rows and 96 BF16 zero controls, all with
+four aligned signed samples and source/render/activation/probe identities.
+Expert 19 receives no routes in this sequence; its three source rows correctly
+retain aligned zeros. The other 93 E4M3 rows have nonzero prices. Their additive
+predicted-loss sum is `0.001974112346254766`. This is the sum of the per-Linear
+screen prices, not a whole-block coherent quality scalar or measured KL.
+Per-row uncertainty is conditional on these fixed calibration tokens.
+
+Final cost artifact:
+`/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/cost-02/joint-cost.json`,
+SHA256 `fcf48abdb0e0b1d8bc324c5c938b9b68ebb821f1c5b0591aefffb4b7c3c45462`.
+Its producer package SHA256 is
+`7265e47475ded17f10b542874c289b054a1cd8c004b30d247fb510b9eeeb6405`.
+The cost consumer and wire producer have separate exact source identities;
+actual cached render tensors and source weights are independently hash-bound.
+
+## Validation and retained evidence
+
+All tests and GPU work ran through PrismaBuild. GPU runs used the existing
+`eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c`
+container with Transformers 5.16.1 and PyTorch 2.13.0+cu130 on GB10. GPU actions
+reserved four CPUs, 40 GiB aggregate memory and 32 GiB GPU memory; native
+threads were bounded to one and PB affinity was preserved. CPU checks used
+2–4 workers. The final selected suite passed 63 tests, followed by two targeted
+checks for grouped QDQ failure cleanup and backend mutation before publication.
+The latter overlaps one test from the 63-test suite; there are 64 distinct
+final checks, with no skips. Scoped pytest-xdist 3.8.0 and execnet 2.1.2 supplied
+parallel CPU execution in the existing image.
+
+| Evidence | PB action | Outcome |
+|---|---|---|
+| Lifetime and packed support regression | `567ebd4a94a94c404a4df913a57448582c14dc2e2d664a03ba22e0c4d3b9d7ec` | Three expected pre-fix failures |
+| Lifetime fix and existing joint checks | `910381a7f145ef54f93b10e3c8d421272e8f24b9630dd89f033f8963d3ee72fe` | 15 passed |
+| Packed views, resume and failure cleanup | `6c48859f61f99ec212dee915980837435d024a6f008041bb7de8a68c514503b9` | 24 passed |
+| Grouped-boundary regression | `1b8d78e28352812432a6f6db8e7d81bc44983a4d5713e204f52894890af0e757` | Expected pre-fix refusal |
+| Canonical source forward/reverse/down-input proof | `9c91cb5cf200df4b3f63a4b7fbe7e1464c532a330f180523b70c101ca3963a14` | GPU rc0, all exact comparisons |
+| Backend resume regression | `8f08b0728520b4ee0df023e07740b09cb2fb8ca681a766bc6d2d89bb26e171b0` | Two expected pre-fix failures |
+| Final selected source/joint/doc checks | `584254592eb3833a8bdb09466b2559406d31c5d4fe6adaefb27e629adc3b117e` | 63 passed |
+| Backend mutation and grouped QDQ cleanup | `92d4c7353b5af7b0394fb56dc06988b04fb577394dda9d0b641e036bdd981d01` | 2 passed |
+| Final original-wire joint costs | `3398c8e2b6880ec84783bb9a02ddd6c2a0417662140aa6cbbe0497a0800d1259` | GPU rc0, 192 valid rows |
+
+The final GPU CAS receipt is
+`d2e8823057de794c124a12e6684c51f8cf315aa53df013c069962c4418679a37`.
+The evidence directory retains terminal summaries, logs, verified CAS result
+receipts, snapshot provenance, harnesses, cProfile files and both hosts' Netdata
+series. The checked-in companion JSON hashes those artifacts. Profiling here
+records correctness-run activity; the runs were not isolated performance arms
+and establish no speedup or work-per-joule comparison.
+
+The first actual source attempt (`39c37...`) stopped at the unsupported grouped
+boundary before gradient collection. An explicitly eager expert diagnostic
+(`f45f...`) passed but is superseded and never joined to the canonical grouped
+capture. `cost-01` passed numerically; `cost-02` supersedes it with explicit
+backend identities, and every signed sample is exactly unchanged. Two early
+parallel CPU attempts (`d74f...`, `4f66...`) collected no tests because xdist was
+missing; the scoped install and later successful runs supersede them. An earlier
+mistyped test filename was corrected and the actual namespace/doc suite passed.
+The first metadata-free subset file was superseded by the metadata-complete
+`operator-subset` artifact above. All superseded data remain bounded evidence.
+
+## Remaining scope
+
+The full 512-sequence draw has not been priced by this screen. Full-draw
+execution needs deterministic calibration microbatching within the shared
+runner/AURA checkpoint path, with global probe indexing/normalization and
+per-Linear signed accumulation across partitions before squaring. Whole-draw
+logits and Fisher tensors must not be materialized at once. Native whole-MoE
+runtime measurements bind the 96-row roster separately; this cost result alone
+does not qualify a serving lane or change any ship gate.

--- a/experiments/lfm_packed_joint_screen.py
+++ b/experiments/lfm_packed_joint_screen.py
@@ -1,0 +1,259 @@
+"""PB-only canonical source/packed-joint screen on an explicit token subset."""
+from __future__ import annotations
+import argparse
+import cProfile
+import gc
+import hashlib
+import json
+import os
+from pathlib import Path
+import pickle
+import socket
+import time
+
+
+def file_sha(path):
+    value = hashlib.sha256()
+    with Path(path).open('rb') as handle:
+        for block in iter(lambda: handle.read(8 << 20), b''):
+            value.update(block)
+    return value.hexdigest()
+
+
+def main():
+    import torch
+    import transformers
+    from safetensors.torch import load_file, save_file
+    from transformers import AutoModelForCausalLM
+    from prismaquant import pretrained_initialization_contract
+    from prismaquant.aura_cost import compute_aura_cost_streamed
+    from prismaquant.cost_streaming import build_streamed_causal_lm, build_streamed_model_identity
+    from prismaquant.joint_aura import validate_joint_aura_entry
+    from prismaquant.kl_fisher import fisher_probe_scalar
+    from prismaquant.model_profiles import detect_profile
+    from prismaquant.production_weight_cache import ProductionWeightCache
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--mode', choices=['source', 'cost'], required=True)
+    parser.add_argument('--model', default='/mnt/shared/models/LFM2.5-8B-A1B-BF16')
+    parser.add_argument('--tokens', type=Path, required=True)
+    parser.add_argument('--tokens-sha256', required=True)
+    parser.add_argument('--row', type=int, default=0)
+    parser.add_argument('--subset-artifact', type=Path)
+    parser.add_argument('--subset-artifact-sha256')
+    parser.add_argument('--cache', type=Path)
+    parser.add_argument('--cache-sha256')
+    parser.add_argument('--out', type=Path, required=True)
+    args = parser.parse_args()
+    args.out.mkdir(parents=True, exist_ok=False)
+    if file_sha(args.tokens) != args.tokens_sha256:
+        raise ValueError('token artifact hash differs')
+    all_ids = load_file(str(args.tokens))['calibration_ids']
+    if all_ids.dtype != torch.int64 or all_ids.ndim != 2 or all_ids.shape[1] != 512:
+        raise ValueError('screen needs the canonical int64 512-token draw')
+    ids_cpu = all_ids[args.row:args.row + 1].contiguous()
+    if ids_cpu.shape != (1, 512):
+        raise ValueError('screen row is absent')
+    subset_path = args.out / 'calibration_subset.safetensors'
+    if args.subset_artifact is not None:
+        subset_path = args.subset_artifact
+        if file_sha(subset_path) != args.subset_artifact_sha256 or not torch.equal(
+                load_file(str(subset_path))['calibration_ids'], ids_cpu):
+            raise ValueError('published operator subset differs from actual source tokens')
+    else:
+        save_file({'calibration_ids': ids_cpu}, str(subset_path))
+    ids = ids_cpu.cuda()
+    unit = 'model.layers.2.feed_forward.experts'
+    names = [f'{unit}.{expert}.{role}' for expert in range(32) for role in ('w1', 'w3', 'w2')]
+    policy = {'n_probes': 4, 'seed_base': 7000, 'token_scope': 'all',
+              'temperature': 1.0, 'distribution': 'rademacher', 'normalization': 'global_kl_fisher'}
+    result = {'schema': 'prismaquant.packed_joint_screen.v1', 'mode': args.mode,
+        'env': {'host': socket.gethostname(), 'started_epoch': time.time(),
+                'torch': torch.__version__, 'transformers': transformers.__version__,
+                'cuda': torch.version.cuda, 'affinity': sorted(os.sched_getaffinity(0)),
+                'production_act_scales': os.environ.get('PRISMAQUANT_PROD_ACT_SCALES')},
+        'calibration_subset': {'artifact': str(args.tokens), 'artifact_sha256': args.tokens_sha256,
+            'subset_artifact': str(subset_path), 'subset_artifact_sha256': file_sha(subset_path),
+            'full_shape': list(all_ids.shape), 'row': args.row, 'shape': list(ids_cpu.shape),
+            'dtype': str(ids_cpu.dtype), 'sha256': hashlib.sha256(ids_cpu.numpy().tobytes()).hexdigest(),
+            'scope': 'first_sequence_operator_screen'},
+        'probe_policy': policy, 'unit_names': names, 'phases': [], 'gradient_comparisons': []}
+    def save():
+        (args.out / 'results.json').write_text(json.dumps(result, indent=2, allow_nan=False) + '\n')
+    def phase(label, call):
+        torch.cuda.synchronize()
+        started = time.time()
+        profiler = cProfile.Profile()
+        try:
+            value = profiler.runcall(call)
+            torch.cuda.synchronize()
+        finally:
+            profiler.dump_stats(str(args.out / (label + '.pstats')))
+            result['phases'].append({'phase': label, 'kind': 'profile',
+                                    'start_epoch': started, 'end_epoch': time.time()})
+            save()
+        return value
+    def digest(tensor):
+        return hashlib.sha256(memoryview(tensor.detach().cpu().contiguous().view(torch.uint8).numpy())).hexdigest()
+    expected_gradients = {}
+    expected_logits = None
+    if args.mode == 'source':
+        reference = AutoModelForCausalLM.from_pretrained(args.model, dtype=torch.bfloat16,
+            trust_remote_code=True, local_files_only=True, attn_implementation='eager').cuda().eval()
+        result['model_load_contract'] = pretrained_initialization_contract(reference)
+        for parameter in reference.parameters():
+            parameter.requires_grad_(False)
+        source_parameters = {name: reference.get_parameter(f'{unit}.{name}')
+                             for name in ('gate_up_proj', 'down_proj')}
+        for parameter in source_parameters.values():
+            parameter.requires_grad_(True)
+        experts = reference.get_submodule(unit)
+        parent = reference.get_submodule(unit.rsplit('.', 1)[0])
+        original_experts_forward = experts.forward
+        def inspect_source(hidden_states, top_k_index, top_k_weights):
+            from prismaquant.measure_quant_cost import derive_per_expert_activations
+            from torch.nn import functional as F
+            derived = derive_per_expert_activations(experts, hidden_states, parent)
+            # The shared derivation orders rows by top-k slot then token;
+            # grouped_mm sorts the flattened token-major route list.
+            flat = top_k_index.reshape(-1)
+            _, permutation = torch.sort(flat)
+            grouped_token = permutation // top_k_index.shape[1]
+            grouped_slot = permutation % top_k_index.shape[1]
+            expected_down = []
+            for expert in range(experts.num_experts):
+                slots, tokens = torch.where(top_k_index.T == expert)
+                keys = tokens * top_k_index.shape[1] + slots
+                selected = flat[permutation] == expert
+                grouped_keys = grouped_token[selected] * top_k_index.shape[1] + grouped_slot[selected]
+                order = torch.argsort(keys)
+                expected_down.append(derived['down'][expert][order[torch.searchsorted(keys[order], grouped_keys)]])
+            expected_down = torch.cat(expected_down)
+            original_grouped = F.grouped_mm
+            def grouped(inputs, weight, *, offs, **kwargs):
+                if weight._base is source_parameters['down_proj']:
+                    delta = (inputs.float() - expected_down.float()).abs()
+                    result['derived_down_comparison'] = {'equal': torch.equal(inputs, expected_down),
+                        'max_abs': float(delta.max()), 'different_elements': int(torch.count_nonzero(delta)),
+                        'shape': list(inputs.shape), 'actual_sha256': digest(inputs),
+                        'derived_sha256': digest(expected_down), 'scope': 'layer2_canonical_row0',
+                        'source_backend': 'grouped_mm', 'derivation_backend': 'shared_F.linear'}
+                return original_grouped(inputs, weight, offs=offs, **kwargs)
+            F.grouped_mm = grouped
+            try:
+                return original_experts_forward(hidden_states, top_k_index, top_k_weights)
+            finally:
+                F.grouped_mm = original_grouped
+        experts.forward = inspect_source
+        def reference_probes():
+            nonlocal expected_logits
+            for index in range(policy['n_probes']):
+                reference.zero_grad(set_to_none=True)
+                logits = reference(ids, use_cache=False).logits
+                if index == 0:
+                    experts.forward = original_experts_forward
+                    expected_logits = logits.detach().cpu()
+                probe = fisher_probe_scalar(logits, seed=policy['seed_base'] + index,
+                    token_scope='all', temperature=1.0, distribution='rademacher')
+                probe.backward()
+                for name, parameter in source_parameters.items():
+                    if parameter.grad is None:
+                        raise RuntimeError(f'reference gradient absent: {name}')
+                    expected_gradients[(name, index)] = parameter.grad.detach().cpu()
+                del logits, probe
+        phase('resident_reference_forward_backward', reference_probes)
+        reference.zero_grad(set_to_none=True)
+        source_parameters.clear()
+        experts = parent = original_experts_forward = None
+        parameter = None
+        del reference
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    profile = detect_profile(args.model)
+    runner = build_streamed_causal_lm(args.model, device=torch.device('cuda'), dtype=torch.bfloat16,
+        offload_folder=str(args.out / 'offload'), profile=profile, attn_implementation='eager',
+        max_cache_slots=24, prefetch_workers=4, prefetch_lookahead=4, cache_headroom_gb=4,
+        prefetch_min_available_gb=2, require_prefetched_residency=True)
+    model_identity = build_streamed_model_identity(runner, args.model,
+        identity_cache_path=args.out / 'model_identity.json')
+    result['source_model_identity'] = model_identity
+    result['streamed_backend'] = runner.model.config._attn_implementation
+    result['source_execution'] = {'attention': runner.model.config._attn_implementation,
+                                  'experts': runner.model.config._experts_implementation}
+    # Prefetch remains owned by the existing streaming context/cache.
+    for layer in range(runner.num_layers):
+        runner.context.schedule_prefetch(layer)
+    if args.mode == 'source':
+        with torch.inference_mode():
+            actual_logits = runner(ids).logits.cpu()
+        difference = (actual_logits.float() - expected_logits.float()).abs()
+        result['source_forward'] = {'shape': list(actual_logits.shape),
+            'equal': torch.equal(actual_logits, expected_logits), 'max_abs': float(difference.max())}
+        del actual_logits, expected_logits, difference
+        assert result['source_forward']['equal'], 'canonical full-vocabulary source forward differs'
+        observed_counts = {'gate_up_proj': 0, 'down_proj': 0}
+        original_install = runner.context.install
+        def install(layer, **kwargs):
+            installed = original_install(layer, **kwargs)
+            if layer == 2:
+                for name in observed_counts:
+                    parameter = runner.model.get_parameter(f'{unit}.{name}')
+                    parameter.requires_grad_(True)
+                    def observe(value, name=name):
+                        index = observed_counts[name]
+                        observed_counts[name] += 1
+                        actual = value.grad.detach().cpu()
+                        expected = expected_gradients.pop((name, index))
+                        equal = torch.equal(actual, expected)
+                        delta = (actual.float() - expected.float()).abs()
+                        result['gradient_comparisons'].append({'parameter': name, 'probe': index,
+                            'shape': list(actual.shape), 'equal': equal, 'max_abs': float(delta.max()),
+                            'actual_sha256': digest(actual), 'expected_sha256': digest(expected)})
+                        save()
+                        assert equal, f'packed source gradient differs: {name}, probe {index}'
+                    parameter.register_post_accumulate_grad_hook(observe)
+            return installed
+        runner.context.install = install
+        cache = ProductionWeightCache(weights={}, levers={})
+        formats = ['BF16']
+    else:
+        if args.cache is None or not args.cache_sha256 or file_sha(args.cache) != args.cache_sha256:
+            raise ValueError('actual original-wire production cache hash is required')
+        with args.cache.open('rb') as handle:
+            cache = pickle.load(handle)
+        if not isinstance(cache, ProductionWeightCache):
+            raise TypeError('expected the existing ProductionWeightCache pickle')
+        result['production_cache'] = {'path': str(args.cache), 'sha256': args.cache_sha256}
+        formats = ['TESSERA_E4M3_K1_R1024', 'BF16']
+    def cost():
+        return compute_aura_cost_streamed(runner, ids, formats, n_probes=4, seed_base=7000,
+            token_scope='all', temperature=1.0, min_free_gib=0, production_cache=cache,
+            joint_activation=True, include_routed_experts=True, profile=profile,
+            model_identity=model_identity, formats_by_qname={name: formats for name in names},
+            checkpoint_identity_extra={'operator_screen_subset': result['calibration_subset'],
+                                       'source_execution': result['source_execution']})
+    payload = phase('streamed_packed_joint', cost)
+    assert set(payload['costs']) == set(names)
+    for name, rows in payload['costs'].items():
+        assert set(rows) == set(formats)
+        for row in rows.values():
+            assert validate_joint_aura_entry(row)
+            assert row['joint_operator_identity']['qname'] == name
+            assert row['probe_ids'] == [7000, 7001, 7002, 7003]
+    payload['provenance']['operator_screen_subset'] = result['calibration_subset']
+    (args.out / 'joint-cost.json').write_text(json.dumps(payload, indent=2, allow_nan=False) + '\n')
+    if args.mode == 'source':
+        assert not expected_gradients and observed_counts == {'gate_up_proj': 4, 'down_proj': 4}
+    result['passed'] = True
+    result['env']['finished_epoch'] = time.time()
+    result['peak_gpu_bytes'] = torch.cuda.max_memory_allocated()
+    result['cost_sha256'] = file_sha(args.out / 'joint-cost.json')
+    save()
+    runner.context.shutdown()
+    print(json.dumps({'passed': True, 'mode': args.mode, 'units': len(names),
+                      'cost_sha256': result['cost_sha256']}), flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/experiments/lfm_packed_joint_screen.py
+++ b/experiments/lfm_packed_joint_screen.py
@@ -28,7 +28,7 @@ def main():
     from prismaquant import pretrained_initialization_contract
     from prismaquant.aura_cost import compute_aura_cost_streamed
     from prismaquant.cost_streaming import build_streamed_causal_lm, build_streamed_model_identity
-    from prismaquant.joint_aura import validate_joint_aura_entry
+    from prismaquant.joint_aura import validate_joint_aura_entry, source_execution_identity
     from prismaquant.kl_fisher import fisher_probe_scalar
     from prismaquant.model_profiles import detect_profile
     from prismaquant.production_weight_cache import ProductionWeightCache
@@ -41,6 +41,8 @@ def main():
     parser.add_argument('--row', type=int, default=0)
     parser.add_argument('--subset-artifact', type=Path)
     parser.add_argument('--subset-artifact-sha256')
+    parser.add_argument('--qualify-boundary', type=Path)
+    parser.add_argument('--qualify-boundary-sha256')
     parser.add_argument('--cache', type=Path)
     parser.add_argument('--cache-sha256')
     parser.add_argument('--out', type=Path, required=True)
@@ -101,6 +103,12 @@ def main():
         reference = AutoModelForCausalLM.from_pretrained(args.model, dtype=torch.bfloat16,
             trust_remote_code=True, local_files_only=True, attn_implementation='eager').cuda().eval()
         result['model_load_contract'] = pretrained_initialization_contract(reference)
+        result['reference_source_execution_identity'] = source_execution_identity(reference)
+        raw_boundary = None
+        if args.qualify_boundary is not None:
+            if file_sha(args.qualify_boundary) != args.qualify_boundary_sha256:
+                raise ValueError('retained boundary artifact hash differs')
+            raw_boundary = torch.load(args.qualify_boundary, map_location='cpu', weights_only=False)
         for parameter in reference.parameters():
             parameter.requires_grad_(False)
         source_parameters = {name: reference.get_parameter(f'{unit}.{name}')
@@ -111,6 +119,26 @@ def main():
         parent = reference.get_submodule(unit.rsplit('.', 1)[0])
         original_experts_forward = experts.forward
         def inspect_source(hidden_states, top_k_index, top_k_weights):
+            if raw_boundary is not None:
+                coordinates = torch.stack((torch.zeros(512, dtype=torch.int64), torch.arange(512)), dim=1)
+                actual_tensors = {'inputs': hidden_states, 'top_k_index': top_k_index,
+                                  'top_k_weights': top_k_weights, 'expert_bias': parent.expert_bias,
+                                  'coordinates': coordinates}
+                checks = {}
+                for name, actual in actual_tensors.items():
+                    expected = raw_boundary[name]
+                    cpu = actual.detach().cpu()
+                    equal = cpu.dtype == expected.dtype and torch.equal(cpu, expected)
+                    checks[name] = {'equal': equal, 'shape': list(cpu.shape), 'dtype': str(cpu.dtype),
+                                    'actual_sha256': digest(cpu), 'captured_sha256': digest(expected)}
+                    if not equal:
+                        raise AssertionError(f'retained canonical boundary differs: {name}')
+                result['retained_boundary_qualification'] = {
+                    'schema': 'prismaquant.packed_source_boundary_qualification.v1',
+                    'unit_qname': unit, 'artifact': str(args.qualify_boundary), 'artifact_sha256': args.qualify_boundary_sha256,
+                    'boundary_metadata': raw_boundary['boundary_metadata'],
+                    'source_execution_identity': result['reference_source_execution_identity'],
+                    'calibration_subset': result['calibration_subset'], 'tensor_comparisons': checks}
             from prismaquant.measure_quant_cost import derive_per_expert_activations
             from torch.nn import functional as F
             derived = derive_per_expert_activations(experts, hidden_states, parent)
@@ -181,6 +209,13 @@ def main():
     result['streamed_backend'] = runner.model.config._attn_implementation
     result['source_execution'] = {'attention': runner.model.config._attn_implementation,
                                   'experts': runner.model.config._experts_implementation}
+    result['streamed_source_execution_identity'] = source_execution_identity(runner.model)
+    if args.mode == 'source':
+        assert result['streamed_source_execution_identity'] == result['reference_source_execution_identity']
+        if 'retained_boundary_qualification' in result:
+            result['retained_boundary_qualification'].update(
+                source_model_identity=model_identity, runtime=result['env'],
+                streamed_source_execution_identity=result['streamed_source_execution_identity'])
     # Prefetch remains owned by the existing streaming context/cache.
     for layer in range(runner.num_layers):
         runner.context.schedule_prefetch(layer)

--- a/experiments/lfm_packed_joint_screen.sh
+++ b/experiments/lfm_packed_joint_screen.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+image=eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
+input_root=/mnt/shared/tessera-measurements/first-model-20260907/inputs
+exec docker run --rm --gpus all --ipc=host --network=host --user "$(id -u):$(id -g)" \
+  -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared -w /workspace --entrypoint python3 \
+  -e PYTHONDONTWRITEBYTECODE=1 -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
+  -e XDG_CACHE_HOME=/tmp/pq-stream-parity-cache -e TORCH_EXTENSIONS_DIR=/tmp/pq-stream-parity-ext \
+  -e HF_HOME=/tmp/pq-stream-parity-hf -e HF_MODULES_CACHE=/tmp/pq-stream-parity-modules \
+  -e PRISMABUILD_CONTAINER_OWNER -e PRISMAQUANT_PROD_ACT_SCALES=0 \
+  -e "PYTHONPATH=/workspace:$input_root/tessera-382a1a97/src:$input_root/container-compatible-deps" \
+  "$image" -m experiments.lfm_packed_joint_screen "$@"

--- a/experiments/lfm_stream_cpu_pytest.sh
+++ b/experiments/lfm_stream_cpu_pytest.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+image=eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
+input_root=/mnt/shared/tessera-measurements/first-model-20260907/inputs
+exec docker run --rm --user "$(id -u):$(id -g)" \
+  -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared -w /workspace --entrypoint python3 \
+  -e PYTHONDONTWRITEBYTECODE=1 -e CUDA_VISIBLE_DEVICES -e NVIDIA_VISIBLE_DEVICES=void \
+  -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
+  -e XDG_CACHE_HOME=/tmp/pq-stream-cpu-cache -e HF_HOME=/tmp/pq-stream-cpu-hf \
+  -e PRISMABUILD_CONTAINER_OWNER \
+  -e "PYTHONPATH=/workspace:$input_root/tessera-382a1a97/src:$input_root/container-compatible-deps:/mnt/shared/tessera-measurements/pq313-packed-joint-20260907/pytest-deps:/mnt/shared/tessera-measurements/lfm-streamed-parity-20260907/pytest-deps" \
+  "$image" -m pytest "$@"

--- a/prismaquant/aura_cost.py
+++ b/prismaquant/aura_cost.py
@@ -2917,6 +2917,7 @@ def compute_aura_cost_streamed(
             finally:
                 if joint_lease is not None:
                     joint_lease.__exit__(None, None, None)
+                    joint_lease = None
                 for handle in hook_handles:
                     handle.remove()
 
@@ -2980,6 +2981,10 @@ def compute_aura_cost_streamed(
             for name in pending:
                 linears[name].weight.grad = None
                 linears[name].weight.requires_grad_(False)
+            # Loop locals and the lease otherwise retain the last layer's
+            # delta plane through the next source install/render window.
+            d_weights.clear()
+            result = delta = weight = None
             del d_weights
             runner.context.unload(layer)
 

--- a/prismaquant/aura_cost.py
+++ b/prismaquant/aura_cost.py
@@ -59,8 +59,11 @@ from prismaquant.nvfp4_cb_footprint import (
     is_cb_format,
 )
 from prismaquant.routed_experts import (
+    PackedExpertProjection,
+    profile_declared_packed_expert_projections,
     profile_declared_routed_expert_targets,
     profile_declared_unpacked_expert_linears,
+    refresh_packed_expert_projections,
     resolve_routed_expert_profile,
 )
 
@@ -1897,6 +1900,7 @@ def compute_aura_cost_streamed(
     profile = resolve_routed_expert_profile(
         runner.model, profile or runner.profile
     )
+    packed_projections = []
     if include_routed_experts:
         routed_targets = set(_packed_expert_targets(runner.model, profile))
         unpacked_targets = {
@@ -1905,7 +1909,10 @@ def compute_aura_cost_streamed(
                 runner.model, profile
             )
         }
-        unsupported = sorted(routed_targets - unpacked_targets)
+        if joint_activation:
+            packed_projections = profile_declared_packed_expert_projections(runner.model, profile)
+        packed_targets = {member.packed_qname for member in packed_projections}
+        unsupported = sorted(routed_targets - unpacked_targets - packed_targets)
         if unsupported:
             raise RuntimeError(
                 "streamed AURA can include routed experts only when the "
@@ -1930,6 +1937,13 @@ def compute_aura_cost_streamed(
         include_routed_experts=include_routed_experts,
         profile=profile,
     )
+    if packed_projections:
+        if anchor_renderer is not None:
+            raise RuntimeError(
+                "packed joint AURA requires decoded ProductionWeightCache entries; "
+                "the on-demand production anchor renderer supports only nn.Linear modules"
+            )
+        linears.update({member.qname: member for member in packed_projections})
     fmts = list(dict.fromkeys(
         fr.canonical_format_name(fmt) for fmt in formats
     ))
@@ -2010,6 +2024,19 @@ def compute_aura_cost_streamed(
     for name in names:
         layer = runner.layer_index_for_qname(name)
         names_by_layer.setdefault(layer, []).append(name)
+
+    def _refresh_packed_layer_views(layer):
+        members = [linears[name] for name in names_by_layer.get(layer, ())
+                   if isinstance(linears[name], PackedExpertProjection)]
+        if members:
+            linears.update({member.qname: member for member in
+                            refresh_packed_expert_projections(members, profile)})
+
+    def _source_parameter(target):
+        return target.parameter if isinstance(target, PackedExpertProjection) else target.weight
+
+    def _source_gradient(target, gradient):
+        return target.gradient_view(gradient) if isinstance(target, PackedExpertProjection) else gradient
 
     unit_formats: dict[str, tuple[str, ...]] = {}
     render_formats: dict[str, tuple[str, ...]] = {}
@@ -2534,6 +2561,7 @@ def compute_aura_cost_streamed(
             layer,
             require_prefetched=runner.require_prefetched_residency,
         )
+        _refresh_packed_layer_views(layer)
         # Forward boundary capture leaves the final lookahead window hot.
         # Keep that pipeline moving in the direction of this traversal: the
         # existing StreamingContext/LayerCache loads the next reverse layer
@@ -2546,9 +2574,14 @@ def compute_aura_cost_streamed(
             if name not in completed_checkpoint_units
         ]
         d_weights: dict[tuple[str, str], torch.Tensor] = {}
+        parameter_members = {}
+        parameters = {}
         try:
             for name in pending:
-                linears[name].weight.requires_grad_(True)
+                parameter = _source_parameter(linears[name])
+                parameter.requires_grad_(True)
+                parameters[id(parameter)] = parameter
+                parameter_members.setdefault(id(parameter), []).append(name)
                 g_trace[name] = 0.0
             with torch.no_grad():
                 if anchor_renderer is not None and pending:
@@ -2807,12 +2840,14 @@ def compute_aura_cost_streamed(
                         x2_probe[key].append(value)
                 harvested.add(name)
 
-            def _make_streamed_gradient_hook(name: str):
+            def _make_streamed_gradient_hook(member_names):
                 def _hook(parameter: torch.Tensor) -> None:
                     gradient = parameter.grad
-                    if gradient is None or name in harvested:
+                    if gradient is None:
                         return
-                    _harvest_streamed_gradient(name, gradient)
+                    for name in member_names:
+                        if name not in harvested:
+                            _harvest_streamed_gradient(name, _source_gradient(linears[name], gradient))
                     parameter.grad = None
 
                 return _hook
@@ -2829,10 +2864,10 @@ def compute_aura_cost_streamed(
             try:
                 if joint_lease is not None:
                     joint_lease.__enter__()
-                for name in pending:
+                for parameter_id, parameter in parameters.items():
                     hook_handles.append(
-                        linears[name].weight.register_post_accumulate_grad_hook(
-                            _make_streamed_gradient_hook(name)
+                        parameter.register_post_accumulate_grad_hook(
+                            _make_streamed_gradient_hook(parameter_members[parameter_id])
                         )
                     )
                 for probe_index in range(n_probes):
@@ -2877,17 +2912,19 @@ def compute_aura_cost_streamed(
                     # plane. In-place rollover bounds the CPU plane to 32
                     # tensors plus the one result currently being copied.
                     grad_outs[probe_index] = x_in.grad.detach().to("cpu")
-                    for name in pending:
-                        if name in harvested:
-                            continue
-                        gradient = linears[name].weight.grad
+                    for parameter_id, parameter in parameters.items():
+                        gradient = parameter.grad
                         if gradient is not None:
                             # Defensive straggler path for a backend that did
                             # not invoke the post-accumulate hook. It performs
                             # the identical reduction and still frees the
                             # gradient before the next probe.
-                            _harvest_streamed_gradient(name, gradient)
-                            linears[name].weight.grad = None
+                            for name in parameter_members[parameter_id]:
+                                if name not in harvested:
+                                    _harvest_streamed_gradient(name, _source_gradient(linears[name], gradient))
+                            parameter.grad = None
+                    for name in pending:
+                        if name in harvested:
                             continue
                         # A routed expert not selected by this probe has an
                         # exact zero projection. Record the sample explicitly
@@ -2978,15 +3015,18 @@ def compute_aura_cost_streamed(
                     f"ETA {remaining / rate / 60:.1f} min)"
                 )
         finally:
-            for name in pending:
-                linears[name].weight.grad = None
-                linears[name].weight.requires_grad_(False)
+            for parameter in parameters.values():
+                parameter.grad = None
+                parameter.requires_grad_(False)
             # Loop locals and the lease otherwise retain the last layer's
             # delta plane through the next source install/render window.
             d_weights.clear()
             result = delta = weight = None
             del d_weights
+            parameters.clear()
+            parameter = None
             runner.context.unload(layer)
+            _refresh_packed_layer_views(layer)
 
     return _finish_streamed_payload()
 

--- a/prismaquant/aura_cost.py
+++ b/prismaquant/aura_cost.py
@@ -2066,6 +2066,7 @@ def compute_aura_cost_streamed(
         from prismaquant.joint_aura import (
             SignedJointProjectionLease, activation_identity, arithmetic_identity,
             identity_sha256, make_joint_aura_entry, prefetch_joint_cache, squared_signed,
+            source_execution_identity,
             validate_joint_aura_entry,
         )
         from prismaquant.production_weight_cache import _cb_cache_tensor_identity
@@ -2080,6 +2081,7 @@ def compute_aura_cost_streamed(
             "token_scope": token_scope, "temperature": temperature,
             "distribution": "rademacher", "normalization": "global_kl_fisher",
             "producer_source_sha256": _aura_source_sha256(),
+            "source_execution": source_execution_identity(runner.model),
             "arithmetic": arithmetic_identity(runner.dtype),
         }
         # Hash actual decoded production outputs before checkpoint admission,
@@ -2959,6 +2961,8 @@ def compute_aura_cost_streamed(
                     handle.remove()
 
             if joint_activation:
+                if source_execution_identity(runner.model) != joint_probe_identity["source_execution"]:
+                    raise RuntimeError("joint AURA source execution backend changed during measurement")
                 for name in pending:
                     joint_rows[name] = {}
                     for fmt in unit_formats[name]:

--- a/prismaquant/joint_aura.py
+++ b/prismaquant/joint_aura.py
@@ -185,9 +185,10 @@ class SignedJointProjectionLease:
     def _install_packed_observer(self, members):
         """Observe the existing per-expert Linear slices without changing them.
 
-        This uses the same temporary F.linear interception and exact dim-0
-        slice recognizer as the packed Fisher and production activation taps.
-        The baseline forward and routing arithmetic execute unchanged.
+        F.linear uses the packed Fisher/activation tap's exact dim-0 slice
+        recognizer. F.grouped_mm uses the exact packed transpose and cumulative
+        expert row offsets. Both execute the original operator unchanged; the
+        baseline forward, expert backend and routing arithmetic are preserved.
         """
         from prismaquant.sensitivity_probe import _packed_expert_slice_index
 
@@ -203,6 +204,7 @@ class SignedJointProjectionLease:
                 raise RuntimeError("joint AURA packed forward outside active probe")
             seen = set()
             original_linear = F.linear
+            original_grouped = getattr(F, "grouped_mm", None)
 
             def linear(inputs, weight, bias=None):
                 base = weight._base if weight._is_view() else weight
@@ -218,13 +220,44 @@ class SignedJointProjectionLease:
                     self._observe(member.qname, member.weight, inputs, output, member.output_slice)
                 return output
 
+            def grouped(inputs, weight, *, offs=None, **kwargs):
+                base = weight._base if weight._is_view() else weight
+                parameter = parameters.get(id(base))
+                if parameter is None:
+                    return original_grouped(inputs, weight, offs=offs, **kwargs)
+                expected = parameter.transpose(-2, -1)
+                if (weight.shape != expected.shape or weight.stride() != expected.stride()
+                        or weight.storage_offset() != expected.storage_offset()
+                        or weight.untyped_storage().data_ptr() != parameter.untyped_storage().data_ptr()
+                        or inputs.ndim != 2 or inputs.shape[1] != parameter.shape[2]
+                        or not isinstance(offs, torch.Tensor) or offs.ndim != 1
+                        or len(offs) != parameter.shape[0] or offs.dtype not in (torch.int32, torch.int64)):
+                    raise RuntimeError("joint AURA grouped weight/offset geometry differs")
+                ends = offs.tolist()
+                if any(end < start for start, end in zip([0, *ends[:-1]], ends)) or ends[-1] > inputs.shape[0]:
+                    raise RuntimeError("joint AURA grouped offsets are outside input rows")
+                output = original_grouped(inputs, weight, offs=offs, **kwargs)
+                seen.add(id(parameter))
+                start = 0
+                for expert, end in enumerate(ends):
+                    if end > start:
+                        for member in by_expert.get((id(parameter), expert), ()):
+                            self._observe(member.qname, member.weight, inputs[start:end], output,
+                                          member.output_slice, slice(start, end))
+                    start = end
+                return output
+
             F.linear = linear
+            if original_grouped is not None:
+                F.grouped_mm = grouped
             try:
                 result = original(*args, **kwargs)
             finally:
                 F.linear = original_linear
+                if original_grouped is not None:
+                    F.grouped_mm = original_grouped
             if seen != set(parameters):
-                raise RuntimeError("joint AURA packed source did not execute declared F.linear boundaries")
+                raise RuntimeError("joint AURA packed source did not execute declared F.linear/grouped_mm boundaries")
             return result
 
         self.forward_originals.append((module, original))
@@ -242,7 +275,7 @@ class SignedJointProjectionLease:
             self._observe(name, module.weight, x, output)
         return observe
 
-    def _observe(self, name, source_weight, x, output, output_slice=None):
+    def _observe(self, name, source_weight, x, output, output_slice=None, row_slice=None):
         if not self.active:
             raise RuntimeError("joint AURA forward outside active probe")
         if not isinstance(x, torch.Tensor) or not isinstance(output, torch.Tensor):
@@ -253,7 +286,8 @@ class SignedJointProjectionLease:
 
         @torch.no_grad()
         def project(gradient):
-            selected = gradient if output_slice is None else gradient[..., output_slice]
+            selected = gradient if row_slice is None else gradient[row_slice]
+            selected = selected if output_slice is None else selected[..., output_slice]
             if x.device != selected.device or x.device != source_weight.device:
                 raise RuntimeError(f"joint AURA residency mismatch for {name}")
             if x.shape[:-1] != selected.shape[:-1] or x.shape[-1] != source_weight.shape[1] or selected.shape[-1] != source_weight.shape[0]:

--- a/prismaquant/joint_aura.py
+++ b/prismaquant/joint_aura.py
@@ -71,6 +71,28 @@ def activation_identity(spec, activation_max_abs: Mapping, qname: str) -> dict:
     }
 
 
+def source_execution_identity(model) -> dict:
+    """Bind resolved dispatch selectors omitted by Transformers config dumps.
+
+    Include module-local configs because a model may override a single layer's
+    backend without changing the root config or any checkpoint tensor.
+    """
+    modules = {}
+    for name, module in model.named_modules():
+        config = getattr(module, "config", None)
+        selectors = {}
+        for label, field in (("attention", "_attn_implementation"),
+                             ("experts", "_experts_implementation")):
+            if config is not None and hasattr(config, field):
+                # Take an independent JSON value, so later config mutation
+                # cannot mutate the sealed identity through a shared dict.
+                selectors[label] = json.loads(json.dumps(
+                    getattr(config, field), sort_keys=True, allow_nan=False))
+        if selectors:
+            modules[name] = selectors
+    return {"schema": "prismaquant.joint_aura.source_execution.v1", "modules": modules}
+
+
 def arithmetic_identity(measurement_dtype) -> dict:
     return {
         "projection_dtype": "torch.float32", "delta_dtype": "torch.float32",

--- a/prismaquant/joint_aura.py
+++ b/prismaquant/joint_aura.py
@@ -14,12 +14,14 @@ import re
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 from prismaquant.perturbed_x_cache import (
     _activation_max_abs_lookup, _activation_qdq, _first_tensor_location,
     _served_nvfp4_act_qdq_enabled,
 )
 from prismaquant.memory_management import env_truthy
+from prismaquant.routed_experts import PackedExpertProjection
 
 
 JOINT_CURRENCY = "joint_aura_predicted_dloss"
@@ -111,14 +113,25 @@ class SignedJointProjectionLease:
         self.deltas = delta_weights
         self.activation_max_abs = dict(activation_max_abs or {})
         self.handles = []
+        self.forward_originals = []
         self.active = False
         self.terms = {}
         self.groups = {}
         self.telemetry = {"qdq_calls": 0, "operator_gemms": 0, "persistent_cache_entries": 0}
-        if len({id(mod) for mod in self.modules.values()}) != len(self.modules):
+        dense_modules = [mod for mod in self.modules.values() if isinstance(mod, nn.Linear)]
+        if len({id(mod) for mod in dense_modules}) != len(dense_modules):
             raise ValueError("joint AURA refuses aliased Linear modules")
+        packed_aliases = set()
         for name, module in self.modules.items():
-            if not isinstance(module, nn.Linear):
+            if isinstance(module, PackedExpertProjection):
+                if module.qname != name:
+                    raise ValueError(f"joint AURA packed projection name differs for {name}")
+                rows = module.output_slice
+                alias = (id(module.parameter), module.expert_id, rows.start, rows.stop)
+                if alias in packed_aliases:
+                    raise ValueError("joint AURA refuses aliased packed projection views")
+                packed_aliases.add(alias)
+            elif not isinstance(module, nn.Linear):
                 raise TypeError(f"joint AURA target {name} is not Linear")
             expected = {fmt for qname, fmt in self.deltas if qname == name}
             if set(self.specs[name]) != expected:
@@ -143,18 +156,79 @@ class SignedJointProjectionLease:
             self.groups[name] = tuple(grouped.values())
 
     def __enter__(self):
-        if self.handles:
+        if self.handles or self.forward_originals:
             raise RuntimeError("joint AURA lease already entered")
-        for name, module in self.modules.items():
-            self.handles.append(module.register_forward_hook(self._hook(name), with_kwargs=True))
+        packed = {}
+        try:
+            for name, module in self.modules.items():
+                if isinstance(module, PackedExpertProjection):
+                    packed.setdefault(id(module.module), []).append(module)
+                else:
+                    self.handles.append(module.register_forward_hook(self._hook(name), with_kwargs=True))
+            for members in packed.values():
+                self._install_packed_observer(members)
+        except Exception:
+            self.__exit__(None, None, None)
+            raise
         return self
 
     def __exit__(self, *_args):
         for handle in self.handles:
             handle.remove()
         self.handles.clear()
+        for module, original in reversed(self.forward_originals):
+            module.forward = original
+        self.forward_originals.clear()
         self.terms.clear()
         self.active = False
+
+    def _install_packed_observer(self, members):
+        """Observe the existing per-expert Linear slices without changing them.
+
+        This uses the same temporary F.linear interception and exact dim-0
+        slice recognizer as the packed Fisher and production activation taps.
+        The baseline forward and routing arithmetic execute unchanged.
+        """
+        from prismaquant.sensitivity_probe import _packed_expert_slice_index
+
+        module = members[0].module
+        original = module.forward
+        parameters = {id(member.parameter): member.parameter for member in members}
+        by_expert = {}
+        for member in members:
+            by_expert.setdefault((id(member.parameter), member.expert_id), []).append(member)
+
+        def forward(*args, **kwargs):
+            if not self.active:
+                raise RuntimeError("joint AURA packed forward outside active probe")
+            seen = set()
+            original_linear = F.linear
+
+            def linear(inputs, weight, bias=None):
+                base = weight._base if weight._is_view() else weight
+                parameter = parameters.get(id(base))
+                if parameter is None:
+                    return original_linear(inputs, weight, bias)
+                expert = _packed_expert_slice_index(weight, parameter)
+                if expert is None:
+                    raise RuntimeError("joint AURA packed weight escaped its declared Linear slice")
+                seen.add(id(parameter))
+                output = original_linear(inputs, weight, bias)
+                for member in by_expert.get((id(parameter), expert), ()):
+                    self._observe(member.qname, member.weight, inputs, output, member.output_slice)
+                return output
+
+            F.linear = linear
+            try:
+                result = original(*args, **kwargs)
+            finally:
+                F.linear = original_linear
+            if seen != set(parameters):
+                raise RuntimeError("joint AURA packed source did not execute declared F.linear boundaries")
+            return result
+
+        self.forward_originals.append((module, original))
+        module.forward = forward
 
     def begin_probe(self):
         if self.active:
@@ -164,49 +238,53 @@ class SignedJointProjectionLease:
 
     def _hook(self, name):
         def observe(module, args, kwargs, output):
-            if not self.active:
-                raise RuntimeError("joint AURA forward outside active probe")
             _, _, x = _first_tensor_location(args, kwargs)
-            if not isinstance(x, torch.Tensor) or not isinstance(output, torch.Tensor):
-                raise TypeError(f"joint AURA Linear {name} needs Tensor input/output")
-            # Detach, without copying the baseline activation or retaining its
-            # upstream graph. The existing reverse window owns its lifetime.
-            x = x.detach()
-
-            @torch.no_grad()
-            def project(gradient):
-                if x.device != gradient.device or x.device != module.weight.device:
-                    raise RuntimeError(f"joint AURA residency mismatch for {name}")
-                if x.shape[:-1] != gradient.shape[:-1] or x.shape[-1] != module.weight.shape[1] or gradient.shape[-1] != module.weight.shape[0]:
-                    raise RuntimeError(f"joint AURA Linear geometry/shape mismatch for {name}")
-                x2 = x.reshape(-1, x.shape[-1]).float()
-                g2 = gradient.reshape(-1, gradient.shape[-1]).float()
-                gw = g2.T @ x2
-                for spec, formats in self.groups[name]:
-                    d_operator = None
-                    activation = torch.zeros((), device=x.device)
-                    if spec.act_quant_changes_input:
-                        quantized = _activation_qdq(x, spec, self.activation_max_abs, name)
-                        if not isinstance(quantized, torch.Tensor) or quantized.shape != x.shape or quantized.device != x.device or quantized.dtype != x.dtype:
-                            raise RuntimeError(f"joint AURA QDQ changed residency/dtype/shape for {name}")
-                        dx = quantized.reshape_as(x2).float() - x2
-                        d_operator = g2.T @ dx
-                        activation = (d_operator * module.weight.float()).sum()
-                        self.telemetry["qdq_calls"] += 1
-                        self.telemetry["operator_gemms"] += 1
-                    for fmt in formats:
-                        delta = self.deltas[(name, fmt)].float()
-                        weight = (gw * delta).sum()
-                        mixed = ((d_operator * delta).sum() if d_operator is not None
-                                 else torch.zeros((), device=x.device))
-                        components = torch.stack((weight, activation, mixed))
-                        key = (name, fmt)
-                        self.terms[key] = self.terms.get(key, 0) + components
-                return gradient
-
-            if output.requires_grad:
-                output.register_hook(project)
+            self._observe(name, module.weight, x, output)
         return observe
+
+    def _observe(self, name, source_weight, x, output, output_slice=None):
+        if not self.active:
+            raise RuntimeError("joint AURA forward outside active probe")
+        if not isinstance(x, torch.Tensor) or not isinstance(output, torch.Tensor):
+            raise TypeError(f"joint AURA Linear {name} needs Tensor input/output")
+        # Detach, without copying the baseline activation or retaining its
+        # upstream graph. The existing reverse window owns its lifetime.
+        x = x.detach()
+
+        @torch.no_grad()
+        def project(gradient):
+            selected = gradient if output_slice is None else gradient[..., output_slice]
+            if x.device != selected.device or x.device != source_weight.device:
+                raise RuntimeError(f"joint AURA residency mismatch for {name}")
+            if x.shape[:-1] != selected.shape[:-1] or x.shape[-1] != source_weight.shape[1] or selected.shape[-1] != source_weight.shape[0]:
+                raise RuntimeError(f"joint AURA Linear geometry/shape mismatch for {name}")
+            x2 = x.reshape(-1, x.shape[-1]).float()
+            g2 = selected.reshape(-1, selected.shape[-1]).float()
+            gw = g2.T @ x2
+            for spec, formats in self.groups[name]:
+                d_operator = None
+                activation = torch.zeros((), device=x.device)
+                if spec.act_quant_changes_input:
+                    quantized = _activation_qdq(x, spec, self.activation_max_abs, name)
+                    if not isinstance(quantized, torch.Tensor) or quantized.shape != x.shape or quantized.device != x.device or quantized.dtype != x.dtype:
+                        raise RuntimeError(f"joint AURA QDQ changed residency/dtype/shape for {name}")
+                    dx = quantized.reshape_as(x2).float() - x2
+                    d_operator = g2.T @ dx
+                    activation = (d_operator * source_weight.float()).sum()
+                    self.telemetry["qdq_calls"] += 1
+                    self.telemetry["operator_gemms"] += 1
+                for fmt in formats:
+                    delta = self.deltas[(name, fmt)].float()
+                    weight = (gw * delta).sum()
+                    mixed = ((d_operator * delta).sum() if d_operator is not None
+                             else torch.zeros((), device=x.device))
+                    components = torch.stack((weight, activation, mixed))
+                    key = (name, fmt)
+                    self.terms[key] = self.terms.get(key, 0) + components
+            return gradient
+
+        if output.requires_grad:
+            output.register_hook(project)
 
     def finish_probe(self):
         if not self.active:

--- a/prismaquant/routed_experts.py
+++ b/prismaquant/routed_experts.py
@@ -9,7 +9,7 @@ accepts both physical representations used by PrismaQuant: a packed parameter
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import re
 
 import torch
@@ -313,6 +313,63 @@ class PackedExpertProjection:
     projection_name: str
     weight: torch.Tensor
 
+    @property
+    def parameter(self) -> nn.Parameter:
+        """The current packed leaf; streaming may replace it between leases."""
+        value = getattr(self.module, self.param_name, None)
+        if not isinstance(value, nn.Parameter) or value.ndim != 3:
+            raise RuntimeError(f"packed projection {self.qname} has no live packed leaf")
+        return value
+
+    @property
+    def output_slice(self) -> slice:
+        """This projection's rows inside its expert's packed Linear output."""
+        parent = self.parameter
+        base = self.weight._base if self.weight._is_view() else self.weight
+        if (base is not parent or self.weight.ndim != 2
+                or self.weight.stride() != parent.stride()[1:]
+                or self.weight.shape[1] != parent.shape[2]
+                or parent.stride(1) <= 0
+                or not 0 <= self.expert_id < parent.shape[0]):
+            raise RuntimeError(f"packed projection {self.qname} is a stale or invalid source view")
+        offset = (self.weight.storage_offset() - parent.storage_offset()
+                  - self.expert_id * parent.stride(0))
+        rows, remainder = divmod(offset, parent.stride(1))
+        stop = rows + self.weight.shape[0]
+        if remainder or rows < 0 or stop > parent.shape[1]:
+            raise RuntimeError(f"packed projection {self.qname} has invalid source row geometry")
+        return slice(rows, stop)
+
+    def gradient_view(self, gradient: torch.Tensor) -> torch.Tensor:
+        if gradient.shape != self.parameter.shape:
+            raise RuntimeError(f"packed projection gradient shape differs for {self.qname}")
+        return gradient[self.expert_id, self.output_slice, :]
+
+
+def refresh_packed_expert_projections(members, profile) -> list[PackedExpertProjection]:
+    """Rebind existing logical views after a streamed install or unload.
+
+    The profile/export split is evaluated once per physical parameter. No
+    checkpoint tensor or rendered tensor is copied or retained separately.
+    """
+    from .export_native_compressed import _split_packed_expert_tensor
+
+    splits = {}
+    refreshed = []
+    for member in members:
+        key = (id(member.module), member.param_name)
+        if key not in splits:
+            splits[key] = dict(_split_packed_expert_tensor(
+                member.parameter, member.param_name, profile))
+        try:
+            weight = splits[key][member.projection_name][member.expert_id]
+        except (KeyError, IndexError) as exc:
+            raise RuntimeError(f"packed projection topology changed for {member.qname}") from exc
+        if weight.shape != member.weight.shape:
+            raise RuntimeError(f"packed projection shape changed for {member.qname}")
+        refreshed.append(replace(member, weight=weight))
+    return refreshed
+
 
 def profile_declared_packed_expert_projections(
     model: nn.Module, profile=None,
@@ -373,6 +430,7 @@ __all__ = [
     "UnpackedExpertLinear",
     "PackedExpertProjection",
     "profile_declared_packed_expert_projections",
+    "refresh_packed_expert_projections",
     "profile_declared_routed_expert_targets",
     "profile_declared_unpacked_expert_linears",
     "resolve_routed_expert_profile",

--- a/tests/test_joint_aura_lease_lifetime.py
+++ b/tests/test_joint_aura_lease_lifetime.py
@@ -1,0 +1,34 @@
+"""The reverse loop releases a completed lease before loading another layer."""
+import weakref
+
+import torch
+
+import prismaquant.aura_cost as aura
+import prismaquant.joint_aura as joint
+from test_joint_aura_streamed import _fixture
+from test_streamed_cost_checkpoints import _model_identity
+
+
+def test_completed_joint_lease_does_not_retain_previous_layer_deltas(monkeypatch):
+    _, context, runner, cache = _fixture()
+    previous_deltas = []
+    released_layers = []
+    original_lease = joint.SignedJointProjectionLease
+    class ObservedLease(original_lease):
+        def __exit__(self, *args):
+            previous_deltas[:] = [weakref.ref(tensor) for tensor in self.deltas.values()]
+            return super().__exit__(*args)
+    monkeypatch.setattr(joint, 'SignedJointProjectionLease', ObservedLease)
+    original_install = context.install
+    def install(layer, **kwargs):
+        if previous_deltas:
+            assert all(reference() is None for reference in previous_deltas), \
+                'completed joint lease retained deltas into the next layer install'
+            released_layers.append(layer)
+        return original_install(layer, **kwargs)
+    context.install = install
+    aura.compute_aura_cost_streamed(runner, torch.tensor([[1, 2, 3, 4]]),
+        ['FP8_DYNAMIC', 'BF16'], n_probes=2, min_free_gib=0,
+        production_cache=cache, joint_activation=True,
+        model_identity=_model_identity('joint-lifetime'))
+    assert released_layers == [0]

--- a/tests/test_joint_aura_packed.py
+++ b/tests/test_joint_aura_packed.py
@@ -139,6 +139,37 @@ def test_packed_joint_rows_match_full_model_residual_oracle():
     assert observed_nonzero_cross_term
 
 
+def test_grouped_packed_joint_matches_eager_source_oracle(monkeypatch):
+    # A CPU grouped GEMM oracle with the same transpose/offset boundary as
+    # Transformers. Source routing executes unchanged under the observer.
+    def grouped_mm(inputs, weights, *, offs):
+        start = 0
+        outputs = []
+        for expert, end in enumerate(offs.tolist()):
+            outputs.append(inputs[start:end] @ weights[expert])
+            start = end
+        return torch.cat(outputs, dim=0)
+    monkeypatch.setattr(F, 'grouped_mm', grouped_mm, raising=False)
+    model, _, runner, profile, cache, _ = _fixture()
+    expected = _run(runner, profile, cache)
+    def grouped_forward(self, x):
+        shape = x.shape
+        inputs = x.reshape(-1, shape[-1])
+        count = inputs.shape[0]
+        inputs = torch.cat([inputs, inputs], dim=0)
+        offsets = torch.tensor([count, count * 2, count * 2], dtype=torch.int32)
+        gate, up = F.grouped_mm(inputs, self.gate_up_proj.transpose(-2, -1), offs=offsets).chunk(2, -1)
+        down = F.grouped_mm(F.silu(gate) * up, self.down_proj.transpose(-2, -1), offs=offsets)
+        return (down[:count] * 0.7 + down[count:] * 0.3).reshape(shape)
+    monkeypatch.setattr(_Experts, 'forward', grouped_forward)
+    _, _, runner, profile, cache, _ = _fixture()
+    observed = _run(runner, profile, cache)
+    assert F.grouped_mm is grouped_mm
+    for name, rows in observed['costs'].items():
+        actual = rows['FP8_E4M3']['signed_per_probe']
+        oracle = expected['costs'][name]['FP8_E4M3']['signed_per_probe']
+        assert actual == pytest.approx(oracle, rel=3e-5, abs=3e-8)
+
 def test_packed_joint_checkpoint_resume_keeps_aligned_unit_roster(tmp_path, monkeypatch):
     monkeypatch.setattr(aura, '_checkpoint_git_commit', lambda: '1' * 40)
     _, _, runner, profile, cache, _ = _fixture()
@@ -199,7 +230,7 @@ def test_packed_observer_refuses_a_source_that_escapes_linear_boundaries(monkeyp
     monkeypatch.setattr(_Experts, 'forward', matmul_forward)
     model, context, runner, profile, cache, _ = _fixture()
     original_linear = F.linear
-    with pytest.raises(RuntimeError, match='did not execute declared F.linear boundaries'):
+    with pytest.raises(RuntimeError, match='did not execute declared F.linear/grouped_mm boundaries'):
         _run(runner, profile, cache)
     assert F.linear is original_linear
     assert context.active == set()

--- a/tests/test_joint_aura_packed.py
+++ b/tests/test_joint_aura_packed.py
@@ -1,0 +1,214 @@
+"""Packed source views produce the same per-Linear joint residual as an oracle."""
+import copy
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+import prismaquant.aura_cost as aura
+import prismaquant.format_registry as fr
+from prismaquant.cost_streaming import StreamedCausalLM
+from prismaquant.joint_aura import validate_joint_aura_entry
+from prismaquant.kl_fisher import fisher_probe_scalar
+from prismaquant.model_profiles.lfm2_moe import Lfm2MoeProfile
+from prismaquant.perturbed_x_cache import _activation_qdq
+from prismaquant.production_weight_cache import ProductionWeightCache
+from prismaquant.routed_experts import profile_declared_packed_expert_projections
+from test_streamed_cost_checkpoints import _FakeStreamingContext, _model_identity
+
+
+class _Experts(nn.Module):
+    def __init__(self, width=16, experts=3):
+        super().__init__()
+        self.gate_up_proj = nn.Parameter(torch.randn(experts, width * 2, width) / 8)
+        self.down_proj = nn.Parameter(torch.randn(experts, width, width) / 8)
+        self.captures = None
+
+    def forward(self, x):
+        shape = x.shape
+        x = x.reshape(-1, shape[-1])
+        y = torch.zeros_like(x)
+        # Every token has two explicit routes; expert 2 is never selected.
+        for expert, route_weight in ((0, 0.7), (1, 0.3)):
+            gate_up = F.linear(x, self.gate_up_proj[expert])
+            gate, up = gate_up.chunk(2, dim=-1)
+            hidden = F.silu(gate) * up
+            down = F.linear(hidden, self.down_proj[expert])
+            if self.captures is not None:
+                gate_up.retain_grad()
+                down.retain_grad()
+                self.captures.append((expert, x.detach(), gate_up, hidden.detach(), down))
+            y = y + route_weight * down
+        return y.reshape(shape)
+
+
+class _Layer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.feed_forward = nn.Module()
+        self.feed_forward.experts = _Experts()
+
+    def forward(self, hidden_states, **kwargs):
+        experts = self.feed_forward.experts
+        # Repeated calls must be added while signed within each logical Linear.
+        return torch.tanh(0.2 * hidden_states + experts(hidden_states) + 0.25 * experts(-hidden_states))
+
+
+class _Model(nn.Module):
+    def __init__(self, state=None):
+        super().__init__()
+        self.model = nn.Module()
+        self.model.config = SimpleNamespace(layer_types=())
+        self.model.embed_tokens = nn.Embedding(23, 16)
+        self.model.layers = nn.ModuleList([_Layer(), _Layer()])
+        self.model.norm = nn.Identity()
+        self.lm_head = nn.Linear(16, 23, bias=False)
+        if state is not None:
+            self.load_state_dict(state)
+
+    def forward(self, ids):
+        hidden = self.model.embed_tokens(ids)
+        for layer in self.model.layers:
+            hidden = layer(hidden)
+        return SimpleNamespace(logits=self.lm_head(hidden))
+
+
+def _fixture(state=None):
+    torch.manual_seed(715)
+    model = _Model(state).eval()
+    profile = Lfm2MoeProfile()
+    context = _FakeStreamingContext(model)
+    runner = StreamedCausalLM(context, profile)
+    views = profile_declared_packed_expert_projections(model, profile)
+    weights = {(member.qname, 'FP8_E4M3'): member.weight.detach().clone() + 0.03125
+               for member in views}
+    cache = ProductionWeightCache(weights=weights, levers={},
+        activation_max_abs={member.qname: 1.0 for member in views})
+    return model, context, runner, profile, cache, views
+
+
+def _run(runner, profile, cache, **kwargs):
+    return aura.compute_aura_cost_streamed(runner, torch.tensor([[1, 2, 3, 4]]),
+        ['FP8_DYNAMIC', 'BF16'], n_probes=3, min_free_gib=0,
+        production_cache=cache, joint_activation=True, include_routed_experts=True,
+        profile=profile, model_identity=_model_identity('packed-joint-source'), **kwargs)
+
+
+def test_packed_joint_rows_match_full_model_residual_oracle():
+    model, context, runner, profile, cache, views = _fixture()
+    state = copy.deepcopy(model.state_dict())
+    payload = _run(runner, profile, cache)
+    assert set(payload['costs']) == {member.qname for member in views}
+    assert context.active == set()
+    oracle = _Model(state).eval()
+    by_name = {member.qname: member for member in profile_declared_packed_expert_projections(oracle, profile)}
+    observed_nonzero_cross_term = False
+    for probe_index in range(3):
+        for layer in oracle.model.layers:
+            layer.feed_forward.experts.captures = []
+        oracle.zero_grad(set_to_none=True)
+        logits = oracle(torch.tensor([[1, 2, 3, 4]])).logits
+        fisher_probe_scalar(logits, seed=7000 + probe_index, token_scope='all',
+            temperature=1.0, distribution='rademacher').backward()
+        expected = {name: 0.0 for name in by_name}
+        for layer_index, layer in enumerate(oracle.model.layers):
+            for expert, x, gu, h, down in layer.feed_forward.experts.captures:
+                for role, inputs, gradient in (
+                    ('w1', x, gu.grad[:, :16]),
+                    ('w3', x, gu.grad[:, 16:]),
+                    ('w2', h, down.grad),
+                ):
+                    name = f'model.layers.{layer_index}.feed_forward.experts.{expert}.{role}'
+                    weight = by_name[name].weight.detach().double()
+                    rendered = cache.get(name, 'FP8_E4M3').double()
+                    qx = _activation_qdq(inputs, fr.get_format('FP8_E4M3'), cache.activation_max_abs, name)
+                    residual = qx.double() @ rendered.T - inputs.double() @ weight.T
+                    expected[name] += float((gradient.double() * residual).sum())
+        for name, rows in payload['costs'].items():
+            row = rows['FP8_E4M3']
+            assert validate_joint_aura_entry(row)
+            assert row['joint_operator_identity']['qname'] == name
+            assert row['probe_ids'] == [7000, 7001, 7002]
+            assert row['signed_per_probe'][probe_index] == pytest.approx(expected[name], rel=3e-5, abs=3e-8)
+            assert rows['BF16']['signed_per_probe'] == [0.0, 0.0, 0.0]
+            if '.experts.2.' in name:
+                assert row['signed_per_probe'] == [0.0, 0.0, 0.0]
+            observed_nonzero_cross_term |= any(abs(term['mixed']) > 0 for term in row['signed_components_per_probe'])
+    assert observed_nonzero_cross_term
+
+
+def test_packed_joint_checkpoint_resume_keeps_aligned_unit_roster(tmp_path, monkeypatch):
+    monkeypatch.setattr(aura, '_checkpoint_git_commit', lambda: '1' * 40)
+    _, _, runner, profile, cache, _ = _fixture()
+    first = _run(runner, profile, cache, checkpoint_dir=tmp_path)
+    _, context, runner, profile, cache, _ = _fixture()
+    second = _run(runner, profile, cache, checkpoint_dir=tmp_path, resume=True)
+    assert first['costs'] == second['costs']
+    assert context.install_calls == 0
+
+
+def test_packed_views_refresh_after_install_and_release_after_unload():
+    import weakref
+    model, context, runner, profile, cache, _ = _fixture()
+    sources = [{name: value.detach().clone() for name, value in layer.named_parameters()}
+               for layer in model.model.layers]
+    released = []
+    original_install, original_unload = context.install, context.unload
+    def install(index, **kwargs):
+        assert all(reference() is None for reference in released), \
+            'logical projection retained a previous streamed source leaf'
+        layer = model.model.layers[index]
+        for name, value in sources[index].items():
+            owner, _, attr = name.rpartition('.')
+            layer.get_submodule(owner)._parameters[attr] = nn.Parameter(value.clone(), requires_grad=False)
+        return original_install(index, **kwargs)
+    def unload(index):
+        layer = model.model.layers[index]
+        released.extend(weakref.ref(parameter) for parameter in layer.parameters())
+        original_unload(index)
+        layer.to_empty(device='meta')
+    context.install, context.unload = install, unload
+    payload = _run(runner, profile, cache)
+    assert len(payload['costs']) == 18
+    assert all(reference() is None for reference in released)
+    assert all(parameter.is_meta for layer in model.model.layers for parameter in layer.parameters())
+
+
+def test_packed_observer_restores_forward_and_linear_after_backward_failure(monkeypatch):
+    import prismaquant.joint_aura as joint
+    model, context, runner, profile, cache, _ = _fixture()
+    original_linear = F.linear
+    original_forwards = [layer.feed_forward.experts.forward for layer in model.model.layers]
+    def fail(*args, **kwargs):
+        raise RuntimeError('QDQ failure sentinel')
+    monkeypatch.setattr(joint, '_activation_qdq', fail)
+    with pytest.raises(RuntimeError, match='QDQ failure sentinel'):
+        _run(runner, profile, cache)
+    assert F.linear is original_linear
+    assert context.active == set()
+    assert [layer.feed_forward.experts.forward for layer in model.model.layers] == original_forwards
+    assert all(parameter.grad is None for parameter in model.parameters())
+
+
+def test_packed_observer_refuses_a_source_that_escapes_linear_boundaries(monkeypatch):
+    def matmul_forward(self, x):
+        gate, up = (x @ self.gate_up_proj[0].T).chunk(2, dim=-1)
+        return (F.silu(gate) * up) @ self.down_proj[0].T
+    monkeypatch.setattr(_Experts, 'forward', matmul_forward)
+    model, context, runner, profile, cache, _ = _fixture()
+    original_linear = F.linear
+    with pytest.raises(RuntimeError, match='did not execute declared F.linear boundaries'):
+        _run(runner, profile, cache)
+    assert F.linear is original_linear
+    assert context.active == set()
+    assert all(layer.feed_forward.experts.forward.__func__ is matmul_forward
+               for layer in model.model.layers)
+
+
+def test_packed_joint_refuses_dense_only_renderer_before_source_forward():
+    _, context, runner, profile, cache, _ = _fixture()
+    with pytest.raises(RuntimeError, match='requires decoded ProductionWeightCache'):
+        _run(runner, profile, cache, anchor_renderer=object())
+    assert context.install_calls == 0

--- a/tests/test_joint_aura_packed.py
+++ b/tests/test_joint_aura_packed.py
@@ -169,6 +169,16 @@ def test_grouped_packed_joint_matches_eager_source_oracle(monkeypatch):
         actual = rows['FP8_E4M3']['signed_per_probe']
         oracle = expected['costs'][name]['FP8_E4M3']['signed_per_probe']
         assert actual == pytest.approx(oracle, rel=3e-5, abs=3e-8)
+    import prismaquant.joint_aura as joint
+    def fail(*args, **kwargs):
+        raise RuntimeError('grouped QDQ failure sentinel')
+    monkeypatch.setattr(joint, '_activation_qdq', fail)
+    _, context, runner, profile, cache, _ = _fixture()
+    with pytest.raises(RuntimeError, match='grouped QDQ failure sentinel'):
+        _run(runner, profile, cache)
+    assert F.grouped_mm is grouped_mm
+    assert context.active == set()
+
 
 def test_packed_joint_checkpoint_resume_keeps_aligned_unit_roster(tmp_path, monkeypatch):
     monkeypatch.setattr(aura, '_checkpoint_git_commit', lambda: '1' * 40)

--- a/tests/test_joint_aura_streamed.py
+++ b/tests/test_joint_aura_streamed.py
@@ -238,3 +238,34 @@ def test_joint_transient_anchor_renderer_is_consumed_and_resumed(tmp_path, monke
     assert first["costs"] == second["costs"]
     assert context.install_calls == 0
     assert renderer.render_count == 0
+
+
+@pytest.mark.parametrize('field', ['_attn_implementation', '_experts_implementation'])
+def test_joint_resume_binds_private_source_backend(tmp_path, monkeypatch, field):
+    from types import SimpleNamespace
+    monkeypatch.setattr(aura, '_checkpoint_git_commit', lambda: '1' * 40)
+    model, _, runner, cache = _fixture()
+    model.model.layers[0].config = SimpleNamespace(**{field: 'eager'})
+    _run(runner, cache, checkpoint_dir=tmp_path)
+    model, context, runner, cache = _fixture()
+    model.model.layers[0].config = SimpleNamespace(**{field: 'changed_backend'})
+    with pytest.raises(RuntimeError, match='identity mismatch'):
+        _run(runner, cache, checkpoint_dir=tmp_path, resume=True)
+    assert context.install_calls == 0
+
+
+def test_joint_refuses_backend_mutation_before_writing_layer_rows(tmp_path):
+    from types import SimpleNamespace
+    model, context, runner, cache = _fixture()
+    layer = model.model.layers[0]
+    layer.config = SimpleNamespace(_experts_implementation='eager')
+    def mutate(*args):
+        layer.config._experts_implementation = 'changed_backend'
+    handle = layer.register_forward_pre_hook(mutate)
+    try:
+        with pytest.raises(RuntimeError, match='backend changed during measurement'):
+            _run(runner, cache, checkpoint_dir=tmp_path)
+    finally:
+        handle.remove()
+    assert context.active == set()
+    assert not list(tmp_path.glob('units/*.pkl'))


### PR DESCRIPTION
Packed MoE source Linears could not produce joint activation/weight AURA prices because they are views of packed Parameters and execute through F.linear or grouped_mm. Extend the shared packed views and joint lease to observe the original operators, harvest each physical gradient once, split expert rows/fused outputs correctly, and emit the existing additive per-Linear currency. Refresh views and release deltas at streamed install/unload boundaries. Seal resolved source backends in probe/checkpoint identities and refuse backend drift.

Closes #313.

Validation through PrismaBuild: 63 targeted CPU checks plus two focused cleanup/mutation checks (64 distinct, no skips), with pre-fix regressions retained. Actual LFM canonical row 0: full 128,000-vocabulary forward and eight packed leaf gradients are bit-exact against ordinary HF; shared derived down inputs are bit-exact against original grouped source inputs. Original E4M3 K1 R1024 wires produce 96 four-probe joint rows plus BF16 controls. This is a one-sequence operator screen; full-calibration quality and serving qualification remain separate.

Evidence, exact inputs/commands, profiler/Netdata artifacts, negative results and hashes: [measurement record](docs/measurements/lfm-packed-joint-aura-2026-09-07.md) and companion JSON. No serving defaults, formats or ship gates change.
