### PR TITLE
Report measured AURA progress without misleading resume ETA

### DIFF
--- a/prismaquant/aura_cost.py
+++ b/prismaquant/aura_cost.py
@@ -3090,19 +3090,17 @@ def compute_aura_cost_streamed(
                         **({"execution_provenance": source_transition.execution_provenance}
                            if source_transition is not None else {})},
                     )
-            # Closed-loop observability: a reverse layer is minutes of silent
-            # render+adjoint work at streamed scale, so each one reports its
-            # own rate and the sweep ETA the moment it lands.
+            # Report measured progress without extrapolating a layer rate:
+            # resumed layers and dense/MoE layers can have very different costs.
             reverse_layers_done += 1
             if pending:
                 elapsed = time.time() - reverse_started
-                rate = reverse_layers_done / max(elapsed, 1e-9)
                 remaining = runner.num_layers - reverse_layers_done
                 _log(
                     f"reverse layer {layer} done "
                     f"({reverse_layers_done}/{runner.num_layers}, "
                     f"{len(pending)} unit(s), {elapsed / 60:.1f} min elapsed, "
-                    f"ETA {remaining / rate / 60:.1f} min)"
+                    f"{remaining} layer(s) remaining)"
                 )
         finally:
             for parameter in parameters.values():


### PR DESCRIPTION
Closes #349.

After a checkpoint resume, quickly reused reverse layers inflate the average layer rate: the current run still had unfinished layers 39 minutes after reporting a 9.3-minute ETA. Report measured elapsed time and the remaining layer count instead. Dense and MoE layers also have different costs, so this change removes the unsupported extrapolation.

This changes progress text only. The active run keeps its frozen source and original log. No new tests mirror the text edit; the live log demonstrates the defect. A PrismaBuild CPU compile check passed (one CPU, 1 GiB, no GPU), action `d2dd570b95f10a197b94a9b6824f4385a12d35e0e38375d961f0ca8484dbb000`. Exit 0, complete cleanup, exact source bundle and actual CAS payload were verified in `/home/rob/tmp/aura-progress-root-cas-audit.json`.
