### PR TITLE
Qualify completed Tessera anchors for exact full-model joint AURA

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,7 +18,11 @@ and eviction; no encoder, cache store or dispatcher is added. A sealed prepared
 record binds every qualified render plus source/backend/calibration/implementation
 identity. The dependent run verifies those bindings and calls existing streamed
 joint AURA with explicit complete-sequence microbatches, global-row probes and
-durable checkpoints. Source BF16 remains the independent zero-cost terminal.
+durable checkpoints. Both preparation and pricing require explicit source-cache
+slots, prefetch workers/lookahead and memory floors, with strict prefetched
+residency enabled; omitted settings and cold-read fallback refuse at intake.
+The plan digest binds these settings through preparation and cost resume.
+Source BF16 remains the independent zero-cost terminal.
 Full-duration in-process profiles and allocation/IO records accompany these
 research actions; no format/default, wire or serving gate changes.
 Gate: `tests/test_tessera_joint_aura.py`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,27 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-07 · `feat/joint-aura-calibration-microbatch`. Stamps
+As of: 2026-09-07 · `feat/tessera-joint-anchor-bridge`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-07, `feat/tessera-joint-anchor-bridge`) for **joint AURA
+from completed measured Tessera anchors** (#322). The explicit
+`prismaquant.tessera_joint_aura.plan.v1` intake binds a complete campaign fanout,
+its fleet receipts, merged scalar payload/journal, full census and canonical
+token/capture artifacts. Only journaled measured wire cells enter the exact
+per-Linear format plan; interpolated MSE rows never become joint prices.
+Preparation derives the producer's encoding identity from actual streamed source
+weights and original prefetched Hessians, verifies original wire bytes, and
+requires their decoded BF16 values to equal original PWC shards. Fused-census
+maxima use the existing static-scale contract and must reproduce measured E2M1
+scales. The existing PWC indexes original absolute donor paths and owns prefetch
+and eviction; no encoder, cache store or dispatcher is added. A sealed prepared
+record binds every qualified render plus source/backend/calibration/implementation
+identity. The dependent run verifies those bindings and calls existing streamed
+joint AURA with explicit complete-sequence microbatches, global-row probes and
+durable checkpoints. Source BF16 remains the independent zero-cost terminal.
+Full-duration in-process profiles and allocation/IO records accompany these
+research actions; no format/default, wire or serving gate changes.
+Gate: `tests/test_tessera_joint_aura.py`.
 
 Re-stamped (2026-09-07, `feat/joint-aura-calibration-microbatch`) for
 **bounded full-calibration streamed joint AURA** (#318). Explicit

--- a/docs/experiments/tessera_joint_anchor_bridge_2026-09-07.md
+++ b/docs/experiments/tessera_joint_anchor_bridge_2026-09-07.md
@@ -80,3 +80,28 @@ adding the difference to the largest seven-candidate layer suggests roughly
 30 GB allocated before slack. This is an estimate, not an observed full-model
 peak. Recompute from the complete actual roster before submission; partial
 telemetry is no basis for shrinking the reservation.
+
+Validation recorded on 2026-09-07: the test-first PB action
+`726501c99f7b842cbeedd2ede6f19a064c1ba31ddd0154d99533e0e8d1d8a6ec`
+failed with the missing bridge module. Initial implementation action
+`ead6ef02494e99826c9c1a4339c284eac39f2affd2d05aa2aaa472202dcd4890`
+passed 14 CPU checks on Sparklina. The final expanded action
+`49f45ef79d16c9ff9e7079e8689917db742d552555183f3018a56772c603ebdc`
+ran the importer, microbatch, packed-joint, exact-calibration, architecture and
+staleness tests on DL380: **64 passed in 9.94 s, no skips**, with touched Python
+modules compiled. CPU environment was Python 3.14.4, torch 2.11.0+cpu,
+Transformers 5.16.1 and compressed-tensors 0.18.0. Native threads were bounded to
+one per each of four pytest workers, with CPU 4/8 GiB admitted. Production GPU
+arithmetic remains qualified separately in the pinned original container.
+
+Actual terminal and cleanup succeeded; CAS payload
+`a0cb90beb94622d669e933def47a452a3b445cef777c1f4c7cc1e9fc351056fe`
+and receipt
+`321aec68b76d43c5d09f6ec04951d9880df0566ba6d20c4ba5f6c6002eac83cf`
+were independently rehashed. Raw logs, requests, summaries, receipts and payloads
+are retained under the first-model `full-model-joint-aura/receipts/`, with a
+hashed `evidence-manifest.json`. Negative intermediate attempts are retained:
+one fixture expected 128 bytes instead of its actual 64 BF16 bytes; the first
+portable CPU environment lacked compressed-tensors and failed collection/setup.
+The fixture and scoped CPU dependencies were corrected before the green run.
+These are control-flow/contract tests, not real-wire numerical qualification.

--- a/docs/experiments/tessera_joint_anchor_bridge_2026-09-07.md
+++ b/docs/experiments/tessera_joint_anchor_bridge_2026-09-07.md
@@ -1,0 +1,82 @@
+# Completed Tessera anchors to full-model joint AURA
+
+Issue #322 adds a checked bridge from a completed Tessera campaign into existing
+streamed joint AURA. The scalar campaign establishes which exact wires and BF16
+decoded renders exist; its MSE and interpolated prices never become joint costs.
+Preparation verifies actual source weights, original prefetched Hessians and
+encoding settings against every wire receipt, decodes that wire, and requires
+exact equality with its original PWC render. Pricing uses precisely those
+per-Linear formats plus source BF16. This research bridge changes no wire format,
+menu default, allocator default, export lane or serving gate.
+
+No full-model joint result has been produced by this bridge at this writing.
+The first-model invocation uses all 2,142 census Linears in all 38 groups from
+`full-model-anchors-02`, with the original 512 × 512 token artifact and capture.
+Settings are all-token joint activation pricing, complete-sequence microbatch 1,
+four global-row Rademacher probes, seed 7000, temperature 1, source BF16, FP32
+weight deltas and optional production activation clipping disabled. Measured
+E2M1 retains its unified fused-module static scale. The plan and prepared record
+bind source/backend/calibration and implementation identities. Resume requires
+the exact existing checkpoint identity; subset draws and mixed checkpoints fail.
+
+The plan schema is `prismaquant.tessera_joint_aura.plan.v1`. Its `inputs` contains
+independently bound `{path, sha256}` entries for campaign plan, census, complete
+fleet receipts, merged cost and merged checkpoint, plus `required_source_units`
+and `required_campaign_groups`. Model, token input, canonical capture, execution
+settings, output root, PWC/GPU budgets, memory floor and profiler are explicit.
+The concrete first-model plan sealer and provisional calculation are retained at
+`/mnt/shared/tessera-measurements/first-model-20260907/full-model-joint-aura/`.
+They cannot seal a plan until required merged artifacts and receipts exist.
+
+After independently verifying the merged campaign and importer qualification,
+use these dependent PB actions. Supply the actual plan SHA256; independently
+rehash the completed preparation record after checking its fleet terminal,
+logs, CAS receipt and contents. Neither action uses a latest-file pointer.
+
+```bash
+python3 /mnt/shared/prismabuild-fleet/repo/tools/pbrun.py \
+  --cwd /home/rob/tmp/pq-joint-anchor-bridge --tag gb10 \
+  --cpus 4 --gpu --demand mem_gb=96 --gpu-memory-gb 40 \
+  --env OMP_NUM_THREADS=1 --env MKL_NUM_THREADS=1 --env OPENBLAS_NUM_THREADS=1 \
+  --detach -- bash experiments/pq322_joint_anchor_run.sh prepare \
+  --plan "$JOINT_PLAN" --plan-sha256 "$PLAN_SHA256"
+
+python3 /mnt/shared/prismabuild-fleet/repo/tools/pbrun.py \
+  --cwd /home/rob/tmp/pq-joint-anchor-bridge --tag gb10 \
+  --cpus 4 --gpu --demand mem_gb=96 --gpu-memory-gb 40 \
+  --env OMP_NUM_THREADS=1 --env MKL_NUM_THREADS=1 --env OPENBLAS_NUM_THREADS=1 \
+  --detach -- bash experiments/pq322_joint_anchor_run.sh run \
+  --plan "$JOINT_PLAN" --plan-sha256 "$PLAN_SHA256" \
+  --prepared "$PREPARED_RECORD" --prepared-sha256 "$PREPARED_SHA256"
+```
+
+The pinned known-good container preserves PB affinity and ownership. PB owns
+placement; preparation and pricing have an actual data dependency. Existing
+streamed pass/calibration/probe semantics do not expose independent model-layer
+jobs, so the bridge adds no dispatcher. Existing completed-layer checkpoints
+retain their restart semantics and are additionally bound to the input plan.
+
+Each action writes full-duration `profile.pstats`, readable `profile.txt`,
+`/proc/self/io` counters, CUDA allocation peaks, source identity, phase epochs and
+`results.json`. Collect both boxes' Netdata series with the existing
+`/mnt/shared/tessera-measurements/pq300-batch-20260907/harness/collect_netdata.py`
+against each result, retaining raw series and any coverage errors. Shared-host
+profiles describe this run and establish no isolated speedup. Check terminal
+status and cleanup, output roster/hashes, CAS payload and receipt before consuming
+`prepare/prepared.json` or `run/joint-cost.pkl`.
+
+The provisional reservation is CPU 4/native 1, 96 GiB aggregate and a 40 GiB GPU
+subset on GB10. The earlier 96-unit, one-render full-calibration run measured
+20,751,726,080 CUDA allocated bytes and 23,603,445,760 reserved bytes, with
+26,843,545,600 CPU boundary bytes. Four rolling BF16 cotangent planes add about
+4 GiB. The largest census decoder layer has 362,807,296 quantizable parameters
+in 100 Linears. At seven measured candidates each, simultaneously resident FP32
+deltas need 10,158,604,288 bytes and CPU BF16 PWC renders need 5,079,302,144 bytes.
+The explicit 6 GiB PWC cap covers only these renders. Source residency, deltas,
+boundary/cotangent planes, activation/backward temporaries, Hessian qualification
+buffers and allocator slack remain inside the aggregate/GPU reservation.
+The measured GPU baseline includes source residency and one-candidate deltas;
+adding the difference to the largest seven-candidate layer suggests roughly
+30 GB allocated before slack. This is an estimate, not an observed full-model
+peak. Recompute from the complete actual roster before submission; partial
+telemetry is no basis for shrinking the reservation.

--- a/docs/experiments/tessera_joint_anchor_bridge_2026-09-07.md
+++ b/docs/experiments/tessera_joint_anchor_bridge_2026-09-07.md
@@ -105,3 +105,29 @@ one fixture expected 128 bytes instead of its actual 64 BF16 bytes; the first
 portable CPU environment lacked compressed-tensors and failed collection/setup.
 The fixture and scoped CPU dependencies were corrected before the green run.
 These are control-flow/contract tests, not real-wire numerical qualification.
+
+The source-prefetch follow-up makes residency settings explicit in the bound
+plan for both preparation and pricing: 24 cache slots, four workers, lookahead
+four, 4 GiB cache headroom, 2 GiB minimum available memory and required prefetched
+residency. Omitting or disabling these settings refuses. This fixes the initial
+builder call inheriting automatic cache sizing and cold-read fallback.
+PB `26622e88f99fce977aa7d8466ace3e0c7c19eb2c8d22744bc795dd05ce234343`
+demonstrated the missing builder arguments before the fix. The corrected bridge
+and policy/doc checks passed **48 tests, no skips**, with compile checks, in PB
+`427a2c72a1d2f82f84d13cb29fe28beec4ccdc0c10dbeba6980590b94c688857`
+on Sparky's CPU-only pinned container (four pytest workers/native threads one).
+Its terminal returned zero with complete cleanup; CAS payload
+`62b7bc4d7e562f72c456f8245df1d77813554b379030bbbffe6e9f770dfb0ddc`
+and canonical receipt
+`ac26d6949537c833fb479790ca5fb387a9f4f40ea6b0799015781cd087d41f64`
+were independently rehashed. This proves argument propagation and refusals;
+the full-model run must still measure its actual residency and memory peak.
+
+Preparation and pricing have separate buffer lifetimes. Preparation keeps the
+declared source cache and one layer's original X/H capture plus BF16 candidate
+renders; it decodes and compares one wire at a time. Pricing releases the
+qualification X/H tensors and keeps source cache, CPU boundaries/cotangents,
+one candidate layer's PWC renders and FP32 deltas, and backward temporaries.
+The 6 GiB PWC limit covers neither source nor derivative buffers. The common
+96 GiB aggregate / 40 GiB GPU reservation is provisional for both actions;
+actual peaks remain acceptance checks, not numbers inferred from that limit.

--- a/experiments/pq322_anchor_wire_qualification.py
+++ b/experiments/pq322_anchor_wire_qualification.py
@@ -1,0 +1,156 @@
+"""PB-only original dense-anchor verification; never a full-model cost run."""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from pathlib import Path
+import pickle
+import socket
+import time
+from types import SimpleNamespace
+
+
+def main():
+    import torch
+    from safetensors import safe_open
+    from prismaquant import tessera_calibration_cache as cc, tessera_campaign as tc, tessera_hessian as th
+    from prismaquant.calibration_data import load_calibration_input
+    from prismaquant.cost_stage_checkpoint import _load_unit, canonical_json_sha256, unit_path
+    from prismaquant.joint_aura import prefetch_joint_cache
+    from prismaquant.model_profiles import detect_profile
+    from prismaquant.native_operator_panel import prepare_native_inputs
+    from prismaquant.production_weight_cache import ProductionWeightCache, _cache_weight_filename
+    from prismaquant.tessera_joint_aura import calibrated_maxima, verify_anchor_render
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--plan', type=Path, required=True)
+    parser.add_argument('--plan-sha256', required=True)
+    args = parser.parse_args()
+    if cc.sha256(args.plan) != args.plan_sha256:
+        raise ValueError('qualification plan changed')
+    plan = json.loads(args.plan.read_text())
+    root = Path(plan['out']); root.mkdir(parents=True, exist_ok=False)
+    for key in ('cost', 'checkpoint', 'census', 'capture', 'tokens'):
+        if cc.sha256(plan[key]['path']) != plan[key]['sha256']:
+            raise ValueError(f'{key} changed')
+    payload = pickle.loads(Path(plan['cost']['path']).read_bytes())
+    checkpoint = Path(plan['checkpoint']['path'])
+    manifest = json.loads(checkpoint.read_text())
+    identity = manifest['identity']
+    if canonical_json_sha256(identity, where='wire qualification') != manifest['identity_sha256']:
+        raise ValueError('journal identity changed')
+    names = sorted(identity['units'])
+    if names != plan['units']:
+        raise ValueError('exact bounded qualification roster changed')
+    census = json.loads(Path(plan['census']['path']).read_text())
+    profile = detect_profile(census['model'])
+    maxima, scales = calibrated_maxima(SimpleNamespace(census=census, payload=payload), profile)
+    capture = cc.require_capture_contract(plan['capture']['path'], expected_sha256=plan['capture']['sha256'])
+    expected = cc.capture_identity(plan['census']['path'],
+        calibration=payload['provenance']['hessian']['calibration_identity'],
+        max_act_rows=capture['identity']['max_act_rows'],
+        model_load_contract=census['model_load_contract'], attention_implementation=census['attention_implementation'])
+    if expected != capture['identity']:
+        raise ValueError('actual source/capture identity changed')
+    (acts, hessians, _counts, _maxima), _ = cc.prefetch_capture(plan['capture']['path'],
+        expected_sha256=plan['capture']['sha256'], expected_identity=expected, census=census, names=names, device='cuda')
+    calibration_source = th.activation_source(hessians, expected['calibration'])
+    _ids, calibration = load_calibration_input(plan['tokens']['path'], expected_sha256=plan['tokens']['sha256'],
+                                               n_samples=512, seqlen=512)
+    weights = {}
+    with safe_open(str(Path(census['model']) / 'model.safetensors'), framework='pt', device='cpu') as stream:
+        for name in names:
+            weights[name] = stream.get_tensor(name + '.weight').cuda()
+    cells = {}
+    parts = checkpoint.with_name(checkpoint.name + '.parts')
+    for name in names:
+        state = _load_unit(unit_path(parts, name), stage='Tessera campaign', qname=name,
+                           identity_sha256=manifest['identity_sha256'])
+        for anchor in state['anchors']:
+            fmt = anchor['format_name']; record = state['wire_records'][fmt]
+            render = Path(payload['provenance']['cache_dir']) / _cache_weight_filename(name, fmt)
+            cells[name, fmt] = dict(anchor=anchor, record=record,
+                wire=str(Path(payload['provenance']['wire_dir']) / record['file']),
+                render=str(render), render_file_sha256=cc.sha256(render))
+    cache = ProductionWeightCache(weights={pair: cell['render'] for pair, cell in cells.items()},
+                                   levers={'tessera_campaign': True}, activation_max_abs=maxima)
+    cache.enable_lru(plan['max_render_bytes'])
+    formats = {name: sorted(fmt for qname, fmt in cells if qname == name) for name in names}
+    prefetched = prefetch_joint_cache(cache, names, formats, max_resident_bytes=plan['max_render_bytes'])
+    result = {'schema': 'prismaquant.anchor_wire_qualification.v1', 'passed': False,
+        'plan_sha256': args.plan_sha256, 'env': {'started_epoch': time.time(), 'host': socket.gethostname(),
+            'torch': str(torch.__version__), 'cuda': torch.version.cuda},
+        'phases': [], 'comparisons': [], 'negative_cases': [], 'prefetch': prefetched}
+
+    def phase(name, fn):
+        torch.cuda.synchronize(); torch.cuda.reset_peak_memory_stats()
+        start = time.time()
+        with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU,
+             torch.profiler.ProfilerActivity.CUDA], profile_memory=True, record_shapes=True) as profiler:
+            value = fn()
+            torch.cuda.synchronize()
+        end = time.time()
+        profiler.export_chrome_trace(str(root / (name + '.trace.json')))
+        (root / (name + '.operators.txt')).write_text(profiler.key_averages().table(sort_by='self_cuda_time_total', row_limit=60))
+        result['phases'].append({'phase': name, 'kind': 'profile', 'start_epoch': start, 'end_epoch': end,
+            'peak_gpu_bytes': torch.cuda.max_memory_allocated(), 'peak_gpu_reserved_bytes': torch.cuda.max_memory_reserved()})
+        return value
+
+    def baseline():
+        refs = {}
+        for (name, fmt), cell in sorted(cells.items()):
+            anchor = tc.CampaignAnchor(**cell['anchor'])
+            encoding = tc._checkpoint_anchor_identity(anchor, weights=weights,
+                menus={name: [SimpleNamespace(format_name=fmt)]}, calibration_source=calibration_source,
+                static_scales=scales)
+            record, tensors = prepare_native_inputs(cache, weights[name], acts[name].to(torch.bfloat16),
+                unit=name, format_name=fmt, calibration_receipt=calibration,
+                wire_blob=Path(cell['wire']).read_bytes(), wire_record=cell['record'],
+                encoding_identity=encoding, numerics={'atol': 0.0, 'rtol': 0.0},
+                prefill_rows=4, decode_rows=1, max_resident_bytes=plan['max_render_bytes'])
+            refs[name, fmt] = {key: record[key] for key in ('source_weight', 'rendered_weight', 'activation')}
+            del tensors, record
+        return refs
+
+    refs = phase('existing_native_input_bridge', baseline)
+    def after():
+        for (name, fmt), cell in sorted(cells.items()):
+            record = verify_anchor_render(cell, weights[name], cache.get(name, fmt).cuda(),
+                calibration_source=calibration_source, projected_unit=None, static_scales=scales)
+            for key in ('source_weight', 'rendered_weight'):
+                if record[key] != refs[name, fmt][key]:
+                    raise ValueError(f'{name}@{fmt}: original/native source or render differs')
+            result['comparisons'].append({'unit': name, 'format': fmt, 'equal': True, **record})
+    phase('checked_anchor_bridge', after)
+    pair = next(pair for pair in sorted(cells) if 'E4M3' in pair[1])
+    name, fmt = pair; cell = cells[pair]
+    kwargs = dict(calibration_source=calibration_source, projected_unit=None, static_scales=scales)
+    for kind in ('render', 'source', 'settings', 'wire'):
+        changed = copy.deepcopy(cell)
+        source, render = weights[name], cache.get(name, fmt).cuda()
+        if kind == 'render':
+            render = render.clone(); render[0, 0] += 1
+        elif kind == 'source':
+            source = source.clone(); source[0, 0] += 1
+        elif kind == 'settings':
+            changed['record']['identity']['recipe']['q256'] += 1
+        else:
+            original = Path(cell['wire']).read_bytes(); altered = bytearray(original); altered[-1] ^= 1
+            corrupt = root / 'intentional-corrupt-wire.bin'; corrupt.write_bytes(altered)
+            changed['wire'] = str(corrupt)
+        try:
+            verify_anchor_render(changed, source, render, **kwargs)
+        except (ValueError, RuntimeError) as exc:
+            result['negative_cases'].append({'case': kind, 'refused': True, 'error': str(exc)})
+        else:
+            raise AssertionError(f'{kind} corruption was accepted')
+    result['env']['finished_epoch'] = time.time(); result['passed'] = True
+    result['units'], result['cells'] = len(names), len(cells)
+    (root / 'results.json').write_text(json.dumps(result, indent=2) + '\n')
+    print(json.dumps({'passed': True, 'units': len(names), 'cells': len(cells),
+                      'result_sha256': cc.sha256(root / 'results.json')}))
+
+
+if __name__ == '__main__':
+    main()

--- a/experiments/pq322_anchor_wire_qualification.sh
+++ b/experiments/pq322_anchor_wire_qualification.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+image=eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
+input_root=/mnt/shared/tessera-measurements/first-model-20260907/inputs
+exec docker run --rm --gpus all --ipc=host --network=host --user "$(id -u):$(id -g)" \
+  -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared -w /workspace --entrypoint python3 \
+  -e PYTHONDONTWRITEBYTECODE=1 -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
+  -e XDG_CACHE_HOME=/tmp/pq-anchor-qualification-cache -e TORCH_EXTENSIONS_DIR=/tmp/pq-anchor-qualification-ext \
+  -e HF_HOME=/tmp/pq-anchor-qualification-hf -e HF_MODULES_CACHE=/tmp/pq-anchor-qualification-modules \
+  -e PRISMABUILD_CONTAINER_OWNER -e PRISMAQUANT_PROD_ACT_SCALES=0 \
+  -e "PYTHONPATH=/workspace:$input_root/tessera-382a1a97/src:$input_root/container-compatible-deps" \
+  "$image" -m experiments.pq322_anchor_wire_qualification "$@"

--- a/experiments/pq322_cpu_checks.sh
+++ b/experiments/pq322_cpu_checks.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# CPU control-flow checks may use the fleet's CPU torch. GPU qualification uses
+# the separately pinned production container and original calibration runtime.
+if [ "$(uname -m)" != x86_64 ]; then
+  exec bash experiments/lfm_stream_cpu_pytest.sh "$@"
+fi
+pq_python=/home/rob/venvs/pb-cpu/bin/python
+pq_tag="$($pq_python -c 'import sys; print(f"py{sys.version_info.major}{sys.version_info.minor}")')"
+pq_target="/home/rob/.cache/prismaquant/pq322-cpu-$pq_tag"
+"$pq_python" -m pip install --disable-pip-version-check --target "$pq_target" \
+  'transformers==5.16.1' 'pytest==9.0.2' 'pytest-xdist==3.8.0'
+export PYTHONPATH="$PWD:$pq_target:/mnt/shared/tessera-measurements/first-model-20260907/inputs/tessera-382a1a97/src"
+export PYTHONDONTWRITEBYTECODE=1
+export OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
+"$pq_python" -c 'import sys, torch, transformers, pytest; print({"python":sys.version, "torch":torch.__version__, "transformers":transformers.__version__, "pytest":pytest.__version__}, flush=True)'
+"$pq_python" -c 'import ast, pathlib; paths=["prismaquant/tessera_joint_aura.py", "experiments/pq322_anchor_wire_qualification.py", "tests/test_tessera_joint_aura.py"]; [compile(pathlib.Path(p).read_text(),p,"exec") for p in paths]; print("Touched Python modules compile",flush=True)'
+exec "$pq_python" -m pytest "$@"

--- a/experiments/pq322_cpu_checks.sh
+++ b/experiments/pq322_cpu_checks.sh
@@ -9,7 +9,11 @@ pq_python=/home/rob/venvs/pb-cpu/bin/python
 pq_tag="$($pq_python -c 'import sys; print(f"py{sys.version_info.major}{sys.version_info.minor}")')"
 pq_target="/home/rob/.cache/prismaquant/pq322-cpu-$pq_tag"
 "$pq_python" -m pip install --disable-pip-version-check --target "$pq_target" \
-  'transformers==5.16.1' 'pytest==9.0.2' 'pytest-xdist==3.8.0'
+  'transformers==5.16.1' 'pytest==9.0.2' 'pytest-xdist==3.8.0' \
+  'pydantic==2.12.5' 'loguru==0.7.3' 'psutil==7.2.2'
+# Keep the fleet's CPU torch; the remaining runtime dependencies are above.
+"$pq_python" -m pip install --disable-pip-version-check --target "$pq_target" \
+  --no-deps 'compressed-tensors==0.18.0'
 export PYTHONPATH="$PWD:$pq_target:/mnt/shared/tessera-measurements/first-model-20260907/inputs/tessera-382a1a97/src"
 export PYTHONDONTWRITEBYTECODE=1
 export OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1

--- a/experiments/pq322_joint_anchor_run.sh
+++ b/experiments/pq322_joint_anchor_run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+image=eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
+input_root=/mnt/shared/tessera-measurements/first-model-20260907/inputs
+exec docker run --rm --gpus all --ipc=host --network=host --user "$(id -u):$(id -g)" \
+  -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared -w /workspace --entrypoint python3 \
+  -e PYTHONDONTWRITEBYTECODE=1 -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
+  -e XDG_CACHE_HOME=/tmp/pq-joint-anchor-cache -e TORCH_EXTENSIONS_DIR=/tmp/pq-joint-anchor-ext \
+  -e HF_HOME=/tmp/pq-joint-anchor-hf -e HF_MODULES_CACHE=/tmp/pq-joint-anchor-modules \
+  -e PRISMABUILD_CONTAINER_OWNER -e PRISMAQUANT_PROD_ACT_SCALES=0 \
+  -e "PYTHONPATH=/workspace:$input_root/tessera-382a1a97/src:$input_root/container-compatible-deps" \
+  "$image" -m prismaquant.tessera_joint_aura "$@"

--- a/prismaquant/aura_cost.py
+++ b/prismaquant/aura_cost.py
@@ -3510,9 +3510,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     p.add_argument(
         "--include-routed-experts",
         action="store_true",
-        help="Include profile-declared per-expert nn.Linear targets in the "
-        "streamed smooth AURA pass. This remains route-flip-blind and "
-        "refuses packed expert Parameters.",
+        help="Include profile-declared expert targets in streamed AURA. "
+        "Packed source Parameters require --joint-activation and decoded "
+        "production-cache renders; the local derivative remains route-flip-blind.",
     )
     p.add_argument("--collect-col-energy", action="store_true",
                    default=os.environ.get("PRISMAQUANT_FISHER_COL_WEIGHTS") == "1",

--- a/prismaquant/source_class_format_plan.py
+++ b/prismaquant/source_class_format_plan.py
@@ -16,8 +16,8 @@ truncating a legal candidate set.
 ``serving_backed_profile`` is the one declared narrowing of "complete
 family", and it is a *serving-legality* restriction, never a demand or disk
 one.  A caller that names a serving profile restricts the family to the
-rungs that profile's fused mid-M lane actually instantiates under the pinned
-Gridbook runtime (``serving_profile_specs/*.json`` ->
+rungs that profile's fused mid-M lane actually instantiates under the selected
+serving profile (``serving_profile_specs/*.json`` ->
 ``fused_mid_m.rungs_by_runtime_version``, resolved through
 ``serving_profiles.serving_lane_route``).  Nothing about the caller's budget,
 cache or preference enters: the set is read off the same immutable pin the
@@ -417,7 +417,7 @@ def build_source_class_format_plan(
     family member; this module intentionally contains no bpp formula.
 
     ``serving_backed_profile`` names a serving profile whose fused mid-M lane
-    bounds the family under the pinned Gridbook runtime (see the module
+    bounds the family under the selected serving profile (see the module
     docstring).  ``None`` -- the default -- keeps the unrestricted contract and
     an unchanged plan body.
     """
@@ -634,7 +634,7 @@ def load_format_plan(
     }
     # A restricted plan carries its own restriction, so the load path
     # re-derives it from the CURRENT pin and refuses on drift: a plan written
-    # under one Gridbook backed set must not be silently reused under another.
+    # under one serving-backed set must not be silently reused under another.
     stored_restriction = raw.get("serving_backed_restriction")
     if stored_restriction is not None and not isinstance(
         stored_restriction, Mapping

--- a/prismaquant/tessera_joint_aura.py
+++ b/prismaquant/tessera_joint_aura.py
@@ -351,10 +351,32 @@ def prepare_cache(runner, data, *, capture, max_render_bytes):
     return cache
 
 
+def _source_prefetch(config):
+    prefetch = config.get("source_prefetch")
+    fields = {"max_cache_slots", "prefetch_workers", "prefetch_lookahead",
+              "cache_headroom_gb", "prefetch_min_available_gb",
+              "require_prefetched_residency"}
+    _require(isinstance(prefetch, dict) and set(prefetch) == fields,
+             "explicit complete source_prefetch settings required")
+    _require(prefetch["require_prefetched_residency"] is True,
+             "source_prefetch must require prefetched residency")
+    for name in ("max_cache_slots", "prefetch_workers", "prefetch_lookahead"):
+        _require(type(prefetch[name]) is int and prefetch[name] > 0,
+                 f"source_prefetch requires positive {name}")
+    _require(prefetch["prefetch_lookahead"] < prefetch["max_cache_slots"],
+             "source_prefetch lookahead must fit the declared cache slots")
+    for name in ("cache_headroom_gb", "prefetch_min_available_gb"):
+        _require(type(prefetch[name]) in (int, float) and
+                 math.isfinite(prefetch[name]) and prefetch[name] > 0,
+                 f"source_prefetch requires positive finite {name}")
+    return dict(prefetch)
+
+
 def _load_plan(path, digest):
     path = _bound({"path": str(path), "sha256": digest}, "joint anchor plan")
     config = json.loads(path.read_text())
     _same(config.get("schema"), SCHEMA, "joint anchor plan schema")
+    _source_prefetch(config)
     execution = config["execution"]
     for name, minimum in (("n_calib_samples", 1), ("calib_seqlen", 1),
                           ("probe_microbatch", 1), ("n_probes", 2)):
@@ -425,9 +447,12 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False):
         for name in ("fit_ids_sha256", "text_sha256", "nsamples", "seqlen", "seed"):
             _same(calibration["provenance"].get(name), original_draw.get(name), f"original full draw {name}")
         result["calibration_input"] = calibration
+        source_prefetch = _source_prefetch(config)
         runner = build_streamed_causal_lm(config["model"], device=torch.device("cuda"),
             dtype=torch.bfloat16, offload_folder=str(root / "offload"),
-            profile=detect_profile(config["model"]), attn_implementation="eager")
+            profile=detect_profile(config["model"]), attn_implementation="eager",
+            **source_prefetch)
+        result["source_prefetch"] = source_prefetch
         source = build_streamed_model_identity(runner, config["model"],
                                                identity_cache_path=root / "source-identity.json")
         source_execution = source_execution_identity(runner.model)

--- a/prismaquant/tessera_joint_aura.py
+++ b/prismaquant/tessera_joint_aura.py
@@ -1,0 +1,550 @@
+"""Research joint AURA over exact, completed Tessera campaign anchors.
+
+The campaign's scalar MSE/interpolation is evidence of which wires were made,
+never a joint price. Original decoded renders enter ProductionWeightCache;
+Tessera's existing source/H/settings receipt and decoder qualify them before
+ordinary streamed joint AURA consumes the exact per-Linear candidate roster.
+"""
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from dataclasses import dataclass
+import hashlib
+import json
+import math
+from pathlib import Path
+import pickle
+import time
+from types import SimpleNamespace
+
+from .cost_stage_checkpoint import (
+    MANIFEST_SCHEMA, _load_unit, atomic_write_bytes, canonical_json_sha256, unit_path,
+)
+
+SCHEMA = "prismaquant.tessera_joint_aura.plan.v1"
+PREPARED_SCHEMA = "prismaquant.tessera_joint_aura.prepared.v1"
+CAMPAIGN_SCHEMA = "prismaquant.tessera_campaign_cost.v1"
+CURRENCY = "output_mse_under_route_activation_contract"
+STAGE = "Tessera campaign"
+
+
+def _require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def _sha(path):
+    with Path(path).open("rb") as handle:
+        return hashlib.file_digest(handle, "sha256").hexdigest()
+
+
+def _bound(record, label):
+    _require(isinstance(record, dict) and set(record) == {"path", "sha256"},
+             f"{label}: independently bound path/SHA256 required")
+    path = Path(record["path"])
+    _require(_sha(path) == record["sha256"], f"{label}: artifact checksum changed")
+    return path
+
+
+def _same(actual, expected, label):
+    _require(actual == expected, f"{label}: identity mismatch")
+
+
+def _json(path, value):
+    atomic_write_bytes(Path(path), (json.dumps(value, indent=2, sort_keys=True,
+                                              allow_nan=False) + "\n").encode())
+
+
+@dataclass
+class MeasuredAnchorInput:
+    inputs: dict
+    payload: dict
+    manifest: dict
+    census: dict
+    campaign_plan: dict
+    cells: dict
+    formats_by_qname: dict
+
+    @property
+    def total_render_bytes(self):
+        return sum(2 * math.prod(self.census["unit_shapes"][name]) for name, _ in self.cells)
+
+    def layer_render_bytes(self, layer_for_name):
+        sizes = defaultdict(int)
+        for name, _fmt in self.cells:
+            sizes[layer_for_name(name)] += 2 * math.prod(self.census["unit_shapes"][name])
+        return dict(sizes)
+
+
+def load_measured_anchor_input(inputs):
+    """Read a complete merged journal and select only its measured wire cells.
+
+    This is a hash/receipt intake. Tensor/source/encoder verification occurs in
+    ``prepare_cache`` using actual source weights and the original capture.
+    Interpolated menu rows are deliberately excluded rather than converted.
+    """
+    from .production_weight_cache import _cache_weight_filename
+    from tools.dispatch_tessera_campaign import _require_receipts
+
+    paths = {key: _bound(inputs[key], key) for key in (
+        "campaign_plan", "census", "campaign_receipts", "merged_cost", "merged_checkpoint")}
+    census = json.loads(paths["census"].read_text())
+    plan = json.loads(paths["campaign_plan"].read_text())
+    _same(plan.get("schema"), "prismaquant.tessera_campaign_plan.v1", "campaign plan schema")
+    _same(Path(plan["census"]).resolve(), paths["census"].resolve(), "campaign census path")
+    _same(paths["campaign_receipts"].resolve(),
+          (paths["campaign_plan"].parent / "receipts.json").resolve(), "campaign receipt path")
+    rows = plan["rows"]
+    _require(len({row["row_id"] for row in rows}) == len(rows), "duplicate campaign row")
+    _require_receipts(paths["campaign_plan"].parent, len(rows))
+    owners, groups = {}, {}
+    for row in rows:
+        for name in row["members"]:
+            _require(name not in owners, f"duplicate campaign unit {name}")
+            owners[name] = Path(row["dir"])
+        for group in row["groups"]:
+            _require(group not in groups, f"duplicate campaign group {group}")
+            groups[group] = row["row_id"]
+    names = set(census["unit_shapes"])
+    _same(set(owners), names, "complete census roster")
+    _same(set(groups), set(census["anchor_groups"]), "complete census groups")
+    _same(len(names), inputs["required_source_units"], "declared full source unit count")
+    _same(len(groups), inputs["required_campaign_groups"], "declared full campaign group count")
+    for group, members in census["anchor_groups"].items():
+        owner = next(row for row in rows if row["row_id"] == groups[group])
+        _require(set(members) <= set(owner["members"]), f"campaign group membership changed: {group}")
+
+    payload = pickle.loads(paths["merged_cost"].read_bytes())
+    _same(payload.get("schema"), CAMPAIGN_SCHEMA, "campaign cost schema")
+    _same(payload.get("currency"), CURRENCY, "campaign scalar currency")
+    _same(set(payload["costs"]), names, "complete merged cost roster")
+    provenance = payload["provenance"]
+    _same(provenance.get("cost_mode"), "production-render-score", "campaign cost mode")
+    _same(provenance.get("model"), census["model"], "campaign model")
+    _same(plan["model"], census["model"], "planned model")
+    _require(provenance.get("stopped_early") is False, "campaign stopped before completing anchors")
+    _same(provenance.get("campaign_fanout", {}).get("rows"),
+          {row["row_id"]: sorted(row["groups"]) for row in rows}, "complete merged fanout")
+
+    manifest = json.loads(paths["merged_checkpoint"].read_text())
+    _same(manifest.get("schema"), MANIFEST_SCHEMA, "campaign checkpoint schema")
+    _same(manifest.get("stage"), STAGE, "campaign checkpoint stage")
+    identity = manifest["identity"]
+    seal = canonical_json_sha256(identity, where="joint anchor input")
+    _same(seal, manifest.get("identity_sha256"), "campaign checkpoint seal")
+    _same(identity.get("campaign_schema"), CAMPAIGN_SCHEMA, "checkpoint campaign schema")
+    _same(identity.get("currency"), CURRENCY, "checkpoint scalar currency")
+    _same(set(identity["units"]), names, "complete checkpoint identity roster")
+    listed = [row["qname"] for row in manifest["units"]]
+    _require(len(listed) == len(names) and set(listed) == names, "incomplete checkpoint unit roster")
+    for key in ("prismaquant_source_sha256", "encoder_source_sha256"):
+        value = identity.get(key)
+        _require(isinstance(value, str) and len(value) == 64 and
+                 all(c in "0123456789abcdef" for c in value), f"missing checkpoint {key}")
+    parts = paths["merged_checkpoint"].with_name(paths["merged_checkpoint"].name + ".parts")
+    for row in manifest["units"]:
+        _same(parts / row["file"], unit_path(parts, row["qname"]), "canonical checkpoint unit path")
+
+    cells, formats = {}, {}
+    wire_dir = Path(provenance["wire_dir"])
+    for name in sorted(names):
+        state = _load_unit(unit_path(parts, name), stage=STAGE, qname=name, identity_sha256=seal)
+        _require(isinstance(state, dict) and set(state) - {"unservable"} == {"anchors", "wire_records"},
+                 f"{name}: incomplete measured anchor journal")
+        anchors = {anchor["format_name"]: anchor for anchor in state["anchors"]}
+        _require(anchors and len(anchors) == len(state["anchors"]) and
+                 set(anchors) == set(state["wire_records"]), f"{name}: anchor/receipt coverage differs")
+        measured = {fmt for fmt, row in payload["costs"][name].items()
+                    if row.get("output_mse_measured") is True}
+        _same(set(anchors), measured, f"{name}: measured payload/journal coverage")
+        unit = identity["units"][name]
+        _same(unit["weight"]["shape"], census["unit_shapes"][name], f"{name}: census source shape")
+        for fmt, anchor in sorted(anchors.items()):
+            row = payload["costs"][name][fmt]
+            _require(fmt in unit["menu"] and anchor["qname"] == name, f"{name}: anchor outside exact menu")
+            _require(row.get("cost_source") == "tessera_campaign_measured" and
+                     row.get("tessera_provenance") == "measured" and row.get("currency") == CURRENCY,
+                     f"{name}@{fmt}: interpolated or foreign measured row")
+            for target, source in (("output_mse", "dloss"), ("tessera_family", "family"),
+                    ("tessera_body_rate_q256", "body_rate_q256"), ("activation_contract", "activation_contract"),
+                    ("activation_quantized", "activation_quantized"), ("wire_bytes", "wire_bytes"),
+                    ("input_global_scale", "input_global_scale")):
+                _same(row.get(target), anchor.get(source), f"{name}@{fmt}: measured {target}")
+            _require(type(anchor["dloss"]) in (int, float) and math.isfinite(anchor["dloss"])
+                     and anchor["dloss"] >= 0, f"{name}@{fmt}: invalid measured value")
+            _same(row["hessian_identity"].get("applied"), anchor["hessian_applied"], f"{name}: H applicability")
+            for key in ("supplied", "capture_sha256", "text_sha256", "fit_ids_sha256", "fit_tokens"):
+                _same(row["hessian_identity"].get(key), provenance["hessian"].get(key), f"{name}: measured H {key}")
+            if anchor.get("input_global_scale") is not None:
+                _same(anchor["input_global_scale"], unit.get("input_global_scale"), f"{name}: checkpoint scale")
+                _same(anchor["input_global_scale"], provenance["activation_static_scales"]["units"].get(name),
+                      f"{name}: merged static scale")
+            record = state["wire_records"][fmt]
+            recorded = record["identity"]
+            _same(recorded.get("unit"), name, f"{name}: wire unit")
+            _same(recorded.get("source"), unit["weight"], f"{name}: recorded source")
+            _same(recorded.get("encoder_source_sha256"), identity["encoder_source_sha256"], f"{name}: encoder source")
+            _same(recorded["recipe"].get("q256"), anchor["body_rate_q256"], f"{name}: wire rung")
+            if anchor["hessian_applied"]:
+                _same(recorded["calibration"]["hessian"], unit["hessian"], f"{name}: recorded H")
+            else:
+                _same(recorded.get("calibration"), None, f"{name}: unexpected recorded H")
+            filename = record["file"]
+            _require(isinstance(filename, str) and Path(filename).name == filename and
+                     filename not in {".", ".."}, f"{name}: escaping wire filename")
+            wire = wire_dir / filename
+            _require(not wire.is_symlink() and wire.resolve().parent == wire_dir.resolve(), f"{name}: escaping wire path")
+            _same(wire.stat().st_size, record["blob_bytes"], f"{name}: wire size")
+            _same(_sha(wire), record["blob_sha256"], f"{name}: wire checksum")
+            render = owners[name] / "cache" / _cache_weight_filename(name, fmt)
+            _require(render.is_file(), f"{name}@{fmt}: original decoded PWC shard missing")
+            cells[name, fmt] = {"anchor": anchor, "record": record, "wire": str(wire.resolve()),
+                               "render": str(render.resolve()), "render_file_sha256": _sha(render)}
+        formats[name] = (*sorted(anchors), "BF16")
+    return MeasuredAnchorInput(dict(inputs), payload, manifest, census, plan, cells, formats)
+
+
+def calibrated_maxima(data, profile):
+    """Reuse the producer's full-census fused scale policy; never invert G."""
+    from . import tessera_campaign as tc
+    from .nvfp4_activation_contract import unify_fused_sibling_max_abs
+
+    positive = {name: float(value) for name, value in data.census["max_abs"].items()
+                if float(value) > 0.0}
+    maxima = unify_fused_sibling_max_abs(positive, profile=profile, tolerate_profile_errors=True)
+    scales, policy = tc._static_input_scales(data.census["max_abs"], profile=profile)
+    stamped = data.payload["provenance"]["activation_static_scales"]
+    _same(policy, stamped["policy"], "campaign static scale policy")
+    _same(scales, stamped["units"], "campaign fused static scales")
+    return maxima, scales
+
+
+def verify_anchor_render(cell, source_weight, rendered_weight, *, calibration_source,
+                         projected_unit, static_scales):
+    """Re-derive encoder inputs from actual source/H and compare decoded bytes."""
+    import torch
+    from tessera.unit_artifact import read_unit_artifact
+    from . import tessera_campaign as tc
+    from .production_weight_cache import _cb_cache_tensor_identity
+
+    anchor = tc.CampaignAnchor(**cell["anchor"])
+    name, fmt = anchor.qname, anchor.format_name
+    _require(source_weight.dtype == rendered_weight.dtype == torch.bfloat16 and
+             source_weight.ndim == 2 and rendered_weight.shape == source_weight.shape,
+             f"{name}@{fmt}: source/render BF16 shape differs")
+    _require(bool(torch.isfinite(source_weight).all()) and bool(torch.isfinite(rendered_weight).all()),
+             f"{name}@{fmt}: source/render is nonfinite")
+    expected = tc._checkpoint_anchor_identity(anchor,
+        weights={name: source_weight}, menus={name: [SimpleNamespace(format_name=fmt)]},
+        calibration_source=calibration_source, static_scales=static_scales,
+        projected_units={} if projected_unit is None else {name: projected_unit})
+    blob = Path(cell["wire"]).read_bytes()
+    tc._checkpoint_identity_api().verify_cached_unit(blob, cell["record"], expected)
+    decoded = read_unit_artifact(blob, device=str(rendered_weight.device)).to(torch.bfloat16)
+    _require(torch.equal(decoded, rendered_weight), f"{name}@{fmt}: decoded wire differs from original PWC render")
+    del decoded
+    return {"source_weight": _cb_cache_tensor_identity(source_weight),
+            "rendered_weight": _cb_cache_tensor_identity(rendered_weight),
+            "encoding_identity_sha256": canonical_json_sha256(expected, where="joint anchor encoding"),
+            "wire_sha256": hashlib.sha256(blob).hexdigest(),
+            "render_file_sha256": cell["render_file_sha256"]}
+
+
+def _live_targets(runner, names):
+    from .aura_cost import _target_linears
+    from .routed_experts import profile_declared_packed_expert_projections
+
+    targets = _target_linears(runner.model, include_routed_experts=True, profile=runner.profile)
+    packed = profile_declared_packed_expert_projections(runner.model, runner.profile)
+    targets.update({member.qname: member for member in packed})
+    _require(set(names) <= set(targets), "census units are absent from the actual streamed source")
+    return {name: targets[name] for name in names}
+
+
+def prepare_cache(runner, data, *, capture, max_render_bytes):
+    """Qualify original per-layer inputs and return the existing PWC object.
+
+    Only the original calibration/PWC/source prefetch mechanisms own tensors.
+    PWC's LRU records absolute donor paths so compact/release stays reversible
+    even though the merged renders have more than one original directory.
+    """
+    import torch
+    from . import tessera_calibration_cache as cc, tessera_hessian as th
+    from .joint_aura import activation_identity, prefetch_joint_cache
+    from .production_weight_cache import ProductionWeightCache
+    from .routed_experts import PackedExpertProjection, refresh_packed_expert_projections
+    from . import format_registry as fr
+
+    _require(type(max_render_bytes) is int and max_render_bytes > 0, "positive PWC residency budget required")
+    capture_path = _bound(capture, "canonical capture")
+    stamped_capture = data.payload["provenance"].get("calibration_cache")
+    _same(capture, stamped_capture, "priced canonical capture")
+    manifest = cc.require_capture_contract(capture_path, expected_sha256=capture["sha256"])
+    recorded = manifest["identity"]
+    # This verifies recorded canonical capture provenance plus current source
+    # bytes/runtime. It does not pretend a from-config streaming skeleton is an
+    # ordinary from_pretrained model or manufacture an initialization witness.
+    expected = cc.capture_identity(data.inputs["census"]["path"],
+        calibration=data.payload["provenance"]["hessian"]["calibration_identity"],
+        max_act_rows=recorded["max_act_rows"],
+        model_load_contract=data.census["model_load_contract"],
+        attention_implementation=data.census["attention_implementation"])
+    _same(expected, recorded, "current source/canonical capture")
+    _same(data.manifest["identity"]["calibration"], recorded["calibration"], "journal/canonical draw")
+    maxima, scales = calibrated_maxima(data, runner.profile)
+    cache = ProductionWeightCache(
+        weights={pair: cell["render"] for pair, cell in data.cells.items()},
+        levers={"tessera_campaign": True}, activation_max_abs=maxima,
+        metadata={"schema": PREPARED_SCHEMA, "inputs": data.inputs})
+    cache.enable_lru(max_render_bytes)
+    targets = _live_targets(runner, data.formats_by_qname)
+    layers = defaultdict(list)
+    for name in targets:
+        layers[runner.layer_index_for_qname(name)].append(name)
+    projected = {name: unit for units in (data.census.get("expert_projection") or {}).get("stacks", {}).values()
+                 for name, unit in units.items()}
+    renders = {name: tuple(fmt for fmt in fmts if fmt != "BF16")
+               for name, fmts in data.formats_by_qname.items()}
+    verified, telemetry = {}, []
+    for depth in range(min(runner.num_layers, runner.prefetch_lookahead + 1)):
+        runner.context.schedule_prefetch(depth)
+    for layer in range(runner.num_layers):
+        names = sorted(layers.get(layer, ()))
+        runner.context.install(layer, require_prefetched=runner.require_prefetched_residency)
+        runner.context.schedule_prefetch(layer + runner.prefetch_lookahead)
+        members = [targets[name] for name in names if isinstance(targets[name], PackedExpertProjection)]
+        try:
+            targets.update({member.qname: member for member in refresh_packed_expert_projections(members, runner.profile)})
+            if not names:
+                continue
+            (acts, hessians, _counts, _maxima), _receipt = cc.prefetch_capture(capture_path,
+                expected_sha256=capture["sha256"], expected_identity=expected,
+                census=data.census, names=names, device=runner.device)
+            calibration_source = th.activation_source(hessians, expected["calibration"])
+            stats = prefetch_joint_cache(cache, names, renders, max_resident_bytes=max_render_bytes)
+            for name in names:
+                source_weight = targets[name].weight.detach()
+                for fmt in renders[name]:
+                    cell = data.cells[name, fmt]
+                    _same(_sha(cell["render"]), cell["render_file_sha256"], f"{name}: original render file changed")
+                    rendered = cache.get(name, fmt).to(runner.device)
+                    record = verify_anchor_render(cell, source_weight, rendered,
+                        calibration_source=calibration_source,
+                        projected_unit=projected.get(name), static_scales=scales)
+                    activation = activation_identity(fr.get_format(fmt), cache.activation_max_abs, name)
+                    _same(activation["input_global_scale"], cell["anchor"].get("input_global_scale"),
+                          f"{name}@{fmt}: joint/campaign static scale")
+                    record["activation"] = activation
+                    verified[name, fmt] = record
+                    del rendered
+            telemetry.append({"layer": layer, **stats})
+            print(json.dumps({"qualified_layer": layer, "qualified_cells": len(verified),
+                              "total_cells": len(data.cells), "prefetch": stats}), flush=True)
+            del acts, hessians, calibration_source, source_weight
+        finally:
+            cache.compact_for_pickle()
+            runner.context.unload(layer)
+            targets.update({member.qname: member for member in refresh_packed_expert_projections(members, runner.profile)})
+    _same(set(verified), set(data.cells), "complete qualified wire/render roster")
+    cache.metadata.update({"verified_cells": verified, "prefetch": telemetry})
+    return cache
+
+
+def _load_plan(path, digest):
+    path = _bound({"path": str(path), "sha256": digest}, "joint anchor plan")
+    config = json.loads(path.read_text())
+    _same(config.get("schema"), SCHEMA, "joint anchor plan schema")
+    execution = config["execution"]
+    for name, minimum in (("n_calib_samples", 1), ("calib_seqlen", 1),
+                          ("probe_microbatch", 1), ("n_probes", 2)):
+        _require(type(execution.get(name)) is int and execution[name] >= minimum,
+                 f"explicit positive {name} required")
+    _require(type(execution.get("seed_base")) is int, "explicit probe seed required")
+    _same(execution.get("token_scope"), "all", "full-draw joint token scope")
+    _same(execution.get("temperature"), 1.0, "joint probe temperature")
+    _same(execution.get("production_act_scales"), "0", "campaign optional activation clipping")
+    _same(config.get("profile_tool"), "cprofile", "full-duration in-process profiler")
+    for name in ("max_render_bytes", "max_gpu_bytes"):
+        _require(type(config.get(name)) is int and config[name] > 0, f"positive {name} required")
+    _require(type(config.get("min_free_gib")) in (int, float) and config["min_free_gib"] >= 0,
+             "nonnegative memory floor required")
+    return config
+
+
+def _io_counters():
+    values = {}
+    for line in Path("/proc/self/io").read_text().splitlines():
+        key, value = line.split(":", 1)
+        values[key] = int(value)
+    return values
+
+
+def execute(command, config, *, plan_sha256, prepared=None, resume=False):
+    """Execute one admitted preparation or one dependent cost action."""
+    import cProfile
+    import io
+    import os
+    import pstats
+    import socket
+    import torch
+    from .aura_cost import compute_aura_cost_streamed, _aura_source_sha256
+    from .calibration_data import load_calibration_input
+    from .cost_streaming import build_streamed_causal_lm, build_streamed_model_identity
+    from .joint_aura import source_execution_identity, validate_joint_aura_entry
+    from .model_profiles import detect_profile
+    from .production_weight_cache import ProductionWeightCache
+    from .gpu_guard import require_cuda_hot_path
+
+    require_cuda_hot_path("tessera_joint_aura", "cuda")
+    os.environ["PRISMAQUANT_PROD_ACT_SCALES"] = config["execution"]["production_act_scales"]
+    torch.set_num_threads(1)
+    torch.set_float32_matmul_precision("highest")
+    torch.backends.cuda.matmul.allow_tf32 = False
+    execution = config["execution"]
+    root = Path(config["output_root"]) / command
+    root.mkdir(parents=True, exist_ok=True)
+    result = {"schema": "prismaquant.tessera_joint_aura.execution.v1", "command": command,
+              "plan_sha256": plan_sha256, "env": {"host": socket.gethostname(),
+                  "started_epoch": time.time(), "torch": str(torch.__version__),
+                  "cuda": torch.version.cuda, "affinity": sorted(os.sched_getaffinity(0))},
+              "phases": [], "passed": False}
+    profiler = cProfile.Profile()
+    runner = None
+    completion_path = completion = output = payload = None
+    started, before_io = time.time(), _io_counters()
+    profiler.enable()
+    try:
+        data = load_measured_anchor_input(config["inputs"])
+        _same(config["model"], data.census["model"], "requested source model")
+        _same(data.census["attention_implementation"], "eager", "qualified source attention")
+        ids, calibration = load_calibration_input(config["calibration_input"]["path"],
+            expected_sha256=config["calibration_input"]["sha256"],
+            n_samples=execution["n_calib_samples"], seqlen=execution["calib_seqlen"])
+        original_draw = data.payload["provenance"]["hessian"]["calibration_identity"]
+        for name in ("fit_ids_sha256", "text_sha256", "nsamples", "seqlen", "seed"):
+            _same(calibration["provenance"].get(name), original_draw.get(name), f"original full draw {name}")
+        result["calibration_input"] = calibration
+        runner = build_streamed_causal_lm(config["model"], device=torch.device("cuda"),
+            dtype=torch.bfloat16, offload_folder=str(root / "offload"),
+            profile=detect_profile(config["model"]), attn_implementation="eager")
+        source = build_streamed_model_identity(runner, config["model"],
+                                               identity_cache_path=root / "source-identity.json")
+        source_execution = source_execution_identity(runner.model)
+        layer_bytes = data.layer_render_bytes(runner.layer_index_for_qname)
+        _require(max(layer_bytes.values()) <= config["max_render_bytes"],
+                 "largest measured candidate layer exceeds explicit PWC budget")
+        result.update(source_model_identity=source, source_execution=source_execution,
+                      units=len(data.formats_by_qname), measured_cells=len(data.cells),
+                      layer_render_bytes=layer_bytes)
+        implementation = _aura_source_sha256()
+        if command == "prepare":
+            _require(prepared is None and not resume, "preparation does not consume a prepared cache or cost resume")
+            completion_path = root / "prepared.json"
+            _require(not completion_path.exists(), "prepared completion already exists; use its bound record")
+            cache = prepare_cache(runner, data, capture=config["canonical_capture"],
+                                  max_render_bytes=config["max_render_bytes"])
+            cache.metadata.update(plan_sha256=plan_sha256, source_model_identity=source,
+                                  source_execution=source_execution, implementation_sha256=implementation)
+            cache.compact_for_pickle()
+            cache_path = root / "production.pkl"
+            atomic_write_bytes(cache_path, pickle.dumps(cache, protocol=pickle.HIGHEST_PROTOCOL))
+            completion = {"schema": PREPARED_SCHEMA, "status": "complete", "plan_sha256": plan_sha256,
+                "implementation_sha256": implementation, "source_model_identity": source,
+                "source_execution": source_execution, "calibration_input": calibration,
+                "production_cache": {"path": str(cache_path), "sha256": _sha(cache_path)},
+                "formats_by_qname": data.formats_by_qname, "measured_cells": len(data.cells)}
+        else:
+            _require(prepared is not None, "cost execution requires independently bound prepared inputs")
+            completion = json.loads(_bound(prepared, "prepared anchors").read_text())
+            _same(completion.get("schema"), PREPARED_SCHEMA, "prepared schema")
+            _same(completion.get("status"), "complete", "prepared completion")
+            for key, value in (("plan_sha256", plan_sha256), ("implementation_sha256", implementation),
+                               ("source_model_identity", source), ("source_execution", source_execution),
+                               ("calibration_input", calibration), ("measured_cells", len(data.cells))):
+                _same(completion.get(key), value, f"prepared {key}")
+            _same(completion["formats_by_qname"], {n: list(v) for n, v in data.formats_by_qname.items()},
+                  "prepared exact candidate roster")
+            cache = pickle.loads(_bound(completion["production_cache"], "qualified PWC").read_bytes())
+            _require(isinstance(cache, ProductionWeightCache), "prepared cache is not ProductionWeightCache")
+            _same(cache.metadata["inputs"], data.inputs, "prepared source bindings")
+            _same(set(cache.metadata["verified_cells"]), set(data.cells), "prepared verified cell coverage")
+            _same(cache.weights, {pair: cell["render"] for pair, cell in data.cells.items()}, "prepared original render paths")
+            for pair, cell in data.cells.items():
+                _same(cache.metadata["verified_cells"][pair]["render_file_sha256"], cell["render_file_sha256"],
+                      f"{pair}: qualified render changed")
+                _same(cache.metadata["verified_cells"][pair]["wire_sha256"], cell["record"]["blob_sha256"],
+                      f"{pair}: qualified wire changed")
+            _live_targets(runner, data.formats_by_qname)
+            formats = list(dict.fromkeys(fmt for values in data.formats_by_qname.values() for fmt in values))
+            payload = compute_aura_cost_streamed(runner, ids.to(runner.device), formats,
+                n_probes=execution["n_probes"], probe_microbatch=execution["probe_microbatch"],
+                seed_base=execution["seed_base"], token_scope="all", temperature=1.0,
+                production_cache=cache, require_production_cache=True, joint_activation=True,
+                include_routed_experts=True, include_lm_head=False, dw_dtype="float32",
+                min_free_gib=config["min_free_gib"], formats_by_qname=data.formats_by_qname,
+                checkpoint_dir=Path(config["output_root"]) / "checkpoints", resume=resume,
+                model_identity=source, profile=runner.profile,
+                checkpoint_identity_extra={"tessera_joint_anchor_plan_sha256": plan_sha256,
+                    "prepared_anchor_sha256": prepared["sha256"], "calibration_input": calibration})
+            _same(set(payload["costs"]), set(data.formats_by_qname), "complete joint output roster")
+            for name, rows in payload["costs"].items():
+                _same(set(rows), set(data.formats_by_qname[name]), f"{name}: joint output candidates")
+                for row in rows.values():
+                    _require(validate_joint_aura_entry(row), f"{name}: invalid measured joint cost")
+            payload["provenance"]["tessera_joint_anchors"] = {
+                "plan_sha256": plan_sha256, "prepared": prepared, "inputs": data.inputs,
+                "calibration_input": calibration, "measured_cells": len(data.cells)}
+            output = root / "joint-cost.pkl"
+        torch.cuda.synchronize()
+        result["peak_gpu_bytes"] = torch.cuda.max_memory_allocated()
+        result["peak_gpu_reserved_bytes"] = torch.cuda.max_memory_reserved()
+        _require(result["peak_gpu_bytes"] <= config["max_gpu_bytes"], "observed GPU allocation exceeds declared budget")
+        # A completion is published only after the source residency owner has
+        # shut down successfully as well as after the allocation gate passes.
+        completed_runner, runner = runner, None
+        completed_runner.shutdown()
+        if command == "prepare":
+            _json(completion_path, completion)
+            result["prepared"] = {"path": str(completion_path), "sha256": _sha(completion_path)}
+        else:
+            atomic_write_bytes(output, pickle.dumps(payload, protocol=pickle.HIGHEST_PROTOCOL))
+            result["cost"] = {"path": str(output), "sha256": _sha(output)}
+        result["passed"] = True
+    finally:
+        profiler.disable()
+        profiler.dump_stats(str(root / "profile.pstats"))
+        text = io.StringIO()
+        pstats.Stats(profiler, stream=text).sort_stats("cumulative").print_stats(100)
+        (root / "profile.txt").write_text(text.getvalue())
+        result["env"]["finished_epoch"] = time.time()
+        result["phases"].append({"phase": command, "kind": "profile", "start_epoch": started,
+                                 "end_epoch": result["env"]["finished_epoch"]})
+        result["io_before"], result["io_after"] = before_io, _io_counters()
+        _json(root / "results.json", result)
+        if runner is not None:
+            runner.shutdown()
+    return result
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("prepare", "run"))
+    parser.add_argument("--plan", type=Path, required=True)
+    parser.add_argument("--plan-sha256", required=True)
+    parser.add_argument("--prepared", type=Path)
+    parser.add_argument("--prepared-sha256")
+    parser.add_argument("--resume", action="store_true")
+    args = parser.parse_args(argv)
+    if bool(args.prepared) != bool(args.prepared_sha256):
+        parser.error("--prepared and --prepared-sha256 are required together")
+    config = _load_plan(args.plan, args.plan_sha256)
+    result = execute(args.command, config, plan_sha256=args.plan_sha256,
+        prepared=None if args.prepared is None else {"path": str(args.prepared), "sha256": args.prepared_sha256},
+        resume=args.resume)
+    print(json.dumps({key: result[key] for key in ("command", "passed", "units", "measured_cells")}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_tessera_joint_aura.py
+++ b/tests/test_tessera_joint_aura.py
@@ -247,6 +247,9 @@ def test_plan_refuses_unqualified_probe_or_activation_policies(tmp_path, field, 
         "seed_base": 7000, "token_scope": "all", "temperature": 1.0,
         "production_act_scales": "0"}, "profile_tool": "cprofile",
         "max_render_bytes": 1024, "max_gpu_bytes": 2048, "min_free_gib": 0}
+    config["source_prefetch"] = dict(max_cache_slots=24, prefetch_workers=4,
+        prefetch_lookahead=4, cache_headroom_gb=4.0,
+        prefetch_min_available_gb=2.0, require_prefetched_residency=True)
     config["execution"][field] = value
     path = tmp_path / "plan.json"; path.write_text(json.dumps(config))
     with pytest.raises(ValueError):
@@ -275,3 +278,54 @@ def test_original_full_draw_refuses_subset_before_model_load(tmp_path, monkeypat
     result = json.loads((tmp_path / "prepare/results.json").read_text())
     assert result["passed"] is False
     assert (tmp_path / "prepare/profile.pstats").is_file()
+
+
+@pytest.mark.parametrize("command", ["prepare", "run"])
+def test_explicit_source_prefetch_reaches_streamed_builder(tmp_path, monkeypatch, command):
+    import torch
+    from types import SimpleNamespace
+    from prismaquant import tessera_joint_aura as bridge, calibration_data, cost_streaming, gpu_guard
+    from prismaquant import model_profiles
+    monkeypatch.setattr(model_profiles, "detect_profile", lambda _path: object())
+    draw = dict(fit_ids_sha256="a" * 64, text_sha256="b" * 64, nsamples=512, seqlen=512, seed=0)
+    monkeypatch.setattr(gpu_guard, "require_cuda_hot_path", lambda *_args: None)
+    monkeypatch.setattr(bridge, "load_measured_anchor_input", lambda _inputs: SimpleNamespace(
+        census={"model": "fixture", "attention_implementation": "eager"},
+        payload={"provenance": {"hessian": {"calibration_identity": draw}}}))
+    monkeypatch.setattr(calibration_data, "load_calibration_input", lambda *_args, **_kwargs:
+        (torch.zeros((512, 512), dtype=torch.int64), {"provenance": draw}))
+    prefetch = dict(max_cache_slots=24, prefetch_workers=4, prefetch_lookahead=4,
+        cache_headroom_gb=4.0, prefetch_min_available_gb=2.0, require_prefetched_residency=True)
+    class Reached(Exception):
+        pass
+    def inspect(*_args, **kwargs):
+        assert {key: kwargs.get(key) for key in prefetch} == prefetch
+        raise Reached
+    monkeypatch.setattr(cost_streaming, "build_streamed_causal_lm", inspect)
+    config = {"model": "fixture", "inputs": {}, "output_root": str(tmp_path),
+        "source_prefetch": prefetch,
+        "calibration_input": {"path": "fixture", "sha256": "a" * 64},
+        "execution": {"production_act_scales": "0", "n_calib_samples": 512, "calib_seqlen": 512}}
+    with pytest.raises(Reached):
+        bridge.execute(command, config, plan_sha256="b" * 64)
+
+
+@pytest.mark.parametrize("defect", ["missing", "disabled", "auto_slots", "zero_workers",
+    "oversize_lookahead", "nonfinite_headroom", "extra_field"])
+def test_source_prefetch_refuses_implicit_or_nonresident_settings(defect):
+    from prismaquant.tessera_joint_aura import _source_prefetch
+    prefetch = dict(max_cache_slots=24, prefetch_workers=4, prefetch_lookahead=4,
+        cache_headroom_gb=4.0, prefetch_min_available_gb=2.0,
+        require_prefetched_residency=True)
+    if defect == "missing":
+        config = {}
+    else:
+        field, value = {"disabled": ("require_prefetched_residency", False),
+            "auto_slots": ("max_cache_slots", None), "zero_workers": ("prefetch_workers", 0),
+            "oversize_lookahead": ("prefetch_lookahead", 24),
+            "nonfinite_headroom": ("cache_headroom_gb", float("inf")),
+            "extra_field": ("unreviewed_fallback", True)}[defect]
+        prefetch[field] = value
+        config = {"source_prefetch": prefetch}
+    with pytest.raises(ValueError, match="source_prefetch"):
+        _source_prefetch(config)

--- a/tests/test_tessera_joint_aura.py
+++ b/tests/test_tessera_joint_aura.py
@@ -116,7 +116,7 @@ def test_exact_measured_roster_excludes_interpolation(tmp_path):
     data = load(config)
     assert data.formats_by_qname == {n: (fmt, "BF16") for n in names}
     assert set(data.cells) == {(n, fmt) for n in names}
-    assert data.maximum_layer_render_bytes == 128
+    assert data.total_render_bytes == 64
 
 
 @pytest.mark.parametrize("mutation", ["missing_unit", "missing_shard", "unfinished_fleet",
@@ -158,3 +158,120 @@ def test_incomplete_or_conflicting_anchor_evidence_refuses(tmp_path, mutation):
     target.write_bytes(pickle.dumps(payload)); config["merged_cost"] = bind(target)
     with pytest.raises((ValueError, RuntimeError, FileNotFoundError)):
         load(config)
+
+
+def test_fused_census_maxima_are_used_and_scale_mismatch_refuses(tmp_path):
+    from prismaquant.tessera_joint_aura import calibrated_maxima
+    from prismaquant.tessera_campaign import _static_input_scales
+    from types import SimpleNamespace
+
+    names = ["model.layers.0.self_attn.q_proj", "model.layers.0.self_attn.k_proj"]
+    maxima = dict(zip(names, (1.0, 4.0)))
+    scales, policy = _static_input_scales(maxima)
+    data = SimpleNamespace(census={"max_abs": maxima}, payload={"provenance": {
+        "activation_static_scales": {"units": scales, "policy": policy}}})
+    unified, actual = calibrated_maxima(data, None)
+    assert unified[names[0]] == unified[names[1]] == 4.0
+    assert actual == scales
+    data.payload["provenance"]["activation_static_scales"]["units"] = {**scales, names[0]: 999.0}
+    with pytest.raises(ValueError, match="fused static scales"):
+        calibrated_maxima(data, None)
+
+
+def test_imported_absolute_pwc_paths_release_without_losing_donors(tmp_path):
+    import torch
+    from prismaquant.production_weight_cache import ProductionWeightCache
+    from prismaquant.joint_aura import prefetch_joint_cache
+
+    fmt = "TESSERA_E4M3_K1_R1024"
+    paths = {}
+    for index, name in enumerate(("a", "b")):
+        path = tmp_path / name / "render.pt"
+        path.parent.mkdir()
+        torch.save(torch.full((16, 16), index, dtype=torch.bfloat16), path)
+        paths[name, fmt] = str(path)
+    cache = ProductionWeightCache(weights=dict(paths), levers={})
+    cache.enable_lru(1 << 20)
+    report = prefetch_joint_cache(cache, ["a", "b"], {"a": [fmt], "b": [fmt]}, max_resident_bytes=1 << 20)
+    assert report["entries"] == 2 and report["loaded"] == 2
+    assert cache.compact_for_pickle() == 2
+    assert cache.weights == paths
+    assert torch.equal(cache.get("b", fmt), torch.ones((16, 16), dtype=torch.bfloat16))
+
+
+def test_wire_verification_rederives_source_before_accepting_render(tmp_path, monkeypatch):
+    import torch
+    from types import SimpleNamespace
+    from prismaquant import tessera_campaign as tc
+    from prismaquant.tessera_joint_aura import verify_anchor_render
+    from tessera import unit_artifact
+
+    source = torch.arange(256, dtype=torch.float32).reshape(16, 16).to(torch.bfloat16)
+    rendered = torch.ones_like(source)
+    expected_inputs = {"source": source.clone(), "calibration": object(), "projection": {"fixture": True}}
+    anchor = dict(qname="model.layers.0.q_proj", format_name="TESSERA_E4M3_K1_R1024",
+        family="TESSERA_E4M3_K1", body_rate_q256=1024, dloss=0.25, dloss_stderr=0.0,
+        memory_bytes=256, bits_per_param=8.0, activation_contract="fp8_e4m3",
+        activation_quantized=True, wire_bytes=4, seconds=0.1, hessian_applied=True,
+        input_global_scale=None)
+    wire = tmp_path / "fixture.wire"; wire.write_bytes(b"wire")
+    cell = {"anchor": anchor, "record": {"expected": "derived"}, "wire": str(wire),
+            "render_file_sha256": "a" * 64}
+    seen = []
+    def derive(value, *, weights, menus, calibration_source, static_scales, projected_units):
+        assert value.qname == anchor["qname"]
+        assert torch.equal(weights[value.qname], expected_inputs["source"])
+        assert calibration_source is expected_inputs["calibration"]
+        assert projected_units[value.qname] is expected_inputs["projection"]
+        assert menus[value.qname][0].format_name == anchor["format_name"]
+        return {"expected": "derived"}
+    def verify(blob, record, expected):
+        seen.append((blob, expected)); assert record == expected
+    monkeypatch.setattr(tc, "_checkpoint_anchor_identity", derive)
+    monkeypatch.setattr(tc, "_checkpoint_identity_api", lambda: SimpleNamespace(verify_cached_unit=verify))
+    monkeypatch.setattr(unit_artifact, "read_unit_artifact", lambda blob, device: rendered.clone())
+    kwargs = dict(calibration_source=expected_inputs["calibration"],
+                  projected_unit=expected_inputs["projection"], static_scales={})
+    result = verify_anchor_render(cell, source, rendered, **kwargs)
+    assert seen and result["wire_sha256"] == sha(wire)
+    with pytest.raises(ValueError, match="decoded wire differs"):
+        verify_anchor_render(cell, source, rendered + 1, **kwargs)
+
+
+@pytest.mark.parametrize("field,value", [("probe_microbatch", 0), ("n_probes", 1),
+    ("token_scope", "last"), ("production_act_scales", "1"), ("temperature", 2.0)])
+def test_plan_refuses_unqualified_probe_or_activation_policies(tmp_path, field, value):
+    from prismaquant.tessera_joint_aura import _load_plan, SCHEMA
+    config = {"schema": SCHEMA, "execution": {"n_calib_samples": 512,
+        "calib_seqlen": 512, "probe_microbatch": 1, "n_probes": 4,
+        "seed_base": 7000, "token_scope": "all", "temperature": 1.0,
+        "production_act_scales": "0"}, "profile_tool": "cprofile",
+        "max_render_bytes": 1024, "max_gpu_bytes": 2048, "min_free_gib": 0}
+    config["execution"][field] = value
+    path = tmp_path / "plan.json"; path.write_text(json.dumps(config))
+    with pytest.raises(ValueError):
+        _load_plan(path, sha(path))
+
+
+def test_original_full_draw_refuses_subset_before_model_load(tmp_path, monkeypatch):
+    import torch
+    from types import SimpleNamespace
+    from prismaquant import tessera_joint_aura as bridge, calibration_data, cost_streaming, gpu_guard
+    draw = dict(fit_ids_sha256="a" * 64, text_sha256="b" * 64, nsamples=512, seqlen=512, seed=0)
+    monkeypatch.setattr(gpu_guard, "require_cuda_hot_path", lambda *_args: None)
+    monkeypatch.setattr(bridge, "load_measured_anchor_input", lambda _inputs: SimpleNamespace(
+        census={"model": "fixture", "attention_implementation": "eager"},
+        payload={"provenance": {"hessian": {"calibration_identity": draw}}}))
+    monkeypatch.setattr(calibration_data, "load_calibration_input", lambda *_args, **_kwargs:
+        (torch.zeros((1, 512), dtype=torch.int64), {"provenance": {**draw, "nsamples": 1}}))
+    def forbidden(*_args, **_kwargs):
+        pytest.fail("subset draw reached model construction")
+    monkeypatch.setattr(cost_streaming, "build_streamed_causal_lm", forbidden)
+    config = {"model": "fixture", "inputs": {}, "output_root": str(tmp_path),
+        "calibration_input": {"path": "fixture", "sha256": "a" * 64},
+        "execution": {"production_act_scales": "0", "n_calib_samples": 1, "calib_seqlen": 512}}
+    with pytest.raises(ValueError, match="original full draw nsamples"):
+        bridge.execute("prepare", config, plan_sha256="b" * 64)
+    result = json.loads((tmp_path / "prepare/results.json").read_text())
+    assert result["passed"] is False
+    assert (tmp_path / "prepare/profile.pstats").is_file()

--- a/tests/test_tessera_joint_aura.py
+++ b/tests/test_tessera_joint_aura.py
@@ -1,0 +1,160 @@
+"""Checked full-campaign intake; inert fixture wires are not GPU qualification."""
+from __future__ import annotations
+
+import hashlib
+import json
+import pickle
+from pathlib import Path
+
+import pytest
+
+from prismaquant.cost_stage_checkpoint import (
+    MANIFEST_SCHEMA, canonical_json_sha256, unit_path, write_unit,
+)
+
+
+def sha(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def bind(path):
+    return {"path": str(path), "sha256": sha(path)}
+
+
+def fixture(tmp_path):
+    names = ["model.layers.0.self_attn.q_proj", "model.layers.0.self_attn.k_proj"]
+    fmt = "TESSERA_E4M3_K1_R1024"
+    root = tmp_path / "campaign"
+    rowdir = root / "rows/row-0000"
+    cache = rowdir / "cache"
+    cache.mkdir(parents=True)
+    wire = tmp_path / "merged/cache/wire"
+    wire.mkdir(parents=True)
+    from prismaquant.production_weight_cache import _cache_weight_filename
+    source = {"shape": [4, 4], "dtype": "bfloat16", "sha256": "a" * 64}
+    identity = {"campaign_schema": "prismaquant.tessera_campaign_cost.v1",
+                "currency": "output_mse_under_route_activation_contract",
+                "prismaquant_source_sha256": "b" * 64, "encoder_source_sha256": "c" * 64,
+                "calibration": {"fit_ids_sha256": "d" * 64},
+                "units": {n: {"weight": source, "hessian": None,
+                               "input_global_scale": None, "menu": [fmt],
+                               "scoring_rows": {"shape": [2, 4], "sha256": "e" * 64}}
+                          for n in names}}
+    checkpoint = tmp_path / "merged/cost.anchors.json"
+    parts = checkpoint.with_name(checkpoint.name + ".parts")
+    seal = canonical_json_sha256(identity, where="fixture")
+    manifest = {"schema": MANIFEST_SCHEMA, "stage": "Tessera campaign",
+                "identity": identity, "identity_sha256": seal,
+                "units": [{"qname": n, "file": str(unit_path(parts, n).relative_to(parts))}
+                          for n in names]}
+    checkpoint.write_text(json.dumps(manifest))
+    costs, states = {}, {}
+    for n in names:
+        filename = n + ".tessera"
+        blob = ("inert " + n).encode()
+        (wire / filename).write_bytes(blob)
+        (cache / _cache_weight_filename(n, fmt)).write_bytes(b"inert render")
+        anchor = {"qname": n, "format_name": fmt, "family": "TESSERA_E4M3_K1",
+                  "body_rate_q256": 1024, "dloss": 0.25, "dloss_stderr": 0.0,
+                  "memory_bytes": 16, "bits_per_param": 8.0,
+                  "activation_contract": "fp8_e4m3", "activation_quantized": True,
+                  "wire_bytes": len(blob), "seconds": 0.1, "hessian_applied": False,
+                  "input_global_scale": None}
+        record = {"file": filename, "blob_bytes": len(blob),
+                  "blob_sha256": hashlib.sha256(blob).hexdigest(),
+                  "identity": {"unit": n, "source": source, "calibration": None,
+                               "encoder_source_sha256": "c" * 64,
+                               "recipe": {"grid": "E4M3", "q256": 1024}}}
+        states[n] = {"anchors": [anchor], "wire_records": {fmt: record}}
+        write_unit(parts, stage="Tessera campaign", qname=n,
+                   identity_sha256=seal, state=states[n])
+        costs[n] = {fmt: {"output_mse": 0.25, "output_mse_measured": True,
+                         "cost_source": "tessera_campaign_measured", "tessera_provenance": "measured",
+                         "currency": identity["currency"], "tessera_family": anchor["family"],
+                         "tessera_body_rate_q256": 1024, "activation_contract": "fp8_e4m3",
+                         "activation_quantized": True, "wire_bytes": len(blob),
+                         "hessian_identity": {"applied": False, "supplied": False}}}
+    census = {"model": "/fixture/model", "unit_shapes": {n: [4, 4] for n in names},
+              "anchor_groups": {"g:qk": names}, "max_abs": {names[0]: 1.0, names[1]: 2.0}}
+    census_path = root / "census.json"
+    census_path.write_text(json.dumps(census))
+    plan = {"schema": "prismaquant.tessera_campaign_plan.v1", "model": census["model"],
+            "census": str(census_path), "rows": [{"row_id": "row-0000", "members": names,
+            "groups": ["g:qk"], "dir": str(rowdir)}]}
+    plan_path = root / "plan.json"
+    plan_path.write_text(json.dumps(plan))
+    receipts = root / "receipts.json"
+    receipts.write_text(json.dumps({"returncode": 0, "rows": [{"key": "f" * 64,
+        "rc": 0, "status": "executed", "host": "fixture"}]}))
+    payload = {"schema": identity["campaign_schema"], "currency": identity["currency"],
+               "costs": costs, "provenance": {"model": census["model"],
+               "cost_mode": "production-render-score", "wire_dir": str(wire),
+               "hessian": {"supplied": False}, "stopped_early": False,
+               "campaign_fanout": {"schema": plan["schema"], "rows": {"row-0000": ["g:qk"]}},
+               "activation_static_scales": {"units": {}, "policy": "fixture"}}}
+    cost_path = tmp_path / "merged/cost.pkl"
+    cost_path.write_bytes(pickle.dumps(payload))
+    config = {"campaign_plan": bind(plan_path), "census": bind(census_path),
+              "campaign_receipts": bind(receipts), "merged_cost": bind(cost_path),
+              "merged_checkpoint": bind(checkpoint), "required_source_units": 2,
+              "required_campaign_groups": 1}
+    return config, names, fmt, payload, states
+
+
+def load(config):
+    from prismaquant.tessera_joint_aura import load_measured_anchor_input
+    return load_measured_anchor_input(config)
+
+
+def test_exact_measured_roster_excludes_interpolation(tmp_path):
+    config, names, fmt, payload, _ = fixture(tmp_path)
+    for rows in payload["costs"].values():
+        rows["TESSERA_E4M3_K1_R1000"] = {"output_mse_measured": False,
+            "cost_source": "tessera_campaign_interpolated", "output_mse": 0.3}
+    path = Path(config["merged_cost"]["path"])
+    path.write_bytes(pickle.dumps(payload)); config["merged_cost"] = bind(path)
+    data = load(config)
+    assert data.formats_by_qname == {n: (fmt, "BF16") for n in names}
+    assert set(data.cells) == {(n, fmt) for n in names}
+    assert data.maximum_layer_render_bytes == 128
+
+
+@pytest.mark.parametrize("mutation", ["missing_unit", "missing_shard", "unfinished_fleet",
+    "interpolated_anchor", "unreceipted_measured", "altered_wire", "missing_render",
+    "wrong_source", "wrong_scale", "partial_fanout"])
+def test_incomplete_or_conflicting_anchor_evidence_refuses(tmp_path, mutation):
+    config, names, fmt, payload, states = fixture(tmp_path)
+    path = Path(config["merged_checkpoint"]["path"])
+    manifest = json.loads(path.read_text())
+    parts = path.with_name(path.name + ".parts")
+    if mutation == "missing_unit":
+        payload["costs"].pop(names[1])
+    elif mutation == "missing_shard":
+        unit_path(parts, names[1]).unlink()
+    elif mutation == "unfinished_fleet":
+        receipt = Path(config["campaign_receipts"]["path"])
+        receipt.write_text(json.dumps({"returncode": 1, "rows": []}))
+        config["campaign_receipts"] = bind(receipt)
+    elif mutation == "interpolated_anchor":
+        payload["costs"][names[0]][fmt]["output_mse_measured"] = False
+    elif mutation == "unreceipted_measured":
+        payload["costs"][names[0]]["TESSERA_E4M3_K1_R896"] = dict(payload["costs"][names[0]][fmt])
+    elif mutation == "altered_wire":
+        (Path(payload["provenance"]["wire_dir"]) / states[names[0]]["wire_records"][fmt]["file"]).write_bytes(b"changed")
+    elif mutation == "missing_render":
+        from prismaquant.production_weight_cache import _cache_weight_filename
+        (tmp_path / "campaign/rows/row-0000/cache" / _cache_weight_filename(names[0], fmt)).unlink()
+    elif mutation in {"wrong_source", "wrong_scale"}:
+        state = states[names[0]]
+        if mutation == "wrong_source":
+            state["wire_records"][fmt]["identity"]["source"] = {"shape": [8, 4], "dtype": "bfloat16", "sha256": "0" * 64}
+        else:
+            state["anchors"][0]["input_global_scale"] = 2.0
+        write_unit(parts, stage="Tessera campaign", qname=names[0],
+                   identity_sha256=manifest["identity_sha256"], state=state)
+    else:
+        payload["provenance"]["campaign_fanout"]["rows"] = {}
+    target = Path(config["merged_cost"]["path"])
+    target.write_bytes(pickle.dumps(payload)); config["merged_cost"] = bind(target)
+    with pytest.raises((ValueError, RuntimeError, FileNotFoundError)):
+        load(config)


### PR DESCRIPTION
Completed Tessera campaigns produce scalar MSE rows and original wire/cache artifacts, but those rows cannot price joint weight-and-activation perturbations. This bridge qualifies the exact measured candidates against their original source, full Hessians, encoding settings and decoded BF16 renders, then feeds the existing streamed joint AURA path. Interpolated rows never enter its candidate roster; source BF16 remains the zero-cost terminal.

The bound plan and prepared-cache record preserve the complete calibration draw, probe identity, source/backend/implementation identity and per-Linear candidate roster. Preparation and pricing both require explicit strict source prefetch and reuse ProductionWeightCache. Research entrypoints add no encoder, dispatcher, format/default or serving-gate change. Architecture and invocation guidance are updated.

Validation: 64 initial CPU contract checks; the source-prefetch regression failed before repair, then 48 targeted bridge/policy/doc checks and compilation passed through PrismaBuild. Original-wire CUDA qualification passed all 14 measured cells on two Linears with exact source/render comparisons and four corruption refusals. PB terminal, cleanup, canonical receipts, payload hashes and result hashes were checked. Both-host Netdata and in-process profiles are retained; these are qualification observations, not a speedup claim. Full-model preparation is a separate dependent action and no full-model joint result is claimed here.

Evidence: docs/experiments/tessera_joint_anchor_bridge_2026-09-07.md and /mnt/shared/tessera-measurements/first-model-20260907/full-model-joint-aura/qualify-row0000-01/ (results SHA256 3aaf2495b2124b52900df467ebb74839e9037b16258b76998348dbb87405976a).

Closes #322
