### PR TITLE
Fix standalone campaign planner package imports

### DIFF
--- a/tests/test_tessera_campaign_fanout.py
+++ b/tests/test_tessera_campaign_fanout.py
@@ -23,6 +23,36 @@ import pytest
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "tools"))
 
 
+def test_standalone_planner_without_pythonpath(tmp_path):
+    import os
+    import subprocess
+
+    root = pathlib.Path(__file__).resolve().parents[1]
+    model = tmp_path / "model"
+    model.mkdir()
+    spec = tmp_path / "spec.json"
+    spec.write_text(json.dumps({
+        "model": str(model), "campaign_argv": [], "cwd": str(root),
+        "python": sys.executable, "env": {},
+    }))
+    workspace = tmp_path / "campaign"
+    workspace.mkdir()
+    (workspace / "census.json").write_text(json.dumps({
+        "model": str(model), "anchor_groups": {"u:linear": ["linear"]},
+        "layer_stride": 1, "unit_shapes": {"linear": [8, 8]},
+    }))
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+    completed = subprocess.run([
+        sys.executable, str(root / "tools/dispatch_tessera_campaign.py"),
+        "plan", "--spec", str(spec), "--workspace", str(workspace),
+    ], cwd=tmp_path, env=env, text=True, capture_output=True)
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    rows = json.loads((workspace / "manifest.json").read_text())
+    assert len(rows) == 1
+    assert rows[0]["argv"][3] == "prismaquant.tessera_campaign"
+
+
 # ---------------------------------------------------------------------------
 # The selection
 # ---------------------------------------------------------------------------

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -69,6 +69,9 @@ from pathlib import Path
 if __package__:
     from .tessera_campaign_container import validate_container
 else:
+    # Direct script execution puts only tools/ on sys.path. Planning also
+    # reads the shared calibration contract from the sibling package.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
     from tessera_campaign_container import validate_container
 
 PBCAMPAIGN = Path("/mnt/shared/prismabuild-fleet/repo/tools/pbcampaign.py")


### PR DESCRIPTION
Running `python3 tools/dispatch_tessera_campaign.py plan ...` from an uninstalled checkout failed with `ModuleNotFoundError: prismaquant` when planning read the shared calibration contract. Direct script execution now resolves the sibling package from its own checkout, so it works without an operator-supplied `PYTHONPATH`.

A subprocess regression runs the planner from another directory with `PYTHONPATH` removed and checks the generated campaign manifest. PrismaBuild action `fb5b782da292f0bf7d0c936cda263285faf37e4b4a4d61172692e63e4500ebb0` passed all 51 fanout/container/merge tests, no skips, on CPU with four workers and native threads bounded to one. Exit 0, completed containment cleanup, and actual CAS payload `34705870fc0f3b2de2cf98f9c4d722bd86867644c3a14dcf7799a3704c270494` independently verified.

Follow-up to the calibration-capture planning integration. Fixes #305.
