### PR TITLE
Keep persistent FP32 buffers unnarrowed through the streaming export

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,18 @@
 As of: 2026-09-07 · `codex/joint-fused-promotion-20260907`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-07, `review/pq325-buffer-precision`) for the compressed-tensors
+streaming export's persistent-buffer read policy (#311). The exporter passes
+the skeleton's declared buffer dtypes to the shared layer reader before
+passthrough emission. Its existing per-layer resume-cache fingerprint and
+shipcard render provenance now include `persistent_buffer_read_policy`.
+Caches without this policy stamp are invalidated through the existing manifest
+comparison, so replay cannot retain FP32 labels over values narrowed by an old
+reader. Parameter dtype and format policy are unchanged. CPU source-read,
+full streaming emission, serialized buffer-byte identity, and legacy-cache
+invalidation are covered by `tests/test_export_buffer_precision.py` and
+`tests/test_export_buffer_resume.py`; no served artifact gate is claimed.
+
 Re-stamped (2026-09-07, `codex/joint-fused-promotion-20260907`) for **explicit
 qualified joint-projection backends**. The joint anchor plan retains the native
 `torch` multiplication/sum reference by default. Its optional

--- a/docs/results/export_buffer_resume_2026-09-07.md
+++ b/docs/results/export_buffer_resume_2026-09-07.md
@@ -1,0 +1,36 @@
+# Persistent-buffer export and resume review — 2026-09-07
+
+The streaming exporter now passes the skeleton's declared buffer dtypes to the
+existing reader. A fresh export preserves FP32 buffer values that BF16 cannot
+represent. The same fix alone did not protect resumes: old layer payloads were
+replayed before the corrected reader ran. The existing render provenance and
+cache fingerprint now include `persistent_buffer_read_policy=model_declared_v1`,
+so those old payloads are invalidated through the existing manifest comparison.
+
+Both regressions execute the real streaming exporter and safetensors emission:
+PB `5b11586cec0e01dc9ab92be36e1bf9d835e485b99dc8ec84cb3f6c473133e8d0`
+failed the fresh serialized-byte check before the reader wiring;
+`ac627badd15c7967f26bdc2d2956077322049063714af1ae6d38006b5c197bef`
+failed the resumed-byte check before the policy stamp (one other test passed).
+Architecture construction is replaced by a small CPU skeleton; actual source
+reads, cache payloads, tensor sink and serialized tensor bytes are exercised.
+
+After both fixes, review PB `d710557982720e28af08d033a22f8ffe7fcec790d2620264a52aa34bc3b643f0`
+and final-main integration PB
+`5f82ab7762507ab06822a2ddecae7c05bd78ee12a95e5994639eb416c342202b`
+each passed 206 tests, with no skips or uncollected modules. The final run took
+10.32 seconds on DL380 CPU, four workers/12 GiB total, native threads one,
+Python 3.14.4, Torch 2.11 CPU and Transformers 5.16.1. Dedicated compile action
+`c328ca41f2eb978840f2c3bbf1389b77edba4115d1406bc9aea0ea62544d88bb`
+also passed. Root independently checked actual exits, canonical CAS receipts,
+payload/source bundle bytes, source equality and complete scope cleanup.
+
+Command: `bash experiments/pq322_cpu_checks.sh -n4 tests/test_export_buffer_resume.py tests/test_export_buffer_precision.py tests/test_prismaquant_export_native_compressed.py tests/test_streaming_buffer_precision.py tests/test_pretrained_buffer_initialization.py tests/test_architecture_doc.py tests/test_docs_staleness.py`.
+All checks were submitted through the published PrismaBuild client with
+portable placement and priority -10.
+
+No LFM compressed-tensors artifact or stock-vLLM load/generation gate was
+measured. Issue #311 remains open for that validation. The separate standalone
+resume-cache source/requested-dtype binding concern is tracked in #340; this
+policy stamp does not claim to solve that provenance contract. Parameter and
+format policy are unchanged.

--- a/prismaquant/export_native_compressed.py
+++ b/prismaquant/export_native_compressed.py
@@ -8532,6 +8532,10 @@ def _render_lever_provenance() -> dict:
     cache.
     """
     return {
+        # Older layer_*.pt payloads may already contain narrowed persistent
+        # buffers. Recompute them even when the source and render knobs match:
+        # replay bypasses the corrected reader and cannot recover lost bits.
+        "persistent_buffer_read_policy": "model_declared_v1",
         "PRISMAQUANT_DO_NO_HARM": os.environ.get(
             "PRISMAQUANT_DO_NO_HARM", "1"),
         "PRISMAQUANT_GPTQ_DAMP_SWEEP": os.environ.get(

--- a/prismaquant/export_native_compressed.py
+++ b/prismaquant/export_native_compressed.py
@@ -6353,6 +6353,19 @@ def materialize_tensors_streaming(
     weight_shard, weight_ckpt = _build_weight_map(
         model_path, multimodal=multimodal_skeleton)
     source_dtype_by_name = _build_source_dtype_map(weight_shard, weight_ckpt)
+    # Persistent buffers are emitted verbatim (3e), so the read must not
+    # narrow them to the parameter dtype the way `_read_layer_to_device`
+    # narrows weights: `_passthrough_tensor` restores the DECLARED dtype
+    # but cannot restore discarded values, and for a router bias the dtype
+    # is arithmetic rather than storage -- a BF16 score plus an FP32 bias
+    # sums in FP32, a BF16 bias rounds before top-k. Same map the resident
+    # and streaming source loads build (`layer_streaming._materialize`,
+    # `StreamingContext.buffer_dtypes`); walked once here rather than per
+    # layer because the skeleton's buffer declarations never change.
+    declared_buffer_dtypes = {
+        name: value.dtype
+        for name, value in model.named_buffers(remove_duplicate=False)
+    }
     # Per-expert -> packed-3D bridge for checkpoints that ship MoE experts
     # unfused while the live module is packed (driven by the model profile;
     # None for every other model). Keeps the exporter's source read aligned
@@ -6637,7 +6650,8 @@ def materialize_tensors_streaming(
         tensors = _read_layer_to_device(
             f"{layers_prefix}{L}.", weight_shard, weight_ckpt, dtype, device,
             fp8_scale_inv_map=fp8_scale_inv_map, pack_experts=expert_packer,
-            merge_concat=concat_merger)
+            merge_concat=concat_merger,
+            buffer_dtypes=declared_buffer_dtypes)
         resolver = _build_install_resolver(model, layer_qname)
         _fast_install(resolver, tensors, device, model=model)
         load_s = time.time() - load_t0

--- a/tests/test_export_buffer_precision.py
+++ b/tests/test_export_buffer_precision.py
@@ -1,0 +1,165 @@
+"""The compressed-tensors export must not narrow persistent FP32 buffers.
+
+`_read_layer_to_device` casts every floating tensor to the requested
+PARAMETER dtype (BF16 on the shipping recipe). Section 3e of
+`materialize_tensors_streaming` then emits persistent layer buffers through
+`_passthrough_tensor`, which restores the dtype the source declared but
+cannot restore values the read already threw away. A router bias is the
+concrete case: BF16 score + FP32 bias sums in FP32, BF16 score + BF16 bias
+rounds before top-k, so the dtype is arithmetic and not just storage.
+
+#310 / PR #312 gave the reader a `buffer_dtypes` map and threaded it through
+the resident and streaming source loads. This file covers the export caller,
+which is the remaining one -- both that the wiring is there (a missing kwarg
+is silent, and the emitted checkpoint is what changes) and that the bytes
+that come out the far end are the source bytes.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+
+import pytest
+
+torch = pytest.importorskip("torch")
+from torch import nn  # noqa: E402
+from safetensors.torch import save_file  # noqa: E402
+
+from prismaquant.export_native_compressed import (  # noqa: E402
+    _build_source_dtype_map,
+    _passthrough_tensor,
+    materialize_tensors_streaming,
+)
+from prismaquant.layer_streaming import (  # noqa: E402
+    _build_install_resolver,
+    _fast_install,
+    _read_layer_to_device,
+)
+
+# 0.5 and 0.5 + 2**-12 are two distinct FP32 values inside ONE BF16 ulp
+# (2**-9 at 0.5), so the cast collapses them onto each other. Two experts
+# whose biases differ by less than a BF16 ulp are exactly the case where
+# preserving the buffer decides the routing: in FP32 the second wins, and
+# after the narrowing they tie and top-1 falls back to the first.
+_BIAS_LO = 0.5
+_BIAS_HI = 0.5 + 2.0 ** -12
+
+
+class _RoutingLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(2, 2, bias=False)
+        # LFM's `expert_bias` shape: FP32, persistent, added to the router
+        # score before top-k.
+        self.register_buffer(
+            'expert_bias',
+            torch.tensor([_BIAS_LO, _BIAS_HI], dtype=torch.float32))
+        self.register_buffer(
+            'route_count', torch.tensor([2], dtype=torch.int64))
+        self.register_buffer(
+            'derived', torch.zeros(2, dtype=torch.float32), persistent=False)
+
+
+def _source_layer(tmp_path):
+    """A meta skeleton plus the shard it streams from, shaped the way
+    `materialize_tensors_streaming` has them at the layer loop."""
+    model = nn.Module()
+    model.layers = nn.ModuleList([_RoutingLayer()])
+    with torch.no_grad():
+        model.layers[0].proj.weight.copy_(torch.eye(2))
+    path = tmp_path / 'source.safetensors'
+    state = {name: value.contiguous()
+             for name, value in model.state_dict().items()}
+    save_file(state, str(path))
+    names = list(state)
+    model.to_empty(device='meta')
+    shards = {name: str(path) for name in names}
+    keys = {name: name for name in names}
+    return model, shards, keys
+
+
+def _emit_layer(tmp_path, *, buffer_dtypes):
+    """Run the export's read -> install -> passthrough-emit sequence."""
+    model, shards, keys = _source_layer(tmp_path)
+    source_dtype_by_name = _build_source_dtype_map(shards, keys)
+    tensors = _read_layer_to_device(
+        'layers.0.', shards, keys, torch.bfloat16, torch.device('cpu'),
+        buffer_dtypes=buffer_dtypes)
+    resolver = _build_install_resolver(model, 'layers.0')
+    _fast_install(resolver, tensors, torch.device('cpu'), model=model)
+
+    layer_mod = model.get_submodule('layers.0')
+    out = {}
+    for mod_name, mod in layer_mod.named_modules():
+        non_persistent = getattr(mod, '_non_persistent_buffers_set', set())
+        for buf_name, buf in mod.named_buffers(recurse=False):
+            if buf_name in non_persistent or buf.is_meta:
+                continue
+            full_modpath = f'layers.0.{mod_name}' if mod_name else 'layers.0'
+            full = f'{full_modpath}.{buf_name}'
+            out[full], _ = _passthrough_tensor(
+                full, buf, source_dtype_by_name)
+    for name, param in layer_mod.named_parameters():
+        out[f'layers.0.{name}'] = param.detach()
+    return out
+
+
+def _declared(tmp_path):
+    model, _, _ = _source_layer(tmp_path)
+    return {name: value.dtype
+            for name, value in model.named_buffers(remove_duplicate=False)}
+
+
+def test_export_emits_source_buffer_bytes(tmp_path):
+    """The FP32 router bias survives the export read bit-identically."""
+    emitted = _emit_layer(tmp_path, buffer_dtypes=_declared(tmp_path))
+    bias = emitted['layers.0.expert_bias']
+    assert bias.dtype == torch.float32
+    assert torch.equal(
+        bias, torch.tensor([_BIAS_LO, _BIAS_HI], dtype=torch.float32))
+    # Non-float buffers were never at risk and must stay untouched; the
+    # non-persistent one is not emitted at all.
+    assert emitted['layers.0.route_count'].dtype == torch.int64
+    assert 'layers.0.derived' not in emitted
+
+
+def test_export_still_narrows_parameters_to_the_recipe_dtype(tmp_path):
+    """Buffer preservation must not widen the parameter policy."""
+    emitted = _emit_layer(tmp_path, buffer_dtypes=_declared(tmp_path))
+    assert emitted['layers.0.proj.weight'].dtype == torch.bfloat16
+
+
+def test_a_narrowed_bias_changes_routing(tmp_path):
+    """Why the loss is not cosmetic. The same emit run WITHOUT the declared
+    map relabels the bias FP32 on the way out -- `_passthrough_tensor`
+    restores the dtype -- but the two experts have already been collapsed
+    onto one BF16 value, and the expert the source ranked first loses."""
+    narrowed = _emit_layer(tmp_path, buffer_dtypes=None)['layers.0.expert_bias']
+    preserved = _emit_layer(
+        tmp_path, buffer_dtypes=_declared(tmp_path))['layers.0.expert_bias']
+    # Both are FP32 on the wire: the dtype survives, the values do not.
+    assert narrowed.dtype == preserved.dtype == torch.float32
+    assert not torch.equal(narrowed, preserved)
+    scores = torch.zeros(1, 2, dtype=torch.bfloat16)
+    assert (scores + preserved).argmax(-1).item() == 1
+    assert (scores + narrowed).argmax(-1).item() == 0
+
+
+def test_export_layer_read_is_wired_to_the_declared_buffer_dtypes():
+    """The wiring itself, because dropping the kwarg is silent: nothing
+    raises, the histogram still labels the buffer FP32, and only the
+    emitted values change. Guards the one line the behaviour above
+    depends on inside a 7k-line function no unit test can drive."""
+    tree = ast.parse(
+        textwrap.dedent(inspect.getsource(materialize_tensors_streaming)))
+    calls = [n for n in ast.walk(tree)
+             if isinstance(n, ast.Call)
+             and isinstance(n.func, ast.Name)
+             and n.func.id == '_read_layer_to_device']
+    assert calls, 'export no longer reads layers through _read_layer_to_device'
+    for call in calls:
+        assert any(kw.arg == 'buffer_dtypes' for kw in call.keywords), (
+            'materialize_tensors_streaming reads a layer without passing '
+            'buffer_dtypes; persistent FP32 buffers narrow to the parameter '
+            'dtype and _passthrough_tensor cannot recover them')

--- a/tests/test_export_buffer_precision.py
+++ b/tests/test_export_buffer_precision.py
@@ -38,7 +38,7 @@ from prismaquant.layer_streaming import (  # noqa: E402
 )
 
 # 0.5 and 0.5 + 2**-12 are two distinct FP32 values inside ONE BF16 ulp
-# (2**-9 at 0.5), so the cast collapses them onto each other. Two experts
+# (2**-8 at 0.5), so the cast collapses them onto each other. Two experts
 # whose biases differ by less than a BF16 ulp are exactly the case where
 # preserving the buffer decides the routing: in FP32 the second wins, and
 # after the narrowing they tie and top-1 falls back to the first.
@@ -150,7 +150,8 @@ def test_export_layer_read_is_wired_to_the_declared_buffer_dtypes():
     """The wiring itself, because dropping the kwarg is silent: nothing
     raises, the histogram still labels the buffer FP32, and only the
     emitted values change. Guards the one line the behaviour above
-    depends on inside a 7k-line function no unit test can drive."""
+    depends on. The full streaming-emission regression is in
+    test_export_buffer_resume.py."""
     tree = ast.parse(
         textwrap.dedent(inspect.getsource(materialize_tensors_streaming)))
     calls = [n for n in ast.walk(tree)

--- a/tests/test_export_buffer_resume.py
+++ b/tests/test_export_buffer_resume.py
@@ -1,0 +1,91 @@
+"""Exercise buffer preservation through the actual streaming exporter."""
+import json
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+from safetensors.torch import load_file, save_file
+
+from prismaquant import export_native_compressed as export
+from prismaquant import layer_streaming, sensitivity_probe, streaming_model
+
+
+def _export_fixture(tmp_path, monkeypatch):
+    """Replace architecture construction only; source reads and emission are real."""
+    expected = torch.tensor([0.5, 0.5 + 2.0 ** -12], dtype=torch.float32)
+    source = tmp_path / "source"
+    source.mkdir()
+    save_file({
+        "model.layers.0.expert_bias": expected,
+        "model.layers.0.proj.weight": torch.eye(2, dtype=torch.bfloat16),
+    }, str(source / "model.safetensors"))
+
+    class Skeleton:
+        @staticmethod
+        def _from_config(config):
+            model = nn.Module()
+            model.model = nn.Module()
+            layer = nn.Module()
+            layer.proj = nn.Linear(2, 2, bias=False, device="meta")
+            layer.register_buffer("expert_bias", torch.empty(2, device="meta", dtype=torch.float32))
+            model.model.layers = nn.ModuleList([layer])
+            return model
+
+    profile = SimpleNamespace(
+        requires_multimodal_skeleton=lambda: False,
+        concat_merge_groups=lambda: (),
+        live_to_recipe_name=lambda name: name,
+        packed_expert_param_names=lambda: (),
+    )
+    from transformers import AutoConfig
+    monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *a, **kw: SimpleNamespace())
+    monkeypatch.setattr(sensitivity_probe, "stage_text_only", lambda path: path)
+    monkeypatch.setattr(streaming_model, "_skeleton_config_and_class",
+                        lambda config, **kw: (config, Skeleton))
+    monkeypatch.setattr(streaming_model, "_init_rotary_inplace", lambda *a: None)
+    monkeypatch.setattr(export, "_PRODUCTION_WEIGHT_CACHE", None)
+
+    def run(cache=None):
+        emitted = {}
+        def sink(tensors):
+            emitted.update(tensors)
+        export.materialize_tensors_streaming(
+            str(source), {}, profile=profile, bf16_passthrough=set(),
+            device=torch.device("cpu"), tensor_sink=sink,
+            export_cache_dir=None if cache is None else str(cache))
+        path = tmp_path / "emitted.safetensors"
+        save_file(emitted, str(path))
+        return load_file(str(path))
+    return run, expected
+
+
+def test_streaming_export_serializes_original_fp32_buffer_bytes(tmp_path, monkeypatch):
+    run, expected = _export_fixture(tmp_path, monkeypatch)
+    emitted = run()
+    actual = emitted["model.layers.0.expert_bias"]
+    assert actual.dtype == torch.float32
+    assert torch.equal(actual.view(torch.uint8), expected.view(torch.uint8))
+    assert emitted["model.layers.0.proj.weight"].dtype == torch.bfloat16
+
+
+def test_streaming_export_invalidates_resume_from_old_buffer_policy(tmp_path, monkeypatch):
+    run, expected = _export_fixture(tmp_path, monkeypatch)
+    cache = tmp_path / "resume"
+    real_read = layer_streaming._read_layer_to_device
+    def old_read(*args, **kwargs):
+        kwargs.pop("buffer_dtypes", None)
+        return real_read(*args, **kwargs)
+    # Produce the prior implementation's layer payload through the real exporter.
+    with monkeypatch.context() as old:
+        old.setattr(layer_streaming, "_read_layer_to_device", old_read)
+        narrowed = run(cache)["model.layers.0.expert_bias"]
+    assert not torch.equal(narrowed, expected)
+    manifest = cache / "manifest.json"
+    legacy = json.loads(manifest.read_text())
+    legacy.pop("persistent_buffer_read_policy", None)
+    manifest.write_text(json.dumps(legacy))
+
+    # Same source/assignment/levers, but the corrected reader must execute.
+    emitted = run(cache)["model.layers.0.expert_bias"]
+    assert torch.equal(emitted.view(torch.uint8), expected.view(torch.uint8))
+    assert json.loads(manifest.read_text())["persistent_buffer_read_policy"]


### PR DESCRIPTION
Streaming export narrowed persistent FP32 buffers to the parameter dtype before relabelling them FP32 at emission. Pass the skeleton's declared buffer dtypes to the existing reader, and add the buffer-read policy to the existing render/cache fingerprint so resumed exports invalidate old narrowed layer payloads. Parameter and format policy remain unchanged.

Real CPU streaming-export and safetensors regressions demonstrate the fresh and resumed byte failures before their respective fixes. Final-main PrismaBuild validation: **206 passed, no skips or uncollected modules** (DL380 CPU4/12 GiB, native threads one, portable placement, pinned Torch CPU/Transformers environment); compilation passed. Root independently verified actual terminal exits, canonical receipts, payload/source bytes and cleanup. Evidence: `docs/results/export_buffer_resume_2026-09-07.md`.

Related to #311, which remains open for an actual LFM compressed-tensors artifact and stock-vLLM load/generation validation. Those gates were not measured. The distinct standalone resume source/requested-dtype binding concern remains tracked in #340.

Closes #342.
