### PR TITLE
Bind the source checkpoint identity into the export resume manifest

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,8 @@ in: `source_identity` (the sha256 of every safetensors shard the run consumes
 AND of the non-shard files it reads from the checkpoint root — `config.json`,
 which decides the skeleton the payloads were quantized against, and
 `model.safetensors.index.json`, which decides where each tensor is read from,
-and any root `*.py` a `trust_remote_code` checkpoint is built through — via the
+and every root `*.py` (all of them, not only the ones `auto_map` names), which
+a `trust_remote_code` checkpoint is built through — via the
 shared `cost_streaming.build_source_checkpoint_identity()`),
 `requested_dtype`, and `declared_buffer_dtypes`, and it computes the recipe
 hash with no swallow. `_admit_export_resume_cache()` decides admission

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,27 @@
 As of: 2026-09-07 · `codex/joint-fused-promotion-20260907`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-07, `triage/340-export-resume-source-identity`) for the
+standalone compressed-tensors export resume cache's **source identity** (#340).
+`--export-cache-dir` replays `layer_NNN.pt` payloads whenever the manifest
+matches. The manifest bound the render levers and the assignment hash and named
+no source, so the same cache dir reused against a different checkpoint replayed
+the first checkpoint's quantized bytes. `_export_resume_fingerprint()` now adds
+three fields the payloads silently bake in: `source_identity` (the sha256 of
+every safetensors shard the run consumes, via the shared
+`cost_streaming.build_source_checkpoint_identity()`), `requested_dtype`, and
+`declared_buffer_dtypes`. `_admit_export_resume_cache()` decides admission
+before any payload is read and fails closed: a manifest missing any of those
+keys — every pre-fix cache — is refused, not treated as a weaker match, and no
+field may degrade to `None`. Identity is CONTENT, not path: a relocated
+checkpoint still resumes, a same-size same-header value edit does not. The hash
+runs only when a cache dir was requested, and a `source_identity_cache.json`
+beside the manifest keys each digest to the shard's full stat fingerprint
+(`ctime_ns` included), so a resume costs one `stat` per shard. Gate:
+`tests/test_export_resume_source_identity.py`, which drives the real streaming
+exporter and asserts on whether a `layer_*.pt` was read at all. No served
+artifact gate is claimed.
+
 Re-stamped (2026-09-07, `fix/joint-source-transition-integration`) for the explicit
 `empty_joint_lease_v1` transition. Its sole approved source closure is the
 interrupted first-model joint run's exact producer package. A CPU preflight
@@ -9891,8 +9912,11 @@ allocator/floor distinction on disk, so `breakdown.dense` is `0` there by constr
 the split is only meaningful in the pre-export `assignment_read_traffic` form.
 
 Also on the card: exact `artifact_bytes`, format histogram, the render-lever
-echo (`_render_lever_provenance()`, shared with the export cache's fingerprint so the two
-cannot drift), and the `PRISMAQUANT_ALLOW_KV_SHARED_FISHER` / `PRISMAQUANT_KV_COTANGENT` state
+echo (`_render_lever_provenance()`, which the export cache's fingerprint folds in whole so
+the render levers cannot drift between the two; the cache additionally binds the source
+checkpoint identity, requested dtype and declared buffer dtypes, which are cache-admission
+facts rather than render levers — see the #340 stamp), and the
+`PRISMAQUANT_ALLOW_KV_SHARED_FISHER` / `PRISMAQUANT_KV_COTANGENT` state
 so an allocation that rode an unvalidated Fisher correction is visible on the artifact rather
 than only in a probe log (D24) — and since 2026-09-03 `verify` refuses a card carrying
 `unvalidated_kv_fisher_correction=true`, and shape-replays the stamped forensic hashes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,8 +15,9 @@ and the swallowed `NameError` stamped a null on every manifest ever written.
 in: `source_identity` (the sha256 of every safetensors shard the run consumes
 AND of the non-shard files it reads from the checkpoint root — `config.json`,
 which decides the skeleton the payloads were quantized against, and
-`model.safetensors.index.json`, which decides where each tensor is read from —
-via the shared `cost_streaming.build_source_checkpoint_identity()`),
+`model.safetensors.index.json`, which decides where each tensor is read from,
+and any root `*.py` a `trust_remote_code` checkpoint is built through — via the
+shared `cost_streaming.build_source_checkpoint_identity()`),
 `requested_dtype`, and `declared_buffer_dtypes`, and it computes the recipe
 hash with no swallow. `_admit_export_resume_cache()` decides admission
 before any payload is read and fails closed: a manifest missing any of those

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,13 +6,19 @@ follow, newest first, each recording its own branch and date.
 Re-stamped (2026-09-07, `triage/340-export-resume-source-identity`) for the
 standalone compressed-tensors export resume cache's **source identity** (#340).
 `--export-cache-dir` replays `layer_NNN.pt` payloads whenever the manifest
-matches. The manifest bound the render levers and the assignment hash and named
-no source, so the same cache dir reused against a different checkpoint replayed
-the first checkpoint's quantized bytes. `_export_resume_fingerprint()` now adds
-three fields the payloads silently bake in: `source_identity` (the sha256 of
-every safetensors shard the run consumes, via the shared
-`cost_streaming.build_source_checkpoint_identity()`), `requested_dtype`, and
-`declared_buffer_dtypes`. `_admit_export_resume_cache()` decides admission
+matches. The manifest bound the render levers and named no source, so the same
+cache dir reused against a different checkpoint replayed the first checkpoint's
+quantized bytes; the `assignment_hash` beside them compared nothing either,
+because `hashlib` was in scope nowhere inside `materialize_tensors_streaming`
+and the swallowed `NameError` stamped a null on every manifest ever written.
+`_export_resume_fingerprint()` now adds three fields the payloads silently bake
+in: `source_identity` (the sha256 of every safetensors shard the run consumes
+AND of the non-shard files it reads from the checkpoint root — `config.json`,
+which decides the skeleton the payloads were quantized against, and
+`model.safetensors.index.json`, which decides where each tensor is read from —
+via the shared `cost_streaming.build_source_checkpoint_identity()`),
+`requested_dtype`, and `declared_buffer_dtypes`, and it computes the recipe
+hash with no swallow. `_admit_export_resume_cache()` decides admission
 before any payload is read and fails closed: a manifest missing any of those
 keys — every pre-fix cache — is refused, not treated as a weaker match, and no
 field may degrade to `None`. Identity is CONTENT, not path: a relocated

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -505,6 +505,20 @@ def build_source_checkpoint_identity(
             f"{root}; refusing to stamp an unidentified source"
         )
     ordered = sorted(shard_paths, key=str)
+    # Name each shard by its position INSIDE the checkpoint. A Hugging Face
+    # snapshot dir holds symlinks into `blobs/`, so the resolved path is named
+    # by an LFS hash; naming shards by that would make the SAME checkpoint
+    # reached through a snapshot and through a plain directory two different
+    # sources. Recover the in-checkpoint spelling from the directory listing.
+    name_by_resolved: dict[str, str] = {}
+    if root.is_dir():
+        for entry in root.rglob("*.safetensors"):
+            try:
+                name_by_resolved.setdefault(
+                    str(entry.resolve()), str(entry.relative_to(root))
+                )
+            except (OSError, ValueError):
+                continue
 
     reusable = (
         _read_source_checkpoint_digest_cache(Path(digest_cache_path))
@@ -526,13 +540,14 @@ def build_source_checkpoint_identity(
                     f"source checkpoint shard changed while hashing: {path}"
                 )
         entries.append({"fingerprint": fingerprint, "sha256": digest})
-        # Name the shard by its position INSIDE the checkpoint, never by the
-        # absolute path: relocating a checkpoint does not change its bytes,
-        # and a path-keyed identity would refuse every moved resume.
-        try:
-            name = str(path.relative_to(root.resolve()))
-        except ValueError:
-            name = path.name
+        # Relocating a checkpoint does not change its bytes, so the identity
+        # is never keyed on the absolute path.
+        name = name_by_resolved.get(str(path))
+        if name is None:
+            try:
+                name = str(path.relative_to(root.resolve()))
+            except ValueError:
+                name = path.name
         shards.append({
             "name": name,
             "size": int(fingerprint["size"]),

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -426,6 +426,10 @@ SOURCE_CHECKPOINT_METADATA_FILES = (
     "config.json",
     "model.safetensors.index.json",
 )
+# ... plus every `*.py` at the checkpoint root, which a `trust_remote_code`
+# checkpoint executes to build the skeleton (MiniMax-M2 ships
+# `configuration_minimax_m2.py` and `modeling_minimax_m2.py`; DeepSeek-V4 uses
+# the same pattern), discovered per call rather than named here.
 SOURCE_CHECKPOINT_DIGEST_CACHE_SCHEMA = (
     "prismaquant.source_checkpoint.digest_cache.v1"
 )
@@ -497,7 +501,9 @@ def build_source_checkpoint_identity(
     payloads were quantized against -- the dtype map, ``tie_word_embeddings``,
     any ``quantization_config``, the layer counts -- and
     ``model.safetensors.index.json`` decides which shard each tensor is read
-    from.  Editing either changes what a replayed ``layer_NNN.pt`` means while
+    from.  Every ``*.py`` at the checkpoint root joins them, because a
+    ``trust_remote_code`` checkpoint executes those to build the skeleton.
+    Editing any of them changes what a replayed ``layer_NNN.pt`` means while
     every shard byte stays identical.  They are kilobytes, so they are hashed
     on every call rather than cached.
 
@@ -577,8 +583,15 @@ def build_source_checkpoint_identity(
 
     # The non-shard files the export reads.  Kilobytes each, so no digest
     # cache: hashing them costs less than deciding not to.
+    metadata_names = list(SOURCE_CHECKPOINT_METADATA_FILES)
+    if root.is_dir():
+        # `trust_remote_code` checkpoints build their skeleton from modules at
+        # the checkpoint root, so those are read bytes too.
+        metadata_names += sorted(
+            path.name for path in root.glob("*.py") if path.is_file()
+        )
     metadata: list[dict[str, object]] = []
-    for name in SOURCE_CHECKPOINT_METADATA_FILES:
+    for name in metadata_names:
         path = root / name
         if not path.is_file():
             continue

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -414,6 +414,168 @@ def _local_checkpoint_shards(
     return None, None
 
 
+SOURCE_CHECKPOINT_IDENTITY_SCHEMA = (
+    "prismaquant.source_checkpoint.identity.v1"
+)
+SOURCE_CHECKPOINT_DIGEST_CACHE_SCHEMA = (
+    "prismaquant.source_checkpoint.digest_cache.v1"
+)
+
+
+def _read_source_checkpoint_digest_cache(
+    cache_path: Path,
+) -> dict[str, dict[str, object]]:
+    """Digests keyed by the six-field stat fingerprint of the file they cover.
+
+    A corrupt or foreign cache is not an error: it simply reuses nothing, and
+    every shard is hashed. The cache can only ever make the identity CHEAPER,
+    never different -- the fingerprint it keys on includes ``ctime_ns``, which
+    ``utime`` cannot restore after an in-place same-size rewrite.
+    """
+    try:
+        payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return {}
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema") != SOURCE_CHECKPOINT_DIGEST_CACHE_SCHEMA
+    ):
+        return {}
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        return {}
+    reusable: dict[str, dict[str, object]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        fingerprint = entry.get("fingerprint")
+        digest = str(entry.get("sha256", "")).lower()
+        if (
+            not isinstance(fingerprint, dict)
+            or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+        ):
+            continue
+        reusable[canonical_fingerprint_key(fingerprint)] = {
+            "fingerprint": fingerprint,
+            "sha256": digest,
+        }
+    return reusable
+
+
+def canonical_fingerprint_key(fingerprint: dict[str, object]) -> str:
+    return json.dumps(fingerprint, sort_keys=True, separators=(",", ":"))
+
+
+def build_source_checkpoint_identity(
+    source_model: str | Path,
+    *,
+    extra_shard_paths: object = (),
+    digest_cache_path: str | Path | None = None,
+) -> dict[str, object]:
+    """Content identity of the exact safetensors byte set a run consumes.
+
+    This is the runner-free half of :func:`build_streamed_model_identity`, for
+    consumers that hold a checkpoint path rather than a live streaming runner
+    -- the standalone compressed-tensors export resume cache is the first
+    (PrismaQuant #340). It binds file CONTENT, so a same-size, same-header
+    value edit is a different source, and the same bytes under a different
+    directory are the same source.
+
+    ``digest_cache_path`` makes the read happen once per (file, machine): a
+    shard whose complete stat fingerprint still matches reuses its recorded
+    digest, so a resume costs one ``stat`` per shard instead of a full
+    checkpoint read. Without it, every call hashes every shard.
+    """
+    from prismaquant.cost_stage_checkpoint import canonical_json_sha256
+
+    root = Path(source_model)
+    _, indexed_shards = _local_checkpoint_shards(source_model)
+    shard_paths = {Path(path).resolve() for path in (indexed_shards or ())}
+    for path in extra_shard_paths or ():
+        shard_paths.add(Path(path).resolve())
+    missing = sorted(str(path) for path in shard_paths if not path.is_file())
+    if missing:
+        raise RuntimeError(
+            f"source checkpoint identity references missing shards: "
+            f"{missing[:8]}"
+        )
+    if not shard_paths:
+        raise RuntimeError(
+            f"source checkpoint identity found no safetensors shards under "
+            f"{root}; refusing to stamp an unidentified source"
+        )
+    ordered = sorted(shard_paths, key=str)
+
+    reusable = (
+        _read_source_checkpoint_digest_cache(Path(digest_cache_path))
+        if digest_cache_path is not None
+        and Path(digest_cache_path).is_file()
+        else {}
+    )
+
+    entries: list[dict[str, object]] = []
+    shards: list[dict[str, object]] = []
+    for path in ordered:
+        fingerprint = _streamed_identity_stat_fingerprint(path)
+        cached = reusable.get(canonical_fingerprint_key(fingerprint))
+        digest = str(cached["sha256"]) if cached is not None else None
+        if digest is None:
+            digest = _file_sha256(path)
+            if _streamed_identity_stat_fingerprint(path) != fingerprint:
+                raise RuntimeError(
+                    f"source checkpoint shard changed while hashing: {path}"
+                )
+        entries.append({"fingerprint": fingerprint, "sha256": digest})
+        # Name the shard by its position INSIDE the checkpoint, never by the
+        # absolute path: relocating a checkpoint does not change its bytes,
+        # and a path-keyed identity would refuse every moved resume.
+        try:
+            name = str(path.relative_to(root.resolve()))
+        except ValueError:
+            name = path.name
+        shards.append({
+            "name": name,
+            "size": int(fingerprint["size"]),
+            "sha256": digest,
+        })
+    shards.sort(key=lambda row: (str(row["name"]), str(row["sha256"])))
+
+    identity = {
+        "schema": SOURCE_CHECKPOINT_IDENTITY_SCHEMA,
+        "shards": shards,
+        "content_sha256": canonical_json_sha256(
+            {
+                "schema": SOURCE_CHECKPOINT_IDENTITY_SCHEMA,
+                "shards": shards,
+            },
+            where="source checkpoint content identity",
+        ),
+    }
+
+    if digest_cache_path is not None:
+        from prismaquant.cost_stage_checkpoint import atomic_write_bytes
+
+        try:
+            atomic_write_bytes(
+                Path(digest_cache_path),
+                json.dumps(
+                    {
+                        "schema": SOURCE_CHECKPOINT_DIGEST_CACHE_SCHEMA,
+                        "entries": entries,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                    ensure_ascii=False,
+                    allow_nan=False,
+                ).encode("utf-8"),
+            )
+        except OSError:
+            # The digest cache is an optimization. A read-only or full cache
+            # directory costs a re-read next time; it never changes identity.
+            pass
+    return identity
+
+
 def _read_streamed_model_identity_cache(
     cache_path: Path,
     *,

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -417,6 +417,15 @@ def _local_checkpoint_shards(
 SOURCE_CHECKPOINT_IDENTITY_SCHEMA = (
     "prismaquant.source_checkpoint.identity.v1"
 )
+# The non-shard files the standalone export reads from the checkpoint root:
+# `config.json` through `stage_text_only`/`AutoConfig` (streaming_model.py:102
+# and the exporter's skeleton build) and the index through
+# `_local_checkpoint_shards` and export_native_compressed.py:6092.  A file that
+# is absent contributes no row, so one appearing later is a different source.
+SOURCE_CHECKPOINT_METADATA_FILES = (
+    "config.json",
+    "model.safetensors.index.json",
+)
 SOURCE_CHECKPOINT_DIGEST_CACHE_SCHEMA = (
     "prismaquant.source_checkpoint.digest_cache.v1"
 )
@@ -480,6 +489,17 @@ def build_source_checkpoint_identity(
     (PrismaQuant #340). It binds file CONTENT, so a same-size, same-header
     value edit is a different source, and the same bytes under a different
     directory are the same source.
+
+    The weight bytes are not the whole source.
+    :data:`SOURCE_CHECKPOINT_METADATA_FILES` names the non-shard files the
+    export reads from the checkpoint root, and their sha256 is folded into
+    the same ``content_sha256``: ``config.json`` decides the skeleton the
+    payloads were quantized against -- the dtype map, ``tie_word_embeddings``,
+    any ``quantization_config``, the layer counts -- and
+    ``model.safetensors.index.json`` decides which shard each tensor is read
+    from.  Editing either changes what a replayed ``layer_NNN.pt`` means while
+    every shard byte stays identical.  They are kilobytes, so they are hashed
+    on every call rather than cached.
 
     ``digest_cache_path`` makes the read happen once per (file, machine): a
     shard whose complete stat fingerprint still matches reuses its recorded
@@ -555,13 +575,35 @@ def build_source_checkpoint_identity(
         })
     shards.sort(key=lambda row: (str(row["name"]), str(row["sha256"])))
 
+    # The non-shard files the export reads.  Kilobytes each, so no digest
+    # cache: hashing them costs less than deciding not to.
+    metadata: list[dict[str, object]] = []
+    for name in SOURCE_CHECKPOINT_METADATA_FILES:
+        path = root / name
+        if not path.is_file():
+            continue
+        fingerprint = _streamed_identity_stat_fingerprint(path)
+        digest = _file_sha256(path)
+        if _streamed_identity_stat_fingerprint(path) != fingerprint:
+            raise RuntimeError(
+                f"source checkpoint metadata changed while hashing: {path}"
+            )
+        metadata.append({
+            "name": name,
+            "size": int(fingerprint["size"]),
+            "sha256": digest,
+        })
+    metadata.sort(key=lambda row: str(row["name"]))
+
     identity = {
         "schema": SOURCE_CHECKPOINT_IDENTITY_SCHEMA,
         "shards": shards,
+        "metadata": metadata,
         "content_sha256": canonical_json_sha256(
             {
                 "schema": SOURCE_CHECKPOINT_IDENTITY_SCHEMA,
                 "shards": shards,
+                "metadata": metadata,
             },
             where="source checkpoint content identity",
         ),

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -426,10 +426,14 @@ SOURCE_CHECKPOINT_METADATA_FILES = (
     "config.json",
     "model.safetensors.index.json",
 )
-# ... plus every `*.py` at the checkpoint root, which a `trust_remote_code`
-# checkpoint executes to build the skeleton (MiniMax-M2 ships
-# `configuration_minimax_m2.py` and `modeling_minimax_m2.py`; DeepSeek-V4 uses
-# the same pattern), discovered per call rather than named here.
+# ... plus every `*.py` at the checkpoint root, because a `trust_remote_code`
+# checkpoint executes modules from there to build the skeleton (MiniMax-M2
+# ships `configuration_minimax_m2.py` and `modeling_minimax_m2.py`;
+# DeepSeek-V4 uses the same pattern), discovered per call rather than named
+# here.  Every one of
+# them is bound, whether or not `auto_map` names it: binding a module nobody
+# imports can cost a false refusal, naming only some can cost a false
+# admission.
 SOURCE_CHECKPOINT_DIGEST_CACHE_SCHEMA = (
     "prismaquant.source_checkpoint.digest_cache.v1"
 )
@@ -502,7 +506,9 @@ def build_source_checkpoint_identity(
     any ``quantization_config``, the layer counts -- and
     ``model.safetensors.index.json`` decides which shard each tensor is read
     from.  Every ``*.py`` at the checkpoint root joins them, because a
-    ``trust_remote_code`` checkpoint executes those to build the skeleton.
+    ``trust_remote_code`` checkpoint executes modules from there to build the
+    skeleton; all of them are bound rather than only those ``auto_map`` names,
+    which can refuse falsely but never admit falsely.
     Editing any of them changes what a replayed ``layer_NNN.pt`` means while
     every shard byte stays identical.  They are kilobytes, so they are hashed
     on every call rather than cached.
@@ -586,7 +592,9 @@ def build_source_checkpoint_identity(
     metadata_names = list(SOURCE_CHECKPOINT_METADATA_FILES)
     if root.is_dir():
         # `trust_remote_code` checkpoints build their skeleton from modules at
-        # the checkpoint root, so those are read bytes too.
+        # the checkpoint root, so those are read bytes too.  All of them, not
+        # only the ones `auto_map` names: over-binding refuses falsely, and
+        # under-binding admits falsely.
         metadata_names += sorted(
             path.name for path in root.glob("*.py") if path.is_file()
         )

--- a/prismaquant/export_native_compressed.py
+++ b/prismaquant/export_native_compressed.py
@@ -6548,59 +6548,19 @@ def materialize_tensors_streaming(
     cache_path = Path(export_cache_dir) if export_cache_dir else None
     if cache_path is not None:
         cache_path.mkdir(parents=True, exist_ok=True)
-
-        # Cache fingerprint (codex review #2): bind the cache to the
-        # quality-affecting state. If any of these change between runs,
-        # the cache is silently wrong because the saved layer tensors
-        # were quantized under a different recipe. Write/check a
-        # manifest.json; mismatch invalidates the cache wholesale.
-        import json as _json
-        fp_state = _render_lever_provenance()
-        # Hash the assignment dict (layer_config recipe) too — recipe
-        # changes invalidate per-Linear quantization output.
-        try:
-            fp_state["assignment_hash"] = hashlib.sha256(
-                _json.dumps(assignment, sort_keys=True).encode()
-            ).hexdigest()[:16]
-        except Exception:
-            fp_state["assignment_hash"] = None
-
-        manifest_path = cache_path / "manifest.json"
-        if manifest_path.exists():
-            try:
-                with manifest_path.open() as _f:
-                    prev = _json.load(_f)
-                if prev != fp_state:
-                    diff_keys = sorted(
-                        set(prev.keys()) | set(fp_state.keys())
-                    )
-                    diffs = [
-                        k for k in diff_keys
-                        if prev.get(k) != fp_state.get(k)
-                    ]
-                    print(f"[export-stream] cache fingerprint MISMATCH "
-                          f"(differs in: {diffs}); invalidating cache",
-                          flush=True)
-                    for _f in cache_path.glob("layer_*.pt"):
-                        _f.unlink()
-                    with manifest_path.open("w") as _f:
-                        _json.dump(fp_state, _f, indent=2)
-                else:
-                    print(f"[export-stream] cache fingerprint match — "
-                          f"resumable from {len(list(cache_path.glob('layer_*.pt')))} "
-                          f"layers", flush=True)
-            except Exception as _e:
-                print(f"[export-stream] cache manifest unreadable "
-                      f"({_e}); invalidating cache", flush=True)
-                for _f in cache_path.glob("layer_*.pt"):
-                    _f.unlink()
-                with manifest_path.open("w") as _f:
-                    _json.dump(fp_state, _f, indent=2)
-        else:
-            with manifest_path.open("w") as _f:
-                _json.dump(fp_state, _f, indent=2)
-            print(f"[export-stream] wrote cache fingerprint to {manifest_path}",
-                  flush=True)
+        # The fingerprint is computed ONLY when a cache dir was asked for, so
+        # the source hash never touches an export that is not resumable.
+        _admit_export_resume_cache(
+            cache_path,
+            _export_resume_fingerprint(
+                assignment=assignment,
+                model_path=model_path,
+                dtype=dtype,
+                declared_buffer_dtypes=declared_buffer_dtypes,
+                extra_shard_paths=set(weight_shard.values()),
+                digest_cache_path=cache_path / "source_identity_cache.json",
+            ),
+        )
 
     def _layer_cache_file(L: int) -> Path | None:
         return None if cache_path is None else cache_path / f"layer_{L:03d}.pt"
@@ -8521,15 +8481,136 @@ def compute_extra_ignore(
     return extra_ignore
 
 
+def _export_resume_fingerprint(
+    *,
+    assignment: dict,
+    model_path: str,
+    dtype: "torch.dtype",
+    declared_buffer_dtypes: dict,
+    extra_shard_paths: object = (),
+    digest_cache_path: str | Path | None = None,
+) -> dict:
+    """Everything a `layer_NNN.pt` payload is only valid under.
+
+    `_render_lever_provenance()` says how the export renders; this adds WHAT
+    it renders. Before #340 the manifest carried the levers and the recipe
+    hash alone, so a cache dir reused against a different checkpoint replayed
+    the first checkpoint's quantized bytes -- the levers matched, the
+    assignment matched, and no field named the source.
+
+    Three bindings, all of which a replayed payload silently bakes in:
+
+    * ``source_identity`` -- the sha256 of every safetensors shard the run
+      consumes (`build_source_checkpoint_identity`). Content, not path: a
+      relocated checkpoint still resumes, a same-size value edit does not.
+    * ``requested_dtype`` -- the parameter dtype the source read narrows to.
+    * ``declared_buffer_dtypes`` -- the skeleton's persistent-buffer dtype
+      map, which is what the reader restores buffers to (#311/PR #325). The
+      policy STAMP alone says the reader is correct; the map says it was
+      handed the same declarations.
+
+    Nothing here may degrade to ``None``: the manifest comparison is
+    equality, and ``None == None`` admits. A source that cannot be identified
+    raises instead.
+    """
+    import hashlib
+
+    from prismaquant.cost_streaming import build_source_checkpoint_identity
+
+    fp_state = _render_lever_provenance()
+    fp_state["assignment_hash"] = hashlib.sha256(
+        json.dumps(assignment, sort_keys=True).encode()
+    ).hexdigest()[:16]
+    fp_state["source_identity"] = build_source_checkpoint_identity(
+        model_path,
+        extra_shard_paths=extra_shard_paths,
+        digest_cache_path=digest_cache_path,
+    )
+    fp_state["requested_dtype"] = str(dtype)
+    fp_state["declared_buffer_dtypes"] = {
+        str(name): str(value)
+        for name, value in sorted(dict(declared_buffer_dtypes).items())
+    }
+    return fp_state
+
+
+# The manifest keys without which replay cannot be authorized. A pre-#340
+# cache carries none of them, and a manifest that lost one is not a weaker
+# match -- it is unreadable, and refused on the same branch.
+_EXPORT_RESUME_REQUIRED_KEYS = (
+    "source_identity",
+    "requested_dtype",
+    "declared_buffer_dtypes",
+    "assignment_hash",
+)
+
+
+def _admit_export_resume_cache(cache_path: Path, fp_state: dict) -> bool:
+    """Decide whether `layer_*.pt` replay is admitted, BEFORE any is read.
+
+    Returns True when the cache may be resumed. On any refusal every
+    `layer_*.pt` is removed and the manifest is rewritten, so the caller's
+    per-layer `cf.exists()` check cannot find a stale payload afterwards.
+    """
+    manifest_path = cache_path / "manifest.json"
+
+    def _refuse(reason: str) -> bool:
+        removed = 0
+        for stale in cache_path.glob("layer_*.pt"):
+            stale.unlink()
+            removed += 1
+        with manifest_path.open("w") as handle:
+            json.dump(fp_state, handle, indent=2)
+        print(f"[export-stream] resume REFUSED ({reason}); "
+              f"discarded {removed} cached layers", flush=True)
+        return False
+
+    if not manifest_path.exists():
+        with manifest_path.open("w") as handle:
+            json.dump(fp_state, handle, indent=2)
+        print(f"[export-stream] wrote cache fingerprint to {manifest_path}",
+              flush=True)
+        return True
+
+    try:
+        with manifest_path.open() as handle:
+            prev = json.load(handle)
+        if not isinstance(prev, dict):
+            raise ValueError("manifest is not an object")
+    except Exception as exc:
+        return _refuse(f"cache manifest unreadable: {exc}")
+
+    absent = [k for k in _EXPORT_RESUME_REQUIRED_KEYS if k not in prev]
+    if absent:
+        return _refuse(
+            f"manifest predates the source-identity contract, missing {absent}")
+
+    if prev != fp_state:
+        diffs = [
+            key for key in sorted(set(prev) | set(fp_state))
+            if prev.get(key) != fp_state.get(key)
+        ]
+        return _refuse(f"fingerprint differs in: {diffs}")
+
+    print(f"[export-stream] cache fingerprint match — resumable from "
+          f"{len(list(cache_path.glob('layer_*.pt')))} layers", flush=True)
+    return True
+
+
 def _render_lever_provenance() -> dict:
     """The quality-affecting render state of this export run.
 
-    Two consumers, one definition: the per-layer export cache binds its
-    `manifest.json` to this dict (a change means the cached layer tensors were
-    quantized under a different recipe and the cache is silently wrong), and the
-    shipcard echoes it so an artifact carries the levers it was rendered under.
-    Keep the key set stable — changing it invalidates every in-flight export
-    cache.
+    Two consumers, one definition: the per-layer export cache folds this dict
+    into its `manifest.json` fingerprint (a change means the cached layer
+    tensors were quantized under a different recipe and the cache is silently
+    wrong), and the shipcard echoes it so an artifact carries the levers it was
+    rendered under. Keep the key set stable — changing it invalidates every
+    in-flight export cache.
+
+    This is HOW the export renders, not WHAT it renders. The source checkpoint
+    identity, the requested dtype and the declared buffer-dtype map belong to
+    the cache fingerprint only (`_export_resume_fingerprint`, #340); the
+    shipcard records the source through its own `source_model` field.
     """
     return {
         # Older layer_*.pt payloads may already contain narrowed persistent

--- a/prismaquant/export_native_compressed.py
+++ b/prismaquant/export_native_compressed.py
@@ -8506,8 +8506,11 @@ def _export_resume_fingerprint(
     Three bindings, all of which a replayed payload silently bakes in:
 
     * ``source_identity`` -- the sha256 of every safetensors shard the run
-      consumes (`build_source_checkpoint_identity`). Content, not path: a
-      relocated checkpoint still resumes, a same-size value edit does not.
+      consumes, and of the non-shard files it reads from the checkpoint root:
+      ``config.json`` (the skeleton the payloads were quantized against) and
+      ``model.safetensors.index.json`` (which shard each tensor comes from).
+      See `build_source_checkpoint_identity`. Content, not path: a relocated
+      checkpoint still resumes, a same-size value edit does not.
     * ``requested_dtype`` -- the parameter dtype the source read narrows to.
     * ``declared_buffer_dtypes`` -- the skeleton's persistent-buffer dtype
       map, which is what the reader restores buffers to (#311/PR #325). The

--- a/prismaquant/export_native_compressed.py
+++ b/prismaquant/export_native_compressed.py
@@ -8509,7 +8509,8 @@ def _export_resume_fingerprint(
       consumes, and of the non-shard files it reads from the checkpoint root:
       ``config.json`` (the skeleton the payloads were quantized against),
       ``model.safetensors.index.json`` (which shard each tensor comes from)
-      and any ``*.py`` a ``trust_remote_code`` checkpoint is built through.
+      and every root ``*.py``, which a ``trust_remote_code`` checkpoint is
+      built through (all of them, not only the ones ``auto_map`` names).
       See `build_source_checkpoint_identity`. Content, not path: a relocated
       checkpoint still resumes, a same-size value edit does not.
     * ``requested_dtype`` -- the parameter dtype the source read narrows to.

--- a/prismaquant/export_native_compressed.py
+++ b/prismaquant/export_native_compressed.py
@@ -8507,8 +8507,9 @@ def _export_resume_fingerprint(
 
     * ``source_identity`` -- the sha256 of every safetensors shard the run
       consumes, and of the non-shard files it reads from the checkpoint root:
-      ``config.json`` (the skeleton the payloads were quantized against) and
-      ``model.safetensors.index.json`` (which shard each tensor comes from).
+      ``config.json`` (the skeleton the payloads were quantized against),
+      ``model.safetensors.index.json`` (which shard each tensor comes from)
+      and any ``*.py`` a ``trust_remote_code`` checkpoint is built through.
       See `build_source_checkpoint_identity`. Content, not path: a relocated
       checkpoint still resumes, a same-size value edit does not.
     * ``requested_dtype`` -- the parameter dtype the source read narrows to.

--- a/prismaquant/export_native_compressed.py
+++ b/prismaquant/export_native_compressed.py
@@ -8493,10 +8493,15 @@ def _export_resume_fingerprint(
     """Everything a `layer_NNN.pt` payload is only valid under.
 
     `_render_lever_provenance()` says how the export renders; this adds WHAT
-    it renders. Before #340 the manifest carried the levers and the recipe
-    hash alone, so a cache dir reused against a different checkpoint replayed
-    the first checkpoint's quantized bytes -- the levers matched, the
-    assignment matched, and no field named the source.
+    it renders. Before #340 the manifest carried the levers alone, so a cache
+    dir reused against a different checkpoint replayed the first checkpoint's
+    quantized bytes -- the levers matched and no field named the source. The
+    `assignment_hash` beside them compared nothing: `hashlib` was in scope
+    nowhere inside `materialize_tensors_streaming`, so the call raised
+    NameError and the `except Exception` stamped a null on every manifest
+    ever written (measured on origin/main, PB action 41e6e63eb9dd). The
+    import is explicit here and there is no swallow: a recipe hash that
+    cannot be computed is a crash, not a null that matches the next null.
 
     Three bindings, all of which a replayed payload silently bakes in:
 

--- a/tests/test_export_resume_source_identity.py
+++ b/tests/test_export_resume_source_identity.py
@@ -254,7 +254,7 @@ def test_source_identity_never_degrades_to_none(tmp_path):
     raise, not stamp a null the next run can match."""
     empty = tmp_path / "empty"
     empty.mkdir()
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError, match="no safetensors shards"):
         _fingerprint(empty)
 
 

--- a/tests/test_export_resume_source_identity.py
+++ b/tests/test_export_resume_source_identity.py
@@ -1,0 +1,299 @@
+"""The standalone export resume cache must bind the source checkpoint.
+
+`materialize_tensors_streaming(..., export_cache_dir=...)` saves each
+quantized layer to `layer_NNN.pt` and, on a restart, replays those payloads
+instead of re-reading the source. Admission was decided by
+`_render_lever_provenance()` plus `assignment_hash` alone, so a cache dir
+reused against a DIFFERENT checkpoint replayed the first checkpoint's
+quantized bytes: the render levers and the recipe both still matched, and
+nothing in the manifest named the source (#340).
+
+These tests drive the real exporter on a tiny synthetic checkpoint. They
+assert on the admission decision (was a `layer_*.pt` read at all?) and on the
+emitted bytes, so a refusal that still replays, or a replay that silently
+re-renders, both fail.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+from torch import nn  # noqa: E402
+from safetensors.torch import save_file  # noqa: E402
+
+from prismaquant import export_native_compressed as export  # noqa: E402
+from prismaquant import sensitivity_probe, streaming_model  # noqa: E402
+
+# Two FP32 values inside one BF16 ulp at 0.5, as in test_export_buffer_*: a
+# buffer edit the parameter dtype cannot represent, so a replayed payload is
+# distinguishable from a re-rendered one.
+_BIAS_A = torch.tensor([0.5, 0.5 + 2.0 ** -12], dtype=torch.float32)
+_BIAS_B = torch.tensor([0.5, 0.5 + 3.0 * 2.0 ** -12], dtype=torch.float32)
+_WEIGHT_A = torch.eye(2, dtype=torch.bfloat16)
+_WEIGHT_B = torch.tensor([[1.0, 0.0], [0.0, 0.5]], dtype=torch.bfloat16)
+
+
+def _write_source(source: Path, *, weight, bias) -> None:
+    source.mkdir(parents=True, exist_ok=True)
+    save_file(
+        {
+            "model.layers.0.expert_bias": bias.clone(),
+            "model.layers.0.proj.weight": weight.clone(),
+        },
+        str(source / "model.safetensors"),
+    )
+
+
+def _exporter(tmp_path, monkeypatch):
+    """Replace architecture construction only; source reads, the cache and
+    emission are the real code paths."""
+
+    class Skeleton:
+        @staticmethod
+        def _from_config(config):
+            model = nn.Module()
+            model.model = nn.Module()
+            layer = nn.Module()
+            layer.proj = nn.Linear(2, 2, bias=False, device="meta")
+            layer.register_buffer(
+                "expert_bias",
+                torch.empty(2, device="meta", dtype=torch.float32),
+            )
+            model.model.layers = nn.ModuleList([layer])
+            return model
+
+    profile = SimpleNamespace(
+        requires_multimodal_skeleton=lambda: False,
+        concat_merge_groups=lambda: (),
+        live_to_recipe_name=lambda name: name,
+        packed_expert_param_names=lambda: (),
+    )
+    from transformers import AutoConfig
+
+    monkeypatch.setattr(
+        AutoConfig, "from_pretrained", lambda *a, **kw: SimpleNamespace())
+    monkeypatch.setattr(sensitivity_probe, "stage_text_only", lambda p: p)
+    monkeypatch.setattr(
+        streaming_model, "_skeleton_config_and_class",
+        lambda config, **kw: (config, Skeleton))
+    monkeypatch.setattr(streaming_model, "_init_rotary_inplace", lambda *a: None)
+    monkeypatch.setattr(export, "_PRODUCTION_WEIGHT_CACHE", None)
+
+    source = tmp_path / "source"
+
+    def run(cache: Path | None, *, replay_log: list | None = None):
+        emitted: dict = {}
+
+        def sink(tensors):
+            emitted.update(tensors)
+
+        if replay_log is None:
+            export.materialize_tensors_streaming(
+                str(source), {}, profile=profile, bf16_passthrough=set(),
+                device=torch.device("cpu"), tensor_sink=sink,
+                export_cache_dir=None if cache is None else str(cache))
+            return emitted
+
+        real_load = torch.load
+
+        def spy(path, *args, **kwargs):
+            if Path(str(path)).name.startswith("layer_"):
+                replay_log.append(str(path))
+            return real_load(path, *args, **kwargs)
+
+        with monkeypatch.context() as patched:
+            patched.setattr(torch, "load", spy)
+            export.materialize_tensors_streaming(
+                str(source), {}, profile=profile, bf16_passthrough=set(),
+                device=torch.device("cpu"), tensor_sink=sink,
+                export_cache_dir=None if cache is None else str(cache))
+        return emitted
+
+    return run, source
+
+
+def _fill_cache(run, source, cache, *, weight, bias):
+    _write_source(source, weight=weight, bias=bias)
+    emitted = run(cache)
+    assert list(cache.glob("layer_*.pt")), "fixture wrote no layer cache"
+    return emitted
+
+
+# --------------------------------------------------------------------------
+# Admission: a changed source must refuse replay.
+# --------------------------------------------------------------------------
+
+def test_changed_source_parameter_refuses_replay(tmp_path, monkeypatch):
+    """Same assignment, same levers, different weight bytes of the same size
+    and shape. The cached layer must not be replayed, and the export must
+    carry the NEW weight."""
+    run, source = _exporter(tmp_path, monkeypatch)
+    cache = tmp_path / "resume"
+    _fill_cache(run, source, cache, weight=_WEIGHT_A, bias=_BIAS_A)
+
+    _write_source(source, weight=_WEIGHT_B, bias=_BIAS_A)
+    replays: list = []
+    emitted = run(cache, replay_log=replays)
+
+    assert replays == [], f"replayed a payload from the previous source: {replays}"
+    assert torch.equal(emitted["model.layers.0.proj.weight"], _WEIGHT_B)
+
+
+def test_changed_persistent_buffer_refuses_replay(tmp_path, monkeypatch):
+    """A persistent FP32 buffer edit is a source change too. Replay would
+    ship the old buffer bytes verbatim."""
+    run, source = _exporter(tmp_path, monkeypatch)
+    cache = tmp_path / "resume"
+    _fill_cache(run, source, cache, weight=_WEIGHT_A, bias=_BIAS_A)
+
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_B)
+    replays: list = []
+    emitted = run(cache, replay_log=replays)
+
+    assert replays == [], f"replayed a payload from the previous source: {replays}"
+    got = emitted["model.layers.0.expert_bias"]
+    assert torch.equal(got.view(torch.uint8), _BIAS_B.view(torch.uint8))
+
+
+def test_manifest_without_source_identity_is_refused(tmp_path, monkeypatch):
+    """Fail closed on a pre-fix cache: a manifest that names no source cannot
+    authorize replay even when nothing else changed."""
+    run, source = _exporter(tmp_path, monkeypatch)
+    cache = tmp_path / "resume"
+    _fill_cache(run, source, cache, weight=_WEIGHT_A, bias=_BIAS_A)
+
+    manifest = cache / "manifest.json"
+    legacy = json.loads(manifest.read_text())
+    assert "source_identity" in legacy, (
+        "the resume manifest binds no source identity")
+    legacy.pop("source_identity")
+    manifest.write_text(json.dumps(legacy))
+
+    replays: list = []
+    run(cache, replay_log=replays)
+    assert replays == [], "a manifest with no source identity admitted replay"
+    assert "source_identity" in json.loads(manifest.read_text())
+
+
+# --------------------------------------------------------------------------
+# The identical-source resume must keep working, byte for byte.
+# --------------------------------------------------------------------------
+
+def test_identical_source_still_replays_byte_identically(tmp_path, monkeypatch):
+    run, source = _exporter(tmp_path, monkeypatch)
+    cache = tmp_path / "resume"
+    first = _fill_cache(run, source, cache, weight=_WEIGHT_A, bias=_BIAS_A)
+    first = {k: v.clone() for k, v in first.items()}
+
+    replays: list = []
+    second = run(cache, replay_log=replays)
+
+    assert replays, "an unchanged source stopped resuming"
+    assert set(first) == set(second)
+    for name, value in first.items():
+        assert value.dtype == second[name].dtype, name
+        assert torch.equal(
+            value.view(torch.uint8), second[name].view(torch.uint8)), name
+
+
+# --------------------------------------------------------------------------
+# The fingerprint itself: dtype and the declared buffer-dtype map are bound.
+# --------------------------------------------------------------------------
+
+def _fingerprint(source: Path, **overrides):
+    kwargs = dict(
+        assignment={},
+        model_path=str(source),
+        dtype=torch.bfloat16,
+        declared_buffer_dtypes={"model.layers.0.expert_bias": torch.float32},
+    )
+    kwargs.update(overrides)
+    return export._export_resume_fingerprint(**kwargs)
+
+
+def test_fingerprint_binds_requested_dtype(tmp_path):
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    assert (_fingerprint(source)["requested_dtype"]
+            != _fingerprint(source, dtype=torch.float16)["requested_dtype"])
+
+
+def test_fingerprint_binds_declared_buffer_dtypes(tmp_path):
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    narrowed = _fingerprint(
+        source,
+        declared_buffer_dtypes={"model.layers.0.expert_bias": torch.bfloat16},
+    )
+    assert (_fingerprint(source)["declared_buffer_dtypes"]
+            != narrowed["declared_buffer_dtypes"])
+
+
+def test_fingerprint_source_identity_tracks_content_not_path(tmp_path):
+    """Content identity: the same bytes under a different directory are the
+    same source; a same-size value edit is a different source."""
+    first = tmp_path / "a"
+    second = tmp_path / "b"
+    _write_source(first, weight=_WEIGHT_A, bias=_BIAS_A)
+    _write_source(second, weight=_WEIGHT_A, bias=_BIAS_A)
+    assert (_fingerprint(first)["source_identity"]["content_sha256"]
+            == _fingerprint(second)["source_identity"]["content_sha256"])
+
+    edited = tmp_path / "c"
+    _write_source(edited, weight=_WEIGHT_A, bias=_BIAS_B)
+    assert (_fingerprint(first)["source_identity"]["content_sha256"]
+            != _fingerprint(edited)["source_identity"]["content_sha256"])
+
+
+def test_source_identity_never_degrades_to_none(tmp_path):
+    """`None == None` would admit. A source that cannot be identified must
+    raise, not stamp a null the next run can match."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(Exception):
+        _fingerprint(empty)
+
+
+# --------------------------------------------------------------------------
+# The shared checkpoint-identity helper.
+# --------------------------------------------------------------------------
+
+def test_digest_cache_rehashes_a_same_size_rewrite(tmp_path):
+    """The digest cache keys on the full stat fingerprint (ctime included),
+    so restoring mtime after an in-place same-size rewrite still re-hashes."""
+    import os
+
+    from prismaquant.cost_streaming import build_source_checkpoint_identity
+
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    shard = source / "model.safetensors"
+    stat = shard.stat()
+    cache = tmp_path / "identity_cache.json"
+
+    before = build_source_checkpoint_identity(
+        str(source), digest_cache_path=cache)
+    assert cache.is_file()
+
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_B)
+    assert shard.stat().st_size == stat.st_size
+    os.utime(shard, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+
+    after = build_source_checkpoint_identity(
+        str(source), digest_cache_path=cache)
+    assert before["content_sha256"] != after["content_sha256"]
+
+
+def test_identity_cache_hit_returns_the_same_digest(tmp_path):
+    from prismaquant.cost_streaming import build_source_checkpoint_identity
+
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    cache = tmp_path / "identity_cache.json"
+    first = build_source_checkpoint_identity(str(source), digest_cache_path=cache)
+    second = build_source_checkpoint_identity(str(source), digest_cache_path=cache)
+    assert first == second

--- a/tests/test_export_resume_source_identity.py
+++ b/tests/test_export_resume_source_identity.py
@@ -454,3 +454,24 @@ def test_changed_index_json_is_a_different_source(tmp_path):
 
     assert before["shards"] == after["shards"], "the shard bytes did not move"
     assert before["content_sha256"] != after["content_sha256"]
+
+
+def test_changed_remote_code_module_is_a_different_source(tmp_path):
+    """`trust_remote_code` checkpoints build their skeleton from `*.py` at
+    the checkpoint root (MiniMax-M2, DeepSeek-V4). Editing one changes the
+    module the payloads were quantized through while config.json and every
+    shard stay identical."""
+    from prismaquant.cost_streaming import build_source_checkpoint_identity
+
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    _write_config(source, auto_map={"AutoConfig": "configuration_toy.ToyConfig"})
+    module = source / "modeling_toy.py"
+    module.write_text("HIDDEN = 2\n")
+    before = build_source_checkpoint_identity(str(source))
+
+    module.write_text("HIDDEN = 4\n")
+    after = build_source_checkpoint_identity(str(source))
+    assert before["shards"] == after["shards"], "the shard bytes did not move"
+    assert before["content_sha256"] != after["content_sha256"]
+    assert "modeling_toy.py" in [row["name"] for row in after["metadata"]]

--- a/tests/test_export_resume_source_identity.py
+++ b/tests/test_export_resume_source_identity.py
@@ -3,10 +3,12 @@
 `materialize_tensors_streaming(..., export_cache_dir=...)` saves each
 quantized layer to `layer_NNN.pt` and, on a restart, replays those payloads
 instead of re-reading the source. Admission was decided by
-`_render_lever_provenance()` plus `assignment_hash` alone, so a cache dir
-reused against a DIFFERENT checkpoint replayed the first checkpoint's
-quantized bytes: the render levers and the recipe both still matched, and
-nothing in the manifest named the source (#340).
+`_render_lever_provenance()` alone, so a cache dir reused against a DIFFERENT
+checkpoint replayed the first checkpoint's quantized bytes: the render levers
+still matched and nothing in the manifest named the source (#340). The
+`assignment_hash` beside them was no help either -- `hashlib` was in scope
+nowhere inside that function, so the call raised NameError, the surrounding
+`except Exception` stamped null, and the recipe was never compared.
 
 These tests drive the real exporter on a tiny synthetic checkpoint. They
 assert on the admission decision (was a `layer_*.pt` read at all?) and on the
@@ -316,3 +318,44 @@ def test_a_symlink_snapshot_is_the_same_source_as_the_plain_directory(tmp_path):
 
     assert (build_source_checkpoint_identity(str(plain))["content_sha256"]
             == build_source_checkpoint_identity(str(snapshot))["content_sha256"])
+
+
+# --------------------------------------------------------------------------
+# The recipe. On main `hashlib` was in scope nowhere inside
+# `materialize_tensors_streaming`, so `hashlib.sha256(...)` raised NameError,
+# the surrounding `except Exception` stamped `assignment_hash: null`, and two
+# runs under DIFFERENT recipes compared equal. The swallow is gone; these keep
+# it gone.
+# --------------------------------------------------------------------------
+
+def test_assignment_hash_is_a_real_digest(tmp_path):
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+
+    empty = _fingerprint(source)["assignment_hash"]
+    assert isinstance(empty, str) and len(empty) == 16
+    int(empty, 16)  # raises unless it is really a hex digest
+
+    other = _fingerprint(
+        source, assignment={"model.layers.0.proj": "BF16"})["assignment_hash"]
+    assert empty != other
+
+
+def test_recipe_change_refuses_replay(tmp_path):
+    """Admission is the seam the exporter calls before reading any payload."""
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    cache = tmp_path / "resume"
+    cache.mkdir()
+
+    first = _fingerprint(source, assignment={"model.layers.0.proj": "BF16"})
+    assert export._admit_export_resume_cache(cache, first) is True
+    (cache / "layer_000.pt").write_bytes(b"payload")
+    assert export._admit_export_resume_cache(cache, first) is True, (
+        "an unchanged recipe stopped resuming")
+
+    second = _fingerprint(source, assignment={"model.layers.0.proj": "NVFP4"})
+    assert export._admit_export_resume_cache(cache, second) is False
+    assert not list(cache.glob("layer_*.pt")), (
+        "a recipe change left the previous recipe's payloads replayable")
+    assert json.loads((cache / "manifest.json").read_text()) == second

--- a/tests/test_export_resume_source_identity.py
+++ b/tests/test_export_resume_source_identity.py
@@ -297,3 +297,22 @@ def test_identity_cache_hit_returns_the_same_digest(tmp_path):
     first = build_source_checkpoint_identity(str(source), digest_cache_path=cache)
     second = build_source_checkpoint_identity(str(source), digest_cache_path=cache)
     assert first == second
+
+
+def test_a_symlink_snapshot_is_the_same_source_as_the_plain_directory(tmp_path):
+    """A Hugging Face snapshot dir holds symlinks into `blobs/`, whose
+    resolved names are LFS hashes. The same checkpoint reached either way is
+    one source, so a resume across the two spellings is not refused."""
+    import os
+
+    from prismaquant.cost_streaming import build_source_checkpoint_identity
+
+    plain = tmp_path / "plain"
+    _write_source(plain, weight=_WEIGHT_A, bias=_BIAS_A)
+
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    os.symlink(plain / "model.safetensors", snapshot / "model.safetensors")
+
+    assert (build_source_checkpoint_identity(str(plain))["content_sha256"]
+            == build_source_checkpoint_identity(str(snapshot))["content_sha256"])

--- a/tests/test_export_resume_source_identity.py
+++ b/tests/test_export_resume_source_identity.py
@@ -359,3 +359,98 @@ def test_recipe_change_refuses_replay(tmp_path):
     assert not list(cache.glob("layer_*.pt")), (
         "a recipe change left the previous recipe's payloads replayable")
     assert json.loads((cache / "manifest.json").read_text()) == second
+
+
+# --------------------------------------------------------------------------
+# The source is not only its weight bytes. `config.json` decides the skeleton
+# the payloads were quantized against; the index decides which shard each
+# tensor comes from. Both can change while every shard byte stays identical.
+# --------------------------------------------------------------------------
+
+def _write_config(source: Path, **fields) -> None:
+    payload = {
+        "architectures": ["ToyForCausalLM"],
+        "num_hidden_layers": 1,
+        "tie_word_embeddings": False,
+        "torch_dtype": "bfloat16",
+    }
+    payload.update(fields)
+    (source / "config.json").write_text(json.dumps(payload, indent=2))
+
+
+def test_changed_config_json_refuses_replay(tmp_path, monkeypatch):
+    """Identical shards, one changed field in `config.json`. The cached
+    layers were quantized against the other skeleton, so replay must refuse
+    before any payload is read."""
+    run, source = _exporter(tmp_path, monkeypatch)
+    cache = tmp_path / "resume"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    _write_config(source)
+    run(cache)
+    assert list(cache.glob("layer_*.pt")), "fixture wrote no layer cache"
+
+    _write_config(source, tie_word_embeddings=True)
+    replays: list = []
+    run(cache, replay_log=replays)
+    assert replays == [], (
+        f"replayed payloads quantized against another config.json: {replays}")
+
+
+def test_config_json_is_part_of_the_content_identity(tmp_path):
+    from prismaquant.cost_streaming import build_source_checkpoint_identity
+
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    _write_config(source)
+    before = build_source_checkpoint_identity(str(source))
+
+    _write_config(source, num_hidden_layers=2)
+    after = build_source_checkpoint_identity(str(source))
+    assert before["content_sha256"] != after["content_sha256"]
+    assert [row["name"] for row in before["metadata"]] == ["config.json"]
+
+
+def test_appearing_config_json_is_a_different_source(tmp_path):
+    """An absent file contributes no row, so a config.json that appears
+    later must not compare equal to the run that had none."""
+    from prismaquant.cost_streaming import build_source_checkpoint_identity
+
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    bare = build_source_checkpoint_identity(str(source))
+    assert bare["metadata"] == []
+
+    _write_config(source)
+    assert (build_source_checkpoint_identity(str(source))["content_sha256"]
+            != bare["content_sha256"])
+
+
+def test_changed_index_json_is_a_different_source(tmp_path):
+    """`model.safetensors.index.json` decides which shard a tensor is read
+    from; the shards it names can be byte-identical either way."""
+    from prismaquant.cost_streaming import build_source_checkpoint_identity
+
+    source = tmp_path / "source"
+    source.mkdir(parents=True, exist_ok=True)
+    save_file({"model.layers.0.proj.weight": _WEIGHT_A.clone()},
+              str(source / "model-00001-of-00001.safetensors"))
+    index = source / "model.safetensors.index.json"
+
+    def _write_index(**extra):
+        payload = {
+            "metadata": {"total_size": 8},
+            "weight_map": {
+                "model.layers.0.proj.weight":
+                    "model-00001-of-00001.safetensors",
+            },
+        }
+        payload["metadata"].update(extra)
+        index.write_text(json.dumps(payload, indent=2))
+
+    _write_index()
+    before = build_source_checkpoint_identity(str(source))
+    _write_index(total_size=16)
+    after = build_source_checkpoint_identity(str(source))
+
+    assert before["shards"] == after["shards"], "the shard bytes did not move"
+    assert before["content_sha256"] != after["content_sha256"]


### PR DESCRIPTION
`materialize_tensors_streaming(..., export_cache_dir=...)` saves each quantized
layer to `layer_NNN.pt` and, on a restart, replays those payloads instead of
re-reading the source. Admission was decided by `_render_lever_provenance()`
alone: a manifest that said how the export renders and never what it renders.
Reusing a cache dir against a different checkpoint — at the same path or a
different one — therefore replayed the first checkpoint's quantized bytes,
because the levers matched and nothing compared the source.

Closes #340.

## Correction: the recipe was never compared either

The manifest also carried an `assignment_hash`, and an earlier draft of this
description said "the recipe matched". It did not match; it was never
computed. `hashlib.sha256(...)` was called inside `materialize_tensors_streaming`,
which imports `hashlib` nowhere, in a module that imports it nowhere either —
so the call raised `NameError`, the surrounding `except Exception` set the
field to `None`, and **every manifest ever written carried
`assignment_hash: null`**. Two runs under different recipes compared equal, and
the cache replayed the other recipe's quantized bytes.

This is measured on `origin/main`, not inferred from reading: a throwaway test
in a clean `origin/main` worktree runs the real exporter and asserts the
manifest's `assignment_hash is None` and that `hashlib` is not an attribute of
the module. PB action `41e6e63eb9dd`, rc 0, 2 passed, claim
`8df132bec5ade146ae0eab8d069cdf01e5851e8c38de2f8c31da5e058ce32bef`.

The rewritten admission imports `hashlib` explicitly and swallows nothing, so
the defect is closed by the same commit that closes #340;
`test_assignment_hash_is_a_real_digest` and `test_recipe_change_refuses_replay`
keep it closed. This is a second live defect in the same admission, not a
hypothetical, and it means an in-flight cache could already be holding another
recipe's layers.

## The identity contract

`cost_streaming.build_source_checkpoint_identity()` is the runner-free half of
the existing `build_streamed_model_identity()` contract already used for
streamed cost runs, so this is the same notion of source identity that the
cost path uses, reached without a live streaming runner. It resolves the exact
safetensors set the run consumes — the Hugging Face index union the exporter's
own `weight_shard` values — and returns, per shard, its in-checkpoint name,
byte size and **sha256 of the file contents**.

The weight bytes are not the whole source, so the identity also covers the
**non-shard files the export reads from the checkpoint root**, hashed the same
way and folded into the same `content_sha256`:

| file | what it decides | read at |
|---|---|---|
| `config.json` | the skeleton the payloads were quantized against: dtype map, `tie_word_embeddings`, any `quantization_config`, layer counts | `streaming_model.py:102`, `AutoConfig.from_pretrained(stage_text_only(...))` |
| `model.safetensors.index.json` | which shard each tensor is read from | `_local_checkpoint_shards`, `export_native_compressed.py:6092` |
| every root `*.py`, whether or not `auto_map` names it | a `trust_remote_code` checkpoint builds its skeleton by executing these (MiniMax-M2's `modeling_minimax_m2.py`, DeepSeek-V4's equivalents) | `AutoConfig`/`_from_config` with `trust_remote_code=True`; the export also carries every one of them into the artifact in `_copy_tokenizer` |

Either can change while every shard byte stays identical, and a replayed
`layer_NNN.pt` then means something different from what it was rendered as.
An absent file contributes no row, so one that appears later is a different
source. Binding *every* root `*.py` rather than only the ones
`auto_map` names is deliberately conservative: a generator module nobody
imports can cost a false refusal (a full re-render), never a false admission. `cost_streaming.py` already noted that the shard and index
fingerprints do not cover `config.json` and read it separately; this is the
same fact, folded into the export's own identity.

**What it detects.** Any change to any byte of any shard the export reads,
including a value edit that keeps the file size and the safetensors header
byte-identical — which is exactly the case the issue names, and which a
header-only identity cannot see. A shard added, removed or renamed. Any change
to `config.json`, `model.safetensors.index.json` or any root `*.py`, including
one that leaves every shard untouched.

**What it does not detect.** Checkpoint-root files the export does not build
anything from: `generation_config.json`, tokenizer and preprocessor files.
`_copy_tokenizer(args.model, out_dir)` (`export_native_compressed.py:9417`)
copies each of those from the source unconditionally — it sits at the top level
of `_main_impl`, inside no branch a resume can skip — so no `layer_NNN.pt` can
be stale with respect to them.

**Identity is content, not path.** A relocated checkpoint still resumes. A
Hugging Face snapshot dir of symlinks into `blobs/` and a plain directory of
the same files are one source (third commit — resolving the symlink names each
shard by an LFS hash, which would have been a false refusal costing a full
re-render).

**Why not the HF etag.** `<model>/.cache/huggingface/download/*.metadata`
carries the LFS sha256 for free, and it was rejected as identity: the sidecar
is not rewritten when the shard is edited in place, so a stale etag would admit
precisely the edit the issue is about.

## Manifest fields added

`_export_resume_fingerprint()` folds `_render_lever_provenance()` in whole and
adds:

| field | binds |
|---|---|
| `source_identity` | `{schema, shards:[{name,size,sha256}], metadata:[{name,size,sha256}], content_sha256}` |
| `requested_dtype` | the parameter dtype the source read narrows to |
| `declared_buffer_dtypes` | the skeleton's persistent-buffer dtype map |

The buffer-dtype map is the companion to PR #325's
`persistent_buffer_read_policy`: the policy stamp says the reader is correct,
the map says it was handed the same declarations.

`_render_lever_provenance()` itself is unchanged, so the shipcard echo does not
move. These three are cache-admission facts, not render levers.

## Fail closed

`_admit_export_resume_cache()` decides admission before any `layer_*.pt` is
opened, and refuses — deleting every cached layer and rewriting the manifest —
when the manifest is unreadable, when it is missing any of `source_identity`,
`requested_dtype`, `declared_buffer_dtypes`, `assignment_hash`, or when it
differs. A pre-fix manifest carries none of the first three and is refused as
*invalid*, not treated as a weaker match.

Nothing may degrade to `None`: the comparison is equality and `None == None`
admits. The `except Exception: fp_state["assignment_hash"] = None` swallow that
nulled the recipe hash on every run is gone, and an unidentifiable source
raises.

**Every in-flight export cache invalidates once**, the same one-time cost PR
#325's policy stamp carried. Identical-source resumes are unaffected and stay
byte-identical (`test_identical_source_still_replays_byte_identically`
round-trips every emitted tensor through `view(torch.uint8)`).

## Measured cost

> **Correction (2026-09-09).** This section measured the primitives, and the
> sentence below the second table originally read them as the whole-function
> cost. Reworded in place; the measured numbers are unchanged, and no new
> benchmark was run. The same scope note is on `docs/ARCHITECTURE.md` at the
> identity paragraph.

Read-only, on sparky (GB10), stdlib `hashlib.sha256` over 16 MiB blocks and
`os.stat` — the exact primitives the function uses, timed without a torch
import so the run needs no GPU
(`/home/rob/tmp/pq-340-evidence/measure_identity_cost.py`). Page-cache state on
the first pass is warm/unknown; caches were not dropped.

| checkpoint | `du -sh` | shards | one-time hash | resume (`stat` only) | header-only (rejected) |
|---|---|---|---|---|---|
| `Qwen3.8-27B` snapshot | 52G (51.75 GiB) | 18 | **64.53 s** (861 MB/s) | 0.07 ms | 0.22 ms |
| `Qwen3-4B` | 7.6G (7.49 GiB) | 3 | **9.21 s** (874 MB/s) | 0.03 ms | 0.07 ms |

Second full pass, page-cache warm: 25.51 s and 3.65 s (~2.2 GB/s).

The non-shard files are hashed on **every** call — no digest cache, because
deciding not to hash them would cost more than hashing them. Measured on the
loop as committed, including the `root.glob("*.py")` readdir and the
stat/sha256/stat pair per file, mean of 200 calls
(`/home/rob/tmp/pq-340-evidence/measure_metadata_cost.py`):

| checkpoint | metadata bytes | root `*.py` | added per call |
|---|---|---|---|
| `Qwen3.8-27B` snapshot | 116.5 KB (2 files) | none | **+0.090 ms** |
| `Qwen3-4B` | 33.5 KB (2 files) | none | **+0.059 ms** |

Both tables time the **primitives** the function calls -- a `stat` loop and a
`sha256`/`stat` loop -- not `build_source_checkpoint_identity()` and not
admission. So 0.07 ms + 0.090 ms on the 27B is a floor on the primitive work in
a resume, not the cost of a resume: shard discovery and resolution, the
`source_identity_cache.json` read and write, canonicalization, and
`_admit_export_resume_cache()` are all outside what was timed and remain
**unmeasured**. The one-time full read is unchanged at 64.53 s. Neither checkpoint ships root `*.py` (measured, `ls`), so
the number above is the readdir with nothing to hash; a `trust_remote_code`
checkpoint adds a handful of files of the same order.

The shard hash runs **only when `--export-cache-dir` was passed**, so an export
with no resume cache pays nothing. `source_identity_cache.json`, written beside the
manifest, keys each digest to the shard's full six-field stat fingerprint
(`ctime_ns` included, which `utime` cannot restore after an in-place same-size
rewrite), so the read happens once per (checkpoint, cache dir) and every resume
after it is the `stat`-only column. The cache can only make the identity
cheaper, never different: an unreadable or foreign cache reuses nothing.

## Receipts

All through PrismaBuild at `--priority -10`, dl380g10, `pq-cpu312`
(`--python /home/rob/venvs/pq-cpu312/bin/python --tag x86`, 2 workers/1 thread
per shard).

**Red** — tests alone at `5ec9453a20`, action `8b85498ae175`, rc 1,
**8 failed, 2 passed**:
`test_manifest_without_source_identity_is_refused`,
`test_changed_source_parameter_refuses_replay`,
`test_changed_persistent_buffer_refuses_replay`,
`test_fingerprint_binds_requested_dtype`,
`test_fingerprint_binds_declared_buffer_dtypes`,
`test_identity_cache_hit_returns_the_same_digest`,
`test_fingerprint_source_identity_tracks_content_not_path`,
`test_digest_cache_rehashes_a_same_size_rewrite`.
The two that passed were `test_identical_source_still_replays_byte_identically`
(the behaviour being preserved) and `test_source_identity_never_degrades_to_none`,
which was **vacuous** in the red run: it asserted a bare `Exception` and the
missing symbol's `AttributeError` satisfied it. It now requires
`RuntimeError, match="no safetensors shards"`.

**Green** — at `60c0ca5cae`, 10/10 shards, 95 passed, 0 skipped. Action keys are
the 12-hex prefixes PB printed on the `pbrun: queued` line; the
`local_result_claim_sha256` values are full:

| file | passed | action | `local_result_claim_sha256` |
|---|---:|---|---|
| `test_export_resume_source_identity.py` | 11 | `3e1ad017fe7f` | `13ccafae9652d55cb6091ecfc5a95e6ba21894b8f5d520782dd92b126c5ae9de` |
| `test_export_cache_resume.py` | 7 | `6d4a81058a49` | `d67f8f15ddc403023111bb88e5a2eba9128626efce3a2940d6ebbbf82cd6467e` |
| `test_export_buffer_resume.py` | 2 | `566c47c493b6` | `3d2aa6c1a81f63de2909b4ca7251d6c08702786052f577dd573551b361fd04ad` |
| `test_export_buffer_precision.py` | 4 | `db11b294fd23` | `52024fa1fffec2974f7d2ede151a2573e9b8a34988f9ee813e2035011604c4c9` |
| `test_export_output_safety.py` | 22 | `b0d5593147ad` | `043e9846527aedd555fe0eae1d8893f696ab9cd58f790dc376a35708b85a7e29` |
| `test_streamed_cost_checkpoints.py` | 17 | `86bea50c17aa` | `59f0fba837760ded22f8ae4d787440b0988776b6cea6b87523eed328ef8420b2` |
| `test_cost_stage_checkpoint_manifest.py` | 2 | `5f332b23908a` | `68c465341c74e52e9857c55d9465d6ac680378f8c5395cf4577d7f7770742dac` |
| `test_source_prefetch.py` | 11 | `465e22f7ee45` | `9df66e9d314854e3387ebd2c9f6e78b1165fd57ac350bb40b0b2adf57ca138df` |
| `test_docs_staleness.py` | 6 | `61c697529773` | `4b3e9b5c8c1b4c36125f6e12f27fae1e81c404fc16e64875e81f4bd2c4e83991` |
| `test_architecture_doc.py` | 13 | `03df393d111e` | `9aae9f0e91fd58da9b48b365eca0640f7ea8d3e5367d33fde2819f229f2c6e4d` |

**Green, re-run after the recipe guard** — at `6ed8e3b1`, 3/3 shards,
22 passed:

| file | passed | action | `local_result_claim_sha256` |
|---|---:|---|---|
| `test_export_resume_source_identity.py` | 13 | `e36a69a68db5` | `c0d368264463d4e20f77d053811ca580f9b5fb0ed2eafdb759de0496d3d8d6e2` |
| `test_export_cache_resume.py` | 7 | `d1fbae574d38` | `f68dc28edd8318b4d0e6fe19d7450a7e7dabf3ff297a23f672f435e39b666de8` |
| `test_export_buffer_resume.py` | 2 | `a7440449fc5f` | `9322dd61d40de5b72e492614031613f153e5332ede77ae8de68039e86b2982c1` |

The other seven files are untouched by that commit, which changed one test file
and two docstrings.

**Red, non-shard identity** — tests alone at `95fa42b58`, action
`3b24f6819e74`, rc 1, **4 failed, 13 passed**:
`test_changed_config_json_refuses_replay` (the end-to-end one: it replayed the
payloads quantized against the other `config.json`),
`test_config_json_is_part_of_the_content_identity`,
`test_appearing_config_json_is_a_different_source`,
`test_changed_index_json_is_a_different_source`. No failing shard emits a
`local_result_claim_sha256`.

**Green, non-shard identity** — at `c30026ca0`, 8/8 shards, **75 passed**. The
two cost-checkpoint files are in scope because this commit changes
`cost_streaming.py`:

| file | passed | action | `local_result_claim_sha256` |
|---|---:|---|---|
| `test_export_resume_source_identity.py` | 17 | `0e32712d01d0` | `4d0315b616576a5db55ea9a6c1eacdf7285b87917b46d278d8e69500d9dae5c3` |
| `test_export_cache_resume.py` | 7 | `d470a3733d41` | `5e7d0f885938a8cfd50e4879d65bd36d6d5e1f9b6c35f0998c9b1eb1588c8ce0` |
| `test_export_buffer_resume.py` | 2 | `1c34ede5bdaf` | `6fe020f75bbf548012e8a65dfe5f1d911eeefaad75afb296239f2b6125c01b7f` |
| `test_streamed_cost_checkpoints.py` | 17 | `334a08cf7c20` | `594e5f179a5c594a9716c8401da3de46d5242dbff06703ace9f28b0d7f0881e2` |
| `test_cost_stage_checkpoint_manifest.py` | 2 | `ca61d3dbd49e` | `7e68292cca7fca6797cd54351c61018b631ff35966287cbf72d72307e37c5ab0` |
| `test_source_prefetch.py` | 11 | `8deb6c96b720` | `73117cdca5166ba65d1a098a8bab9d521971f8478a18130e9c7f1bcc8691a1cb` |
| `test_docs_staleness.py` | 6 | `ffc48f98a1c0` | `ae60087da81cfb95c05485f6b16ef9d20dcae9244ff3be9fedc024fd1e4bb0a0` |
| `test_architecture_doc.py` | 13 | `96cf632ef9c6` | `d0db1ebdbf5b6fae8a2c1c86880833b51b3356f84f6308f07590d88866789b04` |

**Red, remote-code modules** — test alone at `a89d0d01c`, action
`dc6481b6b022`, rc 1, **1 failed, 17 passed**:
`test_changed_remote_code_module_is_a_different_source`.

**Green** — at `5cfb4d6f4`, 8/8 shards, **76 passed**:

| file | passed | action | `local_result_claim_sha256` |
|---|---:|---|---|
| `test_export_resume_source_identity.py` | 18 | `e54ee68223a8` | `55866a3c8f34570d6c6696299625c24e97459aff42df3bb67193d17a978bad62` |
| `test_export_cache_resume.py` | 7 | `594f00d7b215` | `cbf37b6fa1da3db3645495a84c3670fbae25a9da35bd6882b8a2d6b06ed32a2c` |
| `test_export_buffer_resume.py` | 2 | `e4f48636d266` | `f8798792f7a582afa5c773b51e7c55b7d08711ebc8935530cdaafd4e926b838f` |
| `test_streamed_cost_checkpoints.py` | 17 | `7c5b6e7f3182` | `f177671b9239aa55e381b84acdc86aaedaceef4b641710604d734bc6d03095d0` |
| `test_cost_stage_checkpoint_manifest.py` | 2 | `814b4c17a03d` | `949218a76975b099a422f9b4e80c7433f72ac7c045662c69a92a0472b46fca42` |
| `test_source_prefetch.py` | 11 | `374740526e05` | `a7d6dcd5713f19d123663b2292b8654e3c4750311358e31490928ecd9ea9feeb` |
| `test_docs_staleness.py` | 6 | `dd46dd667c42` | `8dc8ee26ca40dc1e03cb3b498059aa411851da72ad7149235bd88637b9e79ca3` |
| `test_architecture_doc.py` | 13 | `89ce29768aff` | `4128b656c04fc0cc8d26f3c68b780cb36a36de2e54d86a7c0f7721369758fba6` |

**Green, final** — at `ecb0e292e` (the prose-only precision commit; the same
eight files, re-run because `cost_streaming.py` and `ARCHITECTURE.md` changed),
8/8 shards, **76 passed**:

| file | passed | action | `local_result_claim_sha256` |
|---|---:|---|---|
| `test_export_resume_source_identity.py` | 18 | `795089c39ab5` | `1daf8f03061e8f8ecdda35e334d385e845faaef9e2f8fb3bd36c39565e2f70c3` |
| `test_export_cache_resume.py` | 7 | `4dc58dbc7d1e` | `90e32aff78ffa796e10f5df7d92dbc3b6696e5852d5dbb6f9578a92227d87e6b` |
| `test_export_buffer_resume.py` | 2 | `470d3560653e` | `2872ca6e1a9071fe1ebc2116fa02e5a8ff056c46f1d49b03d049be2674978f03` |
| `test_streamed_cost_checkpoints.py` | 17 | `d77b18f8f421` | `eec474d36f63758bd6aa68546c1b4e3311c020e3e642af10a39cd0e2038a9163` |
| `test_cost_stage_checkpoint_manifest.py` | 2 | `0a919e6f276c` | `6ee238dd7985c254661a53412661ca16a00a6c863f43feadcfad855619555dce` |
| `test_source_prefetch.py` | 11 | `e07b4b3543c4` | `2fd4a45f259d16fe4cf252bc02f3ce21c2cde34bb16bde439e3bfe9e3c438bba` |
| `test_docs_staleness.py` | 6 | `7c70e8d5d337` | `7ab635d5296b7cb8a1390e49af31825c23d9f8c20aeab3ba8d76505ad503e5c6` |
| `test_architecture_doc.py` | 13 | `08c7dae289ae` | `adc9e959fc6aac775c3309ea78532d52efa10cb27b8581ce3727830c9ca289ac` |

The earlier tables above are superseded by this one for the files they
share; they are kept because each records the state its own commit was in.
Eight files were run where the follow-up asked for three: the two
cost-checkpoint files because `cost_streaming.py` changed, and the docs pair
because `docs/ARCHITECTURE.md` did. Superset, not substitution.

The new tests drive the real streaming exporter over a tiny synthetic
checkpoint (the `tests/test_export_buffer_resume.py` fixture pattern: only
architecture construction is replaced; the source read, the cache and the
emission are the real paths) and assert on the admission decision itself —
whether any `layer_*.pt` was read, via a `torch.load` spy — not only on the
emitted bytes.

## Not run, and gaps

- `tests/test_prismaquant_export_native_compressed.py` **cannot be collected in
  `pq-cpu312`**: `prismaquant.tessera_formats` requires the `tessera` package,
  which is not installed there. Verified pre-existing on unmodified
  `origin/main` `01583d6d00`, action `c8191b25254a`, same 2 collection errors.
  Not a regression from this branch; the environment doc records that
  Tessera-dependent tests still need their pinned source.
- No GPU export, no large-model export, and no served-artifact gate were run.
  The measured number is the identity cost alone, not an end-to-end export
  delta; the export's own read of the same bytes is unchanged.
- The identity covers the safetensors shards, `config.json`,
  `model.safetensors.index.json` and every root `*.py`. Checkpoint-root files
  the export builds nothing from are outside it by construction, not by
  omission: `_copy_tokenizer` re-copies them from the source on every
  invocation, so a resume cannot serve a stale one.
- The digest cache is per export-cache-dir, so two cache dirs over one
  checkpoint each pay the one-time hash once.
- `test_recipe_change_refuses_replay` drives `_admit_export_resume_cache()`
  directly — the seam the exporter calls before opening any payload — rather
  than an end-to-end export under two real recipes, because the synthetic 2x2
  fixture cannot carry a second servable format. It places a real `layer_*.pt`,
  asserts the unchanged recipe still resumes, and asserts the changed one
  refuses and deletes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZQ6PS8BDL7q7s5HUNzs6L

