### PR TITLE
Reuse bound anchor identities and sample joint preparation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,20 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-07 · `perf/joint-anchor-identity-reuse`. Stamps
+As of: 2026-09-07 · `codex/joint-sampling-profiler`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-07, `codex/joint-sampling-profiler`) for **sampling joint
+preparation and cost execution**. The explicit plan profiler may be `py-spy`:
+the admitted container runs a pinned sampler as the command's ancestor, with
+50 Hz Python stack sampling across its subprocesses. The joint process binds
+its actual wrapper's start receipt; the wrapper separately records the observed
+command's exit status. Completion requires both successful child execution and
+nonempty sampled stacks, checked through `profile-result.json` alongside the
+PB terminal and CAS receipt. Sampling avoids deterministic callbacks on every
+grid/hash call. Explicit `cprofile` remains supported for retained plans.
+Both-host Netdata and per-process IO observations remain required when reporting
+performance; sampled stack fractions are not isolated throughput measurements.
+Gate: `tests/test_profile_command.py`, with real sampler cases run under PB.
 
 Re-stamped (2026-09-07, `perf/joint-anchor-identity-reuse`) for an **explicitly
 versioned Tessera reader beside the frozen producer**. An optional plan `reader`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,6 +14,10 @@ anchor/static-scale/H applicability checks, original wire grammar/hash checks
 and exact decoded-render comparison. The binding closes before source unload;
 it accepts no caller-supplied prehash and creates no tensor cache or dispatcher.
 Gate: `tests/test_tessera_bound_identity.py` plus original-wire qualification.
+Initial wire/render content verification may use explicit `file_hash_workers`,
+bounded by PB-assigned CPU affinity. Independent file pairs run in the same
+admitted process; their exact content hashes, before/after race detection and
+per-consumption render drift checks remain mandatory. Placement stays PB's.
 
 Re-stamped (2026-09-07, `feat/tessera-joint-anchor-bridge`) for **joint AURA
 from completed measured Tessera anchors** (#322). The explicit

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,19 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-07 · `feat/tessera-joint-anchor-bridge`. Stamps
+As of: 2026-09-07 · `perf/joint-anchor-identity-reuse`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-07, `perf/joint-anchor-identity-reuse`) for **bounded
+source/H identity reuse during anchor preparation**. The shared campaign seam
+can bind one unit's closed anchor roster from actual source/H tensors through
+Tessera's unchanged producer API. Source finite checks, source/H hashes and the
+PWC source receipt are derived once for that lifetime; storage, version, device,
+shape, stride, dtype, calibration settings and projection guards refuse stale
+reuse. Each format still resolves Tessera's canonical recipe and retains its
+anchor/static-scale/H applicability checks, original wire grammar/hash checks
+and exact decoded-render comparison. The binding closes before source unload;
+it accepts no caller-supplied prehash and creates no tensor cache or dispatcher.
+Gate: `tests/test_tessera_bound_identity.py` plus original-wire qualification.
 
 Re-stamped (2026-09-07, `feat/tessera-joint-anchor-bridge`) for **joint AURA
 from completed measured Tessera anchors** (#322). The explicit

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,19 @@
 As of: 2026-09-07 · `perf/joint-anchor-identity-reuse`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-07, `perf/joint-anchor-identity-reuse`) for an **explicitly
+versioned Tessera reader beside the frozen producer**. An optional plan `reader`
+record declares the external package path and exact source SHA256. The consumer
+loads under its own source-named namespace; imported files are checked against
+that sealed source tree, absolute primary-Tessera imports and serving modules
+are refused. Primary `tessera` still derives original source/H/settings/encoder
+identities. The separate reader verifies these actual expected identities and
+original wire grammar, then decodes bytes; it never substitutes its source seal
+into old producer receipts. Reader identity is bound into prepared PWC/completion
+records and dependent joint checkpoints. This is a producer/consumer boundary,
+not a serving-runtime import or a wire/default change.
+Gate: `tests/test_tessera_reader_namespace.py` plus original-wire old/new parity.
+
 Re-stamped (2026-09-07, `perf/joint-anchor-identity-reuse`) for **bounded
 source/H identity reuse during anchor preparation**. The shared campaign seam
 can bind one unit's closed anchor roster from actual source/H tensors through

--- a/docs/experiments/tessera_anchor_verify_ab_2026-09-07.md
+++ b/docs/experiments/tessera_anchor_verify_ab_2026-09-07.md
@@ -1,0 +1,115 @@
+# Original anchor verifier versus bound identities and a namespaced reader
+
+On Sparklina's GB10, the equal-work fourteen-cell verifier took a median
+3.994050 s with the original reader and 3.199550 s with per-unit source/H
+binding and the separately loaded reader: 1.2483× throughput, or 19.89% less
+wall time. All original verification records remained exactly equal. This
+qualifies the reader and identity reuse on these original inputs; it does not
+measure whole-model preparation, parallel intake hashing, or joint Aura.
+
+## Workload and controls
+
+The two original dense units are `model.layers.0.feed_forward.w1` and `w3`,
+with their fourteen original campaign wires and PWC renders. Source weights
+and the canonical 512×512 calibration capture are prefetched on CUDA; the
+existing PWC owns resident rendered weights. Both arms call the same
+`verify_anchor_render`, rehash the original render file, transfer the PWC
+render to CUDA, independently derive the expected producer identity and
+compare the decoded wire with the original render. Binding work is timed in
+the optimized arm. No additional cache or worker dispatcher is introduced.
+
+The immutable plan binds cost, checkpoint, census, capture and token files.
+The original producer remains at its original package path. The optimized
+consumer is separately loaded under a SHA-specific module namespace; its
+source SHA is `14df443217e2a6a1bc4857532f0b5ead7fa7f5755dbd61e96605659940a8a1bc`.
+Every original producer source file and all producer module objects loaded
+before the consumer remained unchanged. Consumer provenance never substitutes
+for the producer's expected encoding identity.
+
+After retaining the first parse pair, the harness runs AB, BA, AB, with the
+same `perf_counter` and CUDA synchronization in both arms. It then records a
+separate torch CPU/CUDA profile for each arm. A 50 Hz py-spy sampler observes
+the whole process. No deterministic per-call profiler runs during timing.
+The container is
+`eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c`.
+PB admitted four CPUs, 12 GiB total memory and an 8 GiB GPU subset under
+measurement isolation on the submitting Sparklina host. Native threads were
+bounded to one, and PB-assigned container affinity was preserved.
+
+| Pair | Original seconds | Optimized seconds |
+|---|---:|---:|
+| First parse, retained separately | 8.938738 | 7.438363 |
+| Measured 0, AB | 3.987748 | 3.199550 |
+| Measured 1, BA | 3.994050 | 3.213332 |
+| Measured 2, AB | 3.998542 | 3.170379 |
+
+The first pair is not claimed to be disk-cold. Across all ten phases, all
+fourteen records match exactly, including source tensor, rendered tensor,
+encoding identity, wire SHA and render-file SHA. Both arms separately refuse
+render, source, settings and wire corruption: eight refusals. No cases were
+skipped. CUDA allocation peaked at 923,015,168 bytes; reserved memory peaked
+at 968,884,224 bytes. The complete PB scope peaked at 2,628,898,816 bytes,
+used 66.354 CPU seconds over 68.261 wall seconds, and had no OOM events.
+
+## Profile and host evidence
+
+The sampler captured 3,354 samples with zero errors. Aggregated stacks inside
+`before_verify` and `after_verify` include the first-parse and explicit-profile
+phases, so these counts are diagnostic rather than timing estimates for the
+three measured pairs. `grid_digest` appears in 96 of 1,303 original-arm
+samples and zero of 1,047 optimized-arm samples. `tensor_identity` appears in
+202 original-arm samples versus 86 optimized-arm samples. Optimized decoding
+still dominates: `read_unit_artifact` occurs in 591 optimized-arm samples,
+with 236 leaf samples in NumPy `_sum` and 152 in wire `_from_bits`.
+The remaining wire-unpack work was reported to the Tessera owner and the
+full-run coordinator; it is outside this reader's measured change.
+
+Raw Netdata series from both hosts and per-phase summaries are retained.
+Sparklina's measured arms show about 6% aggregate CPU activity and 11–13 W
+interpolated GPU power against the approximately 140 W envelope. This verifier
+remains CPU limited. GPU power samples are ten seconds apart while measured
+arms last three to four seconds: their interpolated energy integrals cannot
+resolve an arm-level work-per-joule comparison. No energy improvement or GPU
+saturation claim is made. This bounded result also does not support a 20×
+whole-run speedup.
+
+## Reproduction and attributable artifacts
+
+Source commit: `1e017316`. Submit from Sparklina because this is a same-device
+measurement, using a complete checkout of that commit:
+
+```bash
+python3 /mnt/shared/prismabuild-fleet/repo/tools/pbrun.py \
+  --cwd CHECKOUT --cpus 4 --demand mem_gb=12 --gpu --gpu-memory-gb 8 \
+  --measurement --detach -- bash experiments/pq322_anchor_verify_ab.sh \
+  SAMPLER_OUTPUT --plan PLAN --plan-sha256 PLAN_SHA256
+```
+
+The plan is
+`/mnt/shared/tessera-measurements/first-model-20260907/full-model-joint-aura/qualify-reader-ab-plan-01.json`,
+SHA `b6f11eb7af4229319dd48e048b76abe88d608ffce9ee54740de31bb96b1a7e94`.
+Reruns require a new output directory in a newly hashed plan; the harness
+refuses to overwrite prior results.
+
+All paths below share
+`/mnt/shared/tessera-measurements/first-model-20260907/full-model-joint-aura/`:
+
+- `qualify-reader-ab-01/results.json`, SHA
+  `5ab6c302dfd418c437fec1936168ecd86b0360726ad2e6205d29a545e8aac8f8`.
+- `qualify-reader-ab-01/verified-evidence.json`, SHA
+  `234bde783b2dde6d3a2b02ee09f955194fbd3592da655acf61d00af0ae61384a`,
+  seals results, both torch traces/tables, both-host Netdata and sampler files.
+- `qualify-reader-ab-01/profile-00-{before,after}.{trace.json,operators.txt}`.
+- `qualify-reader-ab-01/netdata-both-hosts.json`, including raw host series.
+- `qualify-reader-ab-sampler-01/{stacks.raw,profile-result.json,child-exit.json,sampler.log}`.
+- `anchor-identity-reader-cpu-receipts.json`, retaining the prior 64-test
+  combined CPU gate, 33-test and three-test narrower gates, and harness syntax
+  check. These are CPU checks; GPU qualification is the separate action below.
+
+PB action `c9ed62c27e35d4abc52dbbef32e110d5c3b60aa6075af7916796484904628997`
+finished with exit 0 and complete resource-scope cleanup. The real child and
+sampler both exited 0. The 1,899-byte CAS payload SHA is
+`e609fa6266adf72d88631c93a88708667d115696e9fdee5426b682161bc4362a`;
+receipt SHA is `94fe88e396a557c45010b824184a8601982414600094f828ae66c2324b00a4a8`.
+Payload bytes, receipt body, sampler artifacts and result records were
+independently checked after terminal completion.

--- a/experiments/pq322_anchor_verify_ab.py
+++ b/experiments/pq322_anchor_verify_ab.py
@@ -1,0 +1,223 @@
+"""PB-only equal-work A/B of original versus bound, namespaced anchor verification."""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from pathlib import Path
+import pickle
+import socket
+import sys
+import statistics
+import time
+from types import SimpleNamespace
+
+
+def main():
+    import torch
+    from safetensors import safe_open
+    from prismaquant import tessera_calibration_cache as cc, tessera_campaign as tc, tessera_hessian as th
+    from prismaquant.calibration_data import load_calibration_input
+    from prismaquant.cost_stage_checkpoint import _load_unit, canonical_json_sha256, unit_path
+    from prismaquant.joint_aura import prefetch_joint_cache
+    from prismaquant.model_profiles import detect_profile
+    from prismaquant.tessera_reader import load_declared_reader, _source_tree
+    from prismaquant.production_weight_cache import ProductionWeightCache, _cache_weight_filename
+    from prismaquant.tessera_joint_aura import calibrated_maxima, verify_anchor_render
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--plan', type=Path, required=True)
+    parser.add_argument('--plan-sha256', required=True)
+    parser.add_argument('--pairs', type=int, default=3)
+    args = parser.parse_args()
+    if args.pairs < 3:
+        parser.error('at least three interleaved measured pairs are required')
+    if cc.sha256(args.plan) != args.plan_sha256:
+        raise ValueError('qualification plan changed')
+    plan = json.loads(args.plan.read_text())
+    root = Path(plan['out']); root.mkdir(parents=True, exist_ok=False)
+    for key in ('cost', 'checkpoint', 'census', 'capture', 'tokens'):
+        if cc.sha256(plan[key]['path']) != plan[key]['sha256']:
+            raise ValueError(f'{key} changed')
+    payload = pickle.loads(Path(plan['cost']['path']).read_bytes())
+    checkpoint = Path(plan['checkpoint']['path'])
+    manifest = json.loads(checkpoint.read_text())
+    identity = manifest['identity']
+    if canonical_json_sha256(identity, where='wire qualification') != manifest['identity_sha256']:
+        raise ValueError('journal identity changed')
+    names = sorted(identity['units'])
+    if names != plan['units']:
+        raise ValueError('exact bounded qualification roster changed')
+    census = json.loads(Path(plan['census']['path']).read_text())
+    profile = detect_profile(census['model'])
+    maxima, scales = calibrated_maxima(SimpleNamespace(census=census, payload=payload), profile)
+    capture = cc.require_capture_contract(plan['capture']['path'], expected_sha256=plan['capture']['sha256'])
+    expected = cc.capture_identity(plan['census']['path'],
+        calibration=payload['provenance']['hessian']['calibration_identity'],
+        max_act_rows=capture['identity']['max_act_rows'],
+        model_load_contract=census['model_load_contract'], attention_implementation=census['attention_implementation'])
+    if expected != capture['identity']:
+        raise ValueError('actual source/capture identity changed')
+    (acts, hessians, _counts, _maxima), _ = cc.prefetch_capture(plan['capture']['path'],
+        expected_sha256=plan['capture']['sha256'], expected_identity=expected, census=census, names=names, device='cuda')
+    calibration_source = th.activation_source(hessians, expected['calibration'])
+    _ids, calibration = load_calibration_input(plan['tokens']['path'], expected_sha256=plan['tokens']['sha256'],
+                                               n_samples=512, seqlen=512)
+    weights = {}
+    with safe_open(str(Path(census['model']) / 'model.safetensors'), framework='pt', device='cpu') as stream:
+        for name in names:
+            weights[name] = stream.get_tensor(name + '.weight').cuda()
+    cells = {}
+    parts = checkpoint.with_name(checkpoint.name + '.parts')
+    for name in names:
+        state = _load_unit(unit_path(parts, name), stage='Tessera campaign', qname=name,
+                           identity_sha256=manifest['identity_sha256'])
+        for anchor in state['anchors']:
+            fmt = anchor['format_name']; record = state['wire_records'][fmt]
+            render = Path(payload['provenance']['cache_dir']) / _cache_weight_filename(name, fmt)
+            cells[name, fmt] = dict(anchor=anchor, record=record,
+                wire=str(Path(payload['provenance']['wire_dir']) / record['file']),
+                render=str(render), render_file_sha256=cc.sha256(render))
+    cache = ProductionWeightCache(weights={pair: cell['render'] for pair, cell in cells.items()},
+                                   levers={'tessera_campaign': True}, activation_max_abs=maxima)
+    cache.enable_lru(plan['max_render_bytes'])
+    formats = {name: sorted(fmt for qname, fmt in cells if qname == name) for name in names}
+    prefetched = prefetch_joint_cache(cache, names, formats, max_resident_bytes=plan['max_render_bytes'])
+    if len(names) != 2 or len(cells) != 14:
+        raise ValueError('qualification requires original two-unit, fourteen-cell roster')
+    # Load the producer API before the reader so module preservation is observable.
+    api = tc._checkpoint_identity_api()
+    import tessera
+    from tessera.unit_artifact import read_unit_artifact
+    primary_root = Path(tessera.__file__).resolve().parent
+    producer_digest, producer_files = _source_tree(primary_root)
+    primary_modules = {name: module for name, module in sys.modules.items()
+                       if name == 'tessera' or name.startswith('tessera.')}
+    reader = load_declared_reader(plan['reader'])
+    if reader is None:
+        raise ValueError('optimized arm requires a separately bound reader')
+    result = {'schema': 'prismaquant.anchor_verify_ab.v1', 'passed': False,
+        'plan_sha256': args.plan_sha256, 'pairs': args.pairs,
+        'env': {'started_epoch': time.time(), 'host': socket.gethostname(),
+            'torch': str(torch.__version__), 'cuda': torch.version.cuda,
+            'device': torch.cuda.get_device_name(), 'cpu_affinity': sorted(__import__('os').sched_getaffinity(0))},
+        'producer': {'path': str(primary_root), 'source_sha256': producer_digest},
+        'reader': reader.identity, 'phases': [], 'comparisons': [],
+        'negative_cases': [], 'prefetch': prefetched,
+        'workload': 'two original dense units, fourteen original wires/renders; same verify_anchor_render and PWC transfer in each arm',
+        'scope': 'resident-prefetched verification only; excludes whole-model streaming, capture intake, and file-hash intake',
+        'first_pair_policy': 'retained separately; first parse, not claimed disk-cold'}
+    anchors = {name: [tc.CampaignAnchor(**cells[name, fmt]['anchor']) for fmt in formats[name]]
+               for name in names}
+    kwargs = dict(calibration_source=calibration_source, projected_unit=None, static_scales=scales)
+
+    def before_verify():
+        records = {}
+        for name in names:
+            for fmt in formats[name]:
+                cell = cells[name, fmt]
+                if cc.sha256(cell['render']) != cell['render_file_sha256']:
+                    raise ValueError('original render changed')
+                records[name, fmt] = verify_anchor_render(cell, weights[name], cache.get(name, fmt).cuda(), **kwargs)
+        return records
+
+    def after_verify():
+        records = {}
+        for name in names:
+            # Binding, source/H hashing and finite checks are inside the timed arm.
+            with tc.bind_checkpoint_unit_identity(anchors[name], source_weight=weights[name], **kwargs) as bound:
+                for fmt in formats[name]:
+                    cell = cells[name, fmt]
+                    if cc.sha256(cell['render']) != cell['render_file_sha256']:
+                        raise ValueError('original render changed')
+                    records[name, fmt] = verify_anchor_render(cell, weights[name], cache.get(name, fmt).cuda(),
+                                                             bound_unit=bound, reader=reader, **kwargs)
+        return records
+
+    reference = None
+    def phase(arm, kind, index, *, profile=False):
+        nonlocal reference
+        torch.cuda.synchronize(); torch.cuda.reset_peak_memory_stats()
+        fn = before_verify if arm == 'before' else after_verify
+        name = f'{kind}-{index:02d}-{arm}'
+        start_epoch = time.time(); start = time.perf_counter()
+        if profile:
+            with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU,
+                 torch.profiler.ProfilerActivity.CUDA], profile_memory=True, record_shapes=True) as profiler:
+                value = fn(); torch.cuda.synchronize()
+            elapsed = time.perf_counter() - start; end_epoch = time.time()
+            profiler.export_chrome_trace(str(root / (name + '.trace.json')))
+            (root / (name + '.operators.txt')).write_text(profiler.key_averages().table(sort_by='self_cuda_time_total', row_limit=60))
+        else:
+            value = fn(); torch.cuda.synchronize()
+            elapsed = time.perf_counter() - start; end_epoch = time.time()
+        if reference is None:
+            reference = value
+        if value != reference:
+            raise ValueError(f'{name}: original/optimized verification records differ')
+        result['phases'].append({'phase': name, 'arm': arm, 'pair': index, 'kind': kind,
+            'start_epoch': start_epoch, 'end_epoch': end_epoch, 'seconds': elapsed,
+            'peak_gpu_bytes': torch.cuda.max_memory_allocated(),
+            'peak_gpu_reserved_bytes': torch.cuda.max_memory_reserved(), 'equal_records': len(value)})
+        print(json.dumps(result['phases'][-1]), flush=True)
+
+    try:
+        for arm in ('before', 'after'):
+            phase(arm, 'first_parse', 0)
+        for index in range(args.pairs):
+            for arm in (('before', 'after') if index % 2 == 0 else ('after', 'before')):
+                phase(arm, 'measured', index)
+        for arm in ('before', 'after'):
+            phase(arm, 'profile', 0, profile=True)
+        result['comparisons'] = [{'unit': name, 'format': fmt, 'equal': True, **record}
+                                 for (name, fmt), record in sorted(reference.items())]
+        pair = next(pair for pair in sorted(cells) if 'E4M3' in pair[1])
+        name, fmt = pair; cell = cells[pair]
+        for arm in ('before', 'after'):
+            for kind in ('render', 'source', 'settings', 'wire'):
+                changed = copy.deepcopy(cell)
+                source, render = weights[name], cache.get(name, fmt).cuda()
+                if kind == 'render':
+                    render = render.clone(); render[0, 0] += 1
+                elif kind == 'source':
+                    source = source.clone(); source[0, 0] += 1
+                elif kind == 'settings':
+                    changed['record']['identity']['recipe']['q256'] += 1
+                else:
+                    altered = bytearray(Path(cell['wire']).read_bytes()); altered[-1] ^= 1
+                    corrupt = root / f'intentional-corrupt-wire-{arm}.bin'; corrupt.write_bytes(altered)
+                    changed['wire'] = str(corrupt)
+                try:
+                    if arm == 'before':
+                        verify_anchor_render(changed, source, render, **kwargs)
+                    else:
+                        with tc.bind_checkpoint_unit_identity(anchors[name], source_weight=source, **kwargs) as bound:
+                            verify_anchor_render(changed, source, render, bound_unit=bound, reader=reader, **kwargs)
+                except (ValueError, RuntimeError) as exc:
+                    result['negative_cases'].append({'arm': arm, 'case': kind, 'refused': True, 'error': str(exc)})
+                else:
+                    raise AssertionError(f'{arm}: {kind} corruption was accepted')
+        after_digest, after_files = _source_tree(primary_root)
+        if (after_digest, after_files) != (producer_digest, producer_files):
+            raise ValueError('primary producer source files changed')
+        if any(sys.modules.get(name) is not module for name, module in primary_modules.items()):
+            raise ValueError('primary producer module object changed')
+        result['producer']['preserved_modules'] = {name: str(Path(module.__file__).resolve())
+            for name, module in primary_modules.items() if getattr(module, '__file__', None)}
+        result['producer']['files_unchanged'] = result['producer']['module_objects_unchanged'] = True
+        medians = {arm: statistics.median(p['seconds'] for p in result['phases']
+                    if p['kind'] == 'measured' and p['arm'] == arm) for arm in ('before', 'after')}
+        result['measured'] = {'median_seconds': medians, 'ratio_before_over_after': medians['before'] / medians['after']}
+        result['units'], result['cells'] = len(names), len(cells)
+        result['passed'] = True
+    except BaseException as exc:
+        result['error'] = {'type': type(exc).__name__, 'message': str(exc)}
+        raise
+    finally:
+        result['env']['finished_epoch'] = time.time()
+        (root / 'results.json').write_text(json.dumps(result, indent=2) + '\n')
+        print(json.dumps({'passed': result['passed'], 'result_sha256': cc.sha256(root / 'results.json')}), flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/experiments/pq322_anchor_verify_ab.sh
+++ b/experiments/pq322_anchor_verify_ab.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+image=eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
+input_root=/mnt/shared/tessera-measurements/first-model-20260907/inputs
+exec docker run --cap-add SYS_PTRACE --security-opt seccomp=unconfined --rm --gpus all --ipc=host --network=host --user "$(id -u):$(id -g)" \
+  -v /home/rob/venvs/pq-release/bin/py-spy:/py-spy:ro -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared -w /workspace --entrypoint python3 \
+  -e PYTHONDONTWRITEBYTECODE=1 -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
+  -e XDG_CACHE_HOME=/tmp/pq-anchor-qualification-cache -e TORCH_EXTENSIONS_DIR=/tmp/pq-anchor-qualification-ext \
+  -e HF_HOME=/tmp/pq-anchor-qualification-hf -e HF_MODULES_CACHE=/tmp/pq-anchor-qualification-modules \
+  -e PRISMABUILD_CONTAINER_OWNER -e PRISMAQUANT_PROD_ACT_SCALES=0 \
+  -e "PYTHONPATH=/workspace:$input_root/tessera-382a1a97/src:$input_root/container-compatible-deps" \
+  "$image" -m experiments.profile_command --output "$1" --profiler /py-spy --rate 50 -- python3 -m experiments.pq322_anchor_verify_ab "${@:2}"

--- a/experiments/pq322_joint_anchor_run.sh
+++ b/experiments/pq322_joint_anchor_run.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 image=eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
 input_root=/mnt/shared/tessera-measurements/first-model-20260907/inputs
-exec docker run --rm --gpus all --ipc=host --network=host --user "$(id -u):$(id -g)" \
+exec docker run --cap-add SYS_PTRACE --security-opt seccomp=unconfined --rm --gpus all --ipc=host --network=host --user "$(id -u):$(id -g)" \
   -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared -w /workspace --entrypoint python3 \
   -e PYTHONDONTWRITEBYTECODE=1 -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
   -e XDG_CACHE_HOME=/tmp/pq-joint-anchor-cache -e TORCH_EXTENSIONS_DIR=/tmp/pq-joint-anchor-ext \

--- a/experiments/pq322_joint_anchor_run.sh
+++ b/experiments/pq322_joint_anchor_run.sh
@@ -9,4 +9,4 @@ exec docker run --rm --gpus all --ipc=host --network=host --user "$(id -u):$(id 
   -e HF_HOME=/tmp/pq-joint-anchor-hf -e HF_MODULES_CACHE=/tmp/pq-joint-anchor-modules \
   -e PRISMABUILD_CONTAINER_OWNER -e PRISMAQUANT_PROD_ACT_SCALES=0 \
   -e "PYTHONPATH=/workspace:$input_root/tessera-382a1a97/src:$input_root/container-compatible-deps" \
-  "$image" -m prismaquant.tessera_joint_aura "$@"
+  "$image" -m experiments.pq_joint_profile_entry "$@"

--- a/experiments/pq_joint_profile_entry.py
+++ b/experiments/pq_joint_profile_entry.py
@@ -1,0 +1,36 @@
+"""Run joint preparation/cost with its declared profiler inside the PB container."""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from experiments.profile_command import run_profile
+
+
+def main(argv=None):
+    args = list(sys.argv[1:] if argv is None else argv)
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("command", choices=("prepare", "run"))
+    parser.add_argument("--plan", type=Path, required=True)
+    parser.add_argument("--plan-sha256", required=True)
+    options, _ = parser.parse_known_args(args)
+    raw = options.plan.read_bytes()
+    if hashlib.sha256(raw).hexdigest() != options.plan_sha256:
+        raise ValueError("profile launch plan checksum changed")
+    plan = json.loads(raw)
+    command = [sys.executable, "-m", "prismaquant.tessera_joint_aura", *args]
+    if plan["profile_tool"] == "cprofile":
+        return subprocess.run(command, check=False).returncode
+    if plan["profile_tool"] != "py-spy":
+        raise ValueError("unsupported joint profiler")
+    target = Path("/tmp/pq-joint-sampling-tool")
+    subprocess.run([sys.executable, "-m", "pip", "install", "--disable-pip-version-check",
+                    "--quiet", "--target", str(target), "py-spy==0.4.2"], check=True)
+    return run_profile(Path(plan["output_root"]) / options.command / "sampling", command,
+                       profiler=str(target / "bin/py-spy"), rate=50)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/pq_profile_cpu_checks.sh
+++ b/experiments/pq_profile_cpu_checks.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
+if [ "$(uname -m)" != x86_64 ] && [ "${PQ_PROFILE_CONTAINER:-0}" != 1 ]; then
+  image=eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
+  exec docker run --rm --user "$(id -u):$(id -g)" \
+    -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared -w /workspace --entrypoint bash \
+    -e PQ_PROFILE_CONTAINER=1 -e PYTHONDONTWRITEBYTECODE=1 \
+    -e CUDA_VISIBLE_DEVICES -e NVIDIA_VISIBLE_DEVICES=void \
+    -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
+    -e PRISMABUILD_CONTAINER_OWNER \
+    "$image" experiments/pq_profile_cpu_checks.sh
+fi
 pq_profile_deps=$(mktemp -d /tmp/pq-profile-checks.XXXXXX)
 trap 'rm -rf "$pq_profile_deps"' EXIT
 pq_profile_python=/home/rob/venvs/pb-cpu/bin/python
+if [ "${PQ_PROFILE_CONTAINER:-0}" = 1 ]; then pq_profile_python=python3; fi
 "$pq_profile_python" -m pip install --disable-pip-version-check --quiet --target "$pq_profile_deps" \
   'py-spy==0.4.2' 'pytest==9.0.2' 'pytest-xdist==3.8.0'
-export PYTHONPATH="$PWD:$pq_profile_deps${PYTHONPATH:+:$PYTHONPATH}"
+export PYTHONPATH="$PWD:$pq_profile_deps:/mnt/shared/tessera-measurements/first-model-20260907/inputs/tessera-382a1a97/src${PYTHONPATH:+:$PYTHONPATH}"
 export PQ_TEST_PY_SPY="$pq_profile_deps/bin/py-spy"
 "$pq_profile_python" -m pytest -n 2 tests/test_profile_command.py -q -p no:cacheprovider
 "$pq_profile_python" -m compileall -q experiments/profile_command.py tests/test_profile_command.py

--- a/experiments/pq_profile_cpu_checks.sh
+++ b/experiments/pq_profile_cpu_checks.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 if [ "$(uname -m)" != x86_64 ] && [ "${PQ_PROFILE_CONTAINER:-0}" != 1 ]; then
   image=eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
-  exec docker run --rm --user "$(id -u):$(id -g)" \
+  exec docker run --cap-add SYS_PTRACE --security-opt seccomp=unconfined --rm --user "$(id -u):$(id -g)" \
     -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared -w /workspace --entrypoint bash \
     -e PQ_PROFILE_CONTAINER=1 -e PYTHONDONTWRITEBYTECODE=1 \
     -e CUDA_VISIBLE_DEVICES -e NVIDIA_VISIBLE_DEVICES=void \

--- a/experiments/pq_profile_cpu_checks.sh
+++ b/experiments/pq_profile_cpu_checks.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+pq_profile_deps=$(mktemp -d /tmp/pq-profile-checks.XXXXXX)
+trap 'rm -rf "$pq_profile_deps"' EXIT
+pq_profile_python=/home/rob/venvs/pb-cpu/bin/python
+"$pq_profile_python" -m pip install --disable-pip-version-check --quiet --target "$pq_profile_deps" \
+  'py-spy==0.4.2' 'pytest==9.0.2' 'pytest-xdist==3.8.0'
+export PYTHONPATH="$PWD:$pq_profile_deps${PYTHONPATH:+:$PYTHONPATH}"
+export PQ_TEST_PY_SPY="$pq_profile_deps/bin/py-spy"
+"$pq_profile_python" -m pytest -n 2 tests/test_profile_command.py -q -p no:cacheprovider
+"$pq_profile_python" -m compileall -q experiments/profile_command.py tests/test_profile_command.py

--- a/experiments/pq_profile_cpu_checks.sh
+++ b/experiments/pq_profile_cpu_checks.sh
@@ -18,5 +18,5 @@ if [ "${PQ_PROFILE_CONTAINER:-0}" = 1 ]; then pq_profile_python=python3; fi
   'py-spy==0.4.2' 'pytest==9.0.2' 'pytest-xdist==3.8.0'
 export PYTHONPATH="$PWD:$pq_profile_deps:/mnt/shared/tessera-measurements/first-model-20260907/inputs/tessera-382a1a97/src${PYTHONPATH:+:$PYTHONPATH}"
 export PQ_TEST_PY_SPY="$pq_profile_deps/bin/py-spy"
-"$pq_profile_python" -m pytest -n 2 tests/test_profile_command.py -q -p no:cacheprovider
-"$pq_profile_python" -m compileall -q experiments/profile_command.py tests/test_profile_command.py
+"$pq_profile_python" -m pytest -n 2 tests/test_profile_command.py tests/test_tessera_joint_aura.py tests/test_tessera_reader_namespace.py -q -p no:cacheprovider
+"$pq_profile_python" -X "pycache_prefix=$pq_profile_deps/pycache" -m compileall -q experiments/profile_command.py experiments/pq_joint_profile_entry.py prismaquant/tessera_joint_aura.py tests/test_profile_command.py tests/test_tessera_joint_aura.py

--- a/experiments/profile_command.py
+++ b/experiments/profile_command.py
@@ -61,6 +61,7 @@ def run_profile(output, command, *, profiler, rate):
         if path.is_file():
             blob = path.read_bytes()
             result["artifacts"][path.name] = {"bytes": len(blob), "sha256": hashlib.sha256(blob).hexdigest()}
+    result["sampler_log"] = (output / "sampler.log").read_text()
     child = result["child"]
     result["passed"] = (sampled.returncode == 0 and isinstance(child, dict)
                         and child.get("command") == command and type(child.get("returncode")) is int

--- a/experiments/profile_command.py
+++ b/experiments/profile_command.py
@@ -1,0 +1,90 @@
+"""Sample an admitted command without deterministic per-call profiling.
+
+The child writes its own exit receipt: a successful profiler process alone
+does not establish that the observed command succeeded. Run through PB.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+
+def write_json(path, value):
+    with path.open("x") as stream:
+        json.dump(value, stream, sort_keys=True, allow_nan=False)
+        stream.write("\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
+def run_child(output, command):
+    started = time.time()
+    result = {"schema": "prismaquant.profiled_command_exit.v1", "command": command,
+              "started_unix": started, "returncode": None}
+    try:
+        child = subprocess.run(command, check=False)
+        result["returncode"] = child.returncode
+        return child.returncode
+    finally:
+        result["finished_unix"] = time.time()
+        write_json(output / "child-exit.json", result)
+
+
+def run_profile(output, command, *, profiler, rate):
+    output.mkdir(parents=True, exist_ok=False)
+    started = time.time()
+    raw = output / "stacks.raw"
+    argv = [profiler, "record", "--subprocesses", "--rate", str(rate),
+            "--format", "raw", "--output", str(raw), "--", sys.executable,
+            str(Path(__file__).resolve()), "--child", "--output", str(output), "--", *command]
+    with (output / "sampler.log").open("x") as log:
+        sampled = subprocess.run(argv, stdout=log, stderr=subprocess.STDOUT, check=False)
+    result = {"schema": "prismaquant.sampled_command.v1", "command": command,
+              "profiler_command": argv, "profiler_returncode": sampled.returncode,
+              "started_unix": started, "finished_unix": time.time(),
+              "passed": False, "child": None, "artifacts": {}}
+    receipt = output / "child-exit.json"
+    if receipt.is_file():
+        result["child"] = json.loads(receipt.read_text())
+    for path in (receipt, raw, output / "sampler.log"):
+        if path.is_file():
+            blob = path.read_bytes()
+            result["artifacts"][path.name] = {"bytes": len(blob), "sha256": hashlib.sha256(blob).hexdigest()}
+    child = result["child"]
+    result["passed"] = (sampled.returncode == 0 and isinstance(child, dict)
+                        and child.get("command") == command and type(child.get("returncode")) is int
+                        and child["returncode"] == 0 and raw.is_file() and raw.stat().st_size > 0)
+    write_json(output / "profile-result.json", result)
+    print(json.dumps(result, sort_keys=True), flush=True)
+    if result["passed"]:
+        return 0
+    if isinstance(child, dict) and type(child.get("returncode")) is int and child["returncode"]:
+        return child["returncode"] if child["returncode"] > 0 else 128 - child["returncode"]
+    return sampled.returncode or 1
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--profiler", default="py-spy")
+    parser.add_argument("--rate", type=int, default=50)
+    parser.add_argument("--child", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    command = args.command[1:] if args.command[:1] == ["--"] else args.command
+    if not command or not 1 <= args.rate <= 1000:
+        parser.error("a command and a sampling rate in [1,1000] are required")
+    output = args.output.resolve()
+    if args.child:
+        return run_child(output, command)
+    return run_profile(output, command, profiler=args.profiler, rate=args.rate)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/profile_command.py
+++ b/experiments/profile_command.py
@@ -28,7 +28,12 @@ def run_child(output, command):
     result = {"schema": "prismaquant.profiled_command_exit.v1", "command": command,
               "started_unix": started, "returncode": None}
     try:
-        child = subprocess.run(command, check=False)
+        start_path = output / "child-start.json"
+        write_json(start_path, {"schema": "prismaquant.profiled_command_start.v1",
+                               "wrapper_pid": os.getpid(), "command": command,
+                               "started_unix": started})
+        environment = dict(os.environ, PRISMAQUANT_SAMPLER_SESSION=str(start_path))
+        child = subprocess.run(command, check=False, env=environment)
         result["returncode"] = child.returncode
         return child.returncode
     finally:
@@ -52,7 +57,7 @@ def run_profile(output, command, *, profiler, rate):
     receipt = output / "child-exit.json"
     if receipt.is_file():
         result["child"] = json.loads(receipt.read_text())
-    for path in (receipt, raw, output / "sampler.log"):
+    for path in (output / "child-start.json", receipt, raw, output / "sampler.log"):
         if path.is_file():
             blob = path.read_bytes()
             result["artifacts"][path.name] = {"bytes": len(blob), "sha256": hashlib.sha256(blob).hexdigest()}

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -1476,8 +1476,140 @@ def _campaign_checkpoint_identity(*, weights, acts, hessians, menus, args,
     }
 
 
+def _bound_tensor_signature(tensor):
+    """Track one versioned tensor during a caller-owned immutable lifetime."""
+    try:
+        version = tensor._version
+    except RuntimeError as exc:
+        raise ValueError("bound checkpoint identity requires a version-tracked tensor") from exc
+    return (id(tensor), tensor.untyped_storage().data_ptr(), tensor.storage_offset(),
+            tuple(tensor.shape), tuple(tensor.stride()), tensor.device, tensor.dtype, version)
+
+
+class _BoundCheckpointUnitIdentity:
+    """Actual producer inputs shared only across one unit's closed format roster.
+
+    This owns identity records, never weights or a second tensor cache. Strong
+    references and storage/version guards delimit the caller's immutable source
+    and H lifetime; close before unloading, replacing or mutating either tensor.
+    The ordinary producer API supplies the source/H/settings identity once. Its
+    recipe remains Tessera's per-format wire_recipe, not a copied receipt field.
+    """
+
+    def __init__(self, anchors, *, source_weight, calibration_source,
+                 projected_unit, static_scales):
+        import copy
+        import torch
+        from types import SimpleNamespace
+        from .production_weight_cache import _cb_cache_tensor_identity
+
+        anchors = tuple(anchors)
+        names = {anchor.qname for anchor in anchors}
+        formats = {anchor.format_name for anchor in anchors}
+        if len(names) != 1 or not formats or len(formats) != len(anchors):
+            raise ValueError("bound checkpoint identity requires one unit's unique closed anchor roster")
+        self._closed = False
+        self._name = next(iter(names))
+        self._formats = frozenset(formats)
+        self._weight = source_weight
+        self._weight_signature = _bound_tensor_signature(source_weight)
+        if not bool(torch.isfinite(source_weight).all()):
+            raise ValueError("bound checkpoint identity source is nonfinite")
+        # A representative H-bearing anchor supplies the common calibration
+        # record; H-free members remove that record, as the ordinary API does.
+        representative = max(anchors, key=lambda anchor: bool(anchor.hessian_applied))
+        self._calibration = calibration_source if representative.hessian_applied else None
+        self._hessian = None if self._calibration is None else self._calibration.hessians[self._name]
+        self._hessian_signature = None if self._hessian is None else _bound_tensor_signature(self._hessian)
+        if self._hessian is not None and not bool(torch.isfinite(self._hessian).all()):
+            raise ValueError("bound checkpoint identity Hessian is nonfinite")
+        self._projection = projected_unit
+        self._projection_record = copy.deepcopy(projected_unit)
+        self._template = _checkpoint_anchor_identity(representative,
+            weights={self._name: source_weight},
+            menus={self._name: [SimpleNamespace(format_name=fmt) for fmt in formats]},
+            calibration_source=calibration_source, static_scales=static_scales,
+            projected_units={} if projected_unit is None else {self._name: projected_unit})
+        self._settings = self._calibration_settings()
+        self._source_receipt = _cb_cache_tensor_identity(source_weight)
+        self._guard()
+
+    def _calibration_settings(self):
+        if self._calibration is None:
+            return None
+        api = _checkpoint_identity_api()
+        settings = self._calibration.config_block()
+        settings.pop("note", None)
+        settings["hessian"] = {key: self._calibration.provenance[key]
+                               for key in api.HESSIAN_IDENTITY}
+        return settings
+
+    def _guard(self):
+        if self._closed:
+            raise ValueError("bound checkpoint identity is closed")
+        if _bound_tensor_signature(self._weight) != self._weight_signature:
+            raise ValueError("bound checkpoint source tensor changed")
+        if self._calibration is not None:
+            if (self._calibration.hessians.get(self._name) is not self._hessian or
+                    _bound_tensor_signature(self._hessian) != self._hessian_signature):
+                raise ValueError("bound checkpoint Hessian tensor changed")
+            if self._calibration_settings() != self._settings:
+                raise ValueError("bound checkpoint calibration settings changed")
+        if self._projection != self._projection_record:
+            raise ValueError("bound checkpoint producer projection changed")
+
+    def derive(self, *, source_weight, qname, format_name, grid, rung,
+               activation, projected_unit):
+        import copy
+        self._guard()
+        if (source_weight is not self._weight or qname != self._name or
+                format_name not in self._formats or projected_unit != self._projection_record or
+                (activation is not None and activation is not self._calibration)):
+            raise ValueError("inputs differ from bound checkpoint unit")
+        result = copy.deepcopy(self._template)
+        result["calibration"] = None if activation is None else result["calibration"]
+        if activation is not None and result["calibration"] is None:
+            raise ValueError("bound checkpoint unit has no H-bearing identity")
+        # wire_recipe is the unchanged owner used by encoding_input_identity.
+        # Its full settings, including body/plane/reach, are resolved anew.
+        recipe = _checkpoint_identity_api().wire_recipe(grid, rung)
+        result["recipe"] = {"grid": grid.name, "q256": rung, **recipe.to_config()}
+        return result
+
+    def source_receipt(self, source_weight):
+        import copy
+        self._guard()
+        if source_weight is not self._weight:
+            raise ValueError("source differs from bound checkpoint unit")
+        return copy.deepcopy(self._source_receipt)
+
+    def close(self):
+        self._closed = True
+        self._weight = self._hessian = self._calibration = None
+        self._template = self._source_receipt = self._projection = None
+
+    def __enter__(self):
+        self._guard()
+        return self
+
+    def __exit__(self, exc_type, _exc, _traceback):
+        try:
+            if exc_type is None:
+                self._guard()
+        finally:
+            self.close()
+
+
+def bind_checkpoint_unit_identity(anchors, *, source_weight, calibration_source,
+                                  projected_unit, static_scales):
+    """Bind actual inputs once; accepts no caller-supplied hash or receipt."""
+    return _BoundCheckpointUnitIdentity(anchors, source_weight=source_weight,
+        calibration_source=calibration_source, projected_unit=projected_unit,
+        static_scales=static_scales)
+
+
 def _checkpoint_anchor_identity(anchor, *, weights, menus, calibration_source,
-                                static_scales, projected_units=None):
+                                static_scales, projected_units=None, bound_unit=None):
     """The resumed row's inputs, as this run's producer would stamp them.
 
     A unit in ``projected_units`` (``{qname: producer unit record}``) is a
@@ -1517,6 +1649,12 @@ def _checkpoint_anchor_identity(anchor, *, weights, menus, calibration_source,
     _require_resumable_anchor(anchor, static_scales)
     api = _checkpoint_identity_api()
     projected = (projected_units or {}).get(anchor.qname)
+    if bound_unit is not None:
+        if not isinstance(bound_unit, _BoundCheckpointUnitIdentity):
+            raise ValueError("expected an actual bound checkpoint unit identity")
+        return bound_unit.derive(source_weight=weights[anchor.qname], qname=anchor.qname,
+            format_name=anchor.format_name, grid=family.payload_grid(), rung=int(rung),
+            activation=activation, projected_unit=projected)
     if projected is not None:
         return api.unit_input_identity(
             weights[anchor.qname], dict(projected), family.payload_grid(), int(rung),

--- a/prismaquant/tessera_joint_aura.py
+++ b/prismaquant/tessera_joint_aura.py
@@ -221,7 +221,7 @@ def calibrated_maxima(data, profile):
 
 
 def verify_anchor_render(cell, source_weight, rendered_weight, *, calibration_source,
-                         projected_unit, static_scales):
+                         projected_unit, static_scales, bound_unit=None):
     """Re-derive encoder inputs from actual source/H and compare decoded bytes."""
     import torch
     from tessera.unit_artifact import read_unit_artifact
@@ -233,18 +233,21 @@ def verify_anchor_render(cell, source_weight, rendered_weight, *, calibration_so
     _require(source_weight.dtype == rendered_weight.dtype == torch.bfloat16 and
              source_weight.ndim == 2 and rendered_weight.shape == source_weight.shape,
              f"{name}@{fmt}: source/render BF16 shape differs")
-    _require(bool(torch.isfinite(source_weight).all()) and bool(torch.isfinite(rendered_weight).all()),
-             f"{name}@{fmt}: source/render is nonfinite")
+    source_receipt = (None if bound_unit is None else bound_unit.source_receipt(source_weight))
+    _require((bound_unit is not None or bool(torch.isfinite(source_weight).all())) and
+             bool(torch.isfinite(rendered_weight).all()), f"{name}@{fmt}: source/render is nonfinite")
     expected = tc._checkpoint_anchor_identity(anchor,
         weights={name: source_weight}, menus={name: [SimpleNamespace(format_name=fmt)]},
         calibration_source=calibration_source, static_scales=static_scales,
-        projected_units={} if projected_unit is None else {name: projected_unit})
+        projected_units={} if projected_unit is None else {name: projected_unit},
+        **({} if bound_unit is None else {"bound_unit": bound_unit}))
     blob = Path(cell["wire"]).read_bytes()
     tc._checkpoint_identity_api().verify_cached_unit(blob, cell["record"], expected)
     decoded = read_unit_artifact(blob, device=str(rendered_weight.device)).to(torch.bfloat16)
     _require(torch.equal(decoded, rendered_weight), f"{name}@{fmt}: decoded wire differs from original PWC render")
     del decoded
-    return {"source_weight": _cb_cache_tensor_identity(source_weight),
+    return {"source_weight": (_cb_cache_tensor_identity(source_weight)
+                              if source_receipt is None else source_receipt),
             "rendered_weight": _cb_cache_tensor_identity(rendered_weight),
             "encoding_identity_sha256": canonical_json_sha256(expected, where="joint anchor encoding"),
             "wire_sha256": hashlib.sha256(blob).hexdigest(),
@@ -270,7 +273,7 @@ def prepare_cache(runner, data, *, capture, max_render_bytes):
     even though the merged renders have more than one original directory.
     """
     import torch
-    from . import tessera_calibration_cache as cc, tessera_hessian as th
+    from . import tessera_calibration_cache as cc, tessera_hessian as th, tessera_campaign as tc
     from .joint_aura import activation_identity, prefetch_joint_cache
     from .production_weight_cache import ProductionWeightCache
     from .routed_experts import PackedExpertProjection, refresh_packed_expert_projections
@@ -325,19 +328,23 @@ def prepare_cache(runner, data, *, capture, max_render_bytes):
             stats = prefetch_joint_cache(cache, names, renders, max_resident_bytes=max_render_bytes)
             for name in names:
                 source_weight = targets[name].weight.detach()
-                for fmt in renders[name]:
-                    cell = data.cells[name, fmt]
-                    _same(_sha(cell["render"]), cell["render_file_sha256"], f"{name}: original render file changed")
-                    rendered = cache.get(name, fmt).to(runner.device)
-                    record = verify_anchor_render(cell, source_weight, rendered,
-                        calibration_source=calibration_source,
-                        projected_unit=projected.get(name), static_scales=scales)
-                    activation = activation_identity(fr.get_format(fmt), cache.activation_max_abs, name)
-                    _same(activation["input_global_scale"], cell["anchor"].get("input_global_scale"),
-                          f"{name}@{fmt}: joint/campaign static scale")
-                    record["activation"] = activation
-                    verified[name, fmt] = record
-                    del rendered
+                anchors = [tc.CampaignAnchor(**data.cells[name, fmt]["anchor"]) for fmt in renders[name]]
+                with tc.bind_checkpoint_unit_identity(anchors, source_weight=source_weight,
+                        calibration_source=calibration_source, projected_unit=projected.get(name),
+                        static_scales=scales) as bound_unit:
+                    for fmt in renders[name]:
+                        cell = data.cells[name, fmt]
+                        _same(_sha(cell["render"]), cell["render_file_sha256"], f"{name}: original render file changed")
+                        rendered = cache.get(name, fmt).to(runner.device)
+                        record = verify_anchor_render(cell, source_weight, rendered,
+                            calibration_source=calibration_source,
+                            projected_unit=projected.get(name), static_scales=scales, bound_unit=bound_unit)
+                        activation = activation_identity(fr.get_format(fmt), cache.activation_max_abs, name)
+                        _same(activation["input_global_scale"], cell["anchor"].get("input_global_scale"),
+                              f"{name}@{fmt}: joint/campaign static scale")
+                        record["activation"] = activation
+                        verified[name, fmt] = record
+                        del rendered
             telemetry.append({"layer": layer, **stats})
             print(json.dumps({"qualified_layer": layer, "qualified_cells": len(verified),
                               "total_cells": len(data.cells), "prefetch": stats}), flush=True)

--- a/prismaquant/tessera_joint_aura.py
+++ b/prismaquant/tessera_joint_aura.py
@@ -425,7 +425,8 @@ def _load_plan(path, digest):
     _same(execution.get("token_scope"), "all", "full-draw joint token scope")
     _same(execution.get("temperature"), 1.0, "joint probe temperature")
     _same(execution.get("production_act_scales"), "0", "campaign optional activation clipping")
-    _same(config.get("profile_tool"), "cprofile", "full-duration in-process profiler")
+    _require(config.get("profile_tool") in {"cprofile", "py-spy"},
+             "explicit supported full-duration profiler required")
     for name in ("max_render_bytes", "max_gpu_bytes"):
         _require(type(config.get(name)) is int and config[name] > 0, f"positive {name} required")
     _require(type(config.get("min_free_gib")) in (int, float) and config["min_free_gib"] >= 0,
@@ -471,11 +472,25 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False):
                   "started_epoch": time.time(), "torch": str(torch.__version__),
                   "cuda": torch.version.cuda, "affinity": sorted(os.sched_getaffinity(0))},
               "phases": [], "passed": False}
-    profiler = cProfile.Profile()
+    profile_tool = config.get("profile_tool", "cprofile")
+    profiler = cProfile.Profile() if profile_tool == "cprofile" else None
+    result["profile_tool"] = profile_tool
+    if profiler is None:
+        session_path = Path(os.environ.get("PRISMAQUANT_SAMPLER_SESSION", ""))
+        _require(session_path.is_file(), "sampling must run through the checked profiler launcher")
+        session_bytes = session_path.read_bytes()
+        session = json.loads(session_bytes)
+        _same(session.get("schema"), "prismaquant.profiled_command_start.v1", "sampler session schema")
+        _same(session.get("wrapper_pid"), os.getppid(), "actual sampler child parent")
+        _same(session.get("command", [])[1:4],
+              ["-m", "prismaquant.tessera_joint_aura", command], "observed joint command")
+        result["sampling_session"] = {"path": str(session_path),
+                                      "sha256": hashlib.sha256(session_bytes).hexdigest()}
     runner = None
     completion_path = completion = output = payload = None
     started, before_io = time.time(), _io_counters()
-    profiler.enable()
+    if profiler is not None:
+        profiler.enable()
     try:
         file_hash_workers = config.get("file_hash_workers", 1)
         _require(type(file_hash_workers) is int and 0 < file_hash_workers <= len(os.sched_getaffinity(0)),
@@ -589,11 +604,12 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False):
             result["cost"] = {"path": str(output), "sha256": _sha(output)}
         result["passed"] = True
     finally:
-        profiler.disable()
-        profiler.dump_stats(str(root / "profile.pstats"))
-        text = io.StringIO()
-        pstats.Stats(profiler, stream=text).sort_stats("cumulative").print_stats(100)
-        (root / "profile.txt").write_text(text.getvalue())
+        if profiler is not None:
+            profiler.disable()
+            profiler.dump_stats(str(root / "profile.pstats"))
+            text = io.StringIO()
+            pstats.Stats(profiler, stream=text).sort_stats("cumulative").print_stats(100)
+            (root / "profile.txt").write_text(text.getvalue())
         result["env"]["finished_epoch"] = time.time()
         result["phases"].append({"phase": command, "kind": "profile", "start_epoch": started,
                                  "end_epoch": result["env"]["finished_epoch"]})

--- a/prismaquant/tessera_joint_aura.py
+++ b/prismaquant/tessera_joint_aura.py
@@ -247,7 +247,7 @@ def calibrated_maxima(data, profile):
 
 
 def verify_anchor_render(cell, source_weight, rendered_weight, *, calibration_source,
-                         projected_unit, static_scales, bound_unit=None):
+                         projected_unit, static_scales, bound_unit=None, reader=None):
     """Re-derive encoder inputs from actual source/H and compare decoded bytes."""
     import torch
     from tessera.unit_artifact import read_unit_artifact
@@ -268,8 +268,10 @@ def verify_anchor_render(cell, source_weight, rendered_weight, *, calibration_so
         projected_units={} if projected_unit is None else {name: projected_unit},
         **({} if bound_unit is None else {"bound_unit": bound_unit}))
     blob = Path(cell["wire"]).read_bytes()
-    tc._checkpoint_identity_api().verify_cached_unit(blob, cell["record"], expected)
-    decoded = read_unit_artifact(blob, device=str(rendered_weight.device)).to(torch.bfloat16)
+    verifier = tc._checkpoint_identity_api() if reader is None else reader
+    verifier.verify_cached_unit(blob, cell["record"], expected)
+    decode = read_unit_artifact if reader is None else reader.read_unit_artifact
+    decoded = decode(blob, device=str(rendered_weight.device)).to(torch.bfloat16)
     _require(torch.equal(decoded, rendered_weight), f"{name}@{fmt}: decoded wire differs from original PWC render")
     del decoded
     return {"source_weight": (_cb_cache_tensor_identity(source_weight)
@@ -291,7 +293,7 @@ def _live_targets(runner, names):
     return {name: targets[name] for name in names}
 
 
-def prepare_cache(runner, data, *, capture, max_render_bytes):
+def prepare_cache(runner, data, *, capture, max_render_bytes, reader=None):
     """Qualify original per-layer inputs and return the existing PWC object.
 
     Only the original calibration/PWC/source prefetch mechanisms own tensors.
@@ -325,7 +327,8 @@ def prepare_cache(runner, data, *, capture, max_render_bytes):
     cache = ProductionWeightCache(
         weights={pair: cell["render"] for pair, cell in data.cells.items()},
         levers={"tessera_campaign": True}, activation_max_abs=maxima,
-        metadata={"schema": PREPARED_SCHEMA, "inputs": data.inputs})
+        metadata={"schema": PREPARED_SCHEMA, "inputs": data.inputs,
+                  "reader_identity": None if reader is None else reader.identity})
     cache.enable_lru(max_render_bytes)
     targets = _live_targets(runner, data.formats_by_qname)
     layers = defaultdict(list)
@@ -364,7 +367,8 @@ def prepare_cache(runner, data, *, capture, max_render_bytes):
                         rendered = cache.get(name, fmt).to(runner.device)
                         record = verify_anchor_render(cell, source_weight, rendered,
                             calibration_source=calibration_source,
-                            projected_unit=projected.get(name), static_scales=scales, bound_unit=bound_unit)
+                            projected_unit=projected.get(name), static_scales=scales,
+                            bound_unit=bound_unit, reader=reader)
                         activation = activation_identity(fr.get_format(fmt), cache.activation_max_abs, name)
                         _same(activation["input_global_scale"], cell["anchor"].get("input_global_scale"),
                               f"{name}@{fmt}: joint/campaign static scale")
@@ -452,6 +456,7 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False):
     from .model_profiles import detect_profile
     from .production_weight_cache import ProductionWeightCache
     from .gpu_guard import require_cuda_hot_path
+    from .tessera_reader import load_declared_reader
 
     require_cuda_hot_path("tessera_joint_aura", "cuda")
     os.environ["PRISMAQUANT_PROD_ACT_SCALES"] = config["execution"]["production_act_scales"]
@@ -478,6 +483,9 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False):
         data = load_measured_anchor_input(config["inputs"],
             **({} if file_hash_workers == 1 else {"file_hash_workers": file_hash_workers}))
         result["file_hash_workers"] = file_hash_workers
+        reader = load_declared_reader(config.get("reader"))
+        reader_identity = None if reader is None else reader.identity
+        result["reader_identity"] = reader_identity
         _same(config["model"], data.census["model"], "requested source model")
         _same(data.census["attention_implementation"], "eager", "qualified source attention")
         ids, calibration = load_calibration_input(config["calibration_input"]["path"],
@@ -508,7 +516,7 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False):
             completion_path = root / "prepared.json"
             _require(not completion_path.exists(), "prepared completion already exists; use its bound record")
             cache = prepare_cache(runner, data, capture=config["canonical_capture"],
-                                  max_render_bytes=config["max_render_bytes"])
+                                  max_render_bytes=config["max_render_bytes"], reader=reader)
             cache.metadata.update(plan_sha256=plan_sha256, source_model_identity=source,
                                   source_execution=source_execution, implementation_sha256=implementation)
             cache.compact_for_pickle()
@@ -516,6 +524,7 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False):
             atomic_write_bytes(cache_path, pickle.dumps(cache, protocol=pickle.HIGHEST_PROTOCOL))
             completion = {"schema": PREPARED_SCHEMA, "status": "complete", "plan_sha256": plan_sha256,
                 "implementation_sha256": implementation, "source_model_identity": source,
+                "reader_identity": reader_identity,
                 "source_execution": source_execution, "calibration_input": calibration,
                 "production_cache": {"path": str(cache_path), "sha256": _sha(cache_path)},
                 "formats_by_qname": data.formats_by_qname, "measured_cells": len(data.cells)}
@@ -526,13 +535,15 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False):
             _same(completion.get("status"), "complete", "prepared completion")
             for key, value in (("plan_sha256", plan_sha256), ("implementation_sha256", implementation),
                                ("source_model_identity", source), ("source_execution", source_execution),
-                               ("calibration_input", calibration), ("measured_cells", len(data.cells))):
+                               ("calibration_input", calibration), ("measured_cells", len(data.cells)),
+                               ("reader_identity", reader_identity)):
                 _same(completion.get(key), value, f"prepared {key}")
             _same(completion["formats_by_qname"], {n: list(v) for n, v in data.formats_by_qname.items()},
                   "prepared exact candidate roster")
             cache = pickle.loads(_bound(completion["production_cache"], "qualified PWC").read_bytes())
             _require(isinstance(cache, ProductionWeightCache), "prepared cache is not ProductionWeightCache")
             _same(cache.metadata["inputs"], data.inputs, "prepared source bindings")
+            _same(cache.metadata.get("reader_identity"), reader_identity, "prepared reader identity")
             _same(set(cache.metadata["verified_cells"]), set(data.cells), "prepared verified cell coverage")
             _same(cache.weights, {pair: cell["render"] for pair, cell in data.cells.items()}, "prepared original render paths")
             for pair, cell in data.cells.items():
@@ -551,7 +562,8 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False):
                 checkpoint_dir=Path(config["output_root"]) / "checkpoints", resume=resume,
                 model_identity=source, profile=runner.profile,
                 checkpoint_identity_extra={"tessera_joint_anchor_plan_sha256": plan_sha256,
-                    "prepared_anchor_sha256": prepared["sha256"], "calibration_input": calibration})
+                    "prepared_anchor_sha256": prepared["sha256"], "calibration_input": calibration,
+                    "reader_identity": reader_identity})
             _same(set(payload["costs"]), set(data.formats_by_qname), "complete joint output roster")
             for name, rows in payload["costs"].items():
                 _same(set(rows), set(data.formats_by_qname[name]), f"{name}: joint output candidates")

--- a/prismaquant/tessera_joint_aura.py
+++ b/prismaquant/tessera_joint_aura.py
@@ -77,7 +77,7 @@ class MeasuredAnchorInput:
         return dict(sizes)
 
 
-def load_measured_anchor_input(inputs):
+def load_measured_anchor_input(inputs, *, file_hash_workers=1):
     """Read a complete merged journal and select only its measured wire cells.
 
     This is a hash/receipt intake. Tensor/source/encoder verification occurs in
@@ -87,6 +87,8 @@ def load_measured_anchor_input(inputs):
     from .production_weight_cache import _cache_weight_filename
     from tools.dispatch_tessera_campaign import _require_receipts
 
+    _require(type(file_hash_workers) is int and file_hash_workers > 0,
+             "positive file_hash_workers required")
     paths = {key: _bound(inputs[key], key) for key in (
         "campaign_plan", "census", "campaign_receipts", "merged_cost", "merged_checkpoint")}
     census = json.loads(paths["census"].read_text())
@@ -196,12 +198,36 @@ def load_measured_anchor_input(inputs):
             wire = wire_dir / filename
             _require(not wire.is_symlink() and wire.resolve().parent == wire_dir.resolve(), f"{name}: escaping wire path")
             _same(wire.stat().st_size, record["blob_bytes"], f"{name}: wire size")
-            _same(_sha(wire), record["blob_sha256"], f"{name}: wire checksum")
             render = owners[name] / "cache" / _cache_weight_filename(name, fmt)
             _require(render.is_file(), f"{name}@{fmt}: original decoded PWC shard missing")
             cells[name, fmt] = {"anchor": anchor, "record": record, "wire": str(wire.resolve()),
-                               "render": str(render.resolve()), "render_file_sha256": _sha(render)}
+                               "render": str(render.resolve())}
         formats[name] = (*sorted(anchors), "BF16")
+    def verify_files(item):
+        pair, cell = item
+        wire, render = Path(cell["wire"]), Path(cell["render"])
+        # Metadata is only a race detector around the actual content hash.
+        # Every byte is still hashed; neither timestamps nor a previous run
+        # authorize reuse. Existing per-consumption render checks remain below.
+        def signature(path):
+            stat = path.stat()
+            return stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns, stat.st_ctime_ns
+        before = [signature(p) for p in (wire, render)]
+        _same(_sha(wire), cell["record"]["blob_sha256"], f"{pair}: wire checksum")
+        digest = _sha(render)
+        after = [signature(p) for p in (wire, render)]
+        _same(after, before, f"{pair}: input files changed while hashing")
+        return pair, digest
+
+    if file_hash_workers == 1:
+        verified_files = map(verify_files, cells.items())
+        for pair, digest in verified_files:
+            cells[pair]["render_file_sha256"] = digest
+    else:
+        from concurrent.futures import ThreadPoolExecutor
+        with ThreadPoolExecutor(max_workers=file_hash_workers, thread_name_prefix="anchor-file-hash") as workers:
+            for pair, digest in workers.map(verify_files, cells.items()):
+                cells[pair]["render_file_sha256"] = digest
     return MeasuredAnchorInput(dict(inputs), payload, manifest, census, plan, cells, formats)
 
 
@@ -385,6 +411,8 @@ def _load_plan(path, digest):
     _same(config.get("schema"), SCHEMA, "joint anchor plan schema")
     _source_prefetch(config)
     execution = config["execution"]
+    _require(type(config.get("file_hash_workers", 1)) is int and config.get("file_hash_workers", 1) > 0,
+             "positive file_hash_workers required")
     for name, minimum in (("n_calib_samples", 1), ("calib_seqlen", 1),
                           ("probe_microbatch", 1), ("n_probes", 2)):
         _require(type(execution.get(name)) is int and execution[name] >= minimum,
@@ -444,7 +472,12 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False):
     started, before_io = time.time(), _io_counters()
     profiler.enable()
     try:
-        data = load_measured_anchor_input(config["inputs"])
+        file_hash_workers = config.get("file_hash_workers", 1)
+        _require(type(file_hash_workers) is int and 0 < file_hash_workers <= len(os.sched_getaffinity(0)),
+                 "file_hash_workers exceeds PB-assigned CPU affinity")
+        data = load_measured_anchor_input(config["inputs"],
+            **({} if file_hash_workers == 1 else {"file_hash_workers": file_hash_workers}))
+        result["file_hash_workers"] = file_hash_workers
         _same(config["model"], data.census["model"], "requested source model")
         _same(data.census["attention_implementation"], "eager", "qualified source attention")
         ids, calibration = load_calibration_input(config["calibration_input"]["path"],

--- a/prismaquant/tessera_reader.py
+++ b/prismaquant/tessera_reader.py
@@ -1,0 +1,127 @@
+"""An explicitly bound Tessera consumer beside an unchanged primary producer.
+
+The primary ``tessera`` package derives original source/H/encoder inputs. This
+reader consumes those independently derived identities and original bytes;
+its own source digest is separate provenance, never substituted into a producer
+receipt. No serving runtime is imported and no module is monkeypatched.
+"""
+from __future__ import annotations
+
+import ast
+import hashlib
+import importlib
+import importlib.abc
+import importlib.machinery
+import importlib.util
+from pathlib import Path
+import re
+import sys
+from types import SimpleNamespace
+
+SOURCE_SUFFIXES = {'.py', '.cu', '.cuh', '.cpp', '.h'}
+
+
+def _source_tree(root):
+    """The owner's encoder_source_sha256 framing, read without importing it."""
+    digest = hashlib.sha256()
+    files = {}
+    for path in sorted(p for p in root.rglob('*') if p.suffix in SOURCE_SUFFIXES):
+        if path.is_symlink() or not path.is_file():
+            raise ValueError('reader source must be regular files in its declared package')
+        raw = path.read_bytes()
+        relative = path.relative_to(root).as_posix()
+        digest.update(relative.encode() + b'\0'); digest.update(raw); digest.update(b'\0')
+        files[str(path.resolve())] = hashlib.sha256(raw).hexdigest()
+    if not files or not (root / '__init__.py').is_file():
+        raise ValueError('reader source must name a complete package directory')
+    return digest.hexdigest(), files
+
+
+class _ReaderSourceLoader(importlib.machinery.SourceFileLoader):
+    def __init__(self, fullname, path, expected):
+        super().__init__(fullname, path)
+        self.expected = expected
+
+    def get_code(self, fullname):
+        # Always read the bound source, including after another interpreter
+        # wrote bytecode. Every imported file must still match the package seal.
+        raw = Path(self.path).read_bytes()
+        if hashlib.sha256(raw).hexdigest() != self.expected:
+            raise ImportError('reader source changed after its package checksum')
+        tree = ast.parse(raw, filename=self.path)
+        for node in ast.walk(tree):
+            names = []
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.level == 0:
+                names = [node.module or '']
+            elif isinstance(node, ast.Call) and node.args:
+                func = node.func
+                name = func.attr if isinstance(func, ast.Attribute) else getattr(func, 'id', '')
+                if name in {'import_module', '__import__', 'files'} and isinstance(node.args[0], ast.Constant):
+                    names = [node.args[0].value]
+            if any(isinstance(name, str) and (name == 'tessera' or name.startswith('tessera.')) for name in names):
+                raise ImportError(f'{fullname} contains an absolute tessera import; reader namespace would escape')
+        return compile(tree, self.path, 'exec', dont_inherit=True)
+
+
+class _ReaderFinder(importlib.abc.MetaPathFinder):
+    def __init__(self, namespace, root, files):
+        self.namespace, self.root, self.files = namespace, root, files
+
+    def find_spec(self, fullname, path=None, target=None):
+        if not fullname.startswith(self.namespace + '.'):
+            return None
+        relative = fullname[len(self.namespace) + 1:]
+        if relative.split('.')[0] in {'serving', 'stock', 'kernel_window_gemv'}:
+            raise ImportError('the bound reader does not import serving or serving-kernel modules')
+        spec = importlib.machinery.PathFinder.find_spec(fullname, path)
+        if spec is None or spec.origin is None:
+            raise ImportError(f'bound reader module is absent: {fullname}')
+        origin = str(Path(spec.origin).resolve())
+        if origin not in self.files or not origin.endswith('.py'):
+            raise ImportError(f'bound reader module escapes declared source: {fullname}')
+        spec.loader = _ReaderSourceLoader(fullname, origin, self.files[origin])
+        return spec
+
+
+def load_declared_reader(record):
+    """Import a hash-bound consumer without replacing any producer module."""
+    if record is None:
+        return None
+    if not isinstance(record, dict) or set(record) != {'path', 'source_sha256'}:
+        raise ValueError('reader requires an explicit package path and source_sha256')
+    if not re.fullmatch(r'[0-9a-f]{64}', str(record['source_sha256'])):
+        raise ValueError('reader requires an exact source SHA256')
+    root = Path(record['path']).resolve()
+    digest, files = _source_tree(root)
+    if digest != record['source_sha256']:
+        raise ValueError('reader package checksum changed')
+    namespace = 'tessera_reader_' + digest
+    if namespace not in sys.modules:
+        finder = _ReaderFinder(namespace, root, files)
+        spec = importlib.util.spec_from_file_location(namespace, root / '__init__.py',
+            submodule_search_locations=[str(root)],
+            loader=_ReaderSourceLoader(namespace, str(root / '__init__.py'), files[str(root / '__init__.py')]))
+        module = importlib.util.module_from_spec(spec)
+        sys.meta_path.insert(0, finder)
+        sys.modules[namespace] = module
+        try:
+            spec.loader.exec_module(module)
+            importlib.import_module(namespace + '.cached_unit')
+            importlib.import_module(namespace + '.unit_artifact')
+        except BaseException:
+            for name in tuple(sys.modules):
+                if name == namespace or name.startswith(namespace + '.'):
+                    del sys.modules[name]
+            sys.meta_path.remove(finder)
+            raise
+    else:
+        actual = Path(sys.modules[namespace].__file__).resolve().parent
+        if actual != root:
+            raise ValueError('reader namespace is already bound to a different source path')
+    cached = importlib.import_module(namespace + '.cached_unit')
+    artifact = importlib.import_module(namespace + '.unit_artifact')
+    return SimpleNamespace(identity={'schema': 'prismaquant.tessera_reader.v1',
+        'path': str(root), 'source_sha256': digest, 'namespace': namespace},
+        verify_cached_unit=cached.verify_cached_unit, read_unit_artifact=artifact.read_unit_artifact)

--- a/tests/test_profile_command.py
+++ b/tests/test_profile_command.py
@@ -14,7 +14,10 @@ from experiments.profile_command import run_profile
 def test_sampler_preserves_observed_child_result_and_stack_bytes(tmp_path, exit_code):
     profiler = os.environ["PQ_TEST_PY_SPY"]
     target = tmp_path / "target.py"
-    target.write_text("import time\nend=time.monotonic()+1.0\n"
+    target.write_text("import time, os, json\nfrom pathlib import Path\n"
+                      "session=json.loads(Path(os.environ['PRISMAQUANT_SAMPLER_SESSION']).read_text())\n"
+                      "assert session['wrapper_pid'] == os.getppid()\n"
+                      "end=time.monotonic()+1.0\n"
                       "while time.monotonic()<end:\n    sum(range(1000))\n"
                       f"raise SystemExit({exit_code})\n")
     output = tmp_path / "capture"

--- a/tests/test_profile_command.py
+++ b/tests/test_profile_command.py
@@ -9,6 +9,8 @@ from experiments.profile_command import run_profile
 
 
 @pytest.mark.parametrize("exit_code", [0, 7])
+@pytest.mark.skipif("PQ_TEST_PY_SPY" not in os.environ,
+                    reason="PB scoped py-spy integration tooling is not configured")
 def test_sampler_preserves_observed_child_result_and_stack_bytes(tmp_path, exit_code):
     profiler = os.environ["PQ_TEST_PY_SPY"]
     target = tmp_path / "target.py"

--- a/tests/test_profile_command.py
+++ b/tests/test_profile_command.py
@@ -1,0 +1,37 @@
+"""Exercise real sampling and preserve failures of the observed child."""
+import json
+import os
+import sys
+
+import pytest
+
+from experiments.profile_command import run_profile
+
+
+@pytest.mark.parametrize("exit_code", [0, 7])
+def test_sampler_preserves_observed_child_result_and_stack_bytes(tmp_path, exit_code):
+    profiler = os.environ["PQ_TEST_PY_SPY"]
+    target = tmp_path / "target.py"
+    target.write_text("import time\nend=time.monotonic()+1.0\n"
+                      "while time.monotonic()<end:\n    sum(range(1000))\n"
+                      f"raise SystemExit({exit_code})\n")
+    output = tmp_path / "capture"
+    command = [sys.executable, str(target)]
+    assert run_profile(output, command, profiler=profiler, rate=50) == exit_code
+    result = json.loads((output / "profile-result.json").read_text())
+    assert result["passed"] is (exit_code == 0)
+    assert result["child"]["returncode"] == exit_code
+    assert result["child"]["command"] == command
+    assert result["artifacts"]["stacks.raw"]["bytes"] > 0
+    assert "target.py" in (output / "stacks.raw").read_text()
+
+
+def test_profiler_success_without_child_receipt_is_not_success(tmp_path):
+    output = tmp_path / "capture"
+    # /bin/true exits zero without running or recording its trailing command.
+    assert run_profile(output, [sys.executable, "-c", "raise SystemExit(7)"],
+                       profiler="/bin/true", rate=50) == 1
+    result = json.loads((output / "profile-result.json").read_text())
+    assert result["profiler_returncode"] == 0
+    assert result["passed"] is False
+    assert result["child"] is None

--- a/tests/test_tessera_bound_identity.py
+++ b/tests/test_tessera_bound_identity.py
@@ -1,0 +1,102 @@
+"""Actual producer identities remain exact across a bounded immutable unit."""
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+def fixture(*, projected=False):
+    from prismaquant import tessera_campaign as tc, tessera_hessian as th
+    from prismaquant.tessera_formats import parse_tessera_format_name
+    name = "model.layers.0.proj"
+    weight = torch.arange(32 * 256, dtype=torch.float32).reshape(32, 256).to(torch.bfloat16) / 1024
+    hessian = torch.eye(256)
+    source = th.activation_source({name: hessian}, th.calibration_identity(
+        "fixture", [torch.arange(16).reshape(1, 16)], fit_tokens=16))
+    formats = [f"TESSERA_{family}_K1_R{rung}" for family in ("BF16", "E4M3")
+               for rung in (896, 1024, 1152)] + ["TESSERA_E2M1_K2_R896"]
+    anchors = []
+    for fmt in formats:
+        family, rung = parse_tessera_format_name(fmt)
+        anchors.append(tc.CampaignAnchor(qname=name, format_name=fmt, family=family.name,
+            body_rate_q256=rung, dloss=0.1, dloss_stderr=0.0, memory_bytes=8192,
+            bits_per_param=4.0, activation_contract="fixture", activation_quantized=True,
+            wire_bytes=8192, seconds=0.1, hessian_applied=True,
+            input_global_scale=0.125 if "E2M1" in fmt else None))
+    projection = None if not projected else dict(tensor=name + ".weight", source_tensor="packed.weight",
+        source_layout="packed", source_slice={"expert": 0}, expert=0,
+        projection="gate_proj", group="w13", rows=32, cols=256)
+    kwargs = dict(weights={name: weight}, menus={name: [SimpleNamespace(format_name=f) for f in formats]},
+        calibration_source=source, static_scales={name: 0.125},
+        projected_units={} if projection is None else {name: projection})
+    return tc, name, weight, hessian, source, anchors, projection, kwargs
+
+
+@pytest.mark.parametrize("projected", [False, True])
+def test_bound_unit_reuses_actual_source_h_hashes_with_identical_producer_identity(monkeypatch, projected):
+    from tessera import cached_unit
+    tc, name, weight, hessian, source, anchors, projection, kwargs = fixture(projected=projected)
+    expected = [tc._checkpoint_anchor_identity(anchor, **kwargs) for anchor in anchors]
+    actual_hash = cached_unit.tensor_identity
+    calls = []
+    def observed(value):
+        calls.append(id(value))
+        return actual_hash(value)
+    monkeypatch.setattr(cached_unit, "tensor_identity", observed)
+    with tc.bind_checkpoint_unit_identity(anchors, source_weight=weight,
+            calibration_source=source, projected_unit=projection, static_scales=kwargs["static_scales"]) as bound:
+        actual = [tc._checkpoint_anchor_identity(anchor, **kwargs, bound_unit=bound) for anchor in anchors]
+        assert actual == expected
+        assert calls.count(id(weight)) == 1
+        assert calls.count(id(hessian)) == 1
+        actual[0]["source"]["sha256"] = "0" * 64
+        assert tc._checkpoint_anchor_identity(anchors[0], **kwargs, bound_unit=bound) == expected[0]
+    with pytest.raises(ValueError, match="closed"):
+        tc._checkpoint_anchor_identity(anchors[0], **kwargs, bound_unit=bound)
+
+
+@pytest.mark.parametrize("change", ["source_values", "source_storage", "source_view", "h_values", "h_replaced", "settings", "provenance", "projection"])
+def test_bound_unit_refuses_lifetime_mutation(change):
+    tc, name, weight, hessian, source, anchors, projection, kwargs = fixture(projected=True)
+    bound = tc.bind_checkpoint_unit_identity(anchors, source_weight=weight,
+        calibration_source=source, projected_unit=projection, static_scales=kwargs["static_scales"])
+    if change == "source_values":
+        weight[0, 0] += 1
+    elif change == "source_storage":
+        weight.data = weight.clone()
+    elif change == "source_view":
+        kwargs["weights"][name] = weight.t().contiguous().t()
+    elif change == "h_values":
+        hessian[0, 0] += 1
+    elif change == "h_replaced":
+        source.hessians[name] = hessian.clone()
+    elif change == "settings":
+        object.__setattr__(source, "ldlq_sigma", source.ldlq_sigma + 1)
+    elif change == "provenance":
+        source.provenance["fit_tokens"] += 1
+    else:
+        projection["source_slice"]["expert"] += 1
+    from tessera.errors import GrammarError
+    with pytest.raises((ValueError, RuntimeError, GrammarError), match="changed|moved|differs|bound"):
+        tc._checkpoint_anchor_identity(anchors[0], **kwargs, bound_unit=bound)
+
+
+def test_bound_unit_keeps_per_anchor_static_scale_and_hessian_gates():
+    tc, name, weight, hessian, source, anchors, projection, kwargs = fixture()
+    with tc.bind_checkpoint_unit_identity(anchors, source_weight=weight,
+            calibration_source=source, projected_unit=projection, static_scales=kwargs["static_scales"]) as bound:
+        with pytest.raises(RuntimeError, match="Hessian applicability"):
+            tc._checkpoint_anchor_identity(replace(anchors[0], hessian_applied=False), **kwargs, bound_unit=bound)
+        with pytest.raises(tc.ActivationScaleContractError):
+            tc._checkpoint_anchor_identity(replace(anchors[-1], input_global_scale=0.25), **kwargs, bound_unit=bound)
+
+
+def test_bound_unit_refuses_nonfinite_source():
+    tc, name, weight, hessian, source, anchors, projection, kwargs = fixture()
+    weight[0, 0] = float("nan")
+    with pytest.raises(ValueError, match="nonfinite"):
+        tc.bind_checkpoint_unit_identity(anchors, source_weight=weight,
+            calibration_source=source, projected_unit=projection, static_scales=kwargs["static_scales"])

--- a/tests/test_tessera_joint_aura.py
+++ b/tests/test_tessera_joint_aura.py
@@ -256,7 +256,8 @@ def test_plan_refuses_unqualified_probe_or_activation_policies(tmp_path, field, 
         _load_plan(path, sha(path))
 
 
-def test_original_full_draw_refuses_subset_before_model_load(tmp_path, monkeypatch):
+@pytest.mark.parametrize("profile_tool", ["cprofile", "py-spy"])
+def test_original_full_draw_refuses_subset_before_model_load(tmp_path, monkeypatch, profile_tool):
     import torch
     from types import SimpleNamespace
     from prismaquant import tessera_joint_aura as bridge, calibration_data, cost_streaming, gpu_guard
@@ -273,11 +274,21 @@ def test_original_full_draw_refuses_subset_before_model_load(tmp_path, monkeypat
     config = {"model": "fixture", "inputs": {}, "output_root": str(tmp_path),
         "calibration_input": {"path": "fixture", "sha256": "a" * 64},
         "execution": {"production_act_scales": "0", "n_calib_samples": 1, "calib_seqlen": 512}}
+    config["profile_tool"] = profile_tool
+    if profile_tool == "py-spy":
+        import os
+        session = tmp_path / "child-start.json"
+        session.write_text(json.dumps({"schema": "prismaquant.profiled_command_start.v1",
+            "wrapper_pid": os.getppid(),
+            "command": ["python", "-m", "prismaquant.tessera_joint_aura", "prepare"]}))
+        monkeypatch.setenv("PRISMAQUANT_SAMPLER_SESSION", str(session))
     with pytest.raises(ValueError, match="original full draw nsamples"):
         bridge.execute("prepare", config, plan_sha256="b" * 64)
     result = json.loads((tmp_path / "prepare/results.json").read_text())
     assert result["passed"] is False
-    assert (tmp_path / "prepare/profile.pstats").is_file()
+    assert (tmp_path / "prepare/profile.pstats").is_file() is (profile_tool == "cprofile")
+    if profile_tool == "py-spy":
+        assert result["sampling_session"]["sha256"] == sha(session)
 
 
 @pytest.mark.parametrize("command", ["prepare", "run"])
@@ -349,3 +360,27 @@ def test_parallel_intake_hashes_independent_files_without_changing_cells(tmp_pat
     assert actual.cells == expected.cells
     assert actual.formats_by_qname == expected.formats_by_qname
     assert len(workers) == 2
+
+
+@pytest.mark.parametrize("defect", ["missing", "parent", "command", "schema"])
+def test_sampling_refuses_unobserved_execution(tmp_path, monkeypatch, defect):
+    import os
+    from prismaquant import tessera_joint_aura as bridge, gpu_guard
+    monkeypatch.setattr(gpu_guard, "require_cuda_hot_path", lambda *_args: None)
+    session = {"schema": "prismaquant.profiled_command_start.v1",
+        "wrapper_pid": os.getppid(),
+        "command": ["python", "-m", "prismaquant.tessera_joint_aura", "prepare"]}
+    if defect == "parent":
+        session["wrapper_pid"] = -1
+    elif defect == "command":
+        session["command"][-1] = "run"
+    elif defect == "schema":
+        session["schema"] = "unbound"
+    path = tmp_path / "child-start.json"
+    if defect != "missing":
+        path.write_text(json.dumps(session))
+    monkeypatch.setenv("PRISMAQUANT_SAMPLER_SESSION", str(path))
+    config = {"output_root": str(tmp_path), "profile_tool": "py-spy",
+              "execution": {"production_act_scales": "0"}}
+    with pytest.raises(ValueError, match="sampl|observed"):
+        bridge.execute("prepare", config, plan_sha256="b" * 64)

--- a/tests/test_tessera_joint_aura.py
+++ b/tests/test_tessera_joint_aura.py
@@ -329,3 +329,23 @@ def test_source_prefetch_refuses_implicit_or_nonresident_settings(defect):
         config = {"source_prefetch": prefetch}
     with pytest.raises(ValueError, match="source_prefetch"):
         _source_prefetch(config)
+
+
+def test_parallel_intake_hashes_independent_files_without_changing_cells(tmp_path, monkeypatch):
+    import threading
+    from prismaquant import tessera_joint_aura as bridge
+    config, *_ = fixture(tmp_path)
+    expected = bridge.load_measured_anchor_input(config)
+    original = bridge._sha
+    barrier = threading.Barrier(2)
+    workers = set()
+    def observed(path):
+        if str(path).endswith('.tessera'):
+            workers.add(threading.get_ident())
+            barrier.wait(timeout=10)
+        return original(path)
+    monkeypatch.setattr(bridge, '_sha', observed)
+    actual = bridge.load_measured_anchor_input(config, file_hash_workers=2)
+    assert actual.cells == expected.cells
+    assert actual.formats_by_qname == expected.formats_by_qname
+    assert len(workers) == 2

--- a/tests/test_tessera_reader_namespace.py
+++ b/tests/test_tessera_reader_namespace.py
@@ -1,0 +1,50 @@
+"""A declared reader cannot replace or import the primary producer package."""
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def package(tmp_path, *, escaping=False):
+    root = tmp_path / 'tessera'; root.mkdir()
+    (root / '__init__.py').write_text('MARKER = "reader"\n')
+    (root / 'cached_unit.py').write_text('def verify_cached_unit(*args): return __name__, args\n')
+    (root / 'unit_artifact.py').write_text(
+        ('import tessera\n' if escaping else '') +
+        'def read_unit_artifact(*args, **kwargs): return __name__, args, kwargs\n')
+    digest = hashlib.sha256()
+    for path in sorted(root.glob('*.py')):
+        digest.update(path.relative_to(root).as_posix().encode() + b'\0')
+        digest.update(path.read_bytes()); digest.update(b'\0')
+    return {'path': str(root), 'source_sha256': digest.hexdigest()}
+
+
+def test_reader_namespace_preserves_primary_and_binds_actual_sources(tmp_path):
+    import tessera
+    from prismaquant.tessera_reader import load_declared_reader
+    primary = dict((name, module) for name, module in sys.modules.items()
+                   if name == 'tessera' or name.startswith('tessera.'))
+    declared = package(tmp_path)
+    reader = load_declared_reader(declared)
+    assert reader.identity['source_sha256'] == declared['source_sha256']
+    assert reader.read_unit_artifact(b'x')[0].startswith('tessera_reader_')
+    assert reader.verify_cached_unit(b'x', {}, {})[0].startswith('tessera_reader_')
+    assert sys.modules['tessera'] is tessera
+    assert all(sys.modules.get(name) is module for name, module in primary.items())
+    reader.identity['source_sha256'] = '0' * 64
+    assert load_declared_reader(declared).identity['source_sha256'] == declared['source_sha256']
+
+
+def test_reader_refuses_absolute_producer_import(tmp_path):
+    from prismaquant.tessera_reader import load_declared_reader
+    with pytest.raises(ImportError, match='absolute.*tessera'):
+        load_declared_reader(package(tmp_path, escaping=True))
+
+
+def test_reader_refuses_changed_source(tmp_path):
+    from prismaquant.tessera_reader import load_declared_reader
+    declared = package(tmp_path)
+    (Path(declared['path']) / '__init__.py').write_text('CHANGED = True\n')
+    with pytest.raises(ValueError, match='checksum'):
+        load_declared_reader(declared)


### PR DESCRIPTION
Joint anchor preparation repeatedly hashed immutable source/H identities and grid metadata, while deterministic profiling added callbacks to every tiny operation. Bind source/H identity for one unit, verify independent input files with an explicit worker count, and load a separately versioned Tessera reader while preserving the original producer identity and module objects. Joint preparation and cost can now run under pinned 50 Hz py-spy sampling, with independent child exit evidence and refusal of unobserved execution.

The bounded original-wire comparison preserved all 14 records and refused eight corruptions; median verifier time fell from 3.994 to 3.200 seconds across three interleaved pairs. Both torch profiles and both-host Netdata are retained. This is a verifier result; full preparation, energy improvement and joint-cost performance remain unmeasured.

Validation: PB combined identity/namespace gate 64 passed; sampling/joint/namespace gate 41 passed with no skips or missing collection, including real py-spy child success/failure checks; compile checks passed. Exact PB/CAS details and the GPU A/B are recorded in docs/experiments/tessera_anchor_verify_ab_2026-09-07.md. Sampling CPU action b12615739234e0db999b63efac72eb662332eadcd1c3af9f3dd5e0ac71bb83bb passed on Sparklina in the pinned CPU-only container; receipt d2eafcdf3fc871c5de4d5b2551ad36137cd74183d22db35db09f40f43c3000cf. Retained failed attempts exposed read-only compile output and a nonzero profiler exit despite child success; the final helper writes temporary bytecode, declares tracing capability, and retains sampler diagnostics.

Closes #322.
