### PR TITLE
Honor declared dispatch identity rules and repair prefix validation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,16 @@
 As of: 2026-09-07 · `codex/joint-fused-promotion-20260907`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-07, `fix/profile-dispatch-identity`) for declared
+scheme-dispatch identity rewrites. `ModelProfile.to_vllm_internal_name()` now
+honors a matched structure-spec rule even when the spelling stays unchanged.
+The existing `mtp.` identity/stop rule therefore remains authoritative when
+the body runtime's weight-loader map drops or renames MTP keys. Native-causal
+body identity rules are preserved for the same reason; unmatched names still
+use the existing runtime fallback. No profile, mapping declaration, format or
+serving lane is added. CPU regressions cover both drop and rename destinations,
+unchanged body names, completed rewrite chains and unmatched fallbacks.
+
 Re-stamped (2026-09-07, `fix/joint-source-transition-integration`) for the explicit
 `empty_joint_lease_v1` transition. Its sole approved source closure is the
 interrupted first-model joint run's exact producer package. A CPU preflight

--- a/prismaquant/model_profiles/base.py
+++ b/prismaquant/model_profiles/base.py
@@ -570,7 +570,12 @@ class ModelProfile(ABC):
         spec = self.structure_spec()
         if spec is not None and spec.recipe_to_vllm:
             mapped = spec.rewrite_recipe_to_vllm(checkpoint_name)
-            if mapped != checkpoint_name:
+            # An explicit identity rule is still authoritative. In particular,
+            # MTP scheme-dispatch names must not fall through to the body's
+            # weight-loader map, which may drop or rename that namespace.
+            if mapped != checkpoint_name or any(
+                rule.apply(checkpoint_name)[1] for rule in spec.recipe_to_vllm
+            ):
                 return mapped
         return self._name_remapper(checkpoint_name)
 

--- a/prismaquant/model_profiles/qwen3_5.py
+++ b/prismaquant/model_profiles/qwen3_5.py
@@ -130,9 +130,9 @@ class Qwen3_5Profile(ModelProfile):
         """vLLM class to read `packed_modules_mapping` +
         `hf_to_vllm_mapper` from. The base class auto-derives
         `fused_sibling_group()` and the body-part of
-        `to_vllm_internal_name()` from these two attributes. We only
-        override `to_vllm_internal_name()` below to handle the MTP
-        prefix specially."""
+        `to_vllm_internal_name()` from these two attributes. The structure
+        spec's explicit MTP identity rule keeps scheme-dispatch names in
+        their separate `mtp.` namespace."""
         if self._declared_moe_layout() == "native_causal":
             return "Qwen3_5MoeForCausalLM"
         return "Qwen3_5MoeForConditionalGeneration"

--- a/prismaquant/model_profiles/qwen3_5.py
+++ b/prismaquant/model_profiles/qwen3_5.py
@@ -10,9 +10,8 @@ this producer family: its outer config is ``qwen3_5_moe`` with architecture
 ``Qwen3_5MoeForConditionalGeneration``.  Its routed experts are already
 packed as ``gate_up_proj`` / ``down_proj`` tensors (256 experts, top-8), while
 the one shared expert per layer remains split as gate/up/down Linears.  Keep
-the producer id ``qwen3_5``: that is the id declared by Gridbook's serving
-contract, and inventing a release-name ``qwen3_6`` id would make an otherwise
-supported checkpoint fail closed at the repository boundary.
+the producer id ``qwen3_5`` aligned with the checkpoint's actual model family;
+the release name ``qwen3_6`` is not a separate producer architecture.
 
 The naming conventions PrismaQuant must juggle:
 

--- a/prismaquant/model_profiles/validate.py
+++ b/prismaquant/model_profiles/validate.py
@@ -29,9 +29,10 @@ Checks performed:
      truth.
 
   4. **Name remap fixed points.** For every
-     `orig_to_new_prefix` entry in vLLM's `hf_to_vllm_mapper`,
-     `profile.to_vllm_internal_name(orig_prefix + ".x")` starts with
-     the expected `new_prefix`.
+     string-destination `orig_to_new_prefix` entry in vLLM's
+     `hf_to_vllm_mapper`, a probe at a real component boundary starts
+     with the expected `new_prefix`. Loader-only drops (`None`)
+     are counted separately and excluded from dispatch-name checks.
 
   5. **MTP module construction** (if `has_mtp()` is True). The
      profile can instantiate an MTP module from the model's text
@@ -230,8 +231,14 @@ def _check_name_remap(profile) -> CheckResult:
         return CheckResult("to_vllm_internal_name() obeys vLLM's prefix map",
                            True, "vLLM class has no hf_to_vllm_mapper")
     failures = []
+    excluded_drops = 0
     for src, dst in prefix_map.items():
-        probe_name = src + "x.y"
+        # Loader-only drops have no dispatch destination to cross-check.
+        if dst is None:
+            excluded_drops += 1
+            continue
+        separator = "" if not src or src.endswith(".") else "."
+        probe_name = src + separator + "x.y"
         got = profile.to_vllm_internal_name(probe_name)
         expected_prefix = dst
         if not got.startswith(expected_prefix):
@@ -240,7 +247,8 @@ def _check_name_remap(profile) -> CheckResult:
         return CheckResult("to_vllm_internal_name() obeys vLLM's prefix map",
                            False, "; ".join(failures))
     return CheckResult("to_vllm_internal_name() obeys vLLM's prefix map",
-                       True, f"{len(prefix_map)} prefix rewrites agree")
+                       True, f"{len(prefix_map) - excluded_drops} prefix rewrites agree; "
+                       f"{excluded_drops} loader-only drops excluded")
 
 
 def _check_mtp(profile, cfg: dict, model_path: str) -> CheckResult:

--- a/tests/test_profile_identity_rewrites.py
+++ b/tests/test_profile_identity_rewrites.py
@@ -1,0 +1,44 @@
+"""Declared identity rewrites must remain authoritative at scheme dispatch."""
+from dataclasses import replace
+
+import pytest
+
+from prismaquant.model_profiles.qwen3_5 import Qwen3_5Profile
+from prismaquant.model_profiles.qwen3_5_dense import Qwen3_5DenseProfile
+from prismaquant.model_profiles.registry import profile_from_config
+from prismaquant.model_profiles.structure import NameRewriteRule
+from prismaquant.model_profiles.vllm_registry import name_remapper_from_prefix_map
+
+
+@pytest.mark.parametrize("profile_type", [Qwen3_5Profile, Qwen3_5DenseProfile])
+@pytest.mark.parametrize("runtime_destination", [None, "model."])
+def test_declared_mtp_identity_survives_runtime_loader_drop_or_rename(profile_type, runtime_destination):
+    profile = profile_type()
+    profile._name_remapper = name_remapper_from_prefix_map({"mtp.": runtime_destination})
+    name = "mtp.layers.0.mlp.experts.down_proj"
+    assert profile.to_vllm_internal_name(name) == name
+
+
+def test_native_body_identity_is_not_overwritten_by_runtime_fallback():
+    profile = profile_from_config({"model_type": "qwen3_5_moe_text",
+                                   "architectures": ["Qwen3_5MoeForCausalLM"]})
+    profile._name_remapper = name_remapper_from_prefix_map({"model.": "language_model.model."})
+    name = "model.layers.0.mlp.experts.down_proj"
+    assert profile.to_vllm_internal_name(name) == name
+
+
+def test_unmatched_name_still_uses_runtime_mapper():
+    profile = Qwen3_5Profile()
+    profile._name_remapper = name_remapper_from_prefix_map({"other.": "runtime.other."})
+    assert profile.to_vllm_internal_name("other.proj") == "runtime.other.proj"
+
+
+def test_matched_rewrite_chain_returning_original_name_remains_authoritative(monkeypatch):
+    profile = Qwen3_5Profile()
+    spec = replace(profile.structure_spec(), recipe_to_vllm=(
+        NameRewriteRule(prefix="model.", replace="temporary."),
+        NameRewriteRule(prefix="temporary.", replace="model.", stop=True),
+    ))
+    monkeypatch.setattr(profile, "structure_spec", lambda: spec)
+    profile._name_remapper = name_remapper_from_prefix_map({"model.": "wrong."})
+    assert profile.to_vllm_internal_name("model.proj") == "model.proj"

--- a/tests/test_profile_name_remap_validation.py
+++ b/tests/test_profile_name_remap_validation.py
@@ -1,0 +1,44 @@
+"""Runtime loader drops and component prefixes are not dispatch rewrites."""
+from types import SimpleNamespace
+
+import pytest
+
+from prismaquant.model_profiles import vllm_registry
+from prismaquant.model_profiles.validate import _check_name_remap
+
+
+def check(monkeypatch, mapping, rewrite):
+    monkeypatch.setattr(vllm_registry, "vllm_class_for_architecture", lambda _: object)
+    monkeypatch.setattr(vllm_registry, "hf_to_vllm_prefix_map_from_class", lambda _: mapping)
+    return _check_name_remap(SimpleNamespace(
+        vllm_architecture_class=lambda: "Example", to_vllm_internal_name=rewrite,
+    ))
+
+
+def test_loader_drop_is_excluded_and_reported(monkeypatch):
+    seen = []
+    def rewrite(name):
+        seen.append(name)
+        return name.replace("model.", "body.", 1)
+    result = check(monkeypatch, {"mtp.": None, "model.": "body."}, rewrite)
+    assert result.ok
+    assert seen == ["model.x.y"]
+    assert "1 prefix rewrites agree" in result.detail
+    assert "1 loader-only drops excluded" in result.detail
+
+
+@pytest.mark.parametrize("source", ["model.vision_tower", "model.vision_tower."])
+def test_probe_starts_a_real_component(monkeypatch, source):
+    seen = []
+    def rewrite(name):
+        seen.append(name)
+        return name.replace("model.vision_tower.", "vision.", 1)
+    result = check(monkeypatch, {source: "vision."}, rewrite)
+    assert result.ok
+    assert seen == ["model.vision_tower.x.y"]
+
+
+def test_incorrect_rewrite_still_fails(monkeypatch):
+    result = check(monkeypatch, {"model.": "body."}, lambda name: name)
+    assert not result.ok
+    assert "expected prefix 'body.'" in result.detail


### PR DESCRIPTION
Closes #352.

Declared structure-spec identity rules now stop name resolution before the runtime loader fallback. For example, `mtp.layers.0.*` stays in its MTP scheme-dispatch namespace even when the body loader maps MTP keys to `None` or `model.`. Unmatched names retain the existing fallback. A separate commit fixes conformance probes to use component boundaries and report loader-only drops as excluded rather than attempting `startswith(None)`. A third prose-only commit removes the retired Gridbook contract from the Qwen producer rationale. Architecture provenance is updated.

Validation through PrismaBuild, CPU only, native threads bounded to one:

- Existing native export failure reproduced on unmodified main `01583d6d00` in the pinned ARM container (`e89f31a227d3…`). Portable naming regressions: 6 failed, 1 passed before the fix (`441424fb64df…`); focused ARM integration after the fix: 8 passed (`9fdf5a623a57…`).
- Portable validator regressions: 2 failed, 2 passed before the fix (`14106e2b5b68…`).
- Final independent branch `c4a9c2d9c5`, based on main `eee9d8ace4`: **1103 passed, 36 skipped, 1 xfailed**, action `f6e642aea547ac8faaece2bc6fb9b6f96d64c5c1e550fa2db648f079f22cd99f`, Sparky ARM CPU container, 4 CPUs / 8 GiB. Skips: 24 checkpoint-dependent tests without `PQ_CONFORMANCE_MODELS`, 12 fallback/documentation/parse-marker cases. The expected failure is the existing `RuntimePackageSpec.module` missing reader.
- Verified terminal exit 0, CAS payload and receipt hashes, complete resource cleanup/release, and exact production/test/architecture bytes against the branch. Evidence: `/mnt/shared/tessera-measurements/pq-pr348-review-20260907/profile-validator-final-verified.json`, with adjacent logs and red/green evidence packets.

No GPU execution, serving measurement, format change, or performance claim. PR #348 and active measurement source closures remain untouched.
