### PR TITLE
Verify anchor render bytes during PWC preparation loads

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,23 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-07 · `codex/joint-sampling-profiler`. Stamps
+As of: 2026-09-07 · `perf/joint-prepare-single-read`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-07, `perf/joint-prepare-single-read`) for **verified
+single-read PWC preparation**. Joint-anchor preparation performs complete
+metadata/roster/producer-receipt intake, then verifies payload bytes on their
+necessary layer-scoped consumption. The existing PWC loader can capture a
+SHA256 receipt from one explicitly bounded serialized-file read and deserialize
+those exact bytes. Its receipt is valid only for the same unchanged resident
+tensor and donor-file signature; eviction and compaction discard it. Temporary
+serialized buffers are bounded per admitted loader worker and never persist as
+another cache. Preparation uses this load receipt instead of global and
+post-prefetch render scans; the existing verifier reads each original wire,
+checks its recorded SHA/source/H/settings, and compares decoded values exactly.
+Prepared completion remains withheld until every measured cell qualifies.
+The strict intake API default and cost/resume payload scans remain unchanged.
+Gate: `tests/test_pwc_file_load_receipts.py`, `tests/test_tessera_joint_aura.py`,
+and equal-work original fourteen-cell qualification with reader/identity held fixed.
 
 Re-stamped (2026-09-07, `codex/joint-sampling-profiler`) for **sampling joint
 preparation and cost execution**. The explicit plan profiler may be `py-spy`:
@@ -40,10 +56,11 @@ anchor/static-scale/H applicability checks, original wire grammar/hash checks
 and exact decoded-render comparison. The binding closes before source unload;
 it accepts no caller-supplied prehash and creates no tensor cache or dispatcher.
 Gate: `tests/test_tessera_bound_identity.py` plus original-wire qualification.
-Initial wire/render content verification may use explicit `file_hash_workers`,
-bounded by PB-assigned CPU affinity. Independent file pairs run in the same
-admitted process; their exact content hashes, before/after race detection and
-per-consumption render drift checks remain mandatory. Placement stays PB's.
+Strict intake wire/render verification may use explicit `file_hash_workers`,
+bounded by PB-assigned CPU affinity. Preparation instead uses that worker bound
+for the existing PWC loader and its single-read receipts described above.
+Exact content hashes and consumption lifetime guards remain mandatory; placement
+stays PB's.
 
 Re-stamped (2026-09-07, `codex/runtime-provenance-relation`) for **explicit
 cross-run runtime provenance** (#323). Opt-in measured-runtime context/table v2

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,8 +10,9 @@ necessary layer-scoped consumption. The existing PWC loader can capture a
 SHA256 receipt from one explicitly bounded serialized-file read and deserialize
 those exact bytes. Its receipt is valid only for the same unchanged resident
 tensor and donor-file signature; eviction and compaction discard it. Temporary
-serialized buffers are bounded per admitted loader worker and never persist as
-another cache. Preparation uses this load receipt instead of global and
+serialized buffers use each file's observed size, capped before any prefetch
+by the declared PWC budget; they are bounded per admitted loader worker and
+never persist as another cache. Preparation uses this load receipt instead of global and
 post-prefetch render scans; the existing verifier reads each original wire,
 checks its recorded SHA/source/H/settings, and compares decoded values exactly.
 Prepared completion remains withheld until every measured cell qualifies.

--- a/docs/experiments/tessera_prepare_file_reads_2026-09-07.md
+++ b/docs/experiments/tessera_prepare_file_reads_2026-09-07.md
@@ -1,0 +1,126 @@
+# Verified single-read anchor preparation
+
+Preparation previously scanned every wire and render before layer residency,
+loaded each render again through PWC, then rehashed it before consumption. On
+the original fourteen-cell fixture, the complete-path comparison measured
+**70 → 28 target-file opens** and **1,439,737,470 → 514,309,808 bytes read**
+through the file handles, a 64.3% reduction. Warm median time fell from
+3.331945 to 3.102984 seconds (1.0738× throughput; 6.87% less wall time).
+All fourteen verification records remained exactly equal to the previously
+qualified original oracle; eight corruption cases refused.
+
+This is a bounded preparation result. It does not establish a full-model
+speedup, change cost/resume behavior, or require discarding an already qualified
+prepared artifact. The original 2,142-unit, seven-candidate census represents
+103.03125 GiB of rendered tensor payload, exceeding its 6 GiB layer PWC budget;
+a global scan therefore cannot guarantee later layer residency.
+
+## Contract and implementation
+
+The strict importer still hashes payloads by default. Only preparation requests
+metadata-only intake: all complete roster, journal, producer receipt, path and
+size checks remain. The existing PWC loader reads each serialized donor once,
+hashes those bytes, and passes exactly that buffer to `torch.load` with
+`weights_only=True`. Read allocation uses the individual observed file size;
+preparation refuses a global file maximum above the declared PWC budget before
+any layer prefetch. Temporary buffers are bounded per admitted loader worker.
+
+The PWC receipt is valid only for its exact resident tensor object, storage,
+version, shape, stride, dtype, device and unchanged donor signature. Eviction
+and compaction discard it. No additional rendered-weight cache is introduced.
+The existing verifier still checks original wire SHA, source/H/encoding
+settings and exact decoded-render equality. Prepared completion waits for the
+complete verified roster. Cost/resume retain their strict payload scans.
+
+## Complete-path comparison
+
+Both arms use the same bound source/H identity and the same reader source
+`14df443217e2a6a1bc4857532f0b5ead7fa7f5755dbd61e96605659940a8a1bc`.
+Source weights and the canonical 512×512 capture are resident on CUDA in both
+arms. Each timed arm includes actual metadata intake, payload validation,
+a fresh PWC and prefetch, bound identity creation, transfers, verification and
+compaction. Original row0000 producer records remain unchanged inside an
+explicitly retained bounded metadata projection; its original fleet action is
+bound and every imported anchor/record was also checked against the original
+journal in a separate CPU action.
+
+| Arm | Render opens / bytes | Wire opens / bytes |
+|---|---:|---:|
+| Original | 42 / 1,233,260,490 | 28 / 206,476,980 |
+| Single read | 14 / 411,071,318 | 14 / 103,238,490 |
+
+A scoped observer counts actual `read`/`readinto` calls made through both
+Path/hashlib and torch serialization file adapters; it retains no bytes.
+Per-process `/proc` counters are separate: warm `rchar` fell from
+1,495,094,870 to 525,585,716. Every warm arm recorded zero physical `read_bytes`.
+These measurements therefore establish reduced logical reads and warm timing,
+not a cold-storage throughput improvement.
+
+| Pair | Original seconds | Single-read seconds |
+|---|---:|---:|
+| First parse, retained separately | 12.613666 | 3.143335 |
+| Measured 0, AB | 3.332286 | 3.091577 |
+| Measured 1, BA | 3.328836 | 3.102984 |
+| Measured 2, AB | 3.331945 | 3.106612 |
+
+The first pair includes asymmetric startup/cache state and is not used for a
+speedup claim. All ten phases match the original fourteen-record oracle.
+The profiler uses the same 50 Hz py-spy wrapper throughout; separate torch
+CPU/CUDA traces follow timing. The sampler produced 3,543 samples, zero errors.
+Across all optimized-arm phases, including first parse and explicit profiling,
+582 of 757 samples include `read_unit_artifact`; remaining decoding work is the
+Tessera owner's separate optimization, not part of this change.
+
+PB measurement isolation selected Sparky's GB10 with CPU 4, 12 GiB aggregate
+memory and an 8 GiB GPU subset, preserving assigned affinity and one native
+thread per worker. The known production image is
+`eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c`.
+Raw Netdata from both boxes shows roughly 7–9% aggregate CPU activity and
+15–18 W interpolated GPU power in warm phases. Ten-second power sampling cannot
+resolve three-second arms, so no work-per-joule ranking is claimed. The scope
+reached its 12 GiB memory cap without OOM; the first pair is not a memory- or
+storage-isolated timing result.
+
+## Validation and evidence
+
+Test-first PB `62a8600fbba8` exposed the missing receipt/deferred-intake API.
+The main gate `7e6c2d7b0b8d` passed 65 tests; `1f5f79f61b62` then demonstrated
+an oversized read request inherited from a global bound. The corrected guard,
+receipt lifetime and actual torch-read observer gate `6b282fda8f0a` passed 11
+tests. Dedicated changed-module compile action `28753a7807a9` passed, and
+actual bounded metadata action `c011f178160a` preserved all fourteen original
+records. There were no skipped cases. CPU evidence and both red attempts are
+retained; successful terminals, cleanup, CAS bytes and receipts were checked.
+
+All evidence below is under
+`/mnt/shared/tessera-measurements/first-model-20260907/full-model-joint-aura/`:
+
+- Plan `qualify-file-io-ab-plan-01.json`, SHA
+  `2f5587c2de18a200ddc41e9f7fc1fe9c1ff7db8158f4fd000e0b084625636456`.
+- `qualify-file-io-ab-01/results.json`, SHA
+  `783172f73ecd63109c27db3476711c651bef0e39084e3644a8ccb3c837e14b40`.
+- `qualify-file-io-ab-01/verified-evidence.json`, SHA
+  `df03fa2fe55f056901e6ba84b07931d87fc0a8f7a4dc770f7e348d9e850ee814`,
+  seals results, the bounded metadata projection, profiles and both-host Netdata.
+- `qualify-file-io-ab-01/profile-00-{before,after}.{trace.json,operators.txt}`,
+  `profile-observations.json`, and `netdata-both-hosts.json`.
+- `qualify-file-io-ab-sampler-01/` holds raw stacks and independent child/sampler
+  exit receipts; both exit statuses were zero.
+- `prepare-single-read-cpu-receipts.json` and
+  `prepare-single-read-intake-cpu-receipt.json` retain CPU evidence.
+
+GPU action `53fca49df8d345b8ffec4816ad9028cff6e922972a4d6eee9439cde4e7579cb2`
+finished with exit zero and complete cleanup. Its 80,496-byte CAS payload SHA is
+`3aa8b8edac611bb6ade094d9715df140fcabfc92aafa4f01f171f22ecd1b9694`, and receipt SHA is
+`97e8f96070b0b9b35a51e33bf923cfdc635623a4a97b2f8ad2f10c52b0f91f39`.
+Both were independently rehashed.
+
+Reproduce from source `3ac1d094`, with a fresh output directory in a newly
+hashed plan, through PB on the measuring GB10:
+
+```bash
+python3 /mnt/shared/prismabuild-fleet/repo/tools/pbrun.py \
+  --cwd CHECKOUT --cpus 4 --demand mem_gb=12 --gpu --gpu-memory-gb 8 \
+  --measurement --detach -- bash experiments/pq322_anchor_file_io_ab.sh \
+  SAMPLER_OUTPUT --plan PLAN --plan-sha256 PLAN_SHA256
+```

--- a/docs/experiments/tessera_prepare_file_reads_2026-09-07.md
+++ b/docs/experiments/tessera_prepare_file_reads_2026-09-07.md
@@ -10,8 +10,11 @@ All fourteen verification records remained exactly equal to the previously
 qualified original oracle; eight corruption cases refused.
 
 This is a bounded preparation result. It does not establish a full-model
-speedup, change cost/resume behavior, or require discarding an already qualified
-prepared artifact. The original 2,142-unit, seven-candidate census represents
+speedup or change cost/resume behavior. An already qualified prepared artifact
+remains valid under its original frozen implementation. The current v1 source
+gate binds the complete PrismaQuant package, so running an updated implementation
+requires new preparation; this result does not authorize adopting or re-stamping
+the old artifact. The original 2,142-unit, seven-candidate census represents
 103.03125 GiB of rendered tensor payload, exceeding its 6 GiB layer PWC budget;
 a global scan therefore cannot guarantee later layer residency.
 

--- a/experiments/file_read_audit.py
+++ b/experiments/file_read_audit.py
@@ -1,0 +1,82 @@
+"""Count selected file reads in one admitted, synchronous measurement scope."""
+from __future__ import annotations
+
+import builtins
+from contextlib import AbstractContextManager
+import io
+import os
+import threading
+
+
+class _ReadFile:
+    def __init__(self, stream, audit, path):
+        self.stream, self.audit, self.path = stream, audit, path
+
+    def __enter__(self):
+        self.stream.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        return self.stream.__exit__(*args)
+
+    def __getattr__(self, name):
+        return getattr(self.stream, name)
+
+    def read(self, *args):
+        raw = self.stream.read(*args)
+        self.audit.record(self.path, 'read_calls', 1)
+        self.audit.record(self.path, 'read_bytes', len(raw))
+        return raw
+
+    def readinto(self, buffer):
+        count = self.stream.readinto(buffer)
+        self.audit.record(self.path, 'read_calls', 1)
+        self.audit.record(self.path, 'read_bytes', count or 0)
+        return count
+
+
+class FileReadAudit(AbstractContextManager):
+    """Observe real Python/C++-backed file adapters without changing their bytes.
+
+    Path.open uses io.open; torch.serialization uses builtins.open and passes
+    its handle into the C++ reader. Wrapping both records the read/readinto
+    calls made by those handles. No payload is retained. Scope owners must join
+    their file-loader threads before exiting, as PWC.prefetch already does.
+    """
+    def __init__(self, files):
+        self.files = {os.path.abspath(os.fspath(path)): kind for path, kind in files.items()}
+        self.counts = {path: {'kind': kind, 'opens': 0, 'read_calls': 0, 'read_bytes': 0}
+                       for path, kind in self.files.items()}
+        self.lock = threading.Lock()
+
+    def record(self, path, key, amount):
+        with self.lock:
+            self.counts[path][key] += amount
+
+    def _wrapper(self, original):
+        def opened(file, *args, **kwargs):
+            stream = original(file, *args, **kwargs)
+            path = os.path.abspath(os.fsdecode(file)) if isinstance(file, (str, bytes, os.PathLike)) else None
+            if path in self.files:
+                self.record(path, 'opens', 1)
+                return _ReadFile(stream, self, path)
+            return stream
+        return opened
+
+    def __enter__(self):
+        self.original_builtin, self.original_io = builtins.open, io.open
+        builtins.open = self._wrapper(self.original_builtin)
+        io.open = self._wrapper(self.original_io)
+        return self
+
+    def __exit__(self, *_args):
+        builtins.open, io.open = self.original_builtin, self.original_io
+
+    def summary(self):
+        by_kind = {}
+        for record in self.counts.values():
+            target = by_kind.setdefault(record['kind'], {'files': 0, 'opens': 0, 'read_calls': 0, 'read_bytes': 0})
+            target['files'] += 1
+            for key in ('opens', 'read_calls', 'read_bytes'):
+                target[key] += record[key]
+        return {'by_kind': by_kind, 'files': self.counts}

--- a/experiments/pq322_anchor_file_io_ab.py
+++ b/experiments/pq322_anchor_file_io_ab.py
@@ -1,0 +1,313 @@
+"""PB-only complete-path A/B of anchor file scans versus verified PWC single reads."""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+from pathlib import Path
+import pickle
+import socket
+import sys
+import statistics
+import time
+from types import SimpleNamespace
+
+
+def project_intake(plan, root):
+    """Bounded metadata envelope around unchanged original row producer records."""
+    from prismaquant.tessera_calibration_cache import sha256
+    def read(key):
+        path = Path(plan[key]['path'])
+        if sha256(path) != plan[key]['sha256']:
+            raise ValueError(f'original projection input changed: {key}')
+        return path
+    campaign = json.loads(read('campaign_plan').read_text())
+    fleet = json.loads(read('campaign_receipts').read_text())
+    action = json.loads(read('row_action').read_text())
+    if fleet['returncode'] not in (0, '0'):
+        raise ValueError('original campaign was incomplete')
+    row, = [row for row in campaign['rows'] if sorted(row['members']) == plan['units']]
+    command = action['params']['command']
+    if command[command.index('--out') + 1] != plan['cost']['path']:
+        raise ValueError('original fleet action did not produce the bounded cost row')
+    receipt, = [record for record in fleet['rows'] if action['action_key'].startswith(record['key'])]
+    if receipt['rc'] not in (0, '0') or receipt['status'] != 'executed':
+        raise ValueError('bounded row has no executed original fleet receipt')
+    if str(Path(row['dir']) / 'cost.anchors.json') != plan['checkpoint']['path']:
+        raise ValueError('bounded checkpoint differs from original row')
+    output = root / 'bounded-intake'; output.mkdir()
+    census = json.loads(read('census').read_text())
+    census['unit_shapes'] = {name: census['unit_shapes'][name] for name in plan['units']}
+    census['anchor_groups'] = {group: census['anchor_groups'][group] for group in row['groups']}
+    census_path = output / 'census.json'; census_path.write_text(json.dumps(census, sort_keys=True))
+    campaign['rows'] = [row]; campaign['census'] = str(census_path)
+    campaign_path = output / 'plan.json'; campaign_path.write_text(json.dumps(campaign, sort_keys=True))
+    fleet['rows'] = [receipt]
+    fleet_path = output / 'receipts.json'; fleet_path.write_text(json.dumps(fleet, sort_keys=True))
+    cost = pickle.loads(read('cost').read_bytes())
+    cost['provenance']['campaign_fanout'] = {'schema': campaign['schema'], 'rows': {row['row_id']: sorted(row['groups'])}}
+    cost_path = output / 'cost.pkl'; cost_path.write_bytes(pickle.dumps(cost, protocol=pickle.HIGHEST_PROTOCOL))
+    paths = {'campaign_plan': campaign_path, 'census': census_path, 'campaign_receipts': fleet_path,
+             'merged_cost': cost_path, 'merged_checkpoint': read('checkpoint')}
+    inputs = {key: {'path': str(path), 'sha256': sha256(path)} for key, path in paths.items()}
+    inputs.update(required_source_units=len(plan['units']), required_campaign_groups=len(row['groups']))
+    projection = {'schema': 'prismaquant.bounded_anchor_intake_projection.v1', 'inputs': inputs,
+        'original_plan_sha256': sha256(plan['campaign_plan']['path']), 'row_action_key': action['action_key'],
+        'modifications': ['census unit_shapes/anchor_groups scope', 'plan rows/census path',
+                          'receipt rows scope', 'cost campaign_fanout envelope'],
+        'unchanged': ['original checkpoint and unit envelopes', 'every measured cost and anchor',
+                      'source/H/encoding identities', 'wire/render bytes and original paths'],
+        'scope': 'qualification projection only; not a new campaign or full-model result'}
+    (output / 'projection.json').write_text(json.dumps(projection, indent=2) + '\n')
+    return inputs, projection
+
+
+def main():
+    import torch
+    from safetensors import safe_open
+    from prismaquant import tessera_calibration_cache as cc, tessera_campaign as tc, tessera_hessian as th
+    from prismaquant.calibration_data import load_calibration_input
+    from prismaquant.cost_stage_checkpoint import _load_unit, canonical_json_sha256, unit_path
+    from prismaquant.joint_aura import prefetch_joint_cache
+    from prismaquant.model_profiles import detect_profile
+    from prismaquant.tessera_reader import load_declared_reader, _source_tree
+    from prismaquant.production_weight_cache import ProductionWeightCache, _cache_weight_filename
+    from prismaquant.tessera_joint_aura import calibrated_maxima, verify_anchor_render, load_measured_anchor_input, _prepare_file_read_bound, _io_counters
+    from experiments.file_read_audit import FileReadAudit
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--plan', type=Path, required=True)
+    parser.add_argument('--plan-sha256', required=True)
+    parser.add_argument('--pairs', type=int, default=3)
+    args = parser.parse_args()
+    if args.pairs < 3:
+        parser.error('at least three interleaved measured pairs are required')
+    if cc.sha256(args.plan) != args.plan_sha256:
+        raise ValueError('qualification plan changed')
+    plan = json.loads(args.plan.read_text())
+    root = Path(plan['out']); root.mkdir(parents=True, exist_ok=False)
+    for key in ('cost', 'checkpoint', 'census', 'capture', 'tokens', 'oracle'):
+        if cc.sha256(plan[key]['path']) != plan[key]['sha256']:
+            raise ValueError(f'{key} changed')
+    intake_inputs, projection = project_intake(plan, root)
+    payload = pickle.loads(Path(plan['cost']['path']).read_bytes())
+    checkpoint = Path(plan['checkpoint']['path'])
+    manifest = json.loads(checkpoint.read_text())
+    identity = manifest['identity']
+    if canonical_json_sha256(identity, where='wire qualification') != manifest['identity_sha256']:
+        raise ValueError('journal identity changed')
+    names = sorted(identity['units'])
+    if names != plan['units']:
+        raise ValueError('exact bounded qualification roster changed')
+    census = json.loads(Path(plan['census']['path']).read_text())
+    profile = detect_profile(census['model'])
+    maxima, scales = calibrated_maxima(SimpleNamespace(census=census, payload=payload), profile)
+    capture = cc.require_capture_contract(plan['capture']['path'], expected_sha256=plan['capture']['sha256'])
+    expected = cc.capture_identity(plan['census']['path'],
+        calibration=payload['provenance']['hessian']['calibration_identity'],
+        max_act_rows=capture['identity']['max_act_rows'],
+        model_load_contract=census['model_load_contract'], attention_implementation=census['attention_implementation'])
+    if expected != capture['identity']:
+        raise ValueError('actual source/capture identity changed')
+    (acts, hessians, _counts, _maxima), _ = cc.prefetch_capture(plan['capture']['path'],
+        expected_sha256=plan['capture']['sha256'], expected_identity=expected, census=census, names=names, device='cuda')
+    calibration_source = th.activation_source(hessians, expected['calibration'])
+    _ids, calibration = load_calibration_input(plan['tokens']['path'], expected_sha256=plan['tokens']['sha256'],
+                                               n_samples=512, seqlen=512)
+    weights = {}
+    with safe_open(str(Path(census['model']) / 'model.safetensors'), framework='pt', device='cpu') as stream:
+        for name in names:
+            weights[name] = stream.get_tensor(name + '.weight').cuda()
+    cells = {}
+    parts = checkpoint.with_name(checkpoint.name + '.parts')
+    for name in names:
+        state = _load_unit(unit_path(parts, name), stage='Tessera campaign', qname=name,
+                           identity_sha256=manifest['identity_sha256'])
+        for anchor in state['anchors']:
+            fmt = anchor['format_name']; record = state['wire_records'][fmt]
+            render = Path(payload['provenance']['cache_dir']) / _cache_weight_filename(name, fmt)
+            cells[name, fmt] = dict(anchor=anchor, record=record,
+                wire=str(Path(payload['provenance']['wire_dir']) / record['file']),
+                render=str(render))
+    formats = {name: sorted(fmt for qname, fmt in cells if qname == name) for name in names}
+    file_map = {cell[field]: field for cell in cells.values() for field in ('wire', 'render')}
+    file_sizes = {path: Path(path).stat().st_size for path in file_map}
+    file_workers = plan['file_hash_workers']
+    if type(file_workers) is not int or not 0 < file_workers <= len(os.sched_getaffinity(0)):
+        raise ValueError('file workers exceed admitted affinity')
+    oracle = json.loads(Path(plan['oracle']['path']).read_text())
+    if oracle.get('passed') is not True or oracle['cells'] != 14:
+        raise ValueError('original fourteen-cell oracle is not qualified')
+    reference = {(record['unit'], record['format']): {key: value for key, value in record.items()
+        if key not in ('unit', 'format', 'equal')} for record in oracle['comparisons']}
+    if set(reference) != set(cells):
+        raise ValueError('original oracle roster changed')
+    if len(names) != 2 or len(cells) != 14:
+        raise ValueError('qualification requires original two-unit, fourteen-cell roster')
+    # Load the producer API before the reader so module preservation is observable.
+    api = tc._checkpoint_identity_api()
+    import tessera
+    from tessera.unit_artifact import read_unit_artifact
+    primary_root = Path(tessera.__file__).resolve().parent
+    producer_digest, producer_files = _source_tree(primary_root)
+    primary_modules = {name: module for name, module in sys.modules.items()
+                       if name == 'tessera' or name.startswith('tessera.')}
+    reader = load_declared_reader(plan['reader'])
+    if reader is None:
+        raise ValueError('optimized arm requires a separately bound reader')
+    result = {'schema': 'prismaquant.anchor_file_io_ab.v1', 'passed': False,
+        'plan_sha256': args.plan_sha256, 'pairs': args.pairs,
+        'env': {'started_epoch': time.time(), 'host': socket.gethostname(),
+            'torch': str(torch.__version__), 'cuda': torch.version.cuda,
+            'device': torch.cuda.get_device_name(), 'cpu_affinity': sorted(__import__('os').sched_getaffinity(0))},
+        'producer': {'path': str(primary_root), 'source_sha256': producer_digest},
+        'reader': reader.identity, 'phases': [], 'comparisons': [],
+        'negative_cases': [], 'bounded_intake': projection, 'file_workers': file_workers,
+        'workload': 'two original dense units, fourteen wires/renders; complete metadata intake, payload checks, fresh PWC prefetch and verification in each arm',
+        'scope': 'complete relevant file/intake/PWC/verification path; source and original capture held CUDA resident; excludes whole-model streaming',
+        'first_pair_policy': 'retained separately; first parse, not claimed disk-cold'}
+    anchors = {name: [tc.CampaignAnchor(**cells[name, fmt]['anchor']) for fmt in formats[name]]
+               for name in names}
+    kwargs = dict(calibration_source=calibration_source, projected_unit=None, static_scales=scales)
+
+    def verify_arm(arm):
+        data = load_measured_anchor_input(intake_inputs, file_hash_workers=file_workers,
+                                          verify_payloads=arm == 'before')
+        if set(data.cells) != set(cells):
+            raise ValueError('intake changed the original fourteen-cell roster')
+        cache = ProductionWeightCache(weights={pair: cell['render'] for pair, cell in data.cells.items()},
+            levers={'tessera_campaign': True}, activation_max_abs=maxima)
+        cache.enable_lru(plan['max_render_bytes'])
+        if arm == 'after':
+            cache.enable_file_load_receipts(max_file_bytes=_prepare_file_read_bound(data,
+                                                       max_render_bytes=plan['max_render_bytes']))
+        records = {}
+        try:
+            prefetched = prefetch_joint_cache(cache, names, formats,
+                            max_resident_bytes=plan['max_render_bytes'], max_workers=file_workers)
+            for name in names:
+                # Both arms include the same bound identity and same reader14df.
+                with tc.bind_checkpoint_unit_identity(anchors[name], source_weight=weights[name], **kwargs) as bound:
+                    for fmt in formats[name]:
+                        cell = data.cells[name, fmt]
+                        resident = cache.get(name, fmt)
+                        if arm == 'before':
+                            if cc.sha256(cell['render']) != cell['render_file_sha256']:
+                                raise ValueError('original render changed')
+                        else:
+                            cell['render_file_sha256'] = cache.file_load_receipt((name, fmt), resident)['sha256']
+                        rendered = resident.cuda()
+                        records[name, fmt] = verify_anchor_render(cell, weights[name], rendered,
+                                                                 bound_unit=bound, reader=reader, **kwargs)
+                        del rendered, resident
+            return records, prefetched
+        finally:
+            cache.compact_for_pickle(); cache.disable_file_load_receipts()
+            if any(isinstance(value, torch.Tensor) for value in cache.weights.values()):
+                raise AssertionError('arm retained rendered tensors after compaction')
+
+    def before_verify():
+        return verify_arm('before')
+
+    def after_verify():
+        return verify_arm('after')
+
+    def phase(arm, kind, index, *, profile=False):
+        torch.cuda.synchronize(); torch.cuda.reset_peak_memory_stats()
+        fn = before_verify if arm == 'before' else after_verify
+        name = f'{kind}-{index:02d}-{arm}'
+        before_io = _io_counters()
+        start_epoch = time.time(); start = time.perf_counter()
+        with FileReadAudit(file_map) as audit:
+            if profile:
+                with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU,
+                     torch.profiler.ProfilerActivity.CUDA], profile_memory=True, record_shapes=True) as profiler:
+                    value, prefetch = fn(); torch.cuda.synchronize()
+            else:
+                value, prefetch = fn(); torch.cuda.synchronize()
+        elapsed = time.perf_counter() - start; end_epoch = time.time()
+        after_io = _io_counters()
+        io_delta = {key: after_io[key] - before_io.get(key, 0) for key in after_io}
+        observed = audit.summary()
+        expected_opens = {'wire': 2, 'render': 3} if arm == 'before' else {'wire': 1, 'render': 1}
+        for path, record in observed['files'].items():
+            if record['opens'] != expected_opens[record['kind']]:
+                raise AssertionError(f'{name}: unexpected actual open count {path}: {record}')
+            if (arm == 'after' or record['kind'] == 'wire') and record['read_bytes'] != file_sizes[path] * expected_opens[record['kind']]:
+                raise AssertionError(f'{name}: unexpected exact payload bytes read {path}: {record}')
+        if profile:
+            profiler.export_chrome_trace(str(root / (name + '.trace.json')))
+            (root / (name + '.operators.txt')).write_text(profiler.key_averages().table(sort_by='self_cuda_time_total', row_limit=60))
+        if value != reference:
+            raise ValueError(f'{name}: verification records differ from original qualified oracle')
+        result['phases'].append({'phase': name, 'arm': arm, 'pair': index, 'kind': kind,
+            'start_epoch': start_epoch, 'end_epoch': end_epoch, 'seconds': elapsed,
+            'peak_gpu_bytes': torch.cuda.max_memory_allocated(),
+            'peak_gpu_reserved_bytes': torch.cuda.max_memory_reserved(), 'equal_records': len(value),
+            'file_io': observed, 'process_io_delta': io_delta, 'prefetch': prefetch})
+        print(json.dumps(result['phases'][-1]), flush=True)
+
+    try:
+        for arm in ('before', 'after'):
+            phase(arm, 'first_parse', 0)
+        for index in range(args.pairs):
+            for arm in (('before', 'after') if index % 2 == 0 else ('after', 'before')):
+                phase(arm, 'measured', index)
+        for arm in ('before', 'after'):
+            phase(arm, 'profile', 0, profile=True)
+        result['comparisons'] = [{'unit': name, 'format': fmt, 'equal': True, **record}
+                                 for (name, fmt), record in sorted(reference.items())]
+        cache = ProductionWeightCache(weights={pair: cell['render'] for pair, cell in cells.items()},
+            levers={'tessera_campaign': True}, activation_max_abs=maxima)
+        cache.enable_lru(plan['max_render_bytes'])
+        for pair, cell in cells.items():
+            cell['render_file_sha256'] = reference[pair]['render_file_sha256']
+        pair = next(pair for pair in sorted(cells) if 'E4M3' in pair[1])
+        name, fmt = pair; cell = cells[pair]
+        for arm in ('before', 'after'):
+            for kind in ('render', 'source', 'settings', 'wire'):
+                changed = copy.deepcopy(cell)
+                source, render = weights[name], cache.get(name, fmt).cuda()
+                if kind == 'render':
+                    render = render.clone(); render[0, 0] += 1
+                elif kind == 'source':
+                    source = source.clone(); source[0, 0] += 1
+                elif kind == 'settings':
+                    changed['record']['identity']['recipe']['q256'] += 1
+                else:
+                    altered = bytearray(Path(cell['wire']).read_bytes()); altered[-1] ^= 1
+                    corrupt = root / f'intentional-corrupt-wire-{arm}.bin'; corrupt.write_bytes(altered)
+                    changed['wire'] = str(corrupt)
+                try:
+                    with tc.bind_checkpoint_unit_identity(anchors[name], source_weight=source, **kwargs) as bound:
+                        verify_anchor_render(changed, source, render, bound_unit=bound, reader=reader, **kwargs)
+                except (ValueError, RuntimeError) as exc:
+                    result['negative_cases'].append({'arm': arm, 'case': kind, 'refused': True, 'error': str(exc)})
+                else:
+                    raise AssertionError(f'{arm}: {kind} corruption was accepted')
+        cache.compact_for_pickle()
+        after_digest, after_files = _source_tree(primary_root)
+        if (after_digest, after_files) != (producer_digest, producer_files):
+            raise ValueError('primary producer source files changed')
+        if any(sys.modules.get(name) is not module for name, module in primary_modules.items()):
+            raise ValueError('primary producer module object changed')
+        result['producer']['preserved_modules'] = {name: str(Path(module.__file__).resolve())
+            for name, module in primary_modules.items() if getattr(module, '__file__', None)}
+        result['producer']['files_unchanged'] = result['producer']['module_objects_unchanged'] = True
+        medians = {arm: statistics.median(p['seconds'] for p in result['phases']
+                    if p['kind'] == 'measured' and p['arm'] == arm) for arm in ('before', 'after')}
+        result['measured'] = {'median_seconds': medians, 'ratio_before_over_after': medians['before'] / medians['after']}
+        result['units'], result['cells'] = len(names), len(cells)
+        result['passed'] = True
+    except BaseException as exc:
+        result['error'] = {'type': type(exc).__name__, 'message': str(exc)}
+        raise
+    finally:
+        result['env']['finished_epoch'] = time.time()
+        (root / 'results.json').write_text(json.dumps(result, indent=2) + '\n')
+        print(json.dumps({'passed': result['passed'], 'result_sha256': cc.sha256(root / 'results.json')}), flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/experiments/pq322_anchor_file_io_ab.sh
+++ b/experiments/pq322_anchor_file_io_ab.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+image=eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
+input_root=/mnt/shared/tessera-measurements/first-model-20260907/inputs
+exec docker run --cap-add SYS_PTRACE --security-opt seccomp=unconfined --rm --gpus all --ipc=host --network=host --user "$(id -u):$(id -g)" \
+  -v /home/rob/venvs/pq-release/bin/py-spy:/py-spy:ro -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared -w /workspace --entrypoint python3 \
+  -e PYTHONDONTWRITEBYTECODE=1 -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
+  -e XDG_CACHE_HOME=/tmp/pq-anchor-qualification-cache -e TORCH_EXTENSIONS_DIR=/tmp/pq-anchor-qualification-ext \
+  -e HF_HOME=/tmp/pq-anchor-qualification-hf -e HF_MODULES_CACHE=/tmp/pq-anchor-qualification-modules \
+  -e PRISMABUILD_CONTAINER_OWNER -e PRISMAQUANT_PROD_ACT_SCALES=0 \
+  -e "PYTHONPATH=/workspace:$input_root/tessera-382a1a97/src:$input_root/container-compatible-deps" \
+  "$image" -m experiments.profile_command --output "$1" --profiler /py-spy --rate 50 -- python3 -m experiments.pq322_anchor_file_io_ab "${@:2}"

--- a/experiments/pq322_cpu_checks.sh
+++ b/experiments/pq322_cpu_checks.sh
@@ -18,5 +18,5 @@ export PYTHONPATH="$PWD:$pq_target:/mnt/shared/tessera-measurements/first-model-
 export PYTHONDONTWRITEBYTECODE=1
 export OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
 "$pq_python" -c 'import sys, torch, transformers, pytest; print({"python":sys.version, "torch":torch.__version__, "transformers":transformers.__version__, "pytest":pytest.__version__}, flush=True)'
-"$pq_python" -c 'import ast, pathlib; paths=["prismaquant/tessera_joint_aura.py", "experiments/pq322_anchor_wire_qualification.py", "tests/test_tessera_joint_aura.py"]; [compile(pathlib.Path(p).read_text(),p,"exec") for p in paths]; print("Touched Python modules compile",flush=True)'
+"$pq_python" -c 'import ast, pathlib; paths=["prismaquant/tessera_joint_aura.py", "prismaquant/production_weight_cache.py", "prismaquant/joint_aura.py", "experiments/pq322_anchor_file_io_ab.py", "experiments/file_read_audit.py", "tests/test_pwc_file_load_receipts.py", "tests/test_tessera_joint_aura.py", "tests/test_file_read_audit.py"]; [compile(pathlib.Path(p).read_text(),p,"exec") for p in paths]; print("Touched Python modules compile",flush=True)'
 exec "$pq_python" -m pytest "$@"

--- a/prismaquant/joint_aura.py
+++ b/prismaquant/joint_aura.py
@@ -105,7 +105,7 @@ def arithmetic_identity(measurement_dtype) -> dict:
     }
 
 
-def prefetch_joint_cache(cache, names, formats_by_qname, *, max_resident_bytes):
+def prefetch_joint_cache(cache, names, formats_by_qname, *, max_resident_bytes, max_workers=4):
     """Use the production cache's key resolver and prefetch; own no tensors."""
     keys = set()
     for name in names:
@@ -117,7 +117,7 @@ def prefetch_joint_cache(cache, names, formats_by_qname, *, max_resident_bytes):
     nbytes = cache.estimate_nbytes(list(keys))
     if nbytes > max_resident_bytes:
         raise RuntimeError("joint AURA production cache prefetch exceeds resident budget")
-    loaded = cache.prefetch(list(keys))
+    loaded = cache.prefetch(list(keys), max_workers=max_workers)
     return {"entries": len(keys), "resident_bytes": nbytes, "loaded": loaded, "misses": 0}
 
 

--- a/prismaquant/production_weight_cache.py
+++ b/prismaquant/production_weight_cache.py
@@ -70,12 +70,14 @@ from collections.abc import Iterable, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 import hashlib
+import io
 import json
 import math
 import os
 from pathlib import Path
 import re
 import subprocess
+import stat
 import time
 
 import torch
@@ -282,6 +284,8 @@ class ProductionWeightCache:
     _lru_bytes: int = 0
     _lru_max_bytes: int = 0
     _cb_verified_keys: set[tuple[str, str]] | None = None
+    _file_load_max_bytes: int = 0
+    _file_load_receipts: dict | None = None
 
     def __post_init__(self) -> None:
         # Normalize to ``activation_max_abs`` if a caller used the legacy
@@ -325,6 +329,7 @@ class ProductionWeightCache:
         self._lru_order = []
         self._lru_paths = {}
         self._lru_bytes = 0
+        self._file_load_receipts = None
 
     def _evict_to_budget(self) -> None:
         if self._lru_order is None or self._lru_max_bytes <= 0:
@@ -339,6 +344,8 @@ class ProductionWeightCache:
                     self.weights[evict_key] = self._lru_paths[evict_key]
                 if self._cb_verified_keys is not None:
                     self._cb_verified_keys.discard(evict_key)
+                if self._file_load_receipts is not None:
+                    self._file_load_receipts.pop(evict_key, None)
 
     def compact_for_pickle(self) -> int:
         """Restore disk-backed resident tensors to path references.
@@ -366,6 +373,7 @@ class ProductionWeightCache:
         self._lru_order = [] if self._lru_order is not None else None
         self._lru_bytes = 0
         self._cb_verified_keys = None
+        self._file_load_receipts = None
         return compacted
 
     def release_resident_tensors(self) -> int:
@@ -730,6 +738,84 @@ class ProductionWeightCache:
             self._cb_verified_keys = set()
         self._cb_verified_keys.add(key)
 
+    def enable_file_load_receipts(self, *, max_file_bytes: int) -> None:
+        """Capture content provenance on the necessary, bounded PWC file read.
+
+        Receipts describe bytes actually deserialized, not a previous file scan.
+        They exist only while the matching tensor remains resident and unchanged.
+        This is opt-in for preparation; ordinary cache loads retain their path.
+        """
+        if type(max_file_bytes) is not int or max_file_bytes <= 0:
+            raise ValueError("PWC file receipt needs a positive read buffer bound")
+        if self._lru_order is None or self._lru_max_bytes <= 0:
+            raise RuntimeError("PWC file receipts require bounded LRU residency")
+        if any(isinstance(value, torch.Tensor) for value in self.weights.values()):
+            raise RuntimeError("PWC file receipt capture requires unloaded entries")
+        self._file_load_max_bytes = max_file_bytes
+        self._file_load_receipts = {}
+
+    def disable_file_load_receipts(self) -> None:
+        self._file_load_max_bytes = 0
+        self._file_load_receipts = None
+
+    @staticmethod
+    def _file_signature(value):
+        return (value.st_dev, value.st_ino, value.st_size,
+                value.st_mtime_ns, value.st_ctime_ns)
+
+    @staticmethod
+    def _file_tensor_guard(tensor):
+        return (tensor._version, tensor.untyped_storage().data_ptr(),
+                tensor.storage_offset(), tuple(tensor.shape), tuple(tensor.stride()),
+                str(tensor.dtype), str(tensor.device))
+
+    def _load_file_tensor(self, value):
+        path = Path(self._path_for_value(value)).absolute()
+        limit = getattr(self, "_file_load_max_bytes", 0)
+        if not limit:
+            return torch.load(path, map_location="cpu", weights_only=True), None
+        before = path.lstat()
+        if not stat.S_ISREG(before.st_mode):
+            raise RuntimeError("PWC file receipt requires a regular file, not a symlink")
+        if before.st_size > limit:
+            raise RuntimeError("PWC file exceeds the explicit read buffer bound")
+        signature = self._file_signature(before)
+        with path.open("rb") as handle:
+            if self._file_signature(os.fstat(handle.fileno())) != signature:
+                raise RuntimeError("PWC file changed before its content read")
+            raw = handle.read(limit + 1)
+            if (len(raw) != before.st_size or self._file_signature(os.fstat(handle.fileno())) != signature
+                    or self._file_signature(path.lstat()) != signature):
+                raise RuntimeError("PWC file changed during its content read")
+        # The temporary serialized buffer is per loader worker and is released
+        # before its result enters the existing LRU. No whole-cache byte store.
+        receipt = {"path": str(path), "bytes": len(raw), "sha256": hashlib.sha256(raw).hexdigest()}
+        tensor = torch.load(io.BytesIO(raw), map_location="cpu", weights_only=True)
+        if not isinstance(tensor, torch.Tensor):
+            raise RuntimeError("PWC file receipt requires a tensor shard")
+        return tensor, (receipt, signature, self._file_tensor_guard(tensor))
+
+    def _record_file_load(self, key, tensor, observed) -> None:
+        if observed is not None and self.weights.get(key) is tensor:
+            if self._file_load_receipts is None:
+                self._file_load_receipts = {}
+            # This is the same resident object, released with its LRU entry.
+            self._file_load_receipts[key] = (tensor, observed)
+
+    def file_load_receipt(self, key, tensor) -> dict:
+        """Return a detached receipt for this exact resident tensor lifetime."""
+        entry = (self._file_load_receipts or {}).get(key)
+        if entry is None or entry[0] is not tensor or self.weights.get(key) is not tensor:
+            if self._file_load_receipts is not None:
+                self._file_load_receipts.pop(key, None)
+            raise RuntimeError("PWC file receipt has no matching resident tensor")
+        receipt, signature, guard = entry[1]
+        if (self._file_tensor_guard(tensor) != guard or
+                self._file_signature(Path(receipt["path"]).lstat()) != signature):
+            self._file_load_receipts.pop(key, None)
+            raise RuntimeError("PWC file receipt tensor or source file changed")
+        return dict(receipt)
+
     def prefetch(self, keys: Sequence[tuple[str, str]] | None = None,
                  max_workers: int = 4) -> int:
         """Eagerly load (a subset of) cache entries via a thread pool.
@@ -747,6 +833,9 @@ class ProductionWeightCache:
         """
         from concurrent.futures import ThreadPoolExecutor
 
+        if getattr(self, "_file_load_max_bytes", 0):
+            if type(max_workers) is not int or not 0 < max_workers <= len(os.sched_getaffinity(0)):
+                raise ValueError("PWC file receipt workers exceed assigned CPU affinity")
         if keys is None:
             keys = [k for k, v in self.weights.items()
                     if not isinstance(v, torch.Tensor)]
@@ -760,27 +849,21 @@ class ProductionWeightCache:
             value = self.weights.get(key)
             if value is None or isinstance(value, torch.Tensor):
                 return None
-            return (
-                key,
-                value,
-                torch.load(
-                    self._path_for_value(value),
-                    map_location="cpu",
-                    weights_only=True,
-                ),
-            )
+            tensor, receipt = self._load_file_tensor(value)
+            return key, value, tensor, receipt
 
         loaded_count = 0
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             for item in pool.map(_load_one, keys):
                 if item is None:
                     continue
-                key, original_value, tensor = item
+                key, original_value, tensor, receipt = item
                 if isinstance(self.weights.get(key), torch.Tensor):
                     continue
                 self._validate_loaded_cb_pair_tensor(key, tensor)
                 self.weights[key] = tensor
                 self._record_lru_load(key, original_value, tensor)
+                self._record_file_load(key, tensor, receipt)
                 loaded_count += 1
         return loaded_count
 
@@ -801,11 +884,11 @@ class ProductionWeightCache:
                 self._lru_order.append(key)
             return v
         # Treat anything non-tensor as a filename / path.
-        path = self._path_for_value(v)
-        loaded = torch.load(path, map_location="cpu", weights_only=True)
+        loaded, receipt = self._load_file_tensor(v)
         self._validate_loaded_cb_pair_tensor(key, loaded)
         self.weights[key] = loaded
         self._record_lru_load(key, v, loaded)
+        self._record_file_load(key, loaded, receipt)
         return loaded
 
     def get(self, name: str, fmt: str) -> torch.Tensor | None:

--- a/prismaquant/production_weight_cache.py
+++ b/prismaquant/production_weight_cache.py
@@ -783,7 +783,7 @@ class ProductionWeightCache:
         with path.open("rb") as handle:
             if self._file_signature(os.fstat(handle.fileno())) != signature:
                 raise RuntimeError("PWC file changed before its content read")
-            raw = handle.read(limit + 1)
+            raw = handle.read(before.st_size + 1)
             if (len(raw) != before.st_size or self._file_signature(os.fstat(handle.fileno())) != signature
                     or self._file_signature(path.lstat()) != signature):
                 raise RuntimeError("PWC file changed during its content read")

--- a/prismaquant/tessera_joint_aura.py
+++ b/prismaquant/tessera_joint_aura.py
@@ -77,16 +77,19 @@ class MeasuredAnchorInput:
         return dict(sizes)
 
 
-def load_measured_anchor_input(inputs, *, file_hash_workers=1):
+def load_measured_anchor_input(inputs, *, file_hash_workers=1, verify_payloads=True):
     """Read a complete merged journal and select only its measured wire cells.
 
-    This is a hash/receipt intake. Tensor/source/encoder verification occurs in
+    The default hashes all payload files. Preparation may explicitly defer
+    payload reads to the existing PWC loader and wire verifier; metadata and
+    roster gates still run here. Tensor/source/encoder verification occurs in
     ``prepare_cache`` using actual source weights and the original capture.
     Interpolated menu rows are deliberately excluded rather than converted.
     """
     from .production_weight_cache import _cache_weight_filename
     from tools.dispatch_tessera_campaign import _require_receipts
 
+    _require(type(verify_payloads) is bool, "verify_payloads must be an explicit boolean")
     _require(type(file_hash_workers) is int and file_hash_workers > 0,
              "positive file_hash_workers required")
     paths = {key: _bound(inputs[key], key) for key in (
@@ -203,6 +206,9 @@ def load_measured_anchor_input(inputs, *, file_hash_workers=1):
             cells[name, fmt] = {"anchor": anchor, "record": record, "wire": str(wire.resolve()),
                                "render": str(render.resolve())}
         formats[name] = (*sorted(anchors), "BF16")
+    if not verify_payloads:
+        return MeasuredAnchorInput(dict(inputs), payload, manifest, census, plan, cells, formats)
+
     def verify_files(item):
         pair, cell = item
         wire, render = Path(cell["wire"]), Path(cell["render"])
@@ -293,7 +299,7 @@ def _live_targets(runner, names):
     return {name: targets[name] for name in names}
 
 
-def prepare_cache(runner, data, *, capture, max_render_bytes, reader=None):
+def prepare_cache(runner, data, *, capture, max_render_bytes, reader=None, file_load_workers=4):
     """Qualify original per-layer inputs and return the existing PWC object.
 
     Only the original calibration/PWC/source prefetch mechanisms own tensors.
@@ -330,6 +336,8 @@ def prepare_cache(runner, data, *, capture, max_render_bytes, reader=None):
         metadata={"schema": PREPARED_SCHEMA, "inputs": data.inputs,
                   "reader_identity": None if reader is None else reader.identity})
     cache.enable_lru(max_render_bytes)
+    max_file_bytes = max(Path(cell["render"]).stat().st_size for cell in data.cells.values())
+    cache.enable_file_load_receipts(max_file_bytes=max_file_bytes)
     targets = _live_targets(runner, data.formats_by_qname)
     layers = defaultdict(list)
     for name in targets:
@@ -354,7 +362,8 @@ def prepare_cache(runner, data, *, capture, max_render_bytes, reader=None):
                 expected_sha256=capture["sha256"], expected_identity=expected,
                 census=data.census, names=names, device=runner.device)
             calibration_source = th.activation_source(hessians, expected["calibration"])
-            stats = prefetch_joint_cache(cache, names, renders, max_resident_bytes=max_render_bytes)
+            stats = prefetch_joint_cache(cache, names, renders, max_resident_bytes=max_render_bytes,
+                                         max_workers=file_load_workers)
             for name in names:
                 source_weight = targets[name].weight.detach()
                 anchors = [tc.CampaignAnchor(**data.cells[name, fmt]["anchor"]) for fmt in renders[name]]
@@ -363,8 +372,12 @@ def prepare_cache(runner, data, *, capture, max_render_bytes, reader=None):
                         static_scales=scales) as bound_unit:
                     for fmt in renders[name]:
                         cell = data.cells[name, fmt]
-                        _same(_sha(cell["render"]), cell["render_file_sha256"], f"{name}: original render file changed")
-                        rendered = cache.get(name, fmt).to(runner.device)
+                        resident = cache.get(name, fmt)
+                        receipt = cache.file_load_receipt((name, fmt), resident)
+                        if "render_file_sha256" in cell:
+                            _same(receipt["sha256"], cell["render_file_sha256"], f"{name}: original render file changed")
+                        cell["render_file_sha256"] = receipt["sha256"]
+                        rendered = resident.to(runner.device)
                         record = verify_anchor_render(cell, source_weight, rendered,
                             calibration_source=calibration_source,
                             projected_unit=projected.get(name), static_scales=scales,
@@ -374,7 +387,7 @@ def prepare_cache(runner, data, *, capture, max_render_bytes, reader=None):
                               f"{name}@{fmt}: joint/campaign static scale")
                         record["activation"] = activation
                         verified[name, fmt] = record
-                        del rendered
+                        del rendered, resident
             telemetry.append({"layer": layer, **stats})
             print(json.dumps({"qualified_layer": layer, "qualified_cells": len(verified),
                               "total_cells": len(data.cells), "prefetch": stats}), flush=True)
@@ -384,6 +397,7 @@ def prepare_cache(runner, data, *, capture, max_render_bytes, reader=None):
             runner.context.unload(layer)
             targets.update({member.qname: member for member in refresh_packed_expert_projections(members, runner.profile)})
     _same(set(verified), set(data.cells), "complete qualified wire/render roster")
+    cache.disable_file_load_receipts()
     cache.metadata.update({"verified_cells": verified, "prefetch": telemetry})
     return cache
 
@@ -496,7 +510,8 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False):
         _require(type(file_hash_workers) is int and 0 < file_hash_workers <= len(os.sched_getaffinity(0)),
                  "file_hash_workers exceeds PB-assigned CPU affinity")
         data = load_measured_anchor_input(config["inputs"],
-            **({} if file_hash_workers == 1 else {"file_hash_workers": file_hash_workers}))
+            **({} if file_hash_workers == 1 else {"file_hash_workers": file_hash_workers}),
+            **({"verify_payloads": False} if command == "prepare" else {}))
         result["file_hash_workers"] = file_hash_workers
         reader = load_declared_reader(config.get("reader"))
         reader_identity = None if reader is None else reader.identity
@@ -531,7 +546,8 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False):
             completion_path = root / "prepared.json"
             _require(not completion_path.exists(), "prepared completion already exists; use its bound record")
             cache = prepare_cache(runner, data, capture=config["canonical_capture"],
-                                  max_render_bytes=config["max_render_bytes"], reader=reader)
+                                  max_render_bytes=config["max_render_bytes"], reader=reader,
+                                  file_load_workers=file_hash_workers)
             cache.metadata.update(plan_sha256=plan_sha256, source_model_identity=source,
                                   source_execution=source_execution, implementation_sha256=implementation)
             cache.compact_for_pickle()

--- a/prismaquant/tessera_joint_aura.py
+++ b/prismaquant/tessera_joint_aura.py
@@ -299,6 +299,14 @@ def _live_targets(runner, names):
     return {name: targets[name] for name in names}
 
 
+def _prepare_file_read_bound(data, *, max_render_bytes):
+    """Refuse an oversized later donor before any layer allocates read buffers."""
+    maximum = max(Path(cell["render"]).stat().st_size for cell in data.cells.values())
+    _require(0 < maximum <= max_render_bytes,
+             "original render shard exceeds the declared PWC read buffer budget")
+    return maximum
+
+
 def prepare_cache(runner, data, *, capture, max_render_bytes, reader=None, file_load_workers=4):
     """Qualify original per-layer inputs and return the existing PWC object.
 
@@ -336,7 +344,7 @@ def prepare_cache(runner, data, *, capture, max_render_bytes, reader=None, file_
         metadata={"schema": PREPARED_SCHEMA, "inputs": data.inputs,
                   "reader_identity": None if reader is None else reader.identity})
     cache.enable_lru(max_render_bytes)
-    max_file_bytes = max(Path(cell["render"]).stat().st_size for cell in data.cells.values())
+    max_file_bytes = _prepare_file_read_bound(data, max_render_bytes=max_render_bytes)
     cache.enable_file_load_receipts(max_file_bytes=max_file_bytes)
     targets = _live_targets(runner, data.formats_by_qname)
     layers = defaultdict(list)

--- a/tests/test_file_read_audit.py
+++ b/tests/test_file_read_audit.py
@@ -1,0 +1,21 @@
+"""The measurement observer must see real torch serialization I/O."""
+import hashlib
+import torch
+
+from experiments.file_read_audit import FileReadAudit
+
+
+def test_observer_counts_path_hash_and_torch_load_reads(tmp_path):
+    path = tmp_path / 'tensor.pt'
+    tensor = torch.arange(8192, dtype=torch.bfloat16).reshape(128, 64)
+    torch.save(tensor, path)
+    raw = path.read_bytes()
+    with FileReadAudit({path: 'render'}) as audit:
+        with path.open('rb') as handle:
+            assert hashlib.file_digest(handle, 'sha256').hexdigest() == hashlib.sha256(raw).hexdigest()
+        loaded = torch.load(path, weights_only=True)
+        assert torch.equal(loaded, tensor)
+    observed = audit.summary()['by_kind']['render']
+    assert observed['opens'] == 2
+    assert observed['read_bytes'] >= len(raw) + tensor.numel() * tensor.element_size()
+    assert observed['read_calls'] >= 3

--- a/tests/test_pwc_file_load_receipts.py
+++ b/tests/test_pwc_file_load_receipts.py
@@ -1,0 +1,140 @@
+"""Integrity receipts belong to the PWC's actual tensor load and lifetime."""
+from pathlib import Path
+import hashlib
+import pickle
+
+import pytest
+import torch
+
+from prismaquant.production_weight_cache import ProductionWeightCache
+
+
+FMT = 'TESSERA_E4M3_K1_R1024'
+
+
+def make_cache(tmp_path, count=1, *, budget=1024):
+    paths = {}
+    tensors = {}
+    for index in range(count):
+        key = (f'unit{index}', FMT)
+        tensors[key] = torch.arange(16, dtype=torch.bfloat16).reshape(4, 4) + index
+        paths[key] = tmp_path / f'unit{index}.pt'
+        torch.save(tensors[key], paths[key])
+    cache = ProductionWeightCache(weights={k: str(v) for k, v in paths.items()}, levers={})
+    cache.enable_lru(budget)
+    return cache, paths, tensors
+
+
+def test_receipt_hashes_exact_single_read_and_tensor(tmp_path, monkeypatch):
+    cache, paths, tensors = make_cache(tmp_path)
+    key, path = next(iter(paths.items()))
+    blob = path.read_bytes()
+    calls = []
+    original = Path.open
+    class Counted:
+        def __init__(self, stream):
+            self.stream = stream
+        def __enter__(self):
+            return self
+        def __exit__(self, *args):
+            return self.stream.__exit__(*args)
+        def read(self, *args):
+            raw = self.stream.read(*args); calls.append(('read', len(raw))); return raw
+        def __getattr__(self, name):
+            return getattr(self.stream, name)
+    def counted(candidate, *args, **kwargs):
+        stream = original(candidate, *args, **kwargs)
+        if candidate == path:
+            calls.append(('open', None)); return Counted(stream)
+        return stream
+    monkeypatch.setattr(Path, 'open', counted)
+    cache.enable_file_load_receipts(max_file_bytes=len(blob))
+    assert cache.prefetch([key], max_workers=1) == 1
+    tensor = cache.get(*key)
+    receipt = cache.file_load_receipt(key, tensor)
+    assert torch.equal(tensor, tensors[key])
+    assert receipt == {'path': str(path), 'bytes': len(blob), 'sha256': hashlib.sha256(blob).hexdigest()}
+    assert calls == [('open', None), ('read', len(blob))]
+    receipt['sha256'] = '0' * 64
+    assert cache.file_load_receipt(key, tensor)['sha256'] == hashlib.sha256(blob).hexdigest()
+
+
+@pytest.mark.parametrize('mutation', ['tensor', 'replacement', 'file'])
+def test_receipt_refuses_drift_after_load(tmp_path, mutation):
+    cache, paths, _ = make_cache(tmp_path)
+    key, path = next(iter(paths.items()))
+    cache.enable_file_load_receipts(max_file_bytes=path.stat().st_size)
+    cache.prefetch([key], max_workers=1)
+    tensor = cache.get(*key)
+    if mutation == 'tensor':
+        tensor[0, 0] += 1
+    elif mutation == 'replacement':
+        cache.weights[key] = tensor.clone()
+    else:
+        path.write_bytes(path.read_bytes() + b'changed')
+    with pytest.raises(RuntimeError, match='receipt|changed'):
+        cache.file_load_receipt(key, tensor)
+
+
+def test_receipt_dies_at_eviction_and_compaction(tmp_path):
+    cache, paths, _ = make_cache(tmp_path, 2, budget=32)
+    a, b = paths
+    cache.enable_file_load_receipts(max_file_bytes=max(p.stat().st_size for p in paths.values()))
+    old = cache.get(*a)
+    cache.file_load_receipt(a, old)
+    cache.get(*b)
+    with pytest.raises(RuntimeError, match='receipt|resident'):
+        cache.file_load_receipt(a, old)
+    new = cache.get(*a)
+    assert new is not old
+    cache.file_load_receipt(a, new)
+    cache.compact_for_pickle()
+    with pytest.raises(RuntimeError, match='receipt|resident'):
+        cache.file_load_receipt(a, new)
+    cache.disable_file_load_receipts()
+    assert pickle.loads(pickle.dumps(cache)).weights == {k: str(v) for k, v in paths.items()}
+
+
+def test_read_buffer_bound_and_regular_file_required(tmp_path):
+    cache, paths, _ = make_cache(tmp_path)
+    key, path = next(iter(paths.items()))
+    cache.enable_file_load_receipts(max_file_bytes=path.stat().st_size - 1)
+    with pytest.raises((ValueError, RuntimeError), match='budget|bound'):
+        cache.prefetch([key], max_workers=1)
+    assert isinstance(cache.weights[key], str)
+    cache.disable_file_load_receipts()
+    target = path.with_suffix('.original'); path.rename(target); path.symlink_to(target)
+    cache.enable_file_load_receipts(max_file_bytes=target.stat().st_size)
+    with pytest.raises((ValueError, RuntimeError), match='regular|symlink'):
+        cache.prefetch([key], max_workers=1)
+
+
+def test_mutation_during_read_refuses_without_registering_tensor(tmp_path, monkeypatch):
+    cache, paths, _ = make_cache(tmp_path)
+    key, path = next(iter(paths.items()))
+    cache.enable_file_load_receipts(max_file_bytes=path.stat().st_size + 20)
+    original = Path.open
+    class Mutating:
+        def __init__(self, stream): self.stream = stream
+        def __enter__(self): return self
+        def __exit__(self, *args): return self.stream.__exit__(*args)
+        def read(self, *args):
+            raw = self.stream.read(*args)
+            with original(path, 'ab') as writer: writer.write(b'drift')
+            return raw
+        def __getattr__(self, name): return getattr(self.stream, name)
+    def altered(candidate, *args, **kwargs):
+        stream = original(candidate, *args, **kwargs)
+        return Mutating(stream) if candidate == path else stream
+    monkeypatch.setattr(Path, 'open', altered)
+    with pytest.raises(RuntimeError, match='changed'):
+        cache.prefetch([key], max_workers=1)
+    assert isinstance(cache.weights[key], str)
+
+
+def test_receipt_capture_requires_unloaded_entries(tmp_path):
+    cache, paths, _ = make_cache(tmp_path)
+    key, path = next(iter(paths.items()))
+    cache.get(*key)
+    with pytest.raises(RuntimeError, match='resident|unloaded'):
+        cache.enable_file_load_receipts(max_file_bytes=path.stat().st_size)

--- a/tests/test_pwc_file_load_receipts.py
+++ b/tests/test_pwc_file_load_receipts.py
@@ -138,3 +138,24 @@ def test_receipt_capture_requires_unloaded_entries(tmp_path):
     cache.get(*key)
     with pytest.raises(RuntimeError, match='resident|unloaded'):
         cache.enable_file_load_receipts(max_file_bytes=path.stat().st_size)
+
+
+def test_small_file_read_request_ignores_large_global_bound(tmp_path, monkeypatch):
+    cache, paths, _ = make_cache(tmp_path)
+    key, path = next(iter(paths.items()))
+    size = path.stat().st_size
+    cache.enable_file_load_receipts(max_file_bytes=size * 1000)
+    original = Path.open
+    class LimitedRead:
+        def __init__(self, stream): self.stream = stream
+        def __enter__(self): return self
+        def __exit__(self, *args): return self.stream.__exit__(*args)
+        def read(self, requested):
+            assert requested == size + 1, 'small file inherited the whole-cache read bound'
+            return self.stream.read(requested)
+        def __getattr__(self, name): return getattr(self.stream, name)
+    def limited(candidate, *args, **kwargs):
+        stream = original(candidate, *args, **kwargs)
+        return LimitedRead(stream) if candidate == path else stream
+    monkeypatch.setattr(Path, 'open', limited)
+    assert cache.prefetch([key], max_workers=1) == 1

--- a/tests/test_tessera_joint_aura.py
+++ b/tests/test_tessera_joint_aura.py
@@ -263,7 +263,7 @@ def test_original_full_draw_refuses_subset_before_model_load(tmp_path, monkeypat
     from prismaquant import tessera_joint_aura as bridge, calibration_data, cost_streaming, gpu_guard
     draw = dict(fit_ids_sha256="a" * 64, text_sha256="b" * 64, nsamples=512, seqlen=512, seed=0)
     monkeypatch.setattr(gpu_guard, "require_cuda_hot_path", lambda *_args: None)
-    monkeypatch.setattr(bridge, "load_measured_anchor_input", lambda _inputs: SimpleNamespace(
+    monkeypatch.setattr(bridge, "load_measured_anchor_input", lambda _inputs, **_kwargs: SimpleNamespace(
         census={"model": "fixture", "attention_implementation": "eager"},
         payload={"provenance": {"hessian": {"calibration_identity": draw}}}))
     monkeypatch.setattr(calibration_data, "load_calibration_input", lambda *_args, **_kwargs:
@@ -300,9 +300,11 @@ def test_explicit_source_prefetch_reaches_streamed_builder(tmp_path, monkeypatch
     monkeypatch.setattr(model_profiles, "detect_profile", lambda _path: object())
     draw = dict(fit_ids_sha256="a" * 64, text_sha256="b" * 64, nsamples=512, seqlen=512, seed=0)
     monkeypatch.setattr(gpu_guard, "require_cuda_hot_path", lambda *_args: None)
-    monkeypatch.setattr(bridge, "load_measured_anchor_input", lambda _inputs: SimpleNamespace(
-        census={"model": "fixture", "attention_implementation": "eager"},
-        payload={"provenance": {"hessian": {"calibration_identity": draw}}}))
+    def intake(_inputs, **kwargs):
+        assert kwargs == ({"verify_payloads": False} if command == "prepare" else {})
+        return SimpleNamespace(census={"model": "fixture", "attention_implementation": "eager"},
+            payload={"provenance": {"hessian": {"calibration_identity": draw}}})
+    monkeypatch.setattr(bridge, "load_measured_anchor_input", intake)
     monkeypatch.setattr(calibration_data, "load_calibration_input", lambda *_args, **_kwargs:
         (torch.zeros((512, 512), dtype=torch.int64), {"provenance": draw}))
     prefetch = dict(max_cache_slots=24, prefetch_workers=4, prefetch_lookahead=4,
@@ -384,3 +386,23 @@ def test_sampling_refuses_unobserved_execution(tmp_path, monkeypatch, defect):
               "execution": {"production_act_scales": "0"}}
     with pytest.raises(ValueError, match="sampl|observed"):
         bridge.execute("prepare", config, plan_sha256="b" * 64)
+
+
+def test_prepare_metadata_intake_defers_heavy_files_but_keeps_strict_default(tmp_path, monkeypatch):
+    from prismaquant import tessera_joint_aura as bridge
+    config, names, fmt, _payload, _states = fixture(tmp_path)
+    calls = []
+    original = bridge._sha
+    def observed(path):
+        calls.append(Path(path))
+        return original(path)
+    monkeypatch.setattr(bridge, '_sha', observed)
+    metadata = bridge.load_measured_anchor_input(config, verify_payloads=False)
+    heavy = {Path(cell[k]) for cell in metadata.cells.values() for k in ('wire', 'render')}
+    assert not heavy.intersection(calls)
+    assert all('render_file_sha256' not in cell for cell in metadata.cells.values())
+    assert metadata.formats_by_qname == {name: (fmt, 'BF16') for name in names}
+    calls.clear()
+    strict = bridge.load_measured_anchor_input(config)
+    assert heavy <= set(calls)
+    assert all('render_file_sha256' in cell for cell in strict.cells.values())

--- a/tests/test_tessera_joint_aura.py
+++ b/tests/test_tessera_joint_aura.py
@@ -406,3 +406,16 @@ def test_prepare_metadata_intake_defers_heavy_files_but_keeps_strict_default(tmp
     strict = bridge.load_measured_anchor_input(config)
     assert heavy <= set(calls)
     assert all('render_file_sha256' in cell for cell in strict.cells.values())
+
+
+def test_prepare_refuses_oversized_later_render_before_loading_any_layer(tmp_path):
+    from types import SimpleNamespace
+    from prismaquant import tessera_joint_aura as bridge
+    small, huge = tmp_path / 'early.pt', tmp_path / 'later.pt'
+    small.write_bytes(b'early')
+    with huge.open('wb') as stream:
+        stream.truncate(8192)
+    data = SimpleNamespace(cells={('early', 'fmt'): {'render': str(small)},
+                                  ('later', 'fmt'): {'render': str(huge)}})
+    with pytest.raises(ValueError, match='read buffer|shard|budget'):
+        bridge._prepare_file_read_bound(data, max_render_bytes=4096)


### PR DESCRIPTION
## Tracked issue

Closes #322

## Change

Joint-anchor preparation previously read each render three times and each wire twice. It now performs metadata intake first, then verifies render bytes during the existing PWC load and verifies original wires at consumption. PWC hashes the exact bounded buffer it deserializes; receipts expire on tensor mutation, donor changes, eviction, or compaction. Strict intake defaults and cost/resume validation remain unchanged.

On the original fourteen-cell fixture, actual target-file reads fell from 1,439,737,470 to 514,309,808 bytes (64.3%), and warm median wall time fell from 3.331945 to 3.102984 seconds (6.87%). This follows #330, holding its bound identity and the qualified Tessera reader fixed. The architecture contract and complete measurement report are included in `docs/experiments/tessera_prepare_file_reads_2026-09-07.md`.

## Validation

- PrismaBuild CPU gates: 65 tests passed, then 11 receipt/buffer/observer tests passed after a demonstrated oversized-read regression; changed modules compiled; the real metadata projection preserved all fourteen original producer records. No skips.
- PrismaBuild GPU action `53fca49df8d345b8ffec4816ad9028cff6e922972a4d6eee9439cde4e7579cb2`: all ten phases matched the original fourteen-record oracle exactly, and all eight corruption cases refused. Actual per-file read counts, child/sampler exit statuses, cleanup, CAS payload and receipt hashes were independently checked.
- Retained before/after torch CPU/CUDA profiles, py-spy sampling (3,543 samples, zero errors), and raw Netdata from both hosts. Results and artifact seals are recorded in the report.
- Scope: bounded preparation on a GB10 with resident source/capture data. Warm physical read counters were zero; first-parse startup was asymmetric; the scope reached its 12 GiB memory cap without OOM. No full-model, cold-storage, or work-per-joule improvement is claimed.
