### PR TITLE
fix: bind source execution in joint qualification harness

### DIFF
--- a/experiments/pq237_joint_aura_streamed.py
+++ b/experiments/pq237_joint_aura_streamed.py
@@ -45,6 +45,38 @@ def verify_source_manifest(root, path):
     return manifest
 
 
+def expected_currency_bindings(runner, calibration, protocol, model_identity, cache, renders):
+    """Seal dense qualification inputs before the producer returns any rows."""
+    from prismaquant import format_registry as fr
+    from prismaquant.aura_cost import _aura_source_sha256
+    from prismaquant.joint_aura import (
+        activation_identity, arithmetic_identity, identity_sha256, source_execution_identity,
+    )
+    from prismaquant.production_weight_cache import _cb_cache_tensor_identity
+
+    plan = protocol["plan"]
+    expected_probe = {
+        "schema": "prismaquant.joint_aura.probes.v2", "source_model": model_identity,
+        "calibration_sha256": _cb_cache_tensor_identity(calibration)["content_sha256"],
+        "calibration_shape": list(calibration.shape), "calibration_dtype": str(calibration.dtype),
+        "n_probes": protocol["n_probes"], "seed_base": protocol["seed_base"],
+        "token_scope": "causal", "temperature": 1.0, "distribution": "rademacher",
+        "normalization": "global_kl_fisher", "producer_source_sha256": _aura_source_sha256(),
+        "source_execution": source_execution_identity(runner.model),
+        "arithmetic": arithmetic_identity(runner.dtype),
+    }
+    expected_probe_sha256 = identity_sha256(expected_probe)
+    expected = {name: {fmt: identity_sha256({
+        "schema": "prismaquant.joint_aura.operator.v2", "qname": name, "format": fmt,
+        "source_weight": renders[name][fmt]["source_weight"],
+        "rendered_weight": renders[name][fmt]["rendered_weight"],
+        "activation": activation_identity(fr.get_format(fmt), cache.activation_max_abs, name),
+        "arithmetic": expected_probe["arithmetic"],
+        "probe_identity_sha256": expected_probe_sha256,
+    }) for fmt in formats} for name, formats in plan.items()}
+    return expected_probe, expected_probe_sha256, expected
+
+
 def load_candidate_payload(path, plan, operator_bindings, probe_sha256):
     """Validate persisted producer currency against independently held bindings.
 
@@ -452,12 +484,10 @@ def main():
     import transformers
     from transformers import AutoModelForCausalLM
     import tessera
-    from prismaquant.aura_cost import compute_aura_cost_streamed, _aura_source_sha256
+    from prismaquant.aura_cost import compute_aura_cost_streamed
     from prismaquant.cost_streaming import build_streamed_causal_lm, build_streamed_model_identity
-    from prismaquant.joint_aura import activation_identity, arithmetic_identity, identity_sha256, prefetch_joint_cache
-    from prismaquant import format_registry as fr
+    from prismaquant.joint_aura import arithmetic_identity, identity_sha256, prefetch_joint_cache
     from prismaquant.model_profiles import detect_profile
-    from prismaquant.production_weight_cache import _cb_cache_tensor_identity
 
     if not torch.cuda.is_available():
         raise RuntimeError("this qualification requires an admitted GPU action")
@@ -519,24 +549,8 @@ def main():
             identity_cache_path=out / "streamed-model-identity.json")
         # Bind the input contract before the producer returns any rows. Its
         # own self-consistent digest cannot authorize different probe inputs.
-        expected_probe = {
-            "schema": "prismaquant.joint_aura.probes.v2", "source_model": model_identity,
-            "calibration_sha256": _cb_cache_tensor_identity(calibration)["content_sha256"],
-            "calibration_shape": list(calibration.shape), "calibration_dtype": str(calibration.dtype),
-            "n_probes": protocol["n_probes"], "seed_base": protocol["seed_base"],
-            "token_scope": "causal", "temperature": 1.0, "distribution": "rademacher",
-            "normalization": "global_kl_fisher", "producer_source_sha256": _aura_source_sha256(),
-            "arithmetic": arithmetic_identity(torch.bfloat16),
-        }
-        expected_probe_sha256 = identity_sha256(expected_probe)
-        expected = {name: {fmt: identity_sha256({
-            "schema": "prismaquant.joint_aura.operator.v2", "qname": name, "format": fmt,
-            "source_weight": renders[name][fmt]["source_weight"],
-            "rendered_weight": renders[name][fmt]["rendered_weight"],
-            "activation": activation_identity(fr.get_format(fmt), cache.activation_max_abs, name),
-            "arithmetic": arithmetic_identity(torch.bfloat16),
-            "probe_identity_sha256": expected_probe_sha256,
-        }) for fmt in formats} for name, formats in plan.items()}
+        expected_probe, expected_probe_sha256, expected = expected_currency_bindings(
+            runner, calibration, protocol, model_identity, cache, renders)
         dump(out / "expected-currency-bindings.json", {
             "probe": expected_probe, "operator_identity_sha256_by_candidate": expected})
         with torch.no_grad():

--- a/tests/test_pq237_streamed_handoff.py
+++ b/tests/test_pq237_streamed_handoff.py
@@ -116,3 +116,58 @@ def test_four_assignment_diagnostics_keep_background_and_currency_labels(tmp_pat
         pairs["A16"]["joint_quadratic_diagnostic"]["difference_per_probe"], abs=1e-12)
     assert set(pairs["A8"]["joint_quadratic_diagnostic"]["assignment_a"]
                ["operator_identity_sha256_by_unit"]) == set(plan)
+
+
+@pytest.mark.parametrize("changed_selector", [None, "root_attention", "layer_experts"])
+def test_predeclared_harness_bindings_match_current_producer_and_refuse_dispatch_drift(
+        tmp_path, monkeypatch, changed_selector):
+    """Expected bindings come from inputs, never from returned producer rows."""
+    from types import SimpleNamespace
+    import torch
+
+    from experiments.pq237_joint_aura_streamed import expected_currency_bindings
+    from prismaquant.production_weight_cache import _cb_cache_tensor_identity
+    from test_streamed_cost_checkpoints import _model_identity
+
+    monkeypatch.setenv("PRISMAQUANT_COST_UCB_Z", "0")
+    model, _, runner, cache = _fixture()
+    model.config = SimpleNamespace(_attn_implementation="eager")
+    model.model.layers[1].config = SimpleNamespace(_experts_implementation="eager")
+    plan = {name: ("FP8_E4M3", "NVFP4A16", "BF16")
+            for name, module in model.named_modules() if name.endswith(".proj")}
+    renders = {}
+    for name, formats in plan.items():
+        source = model.get_submodule(name).weight.detach()
+        renders[name] = {fmt: {
+            "source_weight": _cb_cache_tensor_identity(source),
+            "rendered_weight": _cb_cache_tensor_identity(
+                source if fmt == "BF16" else cache.get(name, fmt)),
+        } for fmt in formats}
+    protocol = {"plan": plan, "n_probes": 3, "seed_base": 7000}
+    probe, digest, operators = expected_currency_bindings(
+        runner, torch.tensor([[1, 2, 3, 4]]), protocol,
+        _model_identity("joint-source"), cache, renders)
+
+    # A changed real module-local selector is independently observed by the
+    # producer. Even a self-consistent returned envelope must then refuse.
+    if changed_selector == "root_attention":
+        model.config._attn_implementation = "sdpa"
+    elif changed_selector == "layer_experts":
+        model.model.layers[1].config._experts_implementation = "grouped_mm"
+    payload = _run(runner, cache, token_scope="causal")
+    path = tmp_path / "joint.pkl"
+    _write(path, payload)
+    if changed_selector:
+        with pytest.raises(ValueError, match="persisted joint probe identity differs"):
+            load_candidate_payload(path, plan, operators, digest)
+    else:
+        restored, candidates, _ = load_candidate_payload(path, plan, operators, digest)
+        assert restored["provenance"]["probe_identity"] == probe
+        assert probe["schema"] == "prismaquant.joint_aura.probes.v2"
+        assert probe["source_execution"]["modules"][""]["attention"] == "eager"
+        assert probe["source_execution"]["modules"]["model.layers.1"]["experts"] == "eager"
+        assert set(candidates) == set(plan)
+        for name, rows in restored["costs"].items():
+            for fmt, row in rows.items():
+                assert row["joint_operator_identity"]["schema"] == "prismaquant.joint_aura.operator.v2"
+                assert row["joint_operator_identity_sha256"] == operators[name][fmt]


### PR DESCRIPTION
## Tracked issue

Closes #338

## Change

The PQ237 qualification harness omitted `source_execution` from its independently declared v2 probe identity. The current producer includes that field, so the harness rejected valid persisted rows before assignment validation. Include the actual model execution selectors before invoking the producer and derive operator bindings from that complete probe identity.

Extract the existing declaration block into a harness helper so the regression exercises the same path as qualification. A real CPU streamed producer now round-trips through the persisted-payload gate; independently changing root attention or a layer expert selector remains a refusal. Only the experiment harness and tests change; no production package identity, defaults, serving gates, or frozen run artifacts change.

## Validation

All execution used PrismaBuild on DL380 CPU with native threads bounded to one. No GPU qualification, quality, or performance result is claimed.

- RED: `bash experiments/pq322_cpu_checks.sh -n2 tests/test_pq237_streamed_handoff.py -k predeclared` reproduced the defect: **1 failed, 2 passed**, exit 1; action `d4bdc9bc082d27f16691f3cbc3474525a212185d585143b3645b4e19bf8ad212` (2 CPUs, 6 GiB). The matching producer failed with `persisted joint probe identity differs from measured input`.
- Final integrated GREEN: `bash experiments/pq322_cpu_checks.sh -n4 tests/test_pq237_source_closure.py tests/test_pq237_streamed_handoff.py tests/test_pq237_streamed_wire.py tests/test_pq237_streamed_protocol.py tests/test_joint_aura_streamed.py tests/test_pq261_unit_activation_source.py`: **78 passed, 0 skips**, 56 Torch deprecation warnings, exit 0; action `a16a0cbf1015277fadc4a40ceb2ca54686853170c8f8d46446212ee5014b2886` (4 CPUs, 12 GiB). This includes the source-closure checks from main `624a5d6c9`; the merge needed no manual conflict resolution.
- Final integrated compile: `python3 -m compileall -q experiments/pq237_joint_aura_streamed.py tests/test_pq237_streamed_handoff.py`, exit 0; action `f5678372c2a48fa031ea8ec3d63d38d6a3a49f4c4744ee8fa1161ccd0d3f85e7` (1 CPU, 1 GiB).

Verified terminal exit status, logs, CAS receipt and payload hashes, snapshot bundle hashes, and exact tested-file equality with final head `bbacbd4d0cbcd2869670aaa53bf162391136a3bb`. Integration evidence: `/mnt/shared/tessera-measurements/pq338-harness-identity-20260907/verified-integration-actions.json`, SHA256 `524502d384e0d7095be08098b68a13dbd5f089e9d2992a681d5d3b78e7389bfe`; GREEN receipt SHA256 `fcb71dc42f20b80cbed6c6c9a15cb5e173970f21b80348c41f2826ebc81d3830`. The same directory retains all stdout/stderr and the initial RED/GREEN evidence index `verified-actions.json` (SHA256 `cc3474776e17366d495a3ac88fc839c360d269d001fcdd47deb86716f8d6b767`).
