### PR TITLE
Match native FP8 activation arithmetic and preserve signed zero

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,17 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-07 · `integration/native-moe-panel`. Stamps
+As of: 2026-09-07 · `fix/fp8-native-parity`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-07, `fix/fp8-native-parity`) for **served FP8 activation
+arithmetic**. The shared dynamic activation adapter uses FP32 tensor-denominator
+division for per-token scales and direct divide/clamp/cast for codes, matching
+the stock vLLM native kernel's rounding and signed-zero behavior. Scalar
+division's rounded reciprocal can move a scale one ULP and cross FP8 midpoints.
+This applies to plain FP8 and Tessera routes inheriting that activation policy;
+the compressed-tensors weight quantizer, wire recipes, format menu and serving
+gates are unchanged. Existing producer source hashing distinguishes newly
+measured costs from prior arithmetic. Gate: `tests/test_fp8_dynamic_native_parity.py`.
 
 Re-stamped (2026-09-07, `integration/native-moe-panel`) for **whole routed native
 operator evidence** (#309). `prismaquant.native_moe_panel` retains original

--- a/docs/measurements/fp8-native-activation-parity-2026-09-07.md
+++ b/docs/measurements/fp8-native-activation-parity-2026-09-07.md
@@ -1,0 +1,124 @@
+# Native FP8 activation parity — 2026-09-07
+
+The original complete routed-MoE measurement failed its input-QDQ gate even
+though the whole-output tolerance passed. The shared PrismaQuant activation
+adapter had two arithmetic differences from the target native kernel: CUDA
+scalar division by 448 lowered to multiplication by a rounded FP32 reciprocal,
+and the compressed-tensors quantizer added a zero point, erasing negative zero.
+The fix divides by an on-device FP32 tensor and uses the existing direct
+FP32 divide/clamp/cast helper for activations. Weight quantization is unchanged.
+This repairs the existing served arithmetic contract; it does not promote a
+format, change a tolerance, or establish full-model quality or speed.
+
+## Actual failure and arithmetic diagnosis
+
+The frozen native dataset is
+`/mnt/shared/tessera-native376-resource/native-moe-original-r1024/activation-diagnostic-01/diagnostic.safetensors`,
+SHA256 `8452ec28f9b325e52fcc6745ee4aa16d6828374e45650380b3e56ade770fffb2`.
+It contains actual BF16 prefill `[512,2048]` and decode `[1,2048]` inputs,
+native scales, native FP8 bytes, native QDQ and the old PQ references. Native
+capture ran in official vLLM image
+`vllm/vllm-openai@sha256:4e31c581716a5cb9ef31eddb0a425842b75cab07d5cd63fb9572e69ae8794c33`,
+upstream commit `1970f3ed4be7fa8620e4ddc4a12c36a8384cfc27`.
+The exact native source/provenance is retained under that native evidence root
+at `upstream1970/index.json`: scale division is in
+`csrc/libtorch_stable/quantization/w8a8/fp8/common.cu:163`, and the non-inverted
+conversion divides by scale in `csrc/quantization/w8a8/fp8/common.cuh:57`.
+
+The old shared adapter exactly reproduced the old frozen reference. Against
+native prefill, 256 of 512 scales differed by one FP32 ULP, 470 FP8 bytes differed
+(25 were signed zeros), and 4,050 BF16 QDQ elements differed, with maximum
+absolute difference 0.0703125. Decode was already exact. The original native
+measurement `measure-02/receipt.json` (SHA256
+`dffa1514d65612a936876da8398f1553ddaa2e7c7dc36d30dae4877582fc1215`)
+therefore remains negative evidence; its normalized prefill input-QDQ error was
+2.660508 against the unchanged `atol=rtol=0.015625` gate. No timing result from
+that rejected panel is accepted.
+
+One reproducible row has amax 0.96875 and native scale
+0.0021623882930725813; the old adapter produced 0.002162388525903225.
+Inputs `[-0.0908203125, 0.022705078125, 0.36328125]` quantize natively to
+`[-44, 11, 176]`, versus old `[-40, 10, 160]`. These independently recorded
+constants and negative-zero/floor behavior are CPU and CUDA regressions.
+Tensor division and FP64 scale division cast back to FP32 both matched native.
+Multiplying by the reciprocal of the native scale still produced 407 wrong
+code bytes; idealized FP64 division through the entire quantization expression
+also failed (135 wrong code bytes). The two FP32 divisions and their order matter.
+
+After correction, all 512 prefill scales, all 1,048,576 prefill FP8 bytes and
+BF16 QDQ values, and all decode results match native bit-for-bit. The diagnostic
+JSON retains its historical `shared_compressed_tensors` variant label; that
+label denotes the shared adapter loaded from the recorded source hash, which
+now performs direct activation QDQ. It is not a claim that the corrected
+activation route invokes compressed-tensors.
+
+## Validation and retained receipts
+
+Evidence root: `/mnt/shared/tessera-measurements/pq-fp8-native-parity-20260907`.
+All execution below ran through PrismaBuild. Terminal JSONs live under
+`/mnt/shared/prismabuild-fleet/pb-queue/{done,failed}/<action-key>.json` and carry
+exact commands, checkout snapshots, worker identity, stdout, CAS receipt and
+resource cleanup. The source-reference GPU environment is immutable image
+`sha256:9f9b9f05b17531399ba66dc6415b054cf5d68c82270626d0e9150e75c808435f`
+on Sparklina, PyTorch 2.13.0+cu130, CUDA 13.0, NVIDIA GB10, driver 595.84.
+This deliberately differs from the target serving image: the diagnostic checks
+PQ against independently captured target outputs. Native threads are bounded
+to one and PB-assigned affinity is preserved.
+
+| Check | PB action | Actual result |
+| --- | --- | --- |
+| Before arithmetic diagnostic | `be5ed565392b97e0850474728cf53d3f1242b6c10b20d950dcd5954a4c45ccdb` | rc 0; original failure reproduced |
+| Regression before fix | `bd44408bac75641bc74c79963cf0ee2e98d4800c778e387ce5c5a331a5f3e26f` | Four CPU/CUDA cases failed as expected |
+| Regression after fix | `e9b8fe8567c646308c86bb3628764e3030608e35b35065bc6f6ef8b7337f15cb4` | Four passed, no skips, rc 0 |
+| After arithmetic diagnostic | `d1c9f2ba1b7934161fddc88319a81bebe3094e8861e03193f9c5ae23cbd39e4b` | Native bit parity, rc 0 |
+| Native panel, packed/streamed joint and architecture tests | `600ecfcae8673cfabd10e38aa66448fa981ce0902ea5b90b75b0cee66c4c8b1c` | 107 passed, no skips; x86 CPU, four workers, rc 0 |
+| Before profile | `6eabab316edeb1715fe4683df6f2a711ac714b10abe7d6ad3b2c72e330b5b17c` | rc 0, measurement admission |
+| After profile | `cf062332e7a1fab076baaef3ce43521593a2bd44dfb0725364f75b2976198342` | rc 0, measurement admission |
+
+Diagnostic artifact hashes: `diagnostic-01.json`
+`fb22bc8e41f7794cd59ee9a44d7736a5eced60f3ddb10702b9104d71f771d243`;
+`diagnostic-after-01.json`
+`e955dfe266e5f704e38624549d9543019f2d8eec049fcd34ceed3e73ddbefeb6`.
+Profile JSON hashes: `profile-before-01/profile.json`
+`3f2b5bcc584da62b7be0f3700f375cd6fb83176fdaa75e7c1792bfaea7cad02f`;
+`profile-after-01/profile.json`
+`cf012fe7a2c30dddd19adc3f8c038131086169894af3d095c4374c5f92d40ec5`.
+`verification-01.json` records independently rehashed profile/trace/table files,
+CAS payload bytes and receipt hashes, and actual CUDA kernel counts.
+
+## Scoped before/after profiling
+
+The benchmark calls only `fp8_dynamic_activation_qdq_vllm(...).dequant.to(input.dtype)` on the
+same captured GPU-resident inputs. It uses 20 warmup calls, one 20-second timed
+CUDA-event window per phase with synchronization every 32 calls, then 32 calls
+under `torch.profiler` CPU+CUDA. The measured event interval includes host
+launch gaps. Source-before is commit `5a788c47`; source-after is `fa5d88e1`.
+Each measurement requests one CPU, 8 GiB total memory and 4 GiB GPU memory with
+PB measurement admission on Sparklina. The before arm precedes the after arm;
+these are single windows without repeated/interleaved arms or error bars.
+
+| QDQ-only metric | Prefill before | Prefill after | Decode before | Decode after |
+| --- | ---: | ---: | ---: | ---: |
+| ms/call, timed CUDA interval | 0.194001 | 0.123573 | 0.114600 | 0.079243 |
+| CUDA kernels / profiled call | 15 | 13 | 15 | 13 |
+| Actual kernel duration / profiled call, µs | 175.285 | 122.497 | 19.687 | 16.949 |
+| Peak allocated bytes | 30,443,520 | 26,248,704 | 12,649,472 | 12,640,768 |
+| Mean device power, W | 33.342 | 30.789 | 12.289 | 13.132 |
+| Approximate QDQ calls / device joule | 154.6 | 262.8 | 710.1 | 961.0 |
+
+`netdata-before-after-01.json` retains raw Netdata queries and samples for both
+Sparky and Sparklina, covering each phase's integer-second interior (19 samples
+per context): GPU power, CPU user/system/iowait, load, available memory and swap
+I/O. Both boxes show zero swap I/O. Sparky stays at 4 W GPU power; its CPU
+user/system means range 1.0–1.5% / 0.8–1.0%. Sparklina user/system means are
+5.4–5.8% / 0.5–0.6%, with approximately 117,200 MiB available. Its low power
+compared with the approximately 140 W envelope and the decode launch gaps do
+not establish GPU saturation. This repair removes quantization operations but
+does not resolve the helper's launch-bound decode behavior.
+
+Calls/joule divides timed call throughput by the phase-interior Netdata mean
+power; it is a coarse device-energy estimate, includes idle device power, and
+is not whole-system energy. The profiler and power series support only this
+local helper comparison. No full-model KL, bpp, serving throughput or winner
+claim follows; corrected downstream costs and native panels must be regenerated
+and gated with their own complete receipts.

--- a/docs/measurements/fp8-native-activation-parity-2026-09-07.md
+++ b/docs/measurements/fp8-native-activation-parity-2026-09-07.md
@@ -69,7 +69,7 @@ to one and PB-assigned affinity is preserved.
 | --- | --- | --- |
 | Before arithmetic diagnostic | `be5ed565392b97e0850474728cf53d3f1242b6c10b20d950dcd5954a4c45ccdb` | rc 0; original failure reproduced |
 | Regression before fix | `bd44408bac75641bc74c79963cf0ee2e98d4800c778e387ce5c5a331a5f3e26f` | Four CPU/CUDA cases failed as expected |
-| Regression after fix | `e9b8fe8567c646308c86bb3628764e3030608e35b35065bc6f6ef8b7337f15cb4` | Four passed, no skips, rc 0 |
+| Regression after fix | `e9b8fe8567c646308c86bb3628764e3030608e35b35065bc6f6ef8b7337f15cb` | Four passed, no skips, rc 0 |
 | After arithmetic diagnostic | `d1c9f2ba1b7934161fddc88319a81bebe3094e8861e03193f9c5ae23cbd39e4b` | Native bit parity, rc 0 |
 | Native panel, packed/streamed joint and architecture tests | `600ecfcae8673cfabd10e38aa66448fa981ce0902ea5b90b75b0cee66c4c8b1c` | 107 passed, no skips; x86 CPU, four workers, rc 0 |
 | Before profile | `6eabab316edeb1715fe4683df6f2a711ac714b10abe7d6ad3b2c72e330b5b17c` | rc 0, measurement admission |

--- a/experiments/pq_fp8_native_parity.py
+++ b/experiments/pq_fp8_native_parity.py
@@ -1,0 +1,116 @@
+"""PB-only arithmetic diagnosis from independently captured native FP8 tensors."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import inspect
+import json
+import os
+from pathlib import Path
+import socket
+
+
+def sha(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def main():
+    import compressed_tensors
+    import compressed_tensors.quantization.lifecycle.forward_helpers as ct_forward
+    import torch
+    from safetensors.torch import load_file
+    from prismaquant import fp8_dynamic
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tensors", required=True, type=Path)
+    parser.add_argument("--tensors-sha256", required=True)
+    parser.add_argument("--out", required=True, type=Path)
+    args = parser.parse_args()
+    if sha(args.tensors) != args.tensors_sha256:
+        raise ValueError("native tensor artifact hash differs")
+    tensors = load_file(str(args.tensors), device="cuda")
+    report = {"schema": "prismaquant.fp8_native_arithmetic_diagnostic.v1",
+        "input_artifact_sha256": args.tensors_sha256,
+        "environment": {"host": socket.gethostname(), "torch": torch.__version__,
+            "cuda": torch.version.cuda, "device": torch.cuda.get_device_name(),
+            "compressed_tensors": compressed_tensors.__version__, "affinity": sorted(os.sched_getaffinity(0)),
+            "pq_fp8_source_sha256": sha(inspect.getfile(fp8_dynamic)),
+            "compressed_tensors_forward_sha256": sha(inspect.getfile(ct_forward))},
+        "phases": {}}
+
+    def tensor_sha(value):
+        return hashlib.sha256(value.detach().contiguous().view(torch.uint8).cpu().numpy().tobytes()).hexdigest()
+
+    for phase in ("prefill", "decode"):
+        x = tensors[phase + ".input"]
+        reference = tensors[phase + ".expected_qdq"]
+        codes = tensors[phase + ".native_codes_bits"]
+        codes = codes.view(torch.float8_e4m3fn) if codes.dtype == torch.uint8 else codes
+        native_scale = tensors[phase + ".native_scales"]
+        if x.ndim != 2 or x.dtype != torch.bfloat16 or native_scale.shape != (x.shape[0], 1):
+            raise ValueError("diagnostic needs actual BF16 rows and per-token scales")
+        shared = fp8_dynamic.fp8_dynamic_activation_qdq_vllm(x)
+        shared_qdq = shared.dequant.to(x.dtype)
+        rows = x.float()
+        amax = rows.abs().amax(dim=-1, keepdim=True)
+        native_qdq = (codes.float() * native_scale).to(x.dtype)
+        denominator = torch.tensor(448.0, dtype=torch.float32, device=x.device)
+        scale_variants = {"shared_scalar_div": shared.scale,
+            "tensor_div": (amax / denominator).clamp_min(1 / (448 * 512)),
+            "double_div_cast": (amax.double() / 448.0).float().clamp_min(1 / (448 * 512)),
+            "float_reciprocal_multiply": (amax * denominator.reciprocal()).clamp_min(1 / (448 * 512))}
+        scale_comparisons = {}
+        for name, scale in scale_variants.items():
+            candidate = (rows / scale).clamp(-448, 448).to(codes.dtype)
+            qdq = (candidate.float() * scale).to(x.dtype)
+            scale_comparisons[name] = {"scale_values_differ": int((scale != native_scale).sum()),
+                "max_scale_abs": float((scale - native_scale).abs().max()),
+                "code_bytes_differ": int((candidate.view(torch.uint8) != codes.view(torch.uint8)).sum()),
+                "dequant_values_differ": int((qdq != native_qdq).sum()),
+                "max_dequant_abs": float((qdq.float() - native_qdq.float()).abs().max()),
+                "scales_sha256": tensor_sha(scale)}
+        ratios = {"division": rows / shared.scale,
+            "reciprocal_multiply": rows * shared.scale.reciprocal(),
+            "max_ratio_multiply": rows * (448.0 / amax.clamp_min(1 / 512)),
+            "double_max_ratio": rows.double() * (448.0 / amax.double().clamp_min(1 / 512))}
+        variants = {
+            "shared_compressed_tensors": shared.quant,
+            "divide_shared_scale": ratios["division"].clamp(-448, 448).to(codes.dtype),
+            "multiply_reciprocal_shared_scale": ratios["reciprocal_multiply"].clamp(-448, 448).to(codes.dtype),
+            "multiply_max_ratio": ratios["max_ratio_multiply"].clamp(-448, 448).to(codes.dtype),
+            "divide_native_scale": (rows / native_scale).clamp(-448, 448).to(codes.dtype),
+            "multiply_reciprocal_native_scale": (rows * native_scale.reciprocal()).clamp(-448, 448).to(codes.dtype),
+            "double_max_ratio": ratios["double_max_ratio"].clamp(-448, 448).float().to(codes.dtype),
+        }
+        compared = {}
+        for name, candidate in variants.items():
+            qdq = (candidate.float() * native_scale).to(x.dtype)
+            compared[name] = {"code_bytes_differ": int((candidate.view(torch.uint8) != codes.view(torch.uint8)).sum()),
+                "dequant_values_differ": int((qdq != native_qdq).sum()),
+                "max_dequant_abs": float((qdq.float() - native_qdq.float()).abs().max()),
+                "codes_sha256": tensor_sha(candidate)}
+        indices = torch.nonzero(shared.quant.view(torch.uint8) != codes.view(torch.uint8))[:64].cpu().tolist()
+        examples = []
+        for row, col in indices:
+            examples.append({"row": row, "column": col, "x": float(x[row, col]), "amax": float(amax[row, 0]),
+                "shared_scale": float(shared.scale[row, 0]), "native_scale": float(native_scale[row, 0]),
+                "shared_code": float(shared.quant[row, col]), "native_code": float(codes[row, col]),
+                **{name: float(value[row, col]) for name, value in ratios.items()}})
+        report["phases"][phase] = {"shape": list(x.shape), "input_sha256": tensor_sha(x),
+            "shared_reproduces_frozen_reference": torch.equal(shared_qdq, reference),
+            "native_scale_values_differ": int((shared.scale != native_scale).sum()),
+            "max_scale_abs": float((shared.scale - native_scale).abs().max()),
+            "scale_variants": scale_comparisons,
+            "shared_reference_sha256": tensor_sha(shared_qdq), "native_qdq_sha256": tensor_sha(native_qdq),
+            "variants": compared, "first_code_mismatches": examples}
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("x") as stream:
+        json.dump(report, stream, indent=2, allow_nan=False)
+        stream.write("\n")
+    print(json.dumps({"output": str(args.out), "sha256": sha(args.out), "phases": {
+        phase: {key: value for key, value in result.items() if key != "first_code_mismatches"}
+        for phase, result in report["phases"].items()}}, allow_nan=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/pq_fp8_native_parity.sh
+++ b/experiments/pq_fp8_native_parity.sh
@@ -8,5 +8,7 @@ docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" \
   -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared -w /workspace \
   --entrypoint python3 -e PYTHONDONTWRITEBYTECODE=1 \
   -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
+  -e PRISMAQUANT_PROD_ACT_SCALES=0 -e XDG_CACHE_HOME=/tmp/pq-fp8-cache \
+  -e TORCH_EXTENSIONS_DIR=/tmp/pq-fp8-extensions \
   -e "PYTHONPATH=.:$root/inputs/tessera-382a1a97/src:$root/inputs/container-compatible-deps" \
   "$image" -m "$module" "$@"

--- a/experiments/pq_fp8_native_parity.sh
+++ b/experiments/pq_fp8_native_parity.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Replay PQ arithmetic in the immutable original source-reference environment.
+image=sha256:9f9b9f05b17531399ba66dc6415b054cf5d68c82270626d0e9150e75c808435f
+root=/mnt/shared/tessera-measurements/first-model-20260907
+module=${PQ_FP8_DIAGNOSTIC_MODULE:-experiments.pq_fp8_native_parity}
+docker run --rm --gpus all --ipc=host --user "$(id -u):$(id -g)" \
+  -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared -w /workspace \
+  --entrypoint python3 -e PYTHONDONTWRITEBYTECODE=1 \
+  -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
+  -e "PYTHONPATH=.:$root/inputs/tessera-382a1a97/src:$root/inputs/container-compatible-deps" \
+  "$image" -m "$module" "$@"

--- a/experiments/pq_fp8_profile.py
+++ b/experiments/pq_fp8_profile.py
@@ -1,0 +1,80 @@
+"""PB measurement of the shared activation adapter on retained native inputs."""
+import argparse
+import hashlib
+import inspect
+import json
+import os
+from pathlib import Path
+import socket
+import time
+
+
+def digest(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def main():
+    import torch
+    from safetensors.torch import load_file
+    from prismaquant import fp8_dynamic
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tensors", required=True, type=Path)
+    parser.add_argument("--tensors-sha256", required=True)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--seconds", default=20., type=float)
+    args = parser.parse_args()
+    if digest(args.tensors) != args.tensors_sha256:
+        raise ValueError("native inputs changed")
+    args.out.mkdir(parents=True, exist_ok=False)
+    tensors = load_file(str(args.tensors), device="cuda")
+    report = {"schema": "prismaquant.fp8_activation_profile.v1", "input_sha256": args.tensors_sha256,
+        "source_sha256": digest(inspect.getfile(fp8_dynamic)), "host": socket.gethostname(),
+        "torch": torch.__version__, "cuda": torch.version.cuda, "device": torch.cuda.get_device_name(),
+        "affinity": sorted(os.sched_getaffinity(0)), "scope": "shared FP8 activation QDQ only; no model throughput claim",
+        "phases": {}}
+    for phase in ("prefill", "decode"):
+        x = tensors[phase + ".input"]
+        def call():
+            return fp8_dynamic.fp8_dynamic_activation_qdq_vllm(x).dequant.to(x.dtype)
+        for _ in range(20):
+            call()
+        torch.cuda.synchronize()
+        torch.cuda.reset_peak_memory_stats()
+        started = time.time()
+        begin, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
+        begin.record()
+        count = 0
+        while time.time() - started < args.seconds:
+            for _ in range(32):
+                call()
+            count += 32
+            torch.cuda.synchronize()
+        end.record()
+        torch.cuda.synchronize()
+        stopped = time.time()
+        elapsed = begin.elapsed_time(end)
+        with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA], record_shapes=True) as prof:
+            for _ in range(32):
+                with torch.profiler.record_function("shared_fp8_activation_qdq"):
+                    call()
+            torch.cuda.synchronize()
+        trace = args.out / (phase + ".trace.json")
+        prof.export_chrome_trace(str(trace))
+        table = args.out / (phase + ".profile.txt")
+        table.write_text(prof.key_averages().table(sort_by="self_cuda_time_total", row_limit=50))
+        kernels = [{"name": row.key, "count": row.count, "self_cpu_us": row.self_cpu_time_total,
+                    "self_device_us": row.self_device_time_total} for row in prof.key_averages()]
+        report["phases"][phase] = {"shape": list(x.shape), "dtype": str(x.dtype), "calls": count,
+            "window_unix": [started, stopped], "wall_seconds": stopped - started,
+            "cuda_elapsed_ms": elapsed, "cuda_ms_per_call": elapsed / count,
+            "peak_allocated_bytes": torch.cuda.max_memory_allocated(), "trace_sha256": digest(trace),
+            "profile_table_sha256": digest(table), "profiled_calls": 32, "operators": kernels}
+    target = args.out / "profile.json"
+    target.write_text(json.dumps(report, indent=2, allow_nan=False) + "\n")
+    print(json.dumps({"output": str(target), "sha256": digest(target), "phases": {
+        name: {k: v for k, v in value.items() if k != "operators"} for name, value in report["phases"].items()}}))
+
+
+if __name__ == "__main__":
+    main()

--- a/prismaquant/fp8_dynamic.py
+++ b/prismaquant/fp8_dynamic.py
@@ -94,23 +94,20 @@ def fp8_dynamic_activation_qdq_vllm(
     act_f = activation.to(torch.float32)
     rows = act_f.reshape(-1, act_f.shape[-1])
     min_scale = 1.0 / (float(element_max) * 512.0)
+    # CUDA scalar division may multiply by a rounded reciprocal instead. That
+    # moves some scales by one FP32 ULP and can cross an FP8 midpoint. vLLM's
+    # native per-token kernel divides in FP32; keep the denominator on-device
+    # so TensorIterator retains the same operation rather than folding it.
+    denominator = torch.full((), float(element_max), dtype=torch.float32, device=rows.device)
     scale = (
-        rows.abs().amax(dim=-1, keepdim=True) / float(element_max)
+        rows.abs().amax(dim=-1, keepdim=True) / denominator
     ).clamp_min(min_scale)
 
-    if element_dtype != torch.float8_e4m3fn:
-        result = _fallback_fp8_qdq(
-            rows,
-            scale,
-            element_dtype=element_dtype,
-            element_max=element_max,
-        )
-    else:
-        args = FP8_DYNAMIC["input_activations"]
-        zero_point = torch.zeros_like(scale)
-        quant = quantize(rows, scale, zero_point, args, dtype=element_dtype)
-        dequant = quant.to(torch.float32) * scale
-        result = FP8DynamicResult(quant=quant, scale=scale, dequant=dequant)
+    # The native activation kernel directly divides, clamps and casts. Adding
+    # even a zero zero-point (the CT weight/export path) erases negative zero.
+    result = _fallback_fp8_qdq(
+        rows, scale, element_dtype=element_dtype, element_max=element_max,
+    )
 
     return FP8DynamicResult(
         quant=result.quant.reshape(activation.shape),

--- a/tests/test_fp8_dynamic_native_parity.py
+++ b/tests/test_fp8_dynamic_native_parity.py
@@ -1,0 +1,31 @@
+"""Native vLLM 1970f3ed4 observations, independent of the emulation formula."""
+import pytest
+import torch
+
+from prismaquant.fp8_dynamic import fp8_dynamic_activation_qdq_vllm
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_native_fp8_midpoint_scales_codes_and_signed_zero(device):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA arithmetic parity requires a GPU worker")
+    # Actual canonical LFM prefill row 53 (cols 232,354,496), with its maximum;
+    # native diagnostic artifact 8452ec28... includes the independent observations.
+    # Negative zero is independently observed in row 40, column 1819.
+    values = torch.tensor([[.96875, -.0908203125, .022705078125, .36328125, -0.0]],
+                          dtype=torch.bfloat16, device=device)
+    actual = fp8_dynamic_activation_qdq_vllm(values)
+    expected_scale = torch.tensor([[.0021623882930725813]], dtype=torch.float32, device=device)
+    expected_codes = torch.tensor([[448., -44., 11., 176., -0.0]], dtype=torch.float8_e4m3fn, device=device)
+    assert torch.equal(actual.scale, expected_scale)
+    assert torch.equal(actual.quant.view(torch.uint8), expected_codes.view(torch.uint8))
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_zero_tokens_keep_native_scale_floor_and_signed_zero(device):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA arithmetic parity requires a GPU worker")
+    values = torch.tensor([[0., -0.]], dtype=torch.bfloat16, device=device)
+    actual = fp8_dynamic_activation_qdq_vllm(values)
+    assert torch.equal(actual.scale, torch.full_like(actual.scale, 1 / (448 * 512)))
+    assert actual.quant.view(torch.uint8).tolist() == [[0, 128]]


### PR DESCRIPTION
The actual native MoE gate found that PQ's shared FP8 activation QDQ disagreed with vLLM on 256 of 512 row scales and 470 FP8 bytes. Scalar division by 448 could lower to reciprocal multiplication, and adding a zero point erased negative zero. Divide by an on-device FP32 tensor and use the existing direct divide/clamp/cast helper for activations. Weight quantization stays with compressed-tensors.

The corrected adapter matches all 1,048,576 captured prefill FP8 bytes and QDQ values plus decode bit-for-bit. Four CPU/CUDA regression cases fail before and pass after; 107 targeted integration/docs tests pass through PrismaBuild, with no skips. Before/after CPU+CUDA profiler traces, both-host Netdata series, exact environments, negative hypotheses and verified receipts are recorded in `docs/measurements/fp8-native-activation-parity-2026-09-07.md`. The helper-only timing comparison is not a full-model speed or quality claim.

Closes #309. This numerical-gate repair follows the complete native panel implementation in merged #314. Downstream costs and native panels are being regenerated under the corrected adapter; the original rejected panel remains negative evidence.
