### PR TITLE
Read native MoE workspace from the published receipt panel

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,10 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-07 · `feat/tessera-joint-anchor-bridge`. Stamps
+As of: 2026-09-07 · `fix/native-workspace-receipt`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-07, `fix/native-workspace-receipt`) for the native MoE
+workspace receipt binding described below (#328).
 
 Re-stamped (2026-09-07, `feat/tessera-joint-anchor-bridge`) for **joint AURA
 from completed measured Tessera anchors** (#322). The explicit
@@ -71,9 +74,11 @@ panel. The existing packed-expert
 reference applies the shared activation QDQ at both GEMM boundaries. Native
 measurements bind all aligned joint rows through `RuntimeBinding`; no new
 scalar group cost or sum of leaf timings is produced. Persistent vLLM workspace
-is recorded separately from layer residency and per-apply scratch, with
-full-model fixed resources and workspace composition still unknown. This is a
-research boundary; no format, pin, serving gate or production default changes.
+is recorded separately from layer residency and per-apply scratch. Its identity
+is carried in the complete frozen receipt panel and joined to the resource
+observation's workspace digest and byte count; the reader requires no duplicate
+top-level workspace fields. Full-model fixed resources and workspace composition
+remain unknown. This is a research boundary; no format, pin, serving gate or production default changes.
 The research CLI `experiments/pq309_native_moe_panel.py` consumes the existing
 canonical capture-v2 PAC boundary and original PWC/wire artifacts; it re-derives
 encoder identities from the pinned full Hessians and retains lossless routing

--- a/docs/measurements/native-workspace-receipt-2026-09-07.md
+++ b/docs/measurements/native-workspace-receipt-2026-09-07.md
@@ -1,0 +1,36 @@
+# Native MoE workspace receipt reader — 2026-09-07
+
+The actual admitted original-wire native receipt failed PrismaQuant consumption
+with `KeyError: 'workspace'` (PB `d47966d399202329ed0a1110495e491483d76a23cdacc0a7aea3b1a4fa515623`).
+The reader and its fixture expected top-level workspace duplicates absent from
+Tessera's published v1 shape. The corrected reader validates the workspace in
+the already exact-matched frozen panel, then retains the independent observed
+resource digest/byte checks. Measurement bytes remain unchanged; see #328.
+
+The receipt-shaped regression reproduced two intended failures against unmodified
+main through PB `48dd4734584f5aeb05e5485331a0354abffeec701eb0cf28eb84e7a3a9564e1d`.
+The corrected native panel and architecture/staleness tests passed **84 tests,
+zero skips or missing collection** through
+`6dbb1c7966708b055e453704fdf57de4c32e5db57d359d4f187881be63e1d8af`.
+These CPU tests used the existing `pq322_cpu_checks.sh` ARM path and immutable
+`eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c`
+container on Sparklina with GPU visibility disabled, four CPU workers, a 12 GiB
+reservation and native threads bounded to one. Warnings were existing Torch
+JIT deprecations and pytest's read-only cache directory.
+
+Actual unchanged receipt consumption and touched-module compilation passed PB
+`5c5626d6e391486c1d5ebb174becb53651b808d429161814b47338c27776fe5f`,
+using `experiments/pq329_native_receipt_consume.sh` in the same CPU-only container.
+The output at `/mnt/shared/tessera-measurements/first-model-20260907/native-moe-panel-r1024/consumed-03.json`
+has SHA256 `4ec5fe3f02048549ab3abe8a4926572aac91ab89d3333a45d74d8b89617b6ddb`.
+It retains prefill/decode medians 1.906431973/0.263167992 ms, residency 353,042,432
+bytes, persistent workspace 23,068,672 bytes, and scratch 7,367,680/14,848 bytes.
+These values come from the original GPU receipt, not from the CPU reader run.
+`runtime_table_admissible` remains false and `full_model_resources` remains null.
+
+`workspace-reader-328-audit.json` beside that output, SHA256
+`061b971bc210256174b29e14b1ce60cf75a29ce226c80ba0c7b4ea556f5bcda9`,
+records actual exits, complete scope cleanup and rehashed successful CAS payloads.
+Earlier unclaimed x86 validation submissions were withdrawn through PB while
+that worker was unavailable and replaced with the existing qualified ARM path;
+no GPU measurement was repeated for this repair.

--- a/experiments/pq329_native_receipt_consume.sh
+++ b/experiments/pq329_native_receipt_consume.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# The existing qualified CPU container and frozen producer dependencies.
+image=eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
+input_root=/mnt/shared/tessera-measurements/first-model-20260907/inputs
+exec docker run --rm --user "$(id -u):$(id -g)" \
+  -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared -w /workspace --entrypoint python3 \
+  -e PYTHONDONTWRITEBYTECODE=1 -e CUDA_VISIBLE_DEVICES -e NVIDIA_VISIBLE_DEVICES=void \
+  -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
+  -e XDG_CACHE_HOME=/tmp/pq-receipt-cpu-cache -e HF_HOME=/tmp/pq-receipt-cpu-hf \
+  -e PRISMABUILD_CONTAINER_OWNER \
+  -e "PYTHONPATH=/workspace:$input_root/tessera-382a1a97/src:$input_root/container-compatible-deps" \
+  "$image" -c 'import pathlib, runpy; [compile(pathlib.Path(p).read_text(), p, "exec") for p in ("prismaquant/native_moe_panel.py", "tests/test_native_moe_panel.py")]; print("Touched Python modules compile", flush=True); runpy.run_module("experiments.pq309_native_moe_panel", run_name="__main__")' consume "$@"

--- a/prismaquant/native_moe_panel.py
+++ b/prismaquant/native_moe_panel.py
@@ -669,9 +669,12 @@ def consume_moe_receipt(path, *, expected_sha256, expected_panel, memory_trace_p
     _equal(receipt["panel_sha256"], identity_sha256(expected_panel), "receipt panel digest")
     _equal(receipt["runtime"], expected_panel["runtime"], "receipt runtime")
     _equal(receipt["runtime_sha256"], identity_sha256(expected_panel["runtime"]), "receipt runtime digest")
-    _equal(receipt["workspace"], expected_panel["workspace"], "receipt workspace")
-    _equal(receipt["workspace_sha256"], expected_panel["workspace_sha256"], "receipt workspace digest")
-    _workspace_identity(receipt["workspace"])
+    # The producer publishes workspace identity in its complete frozen panel,
+    # with the independently observed bytes/digest in resources below. There
+    # are no duplicate top-level workspace fields in the v1 receipt.
+    workspace = receipt["panel"]["workspace"]
+    _workspace_identity(workspace)
+    _equal(identity_sha256(workspace), expected_panel["workspace_sha256"], "receipt workspace digest")
     binding = RuntimeBinding.from_dict(expected_panel["runtime_binding"])
     members = _member_roster(expected_panel["unit"], expected_panel["members"], expected_panel["shape"])
     _equal(dict(binding.member_formats), {member["unit"]: member["format"] for member in members}, "runtime member coverage")

--- a/tests/test_native_moe_panel.py
+++ b/tests/test_native_moe_panel.py
@@ -316,7 +316,7 @@ def receipt_fixture(joined, complete=True):
     receipt = {"schema": "tessera.native_moe_operator_receipt.v1", "status": "timing_admissible",
         "panel": panel, "panel_sha256": identity_sha256(panel), "operator": preflight["operator"],
         "runtime": preflight["runtime"], "runtime_sha256": preflight["runtime_sha256"],
-        "workspace": preflight["workspace"], "workspace_sha256": preflight["workspace_sha256"], "phases": phases,
+        "phases": phases,
         "resources": {"status": "complete_operator_bound" if complete else "incomplete", "resident_bytes": 100,
             "workspace_resident_bytes": 64, "workspace_sha256": preflight["workspace_sha256"],
             "trace_sha256": identity_sha256(trace), "phases": {
@@ -345,7 +345,7 @@ def test_whole_apply_evidence_preserves_workspace_and_full_model_unknown(joined,
     assert "cross_operator_workspace_composition" in observed["unknown"]
 
 
-@pytest.mark.parametrize("change", ["missing_member", "weights", "workspace", "workspace_bytes", "resource_trace",
+@pytest.mark.parametrize("change", ["missing_member", "weights", "workspace", "workspace_digest", "workspace_bytes", "resource_trace",
                                     "scalar_leaf_sum", "tolerance", "scratch", "route_shape", "config", "raw_identity"])
 def test_whole_receipt_cannot_replace_frozen_inputs_or_resources(joined, tmp_path, change):
     panel, receipt, trace = receipt_fixture(joined)
@@ -354,9 +354,12 @@ def test_whole_receipt_cannot_replace_frozen_inputs_or_resources(joined, tmp_pat
     elif change == "weights":
         receipt["phases"]["prefill"]["topk_weights"] = dict(receipt["phases"]["prefill"]["topk_weights"], content_sha256="0" * 64)
     elif change == "workspace":
-        receipt["workspace"] = copy.deepcopy(receipt["workspace"])
-        receipt["workspace"]["slots"][0]["shape"] = [32]
-        receipt["workspace_sha256"] = identity_sha256(receipt["workspace"])
+        receipt["panel"] = copy.deepcopy(receipt["panel"])
+        receipt["panel"]["workspace"]["slots"][0]["shape"] = [32]
+        receipt["panel"]["workspace_sha256"] = identity_sha256(receipt["panel"]["workspace"])
+        receipt["panel_sha256"] = identity_sha256(receipt["panel"])
+    elif change == "workspace_digest":
+        receipt["resources"]["workspace_sha256"] = "0" * 64
     elif change == "workspace_bytes":
         receipt["resources"]["workspace_resident_bytes"] = 0
     elif change == "resource_trace":


### PR DESCRIPTION
Actual Tessera native MoE receipts carry workspace identity inside their frozen panel and publish the observed digest/byte count under resources. PrismaQuant demanded duplicate top-level fields and raised `KeyError: 'workspace'` when consuming the admitted original-wire measurement.

Read the identity from the already exact-matched panel and verify its digest, retaining the independent resource digest/byte checks. The fixture now follows the published receipt shape and rejects altered panel workspace, resource digest and resource bytes. Architecture documentation records the contract; the retained CPU launcher reproduces actual receipt consumption.

Closes #328.

Validation through PrismaBuild on Sparklina, using the established immutable CPU container with GPU access disabled:

- RED `48dd4734`: two intended `KeyError: 'workspace'` failures against unmodified main.
- GREEN `6dbb1c79`: 84 native-panel and architecture/staleness tests passed; zero skips or missing collection, four CPU workers.
- `5c5626d6`: touched modules compile and the unchanged measured receipt consumes successfully. Output SHA256 `4ec5fe3f02048549ab3abe8a4926572aac91ab89d3333a45d74d8b89617b6ddb` retains all original timings/resource values; full-model runtime admission stays false.

Actual exit, cleanup, stdout-bound output and CAS hashes are audited in `/mnt/shared/tessera-measurements/first-model-20260907/native-moe-panel-r1024/workspace-reader-328-audit.json`, SHA256 `061b971bc210256174b29e14b1ce60cf75a29ce226c80ba0c7b4ea556f5bcda9`. Details and reproduction launcher are recorded in `docs/measurements/native-workspace-receipt-2026-09-07.md`. No GPU measurement was rerun or rewritten for this reader repair.
