### PR TITLE
Skip empty joint projection leases during checkpoint resume

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,13 @@
 As of: 2026-09-07 · `codex/joint-fused-promotion-20260907`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-07, `fix/joint-resume-empty-lease`) for streamed joint
+AURA resume: a fully checkpointed reverse layer skips projection-lease
+construction while still executing every probe's input/shared-state cotangent
+traversal. Earlier pending layers retain the same Fisher probe, signed terms,
+squaring and arithmetic identity. The existing source-identity checks remain
+strict; this fix does not authorize adoption across producer source versions.
+
 Re-stamped (2026-09-07, `review/pq325-buffer-precision`) for the compressed-tensors
 streaming export's persistent-buffer read policy (#311). The exporter passes
 the skeleton's declared buffer dtypes to the shared layer reader before

--- a/docs/design/joint_resume_empty_lease_2026-09-07.md
+++ b/docs/design/joint_resume_empty_lease_2026-09-07.md
@@ -1,0 +1,72 @@
+# Joint AURA checkpointed-layer lease correction — 2026-09-07
+
+A partial streamed joint-AURA resume can have no pending units in the first
+reverse layer while earlier layers remain incomplete. The caller previously
+constructed `SignedJointProjectionLease` with an empty target map. Its fallback
+device is CPU, which a CUDA-prewarmed fused projection backend correctly refuses.
+The default Torch backend accepts that device, so the existing interrupted-resume
+test did not expose this failure.
+
+The caller now constructs a projection lease only when `pending` is nonempty.
+Every reverse layer still runs the full input/shared-state cotangent traversal;
+probe ordering, Fisher construction, GEMMs, QDQ, signed accumulation and squaring
+are unchanged. The backend's device admission remains strict. Existing producer
+source identity checks remain strict too: this commit does not authorize reuse
+across source versions or rewrite any retained production checkpoint.
+
+## Regression and integration evidence
+
+The CPU regression interrupts the existing two-layer fixture after persisting
+its last reverse layer, then resumes with the earlier layer still pending.
+It uses the real fused backend device gate with logical CUDA targets for
+populated leases and the existing CPU fallback for empty leases; numerical
+projections execute through the Torch oracle. It does not load a native GPU
+extension or claim CUDA numerical qualification.
+
+Both ordinary and microbatched variants verify:
+
+- exactly one reused unit and one newly written unit, with preserved checkpoint
+  bytes unchanged;
+- only the pending earlier layer acquires a projection lease;
+- all six reverse input cotangents equal the uninterrupted run bit for bit;
+- complete cost rows, signed terms, probe/arithmetic identity, gradient traces
+  and Fisher column diagnostics equal the uninterrupted run exactly.
+
+PB `c701712f3528` ran those two regression variants before the fix: both failed
+at the fused device gate on the empty lease's CPU device. Exit 1 and completed,
+released scope were verified. Failed actions publish no success CAS receipt;
+actual terminal and stdout/stderr are retained.
+
+PB `590484b22080` ran the following after the fix: **120 passed**, zero skips
+or missing collection, with 56 upstream Torch/Python deprecation warnings.
+
+```text
+bash experiments/pq322_cpu_checks.sh \
+  tests/test_joint_aura_streamed.py tests/test_joint_aura_microbatch.py \
+  tests/test_joint_aura_packed.py tests/test_joint_aura_projection.py \
+  tests/test_joint_projection_backend.py tests/test_streamed_cost_checkpoints.py \
+  tests/test_architecture_doc.py tests/test_docs_staleness.py \
+  -q -n 4 --dist worksteal -p no:cacheprovider
+```
+
+Both actions were portable CPU submissions at priority -10, admitted on dl380g10
+with four CPUs/eight GiB and native threads bounded to one. Runtime: Python
+3.14.4, Torch 2.11.0+cpu, Transformers 5.16.1, pytest 9.0.2. CUDA was disabled.
+The green terminal exit, cleanup, actual CAS payload and canonical receipt hash
+were independently verified. Payload:
+`8e7033407cecca867cb3ae6d6533a59e022c3347869458f9c4761c7f3ccaa88c`;
+receipt:
+`05952743bfada4bbd9158717f8f1c5ad4973fc69c3123bd42bb7f3e5ec4a85ce`.
+
+Evidence root:
+`/mnt/shared/tessera-measurements/joint-resume-empty-lease-20260907/`.
+`red-verified-01.json` and `green-verified-01.json` bind terminal records and
+actual logs. No frozen production source/checkpoint bytes were changed and no
+GPU work or performance measurement was repeated.
+
+PB `a8aab10d7e8c` separately compiled both touched Python modules and verified
+that inverting exactly the guard/comment hunk reproduces the original full
+`aura_cost.py` bytes. It ran on dl380g10 with one CPU/one GiB, exit zero and
+released scope. `compile-inverse-verified-01.json` records the checked CAS
+payload and receipt. Final `aura_cost.py` SHA256:
+`b615fa48377daca8b7264c96a5e5dd853cc963ba1d4c05c1519d3027264c0852`.

--- a/prismaquant/aura_cost.py
+++ b/prismaquant/aura_cost.py
@@ -2926,7 +2926,9 @@ def compute_aura_cost_streamed(
 
             hook_handles = []
             joint_lease = None
-            if joint_activation:
+            # Completed layers still propagate cotangents to pending earlier
+            # layers, but have no target device or projections to lease.
+            if joint_activation and pending:
                 cache_owner = production_cache if production_cache is not None else getattr(anchor_renderer, "cache", None)
                 joint_lease = SignedJointProjectionLease(
                     {name: linears[name] for name in pending},

--- a/tests/test_joint_aura_streamed.py
+++ b/tests/test_joint_aura_streamed.py
@@ -143,6 +143,94 @@ def test_joint_interrupted_resume_preserves_signed_samples(tmp_path, monkeypatch
     assert actual["costs"] == expected["costs"]
 
 
+@pytest.mark.parametrize("probe_microbatch", [0, 1])
+def test_joint_resume_checkpointed_layer_keeps_cotangents_without_empty_lease(
+    tmp_path, monkeypatch, probe_microbatch,
+):
+    from prismaquant import joint_aura, joint_projection_backend as backend
+
+    monkeypatch.setattr(aura, "_checkpoint_git_commit", lambda: "1" * 40)
+    real_lease = joint_aura.SignedJointProjectionLease
+    # CPU numerical fixture for a CUDA-bound backend: populated leases have
+    # a logical CUDA target; an empty lease has the constructor's CPU fallback.
+    # Run the real fused device gate, then the existing Torch projection oracle.
+    # No native extension is loaded and no CUDA tensor is allocated.
+    fused = backend._FusedProjection(
+        None, torch.device("cuda:0"), {"qualified_shapes": [[16, 16]]},
+        seal=backend._PREWARM_SEAL,
+    )
+    leases = []
+
+    def device_enforcing_lease(modules, *args, **kwargs):
+        target = torch.device("cuda:0") if modules else torch.device("cpu")
+        fused.require_device(target)
+        leases.append(tuple(modules))
+        return real_lease(modules, *args, **kwargs)
+
+    monkeypatch.setattr(joint_aura, "SignedJointProjectionLease", device_enforcing_lease)
+
+    def run(*, checkpoint_dir=None, resume=False):
+        _, context, runner, cache = _fixture()
+        backward = []
+        isolated_layer = runner.isolated_layer
+
+        def observed(batch, layer, hidden, *, pass_state):
+            hidden.register_hook(
+                lambda grad: backward.append((layer, grad.detach().clone()))
+            )
+            return isolated_layer(batch, layer, hidden, pass_state=pass_state)
+
+        runner.isolated_layer = observed
+        payload = _run(
+            runner, cache, checkpoint_dir=checkpoint_dir, resume=resume,
+            probe_microbatch=probe_microbatch, collect_col_energy=True,
+        )
+        assert context.active == set()
+        return payload, backward
+
+    expected, expected_backward = run()
+    writer = aura._write_aura_unit_checkpoint
+    written = []
+
+    def interrupt_after_complete_layer(*args, **kwargs):
+        writer(*args, **kwargs)
+        written.append(kwargs["qname"])
+        raise RuntimeError("fixture interruption after complete reverse layer")
+
+    monkeypatch.setattr(aura, "_write_aura_unit_checkpoint", interrupt_after_complete_layer)
+    with pytest.raises(RuntimeError, match="fixture interruption after complete reverse layer"):
+        run(checkpoint_dir=tmp_path)
+    assert written == ["model.layers.1.proj"]
+    preserved = {path: path.read_bytes() for path in (tmp_path / "units").glob("*.pkl")}
+    assert len(preserved) == 1
+
+    def record_write(*args, **kwargs):
+        written.append(kwargs["qname"])
+        return writer(*args, **kwargs)
+
+    monkeypatch.setattr(aura, "_write_aura_unit_checkpoint", record_write)
+    written.clear()
+    leases.clear()
+    actual, actual_backward = run(checkpoint_dir=tmp_path, resume=True)
+    assert leases == [("model.layers.0.proj",)]
+    assert written == ["model.layers.0.proj"]  # one reused unit, one newly measured
+    assert all(path.read_bytes() == raw for path, raw in preserved.items())
+    assert len(list((tmp_path / "units").glob("*.pkl"))) == 2
+    assert actual["costs"] == expected["costs"]  # includes signed components/arithmetic
+    assert actual["provenance"]["probe_identity"] == expected["provenance"]["probe_identity"]
+    assert [layer for layer, _ in actual_backward] == [1, 1, 1, 0, 0, 0]
+    for (layer, gradient), (expected_layer, expected_gradient) in zip(
+        actual_backward, expected_backward, strict=True,
+    ):
+        assert layer == expected_layer
+        torch.testing.assert_close(gradient, expected_gradient, rtol=0, atol=0)
+    for name, stats in expected["stats"].items():
+        assert actual["stats"][name]["h_trace"] == stats["h_trace"]
+        torch.testing.assert_close(
+            actual["stats"][name]["fisher_col"], stats["fisher_col"], rtol=0, atol=0,
+        )
+
+
 def test_joint_checkpoint_refuses_probe_alignment_even_valid_envelope(tmp_path, monkeypatch):
     monkeypatch.setattr(aura, "_checkpoint_git_commit", lambda: "1" * 40)
     _, _, runner, cache = _fixture()


### PR DESCRIPTION
Closes #345.

A partial streamed joint-AURA resume can reach a fully checkpointed reverse layer before an earlier pending layer. Creating an empty projection lease selects the CPU fallback device, which the CUDA-prewarmed fused backend refuses. Construct the lease only when the layer has pending targets; every reverse probe and cotangent traversal still executes.

The CPU regression reproduces the real fused device refusal using logical device admission and Torch numerical projections. It interrupts after one complete reverse layer, resumes through that checkpointed layer, and verifies exact input cotangents, complete signed cost rows/arithmetic identity, gradient diagnostics, one unchanged reused checkpoint and one newly written unit. It covers ordinary and microbatched paths.

Validation through PrismaBuild, CPU only:

- Before: both regression variants fail at fused device admission (`c701712f3528`).
- After: 120 tests pass, zero skips/missing collection (`590484b22080`), covering streamed, packed, microbatched, projection/backend, checkpoint and architecture checks.
- Touched modules compile; reversing exactly the guard/comment hunk reproduces the original full `aura_cost.py` bytes (`a8aab10d7e8c`).
- Actual terminal exits, scope release, CAS payload and canonical receipt hashes independently checked. Evidence: `/mnt/shared/tessera-measurements/joint-resume-empty-lease-20260907/`; dated report: `docs/design/joint_resume_empty_lease_2026-09-07.md`.

Producer source-identity checks remain strict. This fix does not authorize reuse across source versions; the explicit provenance transition is separate. Frozen production sources/checkpoints were untouched, and no GPU work or performance measurement was repeated.
