### PR TITLE
Bind export resumes to source identity and refuse orphaned layers

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,8 @@ in: `source_identity` (the sha256 of every safetensors shard the run consumes
 AND of the non-shard files it reads from the checkpoint root — `config.json`,
 which decides the skeleton the payloads were quantized against, and
 `model.safetensors.index.json`, which decides where each tensor is read from,
-and any root `*.py` a `trust_remote_code` checkpoint is built through — via the
+and every root `*.py` (all of them, not only the ones `auto_map` names), which
+a `trust_remote_code` checkpoint is built through — via the
 shared `cost_streaming.build_source_checkpoint_identity()`),
 `requested_dtype`, and `declared_buffer_dtypes`, and it computes the recipe
 hash with no swallow. `_admit_export_resume_cache()` decides admission

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,27 @@
 As of: 2026-09-07 · `codex/joint-fused-promotion-20260907`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-07, `triage/340-export-resume-source-identity`) for the
+standalone compressed-tensors export resume cache's **source identity** (#340).
+`--export-cache-dir` replays `layer_NNN.pt` payloads whenever the manifest
+matches. The manifest bound the render levers and the assignment hash and named
+no source, so the same cache dir reused against a different checkpoint replayed
+the first checkpoint's quantized bytes. `_export_resume_fingerprint()` now adds
+three fields the payloads silently bake in: `source_identity` (the sha256 of
+every safetensors shard the run consumes, via the shared
+`cost_streaming.build_source_checkpoint_identity()`), `requested_dtype`, and
+`declared_buffer_dtypes`. `_admit_export_resume_cache()` decides admission
+before any payload is read and fails closed: a manifest missing any of those
+keys — every pre-fix cache — is refused, not treated as a weaker match, and no
+field may degrade to `None`. Identity is CONTENT, not path: a relocated
+checkpoint still resumes, a same-size same-header value edit does not. The hash
+runs only when a cache dir was requested, and a `source_identity_cache.json`
+beside the manifest keys each digest to the shard's full stat fingerprint
+(`ctime_ns` included), so a resume costs one `stat` per shard. Gate:
+`tests/test_export_resume_source_identity.py`, which drives the real streaming
+exporter and asserts on whether a `layer_*.pt` was read at all. No served
+artifact gate is claimed.
+
 Re-stamped (2026-09-07, `fix/joint-source-transition-integration`) for the explicit
 `empty_joint_lease_v1` transition. Its sole approved source closure is the
 interrupted first-model joint run's exact producer package. A CPU preflight
@@ -9891,8 +9912,11 @@ allocator/floor distinction on disk, so `breakdown.dense` is `0` there by constr
 the split is only meaningful in the pre-export `assignment_read_traffic` form.
 
 Also on the card: exact `artifact_bytes`, format histogram, the render-lever
-echo (`_render_lever_provenance()`, shared with the export cache's fingerprint so the two
-cannot drift), and the `PRISMAQUANT_ALLOW_KV_SHARED_FISHER` / `PRISMAQUANT_KV_COTANGENT` state
+echo (`_render_lever_provenance()`, which the export cache's fingerprint folds in whole so
+the render levers cannot drift between the two; the cache additionally binds the source
+checkpoint identity, requested dtype and declared buffer dtypes, which are cache-admission
+facts rather than render levers — see the #340 stamp), and the
+`PRISMAQUANT_ALLOW_KV_SHARED_FISHER` / `PRISMAQUANT_KV_COTANGENT` state
 so an allocation that rode an unvalidated Fisher correction is visible on the artifact rather
 than only in a probe log (D24) — and since 2026-09-03 `verify` refuses a card carrying
 `unvalidated_kv_fisher_correction=true`, and shape-replays the stamped forensic hashes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,8 +15,9 @@ and the swallowed `NameError` stamped a null on every manifest ever written.
 in: `source_identity` (the sha256 of every safetensors shard the run consumes
 AND of the non-shard files it reads from the checkpoint root — `config.json`,
 which decides the skeleton the payloads were quantized against, and
-`model.safetensors.index.json`, which decides where each tensor is read from —
-via the shared `cost_streaming.build_source_checkpoint_identity()`),
+`model.safetensors.index.json`, which decides where each tensor is read from,
+and any root `*.py` a `trust_remote_code` checkpoint is built through — via the
+shared `cost_streaming.build_source_checkpoint_identity()`),
 `requested_dtype`, and `declared_buffer_dtypes`, and it computes the recipe
 hash with no swallow. `_admit_export_resume_cache()` decides admission
 before any payload is read and fails closed: a manifest missing any of those

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,13 +6,19 @@ follow, newest first, each recording its own branch and date.
 Re-stamped (2026-09-07, `triage/340-export-resume-source-identity`) for the
 standalone compressed-tensors export resume cache's **source identity** (#340).
 `--export-cache-dir` replays `layer_NNN.pt` payloads whenever the manifest
-matches. The manifest bound the render levers and the assignment hash and named
-no source, so the same cache dir reused against a different checkpoint replayed
-the first checkpoint's quantized bytes. `_export_resume_fingerprint()` now adds
-three fields the payloads silently bake in: `source_identity` (the sha256 of
-every safetensors shard the run consumes, via the shared
-`cost_streaming.build_source_checkpoint_identity()`), `requested_dtype`, and
-`declared_buffer_dtypes`. `_admit_export_resume_cache()` decides admission
+matches. The manifest bound the render levers and named no source, so the same
+cache dir reused against a different checkpoint replayed the first checkpoint's
+quantized bytes; the `assignment_hash` beside them compared nothing either,
+because `hashlib` was in scope nowhere inside `materialize_tensors_streaming`
+and the swallowed `NameError` stamped a null on every manifest ever written.
+`_export_resume_fingerprint()` now adds three fields the payloads silently bake
+in: `source_identity` (the sha256 of every safetensors shard the run consumes
+AND of the non-shard files it reads from the checkpoint root — `config.json`,
+which decides the skeleton the payloads were quantized against, and
+`model.safetensors.index.json`, which decides where each tensor is read from —
+via the shared `cost_streaming.build_source_checkpoint_identity()`),
+`requested_dtype`, and `declared_buffer_dtypes`, and it computes the recipe
+hash with no swallow. `_admit_export_resume_cache()` decides admission
 before any payload is read and fails closed: a manifest missing any of those
 keys — every pre-fix cache — is refused, not treated as a weaker match, and no
 field may degrade to `None`. Identity is CONTENT, not path: a relocated

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,7 +34,10 @@ field may degrade to `None`. Identity is CONTENT, not path: a relocated
 checkpoint still resumes, a same-size same-header value edit does not. The hash
 runs only when a cache dir was requested, and a `source_identity_cache.json`
 beside the manifest keys each digest to the shard's full stat fingerprint
-(`ctime_ns` included), so a resume costs one `stat` per shard. Gate:
+(`ctime_ns` included), so unchanged shards can reuse their recorded content
+digests. Resume still performs source discovery, metadata reads, digest-cache
+JSON handling, identity construction and manifest admission; primitive stat
+timings do not measure that full path. Gate:
 `tests/test_export_resume_source_identity.py`, which drives the real streaming
 exporter and asserts on whether a `layer_*.pt` was read at all. No served
 artifact gate is claimed.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,13 @@
 As of: 2026-09-07 · `codex/joint-fused-promotion-20260907`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-07, `fix/pr348-orphan-cache-root`) for missing-manifest
+export-cache refusal. Existing `layer_*.pt` files without a manifest are
+discarded through the same refusal path as mismatched fingerprints before
+any layer can be replayed. A fresh empty cache retains its initialization
+behavior. Real streaming-export regressions check emitted bytes and absence
+of orphaned payload reads for both unchanged and changed source weights.
+
 Re-stamped (2026-09-07, `triage/340-export-resume-source-identity`) for the
 standalone compressed-tensors export resume cache's **source identity** (#340).
 `--export-cache-dir` replays `layer_NNN.pt` payloads whenever the manifest

--- a/docs/results/export_resume_source_identity_review_2026-09-07.md
+++ b/docs/results/export_resume_source_identity_review_2026-09-07.md
@@ -1,0 +1,55 @@
+# Export resume identity review — 2026-09-07
+
+The standalone compressed-tensors exporter binds resumable layer payloads to
+source shard/config/index/root-Python content, requested parameter dtype,
+persistent-buffer dtype declarations, render policy and assignment. Matching
+inputs retain replay; changed inputs discard old layer payloads through the
+existing admission path. This completes the source identity work in issue #340.
+
+Independent review found one remaining admission hole at author head
+`ecb0e292e91da127c92c6a92a1a06c9c77a79bc9`: deleting `manifest.json` left
+`layer_*.pt` files eligible for replay after writing a new fingerprint. A changed
+source could therefore emit the previous source's weights. The same-source
+orphan also lacked any bound identity. Two real streaming-export regressions
+failed before the correction, action
+`daa537459dba50c00440525dbb30fc4db6a1c1dd1be56fa2f6fce349c41db2ac`.
+They inspect emitted tensors and spy on actual cached-layer loads; only the
+small CPU model skeleton is substituted.
+
+The correction sends missing-manifest caches containing layer payloads through
+the existing refusal path. Fresh empty caches retain initialization behavior.
+The original author's commits are retained, with the review correction and
+prose scope changes in separate commits on a separate integration branch.
+The author checkout and measurement checkouts remain untouched.
+
+After the correction, PrismaBuild action
+`adc5e166123d01a67fd9a5acb4ce870ce52cf330ed9c0bb98e06dcc56181eb9a`
+passed 239 tests and 163 subtests in 9.21 seconds. Final integration with main
+`4f201a6470b1ea8b2837a039f7807ed94e867a31` passed the same 239 tests and
+163 subtests in 9.47 seconds, action
+`3ce3152c3d69e8f16def072a2c515010b856fa8c0c558e4557816e963ab1a2b0`.
+There were no skips or missing collections; both touched producer modules
+compiled in the final action. Both ran on DL380 CPU, four workers/8 GiB total,
+native threads one, using the scoped Python 3.12 CPU environment and recorded
+Tessera producer source dependency. Exact source snapshots, actual terminal
+exits, logs, CAS receipts/payloads and complete resource cleanup were checked.
+The final tested source differs from `d7212ed230` only in the generated PB
+closure file; the dated report added afterward changes no implementation.
+
+Test selection: `tests/test_pr348_review_regressions.py`,
+`tests/test_export_resume_source_identity.py`,
+`tests/test_prismaquant_export_native_compressed.py`,
+`tests/test_export_buffer_precision.py`, `tests/test_export_output_safety.py`,
+`tests/test_architecture_doc.py`, and `tests/test_docs_staleness.py`, with
+`pytest -q -n4 --dist worksteal -p no:cacheprovider` through the published PB
+client. Exact commands and audits are retained in
+`/home/rob/tmp/pr348-root-final-command.json`,
+`/home/rob/tmp/pr348-orphan-root-green-audit.json`, and
+`/home/rob/tmp/pr348-root-final-cas-audit.json`. The earlier independent
+review packet is `/mnt/shared/tessera-measurements/pq-pr348-review-20260907/REVIEW.md`.
+
+No full export identity/admission runtime was benchmarked. Cached shard
+digests avoid rereading unchanged shard contents; source discovery, metadata
+hashing, digest-cache JSON handling and identity construction still execute.
+Primitive hash/stat measurements do not establish total resume latency.
+No GPU, vLLM serving, format change or artifact ship qualification is claimed.

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -505,6 +505,20 @@ def build_source_checkpoint_identity(
             f"{root}; refusing to stamp an unidentified source"
         )
     ordered = sorted(shard_paths, key=str)
+    # Name each shard by its position INSIDE the checkpoint. A Hugging Face
+    # snapshot dir holds symlinks into `blobs/`, so the resolved path is named
+    # by an LFS hash; naming shards by that would make the SAME checkpoint
+    # reached through a snapshot and through a plain directory two different
+    # sources. Recover the in-checkpoint spelling from the directory listing.
+    name_by_resolved: dict[str, str] = {}
+    if root.is_dir():
+        for entry in root.rglob("*.safetensors"):
+            try:
+                name_by_resolved.setdefault(
+                    str(entry.resolve()), str(entry.relative_to(root))
+                )
+            except (OSError, ValueError):
+                continue
 
     reusable = (
         _read_source_checkpoint_digest_cache(Path(digest_cache_path))
@@ -526,13 +540,14 @@ def build_source_checkpoint_identity(
                     f"source checkpoint shard changed while hashing: {path}"
                 )
         entries.append({"fingerprint": fingerprint, "sha256": digest})
-        # Name the shard by its position INSIDE the checkpoint, never by the
-        # absolute path: relocating a checkpoint does not change its bytes,
-        # and a path-keyed identity would refuse every moved resume.
-        try:
-            name = str(path.relative_to(root.resolve()))
-        except ValueError:
-            name = path.name
+        # Relocating a checkpoint does not change its bytes, so the identity
+        # is never keyed on the absolute path.
+        name = name_by_resolved.get(str(path))
+        if name is None:
+            try:
+                name = str(path.relative_to(root.resolve()))
+            except ValueError:
+                name = path.name
         shards.append({
             "name": name,
             "size": int(fingerprint["size"]),

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -515,8 +515,9 @@ def build_source_checkpoint_identity(
 
     ``digest_cache_path`` makes the read happen once per (file, machine): a
     shard whose complete stat fingerprint still matches reuses its recorded
-    digest, so a resume costs one ``stat`` per shard instead of a full
-    checkpoint read. Without it, every call hashes every shard.
+    digest instead of rereading that shard. Discovery, metadata hashing,
+    digest-cache JSON handling and identity construction still run. Without
+    this cache, every call hashes every shard.
     """
     from prismaquant.cost_stage_checkpoint import canonical_json_sha256
 

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -426,6 +426,10 @@ SOURCE_CHECKPOINT_METADATA_FILES = (
     "config.json",
     "model.safetensors.index.json",
 )
+# ... plus every `*.py` at the checkpoint root, which a `trust_remote_code`
+# checkpoint executes to build the skeleton (MiniMax-M2 ships
+# `configuration_minimax_m2.py` and `modeling_minimax_m2.py`; DeepSeek-V4 uses
+# the same pattern), discovered per call rather than named here.
 SOURCE_CHECKPOINT_DIGEST_CACHE_SCHEMA = (
     "prismaquant.source_checkpoint.digest_cache.v1"
 )
@@ -497,7 +501,9 @@ def build_source_checkpoint_identity(
     payloads were quantized against -- the dtype map, ``tie_word_embeddings``,
     any ``quantization_config``, the layer counts -- and
     ``model.safetensors.index.json`` decides which shard each tensor is read
-    from.  Editing either changes what a replayed ``layer_NNN.pt`` means while
+    from.  Every ``*.py`` at the checkpoint root joins them, because a
+    ``trust_remote_code`` checkpoint executes those to build the skeleton.
+    Editing any of them changes what a replayed ``layer_NNN.pt`` means while
     every shard byte stays identical.  They are kilobytes, so they are hashed
     on every call rather than cached.
 
@@ -577,8 +583,15 @@ def build_source_checkpoint_identity(
 
     # The non-shard files the export reads.  Kilobytes each, so no digest
     # cache: hashing them costs less than deciding not to.
+    metadata_names = list(SOURCE_CHECKPOINT_METADATA_FILES)
+    if root.is_dir():
+        # `trust_remote_code` checkpoints build their skeleton from modules at
+        # the checkpoint root, so those are read bytes too.
+        metadata_names += sorted(
+            path.name for path in root.glob("*.py") if path.is_file()
+        )
     metadata: list[dict[str, object]] = []
-    for name in SOURCE_CHECKPOINT_METADATA_FILES:
+    for name in metadata_names:
         path = root / name
         if not path.is_file():
             continue

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -414,6 +414,168 @@ def _local_checkpoint_shards(
     return None, None
 
 
+SOURCE_CHECKPOINT_IDENTITY_SCHEMA = (
+    "prismaquant.source_checkpoint.identity.v1"
+)
+SOURCE_CHECKPOINT_DIGEST_CACHE_SCHEMA = (
+    "prismaquant.source_checkpoint.digest_cache.v1"
+)
+
+
+def _read_source_checkpoint_digest_cache(
+    cache_path: Path,
+) -> dict[str, dict[str, object]]:
+    """Digests keyed by the six-field stat fingerprint of the file they cover.
+
+    A corrupt or foreign cache is not an error: it simply reuses nothing, and
+    every shard is hashed. The cache can only ever make the identity CHEAPER,
+    never different -- the fingerprint it keys on includes ``ctime_ns``, which
+    ``utime`` cannot restore after an in-place same-size rewrite.
+    """
+    try:
+        payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return {}
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema") != SOURCE_CHECKPOINT_DIGEST_CACHE_SCHEMA
+    ):
+        return {}
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        return {}
+    reusable: dict[str, dict[str, object]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        fingerprint = entry.get("fingerprint")
+        digest = str(entry.get("sha256", "")).lower()
+        if (
+            not isinstance(fingerprint, dict)
+            or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+        ):
+            continue
+        reusable[canonical_fingerprint_key(fingerprint)] = {
+            "fingerprint": fingerprint,
+            "sha256": digest,
+        }
+    return reusable
+
+
+def canonical_fingerprint_key(fingerprint: dict[str, object]) -> str:
+    return json.dumps(fingerprint, sort_keys=True, separators=(",", ":"))
+
+
+def build_source_checkpoint_identity(
+    source_model: str | Path,
+    *,
+    extra_shard_paths: object = (),
+    digest_cache_path: str | Path | None = None,
+) -> dict[str, object]:
+    """Content identity of the exact safetensors byte set a run consumes.
+
+    This is the runner-free half of :func:`build_streamed_model_identity`, for
+    consumers that hold a checkpoint path rather than a live streaming runner
+    -- the standalone compressed-tensors export resume cache is the first
+    (PrismaQuant #340). It binds file CONTENT, so a same-size, same-header
+    value edit is a different source, and the same bytes under a different
+    directory are the same source.
+
+    ``digest_cache_path`` makes the read happen once per (file, machine): a
+    shard whose complete stat fingerprint still matches reuses its recorded
+    digest, so a resume costs one ``stat`` per shard instead of a full
+    checkpoint read. Without it, every call hashes every shard.
+    """
+    from prismaquant.cost_stage_checkpoint import canonical_json_sha256
+
+    root = Path(source_model)
+    _, indexed_shards = _local_checkpoint_shards(source_model)
+    shard_paths = {Path(path).resolve() for path in (indexed_shards or ())}
+    for path in extra_shard_paths or ():
+        shard_paths.add(Path(path).resolve())
+    missing = sorted(str(path) for path in shard_paths if not path.is_file())
+    if missing:
+        raise RuntimeError(
+            f"source checkpoint identity references missing shards: "
+            f"{missing[:8]}"
+        )
+    if not shard_paths:
+        raise RuntimeError(
+            f"source checkpoint identity found no safetensors shards under "
+            f"{root}; refusing to stamp an unidentified source"
+        )
+    ordered = sorted(shard_paths, key=str)
+
+    reusable = (
+        _read_source_checkpoint_digest_cache(Path(digest_cache_path))
+        if digest_cache_path is not None
+        and Path(digest_cache_path).is_file()
+        else {}
+    )
+
+    entries: list[dict[str, object]] = []
+    shards: list[dict[str, object]] = []
+    for path in ordered:
+        fingerprint = _streamed_identity_stat_fingerprint(path)
+        cached = reusable.get(canonical_fingerprint_key(fingerprint))
+        digest = str(cached["sha256"]) if cached is not None else None
+        if digest is None:
+            digest = _file_sha256(path)
+            if _streamed_identity_stat_fingerprint(path) != fingerprint:
+                raise RuntimeError(
+                    f"source checkpoint shard changed while hashing: {path}"
+                )
+        entries.append({"fingerprint": fingerprint, "sha256": digest})
+        # Name the shard by its position INSIDE the checkpoint, never by the
+        # absolute path: relocating a checkpoint does not change its bytes,
+        # and a path-keyed identity would refuse every moved resume.
+        try:
+            name = str(path.relative_to(root.resolve()))
+        except ValueError:
+            name = path.name
+        shards.append({
+            "name": name,
+            "size": int(fingerprint["size"]),
+            "sha256": digest,
+        })
+    shards.sort(key=lambda row: (str(row["name"]), str(row["sha256"])))
+
+    identity = {
+        "schema": SOURCE_CHECKPOINT_IDENTITY_SCHEMA,
+        "shards": shards,
+        "content_sha256": canonical_json_sha256(
+            {
+                "schema": SOURCE_CHECKPOINT_IDENTITY_SCHEMA,
+                "shards": shards,
+            },
+            where="source checkpoint content identity",
+        ),
+    }
+
+    if digest_cache_path is not None:
+        from prismaquant.cost_stage_checkpoint import atomic_write_bytes
+
+        try:
+            atomic_write_bytes(
+                Path(digest_cache_path),
+                json.dumps(
+                    {
+                        "schema": SOURCE_CHECKPOINT_DIGEST_CACHE_SCHEMA,
+                        "entries": entries,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                    ensure_ascii=False,
+                    allow_nan=False,
+                ).encode("utf-8"),
+            )
+        except OSError:
+            # The digest cache is an optimization. A read-only or full cache
+            # directory costs a re-read next time; it never changes identity.
+            pass
+    return identity
+
+
 def _read_streamed_model_identity_cache(
     cache_path: Path,
     *,

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -417,6 +417,15 @@ def _local_checkpoint_shards(
 SOURCE_CHECKPOINT_IDENTITY_SCHEMA = (
     "prismaquant.source_checkpoint.identity.v1"
 )
+# The non-shard files the standalone export reads from the checkpoint root:
+# `config.json` through `stage_text_only`/`AutoConfig` (streaming_model.py:102
+# and the exporter's skeleton build) and the index through
+# `_local_checkpoint_shards` and export_native_compressed.py:6092.  A file that
+# is absent contributes no row, so one appearing later is a different source.
+SOURCE_CHECKPOINT_METADATA_FILES = (
+    "config.json",
+    "model.safetensors.index.json",
+)
 SOURCE_CHECKPOINT_DIGEST_CACHE_SCHEMA = (
     "prismaquant.source_checkpoint.digest_cache.v1"
 )
@@ -480,6 +489,17 @@ def build_source_checkpoint_identity(
     (PrismaQuant #340). It binds file CONTENT, so a same-size, same-header
     value edit is a different source, and the same bytes under a different
     directory are the same source.
+
+    The weight bytes are not the whole source.
+    :data:`SOURCE_CHECKPOINT_METADATA_FILES` names the non-shard files the
+    export reads from the checkpoint root, and their sha256 is folded into
+    the same ``content_sha256``: ``config.json`` decides the skeleton the
+    payloads were quantized against -- the dtype map, ``tie_word_embeddings``,
+    any ``quantization_config``, the layer counts -- and
+    ``model.safetensors.index.json`` decides which shard each tensor is read
+    from.  Editing either changes what a replayed ``layer_NNN.pt`` means while
+    every shard byte stays identical.  They are kilobytes, so they are hashed
+    on every call rather than cached.
 
     ``digest_cache_path`` makes the read happen once per (file, machine): a
     shard whose complete stat fingerprint still matches reuses its recorded
@@ -555,13 +575,35 @@ def build_source_checkpoint_identity(
         })
     shards.sort(key=lambda row: (str(row["name"]), str(row["sha256"])))
 
+    # The non-shard files the export reads.  Kilobytes each, so no digest
+    # cache: hashing them costs less than deciding not to.
+    metadata: list[dict[str, object]] = []
+    for name in SOURCE_CHECKPOINT_METADATA_FILES:
+        path = root / name
+        if not path.is_file():
+            continue
+        fingerprint = _streamed_identity_stat_fingerprint(path)
+        digest = _file_sha256(path)
+        if _streamed_identity_stat_fingerprint(path) != fingerprint:
+            raise RuntimeError(
+                f"source checkpoint metadata changed while hashing: {path}"
+            )
+        metadata.append({
+            "name": name,
+            "size": int(fingerprint["size"]),
+            "sha256": digest,
+        })
+    metadata.sort(key=lambda row: str(row["name"]))
+
     identity = {
         "schema": SOURCE_CHECKPOINT_IDENTITY_SCHEMA,
         "shards": shards,
+        "metadata": metadata,
         "content_sha256": canonical_json_sha256(
             {
                 "schema": SOURCE_CHECKPOINT_IDENTITY_SCHEMA,
                 "shards": shards,
+                "metadata": metadata,
             },
             where="source checkpoint content identity",
         ),

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -426,10 +426,14 @@ SOURCE_CHECKPOINT_METADATA_FILES = (
     "config.json",
     "model.safetensors.index.json",
 )
-# ... plus every `*.py` at the checkpoint root, which a `trust_remote_code`
-# checkpoint executes to build the skeleton (MiniMax-M2 ships
-# `configuration_minimax_m2.py` and `modeling_minimax_m2.py`; DeepSeek-V4 uses
-# the same pattern), discovered per call rather than named here.
+# ... plus every `*.py` at the checkpoint root, because a `trust_remote_code`
+# checkpoint executes modules from there to build the skeleton (MiniMax-M2
+# ships `configuration_minimax_m2.py` and `modeling_minimax_m2.py`;
+# DeepSeek-V4 uses the same pattern), discovered per call rather than named
+# here.  Every one of
+# them is bound, whether or not `auto_map` names it: binding a module nobody
+# imports can cost a false refusal, naming only some can cost a false
+# admission.
 SOURCE_CHECKPOINT_DIGEST_CACHE_SCHEMA = (
     "prismaquant.source_checkpoint.digest_cache.v1"
 )
@@ -502,7 +506,9 @@ def build_source_checkpoint_identity(
     any ``quantization_config``, the layer counts -- and
     ``model.safetensors.index.json`` decides which shard each tensor is read
     from.  Every ``*.py`` at the checkpoint root joins them, because a
-    ``trust_remote_code`` checkpoint executes those to build the skeleton.
+    ``trust_remote_code`` checkpoint executes modules from there to build the
+    skeleton; all of them are bound rather than only those ``auto_map`` names,
+    which can refuse falsely but never admit falsely.
     Editing any of them changes what a replayed ``layer_NNN.pt`` means while
     every shard byte stays identical.  They are kilobytes, so they are hashed
     on every call rather than cached.
@@ -586,7 +592,9 @@ def build_source_checkpoint_identity(
     metadata_names = list(SOURCE_CHECKPOINT_METADATA_FILES)
     if root.is_dir():
         # `trust_remote_code` checkpoints build their skeleton from modules at
-        # the checkpoint root, so those are read bytes too.
+        # the checkpoint root, so those are read bytes too.  All of them, not
+        # only the ones `auto_map` names: over-binding refuses falsely, and
+        # under-binding admits falsely.
         metadata_names += sorted(
             path.name for path in root.glob("*.py") if path.is_file()
         )

--- a/prismaquant/export_native_compressed.py
+++ b/prismaquant/export_native_compressed.py
@@ -6548,59 +6548,19 @@ def materialize_tensors_streaming(
     cache_path = Path(export_cache_dir) if export_cache_dir else None
     if cache_path is not None:
         cache_path.mkdir(parents=True, exist_ok=True)
-
-        # Cache fingerprint (codex review #2): bind the cache to the
-        # quality-affecting state. If any of these change between runs,
-        # the cache is silently wrong because the saved layer tensors
-        # were quantized under a different recipe. Write/check a
-        # manifest.json; mismatch invalidates the cache wholesale.
-        import json as _json
-        fp_state = _render_lever_provenance()
-        # Hash the assignment dict (layer_config recipe) too — recipe
-        # changes invalidate per-Linear quantization output.
-        try:
-            fp_state["assignment_hash"] = hashlib.sha256(
-                _json.dumps(assignment, sort_keys=True).encode()
-            ).hexdigest()[:16]
-        except Exception:
-            fp_state["assignment_hash"] = None
-
-        manifest_path = cache_path / "manifest.json"
-        if manifest_path.exists():
-            try:
-                with manifest_path.open() as _f:
-                    prev = _json.load(_f)
-                if prev != fp_state:
-                    diff_keys = sorted(
-                        set(prev.keys()) | set(fp_state.keys())
-                    )
-                    diffs = [
-                        k for k in diff_keys
-                        if prev.get(k) != fp_state.get(k)
-                    ]
-                    print(f"[export-stream] cache fingerprint MISMATCH "
-                          f"(differs in: {diffs}); invalidating cache",
-                          flush=True)
-                    for _f in cache_path.glob("layer_*.pt"):
-                        _f.unlink()
-                    with manifest_path.open("w") as _f:
-                        _json.dump(fp_state, _f, indent=2)
-                else:
-                    print(f"[export-stream] cache fingerprint match — "
-                          f"resumable from {len(list(cache_path.glob('layer_*.pt')))} "
-                          f"layers", flush=True)
-            except Exception as _e:
-                print(f"[export-stream] cache manifest unreadable "
-                      f"({_e}); invalidating cache", flush=True)
-                for _f in cache_path.glob("layer_*.pt"):
-                    _f.unlink()
-                with manifest_path.open("w") as _f:
-                    _json.dump(fp_state, _f, indent=2)
-        else:
-            with manifest_path.open("w") as _f:
-                _json.dump(fp_state, _f, indent=2)
-            print(f"[export-stream] wrote cache fingerprint to {manifest_path}",
-                  flush=True)
+        # The fingerprint is computed ONLY when a cache dir was asked for, so
+        # the source hash never touches an export that is not resumable.
+        _admit_export_resume_cache(
+            cache_path,
+            _export_resume_fingerprint(
+                assignment=assignment,
+                model_path=model_path,
+                dtype=dtype,
+                declared_buffer_dtypes=declared_buffer_dtypes,
+                extra_shard_paths=set(weight_shard.values()),
+                digest_cache_path=cache_path / "source_identity_cache.json",
+            ),
+        )
 
     def _layer_cache_file(L: int) -> Path | None:
         return None if cache_path is None else cache_path / f"layer_{L:03d}.pt"
@@ -8521,15 +8481,136 @@ def compute_extra_ignore(
     return extra_ignore
 
 
+def _export_resume_fingerprint(
+    *,
+    assignment: dict,
+    model_path: str,
+    dtype: "torch.dtype",
+    declared_buffer_dtypes: dict,
+    extra_shard_paths: object = (),
+    digest_cache_path: str | Path | None = None,
+) -> dict:
+    """Everything a `layer_NNN.pt` payload is only valid under.
+
+    `_render_lever_provenance()` says how the export renders; this adds WHAT
+    it renders. Before #340 the manifest carried the levers and the recipe
+    hash alone, so a cache dir reused against a different checkpoint replayed
+    the first checkpoint's quantized bytes -- the levers matched, the
+    assignment matched, and no field named the source.
+
+    Three bindings, all of which a replayed payload silently bakes in:
+
+    * ``source_identity`` -- the sha256 of every safetensors shard the run
+      consumes (`build_source_checkpoint_identity`). Content, not path: a
+      relocated checkpoint still resumes, a same-size value edit does not.
+    * ``requested_dtype`` -- the parameter dtype the source read narrows to.
+    * ``declared_buffer_dtypes`` -- the skeleton's persistent-buffer dtype
+      map, which is what the reader restores buffers to (#311/PR #325). The
+      policy STAMP alone says the reader is correct; the map says it was
+      handed the same declarations.
+
+    Nothing here may degrade to ``None``: the manifest comparison is
+    equality, and ``None == None`` admits. A source that cannot be identified
+    raises instead.
+    """
+    import hashlib
+
+    from prismaquant.cost_streaming import build_source_checkpoint_identity
+
+    fp_state = _render_lever_provenance()
+    fp_state["assignment_hash"] = hashlib.sha256(
+        json.dumps(assignment, sort_keys=True).encode()
+    ).hexdigest()[:16]
+    fp_state["source_identity"] = build_source_checkpoint_identity(
+        model_path,
+        extra_shard_paths=extra_shard_paths,
+        digest_cache_path=digest_cache_path,
+    )
+    fp_state["requested_dtype"] = str(dtype)
+    fp_state["declared_buffer_dtypes"] = {
+        str(name): str(value)
+        for name, value in sorted(dict(declared_buffer_dtypes).items())
+    }
+    return fp_state
+
+
+# The manifest keys without which replay cannot be authorized. A pre-#340
+# cache carries none of them, and a manifest that lost one is not a weaker
+# match -- it is unreadable, and refused on the same branch.
+_EXPORT_RESUME_REQUIRED_KEYS = (
+    "source_identity",
+    "requested_dtype",
+    "declared_buffer_dtypes",
+    "assignment_hash",
+)
+
+
+def _admit_export_resume_cache(cache_path: Path, fp_state: dict) -> bool:
+    """Decide whether `layer_*.pt` replay is admitted, BEFORE any is read.
+
+    Returns True when the cache may be resumed. On any refusal every
+    `layer_*.pt` is removed and the manifest is rewritten, so the caller's
+    per-layer `cf.exists()` check cannot find a stale payload afterwards.
+    """
+    manifest_path = cache_path / "manifest.json"
+
+    def _refuse(reason: str) -> bool:
+        removed = 0
+        for stale in cache_path.glob("layer_*.pt"):
+            stale.unlink()
+            removed += 1
+        with manifest_path.open("w") as handle:
+            json.dump(fp_state, handle, indent=2)
+        print(f"[export-stream] resume REFUSED ({reason}); "
+              f"discarded {removed} cached layers", flush=True)
+        return False
+
+    if not manifest_path.exists():
+        with manifest_path.open("w") as handle:
+            json.dump(fp_state, handle, indent=2)
+        print(f"[export-stream] wrote cache fingerprint to {manifest_path}",
+              flush=True)
+        return True
+
+    try:
+        with manifest_path.open() as handle:
+            prev = json.load(handle)
+        if not isinstance(prev, dict):
+            raise ValueError("manifest is not an object")
+    except Exception as exc:
+        return _refuse(f"cache manifest unreadable: {exc}")
+
+    absent = [k for k in _EXPORT_RESUME_REQUIRED_KEYS if k not in prev]
+    if absent:
+        return _refuse(
+            f"manifest predates the source-identity contract, missing {absent}")
+
+    if prev != fp_state:
+        diffs = [
+            key for key in sorted(set(prev) | set(fp_state))
+            if prev.get(key) != fp_state.get(key)
+        ]
+        return _refuse(f"fingerprint differs in: {diffs}")
+
+    print(f"[export-stream] cache fingerprint match — resumable from "
+          f"{len(list(cache_path.glob('layer_*.pt')))} layers", flush=True)
+    return True
+
+
 def _render_lever_provenance() -> dict:
     """The quality-affecting render state of this export run.
 
-    Two consumers, one definition: the per-layer export cache binds its
-    `manifest.json` to this dict (a change means the cached layer tensors were
-    quantized under a different recipe and the cache is silently wrong), and the
-    shipcard echoes it so an artifact carries the levers it was rendered under.
-    Keep the key set stable — changing it invalidates every in-flight export
-    cache.
+    Two consumers, one definition: the per-layer export cache folds this dict
+    into its `manifest.json` fingerprint (a change means the cached layer
+    tensors were quantized under a different recipe and the cache is silently
+    wrong), and the shipcard echoes it so an artifact carries the levers it was
+    rendered under. Keep the key set stable — changing it invalidates every
+    in-flight export cache.
+
+    This is HOW the export renders, not WHAT it renders. The source checkpoint
+    identity, the requested dtype and the declared buffer-dtype map belong to
+    the cache fingerprint only (`_export_resume_fingerprint`, #340); the
+    shipcard records the source through its own `source_model` field.
     """
     return {
         # Older layer_*.pt payloads may already contain narrowed persistent

--- a/prismaquant/export_native_compressed.py
+++ b/prismaquant/export_native_compressed.py
@@ -8506,8 +8506,11 @@ def _export_resume_fingerprint(
     Three bindings, all of which a replayed payload silently bakes in:
 
     * ``source_identity`` -- the sha256 of every safetensors shard the run
-      consumes (`build_source_checkpoint_identity`). Content, not path: a
-      relocated checkpoint still resumes, a same-size value edit does not.
+      consumes, and of the non-shard files it reads from the checkpoint root:
+      ``config.json`` (the skeleton the payloads were quantized against) and
+      ``model.safetensors.index.json`` (which shard each tensor comes from).
+      See `build_source_checkpoint_identity`. Content, not path: a relocated
+      checkpoint still resumes, a same-size value edit does not.
     * ``requested_dtype`` -- the parameter dtype the source read narrows to.
     * ``declared_buffer_dtypes`` -- the skeleton's persistent-buffer dtype
       map, which is what the reader restores buffers to (#311/PR #325). The

--- a/prismaquant/export_native_compressed.py
+++ b/prismaquant/export_native_compressed.py
@@ -8509,7 +8509,8 @@ def _export_resume_fingerprint(
       consumes, and of the non-shard files it reads from the checkpoint root:
       ``config.json`` (the skeleton the payloads were quantized against),
       ``model.safetensors.index.json`` (which shard each tensor comes from)
-      and any ``*.py`` a ``trust_remote_code`` checkpoint is built through.
+      and every root ``*.py``, which a ``trust_remote_code`` checkpoint is
+      built through (all of them, not only the ones ``auto_map`` names).
       See `build_source_checkpoint_identity`. Content, not path: a relocated
       checkpoint still resumes, a same-size value edit does not.
     * ``requested_dtype`` -- the parameter dtype the source read narrows to.

--- a/prismaquant/export_native_compressed.py
+++ b/prismaquant/export_native_compressed.py
@@ -8507,8 +8507,9 @@ def _export_resume_fingerprint(
 
     * ``source_identity`` -- the sha256 of every safetensors shard the run
       consumes, and of the non-shard files it reads from the checkpoint root:
-      ``config.json`` (the skeleton the payloads were quantized against) and
-      ``model.safetensors.index.json`` (which shard each tensor comes from).
+      ``config.json`` (the skeleton the payloads were quantized against),
+      ``model.safetensors.index.json`` (which shard each tensor comes from)
+      and any ``*.py`` a ``trust_remote_code`` checkpoint is built through.
       See `build_source_checkpoint_identity`. Content, not path: a relocated
       checkpoint still resumes, a same-size value edit does not.
     * ``requested_dtype`` -- the parameter dtype the source read narrows to.

--- a/prismaquant/export_native_compressed.py
+++ b/prismaquant/export_native_compressed.py
@@ -8493,10 +8493,15 @@ def _export_resume_fingerprint(
     """Everything a `layer_NNN.pt` payload is only valid under.
 
     `_render_lever_provenance()` says how the export renders; this adds WHAT
-    it renders. Before #340 the manifest carried the levers and the recipe
-    hash alone, so a cache dir reused against a different checkpoint replayed
-    the first checkpoint's quantized bytes -- the levers matched, the
-    assignment matched, and no field named the source.
+    it renders. Before #340 the manifest carried the levers alone, so a cache
+    dir reused against a different checkpoint replayed the first checkpoint's
+    quantized bytes -- the levers matched and no field named the source. The
+    `assignment_hash` beside them compared nothing: `hashlib` was in scope
+    nowhere inside `materialize_tensors_streaming`, so the call raised
+    NameError and the `except Exception` stamped a null on every manifest
+    ever written (measured on origin/main, PB action 41e6e63eb9dd). The
+    import is explicit here and there is no swallow: a recipe hash that
+    cannot be computed is a crash, not a null that matches the next null.
 
     Three bindings, all of which a replayed payload silently bakes in:
 

--- a/prismaquant/export_native_compressed.py
+++ b/prismaquant/export_native_compressed.py
@@ -8576,6 +8576,8 @@ def _admit_export_resume_cache(cache_path: Path, fp_state: dict) -> bool:
         return False
 
     if not manifest_path.exists():
+        if next(cache_path.glob("layer_*.pt"), None) is not None:
+            return _refuse("cached layers have no manifest binding")
         with manifest_path.open("w") as handle:
             json.dump(fp_state, handle, indent=2)
         print(f"[export-stream] wrote cache fingerprint to {manifest_path}",

--- a/tests/test_export_resume_source_identity.py
+++ b/tests/test_export_resume_source_identity.py
@@ -254,7 +254,7 @@ def test_source_identity_never_degrades_to_none(tmp_path):
     raise, not stamp a null the next run can match."""
     empty = tmp_path / "empty"
     empty.mkdir()
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError, match="no safetensors shards"):
         _fingerprint(empty)
 
 

--- a/tests/test_export_resume_source_identity.py
+++ b/tests/test_export_resume_source_identity.py
@@ -1,0 +1,299 @@
+"""The standalone export resume cache must bind the source checkpoint.
+
+`materialize_tensors_streaming(..., export_cache_dir=...)` saves each
+quantized layer to `layer_NNN.pt` and, on a restart, replays those payloads
+instead of re-reading the source. Admission was decided by
+`_render_lever_provenance()` plus `assignment_hash` alone, so a cache dir
+reused against a DIFFERENT checkpoint replayed the first checkpoint's
+quantized bytes: the render levers and the recipe both still matched, and
+nothing in the manifest named the source (#340).
+
+These tests drive the real exporter on a tiny synthetic checkpoint. They
+assert on the admission decision (was a `layer_*.pt` read at all?) and on the
+emitted bytes, so a refusal that still replays, or a replay that silently
+re-renders, both fail.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+from torch import nn  # noqa: E402
+from safetensors.torch import save_file  # noqa: E402
+
+from prismaquant import export_native_compressed as export  # noqa: E402
+from prismaquant import sensitivity_probe, streaming_model  # noqa: E402
+
+# Two FP32 values inside one BF16 ulp at 0.5, as in test_export_buffer_*: a
+# buffer edit the parameter dtype cannot represent, so a replayed payload is
+# distinguishable from a re-rendered one.
+_BIAS_A = torch.tensor([0.5, 0.5 + 2.0 ** -12], dtype=torch.float32)
+_BIAS_B = torch.tensor([0.5, 0.5 + 3.0 * 2.0 ** -12], dtype=torch.float32)
+_WEIGHT_A = torch.eye(2, dtype=torch.bfloat16)
+_WEIGHT_B = torch.tensor([[1.0, 0.0], [0.0, 0.5]], dtype=torch.bfloat16)
+
+
+def _write_source(source: Path, *, weight, bias) -> None:
+    source.mkdir(parents=True, exist_ok=True)
+    save_file(
+        {
+            "model.layers.0.expert_bias": bias.clone(),
+            "model.layers.0.proj.weight": weight.clone(),
+        },
+        str(source / "model.safetensors"),
+    )
+
+
+def _exporter(tmp_path, monkeypatch):
+    """Replace architecture construction only; source reads, the cache and
+    emission are the real code paths."""
+
+    class Skeleton:
+        @staticmethod
+        def _from_config(config):
+            model = nn.Module()
+            model.model = nn.Module()
+            layer = nn.Module()
+            layer.proj = nn.Linear(2, 2, bias=False, device="meta")
+            layer.register_buffer(
+                "expert_bias",
+                torch.empty(2, device="meta", dtype=torch.float32),
+            )
+            model.model.layers = nn.ModuleList([layer])
+            return model
+
+    profile = SimpleNamespace(
+        requires_multimodal_skeleton=lambda: False,
+        concat_merge_groups=lambda: (),
+        live_to_recipe_name=lambda name: name,
+        packed_expert_param_names=lambda: (),
+    )
+    from transformers import AutoConfig
+
+    monkeypatch.setattr(
+        AutoConfig, "from_pretrained", lambda *a, **kw: SimpleNamespace())
+    monkeypatch.setattr(sensitivity_probe, "stage_text_only", lambda p: p)
+    monkeypatch.setattr(
+        streaming_model, "_skeleton_config_and_class",
+        lambda config, **kw: (config, Skeleton))
+    monkeypatch.setattr(streaming_model, "_init_rotary_inplace", lambda *a: None)
+    monkeypatch.setattr(export, "_PRODUCTION_WEIGHT_CACHE", None)
+
+    source = tmp_path / "source"
+
+    def run(cache: Path | None, *, replay_log: list | None = None):
+        emitted: dict = {}
+
+        def sink(tensors):
+            emitted.update(tensors)
+
+        if replay_log is None:
+            export.materialize_tensors_streaming(
+                str(source), {}, profile=profile, bf16_passthrough=set(),
+                device=torch.device("cpu"), tensor_sink=sink,
+                export_cache_dir=None if cache is None else str(cache))
+            return emitted
+
+        real_load = torch.load
+
+        def spy(path, *args, **kwargs):
+            if Path(str(path)).name.startswith("layer_"):
+                replay_log.append(str(path))
+            return real_load(path, *args, **kwargs)
+
+        with monkeypatch.context() as patched:
+            patched.setattr(torch, "load", spy)
+            export.materialize_tensors_streaming(
+                str(source), {}, profile=profile, bf16_passthrough=set(),
+                device=torch.device("cpu"), tensor_sink=sink,
+                export_cache_dir=None if cache is None else str(cache))
+        return emitted
+
+    return run, source
+
+
+def _fill_cache(run, source, cache, *, weight, bias):
+    _write_source(source, weight=weight, bias=bias)
+    emitted = run(cache)
+    assert list(cache.glob("layer_*.pt")), "fixture wrote no layer cache"
+    return emitted
+
+
+# --------------------------------------------------------------------------
+# Admission: a changed source must refuse replay.
+# --------------------------------------------------------------------------
+
+def test_changed_source_parameter_refuses_replay(tmp_path, monkeypatch):
+    """Same assignment, same levers, different weight bytes of the same size
+    and shape. The cached layer must not be replayed, and the export must
+    carry the NEW weight."""
+    run, source = _exporter(tmp_path, monkeypatch)
+    cache = tmp_path / "resume"
+    _fill_cache(run, source, cache, weight=_WEIGHT_A, bias=_BIAS_A)
+
+    _write_source(source, weight=_WEIGHT_B, bias=_BIAS_A)
+    replays: list = []
+    emitted = run(cache, replay_log=replays)
+
+    assert replays == [], f"replayed a payload from the previous source: {replays}"
+    assert torch.equal(emitted["model.layers.0.proj.weight"], _WEIGHT_B)
+
+
+def test_changed_persistent_buffer_refuses_replay(tmp_path, monkeypatch):
+    """A persistent FP32 buffer edit is a source change too. Replay would
+    ship the old buffer bytes verbatim."""
+    run, source = _exporter(tmp_path, monkeypatch)
+    cache = tmp_path / "resume"
+    _fill_cache(run, source, cache, weight=_WEIGHT_A, bias=_BIAS_A)
+
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_B)
+    replays: list = []
+    emitted = run(cache, replay_log=replays)
+
+    assert replays == [], f"replayed a payload from the previous source: {replays}"
+    got = emitted["model.layers.0.expert_bias"]
+    assert torch.equal(got.view(torch.uint8), _BIAS_B.view(torch.uint8))
+
+
+def test_manifest_without_source_identity_is_refused(tmp_path, monkeypatch):
+    """Fail closed on a pre-fix cache: a manifest that names no source cannot
+    authorize replay even when nothing else changed."""
+    run, source = _exporter(tmp_path, monkeypatch)
+    cache = tmp_path / "resume"
+    _fill_cache(run, source, cache, weight=_WEIGHT_A, bias=_BIAS_A)
+
+    manifest = cache / "manifest.json"
+    legacy = json.loads(manifest.read_text())
+    assert "source_identity" in legacy, (
+        "the resume manifest binds no source identity")
+    legacy.pop("source_identity")
+    manifest.write_text(json.dumps(legacy))
+
+    replays: list = []
+    run(cache, replay_log=replays)
+    assert replays == [], "a manifest with no source identity admitted replay"
+    assert "source_identity" in json.loads(manifest.read_text())
+
+
+# --------------------------------------------------------------------------
+# The identical-source resume must keep working, byte for byte.
+# --------------------------------------------------------------------------
+
+def test_identical_source_still_replays_byte_identically(tmp_path, monkeypatch):
+    run, source = _exporter(tmp_path, monkeypatch)
+    cache = tmp_path / "resume"
+    first = _fill_cache(run, source, cache, weight=_WEIGHT_A, bias=_BIAS_A)
+    first = {k: v.clone() for k, v in first.items()}
+
+    replays: list = []
+    second = run(cache, replay_log=replays)
+
+    assert replays, "an unchanged source stopped resuming"
+    assert set(first) == set(second)
+    for name, value in first.items():
+        assert value.dtype == second[name].dtype, name
+        assert torch.equal(
+            value.view(torch.uint8), second[name].view(torch.uint8)), name
+
+
+# --------------------------------------------------------------------------
+# The fingerprint itself: dtype and the declared buffer-dtype map are bound.
+# --------------------------------------------------------------------------
+
+def _fingerprint(source: Path, **overrides):
+    kwargs = dict(
+        assignment={},
+        model_path=str(source),
+        dtype=torch.bfloat16,
+        declared_buffer_dtypes={"model.layers.0.expert_bias": torch.float32},
+    )
+    kwargs.update(overrides)
+    return export._export_resume_fingerprint(**kwargs)
+
+
+def test_fingerprint_binds_requested_dtype(tmp_path):
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    assert (_fingerprint(source)["requested_dtype"]
+            != _fingerprint(source, dtype=torch.float16)["requested_dtype"])
+
+
+def test_fingerprint_binds_declared_buffer_dtypes(tmp_path):
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    narrowed = _fingerprint(
+        source,
+        declared_buffer_dtypes={"model.layers.0.expert_bias": torch.bfloat16},
+    )
+    assert (_fingerprint(source)["declared_buffer_dtypes"]
+            != narrowed["declared_buffer_dtypes"])
+
+
+def test_fingerprint_source_identity_tracks_content_not_path(tmp_path):
+    """Content identity: the same bytes under a different directory are the
+    same source; a same-size value edit is a different source."""
+    first = tmp_path / "a"
+    second = tmp_path / "b"
+    _write_source(first, weight=_WEIGHT_A, bias=_BIAS_A)
+    _write_source(second, weight=_WEIGHT_A, bias=_BIAS_A)
+    assert (_fingerprint(first)["source_identity"]["content_sha256"]
+            == _fingerprint(second)["source_identity"]["content_sha256"])
+
+    edited = tmp_path / "c"
+    _write_source(edited, weight=_WEIGHT_A, bias=_BIAS_B)
+    assert (_fingerprint(first)["source_identity"]["content_sha256"]
+            != _fingerprint(edited)["source_identity"]["content_sha256"])
+
+
+def test_source_identity_never_degrades_to_none(tmp_path):
+    """`None == None` would admit. A source that cannot be identified must
+    raise, not stamp a null the next run can match."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(Exception):
+        _fingerprint(empty)
+
+
+# --------------------------------------------------------------------------
+# The shared checkpoint-identity helper.
+# --------------------------------------------------------------------------
+
+def test_digest_cache_rehashes_a_same_size_rewrite(tmp_path):
+    """The digest cache keys on the full stat fingerprint (ctime included),
+    so restoring mtime after an in-place same-size rewrite still re-hashes."""
+    import os
+
+    from prismaquant.cost_streaming import build_source_checkpoint_identity
+
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    shard = source / "model.safetensors"
+    stat = shard.stat()
+    cache = tmp_path / "identity_cache.json"
+
+    before = build_source_checkpoint_identity(
+        str(source), digest_cache_path=cache)
+    assert cache.is_file()
+
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_B)
+    assert shard.stat().st_size == stat.st_size
+    os.utime(shard, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+
+    after = build_source_checkpoint_identity(
+        str(source), digest_cache_path=cache)
+    assert before["content_sha256"] != after["content_sha256"]
+
+
+def test_identity_cache_hit_returns_the_same_digest(tmp_path):
+    from prismaquant.cost_streaming import build_source_checkpoint_identity
+
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    cache = tmp_path / "identity_cache.json"
+    first = build_source_checkpoint_identity(str(source), digest_cache_path=cache)
+    second = build_source_checkpoint_identity(str(source), digest_cache_path=cache)
+    assert first == second

--- a/tests/test_export_resume_source_identity.py
+++ b/tests/test_export_resume_source_identity.py
@@ -454,3 +454,24 @@ def test_changed_index_json_is_a_different_source(tmp_path):
 
     assert before["shards"] == after["shards"], "the shard bytes did not move"
     assert before["content_sha256"] != after["content_sha256"]
+
+
+def test_changed_remote_code_module_is_a_different_source(tmp_path):
+    """`trust_remote_code` checkpoints build their skeleton from `*.py` at
+    the checkpoint root (MiniMax-M2, DeepSeek-V4). Editing one changes the
+    module the payloads were quantized through while config.json and every
+    shard stay identical."""
+    from prismaquant.cost_streaming import build_source_checkpoint_identity
+
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    _write_config(source, auto_map={"AutoConfig": "configuration_toy.ToyConfig"})
+    module = source / "modeling_toy.py"
+    module.write_text("HIDDEN = 2\n")
+    before = build_source_checkpoint_identity(str(source))
+
+    module.write_text("HIDDEN = 4\n")
+    after = build_source_checkpoint_identity(str(source))
+    assert before["shards"] == after["shards"], "the shard bytes did not move"
+    assert before["content_sha256"] != after["content_sha256"]
+    assert "modeling_toy.py" in [row["name"] for row in after["metadata"]]

--- a/tests/test_export_resume_source_identity.py
+++ b/tests/test_export_resume_source_identity.py
@@ -3,10 +3,12 @@
 `materialize_tensors_streaming(..., export_cache_dir=...)` saves each
 quantized layer to `layer_NNN.pt` and, on a restart, replays those payloads
 instead of re-reading the source. Admission was decided by
-`_render_lever_provenance()` plus `assignment_hash` alone, so a cache dir
-reused against a DIFFERENT checkpoint replayed the first checkpoint's
-quantized bytes: the render levers and the recipe both still matched, and
-nothing in the manifest named the source (#340).
+`_render_lever_provenance()` alone, so a cache dir reused against a DIFFERENT
+checkpoint replayed the first checkpoint's quantized bytes: the render levers
+still matched and nothing in the manifest named the source (#340). The
+`assignment_hash` beside them was no help either -- `hashlib` was in scope
+nowhere inside that function, so the call raised NameError, the surrounding
+`except Exception` stamped null, and the recipe was never compared.
 
 These tests drive the real exporter on a tiny synthetic checkpoint. They
 assert on the admission decision (was a `layer_*.pt` read at all?) and on the
@@ -316,3 +318,44 @@ def test_a_symlink_snapshot_is_the_same_source_as_the_plain_directory(tmp_path):
 
     assert (build_source_checkpoint_identity(str(plain))["content_sha256"]
             == build_source_checkpoint_identity(str(snapshot))["content_sha256"])
+
+
+# --------------------------------------------------------------------------
+# The recipe. On main `hashlib` was in scope nowhere inside
+# `materialize_tensors_streaming`, so `hashlib.sha256(...)` raised NameError,
+# the surrounding `except Exception` stamped `assignment_hash: null`, and two
+# runs under DIFFERENT recipes compared equal. The swallow is gone; these keep
+# it gone.
+# --------------------------------------------------------------------------
+
+def test_assignment_hash_is_a_real_digest(tmp_path):
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+
+    empty = _fingerprint(source)["assignment_hash"]
+    assert isinstance(empty, str) and len(empty) == 16
+    int(empty, 16)  # raises unless it is really a hex digest
+
+    other = _fingerprint(
+        source, assignment={"model.layers.0.proj": "BF16"})["assignment_hash"]
+    assert empty != other
+
+
+def test_recipe_change_refuses_replay(tmp_path):
+    """Admission is the seam the exporter calls before reading any payload."""
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    cache = tmp_path / "resume"
+    cache.mkdir()
+
+    first = _fingerprint(source, assignment={"model.layers.0.proj": "BF16"})
+    assert export._admit_export_resume_cache(cache, first) is True
+    (cache / "layer_000.pt").write_bytes(b"payload")
+    assert export._admit_export_resume_cache(cache, first) is True, (
+        "an unchanged recipe stopped resuming")
+
+    second = _fingerprint(source, assignment={"model.layers.0.proj": "NVFP4"})
+    assert export._admit_export_resume_cache(cache, second) is False
+    assert not list(cache.glob("layer_*.pt")), (
+        "a recipe change left the previous recipe's payloads replayable")
+    assert json.loads((cache / "manifest.json").read_text()) == second

--- a/tests/test_export_resume_source_identity.py
+++ b/tests/test_export_resume_source_identity.py
@@ -297,3 +297,22 @@ def test_identity_cache_hit_returns_the_same_digest(tmp_path):
     first = build_source_checkpoint_identity(str(source), digest_cache_path=cache)
     second = build_source_checkpoint_identity(str(source), digest_cache_path=cache)
     assert first == second
+
+
+def test_a_symlink_snapshot_is_the_same_source_as_the_plain_directory(tmp_path):
+    """A Hugging Face snapshot dir holds symlinks into `blobs/`, whose
+    resolved names are LFS hashes. The same checkpoint reached either way is
+    one source, so a resume across the two spellings is not refused."""
+    import os
+
+    from prismaquant.cost_streaming import build_source_checkpoint_identity
+
+    plain = tmp_path / "plain"
+    _write_source(plain, weight=_WEIGHT_A, bias=_BIAS_A)
+
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    os.symlink(plain / "model.safetensors", snapshot / "model.safetensors")
+
+    assert (build_source_checkpoint_identity(str(plain))["content_sha256"]
+            == build_source_checkpoint_identity(str(snapshot))["content_sha256"])

--- a/tests/test_export_resume_source_identity.py
+++ b/tests/test_export_resume_source_identity.py
@@ -359,3 +359,98 @@ def test_recipe_change_refuses_replay(tmp_path):
     assert not list(cache.glob("layer_*.pt")), (
         "a recipe change left the previous recipe's payloads replayable")
     assert json.loads((cache / "manifest.json").read_text()) == second
+
+
+# --------------------------------------------------------------------------
+# The source is not only its weight bytes. `config.json` decides the skeleton
+# the payloads were quantized against; the index decides which shard each
+# tensor comes from. Both can change while every shard byte stays identical.
+# --------------------------------------------------------------------------
+
+def _write_config(source: Path, **fields) -> None:
+    payload = {
+        "architectures": ["ToyForCausalLM"],
+        "num_hidden_layers": 1,
+        "tie_word_embeddings": False,
+        "torch_dtype": "bfloat16",
+    }
+    payload.update(fields)
+    (source / "config.json").write_text(json.dumps(payload, indent=2))
+
+
+def test_changed_config_json_refuses_replay(tmp_path, monkeypatch):
+    """Identical shards, one changed field in `config.json`. The cached
+    layers were quantized against the other skeleton, so replay must refuse
+    before any payload is read."""
+    run, source = _exporter(tmp_path, monkeypatch)
+    cache = tmp_path / "resume"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    _write_config(source)
+    run(cache)
+    assert list(cache.glob("layer_*.pt")), "fixture wrote no layer cache"
+
+    _write_config(source, tie_word_embeddings=True)
+    replays: list = []
+    run(cache, replay_log=replays)
+    assert replays == [], (
+        f"replayed payloads quantized against another config.json: {replays}")
+
+
+def test_config_json_is_part_of_the_content_identity(tmp_path):
+    from prismaquant.cost_streaming import build_source_checkpoint_identity
+
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    _write_config(source)
+    before = build_source_checkpoint_identity(str(source))
+
+    _write_config(source, num_hidden_layers=2)
+    after = build_source_checkpoint_identity(str(source))
+    assert before["content_sha256"] != after["content_sha256"]
+    assert [row["name"] for row in before["metadata"]] == ["config.json"]
+
+
+def test_appearing_config_json_is_a_different_source(tmp_path):
+    """An absent file contributes no row, so a config.json that appears
+    later must not compare equal to the run that had none."""
+    from prismaquant.cost_streaming import build_source_checkpoint_identity
+
+    source = tmp_path / "source"
+    _write_source(source, weight=_WEIGHT_A, bias=_BIAS_A)
+    bare = build_source_checkpoint_identity(str(source))
+    assert bare["metadata"] == []
+
+    _write_config(source)
+    assert (build_source_checkpoint_identity(str(source))["content_sha256"]
+            != bare["content_sha256"])
+
+
+def test_changed_index_json_is_a_different_source(tmp_path):
+    """`model.safetensors.index.json` decides which shard a tensor is read
+    from; the shards it names can be byte-identical either way."""
+    from prismaquant.cost_streaming import build_source_checkpoint_identity
+
+    source = tmp_path / "source"
+    source.mkdir(parents=True, exist_ok=True)
+    save_file({"model.layers.0.proj.weight": _WEIGHT_A.clone()},
+              str(source / "model-00001-of-00001.safetensors"))
+    index = source / "model.safetensors.index.json"
+
+    def _write_index(**extra):
+        payload = {
+            "metadata": {"total_size": 8},
+            "weight_map": {
+                "model.layers.0.proj.weight":
+                    "model-00001-of-00001.safetensors",
+            },
+        }
+        payload["metadata"].update(extra)
+        index.write_text(json.dumps(payload, indent=2))
+
+    _write_index()
+    before = build_source_checkpoint_identity(str(source))
+    _write_index(total_size=16)
+    after = build_source_checkpoint_identity(str(source))
+
+    assert before["shards"] == after["shards"], "the shard bytes did not move"
+    assert before["content_sha256"] != after["content_sha256"]

--- a/tests/test_pr348_review_regressions.py
+++ b/tests/test_pr348_review_regressions.py
@@ -1,0 +1,26 @@
+"""Independent regression for PR348's orphaned export-cache admission."""
+from pathlib import Path
+import pytest
+import torch
+from test_export_resume_source_identity import (
+    _exporter, _fill_cache, _write_source, _WEIGHT_A, _WEIGHT_B, _BIAS_A,
+)
+
+
+@pytest.mark.parametrize("change_source", [False, True])
+def test_missing_manifest_never_admits_orphaned_layer_payloads(tmp_path, monkeypatch, change_source):
+    run, source = _exporter(tmp_path, monkeypatch)
+    cache = tmp_path / "resume"
+    _fill_cache(run, source, cache, weight=_WEIGHT_A, bias=_BIAS_A)
+    (cache / "manifest.json").unlink()
+    expected = _WEIGHT_B if change_source else _WEIGHT_A
+    if change_source:
+        _write_source(source, weight=expected, bias=_BIAS_A)
+    replays = []
+    emitted = run(cache, replay_log=replays)
+    got = emitted["model.layers.0.proj.weight"]
+    assert not replays and torch.equal(got, expected), {
+        "orphaned_layers_replayed": replays,
+        "actual_emitted_weight": got.tolist(),
+        "expected_source_weight": expected.tolist(),
+    }


### PR DESCRIPTION
Closes #340.

The standalone export cache now binds layer payloads to source content, requested dtype, declared buffer dtypes, assignment and render policy. An unchanged source still resumes; changed inputs invalidate cached layers. Missing manifests also invalidate orphaned layer payloads, preventing a new source from emitting an old source's weights.

This integrates the original commits from #348 with its independently reproduced orphan-cache correction, current main, and corrected timing prose. The author's branch is preserved. Source identity uses the existing shared checkpoint mechanisms; no quantization format or serving gate changes.

Validation through PrismaBuild on DL380 CPU (4 workers, 8 GiB, native threads 1):

- Both orphan-cache cases failed before the fix (`daa537459dba…`), with exact author production source.
- Final integration: **239 passed, 163 subtests passed, zero skips**; both producer modules compiled. Action `3ce3152c3d69e8f16def072a2c515010b856fa8c0c558e4557816e963ab1a2b0`.
- Actual source bundle, terminal exit, CAS receipt/payload, logs and resource cleanup verified. Dated evidence: `docs/results/export_resume_source_identity_review_2026-09-07.md`.

No complete resume-latency benchmark or GPU/served-artifact result is claimed. The earlier primitive hash/stat timings do not measure full admission.
