### PR TITLE
Bound streamed joint AURA with versioned calibration microbatches

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,28 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-07 · `fix/fp8-native-parity`. Stamps
+As of: 2026-09-07 · `feat/joint-aura-calibration-microbatch`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-07, `feat/joint-aura-calibration-microbatch`) for
+**bounded full-calibration streamed joint AURA** (#318). Explicit
+`--probe-microbatch N` partitions the exact token draw into contiguous complete
+sequence rows through the existing streamed boundary/shared-state mechanism.
+The opt-in `prismaquant.kl_fisher.global_row.v1` noise layout derives each row's
+seed from its global row index, probe seed, scope and token/vocabulary geometry;
+all partitions use the full draw's token normalizer. The same per-Linear signed
+residual lease spans every partition of a probe and squares only after their
+sum. Gradient diagnostics likewise sum FP32 gradients before taking norms.
+GPU full-vocabulary tensors and recompute graphs are bounded by N; CPU boundary
+and cotangent storage still scales with the full draw, and existing source
+prefetch/cache residency remains required. Probe identity seals the full draw,
+source backend and row layout. Its existing arithmetic descriptor also seals N,
+as do execution provenance and checkpoint identity. The row RNG layout stays
+partition independent; paired candidates, assignments and resume reject mixed
+execution sizes because floating-point source kernels can round differently
+across batch shapes. Zero retains the legacy streamed probe draws;
+resident microbatch semantics remain unchanged. This is opt-in research with no
+format, allocator-objective, serving or export gate change.
+Gates: `tests/test_joint_aura_microbatch.py`, `tests/test_joint_aura_packed.py`.
 
 Re-stamped (2026-09-07, `fix/fp8-native-parity`) for **served FP8 activation
 arithmetic**. The shared dynamic activation adapter uses FP32 tensor-denominator

--- a/docs/design/design_guidelines.md
+++ b/docs/design/design_guidelines.md
@@ -203,3 +203,24 @@ state:
 - why the existing mechanism cannot be used;
 - how the exception is isolated behind a flag or research path;
 - what result would justify promoting, deleting, or replacing it.
+
+
+### Streamed joint AURA calibration partitions
+
+Explicit `probe_microbatch > 0` uses versioned global-row Fisher probes on the
+entire supplied calibration draw. The row seed domain includes the probe seed,
+global row index, scope and selected token/vocabulary geometry. Normalize every
+partition by the full selected-token count. Compare partitioned execution with
+an explicit full-size positive microbatch reference using that same layout;
+zero is the legacy layout and its finite probe samples differ.
+
+A logical Linear's weight, activation and mixed residuals sum while signed
+across repeated invocations and every calibration partition before squaring.
+Gradient norm and column-energy diagnostics also square only after the complete
+probe gradient is accumulated. Batch size is part of the existing probe
+arithmetic identity as well as execution provenance and checkpoint identity.
+Shared paired-candidate and assignment consumers reject mixed execution sizes,
+while the row RNG descriptor remains partition independent. BF16 source kernels
+can round differently at different shapes; this is also a resume boundary. Full-draw host boundaries, cotangents, declared shared pass state and
+existing source/cache residency must be included in admission even though GPU
+logits and recompute graphs are bounded by the microbatch.

--- a/docs/measurements/lfm-joint-microbatch-2026-09-07.json
+++ b/docs/measurements/lfm-joint-microbatch-2026-09-07.json
@@ -98,6 +98,31 @@
       "sha256": "5acc61c565159e5e02e7480149d358ccb87eb55bd21ab2b8baa4ced352bb27ce"
     },
     {
+      "path": "cost03-native-qdq/joint-cost.json",
+      "bytes": 55126831,
+      "sha256": "66306b6f5feaecfbf5569a43c596b4229bf133ca036bc016fd2634a113780c39"
+    },
+    {
+      "path": "cost03-native-qdq/model_identity.json",
+      "bytes": 252894,
+      "sha256": "fa7a85734252375df0d01fe5003efc065688348c3c535535305bc9f64d47d339"
+    },
+    {
+      "path": "cost03-native-qdq/netdata-both-hosts.json",
+      "bytes": 42184,
+      "sha256": "8d9dc88baa810f4846a908d9ed2d4ed3f721e27d5eecdbec17ce8bfb3cad431e"
+    },
+    {
+      "path": "cost03-native-qdq/results.json",
+      "bytes": 265035,
+      "sha256": "fe3e20efc15f8cd44b8d086a01d12c3043d9e7c765a160d2c4316d2516fd0081"
+    },
+    {
+      "path": "native-qdq-qualification/diagnostic-after-01.json",
+      "bytes": 7738,
+      "sha256": "e955dfe266e5f704e38624549d9543019f2d8eec049fcd34ceed3e73ddbefeb6"
+    },
+    {
       "path": "receipts/1cf4d668b0f6302f422ac0c303c3ee2310ff95706a02d8cee27962bd14b78fd5.request.json",
       "bytes": 2592,
       "sha256": "fecbe1dcbd3d9f51dd5c911785b8b215a3ce5cd2adbe2c7a78be75bb966b4082"
@@ -166,6 +191,36 @@
       "path": "receipts/25fefb27ac44d59f887d02907e002299aad104969ae3d4c3e4eb9f18123b2e34.summary.json",
       "bytes": 1185,
       "sha256": "0f61ba11b8ea5bb9aa008e573d62cb0e7d0753540bfa957c89568b5d7ad204f6"
+    },
+    {
+      "path": "receipts/43b4b43e7a623cd97a0c024d0ac411572475ba26dab18558a58160e33547910d.payload",
+      "bytes": 1255,
+      "sha256": "b66405a18f2f52f2445f49553d1382078cbe72cf8090255ab9309e74ca0d584a"
+    },
+    {
+      "path": "receipts/43b4b43e7a623cd97a0c024d0ac411572475ba26dab18558a58160e33547910d.receipt.json",
+      "bytes": 2631,
+      "sha256": "9ae171aad5274de215d4b47e434c1ea9d3e7cbbed3ce27f34cddba3ee31a3fb7"
+    },
+    {
+      "path": "receipts/43b4b43e7a623cd97a0c024d0ac411572475ba26dab18558a58160e33547910d.request.json",
+      "bytes": 3936,
+      "sha256": "3ba610f34ce760b259f68d46b50355482a09bd3a53171ef68a8add35ccfdd277"
+    },
+    {
+      "path": "receipts/43b4b43e7a623cd97a0c024d0ac411572475ba26dab18558a58160e33547910d.stderr.txt",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "receipts/43b4b43e7a623cd97a0c024d0ac411572475ba26dab18558a58160e33547910d.stdout.txt",
+      "bytes": 3823,
+      "sha256": "bb084d791fa9b227437cbde7ad0671ea00a11e7ae1a7d6bdf4c0d286857bcb3d"
+    },
+    {
+      "path": "receipts/43b4b43e7a623cd97a0c024d0ac411572475ba26dab18558a58160e33547910d.summary.json",
+      "bytes": 1393,
+      "sha256": "154063ce4902b775b2abb32a3e763a0cef49336f7e84b76dffd566f803b76c99"
     },
     {
       "path": "receipts/6d50e9449fed1df550545ea4c276c707825e60f0d2e5335c1e30b01b5e1d5a63.payload",
@@ -388,6 +443,96 @@
       "sha256": "31feecb5ec3b46428337aa7e0aa79bc2d6375649f703fd67a11d5ffa65fd658c"
     },
     {
+      "path": "receipts/d1c9f2ba1b7934161fddc88319a81bebe3094e8861e03193f9c5ae23cbd39e4b.payload",
+      "bytes": 5634,
+      "sha256": "d772218b53aff0f23561ad2189db00155271c1b0b6eb366cb09171a402474f2d"
+    },
+    {
+      "path": "receipts/d1c9f2ba1b7934161fddc88319a81bebe3094e8861e03193f9c5ae23cbd39e4b.receipt.json",
+      "bytes": 2631,
+      "sha256": "923910f58f71604241f76f93c4a3f26f7ba29900e6bc8e17a9a9a80841f23bb8"
+    },
+    {
+      "path": "receipts/d1c9f2ba1b7934161fddc88319a81bebe3094e8861e03193f9c5ae23cbd39e4b.request.json",
+      "bytes": 2999,
+      "sha256": "9a8ce5ca6a6e33dc6cfcfad41aa9fa6d94d3b958b0abe06176d5f60a2fe60846"
+    },
+    {
+      "path": "receipts/d1c9f2ba1b7934161fddc88319a81bebe3094e8861e03193f9c5ae23cbd39e4b.stderr.txt",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "receipts/d1c9f2ba1b7934161fddc88319a81bebe3094e8861e03193f9c5ae23cbd39e4b.stdout.txt",
+      "bytes": 8202,
+      "sha256": "1c62ea275f35d2fd5f5f953580e5928cf8d9ecf6aaa3111be2ce6b3bc7054c53"
+    },
+    {
+      "path": "receipts/d1c9f2ba1b7934161fddc88319a81bebe3094e8861e03193f9c5ae23cbd39e4b.summary.json",
+      "bytes": 1359,
+      "sha256": "1487a3b5a288a7fb387795bc15e18f0cf5f2e88a7345b7b85306f4461d7066fe"
+    },
+    {
+      "path": "receipts/e9b8fe8567c646308c86bb3628764e3030608e35b35065bc6f6ef8b7337f15cb.payload",
+      "bytes": 545,
+      "sha256": "817dfa168b8563684a8a855f287cabe5eda2436959ad9344aaf26fddc553181f"
+    },
+    {
+      "path": "receipts/e9b8fe8567c646308c86bb3628764e3030608e35b35065bc6f6ef8b7337f15cb.receipt.json",
+      "bytes": 2630,
+      "sha256": "aa59f7e9e779add45c87c8d08204194a4128f1ca028cf92e91c0cdcc1f4c7a14"
+    },
+    {
+      "path": "receipts/e9b8fe8567c646308c86bb3628764e3030608e35b35065bc6f6ef8b7337f15cb.request.json",
+      "bytes": 2559,
+      "sha256": "3f4974a9cdbd46b02409e43dec9cb9dc8c079850b10d6fb7cc4b1d536ca994cd"
+    },
+    {
+      "path": "receipts/e9b8fe8567c646308c86bb3628764e3030608e35b35065bc6f6ef8b7337f15cb.stderr.txt",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "receipts/e9b8fe8567c646308c86bb3628764e3030608e35b35065bc6f6ef8b7337f15cb.stdout.txt",
+      "bytes": 3112,
+      "sha256": "60133b35b5af5d710b365f4107484c5a08983c2917de5a9b53a51e1050ccb75a"
+    },
+    {
+      "path": "receipts/e9b8fe8567c646308c86bb3628764e3030608e35b35065bc6f6ef8b7337f15cb.summary.json",
+      "bytes": 1360,
+      "sha256": "754fb4b6319f602a3d5299fa897c6fa14643f093a8fa2be74a17132336d70b33"
+    },
+    {
+      "path": "receipts/f743a8375609bfb12586000e9e8bd1ea36096410a22bdebf73856204b5935cb9.payload",
+      "bytes": 1115,
+      "sha256": "74d5b657ddb88f88622e0674ab1df2e20896d9c62ebeea81a34bc9d269404611"
+    },
+    {
+      "path": "receipts/f743a8375609bfb12586000e9e8bd1ea36096410a22bdebf73856204b5935cb9.receipt.json",
+      "bytes": 2631,
+      "sha256": "212cd4ed8e2140023766e308cd7a77345e0b201fdb1a9836a0f157c5afe5be27"
+    },
+    {
+      "path": "receipts/f743a8375609bfb12586000e9e8bd1ea36096410a22bdebf73856204b5935cb9.request.json",
+      "bytes": 3230,
+      "sha256": "d54c97695119a23f24ffc40ed98ca2c8e9589c9422777317eba3c5ba07b3e51c"
+    },
+    {
+      "path": "receipts/f743a8375609bfb12586000e9e8bd1ea36096410a22bdebf73856204b5935cb9.stderr.txt",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "receipts/f743a8375609bfb12586000e9e8bd1ea36096410a22bdebf73856204b5935cb9.stdout.txt",
+      "bytes": 3683,
+      "sha256": "9479dd5aac0ef0f14b05562d1722cb9b68dea516f5af4d5b42928ee327054b75"
+    },
+    {
+      "path": "receipts/f743a8375609bfb12586000e9e8bd1ea36096410a22bdebf73856204b5935cb9.summary.json",
+      "bytes": 1379,
+      "sha256": "19e914b012158bb4f1c4ebbd88a7e8444d9ba1f41e356c5d95725d1e833cb92e"
+    },
+    {
       "path": "receipts/fa5598de04a8f35cefa873b7e8bbd1845982f6b9517a831be0a57f00e4cf80db.payload",
       "bytes": 1115,
       "sha256": "8b584043d30ae1cd782469494c780affdabde0dfa13522f9e9cd6dfbd6aec4c7"
@@ -453,5 +598,5 @@
       "sha256": "a74a309609d296f8e8bb12f45e3434b0036f4e29dc115e996d4d488a0186aefb"
     }
   ],
-  "full_canonical_cost_status": "pending_qualified_activation_qdq_and_full_512_row_run"
+  "full_canonical_cost_status": "qualified_activation_qdq_full_512_row_run_active"
 }

--- a/docs/measurements/lfm-joint-microbatch-2026-09-07.json
+++ b/docs/measurements/lfm-joint-microbatch-2026-09-07.json
@@ -123,6 +123,511 @@
       "sha256": "e955dfe266e5f704e38624549d9543019f2d8eec049fcd34ceed3e73ddbefeb6"
     },
     {
+      "path": "full512-batch1/joint-cost.json",
+      "bytes": 55329411,
+      "sha256": "5e94df0523a161e40931b4610c14b8b6667abd05057d4df58c1e3392091d20d8"
+    },
+    {
+      "path": "full512-batch1/model_identity.json",
+      "bytes": 252894,
+      "sha256": "7df54e965502049485b352d2201a2a5eb319c71ffce456bf8952c4e626b57ee6"
+    },
+    {
+      "path": "full512-batch1/netdata-both-hosts.json",
+      "bytes": 821730,
+      "sha256": "796a0067a3d451a16dd1a00f7bae2ec00aa7967a8dae966a58a3a9712c91de0c"
+    },
+    {
+      "path": "full512-batch1/results.json",
+      "bytes": 269640,
+      "sha256": "93f36215c9623277bf954b43e8f93f44d5b743753a0496bf814a9ae831b684a4"
+    },
+    {
+      "path": "full512-checkpoint/manifest.json",
+      "bytes": 749347,
+      "sha256": "5e073936aedbc6517c616074cdacfe6d5e4ae2d4150c5bbd216b49e38d212fae"
+    },
+    {
+      "path": "full512-checkpoint/units/001f55810deaf17e99ccd229e128fd145ad875f95ed6873845c4c27e14ad4655.pkl",
+      "bytes": 240896,
+      "sha256": "9312f5a99640c1c2ee3c6b7a72dae98a52a60af7f3a3ad56e54f22116f58467c"
+    },
+    {
+      "path": "full512-checkpoint/units/06bd186b074ee8f179577e7dab8eed78c72fb3987fe3a23a985d36aebb762520.pkl",
+      "bytes": 240894,
+      "sha256": "2d1ade621d10781a9c45b1caf27061f9cb52c2f340fcf26055d69b7b3bd482c6"
+    },
+    {
+      "path": "full512-checkpoint/units/0b02452f39e081f957b93f72ca9cbec4e0d7387069616e0265808e9b3a58f0c8.pkl",
+      "bytes": 240896,
+      "sha256": "be6a3cc82001c67378a8361914700cad35bb28eac2e8fe449a1f61c2bbcbab33"
+    },
+    {
+      "path": "full512-checkpoint/units/0e3d624d313ede6b5e2cc794534fa0ff7306258dd95488ffcb444631f1c706f8.pkl",
+      "bytes": 240894,
+      "sha256": "af8f4f28018b9eaec332e8619633f5cf4f761fd4b37fc67db1390cbae4796879"
+    },
+    {
+      "path": "full512-checkpoint/units/0f7eb6f92c962a12f2196e0e6265b1e0ab21d0f6487c83fd8f9ea05d2a7c45ce.pkl",
+      "bytes": 240896,
+      "sha256": "fe605c4e22c041575b440cea696ff000127a1cbaa5096e4de9ef1c8aa98f2fb1"
+    },
+    {
+      "path": "full512-checkpoint/units/10a9f06f3a3b47c4c52dd98083208e770f682b753a183cbd013917b7cc4eb831.pkl",
+      "bytes": 240896,
+      "sha256": "eb2f530816d4df13eca317389e3dfd3ff43798eb54040ea4264a274a5225070d"
+    },
+    {
+      "path": "full512-checkpoint/units/12614708b3fbe6d54e842c38cb93b05922a2d751777e4d633dce941008727760.pkl",
+      "bytes": 240894,
+      "sha256": "e60a39c569b423afb3b1da4792311d1ba855ba3be3c1d85450ddae842b91a81b"
+    },
+    {
+      "path": "full512-checkpoint/units/155b97e66ccd623bf4464470f90c8c361449bc32465de723d5888a37f451a4ca.pkl",
+      "bytes": 240896,
+      "sha256": "8f08ce686efeb6413ecccd40b64bca4dce1c6e4e418d344c24cabd91de1b49d2"
+    },
+    {
+      "path": "full512-checkpoint/units/15871929ae4a69d4d1cc9da0755657e1ba6303515b51cf9a355136250a25a754.pkl",
+      "bytes": 240894,
+      "sha256": "84cd6b2778c0c1b5f97eb203364f41dbce22de4852e553c1f87b1fe95433a0b4"
+    },
+    {
+      "path": "full512-checkpoint/units/15fe49b8e780b2dd898b91baca3e2d3e0e1916eec19f580951e690d44636df9b.pkl",
+      "bytes": 240894,
+      "sha256": "1298c9fa50d37ae0c7eea091a616bb822c4c2869f08138380f643e278169bf93"
+    },
+    {
+      "path": "full512-checkpoint/units/17026338b26f66e6a81be4cf12e70a506ea7ca1b4733ab944cbba38fbdbad89e.pkl",
+      "bytes": 240896,
+      "sha256": "bfa84f80cc2b311edcbb7a80bccb7114d92364faac096bd9ad868f86a19b5dd7"
+    },
+    {
+      "path": "full512-checkpoint/units/1a87df179e4d0051666c69a3e111a343b950c293d35554eeedd75628400769cf.pkl",
+      "bytes": 240896,
+      "sha256": "38a05c4f4870724ea5c3ff3e87428198b9a4a7ed154f209959c453e6816f2fcc"
+    },
+    {
+      "path": "full512-checkpoint/units/215f4a2724c80befc83ec0874f82fa7d13ddeec9b91a649b4c190341030aaace.pkl",
+      "bytes": 240896,
+      "sha256": "176c0aad3e1be157b6bb37f101c1a4bcb441332094cfcd103ee1618a386e3db3"
+    },
+    {
+      "path": "full512-checkpoint/units/2290c17b20623e258085432db34860ce8a2dd4ad7654a24e1190a19d59379ad7.pkl",
+      "bytes": 240896,
+      "sha256": "4ac5c1e427b0cc958481294d76f296848e1ff19c45c821069e4e92651cc79ab5"
+    },
+    {
+      "path": "full512-checkpoint/units/297c4c089ab2be0d6f2ebc17d20d6d37fa9fe0d2baec3cc4d1df1dea332eb211.pkl",
+      "bytes": 240894,
+      "sha256": "f405796206131b6c255154e9bd02e1f6f7c714f87931600c7f247d3f9675dc3d"
+    },
+    {
+      "path": "full512-checkpoint/units/33bc7b14a725862475dc291a93a96fdaf354c050b152e6a4e5c9b2d401f17e67.pkl",
+      "bytes": 240896,
+      "sha256": "e8f293086915690d49a7115c4e907c8b0868de42673bdeb8150a00612f17fb9c"
+    },
+    {
+      "path": "full512-checkpoint/units/35e347973049bf964a6658b22f0cc7da522e460724e8d314b9931a7b97abc5aa.pkl",
+      "bytes": 240896,
+      "sha256": "29b0fd84efb7d69e2e9c63924ae5f987fe0242f0cf8c937acbf9844171f5edaf"
+    },
+    {
+      "path": "full512-checkpoint/units/39fca025f27125f0493655fcbade58aae5829e0c6155bcf465751f5c54d83e94.pkl",
+      "bytes": 240896,
+      "sha256": "3a486a86055222091bbd5130cfd17a95fffdc009ad7e071445a74566d30f12a0"
+    },
+    {
+      "path": "full512-checkpoint/units/3fb21d5a8b5dd8cbdf7364e75d41ee5c177cb18f30bf3467e9ff84238d99d66c.pkl",
+      "bytes": 240896,
+      "sha256": "f3fdfecd560a79c2572c1edb187721f7fb3d73f52bd977e87d471828ffd38bc5"
+    },
+    {
+      "path": "full512-checkpoint/units/419ab931320b121cb66a820505056feb250e6f080e942393d04605491f71826f.pkl",
+      "bytes": 240896,
+      "sha256": "09266c972ea0c01484b710b3f9ff5e8193b33245ca9e4410ce4b7e8c086453f5"
+    },
+    {
+      "path": "full512-checkpoint/units/42b123a689f2b4a2f9d0c7eb568b0ff6a8d5597c47c87189f5155d29074ba312.pkl",
+      "bytes": 240896,
+      "sha256": "d735cab7fbb2f24fad6216238fc0a02c5c7fc4b4c27108b44ca55c7c070af123"
+    },
+    {
+      "path": "full512-checkpoint/units/461186a29443effbf5d563ff7d8d9673234888760dc46d0adab6193cc661778b.pkl",
+      "bytes": 240896,
+      "sha256": "1ad3ddaa980140a36fed82746467ed71bc03227a92f40d115e94230ac083e121"
+    },
+    {
+      "path": "full512-checkpoint/units/4a5b6dac7fbe1a154a99b52abc9aecf805cbf6eccaa43ff52c9d73a6b3400f67.pkl",
+      "bytes": 240896,
+      "sha256": "46a92bdff4608e3a961ac517825bbdbc14414b8b815f9410f3f033af6181b1aa"
+    },
+    {
+      "path": "full512-checkpoint/units/4bb77f947a985a10070d67a144dd93c9ceb853223fb512f717439fc581b32d94.pkl",
+      "bytes": 240894,
+      "sha256": "6407a0aaebdacd7724c85b03618c9cb4c3e8a2617d9d89fe824b73de7e2057ee"
+    },
+    {
+      "path": "full512-checkpoint/units/4e9a8169d5a00149a18cf6f347e2e1f869bb7d8f7e1929468715c2b4b535ba68.pkl",
+      "bytes": 240896,
+      "sha256": "f7d3dc9910db0e70f31c70e0001deb6fe4c6d3bb14904af37d27925183b99ed0"
+    },
+    {
+      "path": "full512-checkpoint/units/4f3ac10ea48675633e6e27312d56b901d53db7820dc8a362ff72fc06f428613f.pkl",
+      "bytes": 240894,
+      "sha256": "71048c1f25a6bb4442b1398851a4153678d73c5495cea31780b21da1f05bb28b"
+    },
+    {
+      "path": "full512-checkpoint/units/4f56f2be62fe0ad76f31e125aa27d3c1ff4c526e1766acc40113cee27658d117.pkl",
+      "bytes": 240894,
+      "sha256": "e177ac66640cea3b7f5466c024ebb453f5269b82905d5cd265b8c6968b89cb47"
+    },
+    {
+      "path": "full512-checkpoint/units/507be6ee51ccb0f552b03375e3ccd1752235424802ffe55da4ebd7cc5d049800.pkl",
+      "bytes": 240896,
+      "sha256": "eb123e655e2a94f7ebec404a65b2804c7fb3d861b17da288b4da07901aa23203"
+    },
+    {
+      "path": "full512-checkpoint/units/51d420fd6e5b00ac211d36929df51bdda8279d2cc94dc7eec69a8374affe9bea.pkl",
+      "bytes": 240896,
+      "sha256": "e74231befb147c4bef30fe0ba04f308b25101b185c2f03b699e3e44aa44ed1eb"
+    },
+    {
+      "path": "full512-checkpoint/units/557c578fff3c55959b13fee7dba5b2613dfd462611dadfd2cd0a5fe0809a4b1f.pkl",
+      "bytes": 240896,
+      "sha256": "913e35bac188e11d832dd823d2b23d6d2d6ae2936f650ca7e144dd81c86b3766"
+    },
+    {
+      "path": "full512-checkpoint/units/598cc9f1d489f85e6bddb42a7644543fac830baddd110d5080c3bd6261c4ee7b.pkl",
+      "bytes": 240894,
+      "sha256": "279d4e0718ad0ced448c2ca567a2026bd7810c36d6bb0b9b6d56e7c7d866de90"
+    },
+    {
+      "path": "full512-checkpoint/units/5a70e97584f604515a3434b53a6c5a07b5235269d418ddaa9f55ff40012b44cc.pkl",
+      "bytes": 240896,
+      "sha256": "e76d3e29469fcb02d9689ebfb40dcea71ad33fbe28dd7ad25ea67dd7d950921c"
+    },
+    {
+      "path": "full512-checkpoint/units/60a78cf66d730a77446bfd507a7e97e47217567c47d7ca7a5576e09746f971ea.pkl",
+      "bytes": 240896,
+      "sha256": "8db2a55dc92b332613399d8b84b444ddc07b0ad09648b4d2e5dfdf4006b25199"
+    },
+    {
+      "path": "full512-checkpoint/units/690ede0ce459a2aea4128ed7ae25967c0649c3b808befc3e27ad65e9f97576ca.pkl",
+      "bytes": 240896,
+      "sha256": "7b171ccf345a3c3f66b52fa229c1a0678b487d484644c06408b6799d040f23e8"
+    },
+    {
+      "path": "full512-checkpoint/units/6d325ab6985463f35f07358f773c2b044f27f2e01d66cd40912d4b9af0d15526.pkl",
+      "bytes": 240896,
+      "sha256": "dacbdba965f35cddec6b1495e03ef61400342eef43be6f396a8375a147a5c037"
+    },
+    {
+      "path": "full512-checkpoint/units/6e5dacd773cb62d75c38e01ebaec86ce5c8c43fb53ba6647eaf2680a547ec63c.pkl",
+      "bytes": 240894,
+      "sha256": "219a034646ab28467a312788f185f4f8e895456c4eec9fef6644edafa84346db"
+    },
+    {
+      "path": "full512-checkpoint/units/6fa7c71ff888fbfb32aea61ecec44ba0ef7fdd297aa3cd9c2a02c7eecd54d21c.pkl",
+      "bytes": 240896,
+      "sha256": "438c6d74a9a7bb8fcf19a138fb46fac32c3e445b31f51e624faba345cce93d4d"
+    },
+    {
+      "path": "full512-checkpoint/units/71a4a38d0f740ad355aebc593804258d86f58f14f4a8a44204483d82c1ad02a8.pkl",
+      "bytes": 240896,
+      "sha256": "f3443163d0b1af610ddbced1a80518d508a5400a6a657b8679acab6576cf6312"
+    },
+    {
+      "path": "full512-checkpoint/units/71bdf09dc117c19ab2b3b2b37cb431ab26059948c0dadb693629dec99b949d87.pkl",
+      "bytes": 240896,
+      "sha256": "f2f0a20ea0391016135de349d16b9a6ae46ca976f529ccb60ec97b8fa17ab47d"
+    },
+    {
+      "path": "full512-checkpoint/units/7316eea72307004bf0ce02932a037329474ed0218cb47abee3d70730994e0cce.pkl",
+      "bytes": 240896,
+      "sha256": "2a5e21859a2ef211348e14e8283064bc15a8904058b7316b8e2f2ddeb9c865f8"
+    },
+    {
+      "path": "full512-checkpoint/units/73defe63100fe3759f511a645d40c077b0e508ec246d1c7e9734ddc70a41a406.pkl",
+      "bytes": 240894,
+      "sha256": "1fe95afadca33dd22de8eb609c73aa7610c337b198035939fa4bedf0b7f1fd25"
+    },
+    {
+      "path": "full512-checkpoint/units/75dd3328dfa9561dc19c8b2561831a2c167c45f7f930cf1e2ebe1668b071beda.pkl",
+      "bytes": 240894,
+      "sha256": "75464e3f59efd5cbe347b92e900e166143e4d7016e229efab06cb510f00eabb6"
+    },
+    {
+      "path": "full512-checkpoint/units/76185b74a499e7a3f4eda2c8f018c875d7a48c4d17d4c36a4171e23740666c49.pkl",
+      "bytes": 240894,
+      "sha256": "04303efc7496b7a6ae28e3624fd075a36211abea5d5b0fd51e066ae4ec06a89e"
+    },
+    {
+      "path": "full512-checkpoint/units/77cb3c673e68f6d9b63370c781b4697ae65703b04e0e85c063b709d7ef444598.pkl",
+      "bytes": 240896,
+      "sha256": "7330e755b322ca0911639e1f785d45df343b1665bb25b62ab77984cdc1f038bd"
+    },
+    {
+      "path": "full512-checkpoint/units/7db540ea5166cd0265f04f5e610de65e2f105e4e83ff0f967cb9b7d873dbf16e.pkl",
+      "bytes": 240894,
+      "sha256": "f76977aaa71195aa225aa580d8881dbd3c52a57a44da113d7689dd4a870e3ee3"
+    },
+    {
+      "path": "full512-checkpoint/units/7f7a26fb8bd621e130cbddb69159cc9e68e726355503d0b24f1f283ab38e7421.pkl",
+      "bytes": 240896,
+      "sha256": "87182ea16ee2003c97c2be752dd4a528aeae0a247ccf66a1996d5a4cb57fdb33"
+    },
+    {
+      "path": "full512-checkpoint/units/8377181f18e798f0b8d52873342ad99a9bd4a8ff31a9e2933919cbfcfe90f57f.pkl",
+      "bytes": 240896,
+      "sha256": "a91055955f63e94e1a79c3079bb3a9c8287cb239d9e76b0ba456fa6a8daba497"
+    },
+    {
+      "path": "full512-checkpoint/units/83d58cbfaa5e9d6cbe9b82998a8a02ce4a848d6654f24b57057b665c45f1e05e.pkl",
+      "bytes": 240896,
+      "sha256": "9170815ecec12d17a569c3db6697e82c6d3579ebe9bd6255fa678036ed174b7f"
+    },
+    {
+      "path": "full512-checkpoint/units/8563f7c14e2fdd9a06be00d515fe908d954f0b7b3714c7b3d5a76be019ebb3ed.pkl",
+      "bytes": 240894,
+      "sha256": "7a1b1fc791fc4c1d3214ed04ec93ee597331023dbfab506e905890f927ba3031"
+    },
+    {
+      "path": "full512-checkpoint/units/88975ca8f9ee3afafb9692a65e2404af6ca32e7ec03598f4466a449601c9d235.pkl",
+      "bytes": 240894,
+      "sha256": "e915b6fef728dca1667b2b9627cebd786d7573ce6e65434373737a4cd10eaef4"
+    },
+    {
+      "path": "full512-checkpoint/units/8d94e86c49563b0d6872596506fb6b65841b4156ac45951e97ace493ebe51753.pkl",
+      "bytes": 240894,
+      "sha256": "f122ab5529a842220358849558d25029ed14c24bd435800805244cd640563611"
+    },
+    {
+      "path": "full512-checkpoint/units/90b561f4c43ba6e0e0b258d61d96ee7056cd8dc88efbae9244272b565ccf8559.pkl",
+      "bytes": 240896,
+      "sha256": "e01a71cffe9451018b983e0562c65d014ce5cb95fe48fc68ad5999a32f0f96d7"
+    },
+    {
+      "path": "full512-checkpoint/units/944971ecce08695f6f02eebcdd3158366910db9a346776547f3f67a85317b095.pkl",
+      "bytes": 240894,
+      "sha256": "d23819a02275e99247253b5842da1e3f2e2dfd663e372ebe9cd2723c59781f0b"
+    },
+    {
+      "path": "full512-checkpoint/units/94b34b7fbe3c63f9aed9cc5b970befcc66be4c8981884e622805c35d969390af.pkl",
+      "bytes": 240896,
+      "sha256": "c1c8cd552c0ca4d07613b99bc0f17b0f007658d41c54c10508a6c5415ff00bb0"
+    },
+    {
+      "path": "full512-checkpoint/units/96d10d84272ed8bfe7c67e73ee611992fb6b800cf033122c95d05dfb2225bba2.pkl",
+      "bytes": 240896,
+      "sha256": "93a9688940773115018e3f05bd15cba36f13f1e8155cfcc6ba416e981824eddf"
+    },
+    {
+      "path": "full512-checkpoint/units/970845392f6aab3f16edeeb674c831a1acc1bb561c14ba66b34ba28920447a23.pkl",
+      "bytes": 240896,
+      "sha256": "3c9cb081342d6e9fe5a2352989b86a702c26ce2c960aef0f79d281a6c1319b09"
+    },
+    {
+      "path": "full512-checkpoint/units/98aa730c50855bbb9265a3fb09e0012193a89b15fe1a807386665a8bef1a857d.pkl",
+      "bytes": 240896,
+      "sha256": "0ff01961ccc54bcbf7bfce74caaace9ffb4489d5f7d7c57e35eca08c35933d46"
+    },
+    {
+      "path": "full512-checkpoint/units/9df5f43b432cf2ca849c5a5cb3cebe55bf055aa3580fa1956c5b77102bbe32ee.pkl",
+      "bytes": 240896,
+      "sha256": "b586c2cee392b2f17d57efe3b9a3f28b2d3d524b79c43586839ed6395278fa61"
+    },
+    {
+      "path": "full512-checkpoint/units/9fa88af37a4c70af7a8585a8e3740b2d583be4b3444a784ac16e98bc9a68818c.pkl",
+      "bytes": 240896,
+      "sha256": "256d5095257f39d3857083635ca04df97524270095bb1b90996ce1d1cbb5e44c"
+    },
+    {
+      "path": "full512-checkpoint/units/a71267c6092db21ada53a044dd07997a00c812b4dd9c06a77baa270bf14f0391.pkl",
+      "bytes": 240896,
+      "sha256": "ed37d454ff6e01ae12e442dc77297f510ca44b48035df83d4aec474e655ac2f4"
+    },
+    {
+      "path": "full512-checkpoint/units/aff95828691ce97e6c61ae5aef81ad468e762c74d78f4a91565194cc481e5538.pkl",
+      "bytes": 240896,
+      "sha256": "dc9da10ad9b5c3d549fea1f6bcb227bdd0ad059b5e368d73b857a57a601b3dfd"
+    },
+    {
+      "path": "full512-checkpoint/units/b09fd4f18e5c9e9abb5cc3af98cd857e31f367dc794c5b262af11265b6e7a7cc.pkl",
+      "bytes": 240896,
+      "sha256": "b4dd9ffe08da0bc6d02bda63d3569dcc66e81b5bdadd590f4d84a505f1575bdb"
+    },
+    {
+      "path": "full512-checkpoint/units/b3de95545bff38fb912b7504966c17697c73eb6efea3b8856082074815b78a3e.pkl",
+      "bytes": 240896,
+      "sha256": "4f288cd0c7a3370f86ca88e690c54ebd376c3d334bd967b9fac87dd73e051577"
+    },
+    {
+      "path": "full512-checkpoint/units/b6978903060b7dab4fe24ec134b1f35bd5dbc8f2a93683993d547629201e313f.pkl",
+      "bytes": 240894,
+      "sha256": "b641a88b1fa70c0d88f802b8fbcd65136983417df08f43d3657a2e3f4cfe0dbf"
+    },
+    {
+      "path": "full512-checkpoint/units/b69ec68efdf0aaf2627183d934b13c3ba89aae7fe1f1c7da04d299b292ea3f02.pkl",
+      "bytes": 240896,
+      "sha256": "3ab27b2cabf1c8839f93015bb1cffb2f4fa407262b10066401f15542f238ddde"
+    },
+    {
+      "path": "full512-checkpoint/units/b8db4ae09d0d840bb1579c3e7c47e49151dfc968f7005129c1473b0a45dc1218.pkl",
+      "bytes": 240894,
+      "sha256": "0e3d93a0e3c7eb7839a3eaa97c484d9a17e06ff107b3bfb23800ddcd1f2d2d50"
+    },
+    {
+      "path": "full512-checkpoint/units/ba8d4dec10f648d230bea6d9302d53fbbea8382217b605a34c73e4a83dcfb7d8.pkl",
+      "bytes": 240896,
+      "sha256": "4aa77ac2dc29ba660627060cda1a5c973cdd8679c77fe2a9df0cf27081be2d15"
+    },
+    {
+      "path": "full512-checkpoint/units/bab1619b980105359ab4fd651037d1ca8acf8d152a4ba9919fdf316a80c3ddd9.pkl",
+      "bytes": 240896,
+      "sha256": "51225a27eb51fe71fe9d26e7b84f5705a77e32df1d3d8df6e1c865f4e97b82eb"
+    },
+    {
+      "path": "full512-checkpoint/units/bad5bd3e958e111ebc43d7dd2cfe8be285e8adb1170bafd84a75a5b1b6f2e4da.pkl",
+      "bytes": 240896,
+      "sha256": "b7eedb611f6b2591d4e5b5dc577446a6f22dc598e9aa9761cf03bb7763b71616"
+    },
+    {
+      "path": "full512-checkpoint/units/bcf2730e64a5a8ed6a78aa9ef8f18d61d017dc0e8bf1ad7afb8234844e598500.pkl",
+      "bytes": 240896,
+      "sha256": "ffd8c6f277676df5baadd642329132d51ca31c61ca0a9f0582e436c85333b542"
+    },
+    {
+      "path": "full512-checkpoint/units/c0473f94930edbd380539153f4a94b73d2826b5ecd4a062af45f99a69eeffd51.pkl",
+      "bytes": 240894,
+      "sha256": "886a9708046eff8ed8ec243d8acae59ac67093077ce4bd00bd195e93a4d67a92"
+    },
+    {
+      "path": "full512-checkpoint/units/c0cd6f441c98aac38d83efd8cefc15c5f7797dc0c40e6091bcb56f672e3afabe.pkl",
+      "bytes": 240896,
+      "sha256": "4ea4f38255ad0aa7c3595f2aed3fa9f071890ca5cf96c1b71deb4687ccc943cf"
+    },
+    {
+      "path": "full512-checkpoint/units/c3ae367f4705d5edae4ff1c81f55f79427d12da7496c3c911ec35900ce236076.pkl",
+      "bytes": 240896,
+      "sha256": "8210cbd6d234c3bb508fe2c19ec921094efb0782150f322bb49a4075a224c968"
+    },
+    {
+      "path": "full512-checkpoint/units/c5b5dca2c66ad7de0adf4c4225dc92089c750c9a5cb777d5085f3f4d1aa53ce0.pkl",
+      "bytes": 240896,
+      "sha256": "6a11875cd1e073da89fd2efad822497fa64b8ada8bf8be05df903b8309720e83"
+    },
+    {
+      "path": "full512-checkpoint/units/c6bb45974af0aae86457ca1d76f41ff49564a9aafeef631073ee8c455c1fc477.pkl",
+      "bytes": 240894,
+      "sha256": "639017f0c7aa94767e4b8a1bc3b6315f7e1fa7b69c22f94c2c18ad1b4b83e65f"
+    },
+    {
+      "path": "full512-checkpoint/units/c6f7dd883de0f807ba627a67226528d8ded4b6625ecffefa7350ca8f7927f5f7.pkl",
+      "bytes": 240896,
+      "sha256": "750d23734eb2d3a87beb420b8ea4d300a96c7cea8070173ecce8722b8d256bae"
+    },
+    {
+      "path": "full512-checkpoint/units/c97d3d4cd0de5af99fedf50f80e2623d561f2aec530f76ef8cd950883972a2b2.pkl",
+      "bytes": 240896,
+      "sha256": "4bacddee0d417e50464fe7510d96b58cafab2a6c419c4b58e37689c154943c31"
+    },
+    {
+      "path": "full512-checkpoint/units/cd596e8e63cff9128070fbdce3ccb79cff4149f1d8e4a023f2007f6221c4ca8a.pkl",
+      "bytes": 240896,
+      "sha256": "d12858bc06cb10bda7c37543ca5dca250a29ceb0cde15f443e47f718a9a5feaf"
+    },
+    {
+      "path": "full512-checkpoint/units/dc44ce94efe81168362b653fa45c97760075879162f4567a725fe3e2b907a347.pkl",
+      "bytes": 240896,
+      "sha256": "67623981b751222d829ed96b66fffa9e4500adeaa71c78b2b61f5b7051cbfaee"
+    },
+    {
+      "path": "full512-checkpoint/units/dfe20a234a434a32dbc52cc2aa7ecddba73ae5d5d771f628e41c807bbd29c5b0.pkl",
+      "bytes": 240896,
+      "sha256": "8d38769d9c049c27e4945f26466c1b1a4c4770d3d8d64bf43ed1df9b6e145f36"
+    },
+    {
+      "path": "full512-checkpoint/units/e2900c25900a9d706bba521c239e65bd1edb533f11f6cf5b74cacaacb9942202.pkl",
+      "bytes": 240896,
+      "sha256": "f4f1e59f8e17d425f9e2ef8579c880096507bb6446fffd46e6e2713a19f797da"
+    },
+    {
+      "path": "full512-checkpoint/units/e40b4682c0e475814e31e5bfd8d1490a2c4a96a29f5c63eea2d18653710ab70a.pkl",
+      "bytes": 240894,
+      "sha256": "cbdeb4cf6847000b357e3ba73444c6462e3878bd3fe8e8bfd5c8d3777283ee41"
+    },
+    {
+      "path": "full512-checkpoint/units/e70209bdc229ac1e34ea1b4a39eae8d8b20ab6ceb29f6de35a063f19a59a3663.pkl",
+      "bytes": 240896,
+      "sha256": "a34803d6ef40b1d1175635f8e6c692b77a9662a7316c997945a7bd00d158a5db"
+    },
+    {
+      "path": "full512-checkpoint/units/e739f9f0575f25c222df064d631c58f2c602119078b86aa53ebde75ab5c33aac.pkl",
+      "bytes": 240896,
+      "sha256": "cf087a64ca678b0b48b1c1f58c38fd0b130af650a22b85e38aa37179d95b54b6"
+    },
+    {
+      "path": "full512-checkpoint/units/ead8217463973290e20f5b3994faf27658ffafa6d3537454917ddb936490f2e9.pkl",
+      "bytes": 240896,
+      "sha256": "a241e9a282891ab59ede314a697fb8c318307223cf8ca73737c19123746531fa"
+    },
+    {
+      "path": "full512-checkpoint/units/ec8652e790689ca0e2dae50ec0fa4bb7d42dd2c9f90caee20583a43dcbbb59a8.pkl",
+      "bytes": 240894,
+      "sha256": "19a5cd2a6790dad9bcbe53e3167f9c5b42e698555757a3acf55bcd2db134a2cf"
+    },
+    {
+      "path": "full512-checkpoint/units/ec8d357bf6f9ac2b1393e84bd599f28dc5850e0ff5b5291c9a43bdcf3267ee65.pkl",
+      "bytes": 240894,
+      "sha256": "aac4d7b06e38fca25b93e8ad310bbe461a39e049f0b5c735953ebbdc8cd1138c"
+    },
+    {
+      "path": "full512-checkpoint/units/ecd0a01ea706bcae400902d7c4ce32559ab6899c01250cd8889661b121bd260f.pkl",
+      "bytes": 240896,
+      "sha256": "f59072a49a4db3d27ca5030173a4e283ba33e7ac650bcf7b5f1cbe0c73a46aa6"
+    },
+    {
+      "path": "full512-checkpoint/units/ed2c2d8fd0a386b87c09bd443e09b4c461c5d142a469ec469d2eb613d60d30b3.pkl",
+      "bytes": 240896,
+      "sha256": "22278f881012731e77b126d9b8f28ac91a2e9a21fdc34bd624caa58294977315"
+    },
+    {
+      "path": "full512-checkpoint/units/ee5a4bd9a6663c9382bdf89ba3d3180b5a7d00efbacba79043ce24f7ccaf2bb4.pkl",
+      "bytes": 240894,
+      "sha256": "c9564458829e0db8e59c93e001b1e55bd05704cf34c1a82d9cbc5241927775df"
+    },
+    {
+      "path": "full512-checkpoint/units/f4eefbfeac44542361c7830df1e049b4f17d37c1481034c188923be29f08eafe.pkl",
+      "bytes": 240894,
+      "sha256": "bb026350c975787d9f91057d607d240d1aafc0852bd88a843e3a3dd19a1ab44b"
+    },
+    {
+      "path": "full512-checkpoint/units/f9427bd40ada8ece93569b2cc66648ea6b243d5353e566afbf6e63e1adfd4c5c.pkl",
+      "bytes": 240896,
+      "sha256": "e80aac86a65bf077cb3e67b565a4e63f6d042ca888b9738558a7e10dab596d54"
+    },
+    {
+      "path": "full512-checkpoint/units/fcd2eb083ae8d57b32688fb9f3822d7890319667a4e819329abf7e72a182728b.pkl",
+      "bytes": 240896,
+      "sha256": "6407ee1b5acb9de70afdfc4d4fb913c1048e629fa30131598afba921f475b7b1"
+    },
+    {
+      "path": "full512-checkpoint/units/fcdbcadf018d872ff7b8d4c362d4056f1a349bf200c4f66150a769041a9293cf.pkl",
+      "bytes": 240894,
+      "sha256": "b8c73526232debbbbaa7599fc37a49b82a771df63eb4fbf6c480d1b45b51ba84"
+    },
+    {
+      "path": "full512-checkpoint/units/fde97001fa57b2a1d958d3054aaca23dcb9bbea1420e2a99d3efa22da1519852.pkl",
+      "bytes": 240896,
+      "sha256": "be3ae9745add876a2eb55b3de4d8f1f5a01e23dde3245fefc4c882b0c11dda4d"
+    },
+    {
+      "path": "full512-checkpoint/units/ff86171fb9f2ee2ea61fe4abfe872ffd91cbab696009c1db291ae9af798c3bff.pkl",
+      "bytes": 240894,
+      "sha256": "a63c8411d9d514e8c9f909e0491d7e4872ea08499caf7bc32836e1632ea62014"
+    },
+    {
       "path": "receipts/1cf4d668b0f6302f422ac0c303c3ee2310ff95706a02d8cee27962bd14b78fd5.request.json",
       "bytes": 2592,
       "sha256": "fecbe1dcbd3d9f51dd5c911785b8b215a3ce5cd2adbe2c7a78be75bb966b4082"
@@ -191,6 +696,36 @@
       "path": "receipts/25fefb27ac44d59f887d02907e002299aad104969ae3d4c3e4eb9f18123b2e34.summary.json",
       "bytes": 1185,
       "sha256": "0f61ba11b8ea5bb9aa008e573d62cb0e7d0753540bfa957c89568b5d7ad204f6"
+    },
+    {
+      "path": "receipts/38ec1f47fee64d8f33c38f3644d2ea432355fc76130809f2ffc27487740ff19b.payload",
+      "bytes": 1257,
+      "sha256": "9474451605ce6ab7a6e672ebcc9f90e446494552c5cf3f72f897bfadbff59e0f"
+    },
+    {
+      "path": "receipts/38ec1f47fee64d8f33c38f3644d2ea432355fc76130809f2ffc27487740ff19b.receipt.json",
+      "bytes": 2625,
+      "sha256": "5f562269ec9816b26d543117d1535bce7fa325ae8646fb83d206f667d293ca76"
+    },
+    {
+      "path": "receipts/38ec1f47fee64d8f33c38f3644d2ea432355fc76130809f2ffc27487740ff19b.request.json",
+      "bytes": 4142,
+      "sha256": "5dffad28323c8a652d58900c80fb802f99c5a5091506283ba210762613f6535e"
+    },
+    {
+      "path": "receipts/38ec1f47fee64d8f33c38f3644d2ea432355fc76130809f2ffc27487740ff19b.stderr.txt",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "receipts/38ec1f47fee64d8f33c38f3644d2ea432355fc76130809f2ffc27487740ff19b.stdout.txt",
+      "bytes": 3819,
+      "sha256": "cd25057e7c6baf15611668740c3f398d8745470f0b907e2ab35e274e590e9385"
+    },
+    {
+      "path": "receipts/38ec1f47fee64d8f33c38f3644d2ea432355fc76130809f2ffc27487740ff19b.summary.json",
+      "bytes": 1387,
+      "sha256": "0bf17180f574d6347bdec83ec053a6ad4a66346d631d0353e499a01d26d517c5"
     },
     {
       "path": "receipts/43b4b43e7a623cd97a0c024d0ac411572475ba26dab18558a58160e33547910d.payload",
@@ -598,5 +1133,5 @@
       "sha256": "a74a309609d296f8e8bb12f45e3434b0036f4e29dc115e996d4d488a0186aefb"
     }
   ],
-  "full_canonical_cost_status": "qualified_activation_qdq_full_512_row_run_active"
+  "full_canonical_cost_status": "qualified_activation_qdq_full_512_row_run_passed"
 }

--- a/docs/measurements/lfm-joint-microbatch-2026-09-07.json
+++ b/docs/measurements/lfm-joint-microbatch-2026-09-07.json
@@ -1,0 +1,457 @@
+{
+  "schema": "prismaquant.joint_aura.microbatch_evidence.v1",
+  "artifact_root": "/mnt/shared/tessera-measurements/pq318-joint-microbatch-20260907",
+  "artifacts": [
+    {
+      "path": "rows3-batch3/calibration_subset.safetensors",
+      "bytes": 13088,
+      "sha256": "e69792146f34e1144fde1a20c8309cc645d9f551f99fda52904c494a639843f7"
+    },
+    {
+      "path": "rows3-batch3/joint-cost.json",
+      "bytes": 55190216,
+      "sha256": "3954eba1c38bef1891ba6fafe990bcc064d0dc92162f8f034df6aaf9fa706499"
+    },
+    {
+      "path": "rows3-batch3/model_identity.json",
+      "bytes": 252894,
+      "sha256": "7df54e965502049485b352d2201a2a5eb319c71ffce456bf8952c4e626b57ee6"
+    },
+    {
+      "path": "rows3-batch3/netdata-both-hosts.json",
+      "bytes": 64026,
+      "sha256": "dc4624d41a5283dcedd5ba369621a250b1271827eb816ca0d15055536d138d02"
+    },
+    {
+      "path": "rows3-batch3/results.json",
+      "bytes": 265031,
+      "sha256": "fa80cb6978bbd9820878094979c08471906b0bed2b8c79c8fe23742e0ec86877"
+    },
+    {
+      "path": "rows3-batch3/streamed_packed_joint.profile.txt",
+      "bytes": 26475,
+      "sha256": "066912224901dd8f4f184fd87d29920b47d4801b3be91a91b62e3ab0473eccf0"
+    },
+    {
+      "path": "rows3-batch3/streamed_packed_joint.trace.json",
+      "bytes": 201897998,
+      "sha256": "14bb3ddc2e6e5b4be9fbd6fb1bdec0bb4d7f02c78c5aa145e2f4b44a265b1ba1"
+    },
+    {
+      "path": "rows3-batch1/calibration_subset.safetensors",
+      "bytes": 13088,
+      "sha256": "a4f22a857ccbb95a8a4fe600f1c226b4b5affff8e23dd887053016a506cc972f"
+    },
+    {
+      "path": "rows3-batch1/joint-cost.json",
+      "bytes": 55190296,
+      "sha256": "4a3905404490a2ae54cb0f95735a7e92aa2b362fc44a3091dea9bccb1cdf06b0"
+    },
+    {
+      "path": "rows3-batch1/model_identity.json",
+      "bytes": 252894,
+      "sha256": "7df54e965502049485b352d2201a2a5eb319c71ffce456bf8952c4e626b57ee6"
+    },
+    {
+      "path": "rows3-batch1/netdata-both-hosts.json",
+      "bytes": 83310,
+      "sha256": "57abc8968048381b5d9d38e42020c77e05ecdbddbb92de93a300038e561abffb"
+    },
+    {
+      "path": "rows3-batch1/results.json",
+      "bytes": 265051,
+      "sha256": "c9984295bb515615143ffc9e562c9fb09f9010b5da061dcea9ccfebb78bc5f24"
+    },
+    {
+      "path": "rows3-batch1/streamed_packed_joint.profile.txt",
+      "bytes": 26475,
+      "sha256": "3d97f7c89bc9a4fcfe1335dd806b135197235e4023e0325a2de2b26791d473e9"
+    },
+    {
+      "path": "rows3-batch1/streamed_packed_joint.trace.json",
+      "bytes": 551334777,
+      "sha256": "c9528c352a6d87f905bf0215cbf3ac2c442e6fc279f512d4f3ebd7bfd9da695e"
+    },
+    {
+      "path": "fixed-logit-cuda/results.json",
+      "bytes": 1346,
+      "sha256": "d72bb6b0092863390635693eb40ff2196912ec468dc661dc35ea4863a7ac5751"
+    },
+    {
+      "path": "fixed-logit-cuda02/results.json",
+      "bytes": 1344,
+      "sha256": "0972b109fe1c38e5f179eb1891147ea248e66a3e670dbfc34c6836968a29e8c3"
+    },
+    {
+      "path": "source-control02/model_identity.json",
+      "bytes": 252894,
+      "sha256": "7df54e965502049485b352d2201a2a5eb319c71ffce456bf8952c4e626b57ee6"
+    },
+    {
+      "path": "source-control02/netdata-both-hosts.json",
+      "bytes": 78805,
+      "sha256": "403a536efcdf516f371de3d7f25a83a0dfd81b584658dae10d23f3591d065427"
+    },
+    {
+      "path": "source-control02/results.json",
+      "bytes": 344883,
+      "sha256": "5acc61c565159e5e02e7480149d358ccb87eb55bd21ab2b8baa4ced352bb27ce"
+    },
+    {
+      "path": "receipts/1cf4d668b0f6302f422ac0c303c3ee2310ff95706a02d8cee27962bd14b78fd5.request.json",
+      "bytes": 2592,
+      "sha256": "fecbe1dcbd3d9f51dd5c911785b8b215a3ce5cd2adbe2c7a78be75bb966b4082"
+    },
+    {
+      "path": "receipts/1cf4d668b0f6302f422ac0c303c3ee2310ff95706a02d8cee27962bd14b78fd5.stderr.txt",
+      "bytes": 92,
+      "sha256": "2f5d293c42b18d4b51ec14774b593b9e80ab3961e96104d758f0e6b77d884290"
+    },
+    {
+      "path": "receipts/1cf4d668b0f6302f422ac0c303c3ee2310ff95706a02d8cee27962bd14b78fd5.stdout.txt",
+      "bytes": 968,
+      "sha256": "db5a77e2874fe1a7601f07bf3dce2fb3f0eba27059bf7b7e21916e30a7ea41e3"
+    },
+    {
+      "path": "receipts/1cf4d668b0f6302f422ac0c303c3ee2310ff95706a02d8cee27962bd14b78fd5.summary.json",
+      "bytes": 2716,
+      "sha256": "f1650676dd6ba4f5998e0e8bef9c16117c5b340cd0907fa9ba8c1e695ff3314c"
+    },
+    {
+      "path": "receipts/2361a4cac58abbafbf18aec3c87365aca12117d95fd092bc0dc919c8cd3e0040.payload",
+      "bytes": 3466,
+      "sha256": "ffc5321b36ce81c40e3e2c380bcb668d31170ecce47541cfef465b6f469dfe94"
+    },
+    {
+      "path": "receipts/2361a4cac58abbafbf18aec3c87365aca12117d95fd092bc0dc919c8cd3e0040.receipt.json",
+      "bytes": 2625,
+      "sha256": "8bef0383fbc12146f473a8e256ae0584da515386bce050a2213bc653a48d00ae"
+    },
+    {
+      "path": "receipts/2361a4cac58abbafbf18aec3c87365aca12117d95fd092bc0dc919c8cd3e0040.request.json",
+      "bytes": 2994,
+      "sha256": "8689f84f7fd470373dfa1f7699549e4343135d607b392bd35f82fe989b17d8b3"
+    },
+    {
+      "path": "receipts/2361a4cac58abbafbf18aec3c87365aca12117d95fd092bc0dc919c8cd3e0040.stderr.txt",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "receipts/2361a4cac58abbafbf18aec3c87365aca12117d95fd092bc0dc919c8cd3e0040.stdout.txt",
+      "bytes": 6028,
+      "sha256": "16f34840be2ca43110da40fc3ff4f1bf4ccdb6af1075a965de723ae9c87f7fa6"
+    },
+    {
+      "path": "receipts/2361a4cac58abbafbf18aec3c87365aca12117d95fd092bc0dc919c8cd3e0040.summary.json",
+      "bytes": 1387,
+      "sha256": "c91fb8a0892261cb23f80ff780f6dc9462a24d3fde94c0aca6dfa03d4e7524a6"
+    },
+    {
+      "path": "receipts/25fefb27ac44d59f887d02907e002299aad104969ae3d4c3e4eb9f18123b2e34.request.json",
+      "bytes": 2994,
+      "sha256": "da6b5146c788291e6ac797322e4479ccfb01af0cd1ae16bfd5b3e9884fc84215"
+    },
+    {
+      "path": "receipts/25fefb27ac44d59f887d02907e002299aad104969ae3d4c3e4eb9f18123b2e34.stderr.txt",
+      "bytes": 788,
+      "sha256": "87d0232ea897c5534f24cf1f108c4b71f5cd8d0adb60fbc71ac9919065dd9bfb"
+    },
+    {
+      "path": "receipts/25fefb27ac44d59f887d02907e002299aad104969ae3d4c3e4eb9f18123b2e34.stdout.txt",
+      "bytes": 1293,
+      "sha256": "e57419d42a8aa3ab9730a477751e334fe0a7c9339b50c825f12b18e15afc4f86"
+    },
+    {
+      "path": "receipts/25fefb27ac44d59f887d02907e002299aad104969ae3d4c3e4eb9f18123b2e34.summary.json",
+      "bytes": 1185,
+      "sha256": "0f61ba11b8ea5bb9aa008e573d62cb0e7d0753540bfa957c89568b5d7ad204f6"
+    },
+    {
+      "path": "receipts/6d50e9449fed1df550545ea4c276c707825e60f0d2e5335c1e30b01b5e1d5a63.payload",
+      "bytes": 1034,
+      "sha256": "ad53cc88fae99b904f53276e7c1089f92e04c9f67f63477c30758080ab071c06"
+    },
+    {
+      "path": "receipts/6d50e9449fed1df550545ea4c276c707825e60f0d2e5335c1e30b01b5e1d5a63.receipt.json",
+      "bytes": 2625,
+      "sha256": "d87710dda39380f61948299e077111209e2296b4259b02300b1ab4af90ebc0f7"
+    },
+    {
+      "path": "receipts/6d50e9449fed1df550545ea4c276c707825e60f0d2e5335c1e30b01b5e1d5a63.request.json",
+      "bytes": 2652,
+      "sha256": "efe6860046ef7304dceee5b11aeb2ca130e22915d9941177c186f4a6965a1cbd"
+    },
+    {
+      "path": "receipts/6d50e9449fed1df550545ea4c276c707825e60f0d2e5335c1e30b01b5e1d5a63.stderr.txt",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "receipts/6d50e9449fed1df550545ea4c276c707825e60f0d2e5335c1e30b01b5e1d5a63.stdout.txt",
+      "bytes": 3596,
+      "sha256": "0b2246c6caf01c9988034909cddd6113dd2a11ae13252c7eb7a2039f4da8dac1"
+    },
+    {
+      "path": "receipts/6d50e9449fed1df550545ea4c276c707825e60f0d2e5335c1e30b01b5e1d5a63.summary.json",
+      "bytes": 1372,
+      "sha256": "c54076e8d03217674b1efe6d46fc43f2b94159613770e51b430f1a11e77bd356"
+    },
+    {
+      "path": "receipts/7bbddb3785e70ea6ed9f39418752d0fe3888679f9385e125fdc8d8631f33a18d.payload",
+      "bytes": 1586,
+      "sha256": "defcf2d0bafe30b2b1765fdeeda10a7fef2eb60dce92e2ed9e3002a300d08f6d"
+    },
+    {
+      "path": "receipts/7bbddb3785e70ea6ed9f39418752d0fe3888679f9385e125fdc8d8631f33a18d.receipt.json",
+      "bytes": 2625,
+      "sha256": "b9fef6710a8c04a9f46cf0a037e6100de1d83837def914544e829dd5f4e918e2"
+    },
+    {
+      "path": "receipts/7bbddb3785e70ea6ed9f39418752d0fe3888679f9385e125fdc8d8631f33a18d.request.json",
+      "bytes": 3488,
+      "sha256": "eea7a606cab6bf7b21e840a131257e70353cf198066410da96a9de88d39a0810"
+    },
+    {
+      "path": "receipts/7bbddb3785e70ea6ed9f39418752d0fe3888679f9385e125fdc8d8631f33a18d.stderr.txt",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "receipts/7bbddb3785e70ea6ed9f39418752d0fe3888679f9385e125fdc8d8631f33a18d.stdout.txt",
+      "bytes": 4148,
+      "sha256": "1902b9bbbe38b350e5f3c24a704a15f39e32282d389aa529ff6dee42a6384c0d"
+    },
+    {
+      "path": "receipts/7bbddb3785e70ea6ed9f39418752d0fe3888679f9385e125fdc8d8631f33a18d.summary.json",
+      "bytes": 1387,
+      "sha256": "3897b6c0a788124b982624a0fa14f2f6e411448207fc38ad6a5ca54e92750f55"
+    },
+    {
+      "path": "receipts/8549364a0af9ee6d8e9ac2120894f1e56accc38ba2660d0db7f3ca98fbd29c5c.request.json",
+      "bytes": 2510,
+      "sha256": "2a999793a9c784fb05f34b0919676824416455229b35cc5e6b4e1a1f25066745"
+    },
+    {
+      "path": "receipts/8549364a0af9ee6d8e9ac2120894f1e56accc38ba2660d0db7f3ca98fbd29c5c.stderr.txt",
+      "bytes": 788,
+      "sha256": "87d0232ea897c5534f24cf1f108c4b71f5cd8d0adb60fbc71ac9919065dd9bfb"
+    },
+    {
+      "path": "receipts/8549364a0af9ee6d8e9ac2120894f1e56accc38ba2660d0db7f3ca98fbd29c5c.stdout.txt",
+      "bytes": 6950,
+      "sha256": "cedfbc284968f182f3d8ab5c9980ba6ee5f3391e5b0e05b75c32e4be47e719eb"
+    },
+    {
+      "path": "receipts/8549364a0af9ee6d8e9ac2120894f1e56accc38ba2660d0db7f3ca98fbd29c5c.summary.json",
+      "bytes": 1170,
+      "sha256": "e989067ed8b49f8d1fd7c3f931a646cfa7189d6230ece5a438560e33d2707199"
+    },
+    {
+      "path": "receipts/8bae322557fe9691c6ef90f34158d7e93bc11aecfcd5b46fb11a55c925aaad72.request.json",
+      "bytes": 2466,
+      "sha256": "1d5842af717e2b8461c35287c00a32b07684b00af7fcdc1e39123522629f3418"
+    },
+    {
+      "path": "receipts/8bae322557fe9691c6ef90f34158d7e93bc11aecfcd5b46fb11a55c925aaad72.stderr.txt",
+      "bytes": 788,
+      "sha256": "87d0232ea897c5534f24cf1f108c4b71f5cd8d0adb60fbc71ac9919065dd9bfb"
+    },
+    {
+      "path": "receipts/8bae322557fe9691c6ef90f34158d7e93bc11aecfcd5b46fb11a55c925aaad72.stdout.txt",
+      "bytes": 7657,
+      "sha256": "7b28878268c32a011d1b6f1134adb754b45b31cf07384bb5ada4a209118e3c2c"
+    },
+    {
+      "path": "receipts/8bae322557fe9691c6ef90f34158d7e93bc11aecfcd5b46fb11a55c925aaad72.summary.json",
+      "bytes": 1171,
+      "sha256": "296a3f70b1929e1293eeb0b65f43e9cbd058a08083b91af5085fa819095eccba"
+    },
+    {
+      "path": "receipts/9410e1f58090a45151114d7c5b3012bd8be56f798b72a35a811813173fc8ef92.payload",
+      "bytes": 966,
+      "sha256": "ab549a5f6623678fec64cfa6ca1af293f773c4cf9ed5c8206716c28c65e4e36b"
+    },
+    {
+      "path": "receipts/9410e1f58090a45151114d7c5b3012bd8be56f798b72a35a811813173fc8ef92.receipt.json",
+      "bytes": 2624,
+      "sha256": "e1388cca6b30091e28445a0d7db12cd32a8adbfd74f8539be06f4d57d565d056"
+    },
+    {
+      "path": "receipts/9410e1f58090a45151114d7c5b3012bd8be56f798b72a35a811813173fc8ef92.request.json",
+      "bytes": 2596,
+      "sha256": "4ce4a74640382237dbaeac6cfb3740c4b3621aa3176ccfd0ac931eb384b7904c"
+    },
+    {
+      "path": "receipts/9410e1f58090a45151114d7c5b3012bd8be56f798b72a35a811813173fc8ef92.stderr.txt",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "receipts/9410e1f58090a45151114d7c5b3012bd8be56f798b72a35a811813173fc8ef92.stdout.txt",
+      "bytes": 3527,
+      "sha256": "0386cd85537e36574f98fc52600300fad08c8dcd37b1198a63f3fc43f4acf726"
+    },
+    {
+      "path": "receipts/9410e1f58090a45151114d7c5b3012bd8be56f798b72a35a811813173fc8ef92.summary.json",
+      "bytes": 1365,
+      "sha256": "ded9c22517af5293c6196a25563f030a4904f6e8e881e1f66645d8a695f8bba2"
+    },
+    {
+      "path": "receipts/9dfed90ecf26fdb0954dbd004983d6341ebfb80dbaf58402c745abf91e88bc6c.payload",
+      "bytes": 1034,
+      "sha256": "11d503a6697786475562780e0a76e1699e65403775fdcded407e3e9160e85aa0"
+    },
+    {
+      "path": "receipts/9dfed90ecf26fdb0954dbd004983d6341ebfb80dbaf58402c745abf91e88bc6c.receipt.json",
+      "bytes": 2625,
+      "sha256": "379b1cd68a038d0a702faca29194a979f502b1d0e836feea7999f148bc902892"
+    },
+    {
+      "path": "receipts/9dfed90ecf26fdb0954dbd004983d6341ebfb80dbaf58402c745abf91e88bc6c.request.json",
+      "bytes": 2816,
+      "sha256": "103b52f5d02aae7268eb779a3c452da023e958ecc4d026855ea06c046573ed27"
+    },
+    {
+      "path": "receipts/9dfed90ecf26fdb0954dbd004983d6341ebfb80dbaf58402c745abf91e88bc6c.stderr.txt",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "receipts/9dfed90ecf26fdb0954dbd004983d6341ebfb80dbaf58402c745abf91e88bc6c.stdout.txt",
+      "bytes": 3596,
+      "sha256": "2e4a90a46c9990abd4e09ffc4dee097cef25dd3022ea3808f1d1a9cffd1074bb"
+    },
+    {
+      "path": "receipts/9dfed90ecf26fdb0954dbd004983d6341ebfb80dbaf58402c745abf91e88bc6c.summary.json",
+      "bytes": 1369,
+      "sha256": "e2489d423c80e237b2299f97b865ad13d2c0c06183aebda87affb03e72c546cc"
+    },
+    {
+      "path": "receipts/a0c47bceda5357cf3f347a591f1a1c733a5c9909a009084d84560cb3776ce8ff.payload",
+      "bytes": 1114,
+      "sha256": "6dd8b8a80b438268c8a632559a727d1bd976d6d351517c9c77512f321f435870"
+    },
+    {
+      "path": "receipts/a0c47bceda5357cf3f347a591f1a1c733a5c9909a009084d84560cb3776ce8ff.receipt.json",
+      "bytes": 2631,
+      "sha256": "5ca5a6045ee8c2164deeb8d8b2d160acc0508a6702b5f4721ef7177e8a40f182"
+    },
+    {
+      "path": "receipts/a0c47bceda5357cf3f347a591f1a1c733a5c9909a009084d84560cb3776ce8ff.request.json",
+      "bytes": 3020,
+      "sha256": "8c1f08acfecb33890b323ee4b5bd0bc4107abe521f74da7938ddb1eaed570b89"
+    },
+    {
+      "path": "receipts/a0c47bceda5357cf3f347a591f1a1c733a5c9909a009084d84560cb3776ce8ff.stderr.txt",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "receipts/a0c47bceda5357cf3f347a591f1a1c733a5c9909a009084d84560cb3776ce8ff.stdout.txt",
+      "bytes": 3682,
+      "sha256": "341938d239bd82d5f1e9076ef96ed374238213bf36215edce0c43917304a845f"
+    },
+    {
+      "path": "receipts/a0c47bceda5357cf3f347a591f1a1c733a5c9909a009084d84560cb3776ce8ff.summary.json",
+      "bytes": 1378,
+      "sha256": "1f3363002833d419d71d3e0a8c91bc2d2eccdeffcecec80a5ac730ac7be7ea31"
+    },
+    {
+      "path": "receipts/ada12c11bda42cc6106d4d32a363176024304b1e40aeec1bab2cd80d44fc9a80.payload",
+      "bytes": 1586,
+      "sha256": "23372eef1a845cf7bb31c0781ecca6171b00675bce08e9f1ba7d0ce700938dec"
+    },
+    {
+      "path": "receipts/ada12c11bda42cc6106d4d32a363176024304b1e40aeec1bab2cd80d44fc9a80.receipt.json",
+      "bytes": 2625,
+      "sha256": "f8a99b77e22739eae915d3a004886a7a25311bac813b72647b0b8f22feae0806"
+    },
+    {
+      "path": "receipts/ada12c11bda42cc6106d4d32a363176024304b1e40aeec1bab2cd80d44fc9a80.request.json",
+      "bytes": 3488,
+      "sha256": "f3f37932e0c5e102ce1ff08df78e291623034881e6ce75be72a3153a8ee6305b"
+    },
+    {
+      "path": "receipts/ada12c11bda42cc6106d4d32a363176024304b1e40aeec1bab2cd80d44fc9a80.stderr.txt",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "receipts/ada12c11bda42cc6106d4d32a363176024304b1e40aeec1bab2cd80d44fc9a80.stdout.txt",
+      "bytes": 4148,
+      "sha256": "5eb4da56d3beee0615225381b0a730118fe33925aa202b41c10db1073ada8782"
+    },
+    {
+      "path": "receipts/ada12c11bda42cc6106d4d32a363176024304b1e40aeec1bab2cd80d44fc9a80.summary.json",
+      "bytes": 1385,
+      "sha256": "31feecb5ec3b46428337aa7e0aa79bc2d6375649f703fd67a11d5ffa65fd658c"
+    },
+    {
+      "path": "receipts/fa5598de04a8f35cefa873b7e8bbd1845982f6b9517a831be0a57f00e4cf80db.payload",
+      "bytes": 1115,
+      "sha256": "8b584043d30ae1cd782469494c780affdabde0dfa13522f9e9cd6dfbd6aec4c7"
+    },
+    {
+      "path": "receipts/fa5598de04a8f35cefa873b7e8bbd1845982f6b9517a831be0a57f00e4cf80db.receipt.json",
+      "bytes": 2625,
+      "sha256": "b01e345b3e681186f7f0d9586845a037ed6dfe695c6e67341b254d9af07dfc28"
+    },
+    {
+      "path": "receipts/fa5598de04a8f35cefa873b7e8bbd1845982f6b9517a831be0a57f00e4cf80db.request.json",
+      "bytes": 3118,
+      "sha256": "46d320bf58b5bd31468752c0e41d98d50239aeb3b6082f115d0f67c1b7aa8920"
+    },
+    {
+      "path": "receipts/fa5598de04a8f35cefa873b7e8bbd1845982f6b9517a831be0a57f00e4cf80db.stderr.txt",
+      "bytes": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "path": "receipts/fa5598de04a8f35cefa873b7e8bbd1845982f6b9517a831be0a57f00e4cf80db.stdout.txt",
+      "bytes": 3677,
+      "sha256": "cab79d733ca57316823e5442825d078d47dcd32a59615ad6c93d41f2eeca2b3a"
+    },
+    {
+      "path": "receipts/fa5598de04a8f35cefa873b7e8bbd1845982f6b9517a831be0a57f00e4cf80db.summary.json",
+      "bytes": 1370,
+      "sha256": "f1fdca3be48fa70139317749ff915f77f8f37cb0cb4c8019a55df013b2480d89"
+    },
+    {
+      "path": "harness/lfm_joint_microbatch_diagnose.py",
+      "bytes": 2263,
+      "sha256": "a3737a73e9e53802b4dfd0f20a59aafeefe773c42ae187ec3c94994c97d1685e"
+    },
+    {
+      "path": "harness/lfm_joint_microbatch_diagnose.sh",
+      "bytes": 903,
+      "sha256": "ab1d7c1352a5e9b55f7ac12c35c68d38e43bc986a2446f31befe1f42b6d2b0d6"
+    },
+    {
+      "path": "harness/lfm_joint_microbatch_source.py",
+      "bytes": 12721,
+      "sha256": "29ac2539a4f6d1d9f71d1b732d99a67ed2a3b34ab5a632684cca9ad629622bc8"
+    },
+    {
+      "path": "harness/lfm_joint_microbatch_source.sh",
+      "bytes": 901,
+      "sha256": "629494a51284b9b032770243c9af8bdd7ab03df8be9a136075e3427bd4405ac9"
+    },
+    {
+      "path": "harness/lfm_packed_joint_screen.py",
+      "bytes": 20580,
+      "sha256": "4e2a02e36fc8c33fd99a03aeaafdc044ad5ee7118c16b4b88b620f7fde586349"
+    },
+    {
+      "path": "harness/lfm_packed_joint_screen.sh",
+      "bytes": 897,
+      "sha256": "6d1ceeab69427b0c674dfe7e525e5d9178ae5f63014052e977d79740172c8530"
+    },
+    {
+      "path": "harness/lfm_stream_cpu_pytest.sh",
+      "bytes": 894,
+      "sha256": "a74a309609d296f8e8bb12f45e3434b0036f4e29dc115e996d4d488a0186aefb"
+    }
+  ],
+  "full_canonical_cost_status": "pending_qualified_activation_qdq_and_full_512_row_run"
+}

--- a/docs/measurements/lfm-joint-microbatch-2026-09-07.md
+++ b/docs/measurements/lfm-joint-microbatch-2026-09-07.md
@@ -1,0 +1,139 @@
+# Streamed joint AURA microbatch qualification, 2026-09-07
+
+The opt-in streamed microbatch implementation in #318 is qualified against
+small mathematical fixtures and the actual LFM full-vocabulary source on the
+first three canonical calibration sequences. **The full 512-sequence cost run
+has not yet executed.** It awaits the independently qualified shared activation
+QDQ correction, so a full-cost artifact will price that policy once. These
+controls change no production format, runtime pin, default or serving gate.
+
+`probe_microbatch > 0` uses `prismaquant.kl_fisher.global_row.v1`: every global
+sequence row has a fixed seed domain and the complete draw's token normalizer.
+Local weight, activation and mixed residuals sum while signed across every
+partition before squaring, separately for each source Linear. Diagnostics sum
+FP32 gradients before taking their norm. GPU logits/recompute graphs are bounded
+by batch size; the existing CPU boundaries and probe cotangents still cover the
+full draw. The existing source/cache prefetch mechanism remains in use.
+
+The RNG descriptor is independent of partition size. The complete probe identity
+also describes source arithmetic: its existing `arithmetic` field now seals the
+execution partition. Existing row, paired-candidate and assignment consumers
+therefore reject mixed batch sizes, as does checkpoint resume. Legacy zero
+retains the original streamed draws; it is not the positive full-size reference.
+
+## Actual source and arithmetic controls
+
+All GPU controls used the known-good image
+`eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c`,
+Torch `2.13.0+cu130`, Transformers `5.16.1`, BF16 source weights, explicit eager
+attention and the original grouped expert backend. Probes are Rademacher,
+seeds 7000–7003, all tokens, temperature 1, global normalization. The original
+checkpoint, resolved backend, full token artifact, actual subset tensor and
+original rendered PWC bytes are sealed in the retained records. The canonical
+full token artifact is int64 `[512,512]`, SHA256
+`a38312e3b1eeecc2a4363d2a91739ba535388036d4910bffa815d451dcb9a940`.
+
+The fixed-logit CUDA control `9410e1f58090a45151114d7c5b3012bd8be56f798b72a35a811813173fc8ef92`
+passed all eight seed/partition comparisons exactly at `[3,512,128000]`:
+batch sizes 1 and uneven 2 match size 3 bit for bit. It completed with exit 0,
+aggregate reservation 16 GiB and GPU cap 14 GiB. This isolates Fisher probe
+construction from model arithmetic.
+
+The resident/streamed control
+`2361a4cac58abbafbf18aec3c87365aca12117d95fd092bc0dc919c8cd3e0040`
+completed with exit 0 on Sparky, aggregate reservation 64 GiB and GPU cap 48 GiB.
+It compares the streamed path to ordinary resident HF execution at each
+**same** batch size, using the same three canonical rows and four probes.
+Every comparison below is dtype-identical and bit-exact:
+
+| Batch rows | Decoder boundaries | Layer-2 route tensors | Full-vocabulary logits | Packed leaf gradients |
+|---|---:|---:|---:|---:|
+| 3 | 24 | 3 | 1 | 8 |
+| 1 | 72 | 9 | 3 | 24 |
+
+The two physical leaves are `gate_up_proj [32,3584,2048]` and
+`down_proj [32,2048,1792]`. Route tensors are the original packed expert inputs,
+expert IDs and route weights. Each gradient comparison records both hashes,
+probe and global row offset. The qualification record is
+`source-control02/results.json`, SHA256
+`5acc61c565159e5e02e7480149d358ccb87eb55bd21ab2b8baa4ced352bb27ce`.
+
+**Negative result: resident batch sizes 3 and 1 are not numerically equivalent.**
+Decoder layers 0 and 1 match exactly. Layer 2 first differs by at most
+0.00048828125 (relative L2 0.0009286), even though that layer's routed inputs,
+IDs and weights match exactly. Subsequent layers amplify the difference:
+full-vocabulary logits differ by relative L2 0.0758231 and maximum 9.25;
+packed gradients differ by relative L2 0.4334–0.4514. The first difference is
+inside the unchanged resident layer, not in streaming or probe RNG. This
+control attributes the drift to batch-shaped source arithmetic without claiming
+a particular low-level kernel instruction caused it. Canonical census/capture
+forwards complete `[1,512]` sequences individually; batch size 1 matches that
+arithmetic. CPU partition invariance alone would have missed this distinction.
+
+## Three-row cost and memory controls
+
+Before adding the final arithmetic compatibility seal, original rendered wires
+were priced for the existing 96 w1/w3/w2 source Linears of layer 2, with
+`TESSERA_E4M3_K1_R1024` and BF16. These are bounded diagnostic artifacts, not
+full-calibration or native-panel costs. Their shared RNG identity permitted the
+cross-size comparison that exposed the source arithmetic difference; final
+consumers now refuse that mixed execution.
+
+| PB action | Batch rows | Largest tail | Peak PyTorch GPU allocation |
+|---|---:|---|---:|
+| `ada12c11bda42cc6106d4d32a363176024304b1e40aeec1bab2cd80d44fc9a80` | 3 | `[3,512,128000]` | 23,714,409,472 bytes |
+| `7bbddb3785e70ea6ed9f39418752d0fe3888679f9385e125fdc8d8631f33a18d` | 1 | `[1,512,128000]` | 20,415,026,688 bytes |
+
+Both completed with exit 0 on Sparky under 40 GiB aggregate reservations and
+32 GiB GPU caps. Each captured 157,286,400 bytes of host decoder boundaries.
+The size-1 path made 12 bounded tail calls; size 3 made four. These measurements
+establish bounded tail allocation on actual packed/full-vocabulary geometry.
+They are not total physical-memory peaks and are not throughput claims.
+Both arms retain CPU/CUDA `torch.profiler` memory/operator traces and both
+hosts' Netdata series. Trace export overhead is included in the recorded
+profile phase; those durations are not an isolated speed comparison.
+
+The signed per-probe costs differ by normalized L2 0.42472 across batch sizes.
+Summing the 96 unary predictions gives 0.0030473746 versus 0.0028390700; neither
+sum is measured KL or a coherent whole-block quadratic. The same-size resident
+controls above explain why these differences cannot be dismissed as a probe
+partition bug, nor treated as comparable finite source arithmetic.
+
+The first size-3 control's derived subset header retained its parent's sampling
+counts. Its recorded actual `[3,512]` tensor digest and independently hashed
+parent artifact establish the diagnostic input. That subset is not a native
+panel input. The harness now adjusts subset counts and int32 draw identity;
+size-1 and subsequent derived artifacts use the corrected header.
+
+## Regression and retained evidence
+
+Final targeted CPU validation
+`fa5598de04a8f35cefa873b7e8bbd1845982f6b9517a831be0a57f00e4cf80db`
+passed **121 tests, no skips**, through PB with four workers/native threads 1
+and an 8 GiB aggregate reservation. It covers Fisher all/last/causal scopes,
+uneven partitions, an independent packed row oracle with nonzero cross terms,
+gradient diagnostics, checkpoint refusal, actual paired/assignment consumers,
+legacy streamed/packed behavior and architecture/calibration documentation.
+The initial missing-API regression `8bae3225...` failed five tests as expected;
+`8549364a...` demonstrated that three existing consumers accepted mixed execution
+sizes before the arithmetic seal. Earlier green checks are retained rather
+than substituted for the final snapshot.
+
+The first CUDA probe control `1cf4d668...` wrote eight exact comparisons but
+ended with exit 137: PB stopped it after GPU-reported use 10,834,935,808 bytes
+exceeded its 10,737,418,240-byte cap for two samples. Host OOM counts were zero
+and cleanup completed. Its output is partial evidence, superseded by the
+successful correctly reserved retry. Source control `25fefb27...` failed before
+loading because its `device_map` required absent `accelerate`; it was corrected
+to the already proven `from_pretrained(...).cuda()` load path. One intermediate
+submission refused a changing checkout before any action executed. None of
+these failures is reported as a pass.
+
+[The manifest](lfm-joint-microbatch-2026-09-07.json) hashes the retained outputs,
+exact PB requests, sanitized terminal summaries, logs, independently rehashed
+CAS payloads/receipts and harnesses under
+`/mnt/shared/tessera-measurements/pq318-joint-microbatch-20260907`.
+Each PB checkout snapshot seals the historical code used by that action;
+retained latest harnesses are convenient entry points, not replacements for
+those snapshot identities. Full 512-row validation and final qualified-QDQ
+cost production remain explicitly pending.

--- a/docs/measurements/lfm-joint-microbatch-2026-09-07.md
+++ b/docs/measurements/lfm-joint-microbatch-2026-09-07.md
@@ -137,3 +137,42 @@ Each PB checkout snapshot seals the historical code used by that action;
 retained latest harnesses are convenient entry points, not replacements for
 those snapshot identities. Full 512-row validation and final qualified-QDQ
 cost production remain explicitly pending.
+
+
+## Qualified activation QDQ and regenerated operator screen
+
+The subsequent shared activation-QDQ fix preserves native FP32 tensor division
+by 448 and signed zero in the fallback cast. The native parity diagnostic
+`native-qdq-qualification/diagnostic-after-01.json`, SHA256
+`e955dfe266e5f704e38624549d9543019f2d8eec049fcd34ceed3e73ddbefeb6`,
+compares all 512 retained row scales and 1,048,576 activation codes: scales,
+codes and reconstructed prefill/decode tensors are bit-exact. PB actions
+`e9b8fe8567c646308c86bb3628764e3030608e35b35065bc6f6ef8b7337f15cb`
+(four CPU/CUDA regression parameters) and
+`d1c9f2ba1b7934161fddc88319a81bebe3094e8861e03193f9c5ae23cbd39e4b`
+(actual native parity) both completed with exit 0 and verified cleanup/CAS.
+
+The original row-0 operator screen was regenerated using that qualified QDQ,
+original PWC bytes, original four legacy probes and the same 96 logical members.
+PB `43b4b43e7a623cd97a0c024d0ac411572475ba26dab18558a58160e33547910d`
+completed with exit 0 on Sparklina. `cost03-native-qdq/joint-cost.json` has SHA256
+`66306b6f5feaecfbf5569a43c596b4229bf133ca036bc016fd2634a113780c39`;
+it contains 192 candidate rows. Its producer digest is
+`41f67d31422d3b41605cd5587a5d3432e2b38e1f4a0868c5694e6891cece679f`.
+This supersedes cost02 for the native operator panel after the QDQ correction;
+it remains an operator-subset screen, not a full-calibration cost. Peak PyTorch
+GPU allocation was 19,243,265,024 bytes under a 40 GiB aggregate reservation and
+32 GiB GPU cap. Both hosts' Netdata series are retained with the result.
+
+The combined integration action
+`f743a8375609bfb12586000e9e8bd1ea36096410a22bdebf73856204b5935cb9`
+passed 122 tests in 19.45 seconds with four workers/native threads 1, no skips,
+and an 8 GiB reservation. The CPU-only `-k 'not cuda'` selection deselected two
+CUDA parameters (covered by the QDQ action above) and one existing CPU test
+whose name contains `cuda` (already passed in the previous 121-test run).
+
+An off-task PrismaBuild capability gap was filed as
+[PrismaBuild #340](https://github.com/RobTand/prismabuild/issues/340): campaign
+value parsing cannot express a GPU-memory cap separately from aggregate memory.
+The full and operator-screen actions were submitted as independent ordinary PB
+quanta with explicit caps. PrismaBuild retained placement and admission ownership.

--- a/docs/measurements/lfm-joint-microbatch-2026-09-07.md
+++ b/docs/measurements/lfm-joint-microbatch-2026-09-07.md
@@ -176,3 +176,57 @@ An off-task PrismaBuild capability gap was filed as
 value parsing cannot express a GPU-memory cap separately from aggregate memory.
 The full and operator-screen actions were submitted as independent ordinary PB
 quanta with explicit caps. PrismaBuild retained placement and admission ownership.
+
+
+## Full canonical calibration completed
+
+The pending full draw subsequently completed under the qualified activation
+policy. PB action
+`38ec1f47fee64d8f33c38f3644d2ea432355fc76130809f2ffc27487740ff19b`
+finished on Sparky with exit 0, empty stderr, complete resource cleanup and no
+OOM events. Its independently rehashed CAS payload is
+`9474451605ce6ab7a6e672ebcc9f90e446494552c5cf3f72f897bfadbff59e0f`;
+the receipt digest is
+`d3b11de544a27c80dd49bc6705e3d0a2e485a948b16b02afc60d3cec658cbd9c`.
+
+`full512-batch1/joint-cost.json`, SHA256
+`5e94df0523a161e40931b4610c14b8b6667abd05057d4df58c1e3392091d20d8`,
+prices the same 96 layer-2 w1/w3/w2 members and original PWC bytes using all
+512 canonical sequences, with four probes and 512 complete-sequence partitions.
+There are 192 candidate rows. Every signed vector is finite, has seeds
+7000–7003, and reproduces its stored unary prediction by half the mean square;
+all BF16 candidate costs are zero. The 96 quantized unary predictions sum to
+0.0037147759697539395. This sum is a sum of per-Linear predictions, not measured
+KL or a coherent whole-block quadratic. This full-draw artifact is distinct
+from the row-0 operator-panel screen above.
+
+Its global-row noise identity binds `[512,512]`, vocabulary 128000 and global
+token count 262144. The arithmetic identity binds batch size 1 and 512
+partitions. The producer digest remains
+`41f67d31422d3b41605cd5587a5d3432e2b38e1f4a0868c5694e6891cece679f`.
+The full canonical safetensors artifact itself is supplied as the subset input,
+so its original metadata/path and SHA remain unchanged. The checkpoint manifest
+and all 96 completed unit shards are retained and hashed alongside the cost.
+This run establishes completed checkpoint production; it did not repeat the
+full job to demonstrate resume, whose refusal/recovery behavior is covered by
+the targeted regression suite.
+
+The full run captured 26,843,545,600 bytes of CPU decoder boundaries. It made
+2048 tail calls, all with logits shape `[1,512,128000]`. Peak PyTorch GPU
+allocation was **20,751,726,080 bytes** and peak reserved GPU memory was
+23,603,445,760 bytes. PB reported a separate cgroup memory peak of
+38,643,929,088 bytes under the 80 GiB aggregate reservation and 32 GiB GPU cap.
+These counters describe different memory views and are not added together or
+presented as the system's total physical-memory peak. Host boundaries and probe
+cotangents grow with the full draw; the existing resident GPU source cache is
+already included in PyTorch's allocation count.
+
+The PB wrapper elapsed 963.23 seconds; the harness marked this as a correctness
+phase without an in-process profile. Both hosts' raw Netdata series are retained.
+This is completion and allocation evidence, not a speedup or bottleneck claim;
+the earlier paired three-row controls carry the in-process memory profiles.
+The final manifest now hashes **226 artifacts totaling 1,002,043,668 bytes**,
+including full results, checkpoint shards, both-host telemetry, exact action
+requests, terminal logs and verified CAS receipts. No full-calibration task
+remains pending for this 96-member qualification, and no default or serving
+gate changes as a consequence of it.

--- a/experiments/lfm_joint_microbatch_diagnose.py
+++ b/experiments/lfm_joint_microbatch_diagnose.py
@@ -1,0 +1,47 @@
+"""PB-only fixed-logit CUDA control for the row-indexed probe layout."""
+from pathlib import Path
+import argparse
+import json
+import socket
+import time
+
+
+def main():
+    import torch
+    from prismaquant.kl_fisher import fisher_probe_scalar
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--out', type=Path, required=True)
+    args = parser.parse_args()
+    args.out.mkdir(parents=True, exist_ok=False)
+    result = {'schema': 'prismaquant.joint_aura.cuda_probe_partition.v1',
+              'env': {'host': socket.gethostname(), 'started_epoch': time.time(),
+                      'torch': torch.__version__, 'cuda': torch.version.cuda},
+              'shape': [3, 512, 128000], 'comparisons': []}
+    torch.manual_seed(971)
+    logits = torch.randn(3, 512, 128000, device='cuda', dtype=torch.bfloat16).requires_grad_(True)
+    for seed in range(7000, 7004):
+        kwargs = dict(seed=seed, token_scope='all', distribution='rademacher',
+                      token_count_override=1536)
+        scalar = fisher_probe_scalar(logits, global_row_offset=0, **kwargs)
+        expected, = torch.autograd.grad(scalar, logits)
+        for size in (1, 2):
+            actual = torch.empty_like(expected)
+            for offset in range(0, 3, size):
+                local = logits[offset:offset + size].detach().requires_grad_(True)
+                scalar = fisher_probe_scalar(local, global_row_offset=offset, **kwargs)
+                actual[offset:offset + size], = torch.autograd.grad(scalar, local)
+            delta = actual.float() - expected.float()
+            result['comparisons'].append({'seed': seed, 'batch_rows': size,
+                'equal': torch.equal(actual, expected), 'max_abs': float(delta.abs().max()),
+                'relative_l2': float(delta.norm() / expected.float().norm())})
+    result['peak_gpu_bytes'] = torch.cuda.max_memory_allocated()
+    result['env']['finished_epoch'] = time.time()
+    result['passed'] = all(x['equal'] for x in result['comparisons'])
+    (args.out / 'results.json').write_text(json.dumps(result, indent=2) + '\n')
+    print(json.dumps(result))
+    if not result['passed']:
+        raise AssertionError('fixed-logit CUDA Fisher probes depend on the partition')
+
+
+if __name__ == '__main__':
+    main()

--- a/experiments/lfm_joint_microbatch_diagnose.sh
+++ b/experiments/lfm_joint_microbatch_diagnose.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+image=eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
+input_root=/mnt/shared/tessera-measurements/first-model-20260907/inputs
+exec docker run --rm --gpus all --ipc=host --network=host --user "$(id -u):$(id -g)" \
+  -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared -w /workspace --entrypoint python3 \
+  -e PYTHONDONTWRITEBYTECODE=1 -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
+  -e XDG_CACHE_HOME=/tmp/pq-stream-parity-cache -e TORCH_EXTENSIONS_DIR=/tmp/pq-stream-parity-ext \
+  -e HF_HOME=/tmp/pq-stream-parity-hf -e HF_MODULES_CACHE=/tmp/pq-stream-parity-modules \
+  -e PRISMABUILD_CONTAINER_OWNER -e PRISMAQUANT_PROD_ACT_SCALES=0 \
+  -e "PYTHONPATH=/workspace:$input_root/tessera-382a1a97/src:$input_root/container-compatible-deps" \
+  "$image" -m experiments.lfm_joint_microbatch_diagnose "$@"

--- a/experiments/lfm_joint_microbatch_source.py
+++ b/experiments/lfm_joint_microbatch_source.py
@@ -1,0 +1,233 @@
+"""PB-only resident/streamed, same-size source and packed-gradient controls."""
+from __future__ import annotations
+import argparse
+import gc
+import hashlib
+import json
+import math
+import socket
+import time
+from pathlib import Path
+
+from experiments.lfm_packed_joint_screen import file_sha
+
+
+def main():
+    import torch
+    import transformers
+    from safetensors.torch import load_file
+    from transformers import AutoModelForCausalLM
+    from prismaquant.aura_cost import compute_aura_cost_streamed
+    from prismaquant.cost_streaming import build_streamed_causal_lm, build_streamed_model_identity
+    from prismaquant.joint_aura import source_execution_identity
+    from prismaquant.kl_fisher import fisher_probe_scalar
+    from prismaquant.model_profiles import detect_profile
+    from prismaquant.production_weight_cache import ProductionWeightCache
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--model', default='/mnt/shared/models/LFM2.5-8B-A1B-BF16')
+    parser.add_argument('--tokens', type=Path, required=True)
+    parser.add_argument('--tokens-sha256', required=True)
+    parser.add_argument('--out', type=Path, required=True)
+    args = parser.parse_args()
+    args.out.mkdir(parents=True, exist_ok=False)
+    if file_sha(args.tokens) != args.tokens_sha256:
+        raise ValueError('canonical calibration artifact differs')
+    ids = load_file(str(args.tokens))['calibration_ids'][:3].contiguous()
+    if ids.shape != (3, 512) or ids.dtype != torch.int64:
+        raise ValueError('expected three canonical int64 512-token sequences')
+    result = {'schema': 'prismaquant.joint_aura.microbatch_source_control.v1',
+        'env': {'host': socket.gethostname(), 'started_epoch': time.time(),
+                'torch': torch.__version__, 'transformers': transformers.__version__,
+                'cuda': torch.version.cuda},
+        'calibration': {'artifact': str(args.tokens), 'sha256': args.tokens_sha256,
+                        'rows': [0, 1, 2], 'shape': list(ids.shape),
+                        'tensor_sha256': hashlib.sha256(ids.numpy().tobytes()).hexdigest()},
+        'cross_partition': {}, 'same_size': [], 'phases': []}
+    def save():
+        (args.out / 'results.json').write_text(json.dumps(result, indent=2, allow_nan=False) + '\n')
+    def digest(t):
+        return hashlib.sha256(memoryview(t.contiguous().view(torch.uint8).numpy())).hexdigest()
+    def compare(a, b):
+        if a.shape != b.shape or a.dtype != b.dtype:
+            raise ValueError('comparison geometry/dtype differs')
+        record = {'shape': list(a.shape), 'dtype': str(a.dtype),
+                  'equal': torch.equal(a, b), 'a_sha256': digest(a), 'b_sha256': digest(b)}
+        if record['equal']:
+            return dict(record, max_abs=0.0, relative_l2=0.0, different=0)
+        af, bf = a.reshape(-1), b.reshape(-1)
+        error2 = norm2 = 0.0
+        maximum = 0.0
+        different = 0
+        for start in range(0, a.numel(), 1 << 20):
+            x, y = af[start:start + (1 << 20)].float(), bf[start:start + (1 << 20)].float()
+            d = y - x
+            error2 += float(d.double().square().sum())
+            norm2 += float(x.double().square().sum())
+            maximum = max(maximum, float(d.abs().max()))
+            different += int(torch.count_nonzero(d))
+        return dict(record, max_abs=maximum, relative_l2=math.sqrt(error2 / max(norm2, 1e-100)), different=different)
+    unit = 'model.layers.2.feed_forward.experts'
+    leaf_names = ('gate_up_proj', 'down_proj')
+    expected_grads = {}
+    expected_logits = {}
+    expected_boundaries = {}
+    expected_routes = {}
+    current = None
+    reference = AutoModelForCausalLM.from_pretrained(args.model, dtype=torch.bfloat16,
+        trust_remote_code=True, local_files_only=True, attn_implementation='eager').cuda().eval()
+    result['reference_source_execution'] = source_execution_identity(reference)
+    for parameter in reference.parameters():
+        parameter.requires_grad_(False)
+    parameters = {name: reference.get_parameter(f'{unit}.{name}') for name in leaf_names}
+    for parameter in parameters.values():
+        parameter.requires_grad_(True)
+    def boundary_hook(depth):
+        def record(module, inputs, output):
+            if current[2] == 0:
+                tensor = output[0] if isinstance(output, (tuple, list)) else output
+                expected_boundaries[(*current[:2], depth)] = tensor.detach().cpu()
+        return record
+    handles = [layer.register_forward_hook(boundary_hook(depth))
+               for depth, layer in enumerate(reference.model.layers)]
+    def route_hook(module, inputs):
+        if current[2] == 0:
+            expected_routes[current[:2]] = tuple(x.detach().cpu() for x in inputs)
+    handles.append(reference.get_submodule(unit).register_forward_pre_hook(route_hook))
+    started = time.time()
+    for batch_size in (3, 1):
+        for probe_index in range(4):
+            for offset in range(0, 3, batch_size):
+                current = (batch_size, offset, probe_index)
+                logits = reference(ids[offset:offset + batch_size].cuda()).logits
+                if probe_index == 0:
+                    expected_logits[current[:2]] = logits.detach().cpu()
+                scalar = fisher_probe_scalar(logits, seed=7000 + probe_index,
+                    token_scope='all', distribution='rademacher',
+                    token_count_override=1536, global_row_offset=offset)
+                scalar.backward()
+                for name, parameter in parameters.items():
+                    if parameter.grad is None:
+                        raise AssertionError('resident packed source produced no gradient')
+                    expected_grads[(*current, name)] = parameter.grad.detach().cpu()
+                    parameter.grad = None
+                del scalar, logits
+            save()
+    result['phases'].append({'phase': 'resident', 'kind': 'correctness', 'start_epoch': started, 'end_epoch': time.time()})
+    for handle in handles:
+        handle.remove()
+    parameters.clear()
+    parameter = handle = None
+    del reference
+    gc.collect()
+    torch.cuda.empty_cache()
+    result['cross_partition']['logits'] = compare(expected_logits[(3, 0)], torch.cat([expected_logits[(1, i)] for i in range(3)]))
+    result['cross_partition']['boundaries'] = [dict(layer=depth, **compare(
+        expected_boundaries[(3, 0, depth)], torch.cat([expected_boundaries[(1, i, depth)] for i in range(3)])))
+        for depth in range(24)]
+    result['cross_partition']['routes'] = [dict(tensor=index, **compare(
+        expected_routes[(3, 0)][index], torch.cat([expected_routes[(1, i)][index] for i in range(3)])))
+        for index in range(len(expected_routes[(3, 0)]))]
+    result['cross_partition']['gradients'] = []
+    for probe_index in range(4):
+        for name in leaf_names:
+            full = expected_grads[(3, 0, probe_index, name)].float()
+            partitioned = sum(expected_grads[(1, i, probe_index, name)].float() for i in range(3))
+            result['cross_partition']['gradients'].append(dict(probe=probe_index, parameter=name, **compare(full, partitioned)))
+            del full, partitioned
+    save()
+    for batch_size in (3, 1):
+        profile = detect_profile(args.model)
+        runner = build_streamed_causal_lm(args.model, device=torch.device('cuda'), dtype=torch.bfloat16,
+            offload_folder=str(args.out / f'offload-{batch_size}'), profile=profile,
+            attn_implementation='eager', max_cache_slots=24, prefetch_workers=4,
+            prefetch_lookahead=4, cache_headroom_gb=4, prefetch_min_available_gb=2,
+            require_prefetched_residency=True)
+        model_identity = build_streamed_model_identity(runner, args.model,
+            identity_cache_path=args.out / 'model_identity.json')
+        result['source_model_identity'] = model_identity
+        if source_execution_identity(runner.model) != result['reference_source_execution']:
+            raise AssertionError('streamed source backend differs from resident')
+        for depth in range(runner.num_layers):
+            runner.context.schedule_prefetch(depth)
+        record = {'batch_size': batch_size, 'boundaries': [], 'routes': [], 'logits': [], 'gradients': []}
+        result['same_size'].append(record)
+        original_capture, original_install, original_tail = runner.capture_boundaries, runner.context.install, runner.tail_logits
+        capture_count = 0
+        tail_count = 0
+        grad_count = {name: 0 for name in leaf_names}
+        offsets = list(range(0, 3, batch_size))
+        def captured(calibration):
+            nonlocal capture_count
+            offset = offsets[capture_count]
+            route_values = []
+            def observe_routes(module, values):
+                route_values.append(tuple(x.detach().cpu() for x in values))
+            route_handle = runner.model.get_submodule(unit).register_forward_pre_hook(observe_routes)
+            try:
+                batch = original_capture(calibration)
+            finally:
+                route_handle.remove()
+            if len(route_values) != 1:
+                raise AssertionError('expected one original packed route boundary')
+            for index, value in enumerate(route_values[0]):
+                record['routes'].append(dict(offset=offset, tensor=index, **compare(expected_routes[(batch_size, offset)][index], value)))
+            for depth in range(24):
+                record['boundaries'].append(dict(offset=offset, layer=depth, **compare(
+                    expected_boundaries[(batch_size, offset, depth)], batch.activations_cpu[depth + 1])))
+            capture_count += 1
+            save()
+            return batch
+        def tail(batch, hidden):
+            nonlocal tail_count
+            logits = original_tail(batch, hidden)
+            if tail_count % 4 == 0:
+                offset = offsets[tail_count // 4]
+                record['logits'].append(dict(offset=offset, **compare(expected_logits[(batch_size, offset)], logits.detach().cpu())))
+            tail_count += 1
+            return logits
+        def install(depth, **kwargs):
+            installed = original_install(depth, **kwargs)
+            if depth == 2 and capture_count == len(offsets):
+                for name in leaf_names:
+                    parameter = runner.model.get_parameter(f'{unit}.{name}')
+                    parameter.requires_grad_(True)
+                    def observe(value, name=name):
+                        index = grad_count[name]
+                        grad_count[name] += 1
+                        probe_index, part = divmod(index, len(offsets))
+                        offset = offsets[part]
+                        expected = expected_grads.pop((batch_size, offset, probe_index, name))
+                        actual = value.grad.detach().cpu()
+                        record['gradients'].append(dict(offset=offset, probe=probe_index, parameter=name, **compare(expected, actual)))
+                        save()
+                    parameter.register_post_accumulate_grad_hook(observe)
+            return installed
+        runner.capture_boundaries, runner.tail_logits, runner.context.install = captured, tail, install
+        names = [f'{unit}.{expert}.{role}' for expert in range(32) for role in ('w1', 'w3', 'w2')]
+        started = time.time()
+        compute_aura_cost_streamed(runner, ids, ['BF16'], n_probes=4, seed_base=7000,
+            token_scope='all', production_cache=ProductionWeightCache(weights={}, levers={}),
+            min_free_gib=0, joint_activation=True, include_routed_experts=True,
+            model_identity=model_identity, formats_by_qname={name: ['BF16'] for name in names},
+            probe_microbatch=batch_size, profile=profile)
+        result['phases'].append({'phase': f'streamed-{batch_size}', 'kind': 'correctness', 'start_epoch': started, 'end_epoch': time.time()})
+        if grad_count != {name: 4 * len(offsets) for name in leaf_names}:
+            raise AssertionError('incomplete packed gradient comparisons')
+        runner.context.shutdown()
+        del runner
+        gc.collect()
+        torch.cuda.empty_cache()
+    result['passed'] = not expected_grads and all(
+        value['equal'] for record in result['same_size']
+        for kind in ('boundaries', 'routes', 'logits', 'gradients') for value in record[kind])
+    result['env']['finished_epoch'] = time.time()
+    result['peak_gpu_bytes'] = torch.cuda.max_memory_allocated()
+    save()
+    print(json.dumps({'passed': result['passed'], 'same_size_records': len(result['same_size'])}))
+    if not result['passed']:
+        raise AssertionError('same-size streamed source differs from resident oracle')
+
+
+if __name__ == '__main__':
+    main()

--- a/experiments/lfm_joint_microbatch_source.sh
+++ b/experiments/lfm_joint_microbatch_source.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+image=eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
+input_root=/mnt/shared/tessera-measurements/first-model-20260907/inputs
+exec docker run --rm --gpus all --ipc=host --network=host --user "$(id -u):$(id -g)" \
+  -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared -w /workspace --entrypoint python3 \
+  -e PYTHONDONTWRITEBYTECODE=1 -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
+  -e XDG_CACHE_HOME=/tmp/pq-stream-parity-cache -e TORCH_EXTENSIONS_DIR=/tmp/pq-stream-parity-ext \
+  -e HF_HOME=/tmp/pq-stream-parity-hf -e HF_MODULES_CACHE=/tmp/pq-stream-parity-modules \
+  -e PRISMABUILD_CONTAINER_OWNER -e PRISMAQUANT_PROD_ACT_SCALES=0 \
+  -e "PYTHONPATH=/workspace:$input_root/tessera-382a1a97/src:$input_root/container-compatible-deps" \
+  "$image" -m experiments.lfm_joint_microbatch_source "$@"

--- a/experiments/lfm_packed_joint_screen.py
+++ b/experiments/lfm_packed_joint_screen.py
@@ -39,6 +39,11 @@ def main():
     parser.add_argument('--tokens', type=Path, required=True)
     parser.add_argument('--tokens-sha256', required=True)
     parser.add_argument('--row', type=int, default=0)
+    parser.add_argument('--rows', type=int, default=1)
+    parser.add_argument('--probe-microbatch', type=int, default=0)
+    parser.add_argument('--profile-tool', choices=['cprofile', 'torch', 'none'], default='cprofile')
+    parser.add_argument('--checkpoint-dir', type=Path)
+    parser.add_argument('--resume', action='store_true')
     parser.add_argument('--subset-artifact', type=Path)
     parser.add_argument('--subset-artifact-sha256')
     parser.add_argument('--qualify-boundary', type=Path)
@@ -53,9 +58,9 @@ def main():
     all_ids = load_file(str(args.tokens))['calibration_ids']
     if all_ids.dtype != torch.int64 or all_ids.ndim != 2 or all_ids.shape[1] != 512:
         raise ValueError('screen needs the canonical int64 512-token draw')
-    ids_cpu = all_ids[args.row:args.row + 1].contiguous()
-    if ids_cpu.shape != (1, 512):
-        raise ValueError('screen row is absent')
+    ids_cpu = all_ids[args.row:args.row + args.rows].contiguous()
+    if args.row < 0 or args.rows < 1 or ids_cpu.shape != (args.rows, 512):
+        raise ValueError('requested canonical calibration rows are absent')
     subset_path = args.out / 'calibration_subset.safetensors'
     if args.subset_artifact is not None:
         subset_path = args.subset_artifact
@@ -63,7 +68,17 @@ def main():
                 load_file(str(subset_path))['calibration_ids'], ids_cpu):
             raise ValueError('published operator subset differs from actual source tokens')
     else:
-        save_file({'calibration_ids': ids_cpu}, str(subset_path))
+        from safetensors import safe_open
+        with safe_open(str(args.tokens), framework='pt', device='cpu') as source:
+            metadata = dict(source.metadata() or {})
+        calibration_provenance = json.loads(metadata.get('calibration_provenance', '{}'))
+        calibration_provenance.update(nsamples=args.rows, fit_tokens=ids_cpu.numel(),
+            fit_ids_sha256=hashlib.sha256(ids_cpu.to(torch.int32).numpy().tobytes()).hexdigest())
+        metadata['calibration_provenance'] = json.dumps(calibration_provenance, sort_keys=True)
+        metadata['operator_screen_parent'] = json.dumps({
+            'artifact': str(args.tokens), 'sha256': args.tokens_sha256,
+            'row_start': args.row, 'rows': args.rows})
+        save_file({'calibration_ids': ids_cpu}, str(subset_path), metadata=metadata)
     ids = ids_cpu.cuda()
     unit = 'model.layers.2.feed_forward.experts'
     names = [f'{unit}.{expert}.{role}' for expert in range(32) for role in ('w1', 'w3', 'w2')]
@@ -78,20 +93,40 @@ def main():
             'subset_artifact': str(subset_path), 'subset_artifact_sha256': file_sha(subset_path),
             'full_shape': list(all_ids.shape), 'row': args.row, 'shape': list(ids_cpu.shape),
             'dtype': str(ids_cpu.dtype), 'sha256': hashlib.sha256(ids_cpu.numpy().tobytes()).hexdigest(),
-            'scope': 'first_sequence_operator_screen'},
+            'scope': ('full_canonical_calibration' if args.row == 0 and args.rows == len(all_ids)
+                      else 'canonical_sequence_subset')},
+        'execution': {'probe_microbatch': args.probe_microbatch,
+                      'profile_tool': args.profile_tool},
+        'memory_observations': {'captured_boundary_bytes': 0, 'capture_batch_rows': [],
+                                'tail_shapes': [], 'tail_calls': 0},
         'probe_policy': policy, 'unit_names': names, 'phases': [], 'gradient_comparisons': []}
     def save():
         (args.out / 'results.json').write_text(json.dumps(result, indent=2, allow_nan=False) + '\n')
     def phase(label, call):
         torch.cuda.synchronize()
         started = time.time()
-        profiler = cProfile.Profile()
         try:
-            value = profiler.runcall(call)
+            if args.profile_tool == 'cprofile':
+                profiler = cProfile.Profile()
+                try:
+                    value = profiler.runcall(call)
+                finally:
+                    profiler.dump_stats(str(args.out / (label + '.pstats')))
+            elif args.profile_tool == 'torch':
+                with torch.profiler.profile(
+                    activities=[torch.profiler.ProfilerActivity.CPU,
+                                torch.profiler.ProfilerActivity.CUDA],
+                    profile_memory=True, record_shapes=False,
+                ) as profiler:
+                    value = call()
+                profiler.export_chrome_trace(str(args.out / (label + '.trace.json')))
+                (args.out / (label + '.profile.txt')).write_text(
+                    profiler.key_averages().table(sort_by='self_cuda_time_total', row_limit=100))
+            else:
+                value = call()
             torch.cuda.synchronize()
         finally:
-            profiler.dump_stats(str(args.out / (label + '.pstats')))
-            result['phases'].append({'phase': label, 'kind': 'profile',
+            result['phases'].append({'phase': label, 'kind': 'profile' if args.profile_tool != 'none' else 'correctness',
                                     'start_epoch': started, 'end_epoch': time.time()})
             save()
         return value
@@ -261,8 +296,29 @@ def main():
             raise TypeError('expected the existing ProductionWeightCache pickle')
         result['production_cache'] = {'path': str(args.cache), 'sha256': args.cache_sha256}
         formats = ['TESSERA_E4M3_K1_R1024', 'BF16']
+    original_capture = runner.capture_boundaries
+    original_tail = runner.tail_logits
+    def capture(ids):
+        batch = original_capture(ids)
+        observation = result['memory_observations']
+        observation['capture_batch_rows'].append(len(ids))
+        observation['captured_boundary_bytes'] += sum(x.numel() * x.element_size() for x in batch.activations_cpu)
+        save()
+        return batch
+    def tail(batch, hidden):
+        logits = original_tail(batch, hidden)
+        observation = result['memory_observations']
+        observation['tail_calls'] += 1
+        shape = list(logits.shape)
+        if shape not in observation['tail_shapes']:
+            observation['tail_shapes'].append(shape)
+        return logits
+    runner.capture_boundaries = capture
+    runner.tail_logits = tail
     def cost():
         return compute_aura_cost_streamed(runner, ids, formats, n_probes=4, seed_base=7000,
+            **({'probe_microbatch': args.probe_microbatch} if args.probe_microbatch else {}),
+            checkpoint_dir=args.checkpoint_dir, resume=args.resume,
             token_scope='all', temperature=1.0, min_free_gib=0, production_cache=cache,
             joint_activation=True, include_routed_experts=True, profile=profile,
             model_identity=model_identity, formats_by_qname={name: formats for name in names},
@@ -283,6 +339,7 @@ def main():
     result['passed'] = True
     result['env']['finished_epoch'] = time.time()
     result['peak_gpu_bytes'] = torch.cuda.max_memory_allocated()
+    result['peak_gpu_reserved_bytes'] = torch.cuda.max_memory_reserved()
     result['cost_sha256'] = file_sha(args.out / 'joint-cost.json')
     save()
     runner.context.shutdown()

--- a/prismaquant/aura_cost.py
+++ b/prismaquant/aura_cost.py
@@ -1850,6 +1850,7 @@ def compute_aura_cost_streamed(
     formats: Sequence[str],
     *,
     n_probes: int = 16,
+    probe_microbatch: int = 0,
     token_scope: str = "all",
     temperature: float = 1.0,
     production_cache: object | None = None,
@@ -1881,9 +1882,47 @@ def compute_aura_cost_streamed(
     probe, projects each weight gradient onto production ``dW`` in fp32, and
     unloads the layer.  Thus source weights, gradients, and rendered deltas
     are bounded by one decoder layer; no autograd graph can retain the whole
-    model.  The resident :func:`compute_aura_cost` path is deliberately
-    unchanged.
+    model. ``probe_microbatch > 0`` opts joint AURA into complete-sequence
+    partitions with versioned global-row probes. Local signed terms and weight
+    gradients sum across all partitions before squaring; full-vocabulary GPU
+    tensors are bounded by the partition. CPU boundaries and shared pass state
+    still cover the full calibration. Checkpoints bind the execution partition
+    because floating-point kernels may round differently with batch shape.
+    The resident :func:`compute_aura_cost` path is deliberately unchanged.
     """
+    if type(probe_microbatch) is not int or probe_microbatch < 0:
+        raise ValueError("probe_microbatch must be a nonnegative integer")
+    if calib_ids.ndim != 2 or min(calib_ids.shape) < 1:
+        raise ValueError("streamed AURA needs nonempty [rows, sequence] calibration")
+    if probe_microbatch and not joint_activation:
+        raise ValueError("streamed probe_microbatch currently requires joint_activation")
+    batch_rows = min(probe_microbatch or len(calib_ids), len(calib_ids))
+    row_offsets = list(range(0, len(calib_ids), batch_rows))
+    probe_layout = None
+    if probe_microbatch:
+        from prismaquant.kl_fisher import ROW_PROBE_LAYOUT
+        sequence_length = int(calib_ids.shape[1])
+        selected_tokens = {"all": sequence_length, "last": 1,
+                           "causal": sequence_length - 1}.get(token_scope, 0)
+        if selected_tokens < 1:
+            raise ValueError("invalid token scope or sequence length for streamed probes")
+        probe_layout = {
+            "schema": ROW_PROBE_LAYOUT,
+            "global_rows": len(calib_ids),
+            "sequence_length": sequence_length,
+            "selected_tokens_per_row": selected_tokens,
+            "vocab_size": int(runner._head().weight.shape[0]),
+            "token_scope": token_scope,
+            "global_token_count": len(calib_ids) * selected_tokens,
+        }
+    execution_partition = {
+        "schema": "prismaquant.aura.streamed_microbatch.v1",
+        "requested_rows": probe_microbatch,
+        "effective_rows": batch_rows,
+        "partition_count": len(row_offsets),
+        "row_order": "contiguous_complete_sequences",
+        "gradient_diagnostics": "sum_fp32_gradients_before_norm",
+    } if probe_microbatch else None
     if n_probes < 1:
         raise ValueError(f"n_probes must be >= 1, got {n_probes!r}")
     if resume and checkpoint_dir is None:
@@ -2084,6 +2123,12 @@ def compute_aura_cost_streamed(
             "source_execution": source_execution_identity(runner.model),
             "arithmetic": arithmetic_identity(runner.dtype),
         }
+        if probe_layout is not None:
+            joint_probe_identity["noise_layout"] = probe_layout
+            # RNG row coordinates are partition independent; the source
+            # arithmetic is not. Existing paired/assignment consumers compare
+            # this complete probe identity and must refuse mixed batch shapes.
+            joint_probe_identity["arithmetic"]["execution_partition"] = execution_partition
         # Hash actual decoded production outputs before checkpoint admission,
         # in layer-bounded prefetch windows. This is identity preparation,
         # outside the cotangent/projection hot path; no tensor copy is retained.
@@ -2274,6 +2319,7 @@ def compute_aura_cost_streamed(
             "streamed_gradient_harvest",
             "streamed_cotangent_rollover",
             "streamed_boundary_release",
+            "streamed_microbatch",
         } & set(extra)
         if reserved:
             raise ValueError(
@@ -2281,6 +2327,8 @@ def compute_aura_cost_streamed(
                 f"AURA identity fields: {sorted(reserved)}"
             )
         extra["streaming"] = True
+        if execution_partition is not None:
+            extra["streamed_microbatch"] = execution_partition
         if joint_activation:
             extra["joint_aura"] = joint_run_identity
         extra["streamed_model_identity"] = exact_model_identity
@@ -2316,7 +2364,7 @@ def compute_aura_cost_streamed(
             include_lm_head=False,
             hook_harvest=True,
             allow_packed_expert_omission=allow_packed_expert_omission,
-            probe_microbatch=0,
+            probe_microbatch=probe_microbatch,
             collect_col_energy=collect_col_energy,
             require_production_cache=require_production_cache,
             production_cache=production_cache,
@@ -2404,6 +2452,8 @@ def compute_aura_cost_streamed(
             col_energy=col_energy,
             weight_mse_diagnostic=weight_mse_diagnostic,
         )
+        if execution_partition is not None:
+            payload["provenance"]["streamed_microbatch"] = execution_partition
         if joint_activation:
             if set(joint_rows) != set(names):
                 raise RuntimeError("joint AURA incomplete unit coverage")
@@ -2502,59 +2552,62 @@ def compute_aura_cost_streamed(
             "source_weight": joint_source_tensors[name],
             "rendered_weight": rendered_identity,
             "activation": activation,
-            "arithmetic": arithmetic_identity(runner.dtype),
+            "arithmetic": joint_probe_identity["arithmetic"],
             "probe_identity_sha256": identity_sha256(joint_probe_identity),
         }
         joint_components[(name, fmt)] = []
 
     # Identity validation above is intentionally before the first model
     # forward: a mismatched resume is a refusal, never a recomputation.
-    _log(
-        f"boundary capture: one streamed forward over calib "
-        f"{tuple(calib_ids.shape)} across {runner.num_layers} layers ..."
-    )
+    _log(f"boundary capture: calib {tuple(calib_ids.shape)} in "
+         f"{len(row_offsets)} partition(s) across {runner.num_layers} layers ...")
     capture_started = time.time()
-    batch = runner.capture_boundaries(calib_ids)
-    _log(
-        f"boundary capture done in {(time.time() - capture_started) / 60:.1f} "
-        f"min; starting {n_probes}-probe tail cotangents"
-    )
+    batches = []
+    for offset in row_offsets:
+        available_gib = _free_gib()
+        if available_gib < min_free_gib:
+            raise RuntimeError(f"free UMA {available_gib:.1f} < floor {min_free_gib:.1f}; "
+                               f"abort before calibration row {offset}")
+        batches.append(runner.capture_boundaries(calib_ids[offset:offset + batch_rows]))
+    _log(f"boundary capture done in {(time.time() - capture_started) / 60:.1f} "
+         f"min; starting {n_probes}-probe tail cotangents")
     device = runner.device
     dtype = runner.dtype
 
-    # One independent shared-state cotangent accumulator per KL probe.  This
-    # preserves architectures with declared cross-layer state (e.g. shared
-    # K/V) while remaining an exact no-op for the ordinary decoder contract.
+    # Existing boundary and shared-state mechanisms, one instance per complete
+    # sequence partition. Host boundary/cotangent storage still scales with the
+    # full calibration; only GPU activations and full-vocabulary tensors are
+    # bounded by batch_rows. No second residency or spill cache is introduced.
     from prismaquant.sensitivity_probe import (
         SharedStateCotangents,
         kv_cotangent_path_enabled,
     )
-
-    cotangents = [
-        SharedStateCotangents(enabled=kv_cotangent_path_enabled())
-        for _ in range(n_probes)
-    ]
-    grad_outs: list[torch.Tensor] = []
-    for probe_index in range(n_probes):
-        tail = batch.activations_cpu[-1].to(
-            device=device, dtype=dtype
-        ).detach().requires_grad_(True)
-        logits = runner.tail_logits(batch, tail)
-        probe = fisher_probe_scalar(
-            logits,
-            seed=seed_base + probe_index,
-            token_scope=token_scope,
-            temperature=temperature,
-            distribution="rademacher",
-        )
-        probe.backward()
-        if tail.grad is None:
-            raise RuntimeError("streamed AURA tail produced no cotangent")
-        grad_outs.append(tail.grad.detach().to("cpu"))
-        del logits, probe, tail
-    # The tail cotangents are now independent CPU tensors. Its source output
-    # boundary will not be read again during the reverse sweep.
-    batch.activations_cpu[-1] = torch.empty(0)
+    cotangents = [[SharedStateCotangents(enabled=kv_cotangent_path_enabled())
+                  for _ in batches] for _ in range(n_probes)]
+    grad_outs: list[list[torch.Tensor]] = [[] for _ in range(n_probes)]
+    for batch_index, batch in enumerate(batches):
+        for probe_index in range(n_probes):
+            tail = batch.activations_cpu[-1].to(
+                device=device, dtype=dtype
+            ).detach().requires_grad_(True)
+            logits = runner.tail_logits(batch, tail)
+            if probe_layout is not None and list(logits.shape) != [
+                len(batch.input_ids), int(calib_ids.shape[1]), probe_layout["vocab_size"]
+            ]:
+                raise RuntimeError("streamed AURA tail differs from bound probe geometry")
+            probe = fisher_probe_scalar(
+                logits, seed=seed_base + probe_index, token_scope=token_scope,
+                temperature=temperature, distribution="rademacher",
+                **({"token_count_override": probe_layout["global_token_count"],
+                    "global_row_offset": row_offsets[batch_index]}
+                   if probe_layout is not None else {}),
+            )
+            probe.backward()
+            if tail.grad is None:
+                raise RuntimeError("streamed AURA tail produced no cotangent")
+            grad_outs[probe_index].append(tail.grad.detach().to("cpu"))
+            del logits, probe, tail
+        batch.activations_cpu[-1] = torch.empty(0)
 
     reverse_started = time.time()
     reverse_layers_done = 0
@@ -2800,6 +2853,18 @@ def compute_aura_cost_streamed(
             # that parameter's AccumulateGrad node completes is numerically
             # identical to the old post-backward qname loop.
             harvested: set[str] = set()
+            accumulated_gradients: dict[str, torch.Tensor] = {}
+
+            def _consume_streamed_gradient(name, gradient):
+                if probe_microbatch:
+                    with torch.no_grad():
+                        if name in accumulated_gradients:
+                            accumulated_gradients[name].add_(gradient)
+                        else:
+                            accumulated_gradients[name] = gradient.to(torch.float32, copy=True)
+                else:
+                    _harvest_streamed_gradient(name, gradient)
+
 
             def _harvest_streamed_gradient(
                 name: str, gradient: torch.Tensor
@@ -2849,7 +2914,7 @@ def compute_aura_cost_streamed(
                         return
                     for name in member_names:
                         if name not in harvested:
-                            _harvest_streamed_gradient(name, _source_gradient(linears[name], gradient))
+                            _consume_streamed_gradient(name, _source_gradient(linears[name], gradient))
                     parameter.grad = None
 
                 return _hook
@@ -2873,58 +2938,63 @@ def compute_aura_cost_streamed(
                         )
                     )
                 for probe_index in range(n_probes):
-                    available_gib = _free_gib()
-                    if available_gib < min_free_gib:
-                        raise RuntimeError(
-                            f"free UMA {available_gib:.1f} < floor "
-                            f"{min_free_gib:.1f}; abort before streamed "
-                            f"layer {layer} probe {probe_index + 1}"
-                        )
                     harvested.clear()
+                    accumulated_gradients.clear()
                     if joint_lease is not None:
                         joint_lease.begin_probe()
-                    incoming_grad = grad_outs[probe_index].to(device)
-                    x_in = batch.activations_cpu[layer].to(
-                        device=device, dtype=dtype
-                    ).detach().requires_grad_(True)
-                    isolated = profile.isolated_layer_pass_state(
-                        batch.shared_pass_state, runner.layers[layer]
-                    )
-                    isolated = cotangents[probe_index].graft(isolated)
-                    out = runner.isolated_layer(
-                        batch, layer, x_in, pass_state=isolated
-                    )
-                    roots, root_grads = cotangents[probe_index].produced_roots()
-                    if roots:
-                        torch.autograd.backward(
-                            [out, *roots],
-                            [incoming_grad, *root_grads],
+                    for batch_index, batch in enumerate(batches):
+                        available_gib = _free_gib()
+                        if available_gib < min_free_gib:
+                            raise RuntimeError(
+                                f"free UMA {available_gib:.1f} < floor "
+                                f"{min_free_gib:.1f}; abort before streamed "
+                                f"layer {layer} probe {probe_index + 1}"
+                            )
+                        incoming_grad = grad_outs[probe_index][batch_index].to(device)
+                        x_in = batch.activations_cpu[layer].to(
+                            device=device, dtype=dtype
+                        ).detach().requires_grad_(True)
+                        isolated = profile.isolated_layer_pass_state(
+                            batch.shared_pass_state, runner.layers[layer]
                         )
-                    else:
-                        out.backward(incoming_grad)
-                    cotangents[probe_index].harvest()
-                    if x_in.grad is None:
-                        raise RuntimeError(
-                            f"streamed AURA layer {layer} produced no input "
-                            "cotangent"
+                        isolated = cotangents[probe_index][batch_index].graft(isolated)
+                        out = runner.isolated_layer(
+                            batch, layer, x_in, pass_state=isolated
                         )
-                    # Replace this probe's consumed incoming cotangent now.
-                    # The former next_grad_outs list retained all 32 incoming
-                    # CPU tensors while growing a second complete outgoing
-                    # plane. In-place rollover bounds the CPU plane to 32
-                    # tensors plus the one result currently being copied.
-                    grad_outs[probe_index] = x_in.grad.detach().to("cpu")
-                    for parameter_id, parameter in parameters.items():
-                        gradient = parameter.grad
-                        if gradient is not None:
-                            # Defensive straggler path for a backend that did
-                            # not invoke the post-accumulate hook. It performs
-                            # the identical reduction and still frees the
-                            # gradient before the next probe.
-                            for name in parameter_members[parameter_id]:
-                                if name not in harvested:
-                                    _harvest_streamed_gradient(name, _source_gradient(linears[name], gradient))
-                            parameter.grad = None
+                        roots, root_grads = cotangents[probe_index][batch_index].produced_roots()
+                        if roots:
+                            torch.autograd.backward(
+                                [out, *roots],
+                                [incoming_grad, *root_grads],
+                            )
+                        else:
+                            out.backward(incoming_grad)
+                        cotangents[probe_index][batch_index].harvest()
+                        if x_in.grad is None:
+                            raise RuntimeError(
+                                f"streamed AURA layer {layer} produced no input "
+                                "cotangent"
+                            )
+                        # Replace this probe's consumed incoming cotangent now.
+                        # The former next_grad_outs list retained all 32 incoming
+                        # CPU tensors while growing a second complete outgoing
+                        # plane. In-place rollover bounds the CPU plane to 32
+                        # tensors plus the one result currently being copied.
+                        grad_outs[probe_index][batch_index] = x_in.grad.detach().to("cpu")
+                        for parameter_id, parameter in parameters.items():
+                            gradient = parameter.grad
+                            if gradient is not None:
+                                # Defensive straggler path for a backend that did
+                                # not invoke the post-accumulate hook. It performs
+                                # the identical reduction and still frees the
+                                # gradient before the next probe.
+                                for name in parameter_members[parameter_id]:
+                                    if name not in harvested:
+                                        _consume_streamed_gradient(name, _source_gradient(linears[name], gradient))
+                                parameter.grad = None
+                        del (out, x_in, incoming_grad, isolated, roots, root_grads)
+                    for name in list(accumulated_gradients):
+                        _harvest_streamed_gradient(name, accumulated_gradients.pop(name))
                     for name in pending:
                         if name in harvested:
                             continue
@@ -2945,15 +3015,8 @@ def compute_aura_cost_streamed(
                             s2[key] += value
                             s4[key] += value * value
                             x2_probe[key].append(value)
-                    del (
-                        out,
-                        x_in,
-                        incoming_grad,
-                        isolated,
-                        roots,
-                        root_grads,
-                    )
             finally:
+                accumulated_gradients.clear()
                 if joint_lease is not None:
                     joint_lease.__exit__(None, None, None)
                     joint_lease = None
@@ -2982,7 +3045,8 @@ def compute_aura_cost_streamed(
             # sweep (the next iteration consumes boundary ``layer - 1``).
             # Release it progressively instead of retaining all 44 DSv4
             # hc_mult=4 boundary snapshots to the end.
-            batch.activations_cpu[layer] = torch.empty(0)
+            for batch in batches:
+                batch.activations_cpu[layer] = torch.empty(0)
 
             if checkpoint_root is not None:
                 assert checkpoint_identity_sha256 is not None
@@ -3054,6 +3118,7 @@ def run_streamed_production_anchor_aura(
     checkpoint_dir: str | Path,
     resume: bool,
     n_probes: int,
+    probe_microbatch: int = 0,
     token_scope: str = "all",
     temperature: float = 1.0,
     seed_base: int = 7000,
@@ -3237,6 +3302,7 @@ def run_streamed_production_anchor_aura(
         calib_ids,
         format_union,
         n_probes=n_probes,
+        probe_microbatch=probe_microbatch,
         token_scope=token_scope,
         temperature=temperature,
         production_cache=None,
@@ -3429,8 +3495,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                         "control for production calib volume; the monolithic "
                         "forward's vocab-shaped tensors are ~20 GiB at "
                         "32x1024). 0 = single batch (legacy, bit-identical). "
-                        ">0 changes probe-noise draws: statistically "
-                        "equivalent, not bit-identical to monolithic.")
+                        "Streamed joint AURA uses versioned row-indexed "
+                        "draws independent of the partition; compares against "
+                        "an explicit full-size >0 reference. Resident draws "
+                        "retain the legacy microbatch policy. Checkpoints "
+                        "bind the execution batch size.")
     p.add_argument("--allow-packed-expert-omission", action="store_true",
                    help="Explicit research/debug escape: allow AURA to omit "
                         "profile-declared routed expert targets from the cost "
@@ -3618,6 +3687,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 calib,
                 requested_formats,
                 n_probes=args.n_probes,
+                probe_microbatch=args.probe_microbatch,
                 token_scope=args.token_scope,
                 temperature=args.temperature,
                 production_cache=cache,

--- a/prismaquant/kl_fisher.py
+++ b/prismaquant/kl_fisher.py
@@ -14,6 +14,7 @@ probe for adjoint sketches.
 from __future__ import annotations
 
 import math
+import hashlib
 from typing import Literal
 
 import torch
@@ -21,6 +22,7 @@ import torch
 
 TokenScope = Literal["last", "all", "causal"]
 ProbeDistribution = Literal["gaussian", "rademacher"]
+ROW_PROBE_LAYOUT = "prismaquant.kl_fisher.global_row.v1"
 
 
 def select_token_scope(logits: torch.Tensor, token_scope: str) -> torch.Tensor:
@@ -82,6 +84,7 @@ def fisher_probe_scalar(
     temperature: float = 1.0,
     distribution: str = "gaussian",
     token_count_override: int | None = None,
+    global_row_offset: int | None = None,
 ) -> torch.Tensor:
     """Return a scalar whose logit gradient is one KL/Fisher probe.
 
@@ -97,6 +100,12 @@ def fisher_probe_scalar(
     normalize by the GLOBAL token count, not its own slice's count, or the
     summed gradient is inflated by ``sqrt(n_microbatches)``.  Default ``None``
     preserves the standard per-call normalization exactly.
+
+    ``global_row_offset`` opts into the versioned global-row noise layout.
+    Each complete sequence row uses a SHA256-derived seed with fixed token and
+    vocabulary geometry, independent of how rows are partitioned into calls.
+    Callers must also supply the global token normalizer. None preserves the
+    legacy generator and exact draws; it is not the row-indexed reference.
     """
     temp = float(temperature)
     if not math.isfinite(temp) or temp <= 0.0:
@@ -111,24 +120,40 @@ def fisher_probe_scalar(
     with torch.no_grad():
         probs = torch.softmax(scaled.detach(), dim=-1)
         root = torch.sqrt(torch.clamp(probs, min=0.0))
-        generator = torch.Generator(device=scaled.device)
-        generator.manual_seed(int(seed))
-        if distribution == "gaussian":
-            noise = torch.randn(
-                probs.shape,
-                generator=generator,
-                device=probs.device,
-                dtype=torch.float32,
-            )
-        elif distribution == "rademacher":
-            noise = torch.empty(
-                probs.shape,
-                device=probs.device,
-                dtype=torch.float32,
-            )
-            noise.bernoulli_(0.5, generator=generator).mul_(2.0).sub_(1.0)
-        else:
+        if global_row_offset is not None:
+            if (type(global_row_offset) is not int or global_row_offset < 0
+                    or selected.ndim != 3 or token_count_override is None
+                    or token_count_override < token_count_for_logits(selected)):
+                raise ValueError("global-row probes require a nonnegative row offset, "
+                                 "3D logits and the global token count")
+        if distribution not in {"gaussian", "rademacher"}:
             raise ValueError(f"unknown Fisher probe distribution: {distribution!r}")
+        generator = torch.Generator(device=scaled.device)
+
+        def fill_noise(target, noise_seed):
+            generator.manual_seed(noise_seed)
+            if distribution == "gaussian":
+                target.normal_(generator=generator)
+            else:
+                target.bernoulli_(0.5, generator=generator).mul_(2.0).sub_(1.0)
+
+        if global_row_offset is None:
+            # Keep the original Gaussian operator as well as its seed/layout.
+            generator.manual_seed(int(seed))
+            if distribution == "gaussian":
+                noise = torch.randn(probs.shape, generator=generator,
+                                    device=probs.device, dtype=torch.float32)
+            else:
+                noise = torch.empty_like(probs, dtype=torch.float32)
+                fill_noise(noise, int(seed))
+        else:
+            noise = torch.empty_like(probs, dtype=torch.float32)
+            for local_row in range(selected.shape[0]):
+                domain = (f"{ROW_PROBE_LAYOUT}:{int(seed)}:{token_scope}:"
+                          f"{global_row_offset + local_row}:"
+                          f"{selected.shape[1]}:{selected.shape[2]}")
+                row_seed = int.from_bytes(hashlib.sha256(domain.encode("ascii")).digest()[:8], "little")
+                fill_noise(noise[local_row], row_seed)
         root_noise = root * noise
         probe = root_noise - probs * root_noise.sum(dim=-1, keepdim=True)
         probe = probe / math.sqrt(float(token_count))

--- a/tests/test_joint_aura_microbatch.py
+++ b/tests/test_joint_aura_microbatch.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+import prismaquant.aura_cost as aura
+from prismaquant.kl_fisher import fisher_probe_scalar
+from test_joint_aura_streamed import _fixture
+from test_streamed_cost_checkpoints import _model_identity
+
+
+@pytest.mark.parametrize('scope', ['all', 'last', 'causal'])
+def test_row_indexed_fisher_partition_invariance(scope):
+    torch.manual_seed(80)
+    logits = torch.randn(5, 4, 13, requires_grad=True)
+    tokens = 5 * {'all': 4, 'last': 1, 'causal': 3}[scope]
+    kwargs = dict(seed=7000, token_scope=scope, distribution='rademacher',
+                  token_count_override=tokens)
+    full = fisher_probe_scalar(logits, global_row_offset=0, **kwargs)
+    expected, = torch.autograd.grad(full, logits)
+    for size in (1, 2, 3):
+        actual = torch.zeros_like(logits)
+        for start in range(0, 5, size):
+            part = logits[start:start + size].detach().requires_grad_(True)
+            scalar = fisher_probe_scalar(part, global_row_offset=start, **kwargs)
+            actual[start:start + size], = torch.autograd.grad(scalar, part)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def _run(size, *, checkpoint_dir=None, resume=False, capture_sizes=None):
+    _, context, runner, cache = _fixture()
+    if capture_sizes is not None:
+        capture = runner.capture_boundaries
+        def observed(ids):
+            capture_sizes.append(len(ids))
+            return capture(ids)
+        runner.capture_boundaries = observed
+    return aura.compute_aura_cost_streamed(
+        runner, torch.tensor([[1, 2, 3, 4]] * 5),
+        ['FP8_DYNAMIC', 'NVFP4A16', 'BF16'], n_probes=3,
+        min_free_gib=0, production_cache=cache, joint_activation=True,
+        model_identity=_model_identity('joint-source'), probe_microbatch=size,
+        checkpoint_dir=checkpoint_dir, resume=resume, collect_col_energy=True,
+    ), context
+
+
+def test_joint_microbatch_signed_sum_and_uneven_partition_invariance():
+    full, _ = _run(5)
+    for size in (1, 2, 3):
+        captures = []
+        actual, context = _run(size, capture_sizes=captures)
+        assert max(captures) <= size
+        assert sum(captures) == 5
+        assert context.active == set()
+        actual_identity = actual['provenance']['probe_identity']
+        full_identity = full['provenance']['probe_identity']
+        assert actual_identity['noise_layout'] == full_identity['noise_layout']
+        assert actual_identity['arithmetic']['execution_partition']['effective_rows'] == size
+        assert actual_identity != full_identity
+        for name, stats in full['stats'].items():
+            assert actual['stats'][name]['h_trace'] == pytest.approx(stats['h_trace'], rel=2e-5)
+            torch.testing.assert_close(actual['stats'][name]['fisher_col'], stats['fisher_col'], rtol=2e-5, atol=1e-10)
+        for name, rows in full['costs'].items():
+            for fmt, expected in rows.items():
+                row = actual['costs'][name][fmt]
+                assert row['signed_per_probe'] == pytest.approx(expected['signed_per_probe'], rel=2e-5, abs=2e-9)
+                assert row['x2_per_probe'] == pytest.approx(expected['x2_per_probe'], rel=4e-5, abs=1e-12)
+
+
+def test_microbatch_checkpoint_refuses_changed_partition(tmp_path, monkeypatch):
+    monkeypatch.setattr(aura, '_checkpoint_git_commit', lambda: '1' * 40)
+    first, _ = _run(2, checkpoint_dir=tmp_path)
+    resumed, context = _run(2, checkpoint_dir=tmp_path, resume=True)
+    assert first['costs'] == resumed['costs']
+    assert context.install_calls == 0
+    with pytest.raises(RuntimeError, match='identity mismatch'):
+        _run(3, checkpoint_dir=tmp_path, resume=True)
+
+
+def test_packed_joint_microbatch_matches_independent_row_oracle():
+    from test_joint_aura_packed import _fixture as packed_fixture, _Model
+    from prismaquant.routed_experts import profile_declared_packed_expert_projections
+    from prismaquant.perturbed_x_cache import _activation_qdq
+    from prismaquant import format_registry as fr
+    import copy
+
+    model, _, runner, profile, cache, _ = packed_fixture()
+    oracle = _Model(copy.deepcopy(model.state_dict())).eval()
+    ids = torch.tensor([[1, 2, 3, 4]] * 3 + [[4, 3, 2, 1]] * 2)
+    payload = aura.compute_aura_cost_streamed(
+        runner, ids, ['FP8_DYNAMIC', 'BF16'], n_probes=3, min_free_gib=0,
+        production_cache=cache, joint_activation=True, include_routed_experts=True,
+        profile=profile, model_identity=_model_identity('packed-joint-source'),
+        probe_microbatch=2, collect_col_energy=True)
+    views = {p.qname: p for p in profile_declared_packed_expert_projections(oracle, profile)}
+    nonzero_cross_terms = False
+    for probe_index in range(3):
+        row_terms = {name: [] for name in views}
+        oracle.zero_grad(set_to_none=True)
+        for row_index in range(len(ids)):
+            for layer in oracle.model.layers:
+                layer.feed_forward.experts.captures = []
+            logits = oracle(ids[row_index:row_index + 1]).logits
+            fisher_probe_scalar(logits, seed=7000 + probe_index, token_scope='all',
+                                distribution='rademacher', global_row_offset=row_index,
+                                token_count_override=ids.numel()).backward()
+            terms = {name: 0.0 for name in views}
+            for depth, layer in enumerate(oracle.model.layers):
+                for expert, x, gu, h, down in layer.feed_forward.experts.captures:
+                    for role, inputs, gradient in (('w1', x, gu.grad[:, :16]),
+                                                   ('w3', x, gu.grad[:, 16:]),
+                                                   ('w2', h, down.grad)):
+                        name = f'model.layers.{depth}.feed_forward.experts.{expert}.{role}'
+                        weight = views[name].weight.detach().double()
+                        rendered = cache.get(name, 'FP8_E4M3').double()
+                        qx = _activation_qdq(inputs, fr.get_format('FP8_E4M3'), cache.activation_max_abs, name)
+                        residual = qx.double() @ rendered.T - inputs.double() @ weight.T
+                        terms[name] += float((gradient.double() * residual).sum())
+            for name in views:
+                row_terms[name].append(terms[name])
+        for name, samples in row_terms.items():
+            row = payload['costs'][name]['FP8_E4M3']
+            expected = sum(samples)
+            assert row['signed_per_probe'][probe_index] == pytest.approx(expected, rel=4e-5, abs=4e-9)
+            assert row['x2_per_probe'][probe_index] == pytest.approx(expected ** 2, rel=8e-5, abs=1e-11)
+            nonzero_cross_terms |= abs(expected ** 2 - sum(x*x for x in samples)) > 1e-7
+    assert nonzero_cross_terms, 'fixture must distinguish signed-sum-square from sum-of-squares'
+
+
+@pytest.mark.parametrize('consumer', ['candidate', 'assignment', 'mixed_assignment'])
+def test_joint_consumers_refuse_different_execution_partition(consumer):
+    from prismaquant.joint_aura import (
+        paired_candidate_difference, paired_assignment_difference,
+        assignment_probe_summary,
+    )
+    full, _ = _run(5)
+    partitioned, _ = _run(2)
+    a = {name: rows['FP8_E4M3'] for name, rows in full['costs'].items()}
+    b = {name: rows['FP8_E4M3'] for name, rows in partitioned['costs'].items()}
+    names = list(a)
+    with pytest.raises(ValueError, match='probe alignment mismatch'):
+        if consumer == 'candidate':
+            paired_candidate_difference(a[names[0]], b[names[0]])
+        elif consumer == 'assignment':
+            paired_assignment_difference(a, b)
+        else:
+            assignment_probe_summary({names[0]: a[names[0]], names[1]: b[names[1]]})


### PR DESCRIPTION
Streamed joint AURA previously materialized the complete calibration draw's full-vocabulary tensors. Opt-in `--probe-microbatch N` now uses complete-sequence partitions through the existing streaming runner, fixed global-row Fisher draws and global token normalization. Each source Linear sums all signed contributions before squaring; gradient diagnostics sum FP32 gradients before norms. The arithmetic identity seals batch size, so checkpoint, paired-candidate and assignment consumers refuse mixed execution shapes.

PB validation: 121 targeted CPU tests passed without skips; 122 selected CPU tests passed after the independently qualified native activation-QDQ correction. Full-vocabulary CUDA Fisher construction matches across partitions. On three canonical LFM sequences, B=3 and B=1 streamed execution each exactly match same-size resident boundaries, routing, logits and packed gradients. Resident B=3 versus B=1 itself drifts from layer 2, so canonical B=1 arithmetic is explicitly sealed. Paired memory controls retain torch CPU/CUDA profiles and both hosts' Netdata; no speedup claim.

The full canonical int64 [512,512] draw completed as PB `38ec1f47fee64d8f33c38f3644d2ea432355fc76130809f2ffc27487740ff19b`, exit 0 with verified cleanup and CAS. It produced 192 candidate rows for the original 96 source Linears/PWC bytes with qualified native activation QDQ. All 2048 tail calls were [1,512,128000]; peak PyTorch GPU allocation was 20,751,726,080 bytes. CPU boundaries retain 26,843,545,600 bytes; host storage still scales with the full draw. The 80 GiB aggregate reservation and 32 GiB GPU cap were respected. The evidence document and 226-artifact manifest retain exact requests, full costs, 96 checkpoint shards, terminal logs, CAS receipts and both-host telemetry. The corrected one-row cost is separately retained for the native operator panel.

Changes remain opt-in and introduce no production format/default or serving gate. The observed PrismaBuild campaign GPU-cap parsing gap was filed separately as RobTand/prismabuild#340; ordinary PB submissions retained explicit resource caps and fleet-owned placement.

Closes #318.
