### PR TITLE
Reuse validated joint AURA identities across allocator candidates

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,18 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-07 · `codex/joint-allocation-handoff`. Stamps
+As of: 2026-09-07 · `fix/joint-aura-validation-cost`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-07, `fix/joint-aura-validation-cost`) for allocator-local
+joint-AURA probe identity reuse. After loading a cost table, the allocator
+owns immutable JSON copies of shared probe identities and validates each
+source-model identity once. The row validator reuses only that checked model
+identity and its probe digest; operator, scalar, sample, currency and cross-row
+checks still run. Mutable values returned from an owned identity are detached
+copies, replacement identities receive full validation, and pickle restores
+ordinary dictionaries requiring fresh admission. No persisted cost schema,
+calibration, numerical objective, format, cache or serving gate changes.
+Gate: `tests/test_joint_aura_validation_reuse.py`.
 
 Re-stamped (2026-09-07, `codex/joint-allocation-handoff`) for the opt-in
 completed joint-table allocation handoff (#351). `tessera_joint_allocation`

--- a/docs/results/joint_aura_validation_cost_2026-09-08.md
+++ b/docs/results/joint_aura_validation_cost_2026-09-08.md
@@ -1,0 +1,106 @@
+# Joint-AURA allocator identity reuse — 2026-09-08
+
+The same 114-budget allocation completed in **770.654 seconds before and
+148.395 seconds after**: **5.193× faster, 80.744% less wall time under cProfile**.
+The probe was not repeated. All assignments, prices, bpp, candidate metadata,
+frontier CSV and knee results matched. Forty output files were byte-identical;
+the terminal layer config differed only in its 114 measured `solver_seconds`
+values. Excluding exactly those fields, all 41 files matched.
+
+## Workload and implementation
+
+LFM2.5-8B-A1B; the completed 2,142-unit joint table, seven measured Tessera
+formats plus BF16; the original 114 budgets, 0.0001 bit precision and cost
+settings. Input SHA256:
+`5d08904df98d07d91fa29cffe9d5bb44080e63f8149037b1f29153b6457bd451`.
+Baseline source: `3264f85828f90f2cb4321bc47e0bc1a5604f7e84`.
+Measured implementation: `77d3938075481a84f615b052d0182aaa946bc9d3`.
+
+The allocator owns immutable copies of the loaded table's shared probe
+identities. Each distinct source identity is validated when copied. Its digest
+and validated model identity can then be reused, while every row consumption
+still validates operator identity, digest binding, samples, scalar values and
+currency. Nested values are returned as detached copies. Pickle restores normal
+dictionaries, requiring fresh validation on admission. The original source
+object is checked before JSON normalization, preserving strict type rejection.
+No format, calibration, numerical objective, artifact schema or serving gate
+changes. This extends CPU post-probe allocation; it adds no GPU or weight cache.
+
+## Profile evidence
+
+Both arms ran consecutively in one PrismaBuild measurement on DL380, with one
+preferred physical CPU, 8 GiB reserved, Python 3.12, native threads bounded to
+one, the original producer package and identical input/argv/environment apart
+from output locations. Both arms used cProfile with local profile output before
+archiving to shared storage. This is one profiled pair, not an estimate of
+unprofiled throughput or a multi-run confidence interval.
+
+| Work | Before calls | After calls | Before cumulative s | After cumulative s |
+|---|---:|---:|---:|---:|
+| Joint row validation | 79,554 | 79,554 | 656.323 | 21.173 |
+| Streamed model identity validation | 79,554 | 1,261 | 495.838 | 8.105 |
+| Owned identity preparation | — | 1 | — | 14.138 |
+| Artifact-size calculation | 114 | 114 | 57.915 | 57.977 |
+| Core allocation solves | 114 | 114 | 2.485 | 2.373 |
+
+Cumulative rows overlap. Total in-process profile time fell from 769.374 to
+147.102 seconds. The new identity preparation cost includes its model checks.
+Artifact-size calculation is now the largest remaining component; it was not
+changed by this fix.
+
+Live Netdata CPU/RAM/I/O/load and Spark GPU-power samples cover both arms on all
+three hosts: 155 samples per host before and 30 after, with zero sampling errors.
+DL380 whole-host CPU busy averaged 3.869% before and 4.749% after. PB's combined
+scope recorded 921.058 CPU-seconds, peak memory 2,971,553,792 bytes and complete
+cleanup. Spark telemetry includes unrelated work; this CPU-only experiment makes
+no GPU saturation, energy-efficiency or serving-speed claim.
+
+## Validation and receipts
+
+The initial six feature regressions failed before implementation. A further
+source-type regression reproduced normalization bypass, then passed after the
+constructor preserved the original admission check. The integrated targeted
+suite passed **112 tests, zero skips**, across seven PB shards. Touched Python
+modules and the measurement helper passed compile checks through PB. The final
+source was integrated with main in `be92f57b31`; the allocation and row-validator
+changes match the measured implementation.
+
+Measurement action:
+`8eed82abb3dad3bc65dcd79b974c1dc0af4df7dd38e76eceef63a809a6e56bbf`.
+Both allocator children exited zero. The original wrapper exited one because
+it incorrectly required measured solver timings to match. That failed terminal
+record is retained. No timing run was repeated to repair the comparator.
+
+A separate admitted audit checked the original artifact hashes, required both
+successful children and complete telemetry, and excluded only the exact 114
+`__prismaquant__.solve_diagnostics.<target>.solver_seconds` fields:
+`50c7d6c0ea3144a64417346ced3d7b0bddd0cff318119f7861e60c9d4710ccf9`.
+It exited zero with complete cleanup. Its actual CAS payload binds audit SHA256
+`4a271921c291fa12b74adb803406691560e14b1b13d27750b14ff941e199b4c0`.
+Root independently checked all changed leaves, canonical successful receipts,
+actual CAS payload hashes, source bundles against their Git parents, and every
+artifact hash named by the final audit.
+
+The first cross-host measurement submission failed preflight because it carried
+the Spark's accelerator identity to DL380; no payload ran. A shallow submission
+clone was also refused before submission. The final pair was submitted from
+DL380 using a complete clone and the correct measurement identity.
+
+Evidence root:
+`/mnt/shared/tessera-measurements/first-model-20260907/allocation-preparation-01/validation-pair-01/`.
+It contains both profiles/logs/invocations/telemetry, `comparison.json` (original
+failed comparison), `difference-leaves.json`, `comparison-audited.json`,
+`performance-summary.json`, and `root-final-audit.json` with exact receipt and
+source hashes. Integrated test manifest:
+`/mnt/shared/tessera-measurements/joint-validation-integrated-tests-20260908.json`.
+
+Reproduction uses the checked-in `tools/benchmarks/joint_validation_pair.py`
+through PB `--measurement --cpus 1 --demand mem_gb=8`, on the same DL380 runtime,
+with `--invocation` pointing to the sibling `frontier-invocation-01.json` and a
+new `--output` directory. `--audit-existing` audits retained arms without running
+allocation again.
+
+The existing non-BF16 terminal assignment and conservative fused-group fallback
+are unchanged and unresolved. These outputs remain research evidence, not
+shipping candidates; this result does not establish GLM capture or quant
+shipping completion.

--- a/prismaquant/allocator.py
+++ b/prismaquant/allocator.py
@@ -2352,6 +2352,8 @@ def main():
             cost_data = pickle.load(f)
     validate_probe_payload(probe, args.probe)
     validate_cost_payload(cost_data, args.costs)
+    from .joint_aura import prepare_joint_aura_identities
+    prepare_joint_aura_identities(cost_data)
     # One DP prices in one currency: a cost table carrying Tessera-currency
     # rows (output_mse under the route's activation contract) is admissible
     # only on the objective those rows measure (render-score). Read from the

--- a/prismaquant/joint_aura.py
+++ b/prismaquant/joint_aura.py
@@ -7,6 +7,7 @@ QDQ is the same owner used by PerturbedActivationCache and assignment KL.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 import hashlib
 import json
 import math
@@ -31,7 +32,71 @@ PROBE_UNCERTAINTY_SCOPE = "probe_sampling_conditional_on_fixed_calibration"
 ASSIGNMENT_OBJECTIVES = ("additive", "joint_quadratic")
 
 
+@dataclass(frozen=True, slots=True, init=False)
+class _ValidatedProbeIdentity(Mapping):
+    """Owned immutable JSON fields; mutable values are returned as fresh copies.
+
+    Only this constructor can issue the fast-path type, after checking the
+    source model. Serialization deliberately restores an ordinary dict so a
+    validation result never crosses a persisted artifact boundary.
+    """
+
+    _fields: tuple
+    _sha256: str
+
+    def __init__(self, probe):
+        encoded = json.dumps(probe, sort_keys=True, separators=(",", ":"), allow_nan=False)
+        snapshot = json.loads(encoded)
+        from prismaquant.cost_streaming import validate_streamed_model_identity
+        validate_streamed_model_identity(probe["source_model"], where="joint AURA row")
+        object.__setattr__(self, "_fields", tuple(
+            (key, json.dumps(value, separators=(",", ":"), allow_nan=False))
+            for key, value in snapshot.items()))
+        object.__setattr__(self, "_sha256", hashlib.sha256(encoded.encode()).hexdigest())
+
+    def __getitem__(self, key):
+        for name, encoded in self._fields:
+            if name == key:
+                return json.loads(encoded)
+        raise KeyError(key)
+
+    def __iter__(self):
+        return (name for name, _ in self._fields)
+
+    def __len__(self):
+        return len(self._fields)
+
+    def __reduce__(self):
+        return dict, (dict(self),)
+
+
+def prepare_joint_aura_identities(cost_data):
+    """Own shared probe identities for one allocator table, without trusting rows.
+
+    Pickle preserves shared object references. Deduplicate by that reference
+    only while retaining it here, then discard the temporary index. No global
+    cache, digest-only trust, or caller promise of immutability is involved.
+    Row/operator/digest/sample checks still run at every consumption boundary.
+    """
+    prepared = {}
+    for per_unit in cost_data.get("costs", {}).values():
+        if not isinstance(per_unit, Mapping):
+            continue
+        for row in per_unit.values():
+            if not isinstance(row, dict):
+                continue
+            probe = row.get("probe_identity")
+            if not isinstance(probe, dict) or probe.get("schema") != "prismaquant.joint_aura.probes.v2":
+                continue
+            key = id(probe)
+            if key not in prepared:
+                prepared[key] = (probe, _ValidatedProbeIdentity(probe))
+            row["probe_identity"] = prepared[key][1]
+
+
 def identity_sha256(value) -> str:
+    if type(value) is _ValidatedProbeIdentity:
+        return value._sha256
     return hashlib.sha256(json.dumps(
         value, sort_keys=True, separators=(",", ":"), allow_nan=False,
     ).encode()).hexdigest()
@@ -405,7 +470,8 @@ def validate_joint_aura_entry(entry: Mapping) -> bool:
         raise ValueError("joint AURA probe identity mismatch")
     from prismaquant.cost_streaming import validate_streamed_model_identity
     try:
-        validate_streamed_model_identity(probe["source_model"], where="joint AURA row")
+        if type(probe) is not _ValidatedProbeIdentity:
+            validate_streamed_model_identity(probe["source_model"], where="joint AURA row")
         for field in ("calibration_sha256", "producer_source_sha256"):
             if re.fullmatch(r"[a-f0-9]{64}", probe[field]) is None:
                 raise ValueError(f"invalid {field}")

--- a/tests/test_joint_aura_validation_reuse.py
+++ b/tests/test_joint_aura_validation_reuse.py
@@ -1,0 +1,98 @@
+"""Allocator metadata reuse must preserve mutation and digest rejection."""
+import copy
+
+import pytest
+
+from prismaquant import joint_aura as joint
+from test_joint_aura_assignment_diagnostics import _row, UNIT_A
+
+
+def _prepare(row):
+    payload = {"costs": {UNIT_A: {"FP8_E4M3": row}}}
+    joint.prepare_joint_aura_identities(payload)
+    return row
+
+
+def test_shared_identity_validated_once_and_detached(monkeypatch):
+    from prismaquant import cost_streaming
+    row = _row(UNIT_A, [1, 2, 3])
+    original = row["probe_identity"]
+    other = dict(row)
+    calls = []
+    validate = cost_streaming.validate_streamed_model_identity
+    def counted(*args, **kwargs):
+        calls.append(1)
+        return validate(*args, **kwargs)
+    monkeypatch.setattr(cost_streaming, "validate_streamed_model_identity", counted)
+    joint.prepare_joint_aura_identities({"costs": {UNIT_A: {"a": row, "b": other}}})
+    for entry in (row, other, row):
+        assert joint.validate_joint_aura_entry(entry)
+    assert len(calls) == 1
+    assert row["probe_identity"] is other["probe_identity"]
+    original["source_model"]["shards"][0]["sha256"] = "f" * 64
+    assert joint.validate_joint_aura_entry(row)
+    detached = row["probe_identity"]["source_model"]
+    detached["shards"][0]["sha256"] = "e" * 64
+    assert joint.validate_joint_aura_entry(row)
+    with pytest.raises(TypeError):
+        row["probe_identity"]["temperature"] = 2
+
+
+@pytest.mark.parametrize("field", ["predicted_dloss", "probe_identity_sha256", "joint_operator_identity_sha256"])
+def test_row_mutation_still_rejected(field):
+    row = _prepare(_row(UNIT_A, [1, 2, 3]))
+    row[field] = 999 if field == "predicted_dloss" else "e" * 64
+    with pytest.raises(ValueError):
+        joint.validate_joint_aura_entry(row)
+
+
+def test_replaced_probe_is_validated():
+    row = _row(UNIT_A, [1, 2, 3])
+    replacement = copy.deepcopy(row["probe_identity"])
+    _prepare(row)
+    replacement["source_model"]["config"]["fixture"] = "changed"
+    row["probe_identity"] = replacement
+    row["probe_identity_sha256"] = joint.identity_sha256(replacement)
+    row["joint_operator_identity"]["probe_identity_sha256"] = row["probe_identity_sha256"]
+    row["joint_operator_identity_sha256"] = joint.identity_sha256(row["joint_operator_identity"])
+    with pytest.raises(ValueError, match="content_sha256"):
+        joint.validate_joint_aura_entry(row)
+
+
+def test_corrupt_source_cannot_be_prepared():
+    row = _row(UNIT_A, [1, 2, 3])
+    row["probe_identity"]["source_model"]["shards"][0]["sha256"] = "f" * 64
+    with pytest.raises((RuntimeError, ValueError), match="content_sha256"):
+        _prepare(row)
+
+
+def test_serialization_does_not_preserve_validation_trust():
+    import pickle
+    row = _prepare(_row(UNIT_A, [1, 2, 3]))
+    restored = pickle.loads(pickle.dumps(row))
+    assert type(restored["probe_identity"]) is dict
+    assert joint.validate_joint_aura_entry(restored)
+    restored["probe_identity"]["n_probes"] = True
+    with pytest.raises(ValueError, match="at least two probes"):
+        joint.validate_joint_aura_entry(restored)
+
+
+def test_distinct_probe_objects_do_not_share_digest_trust():
+    good = _row(UNIT_A, [1, 2, 3])
+    bad = copy.deepcopy(good)
+    bad["probe_identity"]["temperature"] = 2.0
+    joint.prepare_joint_aura_identities({"costs": {UNIT_A: {"a": good, "b": bad}}})
+    assert joint.validate_joint_aura_entry(good)
+    with pytest.raises(ValueError, match="probe identity mismatch"):
+        joint.validate_joint_aura_entry(bad)
+
+
+def test_preparation_keeps_original_source_type_rejection():
+    row = _row(UNIT_A, [1, 2, 3])
+    source = row["probe_identity"]["source_model"]
+    source["shards"] = tuple(source["shards"])
+    # JSON hashes are unchanged by list -> tuple; source admission is stricter.
+    with pytest.raises(ValueError, match="source shard"):
+        joint.validate_joint_aura_entry(row)
+    with pytest.raises((RuntimeError, ValueError), match="source shard"):
+        _prepare(row)

--- a/tools/benchmarks/joint_validation_pair.py
+++ b/tools/benchmarks/joint_validation_pair.py
@@ -1,0 +1,107 @@
+"""PB-only paired allocator profiles against an exact Git baseline/input receipt."""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import pstats
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+import urllib.parse
+import urllib.request
+
+
+def sha(path):
+    with path.open('rb') as stream:
+        return hashlib.file_digest(stream, 'sha256').hexdigest()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--invocation', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    inv = json.loads(args.invocation.read_text())
+    root = args.invocation.parent
+    assert sha(root / 'joint-allocation-cost.pkl') == inv['input_sha256']
+    args.output.mkdir(exist_ok=False, parents=True)
+    current = Path.cwd()
+    results = []
+    with tempfile.TemporaryDirectory(prefix='joint-validation-pair-') as tmp:
+        tmp = Path(tmp)
+        baseline = tmp / 'baseline'
+        baseline.mkdir()
+        archive = tmp / 'baseline.tar'
+        with archive.open('wb') as stream:
+            subprocess.run(['git', 'archive', inv['source_commit']], stdout=stream, check=True)
+        subprocess.run(['tar', '-xf', str(archive), '-C', str(baseline)], check=True)
+        for arm, cwd in [('before', baseline), ('after', current)]:
+            out = args.output / arm
+            out.mkdir()
+            profile = tmp / (arm + '.pstats')
+            argv = [s.replace(str(root / 'frontier-01'), str(out / 'frontier')) for s in inv['command']]
+            argv = argv[:1] + ['-m', 'cProfile', '-o', str(profile)] + argv[1:]
+            (out / 'invocation.json').write_text(json.dumps({'argv': argv, 'env': inv['env'], 'cwd': str(cwd)}, indent=2))
+            stopped = threading.Event()
+            errors = []
+            query = urllib.parse.urlencode({'format': 'json', 'filter': 'system.cpu system.ram system.io system.load nvidia_smi.*_power_draw'})
+            def sample(host, address):
+                with (out / (host + '-netdata.jsonl')).open('w') as stream:
+                    while not stopped.is_set():
+                        record = {'host': host, 'time': time.time()}
+                        try:
+                            with urllib.request.urlopen('http://' + address + ':19999/api/v1/allmetrics?' + query, timeout=3) as response:
+                                record['metrics'] = json.load(response)
+                            assert 'system.cpu' in record['metrics']
+                        except Exception as exc:
+                            record['error'] = repr(exc)
+                            errors.append(record)
+                        stream.write(json.dumps(record) + '\n')
+                        stream.flush()
+                        stopped.wait(5)
+            threads = [threading.Thread(target=sample, args=host) for host in [
+                ('dl380g10', '127.0.0.1'), ('sparky', '192.168.1.180'), ('sparklina', '192.168.1.110')]]
+            start = time.time()
+            for thread in threads:
+                thread.start()
+            try:
+                with (out / 'allocator.log').open('w') as stream:
+                    completed = subprocess.run(argv, cwd=cwd, env={**os.environ, **inv['env']}, stdout=stream, stderr=subprocess.STDOUT)
+                elapsed = time.time() - start
+            finally:
+                stopped.set()
+                for thread in threads:
+                    thread.join()
+            shutil.copy2(profile, out / 'allocator.pstats')
+            with (out / 'profile-top.txt').open('w') as stream:
+                pstats.Stats(str(profile), stream=stream).strip_dirs().sort_stats('cumulative').print_stats(45)
+                pstats.Stats(str(profile), stream=stream).strip_dirs().sort_stats('tottime').print_stats(30)
+            result = {'arm': arm, 'elapsed_s': elapsed, 'returncode': completed.returncode, 'started_unix': start, 'netdata_errors': errors}
+            results.append(result)
+            (out / 'result.json').write_text(json.dumps(result, indent=2))
+            print(json.dumps(result), flush=True)
+            assert completed.returncode == 0
+        before = args.output / 'before' / 'frontier'
+        after = args.output / 'after' / 'frontier'
+        files = sorted(path.relative_to(before) for path in before.rglob('*') if path.is_file())
+        assert files == sorted(path.relative_to(after) for path in after.rglob('*') if path.is_file())
+        differences = []
+        for rel in files:
+            a = (before / rel).read_text().replace(str(before), '<FRONTIER>')
+            b = (after / rel).read_text().replace(str(after), '<FRONTIER>')
+            if a != b:
+                differences.append(str(rel))
+        assert sha(root / 'joint-allocation-cost.pkl') == inv['input_sha256']
+        report = {'arms': results, 'output_files': len(files), 'differences': differences,
+                  'artifacts': {str(p.relative_to(args.output)): sha(p) for p in args.output.rglob('*') if p.is_file()}}
+        (args.output / 'comparison.json').write_text(json.dumps(report, indent=2))
+        print(json.dumps({'output_files': len(files), 'differences': differences}), flush=True)
+        assert not differences
+        assert not any(r['netdata_errors'] for r in results)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/benchmarks/joint_validation_pair.py
+++ b/tools/benchmarks/joint_validation_pair.py
@@ -2,6 +2,7 @@
 import argparse
 import hashlib
 import json
+import math
 import os
 from pathlib import Path
 import pstats
@@ -19,14 +20,60 @@ def sha(path):
         return hashlib.file_digest(stream, 'sha256').hexdigest()
 
 
+def audit_outputs(output, inv, root):
+    """Compare artifact values, retaining but excluding measured solver times."""
+    results = [json.loads((output / arm / 'result.json').read_text())
+               for arm in ('before', 'after')]
+    assert all(r['returncode'] == 0 and not r['netdata_errors'] for r in results)
+    original = output / 'comparison.json'
+    if original.exists():
+        for rel, digest in json.loads(original.read_text())['artifacts'].items():
+            assert sha(output / rel) == digest, rel
+    before = output / 'before' / 'frontier'
+    after = output / 'after' / 'frontier'
+    files = sorted(path.relative_to(before) for path in before.rglob('*') if path.is_file())
+    assert files == sorted(path.relative_to(after) for path in after.rglob('*') if path.is_file())
+    differences = []
+    timing_keys = []
+    for rel in files:
+        a = (before / rel).read_text().replace(str(before), '<FRONTIER>')
+        b = (after / rel).read_text().replace(str(after), '<FRONTIER>')
+        if str(rel) == 'terminal-bf16-control.json':
+            a, b = json.loads(a), json.loads(b)
+            left = a['__prismaquant__']['solve_diagnostics']
+            right = b['__prismaquant__']['solve_diagnostics']
+            assert left.keys() == right.keys()
+            for target in left:
+                for side in (left, right):
+                    seconds = side[target].pop('solver_seconds')
+                    assert type(seconds) is float and math.isfinite(seconds) and seconds >= 0
+                timing_keys.append(target)
+        if a != b:
+            differences.append(str(rel))
+    assert sha(root / 'joint-allocation-cost.pkl') == inv['input_sha256']
+    report = {'arms': results, 'output_files': len(files), 'differences': differences,
+              'excluded_solver_seconds_targets': sorted(timing_keys),
+              'artifacts': {str(p.relative_to(output)): sha(p) for p in output.rglob('*')
+                            if p.is_file() and p.name != 'comparison-audited.json'}}
+    (output / 'comparison-audited.json').write_text(json.dumps(report, indent=2))
+    print(json.dumps({'output_files': len(files), 'differences': differences,
+                      'excluded_solver_seconds': len(timing_keys),
+                      'audit_sha256': sha(output / 'comparison-audited.json')}), flush=True)
+    assert not differences
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--invocation', type=Path, required=True)
     parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--audit-existing', action='store_true')
     args = parser.parse_args()
     inv = json.loads(args.invocation.read_text())
     root = args.invocation.parent
     assert sha(root / 'joint-allocation-cost.pkl') == inv['input_sha256']
+    if args.audit_existing:
+        audit_outputs(args.output, inv, root)
+        return
     args.output.mkdir(exist_ok=False, parents=True)
     current = Path.cwd()
     results = []
@@ -84,23 +131,8 @@ def main():
             (out / 'result.json').write_text(json.dumps(result, indent=2))
             print(json.dumps(result), flush=True)
             assert completed.returncode == 0
-        before = args.output / 'before' / 'frontier'
-        after = args.output / 'after' / 'frontier'
-        files = sorted(path.relative_to(before) for path in before.rglob('*') if path.is_file())
-        assert files == sorted(path.relative_to(after) for path in after.rglob('*') if path.is_file())
-        differences = []
-        for rel in files:
-            a = (before / rel).read_text().replace(str(before), '<FRONTIER>')
-            b = (after / rel).read_text().replace(str(after), '<FRONTIER>')
-            if a != b:
-                differences.append(str(rel))
-        assert sha(root / 'joint-allocation-cost.pkl') == inv['input_sha256']
-        report = {'arms': results, 'output_files': len(files), 'differences': differences,
-                  'artifacts': {str(p.relative_to(args.output)): sha(p) for p in args.output.rglob('*') if p.is_file()}}
-        (args.output / 'comparison.json').write_text(json.dumps(report, indent=2))
-        print(json.dumps({'output_files': len(files), 'differences': differences}), flush=True)
-        assert not differences
-        assert not any(r['netdata_errors'] for r in results)
+        audit_outputs(args.output, inv, root)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Allocating 114 budgets from the completed LFM joint-AURA table now takes **148.4 seconds instead of 770.7 seconds under cProfile (5.19× faster)**. The allocator owns immutable validated copies of shared probe identities, while continuing all 79,554 row/operator/sample/currency checks. No reprobe is required.

Nested values are detached copies; replacement identities receive full validation; pickle restores dictionaries requiring fresh admission. Original source types are checked before JSON normalization.

Validation: **112 CPU tests, zero skips**, through seven PrismaBuild shards, plus compile checks and regressions demonstrated before fixing. A same-host paired full 114-budget profile includes live Netdata on DL380 and both Sparks. Forty output files are byte-identical; the remaining terminal file differs only in its 114 measured solver-duration values. A separate PB audit verified those exact exclusions and retained artifact hashes. The original timing-comparator failure is preserved in the report.

Measured source: `77d3938075481a84f615b052d0182aaa946bc9d3`, integrated with current main in `be92f57b31`. Profiles, commands, workload, source/CAS audits and limitations: [measurement report](docs/results/joint_aura_validation_cost_2026-09-08.md). Existing non-BF16 terminal assignment and conservative fused-group fallback remain unresolved; this CPU allocation result does not qualify a shipping quant.

Closes #356
