### PR TITLE
Preserve feasible minimum-loss allocation endpoints

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,18 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-07 · `fix/joint-aura-validation-cost`. Stamps
+As of: 2026-09-08 · `fix/allocator-quality-endpoint`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `fix/allocator-quality-endpoint`) for the allocator's
+unrounded quality endpoint. `solve_with_promotion` first considers each unit's
+minimum measured loss option, breaking local ties toward larger payloads. It
+returns that assignment only if existing serving-group promotion preserves
+every unit's minimum and the unrounded candidate payload fits the declared
+bit target and tolerance. Otherwise the binned search proceeds as before.
+The outer exact artifact/sidecar budget filter remains mandatory. This avoids
+rounding away a feasible zero-loss endpoint without a BF16-specific default,
+changing DP bin charges, re-probing or claiming global artifact optimality.
+Gate: `tests/test_allocator_quality_endpoint.py`.
 
 Re-stamped (2026-09-07, `fix/joint-aura-validation-cost`) for allocator-local
 joint-AURA probe identity reuse. After loading a cost table, the allocator

--- a/docs/results/allocator_quality_endpoint_2026-09-08.md
+++ b/docs/results/allocator_quality_endpoint_2026-09-08.md
@@ -1,0 +1,89 @@
+# Preserve the feasible allocation quality endpoint — 2026-09-08
+
+The completed LFM2.5-8B-A1B joint probe now produces the exact zero-predicted-loss
+16-bpp endpoint: **2,142 BF16 units**, replacing the previous 2,141 BF16 units
+plus `model.layers.10.self_attn.out_proj@TESSERA_BF16_K1_R1024`.
+The remaining **113 budget rows and 35 distinct lower-budget assignment files
+are unchanged**. The original probe and its bytes were not modified or repeated.
+
+## Cause and correction
+
+The actual 38 aggregated solver units had a 3.543686139861996-bpp minimum.
+At 0.0001-bit precision, the globally rounded 16-bpp capacity was 124,564 bins.
+Rounding the BF16 upgrade separately for each unit charged 124,570 bins,
+although its exact candidate payload was 16.0 bpp and its predicted loss zero.
+The solver therefore retained a lossy candidate, producing 15.993667894108281
+bpp and predicted loss 0.00029748423740553554.
+
+`solve_with_promotion` now checks the unconstrained per-unit minimum measured
+loss assignment before the binned proposal. Local equal-loss ties prefer larger
+payloads, consistent with the existing feasible-iterate tie rule. The point is
+accepted only when the existing serving-group promotion preserves every unit's
+minimum and the unrounded candidate bytes fit the declared target and tolerance.
+Otherwise the old search runs. Each unit's loss is compared independently, so a
+large unchanged background term cannot hide a smaller promotion-induced increase.
+
+This is not a BF16 default: another measured format can be a unit's minimum.
+`solve_allocation` and its bin charges are unchanged. The caller's exact shared
+sidecar/artifact price and budget filter remain mandatory, and the full allocator
+still makes no global artifact-optimality claim. No calibration, format menu,
+wire, source checkpoint or serving contract changes.
+
+## Evidence and validation
+
+Source before the correction: `56c51cc28bce3a7dba09b1d9fa55ba731bc00fce`.
+Validated implementation: `7280605d5` (full commit in the PB snapshot receipt).
+Original allocation input SHA256:
+`5d08904df98d07d91fa29cffe9d5bb44080e63f8149037b1f29153b6457bd451`.
+The actual diagnostic's 38-unit numeric inputs are retained with source/probe
+hashes in `tests/fixtures/lfm_quality_endpoint.json`; the test isolates the
+already aggregated units and the full CLI run separately covers real grouping.
+
+- Diagnostic PB `8adeb39b22f1e6996ec4a40fb6af8a8e3a0f9efcb2cc8a79763ae289e310e207`
+  captured the first real solver invocation after normal input admission and
+  intentionally stopped there. Exit0 and complete cleanup; it was not a full
+  allocator run.
+- Regression PB `1e9ea8538cc77b193349a04de9df573d21580592b341d89f5c61b52105b949f1`
+  failed the expected all-BF16 assertion before the fix (one failure, two passes).
+- **67 targeted CPU tests passed, zero skips**, across eight PB shards. Coverage
+  includes bin rounding, strict budgets, format-independent minima, real grouping,
+  promotion loss beside a 1e16 background term, the extracted LFM input,
+  main enforcement, sidecar/byte budgets, serving constraints and architecture.
+- Full-frontier PB `738178c019b6f11820bef45ae58bc7152aae147ca9ee219c2cb9de9a2ca88006`
+  passed compile checks and all 114 budgets. Only the 16-bpp CSV row changed;
+  all 35 other assignment payloads were byte-identical. The final serialized
+  control contains exactly 2,142 W16A16 float entries. Input SHA256 was unchanged.
+
+The full validation was a CPU-only admitted measurement on DL380, one preferred
+physical CPU, 8 GiB reserved, Python3.12 and native threads1, with the original
+producer package and calibration-bound table. It took 140.891 wall-seconds under
+cProfile; the profile total was 139.722 seconds. There were 114 promoted solver
+calls and 113 binned solves (2.178 cumulative seconds in the latter). Live Netdata
+covered DL380 and both Sparks, 29 samples each, zero errors. Mean whole-host CPU
+busy was 2.067% on DL380, 0.773% on Sparky and 0.906% on Sparklina. PB recorded
+143.355 scope CPU-seconds, peak memory 2,815,180,800 bytes and complete cleanup.
+
+The retained before profile is `validation-pair-01/after/allocator.pstats`
+(147.102 profile-seconds), with its contemporaneous all-three-host telemetry.
+These instruments document the hot-path change; this correctness result makes
+no additional speedup, GPU-saturation, energy or serving-quality claim.
+
+Root verified the ten successful canonical PB receipts, actual CAS payload
+hashes, source bundles, all 48 full-validation artifact hashes and the final
+serialized BF16 control. The full measurement source differs from the reviewed
+commit only by PB-generated closure metadata. Test snapshots have the same
+production code, tests, fixture and architecture; the later measurement helper
+is the only additional source file in the committed tree.
+
+Evidence under
+`/mnt/shared/tessera-measurements/first-model-20260907/allocation-preparation-01/`:
+`endpoint-diagnostic-01/solver-inputs.json` and
+`endpoint-validation-01/{result.json,root-audit.json,allocator.pstats,profile-top.txt,frontier/}`,
+plus the three host telemetry files. The test manifest is
+`/mnt/shared/tessera-measurements/allocator-endpoint-tests-20260908.json`.
+Reproduce through PB using the checked-in
+`experiments/allocator_endpoint_validation.py` with a fresh output location;
+its frozen input/reference paths identify this retained experiment.
+
+The earlier fused-group producer-contract fallback remains unresolved. This
+allocator correction does not complete GLM capture or qualify a shipping quant.

--- a/experiments/allocator_endpoint_diagnostic.py
+++ b/experiments/allocator_endpoint_diagnostic.py
@@ -1,0 +1,52 @@
+"""Inspect one real allocator solve from an existing probe; no GPU or reprobe."""
+import dataclasses
+import hashlib
+import json
+import os
+from pathlib import Path
+import runpy
+import sys
+
+root = Path('/mnt/shared/tessera-measurements/first-model-20260907/allocation-preparation-01')
+inv = json.loads((root / 'frontier-invocation-01.json').read_text())
+with (root / 'joint-allocation-cost.pkl').open('rb') as stream:
+    assert hashlib.file_digest(stream, 'sha256').hexdigest() == inv['input_sha256']
+out = root / 'endpoint-diagnostic-01'
+out.mkdir(exist_ok=False)
+os.environ.update(inv['env'])
+from prismaquant import allocator_solver as solver
+original = solver.solve_allocation
+
+def inspect(stats, candidates, target_bits, bit_precision=0.001):
+    result = original(stats, candidates, target_bits, bit_precision)
+    total = sum(stats[n]['n_params'] for n in candidates)
+    baseline = {n: min(cs, key=lambda c: c.bits_per_param) for n, cs in candidates.items()}
+    minimum = sum(baseline[n].bits_per_param * stats[n]['n_params'] for n in candidates) / total
+    best = {n: min(cs, key=lambda c: (c.predicted_dloss, c.bits_per_param)) for n, cs in candidates.items()}
+    bf16 = {n: next((c for c in cs if c.fmt == 'BF16'), None) for n, cs in candidates.items()}
+    assert all(c is not None for c in bf16.values())
+    charges = {n: solver._charged_bins((c.bits_per_param-baseline[n].bits_per_param)*stats[n]['n_params']/total, bit_precision) for n,c in bf16.items()}
+    payload = {'target_bits':target_bits, 'bit_precision':bit_precision, 'total_params':total,
+      'min_bits':minimum, 'capacity_bins':round((target_bits-minimum)/bit_precision)+1,
+      'all_bf16_bins':sum(charges.values()),
+      'all_bf16_exact_bpp':sum(c.bits_per_param*stats[n]['n_params'] for n,c in bf16.items())/total,
+      'all_bf16_loss':sum(c.predicted_dloss for c in bf16.values()),
+      'selected_loss':sum(c.predicted_dloss for c in result[1].values()),
+      'selected_non_bf16':{n:c.fmt for n,c in result[1].items() if c.fmt!='BF16'},
+      'max_baseline_loss':max(c.predicted_dloss for c in baseline.values()),
+      'stats':{n:{'n_params':stats[n]['n_params']} for n in candidates},
+      'candidates':{n:[dataclasses.asdict(c) for c in cs] for n,cs in candidates.items()},
+      'assignment':result[0], 'bf16_charges':charges, 'input_sha256':inv['input_sha256']}
+    (out/'solver-inputs.json').write_text(json.dumps(payload, indent=2))
+    print(json.dumps({k:v for k,v in payload.items() if k not in ('stats','candidates','assignment','bf16_charges')}),flush=True)
+    # Diagnostic intentionally stops after the first real solver invocation.
+    raise SystemExit(0)
+
+solver.solve_allocation = inspect
+argv = inv['command'][3:]
+for option in ('--pareto-output-dir','--pareto-csv','--layer-config'):
+    i=argv.index(option)
+    argv[i+1]=str(out/Path(argv[i+1]).name)
+i=argv.index('--pareto-targets');argv[i+1]='16'
+sys.argv=['prismaquant.allocator',*argv]
+runpy.run_module('prismaquant.allocator',run_name='__main__')

--- a/experiments/allocator_endpoint_validation.py
+++ b/experiments/allocator_endpoint_validation.py
@@ -1,0 +1,99 @@
+"""Profile and verify a corrected full frontier against retained allocation."""
+import csv
+import hashlib
+import json
+import os
+from pathlib import Path
+import pstats
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+import urllib.parse
+import urllib.request
+
+root = Path('/mnt/shared/tessera-measurements/first-model-20260907/allocation-preparation-01')
+inv = json.loads((root/'frontier-invocation-01.json').read_text())
+reference = root/'validation-pair-01/after/frontier'
+out = root/'endpoint-validation-01'
+out.mkdir(exist_ok=False)
+
+def sha(path):
+    with path.open('rb') as stream:
+        return hashlib.file_digest(stream,'sha256').hexdigest()
+
+assert sha(root/'joint-allocation-cost.pkl') == inv['input_sha256']
+stop = threading.Event()
+errors = []
+query = urllib.parse.urlencode({'format':'json','filter':'system.cpu system.ram system.io system.load nvidia_smi.*_power_draw'})
+def sample(host,address):
+    with (out/(host+'-netdata.jsonl')).open('w') as stream:
+        while not stop.is_set():
+            row={'host':host,'time':time.time()}
+            try:
+                with urllib.request.urlopen('http://'+address+':19999/api/v1/allmetrics?'+query,timeout=3) as response:
+                    raw=response.read(131073)
+                assert len(raw)<=131072
+                row['metrics']=json.loads(raw)
+                assert 'system.cpu' in row['metrics']
+            except Exception as exc:
+                row['error']=repr(exc);errors.append(row)
+            stream.write(json.dumps(row)+'\n');stream.flush();stop.wait(5)
+threads=[threading.Thread(target=sample,args=host) for host in [
+    ('dl380g10','127.0.0.1'),('sparky','192.168.1.180'),('sparklina','192.168.1.110')]]
+with tempfile.TemporaryDirectory(prefix='endpoint-profile-') as tmp:
+    profile=Path(tmp)/'allocator.pstats'
+    argv=[x.replace(str(root/'frontier-01'),str(out/'frontier')) for x in inv['command']]
+    argv=argv[:1]+['-m','cProfile','-o',str(profile)]+argv[1:]
+    (out/'invocation.json').write_text(json.dumps({'argv':argv,'env':inv['env'],'input_sha256':inv['input_sha256']},indent=2))
+    for thread in threads:thread.start()
+    start=time.time()
+    try:
+        with (out/'allocator.log').open('w') as log:
+            result=subprocess.run(argv,env={**os.environ,**inv['env']},stdout=log,stderr=subprocess.STDOUT)
+        elapsed=time.time()-start
+    finally:
+        stop.set()
+        for thread in threads:thread.join()
+    shutil.copy2(profile,out/'allocator.pstats')
+    with (out/'profile-top.txt').open('w') as stream:
+        pstats.Stats(str(profile),stream=stream).strip_dirs().sort_stats('cumulative').print_stats(35)
+    assert result.returncode==0
+new=out/'frontier'
+with (reference/'pareto.csv').open() as a, (new/'pareto.csv').open() as b:
+    before=list(csv.DictReader(a));after=list(csv.DictReader(b))
+assert len(before)==len(after)==114
+changed=[]
+for a,b in zip(before,after):
+    assert a['target_bits']==b['target_bits']
+    if a!=b:
+        assert float(b['target_bits'])==16.0
+        changed.append(b['target_bits'])
+        assert float(b['predicted_dloss'])==0.0 and float(b['achieved_bits'])==16.0
+assert changed==['16.0']
+terminal=json.loads((new/'terminal-bf16-control.json').read_text())
+units={k:v for k,v in terminal.items() if k!='__prismaquant__'}
+assert len(units)==2142
+assert all(v['data_type']=='float' and v['bits']==16 for v in units.values())
+# Compare every retained lower-budget assignment payload; only the 16-bpp
+# endpoint's content-addressed name may be replaced by a new assignment.
+a=json.loads((reference/'assignments/manifest.json').read_text())
+b=json.loads((new/'assignments/manifest.json').read_text())
+old={float(x['target_bits']):x for x in a['candidates']}
+current={float(x['target_bits']):x for x in b['candidates']}
+assert old.keys()==current.keys()
+unchanged=[]
+for target in old:
+    if target==16.0:continue
+    left=Path(old[target]['path']).read_bytes();right=Path(current[target]['path']).read_bytes()
+    assert left==right,target
+    unchanged.append(target)
+assert not errors
+assert sha(root/'joint-allocation-cost.pkl')==inv['input_sha256']
+report={'returncode':result.returncode,'elapsed_s':elapsed,'started_unix':start,
+        'targets':114,'changed_targets':changed,'unchanged_assignment_targets':unchanged,
+        'bf16_units':len(units),'netdata_errors':errors,
+        'artifacts':{str(p.relative_to(out)):sha(p) for p in out.rglob('*') if p.is_file()}}
+(out/'result.json').write_text(json.dumps(report,indent=2))
+print(json.dumps({k:v for k,v in report.items() if k!='artifacts'}),flush=True)

--- a/prismaquant/allocator_solver.py
+++ b/prismaquant/allocator_solver.py
@@ -1432,7 +1432,13 @@ def solve_with_promotion(
     correct — the rung label was just wrong, skewing the Pareto curve's
     x-axis rather than fabricating feasibility.
 
-    The search runs in two phases on the *tightened* DP target:
+    First evaluate the per-unit minimum measured loss assignment. Return it
+    if serving promotion preserves every unit's minimum and its unrounded
+    candidate payload fits. Otherwise use the existing two-phase search on
+    the *tightened* DP target. The caller still exact-prices shared sidecars
+    and other non-additive artifact costs before accepting any proposal.
+
+    The binned search runs in two phases:
 
     1. Damped descent (the old loop's cost profile — the first eval at the
        full target is the only expensive DP; every subsequent eval has a
@@ -1504,6 +1510,42 @@ def solve_with_promotion(
     # the format it picks has to be runnable for every member. Built once: the
     # search re-promotes on every DP evaluation.
     legal_formats = legal_formats_from_candidates(candidates)
+
+    # Bin rounding can exclude the exact feasible quality endpoint: every
+    # unit may round upward even when the sum of its real bytes fits. Check
+    # the unconstrained per-unit loss minimum before using the binned proposal.
+    # Equal-loss choices retain the existing preference for larger achieved
+    # payloads. This is format-agnostic; BF16 gets no special treatment.
+    quality_choices = {
+        name: min(options, key=lambda c: (c.predicted_dloss, -c.memory_bytes))
+        for name, options in candidates.items()
+    }
+    quality_assignment = promote_serving_units(
+        {name: c.fmt for name, c in quality_choices.items()},
+        format_rank,
+        profile=profile,
+        include_fused=not no_fused_promote,
+        include_moe=True,
+        legal_formats=legal_formats,
+    )
+    quality_achieved, quality_loss = compute_achieved(
+        stats, quality_assignment, format_specs, candidates=candidates,
+    )
+    # Test each promoted row against its own minimum; comparing rounded sums
+    # could hide a small loss increase beside a very large unchanged row.
+    quality_preserved = all(
+        _candidate_for_assignment(name, fmt, candidates).predicted_dloss
+        == quality_choices[name].predicted_dloss
+        for name, fmt in quality_assignment.items()
+    )
+    diag.update(quality_endpoint_achieved_bits=float(quality_achieved),
+                quality_endpoint_preserves_minimum_loss=quality_preserved)
+    if quality_preserved and quality_achieved - target <= overshoot_tolerance:
+        diag.update(feasible=True, achieved_bits=float(quality_achieved),
+                    predicted_dloss=float(quality_loss),
+                    quality_endpoint_selected=True)
+        return quality_assignment, quality_achieved
+    diag["quality_endpoint_selected"] = False
 
     def _evaluate(t: float) -> float | None:
         """Solve+promote at tightened ``t``; ratchet if feasible.
@@ -1585,8 +1627,8 @@ def solve_with_promotion(
             continue
         if achieved - target <= overshoot_tolerance:
             if achieved >= target - overshoot_tolerance:
-                # Within the band on both sides — no denser feasible
-                # iterate exists; return the ratcheted min-Δloss one.
+                # Within the band on both sides; return the best feasible
+                # iterate seen. Binning does not prove global optimality.
                 return best_assign, best_achieved
             lo = tightened
             break

--- a/tests/fixtures/lfm_quality_endpoint.json
+++ b/tests/fixtures/lfm_quality_endpoint.json
@@ -1,0 +1,768 @@
+{
+  "source_sha256": "b3f54ea59699dd07a1c6a12bbdfa59f9f49f5f4e27ce6ba19ac1518d6bc4663d",
+  "probe_sha256": "5d08904df98d07d91fa29cffe9d5bb44080e63f8149037b1f29153b6457bd451",
+  "units": [
+    {
+      "name": "model.layers.0.feed_forward.w2",
+      "n_params": 14680064,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 29360128,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5111607142857144,
+          "memory_bytes": 6443008,
+          "predicted_dloss": 0.006304780365598535
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R1024",
+          "bits_per_param": 4.011160714285714,
+          "memory_bytes": 7360512,
+          "predicted_dloss": 0.001804353518227313
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R1152",
+          "bits_per_param": 4.511160714285714,
+          "memory_bytes": 8278016,
+          "predicted_dloss": 0.0007034233101471547
+        }
+      ]
+    },
+    {
+      "name": "model.layers.1.feed_forward.w2",
+      "n_params": 14680064,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 29360128,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5111607142857144,
+          "memory_bytes": 6443008,
+          "predicted_dloss": 0.00122667058257037
+        }
+      ]
+    },
+    {
+      "name": "model.layers.10.self_attn.out_proj",
+      "n_params": 4194304,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 8388608,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5390625,
+          "memory_bytes": 1855488,
+          "predicted_dloss": 0.004566241945956486
+        },
+        {
+          "fmt": "TESSERA_BF16_K1_R1024",
+          "bits_per_param": 4.0703125,
+          "memory_bytes": 2134016,
+          "predicted_dloss": 0.00029748423740553554
+        }
+      ]
+    },
+    {
+      "name": "model.layers.14.self_attn.out_proj",
+      "n_params": 4194304,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 8388608,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5390625,
+          "memory_bytes": 1855488,
+          "predicted_dloss": 0.0010260786803534343
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R1152",
+          "bits_per_param": 4.5390625,
+          "memory_bytes": 2379776,
+          "predicted_dloss": 0.0006637849603100441
+        }
+      ]
+    },
+    {
+      "name": "model.layers.18.self_attn.out_proj",
+      "n_params": 4194304,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 8388608,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5390625,
+          "memory_bytes": 1855488,
+          "predicted_dloss": 0.0117397572653755
+        },
+        {
+          "fmt": "TESSERA_BF16_K1_R896",
+          "bits_per_param": 3.5703125,
+          "memory_bytes": 1871872,
+          "predicted_dloss": 0.0023402171734250264
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R1024",
+          "bits_per_param": 4.0390625,
+          "memory_bytes": 2117632,
+          "predicted_dloss": 0.0008918009082313055
+        },
+        {
+          "fmt": "TESSERA_BF16_K1_R1152",
+          "bits_per_param": 4.5703125,
+          "memory_bytes": 2396160,
+          "predicted_dloss": 0.0004398715591219914
+        }
+      ]
+    },
+    {
+      "name": "model.layers.2.self_attn.out_proj",
+      "n_params": 4194304,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 8388608,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5390625,
+          "memory_bytes": 1855488,
+          "predicted_dloss": 0.016354091080306443
+        },
+        {
+          "fmt": "TESSERA_BF16_K1_R896",
+          "bits_per_param": 3.5703125,
+          "memory_bytes": 1871872,
+          "predicted_dloss": 0.0016861841011920693
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R1024",
+          "bits_per_param": 4.0390625,
+          "memory_bytes": 2117632,
+          "predicted_dloss": 0.0013209105190431151
+        }
+      ]
+    },
+    {
+      "name": "model.layers.21.self_attn.out_proj",
+      "n_params": 4194304,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 8388608,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5390625,
+          "memory_bytes": 1855488,
+          "predicted_dloss": 0.004822636637908629
+        },
+        {
+          "fmt": "TESSERA_BF16_K1_R896",
+          "bits_per_param": 3.5703125,
+          "memory_bytes": 1871872,
+          "predicted_dloss": 0.0003802799663727677
+        }
+      ]
+    },
+    {
+      "name": "model.layers.6.self_attn.out_proj",
+      "n_params": 4194304,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 8388608,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5390625,
+          "memory_bytes": 1855488,
+          "predicted_dloss": 0.011414626003454399
+        },
+        {
+          "fmt": "TESSERA_BF16_K1_R896",
+          "bits_per_param": 3.5703125,
+          "memory_bytes": 1871872,
+          "predicted_dloss": 0.0010298967008860451
+        },
+        {
+          "fmt": "TESSERA_BF16_K1_R1024",
+          "bits_per_param": 4.0703125,
+          "memory_bytes": 2134016,
+          "predicted_dloss": 0.0005660441150281701
+        }
+      ]
+    },
+    {
+      "name": "model.layers.10.feed_forward.experts.0.__packed_serving__.model__layers__10__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.0010489913931271612
+        }
+      ]
+    },
+    {
+      "name": "model.layers.11.feed_forward.experts.0.__packed_serving__.model__layers__11__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.0009903385281851888
+        }
+      ]
+    },
+    {
+      "name": "model.layers.12.feed_forward.experts.0.__packed_serving__.model__layers__12__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.000975168255508065
+        }
+      ]
+    },
+    {
+      "name": "model.layers.13.feed_forward.experts.0.__packed_serving__.model__layers__13__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.001510986977513534
+        }
+      ]
+    },
+    {
+      "name": "model.layers.14.feed_forward.experts.0.__packed_serving__.model__layers__14__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.0008176509260202327
+        }
+      ]
+    },
+    {
+      "name": "model.layers.15.feed_forward.experts.0.__packed_serving__.model__layers__15__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.0005798116623155694
+        }
+      ]
+    },
+    {
+      "name": "model.layers.16.feed_forward.experts.0.__packed_serving__.model__layers__16__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.001417692148961959
+        }
+      ]
+    },
+    {
+      "name": "model.layers.17.feed_forward.experts.0.__packed_serving__.model__layers__17__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.0011552693679756
+        }
+      ]
+    },
+    {
+      "name": "model.layers.18.feed_forward.experts.0.__packed_serving__.model__layers__18__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.0006601255254514348
+        }
+      ]
+    },
+    {
+      "name": "model.layers.19.feed_forward.experts.0.__packed_serving__.model__layers__19__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.0009712827259834322
+        }
+      ]
+    },
+    {
+      "name": "model.layers.2.feed_forward.experts.0.__packed_serving__.model__layers__2__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.008626966777560422
+        }
+      ]
+    },
+    {
+      "name": "model.layers.20.feed_forward.experts.0.__packed_serving__.model__layers__20__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.0011852857690366717
+        }
+      ]
+    },
+    {
+      "name": "model.layers.21.feed_forward.experts.0.__packed_serving__.model__layers__21__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.0006852360763392278
+        }
+      ]
+    },
+    {
+      "name": "model.layers.22.feed_forward.experts.0.__packed_serving__.model__layers__22__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.0005865597754269874
+        }
+      ]
+    },
+    {
+      "name": "model.layers.23.feed_forward.experts.0.__packed_serving__.model__layers__23__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.0007415927362775366
+        }
+      ]
+    },
+    {
+      "name": "model.layers.3.feed_forward.experts.0.__packed_serving__.model__layers__3__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.00832176817320481
+        }
+      ]
+    },
+    {
+      "name": "model.layers.4.feed_forward.experts.0.__packed_serving__.model__layers__4__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.0046356053370413715
+        }
+      ]
+    },
+    {
+      "name": "model.layers.5.feed_forward.experts.0.__packed_serving__.model__layers__5__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.008839667490985737
+        }
+      ]
+    },
+    {
+      "name": "model.layers.6.feed_forward.experts.0.__packed_serving__.model__layers__6__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.002768939557967569
+        }
+      ]
+    },
+    {
+      "name": "model.layers.7.feed_forward.experts.0.__packed_serving__.model__layers__7__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.0025994202463908204
+        }
+      ]
+    },
+    {
+      "name": "model.layers.8.feed_forward.experts.0.__packed_serving__.model__layers__8__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.0029779786669550594
+        }
+      ]
+    },
+    {
+      "name": "model.layers.9.feed_forward.experts.0.__packed_serving__.model__layers__9__feed_forward__experts::__packed_format__:w1,w3,w2",
+      "n_params": 352321536,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 704643072,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5438988095238093,
+          "memory_bytes": 156073984,
+          "predicted_dloss": 0.0029535343819712453
+        }
+      ]
+    },
+    {
+      "name": "model.layers.0.feed_forward.__siblings__.model__layers__0__feed_forward__w13",
+      "n_params": 29360128,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 58720256,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5167410714285716,
+          "memory_bytes": 12906496,
+          "predicted_dloss": 0.005640354487604853
+        }
+      ]
+    },
+    {
+      "name": "model.layers.1.feed_forward.__siblings__.model__layers__1__feed_forward__w13",
+      "n_params": 29360128,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 58720256,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5167410714285716,
+          "memory_bytes": 12906496,
+          "predicted_dloss": 0.014150081178882954
+        },
+        {
+          "fmt": "TESSERA_BF16_K1_R1024",
+          "bits_per_param": 4.025669642857143,
+          "memory_bytes": 14774272,
+          "predicted_dloss": 0.0106168963347829
+        }
+      ]
+    },
+    {
+      "name": "model.layers.10.self_attn.__siblings__.model__layers__10__self_attn__qkv_proj",
+      "n_params": 6291456,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 12582912,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5703125,
+          "memory_bytes": 2807808,
+          "predicted_dloss": 0.01075845580400904
+        }
+      ]
+    },
+    {
+      "name": "model.layers.14.self_attn.__siblings__.model__layers__14__self_attn__qkv_proj",
+      "n_params": 6291456,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 12582912,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5703125,
+          "memory_bytes": 2807808,
+          "predicted_dloss": 0.00477868836974173
+        }
+      ]
+    },
+    {
+      "name": "model.layers.18.self_attn.__siblings__.model__layers__18__self_attn__qkv_proj",
+      "n_params": 6291456,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 12582912,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5703125,
+          "memory_bytes": 2807808,
+          "predicted_dloss": 0.008174959412094595
+        }
+      ]
+    },
+    {
+      "name": "model.layers.2.self_attn.__siblings__.model__layers__2__self_attn__qkv_proj",
+      "n_params": 6291456,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 12582912,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5703125,
+          "memory_bytes": 2807808,
+          "predicted_dloss": 0.01999972752863082
+        }
+      ]
+    },
+    {
+      "name": "model.layers.21.self_attn.__siblings__.model__layers__21__self_attn__qkv_proj",
+      "n_params": 6291456,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 12582912,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5703125,
+          "memory_bytes": 2807808,
+          "predicted_dloss": 0.009044566423585611
+        }
+      ]
+    },
+    {
+      "name": "model.layers.6.self_attn.__siblings__.model__layers__6__self_attn__qkv_proj",
+      "n_params": 6291456,
+      "candidates": [
+        {
+          "fmt": "BF16",
+          "bits_per_param": 16.0,
+          "memory_bytes": 12582912,
+          "predicted_dloss": 0.0
+        },
+        {
+          "fmt": "TESSERA_E4M3_K1_R896",
+          "bits_per_param": 3.5703125,
+          "memory_bytes": 2807808,
+          "predicted_dloss": 0.02458035252275414
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_allocator_quality_endpoint.py
+++ b/tests/test_allocator_quality_endpoint.py
@@ -1,0 +1,78 @@
+"""The feasible per-unit quality optimum must survive budget-bin rounding."""
+import pytest
+
+from prismaquant.allocator_solver import Candidate, solve_with_promotion
+
+
+def _inputs():
+    stats = {f'u{i}': {'n_params': 8000} for i in range(8)}
+    candidates = {n: [Candidate('NVFP4', 4.004, 4004, 1.0),
+                      Candidate('BF16', 16.0, 16000, 0.0)] for n in stats}
+    return stats, candidates
+
+
+def test_feasible_quality_endpoint_is_not_excluded_by_bin_rounding():
+    stats, candidates = _inputs()
+    assignment, achieved = solve_with_promotion(
+        stats, candidates, 16.0, {}, {'NVFP4': 0, 'BF16': 1}, 0.001,
+        overshoot_tolerance=0.0)
+    assert set(assignment.values()) == {'BF16'}
+    assert achieved == 16.0
+
+
+def test_quality_endpoint_respects_exact_budget():
+    stats, candidates = _inputs()
+    assignment, achieved = solve_with_promotion(
+        stats, candidates, 15.0, {}, {'NVFP4': 0, 'BF16': 1}, 0.001,
+        overshoot_tolerance=0.0)
+    assert assignment is not None
+    assert achieved <= 15.0
+    assert 'NVFP4' in assignment.values()
+
+
+def test_quality_endpoint_is_measured_per_unit_not_bf16_policy():
+    stats, candidates = _inputs()
+    for values in candidates.values():
+        values[0] = Candidate('NVFP4', 4.004, 4004, 0.0)
+        values[1] = Candidate('BF16', 16.0, 16000, 1.0)
+    assignment, achieved = solve_with_promotion(
+        stats, candidates, 16.0, {}, {'NVFP4': 0, 'BF16': 1}, 0.001,
+        overshoot_tolerance=0.0)
+    assert set(assignment.values()) == {'NVFP4'}
+    assert achieved == pytest.approx(4.004)
+
+
+@pytest.mark.parametrize('background_loss', [0.0, 1e16])
+def test_promotion_must_preserve_each_units_minimum(background_loss):
+    from prismaquant.model_profiles import DefaultProfile
+    q, k, other = 'model.layers.0.self_attn.q_proj', 'model.layers.0.self_attn.k_proj', 'background'
+    stats = {n: {'n_params': 8000} for n in (q, k, other)}
+    candidates = {
+        q: [Candidate('NVFP4', 4.0, 4000, 0.0), Candidate('BF16', 16.0, 16000, 1.0)],
+        k: [Candidate('NVFP4', 4.0, 4000, 2.0), Candidate('BF16', 16.0, 16000, 0.0)],
+        other: [Candidate('BF16', 16.0, 16000, background_loss)],
+    }
+    diag = {}
+    assignment, achieved = solve_with_promotion(
+        stats, candidates, 16.0, {}, {'NVFP4': 0, 'BF16': 1}, 0.001,
+        profile=DefaultProfile(), overshoot_tolerance=0.0, diagnostics=diag)
+    assert assignment[q] == assignment[k]
+    assert achieved <= 16.0
+    assert diag['quality_endpoint_preserves_minimum_loss'] is False
+    assert diag['quality_endpoint_selected'] is False
+    assert diag['evals'] >= 1
+
+
+def test_extracted_lfm_endpoint_has_zero_loss_at_exact_16_bpp():
+    import json
+    from pathlib import Path
+    fixture = json.loads((Path(__file__).parent / 'fixtures' / 'lfm_quality_endpoint.json').read_text())
+    stats = {f'u{i}': {'n_params': row['n_params']} for i, row in enumerate(fixture['units'])}
+    candidates = {f'u{i}': [Candidate(**c) for c in row['candidates']]
+                  for i, row in enumerate(fixture['units'])}
+    assignment, achieved = solve_with_promotion(
+        stats, candidates, 16.0, {}, {}, 0.0001, overshoot_tolerance=0.0)
+    assert set(assignment.values()) == {'BF16'}
+    assert achieved == 16.0
+    assert all(next(c for c in candidates[n] if c.fmt == fmt).predicted_dloss == 0
+               for n, fmt in assignment.items())


### PR DESCRIPTION
The 16-bpp endpoint of the completed LFM joint-AURA frontier retained a lossy Tessera unit even though all-BF16 fit exactly and had zero predicted loss. Per-unit rounding charged 124570 bins against a global capacity of 124564.

`solve_with_promotion` now checks each unit's minimum measured loss option before the binned proposal. It accepts that endpoint only if serving-group promotion preserves every unit's minimum and unrounded bytes fit the target and tolerance. Existing exact artifact/sidecar filtering remains mandatory. BF16 receives no special treatment; DP bin charges are unchanged.

Validation: **67 targeted CPU tests passed, zero skips**, through eight PrismaBuild shards, after demonstrating the rounding regression. The full 114-budget run passed with cProfile and Netdata on all three hosts: **all 2142 units are BF16 at 16 bpp with zero predicted loss; the other 113 rows and 35 lower-budget assignment files are unchanged**. No reprobe. Root verified actual outputs, source bundles and canonical PB/CAS receipts. [Full report](docs/results/allocator_quality_endpoint_2026-09-08.md) records commands, input identity and limitations.

The producer-contract fused fallback and GLM capture remain unfinished; this result does not qualify a shipping quant.

Closes #358
