### PR TITLE
experiment(glm): record successful expandable-allocator workspace

### DIFF
--- a/docs/results/glm_expandable_workspace_2026-09-08.md
+++ b/docs/results/glm_expandable_workspace_2026-09-08.md
@@ -1,0 +1,117 @@
+# GLM layer workspace with expandable CUDA segments — 2026-09-08
+
+The bounded GLM-5.3-Flash BF16 layer-4 workspace completed all **512 original
+512-token, batch-1 forwards**, returned **867 independent CPU outputs**, audited
+every H/X tensor for finite values and recorded its hash, and found the next
+source layer still resident (`delivery: hot`). All 867 row counts equal the
+observations retained by the earlier failed run; the minimum is 1,772 rows.
+This qualifies this one workspace under the recorded environment. It is not a
+production capture, full-model source qualification, probe or served result.
+
+The run selected `PYTORCH_ALLOC_CONF=expandable_segments:True` in the original
+pinned producer container. No production defaults or gates changed. The shared
+collector and completed-source-release options remain explicit experiments.
+
+## Measured memory and attribution
+
+The original run refused during output return after 508 completed groups and
+760 qnames. The new run completed all 579 groups and 867 qnames, returning
+43,637,538,816 Hessian bytes and 6,060,769,280 scoring-input bytes. It retained
+the original 104 GiB PB reservation, 92 GiB GPU subset cap, 102 GiB conservative
+cgroup-plus-CUDA guard and 8 GiB host-available floor. Its continuous sampled
+conservative maximum was **101,422,903,296 bytes (94.46 GiB)**; minimum host
+available memory was **27,823,779,840 bytes (25.91 GiB)**. No guard fired.
+PB's separate cgroup peak was 68,102,283,264 bytes; these are different accounting
+planes and must not be added to peaks measured at another time.
+
+There are 1,017 matching group boundaries. At the last one,
+`before_output_group:model.language_model.layers.4.mlp.experts.67.gate_proj`,
+both runs had completed 508 groups / 760 qnames and had exactly
+30,584,587,264 live CUDA bytes. Reserved bytes changed from **48,754,589,696 to
+36,096,180,224**, a reduction of **12,658,409,472 bytes (11.79 GiB)**.
+Inactive split bytes changed from 18,170,002,432 to zero. After full CPU return,
+the new run held 27,132,675,072 live and 32,782,680,064 reserved CUDA bytes,
+including its resident successor. The old run has no completed output hashes,
+so full-output byte equality against that failed run is not claimed.
+
+**The host NFS module changed between runs.** The kernel release, GPU UUID,
+Torch/CUDA, source snapshot and calibration binding match, and the actual sealed
+commands differ only by the allocator variable and output path. However, the
+baseline nfsv4 source version was `939D67D3912BE82E3030657`, watermark `0`;
+the new version was `25D7A3033B8656AA181BEFD`, watermark `5000`. Both module
+build-ID notes are in the results. The matching live-allocation boundary makes
+the CUDA reservation delta directly checkable, but this is not a fully isolated
+allocator A/B and does not attribute the entire physical-memory result to one
+variable. No repeat was run merely to obtain a speed claim.
+
+## Profiles and host evidence
+
+Both runs retain Torch CPU/CUDA Chrome traces and text profiles for the first
+two target batches and batches 32–33. Recorded kernel durations were
+1,037,933 / 1,298,732 microseconds before and 995,666 / 1,262,505 microseconds
+after, respectively. The later window has 18,948 kernel events in each run;
+these are bounded profile windows, not full-run GPU time. The source-forward
+and output-return scopes remain distinct. Total new workspace wall time was
+568.172 seconds, including its completed output audit; the failed baseline
+stopped at 541.227 seconds. Those durations cover different completed work and
+are not a throughput comparison.
+
+Live Netdata covered both Sparks: 526 samples per host before and 553 after,
+with zero telemetry errors. Mean whole-host CPU non-idle was 10.07% / 8.75%
+on Sparky and 1.68% / 2.04% on Sparklina. Sparky mean GPU power was
+41.80 W / 40.65 W against the 140 W device envelope; Sparklina was about
+3.97 W. PB independently recorded 39.82 W mean and 47.71 W peak across its
+larger action window, 642.938 scope CPU-seconds and complete cleanup.
+No GPU saturation, energy-efficiency improvement or served-quality claim is made.
+
+## Reproduction and verification
+
+Baseline PB action:
+`9b534c59db1b013ff0dc5fb0ccde646818246f3a26d2ddfb9fb5a517acc5bf36`.
+Its exact source snapshot is `f71b9b71713faf1efcdd4c302c90e9a31b64c713`,
+based on reviewed source `5a9b8e525d50694a95a0f23e2a46672fd5af409d`.
+New full workspace PB:
+`0f27ee249a4e54e5c11d9f3c2e59e7668a41d877b8cb94d3e22a0248907e20a0`.
+Its snapshot differs only by PB closure metadata. The GPU action ran on Sparky,
+six preferred CPUs with native threads bounded to one, Torch 2.13.0+cu130 /
+CUDA 13.0, in image
+`sha256:cf3f7f83e6820fa75aae249393e8fa4840af4562192203a1aed3f2082f3ea2f9`.
+The original input binding remains
+`0d52fb4d17cd81e037eb66572a03616df3f53bd1848787fa1a9ff350a1045593`;
+source binding was unchanged at exit.
+
+The tiny support check, `experiments/cuda_expandable_segments_gate.py`,
+executed in the same pinned GPU container as PB
+`705dda3c79d780777dda9bd7ab0743bd239a6d7a802ee098430e8843f4557aeb`.
+It verified 2,097,152 exact GPU round-trip integer values, an actual expandable
+segment in the allocator snapshot, and zero allocated/reserved CUDA bytes
+after release. The first portable attempt could not find that literal Docker
+image ID on Sparklina and did not execute the GPU check; the successful attempt
+retained the original host/image dependency.
+
+CPU trace/telemetry analysis and compile checks passed on DL380 as PB
+`4a274c76f3029bb867a1c65e7d8d318a6a344cbffb5dda208427c26c8ef36393`.
+The initial analysis action `0c9c04146071…` failed because the analysis helper
+mistook the integer unit count for a list; the helper was fixed and rerun, with
+no GPU repetition. An earlier compile-only action `16beea8a4b64…` also passed.
+Root verified four successful canonical CAS receipts, actual payload hashes,
+source bundles, support-check/analysis source equality and all 18 retained
+before/after output artifacts. No test skips or missing runtime tools are
+hidden by these checks; this PR changes experiment helpers and this report.
+
+Evidence root:
+`/mnt/shared/tessera-measurements/glm-streaming-source-20260907/`.
+The exact new command and source binding are in
+`workspace-prefix-07-submission.json`; full results, traces, hashes and telemetry
+are under `workspace-prefix-07-expandable/`, compared with
+`workspace-prefix-06-source-release/`. Analysis and root verification are
+`expandable-analysis-01.json` and `expandable-root-audit-01.json`.
+Re-run the checked-in analysis helper through PB with those `--before` and
+`--after` directories and a fresh `--out` path. Full GPU reproduction uses the
+sealed baseline source and submission command, a fresh output directory and the
+recorded external runtime; current HEAD is not substituted for that source.
+
+The next integration work is to expose the qualified collector/source lifecycle
+through explicit streamed-capture configuration and validate the complete
+source route and calibration census. This result supplies no completed
+production capture and does not admit a shipping GLM quant.

--- a/experiments/cuda_expandable_segments_gate.py
+++ b/experiments/cuda_expandable_segments_gate.py
@@ -1,0 +1,33 @@
+"""PB-only pinned-container qualification of the CUDA allocator option."""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import torch
+
+parser=argparse.ArgumentParser()
+parser.add_argument('--out',type=Path,required=True)
+args=parser.parse_args()
+assert os.environ.get('PYTORCH_ALLOC_CONF')=='expandable_segments:True'
+torch.set_num_threads(1)
+tensor=torch.arange(2**21,dtype=torch.int32,device='cuda')
+returned=tensor.cpu()
+assert torch.equal(returned,torch.arange(2**21,dtype=torch.int32))
+segments=torch.cuda.memory_snapshot()
+assert any(s.get('is_expandable') is True for s in segments), 'allocator option unsupported or inactive'
+result={'schema':'prismaquant.cuda_expandable_segments_gate.v1','torch':torch.__version__,
+        'cuda':torch.version.cuda,'device':torch.cuda.get_device_name(0),
+        'backend':torch.cuda.get_allocator_backend(),'allocator_conf':os.environ['PYTORCH_ALLOC_CONF'],
+        'cpu_affinity':sorted(os.sched_getaffinity(0)),
+        'verified_values':tensor.numel(),'value_sha256':hashlib.sha256(returned.numpy().tobytes()).hexdigest(),
+        'expandable_segments':sum(s.get('is_expandable') is True for s in segments),
+        'allocated_bytes':torch.cuda.memory_allocated(),'reserved_bytes':torch.cuda.memory_reserved()}
+del tensor
+torch.cuda.empty_cache()
+result['allocated_after_release']=torch.cuda.memory_allocated()
+result['reserved_after_release']=torch.cuda.memory_reserved()
+assert result['allocated_after_release']==0
+args.out.parent.mkdir(parents=True,exist_ok=True)
+with args.out.open('x') as stream:json.dump(result,stream,indent=2)
+print(json.dumps(result),flush=True)

--- a/experiments/glm_expandable_analysis.py
+++ b/experiments/glm_expandable_analysis.py
@@ -72,7 +72,7 @@ def summarize(root):
         'status', 'target_batches_completed', 'input_binding_sha256',
         'source_binding_unchanged_at_exit', 'telemetry_errors', 'torch', 'cuda',
         'device_uuid', 'host_kernel_release', 'nfsv4_module_build_id_note_hex']}
-    selected.update(units=len(result['units']), wall_seconds=result['end']-result['begin'], memory=memory,
+    selected.update(units=result['units'], wall_seconds=result['end']-result['begin'], memory=memory,
         phases=phases, traces=traces, telemetry=telemetry,
         materialization={k:v for k,v in result.get('output_materialization_progress',{}).items()
                          if k not in ['completed_groups','group_boundaries','last_observation']},

--- a/experiments/glm_expandable_analysis.py
+++ b/experiments/glm_expandable_analysis.py
@@ -1,0 +1,111 @@
+"""Read retained workspace evidence; execute batch analysis through PrismaBuild."""
+import argparse
+import collections
+import hashlib
+import json
+import statistics
+from pathlib import Path
+
+
+def read_jsonl(path):
+    with path.open() as stream:
+        for line in stream:
+            yield json.loads(line)
+
+
+def digest(path):
+    h = hashlib.sha256()
+    with path.open('rb') as stream:
+        for chunk in iter(lambda: stream.read(2**20), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def summarize(root):
+    result = json.loads((root / 'result.json').read_text())
+    samples = list(read_jsonl(root / 'cgroup-memory.jsonl'))
+    traces = {}
+    for path in sorted(root.glob('forward-*.trace.json')):
+        events = json.loads(path.read_text())['traceEvents']
+        categories = collections.Counter()
+        calls = collections.Counter()
+        kernels = collections.Counter()
+        for event in events:
+            category = event.get('cat', '')
+            if event.get('ph') == 'X':
+                categories[category] += event.get('dur', 0)
+                calls[category] += 1
+                if category == 'kernel':
+                    kernels[event['name']] += event.get('dur', 0)
+        traces[path.name] = dict(sha256=digest(path),
+            category_duration_us=dict(categories), category_calls=dict(calls),
+            top_kernel_duration_us=kernels.most_common(8))
+    hosts = collections.defaultdict(lambda: dict(samples=0, errors=0, series=collections.defaultdict(list)))
+    for record in read_jsonl(root / 'netdata.jsonl'):
+        host = hosts[record['host']]
+        host['samples'] += 1
+        if record.get('error'):
+            host['errors'] += 1
+        for chart, values in record.get('metrics', {}).items():
+            if chart == 'system.cpu' or 'power' in chart:
+                for name, value in values.get('dimensions', {}).items():
+                    number = value.get('value')
+                    if isinstance(number, (int, float)):
+                        host['series'][chart + '/' + name].append(number)
+    telemetry = {}
+    for name, host in hosts.items():
+        telemetry[name] = dict(samples=host['samples'], errors=host['errors'],
+            metrics={key: dict(n=len(values), mean=statistics.mean(values),
+                              min=min(values), max=max(values))
+                     for key, values in host['series'].items()})
+    fields = ['cgroup_current_bytes', 'cuda_reserved_bytes',
+              'conservative_cgroup_plus_cuda_reserved_bytes', 'cuda_allocated_bytes']
+    memory = {key: max(record[key] for record in samples) for key in fields}
+    memory['minimum_host_available_bytes'] = min(r['host_mem_available_bytes'] for r in samples)
+    memory['guard_tripped_samples'] = sum(bool(r.get('guard_tripped')) for r in samples)
+    phases = [{k: v for k, v in row.items() if k in {
+        'label', 'time', 'allocated', 'reserved', 'inactive_split_bytes',
+        'source_layer', 'source_cache_layers', 'source_prefetch_memory_skips',
+        'source_prefetch_delivered_unretained', 'hessian_bytes', 'prefix_bytes',
+        'minimum_observed_rows', 'delivery'}} for row in result['phases']]
+    selected = {key: result.get(key) for key in [
+        'status', 'target_batches_completed', 'input_binding_sha256',
+        'source_binding_unchanged_at_exit', 'telemetry_errors', 'torch', 'cuda',
+        'device_uuid', 'host_kernel_release', 'nfsv4_module_build_id_note_hex']}
+    selected.update(units=len(result['units']), wall_seconds=result['end']-result['begin'], memory=memory,
+        phases=phases, traces=traces, telemetry=telemetry,
+        materialization={k:v for k,v in result.get('output_materialization_progress',{}).items()
+                         if k not in ['completed_groups','group_boundaries','last_observation']},
+        unit_results_count=len(result.get('unit_results',{})),
+        artifact_sha256={p.name:digest(p) for p in sorted(root.iterdir()) if p.is_file()})
+    return selected
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--before', type=Path, required=True)
+    parser.add_argument('--after', type=Path, required=True)
+    parser.add_argument('--out', type=Path, required=True)
+    args = parser.parse_args()
+    report = dict(schema='prismaquant.glm_expandable_analysis.v1',
+                  before=summarize(args.before), after=summarize(args.after),
+                  scope='bounded_workspace_memory_and_profile_evidence_not_full_model_or_served_quality')
+    before = json.loads((args.before/'result.json').read_text())
+    after = json.loads((args.after/'result.json').read_text())
+    left = before.get('partial_target_row_observations', {}).get('rows')
+    right = after.get('returned_target_row_observations', {}).get('rows')
+    report['all_observed_row_counts_equal'] = left == right if left is not None and right is not None else None
+    old = {r['checkpoint']:r for r in before['output_materialization_progress']['group_boundaries']}
+    new = {r['checkpoint']:r for r in after.get('output_materialization_progress',{}).get('group_boundaries',[])}
+    common = [k for k in old if k in new]
+    report['matched_group_boundaries'] = len(common)
+    report['last_matched_group_boundary'] = ({'checkpoint': common[-1],
+        'before':old[common[-1]], 'after':new[common[-1]]} if common else None)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open('x') as stream:
+        json.dump(report, stream, indent=2, sort_keys=True)
+    print(json.dumps({k:v for k,v in report.items() if k not in ['before','after','last_matched_group_boundary']}))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The full GLM layer-4 workspace now has a passing bounded measurement: 512 original source forwards, all 867 finite CPU outputs hashed, and the next source layer retained as a hot cache hit under the unchanged memory guard. This PR retains the pinned-container allocator support check, trace/telemetry analysis helper and measured report. Production defaults and serving gates are unchanged.

At an identical output-group boundary, live CUDA bytes match and reserved bytes are 11.79 GiB lower. The host NFS module also changed between runs, so the report explicitly limits causal attribution and makes no speedup or full-model capture claim. All 867 row counts match the failed baseline's retained observations.

Validation: successful full GPU PB `0f27ee249a4e…`, pinned-container support check `705dda3c79d7…`, and CPU analysis plus compile PB `4a274c76f302…`; canonical receipts, source bundles and all 18 before/after artifacts independently verified. The report includes both-host telemetry, profiles, exact commands, the failed first analysis attempt and remaining integration work.

Closes #360
