### PR TITLE
Reuse resident NVFP4 codepoints in joint projection QDQ

### DIFF
--- a/docs/results/nvfp4_codepoint_residency_2026-09-07.md
+++ b/docs/results/nvfp4_codepoint_residency_2026-09-07.md
@@ -1,0 +1,151 @@
+# Served NVFP4 codepoint residency — 2026-09-07
+
+Reusing the format registry's existing device codebook removes a host-to-device
+copy and synchronization from each served NVFP4 QDQ call. It preserves output
+bytes, midpoint rounding, signed zero, underflow, and the joint projection's
+signed components. On the actual routed calls below, the measured wall-time
+reduction is **2.542%**. This does **not** resolve the stopped full joint run's
+performance problem: elementwise multiplication still occupies about 70% of
+the measured CUDA time. The sampled energy comparison establishes no gain.
+
+## Change and numerical qualification
+
+`nvfp4_activation_qdq_served` formerly constructed an eight-element FP32 tensor
+from `_E2M1_POSITIVE` on every invocation. The registry's sorted E2M1 table
+already contains precisely those eight positive encodings, including positive
+zero, at its end. The owner now takes that view through the existing
+`_codebook_on_device` cache. It adds no cache, quantization policy, arithmetic
+reassociation, format, or pipeline default.
+
+The CPU regression failed before the change because three warm calls rebuilt
+the codepoints three times. The same test and related contract/projection
+suites passed after the change: **81 passed, 6 CUDA-required skips**. In the
+pinned GPU container, all **12 CPU/CUDA residency and numerical golden tests
+passed**, including FP32/BF16/FP16 midpoint ties and signed zero, scale
+underflow, and exact device-grid bytes.
+
+Both GPU A/B comparisons also required exact forward, input-gradient and
+weight-gradient hashes, plus all weight/activation/mixed/total signed
+components for four probes and seven original measured formats. All passed.
+No candidate bytes, calibration tokens, static scales, source weights or
+source model batching changed.
+
+## Matched measurements
+
+Environment: Sparky, NVIDIA GB10, PyTorch `2.13.0+cu130`, CUDA 13.0, pinned
+`eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c`.
+PB measurement admission reserved four CPU cores, 12 GiB total memory and an
+8 GiB GPU subset. Native threads were bounded to one. CPU/CUDA
+`torch.profiler` traces were collected separately from steady ABBA timings;
+raw Netdata CPU, RAM, I/O and GPU-power series cover both hosts.
+
+The unit is `model.layers.23.feed_forward.experts.0.w1`, BF16 weight shape
+`[1792, 2048]`, with its seven original measured PWC renders. The harness
+verified the prepared artifact, source tensor identity, original render-file
+and tensor hashes, activation identities, canonical manifest/census, and
+capture payload metadata. Existing PWC/capture prefetch reported zero misses;
+the measured arms recorded zero process `read_bytes` and `write_bytes`.
+
+| Workload | Old A1 | Reused B1 | Reused B2 | Old A2 | Median old → reused |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Canonical 512-row prefix, four fixed random BF16 cotangents; 1,696 cycles | 34.7277 s | 34.6955 s | 34.6856 s | 34.8122 s | 34.7700 → 34.6905 s; 0.228% less |
+| Actual B1 routed calls, four actual Fisher probes; 632 cycles | 36.1002 s | 35.1915 s | 35.2405 s | 36.1689 s | 36.1345 → 35.2160 s; 2.542% less |
+
+The first comparison is a useful negative measurement: the canonical scoring
+prefix combines several invocations and is not the triggering per-call shape.
+The second replay retains four actual invocation shapes, **137, 102, 74 and
+80 rows**, from original complete calibration sequences 0–3. It accumulates
+their signed terms in the actual invocation order before finishing each probe.
+The replay exercises the real projection hook with retained X/g and an
+isolated Linear; it is not a timing of the entire grouped model forward or
+the complete 512-sequence joint cost.
+
+The source-control capture used the existing streaming source path and
+original prefetch contract, B1 full 512-token sequences, eager attention,
+original source/dispatch identity, seeds 7000–7003 and global row offsets
+0–3. Fisher normalization remained **262,144 global tokens**, as in the full
+512-by-512 draw. It retained actual selected output cotangents, not generated
+replacement gradients. Its peak CUDA allocation was 19.262 GB; the separate
+capture was admitted for 36 GiB total memory and a 24 GiB GPU subset.
+
+The actual-call profiles cover 48 invocations per arm. Reuse removes **48
+pageable H→D copies**, reducing `cudaMemcpyAsync` and `cudaStreamSynchronize`
+counts from 132 to 84 each; the remaining 84 copies are D→H. Device-kernel
+count stays 5,280. `aten::mul` CUDA time is **111.211 → 111.142 ms**, about
+70.1% of the CUDA total in each arm; GEMM is about 9.9%, and sum reduction
+about 8.3%. A stack waiting at the old constructor therefore does not identify
+the constructor as the owner of all preceding queued GPU work.
+
+Actual-call mean GPU power by arm was 39.43, 41.26, 42.00 and 41.39 W, about
+28–30% of the approximately 140 W envelope. Interpolated median GPU energy
+was **1,460.24 → 1,466.05 J**; useful cycles/J were **0.43281 → 0.43109**
+(ratio 0.9960). These are GPU-only estimates from ten-second samples, not
+whole-host energy or evidence of an efficiency gain. The 512-row comparison
+also showed no energy improvement (work/J ratio 0.9679). Neither comparison
+establishes GPU saturation or full-model throughput. Actual replay peak CUDA
+allocation was 345.6 MB; PB scope memory peak was 2.211 GB.
+
+## Capture-order diagnosis and retained unsuccessful attempts
+
+An initial check incorrectly assumed that actual grouped rows have the same
+order as the canonical scoring prefix. The canonical collector re-derives
+packed rows via `derive_per_expert_activations`, ordered by top-k position
+then token; the grouped observer records the runtime's contiguous expert
+slice. A PB CPU comparison proved that all **393 rows match byte-for-byte as
+multisets**, including separately within each 137/102/74/80-row invocation.
+It retained the complete permutation. The final harness verifies that
+per-invocation bijection and exact mapped bytes while preserving actual X/g
+order for projection. The apparent positional difference was not source
+arithmetic drift.
+
+Retained failures contain no timing claim: the first container lacked pytest
+(fixed with a scoped pinned install); the next harness incorrectly treated a
+canonical capture dictionary as a Tensor (fixed by using the existing
+validated capture reader); and the first actual replay stopped on the invalid
+row-order assumption above. The original CPU red is the intentional
+three-allocation regression, not an environment failure.
+
+## Attributable artifacts
+
+All evidence is retained under
+`/mnt/shared/tessera-measurements/first-model-20260907/qdq-residency/`.
+`frozen-source/source-manifest.json` binds exact per-action source snapshots,
+including unsuccessful harnesses; `run-02/` and `actual-replay-02/` contain
+receipts, before/after source functions, CPU/CUDA tables, Chrome traces,
+both-host raw Netdata and independently checked PB/CAS records.
+`source-capture-01/` binds the actual X/g payload; its receipt SHA is
+`bf5337381562e2b4ae1fbdb672e85f198679e2848487b291590d7810990872d3`.
+`capture-order-diagnosis.json` retains the exact row permutation.
+
+The checked-in experiment entry points are
+`experiments/qdq_projection_source_capture.py`,
+`experiments/qdq_capture_order_diagnose.py` and
+`experiments/qdq_constant_residency.py`. Historical executed versions are
+retained per action above. The final replay command, with a fresh output
+directory substituted, is:
+
+```bash
+python3 /mnt/shared/prismabuild-fleet/repo/tools/pbrun.py \
+  --cwd CHECKOUT --gpu --measurement --cpus 4 \
+  --demand mem_gb=12 --gpu-memory-gb 8 --timeout-s 1500 -- \
+  bash experiments/qdq_constant_residency_run.sh --output NEW_OUTPUT \
+  --source-receipt /mnt/shared/tessera-measurements/first-model-20260907/qdq-residency/source-capture-01/receipt.json \
+  --source-sha256 bf5337381562e2b4ae1fbdb672e85f198679e2848487b291590d7810990872d3
+```
+
+| Qualification | PB action | Verified CAS stdout SHA-256 |
+| --- | --- | --- |
+| CPU regression red | `de66fa46439d203719c8a61d0b548d1c5aa87c261ce932e30bfb16b0bc7c3e3f` | Intentional failure; terminal retains assertion |
+| CPU green | `d023dda6d25f6302600f722655ab2184f2966ebedbf1527d13b447cc6341954a` | `fe76df4904e347318babde2b75e7fb7be1d16926e424d889e77264d685e122ec` |
+| CUDA goldens and M512 ABBA | `f2dddac6864b0ec49e18f6f722a27ee3dce1ce43957a471e719bbe768e42369a` | `74e2d9c575de865b6e1524947a822e2b43b5e0bcc1418b488f8cc4886ad08cca` |
+| Actual source capture | `ac687314a937173c33a437242dd1a69631df30c89204d9b113bed537762f2191` | `85eabb6dd01613fc12790335048b3340209dcb9239167adaeb2526fdcaf8e1f5` |
+| CPU row-order proof | `759ea5d8e839df82923b6dffc3a02e40043c360b8cb18e72b050ecdfe5a6f3a5` | `3da0caa74eae7964cea317fc1fc1bac877a1c7e1c3363565136822e6a87371d7` |
+| Actual-call ABBA | `78cbb9c1fc0903c8d676e30bfded803d39fdf4aaef5bb958579800f3a5b3b460` | `cd51dc438bb8524b79cf1b8ea80fdb50cd22802a4819bda1cc22b811ddfeecd6` |
+
+All successful actions above have checked exit status 0 and actual payloads;
+the GPU scopes completed cleanup. The benchmark source base is
+`d10b5bfcf38e52e03934764ea99e4395abff7518`; the final measured snapshot is
+`acc3f0952e507a10937462db1797ad90759828e3`. This result qualifies the small
+QDQ constant reuse only. Repeated product temporaries remain a separate
+profiled optimization target requiring its own numerical and performance
+qualification.

--- a/experiments/qdq_capture_order_diagnose.py
+++ b/experiments/qdq_capture_order_diagnose.py
@@ -1,0 +1,61 @@
+"""PB CPU comparison of retained canonical and actual routed input rows."""
+from collections import Counter, defaultdict, deque
+import json
+from pathlib import Path
+
+import torch
+
+from experiments.qdq_constant_residency import ROOT, NAME, sha, tensor_sha
+
+
+def main():
+    torch.set_num_threads(1)
+    source_root = ROOT / 'qdq-residency/source-capture-01'
+    receipt = json.loads((source_root / 'receipt.json').read_text())
+    assert sha(receipt['payload']['path']) == receipt['payload']['sha256']
+    payload = torch.load(receipt['payload']['path'], map_location='cpu', weights_only=True)
+    manifest_path = ROOT / 'capture-reuse/canonical/capture_manifest.json'
+    manifest = json.loads(manifest_path.read_text())
+    record = manifest['entries'][NAME]
+    path = manifest_path.parent / record['path']
+    assert sha(path) == record['sha256']
+    canonical = torch.load(path, map_location='cpu', weights_only=True)['inputs']
+    actual_records = [entry for entry in payload['records'] if entry['probe'] == 0]
+    actual = torch.cat([entry['x'].float() for entry in actual_records])
+    original = canonical[:len(actual)]
+    delta = actual - original
+    first = (delta != 0).nonzero()[0].tolist()
+    actual_hashes = [tensor_sha(row) for row in actual]
+    original_hashes = [tensor_sha(row) for row in original]
+    indices = defaultdict(deque)
+    for i, digest in enumerate(original_hashes):
+        indices[digest].append(i)
+    order = [indices[digest].popleft() if indices[digest] else None for digest in actual_hashes]
+    result = {'source_receipt_sha256': sha(source_root / 'receipt.json'),
+              'canonical_sha256': record['sha256'], 'shapes': [list(actual.shape), list(canonical.shape)],
+              'first_difference': {'index': first, 'actual': actual[tuple(first)].item(), 'canonical': original[tuple(first)].item()},
+              'ordered_max_abs': delta.abs().max().item(), 'ordered_relative_l2': (delta.norm()/original.norm()).item(),
+              'exact_multiset_equal': Counter(actual_hashes) == Counter(original_hashes),
+              'ordered_equal': torch.equal(actual, original),
+              'actual_to_canonical_row': order, 'invocation_checks': []}
+    start = 0
+    for entry in actual_records:
+        end = start + len(entry['x'])
+        result['invocation_checks'].append({'source_row': entry['row'], 'rows': end-start,
+            'equal_multiset': Counter(actual_hashes[start:end]) == Counter(original_hashes[start:end]),
+            'same_order': actual_hashes[start:end] == original_hashes[start:end]})
+        start = end
+    if not result['exact_multiset_equal']:
+        distances = torch.cdist(actual, canonical)
+        best = distances.argmin(dim=1)
+        diff = actual - canonical[best]
+        result['nearest_canonical_rows'] = best.tolist()
+        result['nearest_max_abs'] = diff.abs().max().item()
+        result['nearest_relative_l2'] = (diff.norm()/actual.norm()).item()
+    out = ROOT / 'qdq-residency/capture-order-diagnosis.json'
+    out.write_text(json.dumps(result, indent=2))
+    print(json.dumps({k:v for k,v in result.items() if k != 'actual_to_canonical_row'}))
+
+
+if __name__ == '__main__':
+    main()

--- a/experiments/qdq_constant_residency.py
+++ b/experiments/qdq_constant_residency.py
@@ -1,0 +1,266 @@
+"""Bounded, admitted A/B of the served QDQ owner in actual joint projections.
+
+Uses one retained canonical unit and original measured PWC renders. The four
+fixed random cotangents qualify projection arithmetic, not model Fisher costs.
+"""
+import argparse
+import ast
+import hashlib
+import inspect
+import json
+import math
+import os
+from pathlib import Path
+import pickle
+import resource
+import socket
+import time
+
+import torch
+from safetensors import safe_open
+
+from prismaquant import format_registry as fr
+from prismaquant import nvfp4_activation_contract as owner
+from prismaquant.joint_aura import SignedJointProjectionLease, activation_identity, prefetch_joint_cache
+from prismaquant.production_weight_cache import _cb_cache_tensor_identity
+from prismaquant.tessera_calibration_cache import prefetch_capture, require_capture_contract
+
+
+ROOT = Path('/mnt/shared/tessera-measurements/first-model-20260907')
+NAME = 'model.layers.23.feed_forward.experts.0.w1'
+
+
+def sha(path):
+    with Path(path).open('rb') as stream:
+        return hashlib.file_digest(stream, 'sha256').hexdigest()
+
+
+def tensor_sha(value):
+    return hashlib.sha256(value.detach().contiguous().view(torch.uint8).cpu().numpy().tobytes()).hexdigest()
+
+
+def io_counters():
+    return {key: int(value) for key, value in
+            (line.split(':') for line in Path('/proc/self/io').read_text().splitlines())}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--target-seconds', type=float, default=35)
+    parser.add_argument('--source-receipt', type=Path)
+    parser.add_argument('--source-sha256')
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=False)
+    torch.set_num_threads(1)
+    torch.set_float32_matmul_precision('highest')
+    torch.backends.cuda.matmul.allow_tf32 = False
+    assert torch.cuda.is_available()
+    receipt = {'schema': 'pq.qdq_constant_residency.v1', 'passed': False, 'phases': [],
+               'env': {'started_epoch': time.time(), 'host': socket.gethostname(),
+                       'torch': str(torch.__version__), 'cuda': torch.version.cuda,
+                       'device': torch.cuda.get_device_name(), 'affinity': sorted(os.sched_getaffinity(0))}}
+
+    def save():
+        (args.output / 'receipt.json').write_text(json.dumps(receipt, indent=2, allow_nan=False))
+
+    save()
+    baseline_path = ROOT / 'qdq-residency/frozen-source/baseline_nvfp4_activation_contract.py'
+    baseline_text = baseline_path.read_text()
+    tree = ast.parse(baseline_text)
+    function = next(node for node in tree.body if isinstance(node, ast.FunctionDef)
+                    and node.name == 'nvfp4_activation_qdq_served')
+    baseline_function = ast.get_source_segment(baseline_text, function)
+    namespace = dict(owner.__dict__)
+    exec(compile(baseline_function, str(baseline_path), 'exec'), namespace)
+    before = namespace['nvfp4_activation_qdq_served']
+    after = owner.nvfp4_activation_qdq_served
+    (args.output / 'before.py').write_text(baseline_function)
+    (args.output / 'after.py').write_text(inspect.getsource(after))
+    prepared_path = ROOT / 'full-model-joint-aura/run-02/prepare/prepared.json'
+    assert sha(prepared_path) == '69a56bff2d29beaf38759b309dee1ac94ca9e091e50f846590d8b51cb0ba5908'
+    prepared = json.loads(prepared_path.read_text())
+    cache_path = Path(prepared['production_cache']['path'])
+    assert sha(cache_path) == prepared['production_cache']['sha256']
+    cache = pickle.loads(cache_path.read_bytes())
+    formats = [fmt for fmt in prepared['formats_by_qname'][NAME] if fmt != 'BF16']
+    render_paths = {fmt: Path(cache.weights[NAME, fmt]) for fmt in formats}
+    for fmt, path in render_paths.items():
+        assert sha(path) == cache.metadata['verified_cells'][NAME, fmt]['render_file_sha256']
+    manifest_path = ROOT / 'capture-reuse/canonical/capture_manifest.json'
+    manifest_sha = 'db3cd996ee8a3ac82d62c6e7e2f23cdb995874b831adcf9360acdae682654823'
+    manifest = require_capture_contract(manifest_path, expected_sha256=manifest_sha)
+    census_path = ROOT / 'canonical-census-512/census.json'
+    assert sha(census_path) == manifest['identity']['census_sha256']
+    census = json.loads(census_path.read_text())
+    capture = manifest['entries'][NAME]
+    x_path = manifest_path.parent / capture['path']
+    assert sha(x_path) == capture['sha256'] == '87ffaceab268f0747aaa325aeb872cb358cd1de1dbba6b6f44044833e05d71ba'
+    (acts, hessians, counts, maxima), capture_receipt = prefetch_capture(
+        manifest_path, expected_identity=manifest['identity'], census=census,
+        names=[NAME], device='cuda', expected_sha256=manifest_sha)
+    captured = acts[NAME]
+    assert isinstance(captured, torch.Tensor) and captured.shape == (512, 2048)
+    with safe_open('/mnt/shared/models/LFM2.5-8B-A1B-BF16/model.safetensors', framework='pt', device='cpu') as model:
+        source = model.get_tensor(NAME + '.weight')
+    assert source.dtype == torch.bfloat16 and source.shape == (1792, 2048)
+    source_identity = _cb_cache_tensor_identity(source)
+    for fmt in formats:
+        assert source_identity == cache.metadata['verified_cells'][NAME, fmt]['source_weight']
+    prefetch = prefetch_joint_cache(cache, [NAME], {NAME: formats}, max_resident_bytes=256 * 2**20)
+    source = source.cuda()
+    renders = {fmt: cache.get(NAME, fmt).cuda() for fmt in formats}
+    for fmt, value in renders.items():
+        assert _cb_cache_tensor_identity(value) == cache.metadata['verified_cells'][NAME, fmt]['rendered_weight']
+    deltas = {(NAME, fmt): value.float() - source.float() for fmt, value in renders.items()}
+    specs = {NAME: {fmt: fr.get_format(fmt) for fmt in formats}}
+    for fmt in formats:
+        assert activation_identity(specs[NAME][fmt], cache.activation_max_abs, NAME) == cache.metadata['verified_cells'][NAME, fmt]['activation']
+    layer = torch.nn.Linear(2048, 1792, bias=False, device='cuda', dtype=torch.bfloat16)
+    with torch.no_grad():
+        layer.weight.copy_(source)
+    x = captured.to(device='cuda', dtype=torch.bfloat16).requires_grad_()
+    assert torch.equal(x.float(), captured)
+    generator = torch.Generator(device='cuda').manual_seed(7000)
+    gradients = ([torch.randn((512, 1792), generator=generator, device='cuda', dtype=torch.bfloat16) for _ in range(4)]
+                 if args.source_receipt is None else [])
+    probe_inputs = [[(x, gradient)] for gradient in gradients]
+    source_capture = None
+    if args.source_receipt is not None:
+        assert args.source_sha256 and sha(args.source_receipt) == args.source_sha256
+        source_capture = json.loads(args.source_receipt.read_text())
+        assert source_capture['schema'] == 'pq.actual_routed_projection_capture.v1' and source_capture['passed'] is True
+        assert source_capture['unit'] == NAME and source_capture['global_token_count'] == 262144
+        assert source_capture['source_model_identity'] == prepared['source_model_identity']
+        assert source_capture['source_execution'] == prepared['source_execution']
+        assert source_capture['calibration'] == prepared['calibration_input']
+        assert source_capture['source_weight'] == source_identity
+        payload_path = Path(source_capture['payload']['path'])
+        assert sha(payload_path) == source_capture['payload']['sha256']
+        payload = torch.load(payload_path, map_location='cpu', weights_only=True)
+        assert _cb_cache_tensor_identity(payload['source_weight']) == source_identity
+        probe_inputs = [[] for _ in range(4)]
+        for entry, bound in zip(payload['records'], source_capture['records'], strict=True):
+            assert entry['probe'] == bound['probe'] and entry['row'] == bound['row']
+            assert tensor_sha(entry['x']) == bound['x_sha256'] and tensor_sha(entry['g']) == bound['g_sha256']
+            probe_inputs[entry['probe']].append((entry['x'].cuda().requires_grad_(), entry['g'].cuda()))
+        assert [len(values) for values in probe_inputs] == [4, 4, 4, 4]
+        actual_prefix = torch.cat([inputs.detach() for inputs, _ in probe_inputs[0]])
+        assert len(actual_prefix) <= len(captured)
+        order_path = ROOT / 'qdq-residency/capture-order-diagnosis.json'
+        order_proof = json.loads(order_path.read_text())
+        assert order_proof['source_receipt_sha256'] == args.source_sha256
+        assert order_proof['canonical_sha256'] == capture['sha256']
+        order = order_proof['actual_to_canonical_row']
+        assert sorted(order) == list(range(len(actual_prefix)))
+        start = 0
+        for inputs, _ in probe_inputs[0]:
+            end = start + len(inputs)
+            assert sorted(order[start:end]) == list(range(start, end))
+            start = end
+        reordered_canonical = captured[torch.tensor(order, device=captured.device)]
+        assert torch.equal(actual_prefix.float(), reordered_canonical), 'actual B1 routed input bytes differ from original canonical rows'
+    receipt['inputs'] = {'unit': NAME, 'rows': 512, 'formats': formats, 'probe_count': 4,
+                         'cotangent_kind': 'fixed random BF16; not model-output Fisher probes',
+                         'seed': 7000, 'prepared': {'path': str(prepared_path), 'sha256': sha(prepared_path)},
+                         'cache_sha256': sha(cache_path), 'capture_sha256': sha(x_path),
+                         'manifest_sha256': manifest_sha, 'census_sha256': sha(census_path),
+                         'capture_receipt': capture_receipt, 'capture_count': counts[NAME],
+                         'capture_maximum': maxima[NAME], 'source_identity': source_identity,
+                         'render_file_sha256': {fmt: sha(path) for fmt, path in render_paths.items()},
+                         'x_sha256': tensor_sha(x), 'gradient_sha256': [tensor_sha(g) for g in gradients],
+                         'prefetch': prefetch, 'before_module_sha256': sha(baseline_path),
+                         'before_function_sha256': sha(args.output / 'before.py'),
+                         'after_function_sha256': sha(args.output / 'after.py')}
+    if source_capture is not None:
+        receipt['inputs'].update(cotangent_kind='actual source-tail Fisher; unchanged B1 rows 0–3',
+            rows=None, actual_source_rows=source_capture['rows'],
+            canonical_prefix_permutation_equal_rows=len(actual_prefix),
+            canonical_order_diagnosis_sha256=sha(order_path),
+            source_capture={'path': str(args.source_receipt), 'sha256': args.source_sha256},
+            actual_invocations=source_capture['records'], rows_per_probe=[sum(len(v[0]) for v in values) for values in probe_inputs],
+            projection_scope='four actual per-expert invocations accumulated per probe; not full-model cost')
+    save()
+    lease = SignedJointProjectionLease({NAME: layer}, specs, deltas, activation_max_abs=cache.activation_max_abs)
+
+    def cycle(check=False):
+        results = []
+        for values in probe_inputs:
+            lease.begin_probe()
+            hashes = []
+            for inputs, gradient in values:
+                layer.weight.grad = None
+                inputs.grad = None
+                y = layer(inputs)
+                y.backward(gradient)
+                if check:
+                    hashes.append({'output': tensor_sha(y), 'input_grad': tensor_sha(inputs.grad),
+                                   'weight_grad': tensor_sha(layer.weight.grad)})
+            terms = lease.finish_probe()
+            if check:
+                results.append({'terms': {fmt: terms[NAME, fmt] for fmt in formats}, 'invocations': hashes})
+        return results
+
+    with lease:
+        owner.nvfp4_activation_qdq_served = before
+        expected = cycle(check=True)
+        owner.nvfp4_activation_qdq_served = after
+        actual = cycle(check=True)
+        assert actual == expected, 'baseline/output/backward/signed projection bits differ'
+        receipt['qualification'] = {'exact_projection_and_forward_backward': True, 'probes': actual}
+        timings = []
+        for function in (before, after):
+            owner.nvfp4_activation_qdq_served = function
+            cycle()
+            torch.cuda.synchronize()
+            start = time.perf_counter()
+            for _ in range(3):
+                cycle()
+            torch.cuda.synchronize()
+            timings.append((time.perf_counter() - start) / 3)
+        count = max(1, math.ceil(args.target_seconds / min(timings)))
+        assert count <= 5000, count
+        receipt['calibration'] = {'seconds_per_cycle': timings, 'cycles_per_arm': count}
+        save()
+        for index, (label, function) in enumerate((('before', before), ('after', after), ('after', after), ('before', before))):
+            owner.nvfp4_activation_qdq_served = function
+            torch.cuda.synchronize()
+            start, counters = time.time(), io_counters()
+            for _ in range(count):
+                cycle()
+            torch.cuda.synchronize()
+            end = time.time()
+            after_counters = io_counters()
+            phase = {'phase': f'{index}-{label}', 'kind': 'measured', 'arm': label,
+                     'start_epoch': start, 'end_epoch': end, 'seconds': end - start,
+                     'cycles': count, 'projection_terms': count * 4 * len(formats),
+                     'io_delta': {key: after_counters[key] - value for key, value in counters.items()}}
+            receipt['phases'].append(phase)
+            save()
+            print(json.dumps(phase), flush=True)
+        for label, function in (('before', before), ('after', after)):
+            owner.nvfp4_activation_qdq_served = function
+            torch.cuda.synchronize()
+            start = time.time()
+            with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
+                                        record_shapes=True, profile_memory=True, with_stack=True) as profiler:
+                for _ in range(3):
+                    cycle()
+            torch.cuda.synchronize()
+            end = time.time()
+            profiler.export_chrome_trace(str(args.output / f'{label}-trace.json'))
+            events = profiler.key_averages()
+            (args.output / f'{label}-cpu.txt').write_text(events.table(sort_by='self_cpu_time_total', row_limit=100))
+            (args.output / f'{label}-cuda.txt').write_text(events.table(sort_by='self_device_time_total', row_limit=100))
+            receipt['phases'].append({'phase': label + '-profile', 'kind': 'profile', 'start_epoch': start, 'end_epoch': end})
+            save()
+    owner.nvfp4_activation_qdq_served = after
+    receipt.update(passed=True, telemetry=lease.telemetry, max_rss_kib=resource.getrusage(resource.RUSAGE_SELF).ru_maxrss,
+                   cuda_max_allocated=torch.cuda.max_memory_allocated(), cuda_max_reserved=torch.cuda.max_memory_reserved())
+    receipt['env']['finished_epoch'] = time.time()
+    save()
+    print(json.dumps({'passed': True, 'receipt': str(args.output / 'receipt.json')}), flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/experiments/qdq_constant_residency_run.sh
+++ b/experiments/qdq_constant_residency_run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+image=eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
+input_root=/mnt/shared/tessera-measurements/first-model-20260907/inputs
+entry=experiments.qdq_constant_residency
+if [[ "${1:-}" == --source-capture ]]; then
+  entry=experiments.qdq_projection_source_capture
+  shift
+fi
+exec docker run --rm --gpus all --ipc=host --network=host --user "$(id -u):$(id -g)" \
+  -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared -w /workspace --entrypoint bash \
+  -e PYTHONDONTWRITEBYTECODE=1 -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
+  -e PRISMABUILD_CONTAINER_OWNER -e PRISMAQUANT_PROD_ACT_SCALES=0 \
+  -e XDG_CACHE_HOME=/tmp/qdq-cache -e HF_HOME=/tmp/qdq-hf -e HF_MODULES_CACHE=/tmp/qdq-modules \
+  -e "QDQ_ENTRY_MODULE=$entry" \
+  -e "PYTHONPATH=/workspace:$input_root/tessera-382a1a97/src:$input_root/container-compatible-deps" \
+  "$image" -c 'python3 -m "$QDQ_ENTRY_MODULE" "$@"' bash "$@"

--- a/experiments/qdq_projection_source_capture.py
+++ b/experiments/qdq_projection_source_capture.py
@@ -1,0 +1,153 @@
+"""Record actual B1 routed projection inputs/cotangents from original rows.
+
+The source model, streaming path, complete sequences, probe seeds and global
+normalization are those of the stopped full joint run. This records evidence;
+it neither prices candidates nor adopts the old prepared cache for a new run.
+"""
+import argparse
+import gc
+import json
+from pathlib import Path
+import socket
+import time
+
+import torch
+
+from experiments.qdq_constant_residency import NAME, ROOT, sha, tensor_sha
+from prismaquant.calibration_data import load_calibration_input
+from prismaquant.cost_streaming import build_streamed_causal_lm, build_streamed_model_identity
+from prismaquant.joint_aura import SignedJointProjectionLease, source_execution_identity
+from prismaquant.kl_fisher import fisher_probe_scalar
+from prismaquant.model_profiles import detect_profile
+from prismaquant.production_weight_cache import _cb_cache_tensor_identity
+from prismaquant.routed_experts import profile_declared_packed_expert_projections
+from prismaquant.sensitivity_probe import SharedStateCotangents, kv_cotangent_path_enabled
+from prismaquant.tessera_joint_aura import _source_prefetch
+from prismaquant import format_registry as fr
+
+
+class CaptureLease(SignedJointProjectionLease):
+    def _observe(self, name, source_weight, x, output, output_slice=None, row_slice=None):
+        if not self.active:
+            raise RuntimeError('source capture outside active probe')
+        value = x.detach().clone()
+        probe, row = self.capture_key
+
+        def record(gradient):
+            selected = gradient if row_slice is None else gradient[row_slice]
+            selected = selected if output_slice is None else selected[..., output_slice]
+            assert value.shape[:-1] == selected.shape[:-1]
+            self.records.append({'probe': probe, 'row': row, 'x': value.cpu(),
+                                 'g': selected.detach().contiguous().cpu()})
+            return gradient
+
+        output.register_hook(record)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=False)
+    torch.set_num_threads(1)
+    torch.set_float32_matmul_precision('highest')
+    torch.backends.cuda.matmul.allow_tf32 = False
+    plan_path = ROOT / 'full-model-joint-aura/plan-02.json'
+    plan = json.loads(plan_path.read_text())
+    prepared_path = ROOT / 'full-model-joint-aura/run-02/prepare/prepared.json'
+    assert sha(prepared_path) == '69a56bff2d29beaf38759b309dee1ac94ca9e091e50f846590d8b51cb0ba5908'
+    prepared = json.loads(prepared_path.read_text())
+    assert sha(plan_path) == prepared['plan_sha256']
+    assert plan['execution']['probe_microbatch'] == 1
+    ids, calibration = load_calibration_input(plan['calibration_input']['path'],
+        expected_sha256=plan['calibration_input']['sha256'], n_samples=512, seqlen=512)
+    assert calibration == prepared['calibration_input']
+    receipt = {'schema': 'pq.actual_routed_projection_capture.v1', 'passed': False,
+               'env': {'started_epoch': time.time(), 'host': socket.gethostname(),
+                       'torch': str(torch.__version__), 'cuda': torch.version.cuda},
+               'original_plan_sha256': sha(plan_path), 'calibration': calibration,
+               'rows': [0, 1, 2, 3], 'input_ids_sha256': tensor_sha(ids[:4]),
+               'global_token_count': ids.numel(), 'seed_base': 7000, 'n_probes': 4,
+               'unit': NAME, 'phases': []}
+
+    def save():
+        (args.output / 'receipt.json').write_text(json.dumps(receipt, indent=2))
+
+    save()
+    profile = detect_profile(plan['model'])
+    runner = build_streamed_causal_lm(plan['model'], device=torch.device('cuda'), dtype=torch.bfloat16,
+        offload_folder=str(args.output / 'offload'), profile=profile, attn_implementation='eager',
+        **_source_prefetch(plan))
+    try:
+        source = build_streamed_model_identity(runner, plan['model'], identity_cache_path=args.output / 'source-identity.json')
+        assert source == prepared['source_model_identity']
+        execution = source_execution_identity(runner.model)
+        assert execution == prepared['source_execution']
+        receipt.update(source_model_identity=source, source_execution=execution,
+                       source_prefetch=_source_prefetch(plan))
+        batches = []
+        for row in receipt['rows']:
+            batches.append(runner.capture_boundaries(ids[row:row + 1]))
+            print(json.dumps({'captured_boundary_row': row}), flush=True)
+        layer = 23
+        runner.context.install(layer, require_prefetched=runner.require_prefetched_residency)
+        members = profile_declared_packed_expert_projections(runner.model, profile=profile)
+        target = next(member for member in members if member.qname == NAME)
+        receipt['source_weight'] = _cb_cache_tensor_identity(target.weight)
+        source_weight = target.weight.detach().cpu().clone()
+        target.parameter.requires_grad_(True)
+
+        def clear(parameter):
+            parameter.grad = None
+
+        handle = target.parameter.register_post_accumulate_grad_hook(clear)
+        lease = CaptureLease({NAME: target}, {NAME: {'BF16': fr.get_format('BF16')}},
+                             {(NAME, 'BF16'): torch.zeros_like(target.weight, dtype=torch.float32)})
+        lease.records = []
+        with lease:
+            for probe in range(4):
+                lease.begin_probe()
+                for row, batch in zip(receipt['rows'], batches):
+                    tail = batch.activations_cpu[-1].to(device=runner.device, dtype=runner.dtype).detach().requires_grad_(True)
+                    logits = runner.tail_logits(batch, tail)
+                    scalar = fisher_probe_scalar(logits, seed=7000 + probe, token_scope='all',
+                        temperature=1.0, distribution='rademacher', token_count_override=ids.numel(),
+                        global_row_offset=row)
+                    scalar.backward()
+                    incoming = tail.grad.detach().clone()
+                    del tail, scalar, logits
+                    x_in = batch.activations_cpu[layer].to(device=runner.device, dtype=runner.dtype).detach().requires_grad_(True)
+                    cotangents = SharedStateCotangents(enabled=kv_cotangent_path_enabled())
+                    isolated = profile.isolated_layer_pass_state(batch.shared_pass_state, runner.layers[layer])
+                    isolated = cotangents.graft(isolated)
+                    lease.capture_key = probe, row
+                    out = runner.isolated_layer(batch, layer, x_in, pass_state=isolated)
+                    roots, root_grads = cotangents.produced_roots()
+                    torch.autograd.backward((out, *roots), (incoming, *root_grads))
+                    del out, x_in, incoming, isolated, cotangents, roots, root_grads
+                lease.finish_probe()
+                print(json.dumps({'captured_probe': probe, 'calls': len(lease.records)}), flush=True)
+        handle.remove()
+        assert len(lease.records) == 16
+        assert {(v['probe'], v['row']) for v in lease.records} == {(p, r) for p in range(4) for r in range(4)}
+        for record in lease.records:
+            assert record['x'].dtype == record['g'].dtype == torch.bfloat16
+            assert record['x'].ndim == 2 and record['x'].shape[1] == 2048 and record['g'].shape[1] == 1792
+        payload = args.output / 'projection-inputs.pt'
+        torch.save({'records': lease.records, 'source_weight': source_weight}, payload)
+        receipt['records'] = [{k: v for k, v in record.items() if k not in ('x', 'g')} |
+                              {'rows': len(record['x']), 'x_sha256': tensor_sha(record['x']), 'g_sha256': tensor_sha(record['g'])}
+                              for record in lease.records]
+        receipt['payload'] = {'path': str(payload), 'sha256': sha(payload)}
+        receipt.update(passed=True, cuda_max_allocated=torch.cuda.max_memory_allocated(),
+                       cuda_max_reserved=torch.cuda.max_memory_reserved())
+        receipt['env']['finished_epoch'] = time.time()
+        save()
+        print(json.dumps({'passed': True, 'records': receipt['records']}), flush=True)
+    finally:
+        runner.shutdown()
+        gc.collect()
+
+
+if __name__ == '__main__':
+    main()

--- a/prismaquant/nvfp4_activation_contract.py
+++ b/prismaquant/nvfp4_activation_contract.py
@@ -1154,11 +1154,14 @@ def nvfp4_activation_qdq_served(
         -FP4_E2M1_MAX,
         FP4_E2M1_MAX,
     )
-    positive = torch.tensor(
-        _E2M1_POSITIVE,
-        device=normalized.device,
-        dtype=torch.float32,
-    )
+    # The registry already owns device-resident format constants. Its sorted
+    # E2M1 table ends with these eight positive encodings, including +0. Reuse
+    # that view instead of copying a Python tuple to CUDA on every QDQ call.
+    from .format_registry import _CODEBOOKS, _codebook_on_device
+
+    positive = _codebook_on_device(
+        _CODEBOOKS["fp4_e2m1"], device=normalized.device, dtype=torch.float32,
+    )[-len(_E2M1_POSITIVE):]
     magnitude = normalized.abs().contiguous()
     upper_index = torch.bucketize(magnitude, positive).clamp_max(
         positive.numel() - 1

--- a/tests/test_nvfp4_served_codebook_residency.py
+++ b/tests/test_nvfp4_served_codebook_residency.py
@@ -1,0 +1,64 @@
+"""Static-G QDQ must reuse its device constants without changing any output bit."""
+import pytest
+import torch
+
+from prismaquant import nvfp4_activation_contract as owner
+
+
+@pytest.fixture(params=["cpu", "cuda"])
+def device(request):
+    if request.param == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA numerical/device-residency qualification")
+    return torch.device("cuda", torch.cuda.current_device()) if request.param == "cuda" else torch.device("cpu")
+
+
+def test_warm_qdq_does_not_rebuild_host_codepoints(monkeypatch, device):
+    x = torch.ones((32, 64), device=device, dtype=torch.bfloat16)
+    expected = owner.nvfp4_activation_qdq_served(x, 1.0)
+    original = torch.tensor
+    rebuilt = []
+
+    def observe(data, *args, **kwargs):
+        if data is owner._E2M1_POSITIVE:
+            rebuilt.append(kwargs.get("device"))
+        return original(data, *args, **kwargs)
+
+    monkeypatch.setattr(torch, "tensor", observe)
+    for _ in range(3):
+        actual = owner.nvfp4_activation_qdq_served(x, 1.0)
+        assert torch.equal(actual.view(torch.uint8), expected.view(torch.uint8))
+    assert not rebuilt, "warm QDQ rebuilt the invariant host codepoints on its device"
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_midpoint_goldens_and_signed_zero(device, dtype):
+    # Every block contains +/-6, so G=1 gives a stored/used scale of exactly 1.
+    # E2M1 midpoint ties choose the even encoded positive index.
+    midpoints = (0.0, 0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0)
+    rounded = (0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 4.0, 4.0)
+    x = torch.tensor([[v, -v, 6.0, -6.0] + [0.0] * 12 for v in midpoints],
+                     device=device, dtype=dtype)
+    expected = torch.tensor([[v, -v, 6.0, -6.0] + [0.0] * 12 for v in rounded],
+                            device=device, dtype=dtype)
+    actual = owner.nvfp4_activation_qdq_served(x, 1.0)
+    assert actual.device == device and actual.dtype == dtype
+    assert torch.equal(actual.view(torch.uint8), expected.view(torch.uint8))
+
+
+def test_scale_underflow_keeps_positive_zero(device):
+    # Exactly halfway to the first E4M3 subnormal rounds the stored scale to 0.
+    value = 6.0 * 2.0 ** -10
+    x = torch.tensor([[value, -value] * 8], device=device)
+    actual = owner.nvfp4_activation_qdq_served(x, 1.0)
+    expected = torch.zeros_like(x)
+    assert torch.equal(actual.view(torch.uint8), expected.view(torch.uint8))
+
+
+def test_shared_grid_is_exact_and_device_specific(device):
+    from prismaquant import format_registry as fr
+
+    grid = fr._codebook_on_device(fr._CODEBOOKS["fp4_e2m1"], device=device,
+                                  dtype=torch.float32)[-len(owner._E2M1_POSITIVE):]
+    expected = torch.tensor(owner._E2M1_POSITIVE, device=device, dtype=torch.float32)
+    assert grid.device == device and grid.dtype == torch.float32
+    assert torch.equal(grid.view(torch.uint8), expected.view(torch.uint8))


### PR DESCRIPTION
Served NVFP4 QDQ rebuilt its eight fixed codepoints on CUDA for every call. Reuse the existing format registry's device codebook, preserving output bytes, rounding, signed zero and all measured joint projection components.

On retained real LFM B1 expert calls (137/102/74/80 rows, four original Fisher probes, seven measured renders), an interleaved comparison measured 36.1345 → 35.2160 seconds, 2.542% less time. It removed 48 profiled host-to-device copies and matching synchronizations, with unchanged kernel count and no measured energy improvement. A 512-row replay improved only 0.228%; this does not resolve the full joint probe's performance problem.

Validation: original CPU regression failed before the change; 81 tests passed with 6 CUDA skips after it, and all 12 residency/numerical goldens passed on GB10. Before/after profiles, both-host Netdata, exact source/input identities, unsuccessful harness attempts and PB receipts are recorded in docs/results/nvfp4_codepoint_residency_2026-09-07.md. Root independently verified the terminal logs, successful CAS payloads and capture-order diagnosis. Current-main interaction validation passed through PB action d872ed55bea1f4fd67feb3a54e7a59fb23fcdcc410e52ebf65519b90093aa9c9: 81 passed, 6 CUDA skips, plus compile checks (x86, Torch CPU, eight workers/native threads one). The first submission omitted the required external Tessera producer on PYTHONPATH and failed; its logs are retained.

Closes #333. Refs #237.
