### PR TITLE
Respect zero automatic file-prefetch budgets

### DIFF
--- a/docs/results/server_cache_prewarm_2026-09-07.md
+++ b/docs/results/server_cache_prewarm_2026-09-07.md
@@ -1,0 +1,57 @@
+# Bounded shared-server cache warm-up — 2026-09-07
+
+Rob asked whether known future inputs could be cached on dl380g10 before the
+GPU stage needs them. The existing
+`source_prefetch.prefetch_files_to_page_cache` can perform that anticipatory
+read as an ordinary admitted PB action. It retains no tensors or additional
+cache. `/mnt/shared` is backed by ZFS on this host: the read warms its ARC,
+not a guaranteed pinned allocation. Future eviction and the Spark's own
+NFS/application prefetch remain separate concerns.
+
+At inspection, ARC held about 224 GiB with a configured 240 GiB maximum.
+Linux reported roughly 54 GiB available and zero memory PSI. Reading the whole
+roughly 598 GiB GLM checkpoint would exceed this cache; prospective warming
+should use an explicit next-stage input set and a bounded memory budget.
+There is no implemented PB speculative-cache policy inferred from this run.
+The current pipeline's existing residency and integrity gates remain required.
+
+A single admitted warm-up read the next LFM source checkpoint,
+`/mnt/shared/models/LFM2.5-8B-A1B-BF16/model.safetensors`: **16,936,006,912
+bytes in 6.6848 seconds**. Source file size/mtime were checked before and after.
+PB reserved 1 CPU and 20 GiB, with native thread limits of one; the helper's
+file budget was 18 GiB and an explicit preflight required 36 GiB available.
+The source is one file, so the existing reader used one worker. No cache was
+dropped, no model payload changed and no cold-cache benchmark ran.
+
+During that window, global ARC demand-data counters increased by 16,660 hits
+and 23 misses; prefetch-data misses increased by 258. This suggests the file
+was largely warm already. These are host counters, not per-file attribution.
+The result establishes a completed anticipatory read, not a downstream
+speedup, permanent residency or an end-to-end bottleneck diagnosis.
+
+PB action:
+`a3d209e3a8bc438f4842e35fbcf81f471f30cb9e02c6590b8f0ebba856a12498`.
+Actual exit 0, logs, source bundle, complete cleanup, CAS receipt and artifact
+hashes were independently verified. CAS receipt SHA256:
+`ea808b055d30eb32ab9fd7504d5df917ed6ab9bb097adc71188965d28e50ccd0`;
+output SHA256:
+`2c43d59f06dbf5bd64c627a9189a0de9248077b0c96cfa4a4ddbf7f4b253a734`.
+The sealed PB request retains the exact invocation. Evidence under
+`/mnt/shared/tessera-measurements/first-model-20260907/server-prewarm/lfm-source-01/`
+contains `receipt.json`, `reader.pstats`, before/after ARC, memory, pressure,
+block-I/O and process-I/O counters, plus `netdata-three-hosts.json` (17 raw
+series covering dl380g10 and both Sparks). Raw Netdata SHA256:
+`077a9fe12575bb52fa264cd032891ba97ed1635077576f7d50cf3e6e41f1f3f4`.
+
+Inspection also found an unavailable configured L2ARC device. The four data
+disks were online with no known data errors. The stale-name hypothesis and
+exact GUID/path evidence are recorded in PrismaBuild issue 361; candidate
+label inspection required unavailable administrator authentication, so no
+storage configuration was changed. RAM-cache warming remains usable.
+
+A separate code fix in this branch closes an existing exhausted-budget hole:
+a zero automatically computed budget used to bypass the size check. Eight
+bounded CPU regression cases reproduced it before the fix; after the fix,
+67 prefetch/PWC tests passed. Auto mode now skips and require mode refuses
+positive-sized input sets when no usable automatic budget exists. This
+changes no positive-budget behavior and makes no performance claim.

--- a/prismaquant/source_prefetch.py
+++ b/prismaquant/source_prefetch.py
@@ -127,7 +127,8 @@ def prefetch_files_to_page_cache(
         else:
             max_resident_bytes = 0
     stats["max_resident_bytes"] = int(max_resident_bytes or 0)
-    if max_resident_bytes and total_bytes > int(max_resident_bytes):
+    # An exhausted or unknown automatic budget is zero, never unlimited.
+    if total_bytes > int(max_resident_bytes):
         stats["skipped"] = True
         stats["reason"] = (
             f"{label} require {total_bytes / 1024**3:.2f} GiB, "

--- a/tests/test_source_prefetch.py
+++ b/tests/test_source_prefetch.py
@@ -49,3 +49,23 @@ def test_source_prefetch_budget_fail_fast(tmp_path):
             progress=False,
         )
 
+
+
+@pytest.mark.parametrize("available", [None, 0, 4 * 1024**3, 16 * 1024**3])
+@pytest.mark.parametrize("mode", ["auto", "require"])
+def test_exhausted_or_unknown_auto_budget_never_starts_file_reads(tmp_path, monkeypatch, available, mode):
+    from prismaquant import source_prefetch
+
+    (tmp_path / "model.safetensors").write_bytes(b"checkpoint")
+    monkeypatch.setattr(source_prefetch, "_available_memory_bytes", lambda: available)
+    reads = []
+    monkeypatch.setattr(source_prefetch, "_read_file_to_page_cache",
+                        lambda path, **kwargs: reads.append(path) or path.stat().st_size)
+    if mode == "require":
+        with pytest.raises(RuntimeError, match="budget"):
+            prefetch_safetensors_checkpoint(tmp_path, mode=mode, progress=False)
+    else:
+        stats = prefetch_safetensors_checkpoint(tmp_path, mode=mode, progress=False)
+        assert stats["skipped"] and stats["max_resident_bytes"] == 0
+        assert stats["prefetched_bytes"] == 0
+    assert reads == []


### PR DESCRIPTION
Closes #334.

When available memory is unknown or below the configured headroom, the file-prefetch helper computes a zero budget. Its truthiness check then bypassed the limit and read every file. Compare the requested bytes against zero too: auto mode skips and require mode refuses before starting reads. Positive explicit budgets retain their existing behavior.

PB CPU regression on main: 8 failed, 3 passed (`6a577e81d9214262fb1e29dc3f47ad3854fabb1bd7ef0801936bf6e2deb6f63f`). After fix, prefetch plus production-cache suite: 67 passed, no skips, and module compile passed (`b7f7c8d4de1f6e025c89d7258851786a100a878b1b8b9ad486c235f126e30a5b`). Actual terminal/attempt exits, log bytes, cleanup, snapshot bundle and CAS receipt/output were independently verified; receipt `2a272686cfb0df6de90fbe520f923a15c948c7c078ce82e7cc3c1a96be9d4280`.

CPU mode: dl380g10, Python 3.12.11, Torch 2.11 CPU, 4 xdist workers, native threads 1. Two initial environment attempts collected no tests (Sparky's PB-only venv lacked Torch; dl380's PB-only venv lacked compressed-tensors); the project `pq-cpu312` environment produced the red/green above. This repairs an existing fail-closed budget contract; no GPU arithmetic, serving/default change or performance claim. Found during the requested server-cache investigation and isolated in this commit.
