### PR TITLE
Add qualified opt-in fused joint projection backend

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,42 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-07 · `perf/joint-prepare-single-read`. Stamps
+As of: 2026-09-07 · `codex/joint-fused-promotion-20260907`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-07, `codex/joint-fused-promotion-20260907`) for **explicit
+qualified joint-projection backends**. The joint anchor plan retains the native
+`torch` multiplication/sum reference by default. Its optional
+`execution.projection_backend` selects `fused_fp32_v1` only with an independently
+SHA256-bound prebuilt extension. The existing joint lease uses the selected
+backend at its weight, activation, and mixed product/reductions, preserving FP32
+leaf rounding, PyTorch's native reduction tree, GEMMs, invocation/format/probe
+order, QDQ and signed accumulation. No cache or activation residency owner is
+replaced; the backend retains code modules and device-prewarm markers only.
+
+`joint_projection_backend.py` verifies the packaged qualification before
+loading: exact Torch/version/git/CUDA, reduction header hashes, compiler identity,
+source/compiler flags, GB10 device geometry, and actual loaded binary SHA256.
+Production never JIT-builds an unqualified replacement. Prewarm launches a
+transient zero-matrix check before source/projection hot execution; a lease
+refuses a selector that has not been prewarmed, a different device, or an
+unqualified matrix shape. The six original-census shapes are explicitly
+qualified; ineligible alignment/layout/dtype retains the reference expression.
+Runtime/backend identity is sealed in prepared PWC metadata, completion,
+probe arithmetic and resumable operator identities. This changes prepared,
+probe, operator and joint-run schemas to **v2**: v1 prepared and signed artifacts
+require fresh preparation and recomputation, including when choosing `torch`.
+There is no legacy-cache adoption or checkpoint identity override.
+
+The exact-tree kernel's local actual-source evidence is 208 bit-exact individual
+reductions and four seven-rung signed/forward/backward comparisons; five
+additional original source/capture/rung geometry gates each add 52 exact
+reductions using explicitly seeded qualification cotangents. These cover all
+six matrix shapes in the first model's 2142-unit census. They do not establish
+full-model timing or served quality. The opt-in does not change a format,
+serving gate, allocator objective, calibration draw or pipeline default.
+Gates: `tests/test_joint_projection_backend.py`, `tests/test_joint_projection_reduce.py`,
+the retained-source production-lease replay and
+`docs/results/joint_projection_backend_promotion_2026-09-07.md`.
 
 Re-stamped (2026-09-07, `perf/joint-prepare-single-read`) for **verified
 single-read PWC preparation**. Joint-anchor preparation performs complete

--- a/docs/results/joint_projection_backend_promotion_2026-09-07.md
+++ b/docs/results/joint_projection_backend_promotion_2026-09-07.md
@@ -1,0 +1,179 @@
+# Qualified opt-in joint projection backend — 2026-09-07
+
+The existing joint AURA path now has an explicit `fused_fp32_v1` backend. The
+native `torch` expression remains the default. Promotion preserves the
+[measured exact-tree kernel](joint_projection_fused_reduction_2026-09-07.md)
+and adds runtime admission, prewarming, versioned arithmetic identity and
+production lease wiring. No format menu, serving gate, calibration or allocator
+objective changes.
+
+## Selection and admission
+
+The joint anchor plan's `execution` may include:
+
+```json
+"projection_backend": {
+  "name": "fused_fp32_v1",
+  "binary": {
+    "path": "/mnt/shared/tessera-measurements/first-model-20260907/joint-fused-projection/actual-ab-01/pq_joint_projection_reduce_17d100e93d552b85.so",
+    "sha256": "9305c183c5214dc5ff1f73382963f8275eb1b6197cb8d173c6a93bffd700c115"
+  }
+}
+```
+
+Omission or `{"name": "torch"}` selects the reference. Unknown selectors,
+extra fields and unqualified binary hashes are rejected. `prewarm_projection_backend`
+checks the packaged qualification's exact Torch/version/git/CUDA, critical
+reduction headers, compiler identities, source/compiler flags, device name,
+compute capability and SM count. The binary file and actually loaded extension
+must match the qualified SHA256. Production loads this prebuilt artifact; it
+never silently JIT-builds another binary or adopts a different runtime.
+The qualified environment is the original pinned container, Torch
+2.13.0+cu130 at `cf30153c4c131c8164ee7798e5022d810682e2cb`, CUDA 13.0 and
+48-SM GB10 / compute capability 12.1. The package JSON contains complete fields.
+
+Prewarm executes a transient zero-matrix exactness check on the selected device
+before source/cotangent hot execution. Only immutable qualification metadata,
+loaded code modules and device markers persist; no new tensor cache exists.
+Repeated row admission uses that metadata without reopening its file. A lease
+requires the prewarmed handle, refuses a different device, and uses the backend
+at exactly the three weight, activation and mixed product/reduction sites.
+Ineligible alignment/layout/dtype retains the reference expression, while an
+unqualified matrix shape is refused. The observer's `no_grad`, GEMMs, QDQ,
+invocation/format/probe order and signed accumulation remain unchanged.
+
+The streamed API accepts `joint_projection_backend=<selector or prewarmed handle>`.
+A direct `SignedJointProjectionLease` accepts only
+`projection_backend=<prewarmed handle>` for the fused path. Runtime loading,
+hashing and compilation cannot be triggered implicitly inside its projection
+callback. All production source files, CUDA/C++ files and qualification JSON are
+already included by the existing complete-package AURA implementation digest.
+
+## Identity migration
+
+Prepared completion/PWC metadata now binds the resolved backend identity, and
+prepare/run compare it exactly. Probe arithmetic includes its qualified runtime
+and loaded build identity. Prepared, probe, operator and joint-run schemas are
+**v2**; legacy v1 signed rows and prepared records fail closed. Users must run
+fresh preparation and recompute costs, even when choosing the reference backend.
+The v1 plan remains readable with its reference default. There is no conversion
+of old signed rows, prepared adoption, or checkpoint identity override.
+
+Historical prepared artifacts used below are read-only inputs to bounded
+numerical qualification. They are never passed through the production run's
+prepared-cache admission as though produced by this implementation.
+
+## Qualification
+
+All six source matrix shapes in the original 2142-unit first-model census are
+covered. The original actual-source expert-w1 capture retains its real Fisher
+cotangents, four complete B1 source sequences, actual invocation row counts
+137/102/74/80, and all seven original prepared rungs. The five added geometry
+cases use actual source weights, canonical captured X and original seven-rung
+renders, with explicitly seeded BF16 qualification cotangents; those cases do
+not claim source-model Fisher costs or model-quality measurements.
+
+| Representative unit | Matrix shape | Captured X | Exact reductions |
+|---|---|---|---:|
+| Layer 23 expert 0 w1, actual source cotangents | 1792×2048 | 16 actual invocations across four probes | 208 |
+| Layer 0 dense w1 | 7168×2048 | 512×2048 | 52 |
+| Layer 0 dense w2 | 2048×7168 | 512×7168 | 52 |
+| Layer 23 expert 0 w2 | 2048×1792 | 512×1792 | 52 |
+| Layer 10 attention k_proj | 512×2048 | 512×2048 | 52 |
+| Layer 10 attention q_proj | 2048×2048 | 512×2048 | 52 |
+
+Each case preserves all four probes × seven formats' weight/activation/mixed/
+total signed components and forward/input-gradient/weight-gradient hashes.
+Individual reductions compare FP32 integer bits; no tolerance was relaxed.
+The actual-source gate was then repeated through two real production leases,
+constructed with separately selected reference/fused prewarmed handles:
+**208/208 exact reductions and all signed/forward/backward hashes match**.
+
+The final CPU suite passes **297 tests, zero skips** across backend refusal,
+legacy prepared/signed-record rejection before cache adoption, streamed/packed/
+microbatch/lease/probe policies, downstream row consumers and architecture
+checks. Touched production modules compile. This includes a regression ensuring
+repeated serialized row admission performs no qualification-file I/O. The
+initial 296-test pass preceded that final metadata-cache refinement; both
+receipts are retained. Fifty-six existing Torch JIT deprecation warnings are
+reported; no test is omitted. The original 22 CUDA reduction-tree tests remain
+recorded in the preceding result and were not unnecessarily repeated.
+
+## Production-path profile
+
+A separate admitted profile, without another steady ABBA run, exercises three
+cycles per arm through the production backend directly. The individual-bit
+instrumentation is removed during profiling. All inputs and rendered weights
+are resident through the existing prefetch owners.
+
+| Three-cycle CUDA profile | Reference | Qualified production backend |
+|---|---:|---:|
+| Large product kernels | 624 / 110.846 ms | 0 |
+| Reference sum kernels | 624 / 12.812 ms | 0 |
+| Fused reductions | 0 | 624 / 71.066 ms |
+| All kernels | 5280 / 158.165 ms | 4656 / 102.846 ms |
+| `cudaLaunchKernel` calls | 4992 | 4368 |
+| DtoH copies / stream synchronizations | 84 / 84 | 84 / 84 |
+
+Both hosts' raw Netdata CPU, load, RAM, available-memory, host-I/O and GPU-power
+series are retained for this action. The subsecond profile windows are shorter
+than the ten-second power sampling period, so they support no new work/joule
+claim. The earlier fixed-work candidate ABBA remains the attributable
+**1.4731× local replay speed / 1.3751× work per GPU joule** result; production
+full-model throughput and energy await the fresh full-cost run. This profile
+shows that the admitted production path removes the same large intermediates;
+it does not establish GPU saturation or a full-model speedup.
+
+## Attributable artifacts and reproduction
+
+All artifact paths below are relative to
+`/mnt/shared/tessera-measurements/first-model-20260907/joint-fused-projection`.
+Every cited PB terminal, actual CAS payload/hash, exit status and successful
+resource cleanup was independently checked. All actions returned zero.
+
+| Action | PB action key | Verified actual CAS payload SHA256 |
+|---|---|---|
+| Final CPU suite, `promotion-cpu-02` | `90f197b7ea1bb4fb97189dfe767ff6c367f693b2808c421a78615ef174f3b410` | `c32f93f5f8681a518ca46bbfe09aafb77cf862e86f975411d1813bb52b05ba0c` |
+| Production actual-source gate, `promotion-actual-01` | `a95e957a99aa9c8ca98a324c2abc7c0ed8c8e27268e4819f0e5d49ba2d82a329` | `e55ffd75143ccf5073414eebcfcfc2041cabf6c6c5e9cbc996de08f13627bf59` |
+| Production profile, `promotion-profile-01` | `87287a3175a7443e355eaef7d31d929b55cf24689f9965b6c0e22f923e3c4f37` | `8cb2c9ea41c1ce29cb985f8cd124ed65e91e747bed0b5c62c58803223321aabc` |
+
+`geometry-01-campaign.json` records the five independently submitted geometry
+commands. Per-unit `geometry-01/<unit>/verified-pb.json` binds each PB action,
+terminal and CAS payload. The packaged qualification's `evidence` records
+those action keys and explicitly named `artifact_receipt_sha256` fields for
+the numerical receipt files, distinct from PB's own CAS receipts.
+
+`promotion-actual-01/receipt.json` SHA256 is
+`0810adeba9bc4598dbacff48eda029a6159eeb05ebe81604c068767c52b24064`.
+`promotion-profile-01/receipt.json` SHA256 is
+`ea62d63f9ec4ac88e8d796d197baccb45a437cd8a818d674c1af22928f80c64b`.
+That profile directory also holds both CPU/CUDA tables, Chrome traces,
+`profile-analysis.json`, `netdata-both-hosts.json`, the actual `.so`, build recipe,
+and verified PB record. `promotion-cpu-02/pytest.xml` records every test and the
+actual CPU-only mode. Source manifests preserve the actual sealed PB snapshots,
+including final CPU snapshot `2ea0186de817b13292f63afb2d494460de2ae704`.
+
+The actions use the original pinned container, native thread bounds of one and
+four PB-assigned CPUs. CPU and GPU actions reserve 12 GiB total memory; GPU
+qualification/profile actions additionally declare an 8 GiB GPU subset budget.
+Docker retains PB's assigned affinity. CPU qualification uses four pytest
+workers. The profiler action uses PB measurement isolation; numerical geometry
+and production qualification remain portable between eligible GB10 workers.
+
+To repeat only the production-path exact gate with an unused output directory:
+
+```bash
+python3 /mnt/shared/prismabuild-fleet/repo/tools/pbrun.py \
+  --gpu --tag gb10 --cpus 4 --demand mem_gb=12 --gpu-memory-gb 8 \
+  --timeout-s 600 --detach -- \
+  bash experiments/joint_projection_reduce_run.sh production \
+  --output /mnt/shared/tessera-measurements/first-model-20260907/joint-fused-projection/production-repeat \
+  --source-receipt /mnt/shared/tessera-measurements/first-model-20260907/qdq-residency/source-capture-01/receipt.json \
+  --source-sha256 bf5337381562e2b4ae1fbdb672e85f198679e2848487b291590d7810990872d3
+```
+
+Add `--profile-qualified` after `production` and use PB `--measurement` for the
+short before/after profile. `policy_tests --output <unused-path>` with CPU-only
+PB admission runs the recorded contract suite. Source-model assets, the original
+prepared and capture artifacts, and the explicitly qualified binary are required;
+missing or foreign artifacts fail closed.

--- a/docs/results/joint_projection_fused_reduction_2026-09-07.md
+++ b/docs/results/joint_projection_fused_reduction_2026-09-07.md
@@ -1,0 +1,170 @@
+# Exact-tree fused joint projection reduction — 2026-09-07
+
+Status: measured research candidate, unused by the production call path. The
+retained actual-source replay takes **51.9208 → 35.2451 seconds** for the same
+work, a **1.4731× speedup / 32.1176% elapsed reduction**. Measured work per GPU
+joule improves **1.3751×**. Every captured individual reduction, signed component,
+and forward/backward hash matches exactly. This is a local projection result,
+not a full-model throughput, quality, export, or serving measurement.
+
+## Mechanism and numerical boundary
+
+The prior [QDQ residency measurement](nvfp4_codepoint_residency_2026-09-07.md)
+identified large FP32 products as the dominant remaining CUDA work. The candidate
+extends the existing kernels namespace and retains `SignedJointProjectionLease`
+and its cache wiring. The replay changes only three `(left * right).sum()` sites:
+weight, activation, and mixed projections. It retains the materialized FP32
+operators, all GEMMs, source invocation boundaries/order, format order, and
+probe accumulation order. QDQ codepoint reuse is enabled in both arms.
+
+The CUDA candidate uses the **running PyTorch release's**
+`gpu_reduce_kernel<float, float, 4, 4>` tree, matching the loaded reference sum
+kernel. Each leaf performs separately rounded `__fmul_rn` then `__fadd_rn`;
+partial reductions use `__fadd_rn` without another multiplication. This avoids
+the large product tensor without changing the reduction association. Compilation
+disables FMA and flush-to-zero. It binds the actual binary, source, flags, Torch
+version/commit, and five reduction-related header hashes in the receipt.
+
+The fast path requires same-device, same-shape, contiguous, nonempty FP32 CUDA
+operands with 16-byte-aligned pointers and bounded 32-bit indexing. Other
+layouts/dtypes, empty expert inputs, and CPU inputs retain `(left * right).sum()`.
+CUDA device guard and PyTorch's current stream are used. Eligible inputs that
+require autograd raise unless grad mode is disabled; the observer already runs
+under `no_grad`. The module caches compiled code only; callers retain input
+residency. Compilation is warmed before measured work.
+
+This is qualified against Torch **2.13.0+cu130**, git
+`cf30153c4c131c8164ee7798e5022d810682e2cb`, CUDA 13.0, GB10 SM 12.1. A different
+Torch reduction implementation/compiler/device is not qualified by this result.
+Production promotion needs explicit supported-runtime qualification and a
+prewarm contract; the research helper is not a general bit-exact replacement
+across releases. No production default, pipeline stage, format, export metadata,
+serving gate, or architecture contract changes in this commit.
+
+## Workload and exact gate
+
+The source is the retained actual forward-input and backward-cotangent capture
+for the same first model, original 512×512 calibration contract, sequence rows
+0–3, Fisher probes 7000–7003, and `model.layers.23.feed_forward.experts.0.w1` projection used in the
+preceding result. Its 16 invocations have actual row counts **137, 102, 74, 80**
+per probe and FP32 projection operators of shape **1792×2048**. The capture keeps
+the actual grouped-runtime row order. The previously established per-invocation
+bijective mapping to canonical activation rows is checked, but no replay X/g
+permutation is introduced.
+
+Before timing, all **208 individual product/reductions** (13 per invocation)
+match FP32 integer bits. All **4 probes × 7 formats** preserve weight,
+activation, mixed, total signed components and forward, input-gradient, and
+weight-gradient hashes. No tolerance relaxation is used. The original
+`ProductionWeightCache` loads seven rendered entries (51,396,678 bytes), with
+zero misses; calibration prefetch holds 20,971,520 bytes with zero misses. The
+source weight, capture payload, prepared plan, and original calibration identity
+remain hash-bound by the replay harness. No additional full-model capture ran.
+
+The targeted GPU suite has **22 passed, 0 skipped**: exact finite reductions at
+14 lengths including 3,670,016 elements, cancellation/subnormals/signed zeros,
+strided/transposed/misaligned/empty fallbacks, FP16/BF16/FP64 and CPU fallback,
+nondefault-stream execution, and the autograd rejection/no-grad boundary. One
+pytest warning reports an already imported anyio module; no test is omitted.
+Nonfinite NaN payload equivalence is not established.
+
+## Measurements
+
+One cycle runs all four probes and their four actual invocations through the
+existing signed lease, seven formats per probe. Each steady arm runs 952 cycles
+(26,656 completed format/probe results). ABBA order controls short-term drift;
+profiles run separately for three cycles (48 invocations) per arm.
+
+| Arm | Seconds | Mean GPU power (W) | Integrated GPU joules |
+|---|---:|---:|---:|
+| Before 0 | 51.948670 | 39.886557 | 2072.053570 |
+| After 1 | 35.231539 | 41.999942 | 1479.722627 |
+| After 2 | 35.258659 | 42.717809 | 1506.172666 |
+| Before 3 | 51.892981 | 39.194949 | 2033.942750 |
+
+Median joules are 2052.998160 → 1492.947646; replay cycles/GPU-joule are
+0.463712 → 0.637665. Power is only approximately 28–31% of the ~140 W envelope;
+this is not evidence of saturation. Energy integrates the raw 10-second Netdata
+GPU-power samples with linear interpolation over each arm; the coarse sampling
+limits precision. This is GPU energy, not whole-system energy. Sparklina's power
+was 4.0/4.0/4.0/8.66 W during the arms and is excluded from that ratio.
+
+Both hosts' raw CPU, load, RAM, available memory, host I/O, and GPU-power series
+are retained. Sparky's mean user+system CPU ranges 7.81–8.93% of the host across
+the arms; Sparklina ranges 0.88–6.98%. Host I/O includes unrelated activity; the
+measured process reports **zero read_bytes/write_bytes and zero write syscalls**
+in every steady arm. Its two read syscalls per arm read `/proc/self/io`.
+
+| Three-cycle CUDA profile | Before | After |
+|---|---:|---:|
+| Large product kernels | 624 / 107.752 ms | 0 |
+| Matching reference sum kernels | 624 / 12.226 ms | 0 |
+| Fused product/sum kernels | 0 | 624 / 68.279 ms |
+| All CUDA kernels | 5280 / 154.428 ms | 4656 / 99.907 ms |
+| `cudaLaunchKernel` calls | 4992 | 4368 |
+| DtoH copies / stream synchronizations | 84 / 84 | 84 / 84 |
+
+The profiler attributes 8.61 GB of cumulative allocation to `aten::mul` before
+(the table's displayed units); the 624 eliminated 1792×2048 FP32 products account
+for exactly **9,160,359,936 bytes** of that cumulative allocation. This is not
+peak resident memory. Fused reduction remains 68.17% of after-profile kernel
+time, so the result does not establish that all remaining projection bottlenecks
+are solved. CUDA high-water allocation is 345,611,776 bytes, reserved 385,875,968
+bytes, measured across both arms together; peak RSS is 2,207,332 KiB. These shared
+high-water figures cannot establish a per-arm peak-memory improvement.
+
+## Reproduction and attributable artifacts
+
+Artifact root:
+`/mnt/shared/tessera-measurements/first-model-20260907/joint-fused-projection`.
+All execution used PrismaBuild and the existing pinned container
+`eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c`.
+Native threads are bounded to one, compile workers to four. The measured worker
+was Sparky, CPU affinity 5–8, with 4 CPUs, 12 GiB memory and 8 GiB GPU memory
+reserved. Its terminal resource cleanup is complete with release `ok: true`,
+no OOM, and scope peak memory 3,548,872,704 bytes (includes extension build).
+
+| Action | PB key | Verified CAS result SHA-256 |
+|---|---|---|
+| Portable CPU extension build, `build-01` | `0ade5ec62dcf57aba538badcabbc7087aafe8c9b9a538a0c96b2ee4a468fbd67` | `b86c51ef34261e772ce500a0d5c21957a3a2bd8d929a814ac1aa80dfda10c4a1` |
+| GPU qualification, `qualify-01` | `9deeac16c469cbf286e5e366e839eeb516ac4fd8ea6d5fc100b795b38798073f` | `3da48d904031516aef03becddc538e3c5af5145f2efc43f5be74044bf2ba9c74` |
+| Actual-source ABBA, `actual-ab-01` | `24c59324f3d263a30450fa3ffb88e0d5389317da40a162f5833813da5b2fcbae` | `048e0c474c834d61e0a06600b2585fe733016328a4e79d95bbbe2916f0d1873e` |
+
+All three terminals and actual CAS bytes were independently read and rehashed;
+all exit statuses are zero. Per-action `verified-pb.json` retains the terminal
+and CAS receipt. `qualify-01/pytest.xml` records collection/results. Build and
+measurement preserve their own loaded `.so` and `build.ninja`: recompilation
+under distinct snapshots produced different binary hashes, so binaries are not
+silently equated. The measured binary SHA is
+`9305c183c5214dc5ff1f73382963f8275eb1b6197cb8d173c6a93bffd700c115`.
+The compiler warns that `.minnctapersm` is ignored for the instantiated kernel;
+the tested and timed binary includes that warning, retained in the CAS log.
+
+`actual-ab-01` also contains `receipt.json`, `before.py`, `after.py`, both
+`*-trace.json` traces and CPU/CUDA tables, `netdata-both-hosts.json`, and
+`analysis.json`. `source-manifest.json` and `frozen-source/` were extracted from
+the independently rehashed PB snapshot bundle for measured source commit
+`783a2554ce1d4f44e2e83db79f461d3f2a2330f8`. `build-01/headers/` preserves the
+five headers whose hashes match the measured build identity. Final receipt SHA:
+`4c54fa604496fb06a2c275616506fd7d6d8ab6029e24080a15ef98d5917985b5`;
+raw Netdata SHA:
+`629d9a88c0f6e4d40913a2ee771f5e18594fa3b5f560ef1323ab3cd7d4d8f83e`.
+
+From the repository, with an unused output directory and the retained input
+artifacts available on eligible workers:
+
+```bash
+python3 /mnt/shared/prismabuild-fleet/repo/tools/pbrun.py \
+  --gpu --cpus 4 --demand mem_gb=12 --gpu-memory-gb 8 \
+  --measurement --timeout-s 1500 --detach -- \
+  bash experiments/joint_projection_reduce_run.sh bench \
+  --output /mnt/shared/tessera-measurements/first-model-20260907/joint-fused-projection/actual-ab-repeat \
+  --source-receipt /mnt/shared/tessera-measurements/first-model-20260907/qdq-residency/source-capture-01/receipt.json \
+  --source-sha256 bf5337381562e2b4ae1fbdb672e85f198679e2848487b291590d7810990872d3
+```
+
+Use `qualify --output <unused-path>` with the same wrapper for the targeted GPU
+suite, omitting `--measurement`; `build --output <unused-path>` uses CPU-only
+Docker under a portable PB reservation. The raw Netdata collector is retained at
+`qdq-residency/frozen-source/collect_netdata.py`; run it read-only against the
+finished benchmark receipt while the time series remains available.

--- a/experiments/joint_projection_reduce_bench.py
+++ b/experiments/joint_projection_reduce_bench.py
@@ -1,0 +1,95 @@
+"""Actual captured X/g replay; change only the three product/reduction sites."""
+import argparse
+import ast
+import inspect
+import json
+from pathlib import Path
+import shutil
+import textwrap
+
+import torch
+
+from experiments.qdq_constant_residency import main as replay
+from prismaquant import joint_aura
+from prismaquant.kernels import joint_projection_reduce as kernel
+
+
+class Candidate:
+    schema = 'pq.joint_projection_reduction.v1'
+
+    def __init__(self, output):
+        self.output = output
+        self.identity = kernel.build_identity()
+        self.identity['acceptance'] = 'bit-exact FP32 individual reductions and signed probe components; no relaxed tolerance'
+        self.baseline_path = Path(joint_aura.__file__)
+        self.before = joint_aura.SignedJointProjectionLease._observe
+        self.before_source = textwrap.dedent(inspect.getsource(self.before))
+        tree = ast.parse(self.before_source)
+        changed = []
+
+        class Replace(ast.NodeTransformer):
+            def visit_Call(self, node):
+                if (isinstance(node.func, ast.Attribute) and node.func.attr == 'sum'
+                        and isinstance(node.func.value, ast.BinOp) and isinstance(node.func.value.op, ast.Mult)
+                        and not node.args and not node.keywords):
+                    product = node.func.value
+                    left = ast.unparse(product.left)
+                    right = ast.unparse(product.right)
+                    component = {('gw', 'delta'): 'weight',
+                                 ('d_operator', 'source_weight.float()'): 'activation',
+                                 ('d_operator', 'delta'): 'mixed'}[(left, right)]
+                    changed.append(component)
+                    return ast.copy_location(ast.Call(func=ast.Name(id='_projection_product_sum', ctx=ast.Load()),
+                        args=[product.left, product.right], keywords=[ast.keyword(arg='component', value=ast.Constant(component))]), node)
+                return self.generic_visit(node)
+
+        tree = ast.fix_missing_locations(Replace().visit(tree))
+        assert sorted(changed) == ['activation', 'mixed', 'weight']
+        self.after_source = ast.unparse(tree) + '\n'
+        namespace = dict(vars(joint_aura))
+        namespace['_projection_product_sum'] = self.product
+        exec(compile(tree, str(output / 'after.py'), 'exec'), namespace)
+        self.after = namespace['_observe']
+        self.checking = False
+        self.reduction_checks = []
+
+    def activate(self, function):
+        joint_aura.SignedJointProjectionLease._observe = function
+
+    def persist_binary(self, output):
+        binary = Path(self.identity['binary_path'])
+        shutil.copy2(binary, output / binary.name)
+        shutil.copy2(binary.parent / 'build.ninja', output / 'build.ninja')
+
+    def product(self, left, right, *, component):
+        if not kernel.fast_path_eligible(left, right):
+            raise RuntimeError('actual projection escaped the measured fused CUDA geometry')
+        actual = kernel.fused_product_sum(left, right)
+        if self.checking:
+            expected = (left * right).sum()
+            bits = actual.view(torch.int32).item()
+            reference = expected.view(torch.int32).item()
+            check = {'index': len(self.reduction_checks), 'component': component,
+                     'shape': list(left.shape), 'left_stride': list(left.stride()), 'right_stride': list(right.stride()),
+                     'candidate_bits': bits, 'reference_bits': reference,
+                     'candidate_value': actual.item(), 'reference_value': expected.item(), 'equal': bits == reference}
+            self.reduction_checks.append(check)
+            if bits != reference:
+                (self.output / 'numerical-failure.json').write_text(json.dumps(self.reduction_checks, indent=2))
+                raise AssertionError(f'fused reduction changed FP32 bits: {check}')
+        return actual
+
+
+def main():
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument('--output', type=Path, required=True)
+    args, _ = parser.parse_known_args()
+    candidate = Candidate(args.output)
+    try:
+        replay(variant_controller=candidate)
+    finally:
+        candidate.activate(candidate.before)
+
+
+if __name__ == '__main__':
+    main()

--- a/experiments/joint_projection_reduce_bench.py
+++ b/experiments/joint_projection_reduce_bench.py
@@ -29,18 +29,23 @@ class Candidate:
 
         class Replace(ast.NodeTransformer):
             def visit_Call(self, node):
+                operands = None
                 if (isinstance(node.func, ast.Attribute) and node.func.attr == 'sum'
                         and isinstance(node.func.value, ast.BinOp) and isinstance(node.func.value.op, ast.Mult)
                         and not node.args and not node.keywords):
-                    product = node.func.value
-                    left = ast.unparse(product.left)
-                    right = ast.unparse(product.right)
+                    operands = node.func.value.left, node.func.value.right
+                elif (isinstance(node.func, ast.Attribute) and node.func.attr == '_projection_product_sum'
+                      and isinstance(node.func.value, ast.Name) and node.func.value.id == 'self'
+                      and len(node.args) == 2 and not node.keywords):
+                    operands = tuple(node.args)
+                if operands is not None:
+                    left, right = map(ast.unparse, operands)
                     component = {('gw', 'delta'): 'weight',
                                  ('d_operator', 'source_weight.float()'): 'activation',
                                  ('d_operator', 'delta'): 'mixed'}[(left, right)]
                     changed.append(component)
                     return ast.copy_location(ast.Call(func=ast.Name(id='_projection_product_sum', ctx=ast.Load()),
-                        args=[product.left, product.right], keywords=[ast.keyword(arg='component', value=ast.Constant(component))]), node)
+                        args=list(operands), keywords=[ast.keyword(arg='component', value=ast.Constant(component))]), node)
                 return self.generic_visit(node)
 
         tree = ast.fix_missing_locations(Replace().visit(tree))

--- a/experiments/joint_projection_reduce_build.py
+++ b/experiments/joint_projection_reduce_build.py
@@ -1,0 +1,34 @@
+"""PB CPU action: compile candidate against the pinned container and seal inputs."""
+import argparse
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import torch
+
+from prismaquant.kernels.joint_projection_reduce import build_identity
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=False)
+    identity = build_identity()
+    identity['nvcc_version'] = subprocess.check_output(['/usr/local/cuda/bin/nvcc', '--version'], text=True)
+    identity['cxx_version'] = subprocess.check_output(['c++', '--version'], text=True)
+    binary = Path(identity['binary_path'])
+    shutil.copy2(binary, args.output / binary.name)
+    shutil.copy2(binary.parent / 'build.ninja', args.output / 'build.ninja')
+    include = Path(torch.__file__).parent / 'include'
+    for relative in identity['headers']:
+        path = args.output / 'headers' / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(include / relative, path)
+    (args.output / 'identity.json').write_text(json.dumps(identity, indent=2))
+    print(json.dumps(identity), flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/experiments/joint_projection_reduce_geometry.py
+++ b/experiments/joint_projection_reduce_geometry.py
@@ -1,0 +1,129 @@
+"""Numerical qualification on retained source weights, captured X and wire rungs.
+
+Cotangents are explicitly seeded local operands, not source-model Fisher probes.
+Each invocation qualifies one original model unit; PrismaBuild owns placement.
+"""
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import pickle
+import socket
+import time
+
+import torch
+from safetensors import safe_open
+
+from experiments.qdq_constant_residency import ROOT, sha, tensor_sha
+from experiments.joint_projection_reduce_bench import Candidate
+from prismaquant import format_registry as fr
+from prismaquant.joint_aura import SignedJointProjectionLease, activation_identity, prefetch_joint_cache
+from prismaquant.kernels import joint_projection_reduce as kernel
+from prismaquant.production_weight_cache import _cb_cache_tensor_identity
+from prismaquant.tessera_calibration_cache import prefetch_capture, require_capture_contract
+
+BINARY = ROOT / 'joint-fused-projection/actual-ab-01/pq_joint_projection_reduce_17d100e93d552b85.so'
+BINARY_SHA = '9305c183c5214dc5ff1f73382963f8275eb1b6197cb8d173c6a93bffd700c115'
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--unit', required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=False)
+    torch.set_num_threads(1)
+    torch.set_float32_matmul_precision('highest')
+    torch.backends.cuda.matmul.allow_tf32 = False
+    assert sha(BINARY) == BINARY_SHA
+    spec = importlib.util.spec_from_file_location(BINARY.stem, BINARY)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    kernel.load_backend = lambda: module  # Research replay of the already measured binary.
+    candidate = Candidate(args.output)
+    candidate.persist_binary(args.output)
+    prepared_path = ROOT / 'full-model-joint-aura/run-02/prepare/prepared.json'
+    assert sha(prepared_path) == '69a56bff2d29beaf38759b309dee1ac94ca9e091e50f846590d8b51cb0ba5908'
+    prepared = json.loads(prepared_path.read_text())
+    cache_path = Path(prepared['production_cache']['path'])
+    assert sha(cache_path) == prepared['production_cache']['sha256']
+    cache = pickle.loads(cache_path.read_bytes())
+    name = args.unit
+    formats = [fmt for fmt in prepared['formats_by_qname'][name] if fmt != 'BF16']
+    assert len(formats) == 7
+    for fmt in formats:
+        assert sha(Path(cache.weights[name, fmt])) == cache.metadata['verified_cells'][name, fmt]['render_file_sha256']
+    manifest_path = ROOT / 'capture-reuse/canonical/capture_manifest.json'
+    manifest_sha = 'db3cd996ee8a3ac82d62c6e7e2f23cdb995874b831adcf9360acdae682654823'
+    manifest = require_capture_contract(manifest_path, expected_sha256=manifest_sha)
+    census_path = ROOT / 'canonical-census-512/census.json'
+    assert sha(census_path) == manifest['identity']['census_sha256']
+    census = json.loads(census_path.read_text())
+    (acts, _, counts, maxima), capture_receipt = prefetch_capture(
+        manifest_path, expected_identity=manifest['identity'], census=census,
+        names=[name], device='cuda', expected_sha256=manifest_sha)
+    with safe_open('/mnt/shared/models/LFM2.5-8B-A1B-BF16/model.safetensors', framework='pt', device='cpu') as model:
+        source = model.get_tensor(name + '.weight')
+    source_identity = _cb_cache_tensor_identity(source)
+    for fmt in formats:
+        assert source_identity == cache.metadata['verified_cells'][name, fmt]['source_weight']
+    prefetch = prefetch_joint_cache(cache, [name], {name: formats}, max_resident_bytes=1024 * 2**20)
+    source = source.cuda()
+    renders = {fmt: cache.get(name, fmt).cuda() for fmt in formats}
+    for fmt, value in renders.items():
+        assert _cb_cache_tensor_identity(value) == cache.metadata['verified_cells'][name, fmt]['rendered_weight']
+    deltas = {(name, fmt): value.float() - source.float() for fmt, value in renders.items()}
+    specs = {name: {fmt: fr.get_format(fmt) for fmt in formats}}
+    for fmt in formats:
+        assert activation_identity(specs[name][fmt], cache.activation_max_abs, name) == cache.metadata['verified_cells'][name, fmt]['activation']
+    layer = torch.nn.Linear(source.shape[1], source.shape[0], bias=False, device='cuda', dtype=torch.bfloat16)
+    with torch.no_grad():
+        layer.weight.copy_(source)
+    x = acts[name].to(dtype=torch.bfloat16).requires_grad_()
+    assert torch.equal(x.float(), acts[name])
+    generator = torch.Generator(device='cuda').manual_seed(7000)
+    gradients = [torch.randn((len(x), source.shape[0]), generator=generator, device='cuda', dtype=torch.bfloat16) for _ in range(4)]
+    receipt = {'schema': 'pq.joint_projection_geometry_qualification.v1', 'passed': False,
+               'unit': name, 'source_weight': source_identity, 'x_sha256': tensor_sha(x),
+               'x_shape': list(x.shape), 'formats': formats, 'prefetch': prefetch,
+               'prepared': {'path': str(prepared_path), 'sha256': sha(prepared_path)},
+               'capture_receipt': capture_receipt, 'capture_count': counts[name], 'capture_maximum': maxima[name],
+               'cotangents': {'kind': 'seeded BF16 qualification operands; not source Fisher', 'seed': 7000,
+                              'sha256': [tensor_sha(g) for g in gradients]},
+               'candidate': candidate.identity,
+               'env': {'host': socket.gethostname(), 'started_epoch': time.time()}}
+    (args.output / 'before.py').write_text(candidate.before_source)
+    (args.output / 'after.py').write_text(candidate.after_source)
+    lease = SignedJointProjectionLease({name: layer}, specs, deltas, activation_max_abs=cache.activation_max_abs)
+
+    def cycle():
+        result = []
+        for gradient in gradients:
+            lease.begin_probe()
+            x.grad = layer.weight.grad = None
+            output = layer(x)
+            output.backward(gradient)
+            terms = lease.finish_probe()
+            result.append({'signed': {fmt: terms[name, fmt] for fmt in formats}, 'output': tensor_sha(output),
+                           'dx': tensor_sha(x.grad), 'dw': tensor_sha(layer.weight.grad)})
+        return result
+
+    try:
+        with lease:
+            candidate.activate(candidate.before)
+            expected = cycle()
+            candidate.activate(candidate.after)
+            candidate.checking = True
+            actual = cycle()
+        assert actual == expected, 'signed components or forward/backward hashes changed'
+        assert len(candidate.reduction_checks) == 52 and all(x['equal'] for x in candidate.reduction_checks)
+        receipt.update(passed=True, qualification={'probes': actual, 'reductions': candidate.reduction_checks})
+    finally:
+        candidate.activate(candidate.before)
+        receipt['env']['finished_epoch'] = time.time()
+        (args.output / 'receipt.json').write_text(json.dumps(receipt, indent=2))
+    print(json.dumps({'passed': receipt['passed'], 'unit': name, 'output': str(args.output)}), flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/experiments/joint_projection_reduce_policy_tests.py
+++ b/experiments/joint_projection_reduce_policy_tests.py
@@ -1,0 +1,42 @@
+"""Run CPU contract/schema regressions inside an admitted container."""
+import argparse
+import json
+from pathlib import Path
+import py_compile
+import subprocess
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=False)
+    tooling = '/tmp/pq-fused-policy-tools'
+    subprocess.run([sys.executable, '-m', 'pip', 'install', '--quiet', '--disable-pip-version-check',
+                    '--target', tooling, 'pytest==8.4.2', 'pytest-xdist==3.8.0'], check=True)
+    sys.path.insert(0, tooling)
+    import os
+    os.environ['PYTHONPATH'] = tooling + ':' + os.environ['PYTHONPATH']
+    import pytest
+    files = ['tests/test_joint_projection_backend.py', 'tests/test_joint_aura_projection.py',
+             'tests/test_joint_aura_streamed.py', 'tests/test_joint_aura_packed.py',
+             'tests/test_joint_aura_microbatch.py', 'tests/test_joint_aura_lease_lifetime.py',
+             'tests/test_joint_aura_one_squaring.py', 'tests/test_joint_aura_assignment_diagnostics.py',
+             'tests/test_joint_aura_allocator_currency.py', 'tests/test_tessera_joint_aura.py',
+             'tests/test_native_operator_panel.py', 'tests/test_native_moe_panel.py',
+             'tests/test_allocator_measured_runtime_cli.py', 'tests/test_architecture_doc.py',
+             'tests/test_docs_staleness.py']
+    for name in ['prismaquant/joint_projection_backend.py', 'prismaquant/joint_aura.py',
+                 'prismaquant/aura_cost.py', 'prismaquant/tessera_joint_aura.py',
+                 'experiments/joint_projection_reduce_production.py']:
+        py_compile.compile(name, cfile=str(args.output / (Path(name).name + 'c')), doraise=True)
+    code = pytest.main(['-q', '-n', '4', '-p', 'no:cacheprovider', *files,
+                        '--junitxml', str(args.output / 'pytest.xml')])
+    (args.output / 'receipt.json').write_text(json.dumps({'test_exit_code': code, 'files': files,
+                                                       'mode': 'CPU-only; four pytest workers, native threads one'}, indent=2))
+    return code
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/experiments/joint_projection_reduce_production.py
+++ b/experiments/joint_projection_reduce_production.py
@@ -1,0 +1,118 @@
+"""Qualify actual source X/g through the real prewarmed production lease API."""
+import inspect
+from pathlib import Path
+import shutil
+import sys
+import textwrap
+
+import torch
+
+from experiments.qdq_constant_residency import main as replay, ROOT
+from prismaquant import joint_aura
+from prismaquant.joint_projection_backend import prewarm_projection_backend
+
+BINARY = ROOT / 'joint-fused-projection/actual-ab-01/pq_joint_projection_reduce_17d100e93d552b85.so'
+BINARY_SHA = '9305c183c5214dc5ff1f73382963f8275eb1b6197cb8d173c6a93bffd700c115'
+
+
+class LeasePair:
+    def __init__(self, reference, fused):
+        self.leases = {'before': reference, 'after': fused}
+        self.current = 'before'
+        self.entered = False
+
+    def __enter__(self):
+        self.leases[self.current].__enter__()
+        self.entered = True
+        return self
+
+    def switch(self, label):
+        if label == self.current:
+            return
+        if self.entered:
+            self.leases[self.current].__exit__(None, None, None)
+        self.current = label
+        if self.entered:
+            self.leases[self.current].__enter__()
+
+    def __exit__(self, *args):
+        self.entered = False
+        self.leases[self.current].__exit__(*args)
+
+    def begin_probe(self):
+        self.leases[self.current].begin_probe()
+
+    def finish_probe(self):
+        return self.leases[self.current].finish_probe()
+
+    @property
+    def telemetry(self):
+        return {name: sum(lease.telemetry[name] for lease in self.leases.values())
+                for name in self.leases['before'].telemetry}
+
+
+class ProductionCandidate:
+    schema = 'pq.production_joint_projection_qualification.v1'
+    before, after = 'before', 'after'
+
+    def __init__(self):
+        self.reference = prewarm_projection_backend({'name': 'torch'}, device='cuda')
+        self.fused = prewarm_projection_backend({'name': 'fused_fp32_v1',
+            'binary': {'path': str(BINARY), 'sha256': BINARY_SHA}}, device='cuda')
+        self.identity = self.fused.identity
+        self.baseline_path = Path(joint_aura.__file__)
+        self.before_source = self.after_source = textwrap.dedent(inspect.getsource(joint_aura.SignedJointProjectionLease._observe))
+        self.checking = False
+        self.reduction_checks = []
+        self.original_product = self.fused.product_sum
+        self.fused.product_sum = self.product
+
+    @property
+    def checking(self):
+        return self._checking
+
+    @checking.setter
+    def checking(self, enabled):
+        self._checking = bool(enabled)
+        if hasattr(self, 'pair'):
+            # Instrument individual bits only during qualification. Profiles
+            # call the original admitted production backend directly.
+            self.pair.leases['after']._projection_product_sum = (self.product if enabled
+                                                                else self.original_product)
+
+    def product(self, left, right):
+        actual = self.original_product(left, right)
+        if self.checking:
+            expected = (left * right).sum()
+            bits, reference = actual.view(torch.int32).item(), expected.view(torch.int32).item()
+            row = {'shape': list(left.shape), 'left_stride': list(left.stride()),
+                   'right_stride': list(right.stride()), 'candidate_bits': bits, 'reference_bits': reference,
+                   'equal': bits == reference}
+            self.reduction_checks.append(row)
+            assert row['equal'], f'production fused reduction changed FP32 bits: {row}'
+        return actual
+
+    def make_lease(self, *args, **kwargs):
+        self.pair = LeasePair(
+            joint_aura.SignedJointProjectionLease(*args, **kwargs, projection_backend=self.reference),
+            joint_aura.SignedJointProjectionLease(*args, **kwargs, projection_backend=self.fused))
+        return self.pair
+
+    def activate(self, label):
+        self.pair.switch(label)
+
+    def persist_binary(self, output):
+        shutil.copy2(BINARY, output / BINARY.name)
+        shutil.copy2(BINARY.with_name('build.ninja'), output / 'build.ninja')
+
+
+def main():
+    candidate = ProductionCandidate()
+    if '--qualification-only' not in sys.argv:
+        sys.argv.append('--qualification-only')
+    replay(variant_controller=candidate)
+    assert len(candidate.reduction_checks) == 208
+
+
+if __name__ == '__main__':
+    main()

--- a/experiments/joint_projection_reduce_qualify.py
+++ b/experiments/joint_projection_reduce_qualify.py
@@ -1,0 +1,33 @@
+"""Run the CUDA numerical/stream/layout gate inside one admitted action."""
+import argparse
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+from prismaquant.kernels.joint_projection_reduce import build_identity
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=False)
+    tooling = '/tmp/pq-fused-test-tools'
+    subprocess.run([sys.executable, '-m', 'pip', 'install', '--quiet', '--disable-pip-version-check',
+                    '--target', tooling, 'pytest==8.4.2'], check=True)
+    sys.path.insert(0, tooling)
+    import pytest
+    identity = build_identity()
+    binary = Path(identity['binary_path'])
+    shutil.copy2(binary, args.output / binary.name)
+    shutil.copy2(binary.parent / 'build.ninja', args.output / 'build.ninja')
+    code = pytest.main(['-q', '-p', 'no:cacheprovider', 'tests/test_joint_projection_reduce.py',
+                        '--junitxml', str(args.output / 'pytest.xml')])
+    (args.output / 'receipt.json').write_text(json.dumps({'candidate': identity, 'test_exit_code': code}, indent=2))
+    return code
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/experiments/joint_projection_reduce_run.sh
+++ b/experiments/joint_projection_reduce_run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+image=eugr/spark-vllm@sha256:0afec8d4f79f44685a1ddf758659d33aef3b0f3ec9068e5a7cd1108d30e5581c
+input_root=/mnt/shared/tessera-measurements/first-model-20260907/inputs
+run_root=/mnt/shared/tessera-measurements/first-model-20260907/joint-fused-projection
+mode=$1
+shift
+gpu_args=()
+if [[ "$mode" != build ]]; then
+  gpu_args=(--gpus all)
+fi
+exec docker run --rm "${gpu_args[@]}" --ipc=host --network=host --user "$(id -u):$(id -g)" \
+  -v "$PWD:/workspace:ro" -v /mnt/shared:/mnt/shared -w /workspace --entrypoint python3 \
+  -e PYTHONDONTWRITEBYTECODE=1 -e OMP_NUM_THREADS=1 -e MKL_NUM_THREADS=1 -e OPENBLAS_NUM_THREADS=1 \
+  -e MAX_JOBS=4 -e TORCH_CUDA_ARCH_LIST=12.1 -e "TORCH_EXTENSIONS_DIR=$run_root/extensions" \
+  -e XDG_CACHE_HOME=/tmp/pq-reduction-cache -e HF_HOME=/tmp/pq-reduction-hf \
+  -e PRISMABUILD_CONTAINER_OWNER -e PRISMAQUANT_PROD_ACT_SCALES=0 \
+  -e "PYTHONPATH=/workspace:$input_root/tessera-382a1a97/src:$input_root/container-compatible-deps" \
+  "$image" -m "experiments.joint_projection_reduce_$mode" "$@"

--- a/experiments/joint_projection_reduce_run.sh
+++ b/experiments/joint_projection_reduce_run.sh
@@ -6,7 +6,7 @@ run_root=/mnt/shared/tessera-measurements/first-model-20260907/joint-fused-proje
 mode=$1
 shift
 gpu_args=()
-if [[ "$mode" != build ]]; then
+if [[ "$mode" != build && "$mode" != policy_tests ]]; then
   gpu_args=(--gpus all)
 fi
 exec docker run --rm "${gpu_args[@]}" --ipc=host --network=host --user "$(id -u):$(id -g)" \

--- a/experiments/pq237_joint_aura_streamed.py
+++ b/experiments/pq237_joint_aura_streamed.py
@@ -520,7 +520,7 @@ def main():
         # Bind the input contract before the producer returns any rows. Its
         # own self-consistent digest cannot authorize different probe inputs.
         expected_probe = {
-            "schema": "prismaquant.joint_aura.probes.v1", "source_model": model_identity,
+            "schema": "prismaquant.joint_aura.probes.v2", "source_model": model_identity,
             "calibration_sha256": _cb_cache_tensor_identity(calibration)["content_sha256"],
             "calibration_shape": list(calibration.shape), "calibration_dtype": str(calibration.dtype),
             "n_probes": protocol["n_probes"], "seed_base": protocol["seed_base"],
@@ -530,7 +530,7 @@ def main():
         }
         expected_probe_sha256 = identity_sha256(expected_probe)
         expected = {name: {fmt: identity_sha256({
-            "schema": "prismaquant.joint_aura.operator.v1", "qname": name, "format": fmt,
+            "schema": "prismaquant.joint_aura.operator.v2", "qname": name, "format": fmt,
             "source_weight": renders[name][fmt]["source_weight"],
             "rendered_weight": renders[name][fmt]["rendered_weight"],
             "activation": activation_identity(fr.get_format(fmt), cache.activation_max_abs, name),

--- a/experiments/qdq_constant_residency.py
+++ b/experiments/qdq_constant_residency.py
@@ -48,6 +48,8 @@ def main(*, variant_controller=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('--output', type=Path, required=True)
     parser.add_argument('--target-seconds', type=float, default=35)
+    parser.add_argument('--qualification-only', action='store_true')
+    parser.add_argument('--profile-qualified', action='store_true')
     parser.add_argument('--source-receipt', type=Path)
     parser.add_argument('--source-sha256')
     args = parser.parse_args()
@@ -196,7 +198,9 @@ def main(*, variant_controller=None):
             actual_invocations=source_capture['records'], rows_per_probe=[sum(len(v[0]) for v in values) for values in probe_inputs],
             projection_scope='four actual per-expert invocations accumulated per probe; not full-model cost')
     save()
-    lease = SignedJointProjectionLease({NAME: layer}, specs, deltas, activation_max_abs=cache.activation_max_abs)
+    lease_factory = (variant_controller.make_lease if variant_controller is not None
+                     and hasattr(variant_controller, 'make_lease') else SignedJointProjectionLease)
+    lease = lease_factory({NAME: layer}, specs, deltas, activation_max_abs=cache.activation_max_abs)
 
     def cycle(check=False):
         if variant_controller is not None:
@@ -227,56 +231,58 @@ def main(*, variant_controller=None):
         receipt['qualification'] = {'exact_projection_and_forward_backward': True, 'probes': actual}
         if variant_controller is not None:
             receipt['qualification']['reductions'] = variant_controller.reduction_checks
-        timings = []
-        for function in (before, after):
-            activate(function)
-            cycle()
-            torch.cuda.synchronize()
-            start = time.perf_counter()
-            for _ in range(3):
+        if not args.qualification_only:
+            timings = []
+            for function in (before, after):
+                activate(function)
                 cycle()
-            torch.cuda.synchronize()
-            timings.append((time.perf_counter() - start) / 3)
-        count = max(1, math.ceil(args.target_seconds / min(timings)))
-        assert count <= 5000, count
-        receipt['calibration'] = {'seconds_per_cycle': timings, 'cycles_per_arm': count}
-        save()
-        for index, (label, function) in enumerate((('before', before), ('after', after), ('after', after), ('before', before))):
-            activate(function)
-            receipt['active_phase'] = {'phase': f'{index}-{label}', 'cycles': count, 'started_epoch': time.time()}
-            save()
-            print(json.dumps({'starting': receipt['active_phase']}), flush=True)
-            torch.cuda.synchronize()
-            start, counters = time.time(), io_counters()
-            for _ in range(count):
-                cycle()
-            torch.cuda.synchronize()
-            end = time.time()
-            after_counters = io_counters()
-            phase = {'phase': f'{index}-{label}', 'kind': 'measured', 'arm': label,
-                     'start_epoch': start, 'end_epoch': end, 'seconds': end - start,
-                     'cycles': count, 'projection_terms': count * 4 * len(formats),
-                     'io_delta': {key: after_counters[key] - value for key, value in counters.items()}}
-            receipt['phases'].append(phase)
-            receipt.pop('active_phase', None)
-            save()
-            print(json.dumps(phase), flush=True)
-        for label, function in (('before', before), ('after', after)):
-            activate(function)
-            torch.cuda.synchronize()
-            start = time.time()
-            with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
-                                        record_shapes=True, profile_memory=True, with_stack=True) as profiler:
+                torch.cuda.synchronize()
+                start = time.perf_counter()
                 for _ in range(3):
                     cycle()
-            torch.cuda.synchronize()
-            end = time.time()
-            profiler.export_chrome_trace(str(args.output / f'{label}-trace.json'))
-            events = profiler.key_averages()
-            (args.output / f'{label}-cpu.txt').write_text(events.table(sort_by='self_cpu_time_total', row_limit=100))
-            (args.output / f'{label}-cuda.txt').write_text(events.table(sort_by='self_device_time_total', row_limit=100))
-            receipt['phases'].append({'phase': label + '-profile', 'kind': 'profile', 'start_epoch': start, 'end_epoch': end})
+                torch.cuda.synchronize()
+                timings.append((time.perf_counter() - start) / 3)
+            count = max(1, math.ceil(args.target_seconds / min(timings)))
+            assert count <= 5000, count
+            receipt['calibration'] = {'seconds_per_cycle': timings, 'cycles_per_arm': count}
             save()
+            for index, (label, function) in enumerate((('before', before), ('after', after), ('after', after), ('before', before))):
+                activate(function)
+                receipt['active_phase'] = {'phase': f'{index}-{label}', 'cycles': count, 'started_epoch': time.time()}
+                save()
+                print(json.dumps({'starting': receipt['active_phase']}), flush=True)
+                torch.cuda.synchronize()
+                start, counters = time.time(), io_counters()
+                for _ in range(count):
+                    cycle()
+                torch.cuda.synchronize()
+                end = time.time()
+                after_counters = io_counters()
+                phase = {'phase': f'{index}-{label}', 'kind': 'measured', 'arm': label,
+                         'start_epoch': start, 'end_epoch': end, 'seconds': end - start,
+                         'cycles': count, 'projection_terms': count * 4 * len(formats),
+                         'io_delta': {key: after_counters[key] - value for key, value in counters.items()}}
+                receipt['phases'].append(phase)
+                receipt.pop('active_phase', None)
+                save()
+                print(json.dumps(phase), flush=True)
+        if not args.qualification_only or args.profile_qualified:
+            for label, function in (('before', before), ('after', after)):
+                activate(function)
+                torch.cuda.synchronize()
+                start = time.time()
+                with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
+                                            record_shapes=True, profile_memory=True, with_stack=True) as profiler:
+                    for _ in range(3):
+                        cycle()
+                torch.cuda.synchronize()
+                end = time.time()
+                profiler.export_chrome_trace(str(args.output / f'{label}-trace.json'))
+                events = profiler.key_averages()
+                (args.output / f'{label}-cpu.txt').write_text(events.table(sort_by='self_cpu_time_total', row_limit=100))
+                (args.output / f'{label}-cuda.txt').write_text(events.table(sort_by='self_device_time_total', row_limit=100))
+                receipt['phases'].append({'phase': label + '-profile', 'kind': 'profile', 'start_epoch': start, 'end_epoch': end})
+                save()
     activate(after)
     receipt.update(passed=True, telemetry=lease.telemetry, max_rss_kib=resource.getrusage(resource.RUSAGE_SELF).ru_maxrss,
                    cuda_max_allocated=torch.cuda.max_memory_allocated(), cuda_max_reserved=torch.cuda.max_memory_reserved())

--- a/experiments/qdq_constant_residency.py
+++ b/experiments/qdq_constant_residency.py
@@ -44,7 +44,7 @@ def io_counters():
             (line.split(':') for line in Path('/proc/self/io').read_text().splitlines())}
 
 
-def main():
+def main(*, variant_controller=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('--output', type=Path, required=True)
     parser.add_argument('--target-seconds', type=float, default=35)
@@ -52,6 +52,8 @@ def main():
     parser.add_argument('--source-sha256')
     args = parser.parse_args()
     args.output.mkdir(parents=True, exist_ok=False)
+    if variant_controller is not None:
+        variant_controller.persist_binary(args.output)
     torch.set_num_threads(1)
     torch.set_float32_matmul_precision('highest')
     torch.backends.cuda.matmul.allow_tf32 = False
@@ -60,23 +62,36 @@ def main():
                'env': {'started_epoch': time.time(), 'host': socket.gethostname(),
                        'torch': str(torch.__version__), 'cuda': torch.version.cuda,
                        'device': torch.cuda.get_device_name(), 'affinity': sorted(os.sched_getaffinity(0))}}
+    if variant_controller is not None:
+        receipt.update(schema=variant_controller.schema, variant=variant_controller.identity)
 
     def save():
         (args.output / 'receipt.json').write_text(json.dumps(receipt, indent=2, allow_nan=False))
 
     save()
-    baseline_path = ROOT / 'qdq-residency/frozen-source/baseline_nvfp4_activation_contract.py'
-    baseline_text = baseline_path.read_text()
-    tree = ast.parse(baseline_text)
-    function = next(node for node in tree.body if isinstance(node, ast.FunctionDef)
-                    and node.name == 'nvfp4_activation_qdq_served')
-    baseline_function = ast.get_source_segment(baseline_text, function)
-    namespace = dict(owner.__dict__)
-    exec(compile(baseline_function, str(baseline_path), 'exec'), namespace)
-    before = namespace['nvfp4_activation_qdq_served']
-    after = owner.nvfp4_activation_qdq_served
+    if variant_controller is None:
+        baseline_path = ROOT / 'qdq-residency/frozen-source/baseline_nvfp4_activation_contract.py'
+        baseline_text = baseline_path.read_text()
+        tree = ast.parse(baseline_text)
+        function = next(node for node in tree.body if isinstance(node, ast.FunctionDef)
+                        and node.name == 'nvfp4_activation_qdq_served')
+        baseline_function = ast.get_source_segment(baseline_text, function)
+        namespace = dict(owner.__dict__)
+        exec(compile(baseline_function, str(baseline_path), 'exec'), namespace)
+        before = namespace['nvfp4_activation_qdq_served']
+        after = owner.nvfp4_activation_qdq_served
+        after_function = inspect.getsource(after)
+
+        def activate(function):
+            owner.nvfp4_activation_qdq_served = function
+    else:
+        baseline_path = variant_controller.baseline_path
+        baseline_function = variant_controller.before_source
+        after_function = variant_controller.after_source
+        before, after = variant_controller.before, variant_controller.after
+        activate = variant_controller.activate
     (args.output / 'before.py').write_text(baseline_function)
-    (args.output / 'after.py').write_text(inspect.getsource(after))
+    (args.output / 'after.py').write_text(after_function)
     prepared_path = ROOT / 'full-model-joint-aura/run-02/prepare/prepared.json'
     assert sha(prepared_path) == '69a56bff2d29beaf38759b309dee1ac94ca9e091e50f846590d8b51cb0ba5908'
     prepared = json.loads(prepared_path.read_text())
@@ -184,6 +199,8 @@ def main():
     lease = SignedJointProjectionLease({NAME: layer}, specs, deltas, activation_max_abs=cache.activation_max_abs)
 
     def cycle(check=False):
+        if variant_controller is not None:
+            variant_controller.checking = check
         results = []
         for values in probe_inputs:
             lease.begin_probe()
@@ -202,15 +219,17 @@ def main():
         return results
 
     with lease:
-        owner.nvfp4_activation_qdq_served = before
+        activate(before)
         expected = cycle(check=True)
-        owner.nvfp4_activation_qdq_served = after
+        activate(after)
         actual = cycle(check=True)
         assert actual == expected, 'baseline/output/backward/signed projection bits differ'
         receipt['qualification'] = {'exact_projection_and_forward_backward': True, 'probes': actual}
+        if variant_controller is not None:
+            receipt['qualification']['reductions'] = variant_controller.reduction_checks
         timings = []
         for function in (before, after):
-            owner.nvfp4_activation_qdq_served = function
+            activate(function)
             cycle()
             torch.cuda.synchronize()
             start = time.perf_counter()
@@ -223,7 +242,10 @@ def main():
         receipt['calibration'] = {'seconds_per_cycle': timings, 'cycles_per_arm': count}
         save()
         for index, (label, function) in enumerate((('before', before), ('after', after), ('after', after), ('before', before))):
-            owner.nvfp4_activation_qdq_served = function
+            activate(function)
+            receipt['active_phase'] = {'phase': f'{index}-{label}', 'cycles': count, 'started_epoch': time.time()}
+            save()
+            print(json.dumps({'starting': receipt['active_phase']}), flush=True)
             torch.cuda.synchronize()
             start, counters = time.time(), io_counters()
             for _ in range(count):
@@ -236,10 +258,11 @@ def main():
                      'cycles': count, 'projection_terms': count * 4 * len(formats),
                      'io_delta': {key: after_counters[key] - value for key, value in counters.items()}}
             receipt['phases'].append(phase)
+            receipt.pop('active_phase', None)
             save()
             print(json.dumps(phase), flush=True)
         for label, function in (('before', before), ('after', after)):
-            owner.nvfp4_activation_qdq_served = function
+            activate(function)
             torch.cuda.synchronize()
             start = time.time()
             with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
@@ -254,7 +277,7 @@ def main():
             (args.output / f'{label}-cuda.txt').write_text(events.table(sort_by='self_device_time_total', row_limit=100))
             receipt['phases'].append({'phase': label + '-profile', 'kind': 'profile', 'start_epoch': start, 'end_epoch': end})
             save()
-    owner.nvfp4_activation_qdq_served = after
+    activate(after)
     receipt.update(passed=True, telemetry=lease.telemetry, max_rss_kib=resource.getrusage(resource.RUSAGE_SELF).ru_maxrss,
                    cuda_max_allocated=torch.cuda.max_memory_allocated(), cuda_max_reserved=torch.cuda.max_memory_reserved())
     receipt['env']['finished_epoch'] = time.time()

--- a/prismaquant/aura_cost.py
+++ b/prismaquant/aura_cost.py
@@ -1873,6 +1873,7 @@ def compute_aura_cost_streamed(
     include_routed_experts: bool = False,
     diagnostic_weight_mse_pairs: Sequence[tuple[str, str]] | None = None,
     joint_activation: bool = False,
+    joint_projection_backend=None,
     profile=None,
 ) -> dict:
     """Layer-streamed KL-adjoint with identity-bound per-Linear shards.
@@ -1894,6 +1895,8 @@ def compute_aura_cost_streamed(
         raise ValueError("probe_microbatch must be a nonnegative integer")
     if calib_ids.ndim != 2 or min(calib_ids.shape) < 1:
         raise ValueError("streamed AURA needs nonempty [rows, sequence] calibration")
+    if joint_projection_backend is not None and not joint_activation:
+        raise ValueError("joint_projection_backend requires joint_activation")
     if probe_microbatch and not joint_activation:
         raise ValueError("streamed probe_microbatch currently requires joint_activation")
     batch_rows = min(probe_microbatch or len(calib_ids), len(calib_ids))
@@ -2101,6 +2104,8 @@ def compute_aura_cost_streamed(
     joint_cache_renders: dict[str, dict[str, dict]] = {}
     joint_prefetch_stats: list[dict] = []
     if joint_activation:
+        from prismaquant.joint_projection_backend import prewarm_projection_backend
+        joint_projection_backend = prewarm_projection_backend(joint_projection_backend, device=runner.device)
         from prismaquant.cost_streaming import validate_streamed_model_identity
         from prismaquant.joint_aura import (
             SignedJointProjectionLease, activation_identity, arithmetic_identity,
@@ -2111,7 +2116,7 @@ def compute_aura_cost_streamed(
         from prismaquant.production_weight_cache import _cb_cache_tensor_identity
 
         joint_probe_identity = {
-            "schema": "prismaquant.joint_aura.probes.v1",
+            "schema": "prismaquant.joint_aura.probes.v2",
             "source_model": validate_streamed_model_identity(model_identity, where="joint AURA"),
             "calibration_sha256": hashlib.sha256(calib_ids.detach().cpu().contiguous().numpy().tobytes()).hexdigest(),
             "calibration_shape": list(calib_ids.shape),
@@ -2121,7 +2126,7 @@ def compute_aura_cost_streamed(
             "distribution": "rademacher", "normalization": "global_kl_fisher",
             "producer_source_sha256": _aura_source_sha256(),
             "source_execution": source_execution_identity(runner.model),
-            "arithmetic": arithmetic_identity(runner.dtype),
+            "arithmetic": arithmetic_identity(runner.dtype, joint_projection_backend),
         }
         if probe_layout is not None:
             joint_probe_identity["noise_layout"] = probe_layout
@@ -2145,7 +2150,7 @@ def compute_aura_cost_streamed(
                     }
                 production_cache.compact_for_pickle()
         joint_run_identity = {
-            "schema": "prismaquant.joint_aura.run.v1",
+            "schema": "prismaquant.joint_aura.run.v2",
             "probe_identity": joint_probe_identity,
             "cached_rendered_weights": joint_cache_renders,
             "activation_contracts": ({
@@ -2547,7 +2552,7 @@ def compute_aura_cost_streamed(
         if name not in joint_source_tensors:
             joint_source_tensors[name] = _cb_cache_tensor_identity(source)
         joint_operators[(name, fmt)] = {
-            "schema": "prismaquant.joint_aura.operator.v1",
+            "schema": "prismaquant.joint_aura.operator.v2",
             "qname": name, "format": fmt,
             "source_weight": joint_source_tensors[name],
             "rendered_weight": rendered_identity,
@@ -2927,6 +2932,7 @@ def compute_aura_cost_streamed(
                     {name: linears[name] for name in pending},
                     {name: {fmt: fr.get_format(fmt) for fmt in render_formats[name]} for name in pending},
                     d_weights, activation_max_abs=getattr(cache_owner, "activation_max_abs", None),
+                    projection_backend=joint_projection_backend,
                 )
             try:
                 if joint_lease is not None:
@@ -3130,6 +3136,7 @@ def run_streamed_production_anchor_aura(
     allow_packed_expert_omission: bool = False,
     collect_col_energy: bool = False,
     joint_activation: bool = False,
+    joint_projection_backend=None,
     profile=None,
 ) -> dict:
     """Run one streamed KL adjoint over an exact production-anchor plan.
@@ -3317,6 +3324,7 @@ def run_streamed_production_anchor_aura(
         allow_packed_expert_omission=allow_packed_expert_omission,
         collect_col_energy=collect_col_energy,
         joint_activation=joint_activation,
+        joint_projection_backend=joint_projection_backend,
         checkpoint_dir=checkpoint_dir,
         resume=resume,
         model_identity=model_identity,

--- a/prismaquant/joint_aura.py
+++ b/prismaquant/joint_aura.py
@@ -93,8 +93,14 @@ def source_execution_identity(model) -> dict:
     return {"schema": "prismaquant.joint_aura.source_execution.v1", "modules": modules}
 
 
-def arithmetic_identity(measurement_dtype) -> dict:
+def arithmetic_identity(measurement_dtype, projection_backend=None) -> dict:
+    from .joint_projection_backend import REFERENCE_IDENTITY, validate_projection_backend_identity
+
+    backend_identity = (dict(REFERENCE_IDENTITY) if projection_backend is None
+                        else projection_backend.identity)
+    validate_projection_backend_identity(backend_identity)
     return {
+        "projection_backend": backend_identity,
         "projection_dtype": "torch.float32", "delta_dtype": "torch.float32",
         "measurement_dtype": str(measurement_dtype),
         "matmul_precision": torch.get_float32_matmul_precision(),
@@ -129,8 +135,15 @@ class SignedJointProjectionLease:
     with the same activation receipt AND the same dynamic QDQ callable.
     """
 
-    def __init__(self, modules, specs_by_qname, delta_weights, *, activation_max_abs=None):
+    def __init__(self, modules, specs_by_qname, delta_weights, *, activation_max_abs=None,
+                 projection_backend=None):
+        from .joint_projection_backend import require_prewarmed_projection
+
         self.modules = dict(modules)
+        device = next((module.weight.device for module in self.modules.values()
+                       if isinstance(module, (nn.Linear, PackedExpertProjection))), torch.device("cpu"))
+        self.projection_backend = require_prewarmed_projection(projection_backend, device=device)
+        self._projection_product_sum = self.projection_backend.product_sum
         self.specs = specs_by_qname
         self.deltas = delta_weights
         self.activation_max_abs = dict(activation_max_abs or {})
@@ -155,6 +168,7 @@ class SignedJointProjectionLease:
                 packed_aliases.add(alias)
             elif not isinstance(module, nn.Linear):
                 raise TypeError(f"joint AURA target {name} is not Linear")
+            self.projection_backend.require_device(module.weight.device)
             expected = {fmt for qname, fmt in self.deltas if qname == name}
             if set(self.specs[name]) != expected:
                 raise ValueError(f"joint AURA render/spec coverage mismatch for {name}")
@@ -326,13 +340,13 @@ class SignedJointProjectionLease:
                         raise RuntimeError(f"joint AURA QDQ changed residency/dtype/shape for {name}")
                     dx = quantized.reshape_as(x2).float() - x2
                     d_operator = g2.T @ dx
-                    activation = (d_operator * source_weight.float()).sum()
+                    activation = self._projection_product_sum(d_operator, source_weight.float())
                     self.telemetry["qdq_calls"] += 1
                     self.telemetry["operator_gemms"] += 1
                 for fmt in formats:
                     delta = self.deltas[(name, fmt)].float()
-                    weight = (gw * delta).sum()
-                    mixed = ((d_operator * delta).sum() if d_operator is not None
+                    weight = self._projection_product_sum(gw, delta)
+                    mixed = (self._projection_product_sum(d_operator, delta) if d_operator is not None
                              else torch.zeros((), device=x.device))
                     components = torch.stack((weight, activation, mixed))
                     key = (name, fmt)
@@ -381,13 +395,13 @@ def validate_joint_aura_entry(entry: Mapping) -> bool:
     if any(key in entry for key in ("act_dloss", "act_dloss_applied", "aqua_activation_dloss", "activation_pricing_applied", "output_mse")):
         raise ValueError("joint AURA refuses a second activation/Fisher application")
     operator = entry.get("joint_operator_identity")
-    if not isinstance(operator, Mapping) or operator.get("schema") != "prismaquant.joint_aura.operator.v1":
-        raise ValueError("joint AURA lacks operator identity")
+    if not isinstance(operator, Mapping) or operator.get("schema") != "prismaquant.joint_aura.operator.v2":
+        raise ValueError("joint AURA requires v2 operator identity; legacy artifacts require fresh prepare and recompute")
     if identity_sha256(operator) != entry.get("joint_operator_identity_sha256"):
         raise ValueError("joint AURA operator identity digest mismatch")
     probe = entry.get("probe_identity")
     digest = entry.get("probe_identity_sha256")
-    if not isinstance(probe, Mapping) or probe.get("schema") != "prismaquant.joint_aura.probes.v1" or identity_sha256(probe) != digest or operator.get("probe_identity_sha256") != digest:
+    if not isinstance(probe, Mapping) or probe.get("schema") != "prismaquant.joint_aura.probes.v2" or identity_sha256(probe) != digest or operator.get("probe_identity_sha256") != digest:
         raise ValueError("joint AURA probe identity mismatch")
     from prismaquant.cost_streaming import validate_streamed_model_identity
     try:
@@ -420,6 +434,8 @@ def validate_joint_aura_entry(entry: Mapping) -> bool:
             if activation[field] is not None and not math.isfinite(float(activation[field])):
                 raise ValueError("nonfinite activation scale")
         arithmetic = operator["arithmetic"]
+        from .joint_projection_backend import validate_projection_backend_identity
+        validate_projection_backend_identity(arithmetic["projection_backend"])
         if arithmetic != probe["arithmetic"] or arithmetic["projection_dtype"] != "torch.float32" or arithmetic["delta_dtype"] != "torch.float32" or arithmetic["aggregation"] != "sum_signed_invocations_then_square":
             raise ValueError("invalid projection arithmetic")
     except (KeyError, TypeError, RuntimeError) as exc:

--- a/prismaquant/joint_projection_backend.py
+++ b/prismaquant/joint_projection_backend.py
@@ -1,0 +1,213 @@
+"""Explicit joint-projection backend admission and prewarm, owning no tensors.
+
+The default remains the native torch expression. The opt-in fused backend loads
+only a prebuilt binary with the packaged numerical qualification; compilation
+belongs to the separately admitted build/qualification workflow.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from functools import lru_cache
+import hashlib
+import importlib.machinery
+import importlib.util
+import json
+from pathlib import Path
+import platform
+import re
+import subprocess
+
+import torch
+
+from .kernels import joint_projection_reduce as kernel
+
+SCHEMA = 'prismaquant.joint_projection_backend.v1'
+FUSED_NAME = 'fused_fp32_v1'
+QUALIFICATION_PATH = Path(__file__).with_name('kernels') / 'joint_projection_reduce_qualification.json'
+REFERENCE_IDENTITY = {'schema': SCHEMA, 'name': 'torch', 'expression': '(left * right).sum()'}
+_PREWARM_SEAL = object()
+# Code modules only: all resident input tensors remain owned by the caller.
+_LOADED_MODULES = {}
+_WARMED_DEVICES = set()
+
+
+def _sha(path):
+    with Path(path).open('rb') as stream:
+        return hashlib.file_digest(stream, 'sha256').hexdigest()
+
+
+@lru_cache(maxsize=1)
+def _qualification():
+    # Immutable package metadata, like the loaded code; row admission must not
+    # reopen the qualification file for every format/probe result.
+    data = QUALIFICATION_PATH.read_bytes()
+    value = json.loads(data)
+    if value.get('schema') != 'prismaquant.joint_projection_qualification.v1' or value.get('status') != 'qualified':
+        raise RuntimeError('joint projection backend has no qualified packaged runtime')
+    return value, hashlib.sha256(data).hexdigest()
+
+
+def normalize_projection_backend(config=None):
+    """Validate the complete plan selector without accessing CUDA or a compiler."""
+    if config is None:
+        return {'name': 'torch'}
+    if not isinstance(config, Mapping):
+        raise ValueError('joint projection backend must be an explicit mapping')
+    config = deepcopy(dict(config))
+    if config == {'name': 'torch'}:
+        return config
+    if set(config) != {'name', 'binary'} or config['name'] != FUSED_NAME:
+        raise ValueError('unsupported joint projection backend or selector fields')
+    binary = config['binary']
+    if (not isinstance(binary, dict) or set(binary) != {'path', 'sha256'}
+            or not isinstance(binary['path'], str) or not binary['path']
+            or not isinstance(binary['sha256'], str) or re.fullmatch('[a-f0-9]{64}', binary['sha256']) is None):
+        raise ValueError('fused joint projection requires an independently bound binary path/SHA256')
+    qualification, _ = _qualification()
+    if binary['sha256'] != qualification['build']['binary_sha256']:
+        raise ValueError('joint projection binary is outside the packaged qualification')
+    return config
+
+
+def _runtime_identity(device):
+    """Read the runtime/compiler/header identity once, before any lease."""
+    props = torch.cuda.get_device_properties(device)
+    include = Path(torch.__file__).parent / 'include'
+    qualification, _ = _qualification()
+    return {'torch': str(torch.__version__), 'torch_git': torch.version.git_version,
+            'cuda': torch.version.cuda, 'machine': platform.machine(),
+            'device': {'name': props.name, 'major': props.major, 'minor': props.minor,
+                       'multi_processor_count': props.multi_processor_count},
+            'headers': {name: _sha(include / name) for name in qualification['runtime']['headers']},
+            'compiler': {
+                'nvcc_version': subprocess.check_output(['/usr/local/cuda/bin/nvcc', '--version'], text=True),
+                'cxx_version': subprocess.check_output(['c++', '--version'], text=True)}}
+
+
+def _require_runtime(actual, expected):
+    if actual != expected:
+        changed = sorted(key for key in set(actual) | set(expected) if actual.get(key) != expected.get(key))
+        raise RuntimeError('joint projection unqualified runtime identity: ' + ', '.join(changed))
+
+
+def validate_projection_backend_identity(identity):
+    """Validate the serialized arithmetic contract without loading GPU code."""
+    if identity == REFERENCE_IDENTITY:
+        return
+    qualification, digest = _qualification()
+    expected = {'schema': SCHEMA, 'name': FUSED_NAME, 'qualification_sha256': digest,
+                'build': qualification['build'], 'runtime': qualification['runtime'],
+                'qualified_shapes': qualification['qualified_shapes'],
+                'ineligible_layout': 'torch_reference'}
+    if identity != expected:
+        raise ValueError('joint projection arithmetic has an unqualified backend identity')
+
+
+class _TorchProjection:
+    @property
+    def identity(self):
+        return deepcopy(REFERENCE_IDENTITY)
+
+    def require_device(self, device):
+        pass
+
+    @staticmethod
+    def product_sum(left, right):
+        return (left * right).sum()
+
+
+class _FusedProjection:
+    def __init__(self, module, device, identity, *, seal):
+        if seal is not _PREWARM_SEAL:
+            raise RuntimeError('joint projection fused backend requires explicit prewarm')
+        self._module = module
+        self._device = device
+        self._identity = deepcopy(identity)
+        self._shapes = frozenset(tuple(shape) for shape in identity['qualified_shapes'])
+
+    @property
+    def identity(self):
+        return deepcopy(self._identity)
+
+    def require_device(self, device):
+        device = torch.device(device)
+        if device.type == 'cuda' and device.index is None:
+            device = torch.device('cuda', torch.cuda.current_device())
+        if device != self._device:
+            raise RuntimeError('joint projection fused backend was not prewarmed for this device')
+
+    def product_sum(self, left, right):
+        self.require_device(left.device)
+        self.require_device(right.device)
+        if tuple(left.shape) not in self._shapes or left.shape != right.shape:
+            raise RuntimeError('joint projection matrix shape is outside the packaged qualification')
+        if torch.is_grad_enabled() and (left.requires_grad or right.requires_grad):
+            raise RuntimeError('joint projection reduction has no autograd registration; use under no_grad')
+        if not kernel.fast_path_eligible(left, right):
+            return (left * right).sum()
+        return self._module.mul_sum(left, right)
+
+
+def require_prewarmed_projection(backend, *, device):
+    """Lease admission does no compilation, file reads, or implicit prewarm."""
+    if backend is None:
+        return _TorchProjection()
+    if type(backend) not in (_TorchProjection, _FusedProjection):
+        raise RuntimeError('joint projection backend must be explicitly prewarmed before the lease')
+    backend.require_device(device)
+    return backend
+
+
+def prewarm_projection_backend(config=None, *, device):
+    """Verify/load a qualified binary before source/cotangent hot execution."""
+    if type(config) in (_TorchProjection, _FusedProjection):
+        return require_prewarmed_projection(config, device=device)
+    config = normalize_projection_backend(config)
+    if config['name'] == 'torch':
+        return _TorchProjection()
+    device = torch.device(device)
+    if device.type != 'cuda' or not torch.cuda.is_available():
+        raise RuntimeError('qualified joint projection requires a CUDA device')
+    if device.index is None:
+        device = torch.device('cuda', torch.cuda.current_device())
+    qualification, digest = _qualification()
+    runtime = _runtime_identity(device)
+    _require_runtime(runtime, qualification['runtime'])
+    build = qualification['build']
+    if (kernel._source_digest() != build['source_sha256'] or kernel.CPP_FLAGS != build['cpp_flags']
+            or kernel.CUDA_FLAGS != build['cuda_flags']):
+        raise RuntimeError('joint projection kernel source/compiler flags differ from qualification')
+    path = Path(config['binary']['path']).resolve(strict=True)
+    if _sha(path) != build['binary_sha256']:
+        raise RuntimeError('joint projection binary bytes differ from qualification')
+    # The qualified extension name is part of its Python initialization ABI.
+    name = build['module_name']
+    key = (str(path), build['binary_sha256'])
+    module = _LOADED_MODULES.get(key)
+    if module is None:
+        loader = importlib.machinery.ExtensionFileLoader(name, str(path))
+        spec = importlib.util.spec_from_file_location(name, path, loader=loader)
+        module = importlib.util.module_from_spec(spec)
+        loader.exec_module(module)
+        if Path(module.__file__).resolve() != path or _sha(module.__file__) != build['binary_sha256']:
+            raise RuntimeError('joint projection actually loaded a different binary')
+        _LOADED_MODULES[key] = module
+    warm_key = (key, device.index)
+    if warm_key not in _WARMED_DEVICES:
+        # Temporary zero operands load the qualified kernel on the current
+        # stream before a lease; only the code/device marker survives.
+        with torch.no_grad():
+            zeros = torch.zeros(qualification['qualified_shapes'][0], device=device, dtype=torch.float32)
+            actual = module.mul_sum(zeros, zeros)
+            expected = (zeros * zeros).sum()
+            if actual.view(torch.int32).item() != expected.view(torch.int32).item():
+                raise RuntimeError('joint projection prewarm changed reference reduction bits')
+        del zeros, actual, expected
+        _WARMED_DEVICES.add(warm_key)
+    identity = {'schema': SCHEMA, 'name': FUSED_NAME, 'qualification_sha256': digest,
+                'build': deepcopy(build), 'runtime': runtime,
+                'qualified_shapes': deepcopy(qualification['qualified_shapes']),
+                'ineligible_layout': 'torch_reference'}
+    validate_projection_backend_identity(identity)
+    return _FusedProjection(module, device, identity, seal=_PREWARM_SEAL)

--- a/prismaquant/kernels/joint_projection_reduce.cpp
+++ b/prismaquant/kernels/joint_projection_reduce.cpp
@@ -1,0 +1,9 @@
+#include <torch/extension.h>
+
+at::Tensor joint_projection_mul_sum_cuda(const at::Tensor& left,
+                                        const at::Tensor& right);
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
+  module.def("mul_sum", &joint_projection_mul_sum_cuda,
+             "FP32 product with the installed PyTorch sum reduction tree");
+}

--- a/prismaquant/kernels/joint_projection_reduce.cu
+++ b/prismaquant/kernels/joint_projection_reduce.cu
@@ -1,0 +1,49 @@
+// Research candidate: the installed PyTorch sum reduction tree with an inline
+// separately rounded product. No large product tensor and no fused multiply-add.
+#include <ATen/ATen.h>
+#include <ATen/TensorIterator.h>
+#include <ATen/native/cuda/Reduce.cuh>
+#include <c10/cuda/CUDAGuard.h>
+#include <cstdint>
+
+namespace {
+struct ProductSumOps {
+  const float* right;
+
+  __device__ float reduce(float accumulated, float left, int64_t index) const {
+    return __fadd_rn(accumulated, __fmul_rn(left, right[index]));
+  }
+  __device__ float combine(float left, float right_value) const {
+    return __fadd_rn(left, right_value);
+  }
+  __device__ float project(float value) const { return value; }
+  __device__ float translate_idx(float value, int64_t) const { return value; }
+  __device__ float warp_shfl_down(float value, int offset) const {
+    return WARP_SHFL_DOWN(value, offset);
+  }
+};
+}  // namespace
+
+at::Tensor joint_projection_mul_sum_cuda(const at::Tensor& left,
+                                        const at::Tensor& right) {
+  TORCH_CHECK(left.is_cuda() && right.is_cuda(), "CUDA operands required");
+  TORCH_CHECK(left.device() == right.device(), "operand devices differ");
+  TORCH_CHECK(left.scalar_type() == at::kFloat && right.scalar_type() == at::kFloat,
+              "FP32 operands required");
+  TORCH_CHECK(left.sizes() == right.sizes(), "operand shapes differ");
+  TORCH_CHECK(left.is_contiguous() && right.is_contiguous(), "contiguous operands required");
+  TORCH_CHECK(left.numel() > 0, "nonempty operands required");
+  // The reference materialized product is aligned. Requiring the same input
+  // alignment prevents ReduceOp's misaligned-header branch changing its tree.
+  TORCH_CHECK(reinterpret_cast<uintptr_t>(left.const_data_ptr<float>()) % 16 == 0 &&
+              reinterpret_cast<uintptr_t>(right.const_data_ptr<float>()) % 16 == 0,
+              "16-byte-aligned operands required");
+  const c10::cuda::CUDAGuard guard(left.device());
+  auto output = at::empty({}, left.options());
+  auto iter = at::TensorIterator::reduce_op(output, left);
+  // Recursive sub-iterator offsets need a separately derived index contract.
+  TORCH_CHECK(iter.can_use_32bit_indexing(), "32-bit reduction indexing required");
+  at::native::gpu_reduce_kernel<float, float, 4, 4>(
+      iter, ProductSumOps{right.const_data_ptr<float>()}, 0.0f);
+  return output;
+}

--- a/prismaquant/kernels/joint_projection_reduce.py
+++ b/prismaquant/kernels/joint_projection_reduce.py
@@ -1,0 +1,71 @@
+"""Research-only fused product/reduction, not wired into production projections.
+
+The candidate reuses the running PyTorch release's native CUDA reduction tree.
+Eligibility keeps its indexing/alignment identical to an allocated FP32 product;
+other layouts, dtypes, empty inputs and CPU inputs use the unchanged expression.
+The caller owns all input residency. This module caches compiled code, no tensors.
+"""
+from functools import lru_cache
+import hashlib
+import os
+from pathlib import Path
+
+import torch
+
+
+CUDA_FLAGS = ['-O3', '--fmad=false', '--ftz=false', '--prec-div=true', '--prec-sqrt=true', '-lineinfo']
+CPP_FLAGS = ['-O3']
+
+
+def _source_digest():
+    digest = hashlib.sha256()
+    for suffix in ('.cpp', '.cu'):
+        digest.update(Path(__file__).with_suffix(suffix).read_bytes())
+    digest.update(str((torch.__version__, torch.version.cuda, CUDA_FLAGS, CPP_FLAGS)).encode())
+    return digest.hexdigest()
+
+
+@lru_cache(maxsize=1)
+def load_backend():
+    """Compile/load before the measured projection lease is entered."""
+    from torch.utils.cpp_extension import load
+
+    return load(name='pq_joint_projection_reduce_' + _source_digest()[:16],
+                sources=[str(Path(__file__).with_suffix(suffix)) for suffix in ('.cpp', '.cu')],
+                extra_cflags=CPP_FLAGS, extra_cuda_cflags=CUDA_FLAGS,
+                with_cuda=True, verbose=True)
+
+
+def fast_path_eligible(left, right):
+    return (left.device.type == 'cuda' and left.device == right.device
+            and left.dtype == right.dtype == torch.float32 and left.shape == right.shape
+            and left.is_contiguous() and right.is_contiguous()
+            and 0 < left.numel() < (2**31 // 4)
+            and left.data_ptr() % 16 == 0 and right.data_ptr() % 16 == 0)
+
+
+def fused_product_sum(left, right):
+    """Opt-in experimental equivalent of ``(left * right).sum()``."""
+    if not fast_path_eligible(left, right):
+        return (left * right).sum()
+    if torch.is_grad_enabled() and (left.requires_grad or right.requires_grad):
+        raise RuntimeError('joint projection reduction has no autograd registration; use under no_grad')
+    return load_backend().mul_sum(left, right)
+
+
+def build_identity():
+    """Bind the actual loaded binary, compiler flags and reduction headers."""
+    module = load_backend()
+    include = Path(torch.__file__).parent / 'include'
+    names = ['ATen/native/cuda/Reduce.cuh', 'ATen/native/cuda/MemoryAccess.cuh',
+             'ATen/native/cuda/thread_constants.h', 'ATen/cuda/DeviceUtils.cuh',
+             'ATen/TensorIterator.h']
+    return {'source_sha256': _source_digest(),
+            'python_source_sha256': hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+            'torch': str(torch.__version__),
+            'torch_git': torch.version.git_version, 'cuda': torch.version.cuda,
+            'arch_list': os.environ.get('TORCH_CUDA_ARCH_LIST'),
+            'cpp_flags': CPP_FLAGS, 'cuda_flags': CUDA_FLAGS,
+            'binary_path': module.__file__,
+            'binary_sha256': hashlib.sha256(Path(module.__file__).read_bytes()).hexdigest(),
+            'headers': {name: hashlib.sha256((include / name).read_bytes()).hexdigest() for name in names}}

--- a/prismaquant/kernels/joint_projection_reduce_qualification.json
+++ b/prismaquant/kernels/joint_projection_reduce_qualification.json
@@ -1,0 +1,107 @@
+{
+  "schema": "prismaquant.joint_projection_qualification.v1",
+  "status": "qualified",
+  "build": {
+    "source_sha256": "17d100e93d552b8566e58c3764f2aa8d9d5d93746ccd6802db26b6e124344a80",
+    "binary_sha256": "9305c183c5214dc5ff1f73382963f8275eb1b6197cb8d173c6a93bffd700c115",
+    "cpp_flags": [
+      "-O3"
+    ],
+    "cuda_flags": [
+      "-O3",
+      "--fmad=false",
+      "--ftz=false",
+      "--prec-div=true",
+      "--prec-sqrt=true",
+      "-lineinfo"
+    ],
+    "arch_list": "12.1",
+    "module_name": "pq_joint_projection_reduce_17d100e93d552b85"
+  },
+  "runtime": {
+    "torch": "2.13.0+cu130",
+    "torch_git": "cf30153c4c131c8164ee7798e5022d810682e2cb",
+    "cuda": "13.0",
+    "headers": {
+      "ATen/native/cuda/Reduce.cuh": "ef9bea8fdfd03cec2d7e7421cbe75d98fddfdaafddb4f25a1ed655c5861dfb65",
+      "ATen/native/cuda/MemoryAccess.cuh": "972ade42c472053033ee75a75c18a279517a20e208bfea278c99f8accb6ba46e",
+      "ATen/native/cuda/thread_constants.h": "61e0f733a01a729f96036cd84b78645731d126534f3ecc972a3e91d3c37416d2",
+      "ATen/cuda/DeviceUtils.cuh": "724844fa2f9ee79699ac19a1e80d0a31ad0a25ffdde326a7d4067e6190b0945f",
+      "ATen/TensorIterator.h": "078c3720cfc9e4b211f5ca5d21e6c2b2068ae35d723527e138c2eb214cf13116"
+    },
+    "machine": "aarch64",
+    "device": {
+      "name": "NVIDIA GB10",
+      "major": 12,
+      "minor": 1,
+      "multi_processor_count": 48
+    },
+    "compiler": {
+      "nvcc_version": "nvcc: NVIDIA (R) Cuda compiler driver\nCopyright (c) 2005-2025 NVIDIA Corporation\nBuilt on Wed_Aug_20_01:57:39_PM_PDT_2025\nCuda compilation tools, release 13.0, V13.0.88\nBuild cuda_13.0.r13.0/compiler.36424714_0\n",
+      "cxx_version": "c++ (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0\nCopyright (C) 2023 Free Software Foundation, Inc.\nThis is free software; see the source for copying conditions.  There is NO\nwarranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n"
+    }
+  },
+  "qualified_shapes": [
+    [
+      512,
+      2048
+    ],
+    [
+      1792,
+      2048
+    ],
+    [
+      2048,
+      1792
+    ],
+    [
+      2048,
+      2048
+    ],
+    [
+      2048,
+      7168
+    ],
+    [
+      7168,
+      2048
+    ]
+  ],
+  "evidence": [
+    {
+      "pb_action": "24c59324f3d263a30450fa3ffb88e0d5389317da40a162f5833813da5b2fcbae",
+      "gate": "208 individual FP32 reductions and four actual-source seven-rung probes; bit-exact",
+      "artifact_receipt_sha256": "4c54fa604496fb06a2c275616506fd7d6d8ab6029e24080a15ef98d5917985b5"
+    },
+    {
+      "pb_action": "2953d23e60517f4bfcc998008d60dc35e3361781283d8148e7d69e23211c4a0c",
+      "unit": "model.layers.0.feed_forward.w1",
+      "gate": "52 individual reductions and four seven-rung projections, real captured X/source/renders and seeded qualification cotangents; bit-exact",
+      "artifact_receipt_sha256": "f61d5c54e1f6669a151a4cb4235353a2ded64bd00e16d05274b1f9b2fe6f8511"
+    },
+    {
+      "pb_action": "269e5ae7e381086adec9fce92ee0ba99fbef5600e28c8ec00a892c3200a70c2e",
+      "unit": "model.layers.0.feed_forward.w2",
+      "gate": "52 individual reductions and four seven-rung projections, real captured X/source/renders and seeded qualification cotangents; bit-exact",
+      "artifact_receipt_sha256": "3e8c1fb070b52d71321f4dfd9346e612daf1c6fa0b58a53bf643422d4b865f83"
+    },
+    {
+      "pb_action": "f4f13a24bf9e8e3761f0dd5fb5f1c3571df711fcfbf19f2f7ee58ab152dd3a58",
+      "unit": "model.layers.10.self_attn.k_proj",
+      "gate": "52 individual reductions and four seven-rung projections, real captured X/source/renders and seeded qualification cotangents; bit-exact",
+      "artifact_receipt_sha256": "2a91f07e3ea2c93ccb3a53bab65ddc2f13d97a7e5c6e3dbeb0eb93e23617a6eb"
+    },
+    {
+      "pb_action": "f6cd1965e4fe417ef859c89311366f7573110bbf77645fad0e336267d909c351",
+      "unit": "model.layers.10.self_attn.q_proj",
+      "gate": "52 individual reductions and four seven-rung projections, real captured X/source/renders and seeded qualification cotangents; bit-exact",
+      "artifact_receipt_sha256": "ab36232c28b9b8fd3a79087e8977c564edbab52e7d06d4e2e82911cb2ce3a901"
+    },
+    {
+      "pb_action": "f2d04f245e367a3a9c14a3baaaf184dbca63e9bed5134778925b06e5bd67788f",
+      "unit": "model.layers.23.feed_forward.experts.0.w2",
+      "gate": "52 individual reductions and four seven-rung projections, real captured X/source/renders and seeded qualification cotangents; bit-exact",
+      "artifact_receipt_sha256": "932e63e81cd32b435711b33429c25bd654fa645dd5ad2abd4c6706e567a09185"
+    }
+  ]
+}

--- a/prismaquant/tessera_joint_aura.py
+++ b/prismaquant/tessera_joint_aura.py
@@ -23,7 +23,7 @@ from .cost_stage_checkpoint import (
 )
 
 SCHEMA = "prismaquant.tessera_joint_aura.plan.v1"
-PREPARED_SCHEMA = "prismaquant.tessera_joint_aura.prepared.v1"
+PREPARED_SCHEMA = "prismaquant.tessera_joint_aura.prepared.v2"
 CAMPAIGN_SCHEMA = "prismaquant.tessera_campaign_cost.v1"
 CURRENCY = "output_mse_under_route_activation_contract"
 STAGE = "Tessera campaign"
@@ -437,6 +437,8 @@ def _load_plan(path, digest):
     _same(config.get("schema"), SCHEMA, "joint anchor plan schema")
     _source_prefetch(config)
     execution = config["execution"]
+    from .joint_projection_backend import normalize_projection_backend
+    normalize_projection_backend(execution.get("projection_backend"))
     _require(type(config.get("file_hash_workers", 1)) is int and config.get("file_hash_workers", 1) > 0,
              "positive file_hash_workers required")
     for name, minimum in (("n_calib_samples", 1), ("calib_seqlen", 1),
@@ -476,6 +478,7 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False):
     from .calibration_data import load_calibration_input
     from .cost_streaming import build_streamed_causal_lm, build_streamed_model_identity
     from .joint_aura import source_execution_identity, validate_joint_aura_entry
+    from .joint_projection_backend import prewarm_projection_backend
     from .model_profiles import detect_profile
     from .production_weight_cache import ProductionWeightCache
     from .gpu_guard import require_cuda_hot_path
@@ -533,6 +536,8 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False):
         for name in ("fit_ids_sha256", "text_sha256", "nsamples", "seqlen", "seed"):
             _same(calibration["provenance"].get(name), original_draw.get(name), f"original full draw {name}")
         result["calibration_input"] = calibration
+        projection_backend = prewarm_projection_backend(execution.get("projection_backend"), device="cuda")
+        result["projection_backend"] = projection_backend.identity
         source_prefetch = _source_prefetch(config)
         runner = build_streamed_causal_lm(config["model"], device=torch.device("cuda"),
             dtype=torch.bfloat16, offload_folder=str(root / "offload"),
@@ -557,25 +562,28 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False):
                                   max_render_bytes=config["max_render_bytes"], reader=reader,
                                   file_load_workers=file_hash_workers)
             cache.metadata.update(plan_sha256=plan_sha256, source_model_identity=source,
-                                  source_execution=source_execution, implementation_sha256=implementation)
+                                  source_execution=source_execution, implementation_sha256=implementation,
+                                  projection_backend=projection_backend.identity)
             cache.compact_for_pickle()
             cache_path = root / "production.pkl"
             atomic_write_bytes(cache_path, pickle.dumps(cache, protocol=pickle.HIGHEST_PROTOCOL))
             completion = {"schema": PREPARED_SCHEMA, "status": "complete", "plan_sha256": plan_sha256,
                 "implementation_sha256": implementation, "source_model_identity": source,
-                "reader_identity": reader_identity,
+                "reader_identity": reader_identity, "projection_backend": projection_backend.identity,
                 "source_execution": source_execution, "calibration_input": calibration,
                 "production_cache": {"path": str(cache_path), "sha256": _sha(cache_path)},
                 "formats_by_qname": data.formats_by_qname, "measured_cells": len(data.cells)}
         else:
             _require(prepared is not None, "cost execution requires independently bound prepared inputs")
             completion = json.loads(_bound(prepared, "prepared anchors").read_text())
-            _same(completion.get("schema"), PREPARED_SCHEMA, "prepared schema")
+            _same(completion.get("schema"), PREPARED_SCHEMA,
+                  "prepared v2 schema required; legacy preparation requires fresh prepare and recompute")
             _same(completion.get("status"), "complete", "prepared completion")
             for key, value in (("plan_sha256", plan_sha256), ("implementation_sha256", implementation),
                                ("source_model_identity", source), ("source_execution", source_execution),
                                ("calibration_input", calibration), ("measured_cells", len(data.cells)),
-                               ("reader_identity", reader_identity)):
+                               ("reader_identity", reader_identity),
+                               ("projection_backend", projection_backend.identity)):
                 _same(completion.get(key), value, f"prepared {key}")
             _same(completion["formats_by_qname"], {n: list(v) for n, v in data.formats_by_qname.items()},
                   "prepared exact candidate roster")
@@ -583,6 +591,7 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False):
             _require(isinstance(cache, ProductionWeightCache), "prepared cache is not ProductionWeightCache")
             _same(cache.metadata["inputs"], data.inputs, "prepared source bindings")
             _same(cache.metadata.get("reader_identity"), reader_identity, "prepared reader identity")
+            _same(cache.metadata.get("projection_backend"), projection_backend.identity, "prepared backend identity")
             _same(set(cache.metadata["verified_cells"]), set(data.cells), "prepared verified cell coverage")
             _same(cache.weights, {pair: cell["render"] for pair, cell in data.cells.items()}, "prepared original render paths")
             for pair, cell in data.cells.items():
@@ -596,6 +605,7 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False):
                 n_probes=execution["n_probes"], probe_microbatch=execution["probe_microbatch"],
                 seed_base=execution["seed_base"], token_scope="all", temperature=1.0,
                 production_cache=cache, require_production_cache=True, joint_activation=True,
+                joint_projection_backend=projection_backend,
                 include_routed_experts=True, include_lm_head=False, dw_dtype="float32",
                 min_free_gib=config["min_free_gib"], formats_by_qname=data.formats_by_qname,
                 checkpoint_dir=Path(config["output_root"]) / "checkpoints", resume=resume,

--- a/tests/test_allocator_measured_runtime_cli.py
+++ b/tests/test_allocator_measured_runtime_cli.py
@@ -95,12 +95,12 @@ def _main_fixture(tmp_path, *, fixed_ms=0.0):
     arithmetic = arithmetic_identity(torch.float32)
     rows = {}
     for fmt, loss in zip(formats, (1.0, 2.0)):
-        probe = {"schema": "prismaquant.joint_aura.probes.v1", "seed_base": 0,
+        probe = {"schema": "prismaquant.joint_aura.probes.v2", "seed_base": 0,
                  "n_probes": 3, "calibration_sha256": "c" * 64,
                  "producer_source_sha256": "d" * 64, "source_model": source_model,
                  "distribution": "rademacher", "normalization": "global_kl_fisher",
                  "temperature": 1.0, "arithmetic": arithmetic}
-        operator = {"schema": "prismaquant.joint_aura.operator.v1", "qname": name,
+        operator = {"schema": "prismaquant.joint_aura.operator.v2", "qname": name,
                     "format": fmt, "probe_identity_sha256": identity_sha256(probe),
                     "source_weight": {"content_sha256": "a" * 64, "shape": list(shape),
                                       "dtype": "torch.float32", "logical_bytes": 16384},

--- a/tests/test_joint_aura_assignment_diagnostics.py
+++ b/tests/test_joint_aura_assignment_diagnostics.py
@@ -38,14 +38,14 @@ def _row(name, signed, *, fmt="FP8_E4M3"):
     }
     arithmetic = joint.arithmetic_identity(torch.float32)
     probe = {
-        "schema": "prismaquant.joint_aura.probes.v1", "seed_base": 237000,
+        "schema": "prismaquant.joint_aura.probes.v2", "seed_base": 237000,
         "n_probes": len(signed), "calibration_sha256": "c" * 64,
         "producer_source_sha256": "d" * 64, "source_model": source_model,
         "distribution": "rademacher", "normalization": "global_kl_fisher",
         "temperature": 1.0, "arithmetic": arithmetic,
     }
     operator = {
-        "schema": "prismaquant.joint_aura.operator.v1", "qname": name,
+        "schema": "prismaquant.joint_aura.operator.v2", "qname": name,
         "format": fmt, "probe_identity_sha256": joint.identity_sha256(probe),
         "source_weight": {
             "content_sha256": joint.identity_sha256({"source": name}),

--- a/tests/test_joint_aura_one_squaring.py
+++ b/tests/test_joint_aura_one_squaring.py
@@ -33,13 +33,13 @@ def test_row_squares_with_squared_signed():
     source_model = {"schema": STREAMED_MODEL_IDENTITY_SCHEMA, "source": "synthetic", "resolved_commit": None,
                     "content_sha256": canonical_json_sha256(source_content, where="one-squaring fixture"),
                     **source_content}
-    probe = {"schema": "prismaquant.joint_aura.probes.v1", "seed_base": 0,
+    probe = {"schema": "prismaquant.joint_aura.probes.v2", "seed_base": 0,
              "n_probes": len(RECORDED), "calibration_sha256": "c" * 64,
              "producer_source_sha256": "d" * 64, "source_model": source_model,
              "distribution": "rademacher", "normalization": "global_kl_fisher",
              "temperature": 1.0, "arithmetic": arithmetic}
     name, fmt = "model.layers.0.mlp.down_proj", "NVFP4"
-    operator = {"schema": "prismaquant.joint_aura.operator.v1", "qname": name, "format": fmt,
+    operator = {"schema": "prismaquant.joint_aura.operator.v2", "qname": name, "format": fmt,
                 "probe_identity_sha256": identity_sha256(probe),
                 "source_weight": {"content_sha256": "a" * 64, "shape": [64, 64],
                                   "dtype": "torch.float32", "logical_bytes": 16384},

--- a/tests/test_joint_projection_backend.py
+++ b/tests/test_joint_projection_backend.py
@@ -1,0 +1,220 @@
+"""Fail-closed projection selection, prewarm and serialized arithmetic policy."""
+from copy import deepcopy
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from prismaquant import joint_projection_backend as backend
+from prismaquant import format_registry as fr
+from prismaquant.joint_aura import SignedJointProjectionLease, arithmetic_identity, identity_sha256
+
+
+def selector(path='missing.so'):
+    qualification, _ = backend._qualification()
+    return {'name': backend.FUSED_NAME,
+            'binary': {'path': str(path), 'sha256': qualification['build']['binary_sha256']}}
+
+
+def test_reference_remains_available_without_cuda_compiler_or_artifact(monkeypatch):
+    monkeypatch.setattr(backend, '_qualification', lambda: pytest.fail('reference read fused qualification'))
+    monkeypatch.setattr(backend.kernel, 'load_backend', lambda: pytest.fail('reference compiled GPU code'))
+    monkeypatch.setattr(backend, '_runtime_identity', lambda _: pytest.fail('reference inspected GPU runtime'))
+    prepared = backend.prewarm_projection_backend(None, device='cpu')
+    layer = torch.nn.Linear(8, 4, bias=False)
+    x = torch.arange(16, dtype=torch.float32).reshape(2, 8).requires_grad_()
+    delta = torch.ones_like(layer.weight)
+    with SignedJointProjectionLease({'unit': layer}, {'unit': {'BF16': fr.get_format('BF16')}},
+                                    {('unit', 'BF16'): delta}, projection_backend=prepared) as lease:
+        lease.begin_probe()
+        layer(x).sum().backward()
+        values = lease.finish_probe()['unit', 'BF16']
+    assert values['weight'] == float((torch.ones((2, 4)).T @ x.detach() * delta).sum())
+    assert values['activation'] == values['mixed'] == 0.0
+    assert prepared.identity == arithmetic_identity(torch.float32)['projection_backend'] == backend.REFERENCE_IDENTITY
+
+
+@pytest.mark.parametrize('config', ['fused_fp32_v1', {}, {'name': 'surprise'}, {'name': 'torch', 'enable': True},
+    {'name': 'fused_fp32_v1'}, {'name': 'fused_fp32_v1', 'binary': {'path': '/tmp/x', 'sha256': 'a' * 64}},
+    {'name': 'fused_fp32_v1', 'binary': {'path': '/tmp/x', 'sha256': None}}])
+def test_selector_refuses_unknown_or_unqualified_inputs(config):
+    with pytest.raises(ValueError):
+        backend.normalize_projection_backend(config)
+
+
+def test_fused_lease_refuses_missing_explicit_prewarm():
+    layer = torch.nn.Linear(8, 4, bias=False)
+    with pytest.raises(RuntimeError, match='explicitly prewarmed before the lease'):
+        SignedJointProjectionLease({'unit': layer}, {'unit': {'BF16': fr.get_format('BF16')}},
+            {('unit', 'BF16'): torch.zeros_like(layer.weight)}, projection_backend=selector())
+    assert not layer._forward_hooks
+
+
+@pytest.mark.parametrize('field', ['torch', 'torch_git', 'cuda', 'machine', 'device', 'headers', 'compiler'])
+def test_prewarm_refuses_each_unqualified_runtime_dimension(monkeypatch, field):
+    qualification, _ = backend._qualification()
+    actual = deepcopy(qualification['runtime'])
+    actual[field] = 'different-runtime'
+    monkeypatch.setattr(torch.cuda, 'is_available', lambda: True)
+    monkeypatch.setattr(backend, '_runtime_identity', lambda _: actual)
+    monkeypatch.setattr(backend.importlib.util, 'module_from_spec', lambda _: pytest.fail('unqualified runtime loaded code'))
+    with pytest.raises(RuntimeError, match='unqualified runtime identity: ' + field):
+        backend.prewarm_projection_backend(selector(), device='cuda:0')
+
+
+def qualify_mock_runtime(monkeypatch):
+    qualification, _ = backend._qualification()
+    monkeypatch.setattr(torch.cuda, 'is_available', lambda: True)
+    monkeypatch.setattr(backend, '_runtime_identity', lambda _: deepcopy(qualification['runtime']))
+    monkeypatch.setattr(backend.kernel, '_source_digest', lambda: qualification['build']['source_sha256'])
+    monkeypatch.setattr(backend.importlib.util, 'module_from_spec', lambda _: pytest.fail('invalid input loaded code'))
+    return qualification
+
+
+@pytest.mark.parametrize('field', ['CUDA_FLAGS', 'CPP_FLAGS', 'source'])
+def test_prewarm_refuses_changed_source_or_build_flags(monkeypatch, field):
+    qualify_mock_runtime(monkeypatch)
+    if field == 'source':
+        monkeypatch.setattr(backend.kernel, '_source_digest', lambda: '0' * 64)
+    else:
+        monkeypatch.setattr(backend.kernel, field, getattr(backend.kernel, field) + ['unqualified'])
+    with pytest.raises(RuntimeError, match='source/compiler flags differ'):
+        backend.prewarm_projection_backend(selector(), device='cuda:0')
+
+
+def test_binary_bytes_are_checked_before_loading(tmp_path, monkeypatch):
+    qualify_mock_runtime(monkeypatch)
+    path = tmp_path / 'foreign.so'
+    path.write_bytes(b'not the hash-bound qualified binary')
+    with pytest.raises(RuntimeError, match='binary bytes differ'):
+        backend.prewarm_projection_backend(selector(path), device='cuda:0')
+
+
+def test_missing_artifact_cannot_trigger_implicit_build(tmp_path, monkeypatch):
+    qualify_mock_runtime(monkeypatch)
+    monkeypatch.setattr(backend.kernel, 'load_backend', lambda: pytest.fail('missing artifact triggered JIT'))
+    with pytest.raises(FileNotFoundError):
+        backend.prewarm_projection_backend(selector(tmp_path / 'missing.so'), device='cuda:0')
+
+
+def test_serialized_backend_identity_is_complete_and_changes_probe_contract():
+    qualification, digest = backend._qualification()
+    identity = {'schema': backend.SCHEMA, 'name': backend.FUSED_NAME,
+                'qualification_sha256': digest, 'build': qualification['build'],
+                'runtime': qualification['runtime'], 'qualified_shapes': qualification['qualified_shapes'],
+                'ineligible_layout': 'torch_reference'}
+    backend.validate_projection_backend_identity(identity)
+    fused = arithmetic_identity(torch.float32, SimpleNamespace(identity=identity))
+    assert identity_sha256(fused) != identity_sha256(arithmetic_identity(torch.float32))
+    for field in identity:
+        invalid = deepcopy(identity)
+        invalid.pop(field)
+        with pytest.raises(ValueError, match='unqualified backend identity'):
+            backend.validate_projection_backend_identity(invalid)
+
+
+def test_legacy_v1_signed_rows_require_fresh_recomputation():
+    from test_joint_aura_assignment_diagnostics import _row
+    from prismaquant.joint_aura import validate_joint_aura_entry
+    # This test uses the same valid row fixture as assignment diagnostics.
+    row = _row("model.layers.0.mlp.down_proj", [1.0, 2.0])
+    row['joint_operator_identity']['schema'] = 'prismaquant.joint_aura.operator.v1'
+    row['joint_operator_identity_sha256'] = identity_sha256(row['joint_operator_identity'])
+    with pytest.raises(ValueError, match='legacy artifacts require fresh prepare and recompute'):
+        validate_joint_aura_entry(row)
+
+
+def test_loader_cannot_substitute_another_binary(tmp_path, monkeypatch):
+    qualification = qualify_mock_runtime(monkeypatch)
+    intended = tmp_path / 'qualified.so'
+    intended.write_bytes(b'fixture, hash mocked below')
+    foreign = tmp_path / 'substituted.so'
+    foreign.write_bytes(b'foreign fixture')
+    monkeypatch.setattr(backend, '_sha', lambda path: qualification['build']['binary_sha256']
+                        if Path(path) == intended else '0' * 64)
+    monkeypatch.setattr(backend.importlib.util, 'module_from_spec', lambda _: SimpleNamespace(__file__=str(foreign)))
+    monkeypatch.setattr(backend.importlib.machinery.ExtensionFileLoader, 'exec_module', lambda *_: None)
+    with pytest.raises(RuntimeError, match='actually loaded a different binary'):
+        backend.prewarm_projection_backend(selector(intended), device='cuda:0')
+
+
+def test_prewarmer_device_scope_cannot_be_reused_for_another_device():
+    fused = backend._FusedProjection(None, torch.device('cuda:0'), {'qualified_shapes': [[2, 2]]},
+                                    seal=backend._PREWARM_SEAL)
+    with pytest.raises(RuntimeError, match='not prewarmed for this device'):
+        backend.require_prewarmed_projection(fused, device='cuda:1')
+
+
+def _plan(tmp_path):
+    from prismaquant.tessera_joint_aura import SCHEMA
+    return {'schema': SCHEMA, 'model': 'fixture', 'inputs': {}, 'output_root': str(tmp_path),
+        'calibration_input': {'path': 'fixture', 'sha256': 'a' * 64},
+        'execution': {'n_calib_samples': 512, 'calib_seqlen': 512, 'probe_microbatch': 1,
+                      'n_probes': 4, 'seed_base': 7000, 'token_scope': 'all', 'temperature': 1.0,
+                      'production_act_scales': '0'}, 'profile_tool': 'cprofile',
+        'max_render_bytes': 1024, 'max_gpu_bytes': 2048, 'min_free_gib': 0,
+        'source_prefetch': {'max_cache_slots': 24, 'prefetch_workers': 4, 'prefetch_lookahead': 4,
+                           'cache_headroom_gb': 4.0, 'prefetch_min_available_gb': 2.0,
+                           'require_prefetched_residency': True}}
+
+
+def test_plan_admits_reference_default_but_refuses_unknown_backend(tmp_path):
+    from prismaquant.tessera_joint_aura import _load_plan, _sha
+    config = _plan(tmp_path)
+    path = tmp_path / 'plan.json'
+    path.write_text(json.dumps(config))
+    assert _load_plan(path, _sha(path)) == config
+    config['execution']['projection_backend'] = {'name': 'unqualified'}
+    path.write_text(json.dumps(config))
+    with pytest.raises(ValueError, match='unsupported joint projection backend'):
+        _load_plan(path, _sha(path))
+
+
+@pytest.mark.parametrize('legacy_schema', [True, False])
+def test_cost_refuses_legacy_or_backend_changed_preparation_before_cache_adoption(tmp_path, monkeypatch, legacy_schema):
+    from prismaquant import tessera_joint_aura as bridge, calibration_data, cost_streaming, gpu_guard
+    from prismaquant import model_profiles, aura_cost, joint_aura
+    monkeypatch.setattr(gpu_guard, 'require_cuda_hot_path', lambda *_: None)
+    monkeypatch.setattr(model_profiles, 'detect_profile', lambda _: object())
+    draw = dict(fit_ids_sha256='a' * 64, text_sha256='b' * 64, nsamples=512, seqlen=512, seed=0)
+    calibration = {'provenance': draw}
+    source = {'fixture': 'source-model-identity'}
+    execution = {'fixture': 'source-execution'}
+    data = SimpleNamespace(census={'model': 'fixture', 'attention_implementation': 'eager'},
+        payload={'provenance': {'hessian': {'calibration_identity': draw}}},
+        layer_render_bytes=lambda _: {0: 64}, formats_by_qname={'unit': ['BF16']}, cells={('unit', 'BF16'): {}})
+    monkeypatch.setattr(bridge, 'load_measured_anchor_input', lambda *_args, **_kwargs: data)
+    monkeypatch.setattr(calibration_data, 'load_calibration_input', lambda *_args, **_kwargs:
+        (torch.zeros((512, 512), dtype=torch.int64), calibration))
+    runner = SimpleNamespace(model=object(), layer_index_for_qname=lambda _: 0, shutdown=lambda: None)
+    monkeypatch.setattr(cost_streaming, 'build_streamed_causal_lm', lambda *_args, **_kwargs: runner)
+    monkeypatch.setattr(cost_streaming, 'build_streamed_model_identity', lambda *_args, **_kwargs: source)
+    monkeypatch.setattr(joint_aura, 'source_execution_identity', lambda _: execution)
+    monkeypatch.setattr(aura_cost, '_aura_source_sha256', lambda: 'c' * 64)
+    monkeypatch.setattr(aura_cost, 'compute_aura_cost_streamed', lambda *_args, **_kwargs:
+        pytest.fail('foreign preparation reached the adjoint'))
+    monkeypatch.setattr(bridge.pickle, 'loads', lambda _: pytest.fail('foreign preparation adopted PWC'))
+    record = {'schema': 'prismaquant.tessera_joint_aura.prepared.v1' if legacy_schema else bridge.PREPARED_SCHEMA,
+        'status': 'complete', 'plan_sha256': 'd' * 64, 'implementation_sha256': 'c' * 64,
+        'source_model_identity': source, 'source_execution': execution, 'calibration_input': calibration,
+        'measured_cells': 1, 'reader_identity': None, 'projection_backend': {'name': 'foreign'}}
+    path = tmp_path / 'prepared.json'
+    path.write_text(json.dumps(record))
+    with pytest.raises(ValueError, match='fresh prepare and recompute' if legacy_schema else 'prepared projection_backend'):
+        bridge.execute('run', _plan(tmp_path), plan_sha256='d' * 64,
+                       prepared={'path': str(path), 'sha256': bridge._sha(path)})
+    assert json.loads((tmp_path / 'run/results.json').read_text())['passed'] is False
+
+
+def test_repeated_row_admission_uses_prewarmed_metadata_without_file_io(monkeypatch):
+    backend._qualification.cache_clear()
+    qualification, digest = backend._qualification()
+    identity = {'schema': backend.SCHEMA, 'name': backend.FUSED_NAME,
+                'qualification_sha256': digest, 'build': qualification['build'],
+                'runtime': qualification['runtime'], 'qualified_shapes': qualification['qualified_shapes'],
+                'ineligible_layout': 'torch_reference'}
+    monkeypatch.setattr(Path, 'read_bytes', lambda _: pytest.fail('row admission reopened package metadata'))
+    backend.validate_projection_backend_identity(identity)
+    backend.validate_projection_backend_identity(deepcopy(identity))

--- a/tests/test_joint_projection_reduce.py
+++ b/tests/test_joint_projection_reduce.py
@@ -1,0 +1,89 @@
+"""The experimental fused reduction must preserve the native FP32 sum tree."""
+import pytest
+import torch
+
+from prismaquant.kernels import joint_projection_reduce as kernel
+
+
+@pytest.fixture
+def cuda():
+    if not torch.cuda.is_available():
+        pytest.skip('CUDA reduction-tree qualification')
+    return torch.device('cuda', torch.cuda.current_device())
+
+
+def exact(actual, expected):
+    assert actual.dtype == expected.dtype and actual.device == expected.device
+    assert actual.shape == expected.shape == torch.Size([])
+    assert torch.equal(actual.view(torch.int32), expected.view(torch.int32)), (actual.item(), expected.item())
+
+
+@pytest.mark.parametrize('size', [1, 3, 15, 16, 17, 31, 32, 33, 511, 512, 513, 1023, 4096, 3670016])
+def test_finite_fp32_products_keep_native_reduction_bits(cuda, size):
+    generator = torch.Generator(device=cuda).manual_seed(935 + size)
+    left = torch.randn(size, generator=generator, device=cuda)
+    right = torch.randn(size, generator=generator, device=cuda)
+    assert kernel.fast_path_eligible(left, right)
+    exact(kernel.fused_product_sum(left, right), (left * right).sum())
+
+
+def test_cancellation_subnormals_and_signed_zero(cuda):
+    values = [0.0, -0.0, 2.0**-126, 2.0**-140, 2.0**-149,
+              2.0**24, 1.0, -(2.0**24), -1.0, 2.0**-24]
+    left = torch.tensor(values * 4096, device=cuda)
+    right = torch.tensor([1.0, -1.0, 0.5, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, -1.0] * 4096, device=cuda)
+    exact(kernel.fused_product_sum(left, right), (left * right).sum())
+    for negative in (False, True):
+        left = torch.full((4096,), -0.0 if negative else 0.0, device=cuda)
+        exact(kernel.fused_product_sum(left, torch.ones_like(left)), (left * 1.0).sum())
+
+
+def test_strides_alignment_and_empty_keep_reference_semantics(cuda, monkeypatch):
+    base = torch.arange(33 * 64, device=cuda, dtype=torch.float32).reshape(33, 64)
+    values = [base.T, base[:, ::2], base.flatten()[1:1025], base[:0]]
+
+    def refuse():
+        raise AssertionError('ineligible layout attempted the fused kernel')
+
+    monkeypatch.setattr(kernel, 'load_backend', refuse)
+    for left in values:
+        right = left.clone()
+        assert not kernel.fast_path_eligible(left, right)
+        exact(kernel.fused_product_sum(left, right), (left * right).sum())
+
+
+@pytest.mark.parametrize('dtype', [torch.float16, torch.bfloat16, torch.float64])
+def test_other_dtypes_keep_reference(cuda, dtype, monkeypatch):
+    left = torch.arange(128, device=cuda, dtype=dtype)
+    right = torch.ones_like(left)
+    monkeypatch.setattr(kernel, 'load_backend', lambda: pytest.fail('dtype entered FP32 kernel'))
+    actual = kernel.fused_product_sum(left, right)
+    expected = (left * right).sum()
+    assert actual.dtype == dtype and actual.device == cuda
+    assert torch.equal(actual.reshape(1).view(torch.uint8), expected.reshape(1).view(torch.uint8))
+
+
+def test_cpu_reference_requires_no_compiler(monkeypatch):
+    left = torch.tensor([1.0, -2.0, 3.0])
+    monkeypatch.setattr(kernel, 'load_backend', lambda: pytest.fail('CPU entered CUDA compiler'))
+    exact(kernel.fused_product_sum(left, left), (left * left).sum())
+
+
+def test_nondefault_stream_keeps_device_and_dependency_order(cuda):
+    kernel.load_backend()
+    stream = torch.cuda.Stream(device=cuda)
+    with torch.cuda.stream(stream):
+        left = torch.arange(1024 * 1024, device=cuda, dtype=torch.float32)
+        right = torch.empty_like(left).fill_(0.25)
+        actual = kernel.fused_product_sum(left, right)
+        expected = (left * right).sum()
+    stream.synchronize()
+    exact(actual, expected)
+
+
+def test_autograd_is_explicitly_refused(cuda):
+    left = torch.ones(32, device=cuda, requires_grad=True)
+    with pytest.raises(RuntimeError, match='no autograd registration'):
+        kernel.fused_product_sum(left, left)
+    with torch.no_grad():
+        exact(kernel.fused_product_sum(left, left), (left * left).sum())

--- a/tests/test_native_moe_panel.py
+++ b/tests/test_native_moe_panel.py
@@ -63,14 +63,14 @@ def joined():
     model = {"schema": "prismaquant.streamed_model.identity.v1", "source": "/fixture", "resolved_commit": None,
              "content_sha256": identity_sha256(value), **value}
     arithmetic = arithmetic_identity(torch.bfloat16)
-    probe = {"schema": "prismaquant.joint_aura.probes.v1", "source_model": model,
+    probe = {"schema": "prismaquant.joint_aura.probes.v2", "source_model": model,
         "calibration_sha256": "1" * 64, "calibration_shape": [1, 2], "calibration_dtype": "torch.int64",
         "producer_source_sha256": "2" * 64, "n_probes": 3, "seed_base": 7, "token_scope": "causal",
         "distribution": "rademacher", "normalization": "global_kl_fisher", "temperature": 1.0,
         "arithmetic": arithmetic, "source_execution": copy.deepcopy(source_execution)}
     rows = {}
     for member in members:
-        joint = {"schema": "prismaquant.joint_aura.operator.v1", "qname": member["unit"], "format": FORMAT,
+        joint = {"schema": "prismaquant.joint_aura.operator.v2", "qname": member["unit"], "format": FORMAT,
             **{key: member[key] for key in ("source_weight", "rendered_weight", "activation")},
             "arithmetic": arithmetic, "probe_identity_sha256": identity_sha256(probe)}
         rows[member["unit"]] = make_joint_aura_entry(operator_identity=joint, probe_identity=probe,

--- a/tests/test_native_operator_panel.py
+++ b/tests/test_native_operator_panel.py
@@ -24,13 +24,13 @@ def joined():
     activation = {"schema": "prismaquant.joint_aura.activation.v1", "quantizes_input": False,
                   "activation_max_abs": None, "input_global_scale": None, "clip_enabled": False}
     arithmetic = arithmetic_identity(torch.bfloat16)
-    probe = {"schema": "prismaquant.joint_aura.probes.v1", "source_model": _model_identity("panel-fixture"),
+    probe = {"schema": "prismaquant.joint_aura.probes.v2", "source_model": _model_identity("panel-fixture"),
              "calibration_sha256": "1" * 64, "calibration_shape": [1, 4], "calibration_dtype": "torch.int64",
              "producer_source_sha256": "2" * 64, "n_probes": 3, "seed_base": 7,
              "token_scope": "causal",
              "distribution": "rademacher", "normalization": "global_kl_fisher", "temperature": 1.0,
              "arithmetic": arithmetic}
-    joint = {"schema": "prismaquant.joint_aura.operator.v1", "qname": unit, "format": fmt,
+    joint = {"schema": "prismaquant.joint_aura.operator.v2", "qname": unit, "format": fmt,
              "source_weight": weight, "rendered_weight": weight, "activation": activation,
              "arithmetic": arithmetic, "probe_identity_sha256": identity_sha256(probe)}
     row = make_joint_aura_entry(operator_identity=joint, probe_identity=probe, signed_components=[


### PR DESCRIPTION
Closes #337. Refs #237.

Joint AURA materializes a large FP32 product at each weight, activation, and mixed reduction. Add an explicit `fused_fp32_v1` option that performs the same separately rounded products within the qualified PyTorch reduction tree. The plan selects a hash-bound prebuilt extension; admission verifies the exact runtime, headers, compiler identity, source/flags, device geometry, and actually loaded binary, then prewarms before the projection lease. The native torch expression remains the default.

Prepared, probe, operator, and joint-run identities become v2 and bind the backend. Legacy signed/prepared artifacts require fresh preparation and recomputation. ARCHITECTURE and the promotion report document the selector, migration, qualified shapes, and artifact provenance.

Validation through PrismaBuild:

- 297 CPU tests passed, zero skips, including unsupported-runtime/missing-prewarm refusals, rejection before old-cache adoption, downstream row consumers, and architecture checks.
- All 208 reductions from retained actual source X/g, all four probes × seven rungs, and forward/backward hashes match exactly through the production lease API.
- Five additional original source/capture/rung cases each pass 52 exact reductions; coverage includes all six matrix shapes in the first model's 2142-unit census.
- Production profiles remove 624 large product materializations: reference products/sums total 123.658 ms versus 71.066 ms for fused reductions over 48 actual invocations. Both-host Netdata is retained. The earlier fixed-work candidate replay measured 1.473× speed and 1.375× work/GPU-joule; full-model throughput remains unmeasured.

All PB terminal statuses, CAS payload hashes/logs, and resource cleanup were independently verified. Full commands, source/binary identities, receipt paths, and limitations are in [the promotion report](docs/results/joint_projection_backend_promotion_2026-09-07.md).

Rebased without conflicts onto `2b2715be6` to include #335. The validated projection production files remain byte-identical across that rebase; #335 has its own validation.
