### PR TITLE
Expose opt-in shared-input release for streamed capture

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,22 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `fix/allocator-quality-endpoint`. Stamps
+As of: 2026-09-08 · `feat/streamed-shared-capture`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `feat/streamed-shared-capture`) for the experimental
+campaign `--streaming-capture-policy shared-inputs-release-v1`. Only full-scope
+streamed capture accepts it. It selects the existing shared packed-input
+collector and releases the exhausted current source through
+`StreamingContext.release_completed_layer` after original forwards and hook
+removal, before CPU output materialization. The existing next-layer prefetch,
+per-unit capture writer and census identity gates remain authoritative.
+Capture telemetry records the selected policy and completed release boundary;
+the canonical numerical identity stays the same because H/X/count/max bytes
+must match the legacy policy. The default is `legacy`, and the existing
+conservative resource reservation is unchanged. A bounded workspace fit does
+not establish that the complete campaign capture fits; full-model admission
+and measurement remain required. Gates: `tests/test_glm_campaign_streaming.py`
+and the collector's existing shared-input and source-lifetime regressions.
 
 Re-stamped (2026-09-08, `fix/allocator-quality-endpoint`) for the allocator's
 unrounded quality endpoint. `solve_with_promotion` first considers each unit's

--- a/prismaquant/tessera_calibration_cache.py
+++ b/prismaquant/tessera_calibration_cache.py
@@ -206,6 +206,9 @@ class CaptureWriter:
                 if not torch.equal(old_x, acts[name]) or not torch.equal(old_h, hessians[name]):
                     raise RuntimeError(f'{name}: replayed capture differs from interrupted entry')
                 record = previous
+                # Admission allows one loaded validation entry alongside the
+                # current capture. Drop all views before loading its successor.
+                del old, old_x, old_h
             else:
                 path = write_activation_cache_entry(self.root/'inputs', name, acts[name],
                     source=SOURCE, durable=True, hessian=hessians[name],

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -3405,6 +3405,10 @@ def _run_streamed_calibration(args, runner, profile, *, mode, population,
         writer = store.CaptureWriter(args.capture_calibration_out,
             census_path=args.calibration_census, identity=identity)
 
+    capture_policy = getattr(args, 'streaming_capture_policy', 'legacy')
+    shared_capture = capture_policy == 'shared-inputs-release-v1'
+    if shared_capture and writer is None:
+        raise RuntimeError('shared-inputs-release-v1 requires streamed calibration capture')
     counts, maxima, telemetry = {}, {}, []
     runner.context.begin_source_initialization_audit()
 
@@ -3419,17 +3423,26 @@ def _run_streamed_calibration(args, runner, profile, *, mode, population,
         # The source identity check is complete. The collector creates its own
         # live views; this caller must not pin old packed storage through return.
         del live
+        completed_source_released = False
+        def release_completed_source():
+            nonlocal completed_source_released
+            runner.context.release_completed_layer(layer)
+            completed_source_released = True
+
         before = time.perf_counter()
         acts, hessians, rows, amax = _collect_activations(runner.model, names, tokens,
             args.max_act_rows if writer is not None else 0, runner.device,
-            want_hessian=writer is not None, profile=profile, forward_batch=forward_batch)
+            want_hessian=writer is not None, profile=profile, forward_batch=forward_batch,
+            shared_packed_inputs=shared_capture,
+            on_forwards_complete=release_completed_source if shared_capture else None)
         collected = time.perf_counter()
         counts.update(rows)
         maxima.update(amax)
         if writer is not None:
             writer.write(acts=acts, hessians=hessians, counts=rows, maxima=amax)
         flushed = time.perf_counter()
-        record = dict(layer=layer, units=len(names), collect_seconds=collected-before,
+        record = dict(layer=layer, units=len(names), capture_policy=capture_policy,
+            completed_source_released=completed_source_released, collect_seconds=collected-before,
             flush_seconds=flushed-collected,
             capture_tensor_bytes=sum(t.numel()*t.element_size()
                 for t in [*acts.values(), *hessians.values()] if t is not None))
@@ -3583,6 +3596,9 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     ap.add_argument("--streaming-cache-slots", type=int, default=2)
     ap.add_argument("--streaming-prefetch-workers", type=int, default=1)
     ap.add_argument("--streaming-cache-headroom-gb", type=float, default=24)
+    ap.add_argument("--streaming-capture-policy", default="legacy",
+                    choices=("legacy", "shared-inputs-release-v1"),
+                    help="Opt-in shared packed inputs and completed-source release for capture.")
     ap.add_argument("--capture-calibration-out", default=None,
                     help="Capture full-census float32 prefix X and uncapped H once, then exit.")
     ap.add_argument("--calibration-cache", default=None,
@@ -3590,6 +3606,8 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     ap.add_argument("--calibration-cache-sha256", default=None,
                     help="Expected capture manifest hash, sealed by the campaign planner.")
     args = ap.parse_args(argv)
+    if args.streaming_capture_policy != "legacy" and not (args.streaming and args.capture_calibration_out):
+        ap.error("--streaming-capture-policy requires --streaming and --capture-calibration-out")
     if args.streaming and (not (args.census_out or args.capture_calibration_out) or args.units):
         ap.error("--streaming currently requires full-scope --census-out or --capture-calibration-out")
     if args.streaming and (args.streaming_cache_slots < 2 or args.streaming_prefetch_workers < 1):

--- a/tests/test_glm_campaign_streaming.py
+++ b/tests/test_glm_campaign_streaming.py
@@ -209,6 +209,41 @@ def test_streamed_campaign_publishes_original_layout_census_and_capture(glm_chec
     capture.require_capture_contract(manifest)
     assert json.loads(manifest.read_text())['status'] == 'complete'
 
+    # The explicit policy must traverse the same source and publish the same
+    # per-unit tensors, while releasing each exhausted layer before return.
+    from prismaquant.streaming_model import StreamingContext
+    released = []
+    release = StreamingContext.release_completed_layer
+    def track_release(context, layer):
+        release(context, layer)
+        assert all(p.is_meta for p in context.layers[layer].parameters())
+        assert layer not in context.layer_cache._cache
+        released.append(layer)
+    monkeypatch.setattr(StreamingContext, 'release_completed_layer', track_release)
+    shared_root = tmp_path/'shared-capture'
+    campaign.main([*common, '--cache-dir', str(tmp_path/'shared-capture-cache'),
+        '--calibration-census', str(census), '--capture-calibration-out', str(shared_root),
+        '--streaming-capture-policy', 'shared-inputs-release-v1'])
+    shared_manifest = shared_root/'capture_manifest.json'
+    capture.require_capture_contract(shared_manifest)
+    baseline = json.loads(manifest.read_text())
+    candidate = json.loads(shared_manifest.read_text())
+    assert candidate['identity'] == baseline['identity']
+    assert candidate['entries'].keys() == baseline['entries'].keys()
+    for name, entry in baseline['entries'].items():
+        before = torch.load(root/entry['path'], weights_only=True)
+        after = torch.load(shared_root/candidate['entries'][name]['path'], weights_only=True)
+        assert before.keys() == after.keys()
+        for key, value in before.items():
+            if isinstance(value, torch.Tensor):
+                assert torch.equal(value.view(torch.uint8), after[key].view(torch.uint8)), (name, key)
+            else:
+                assert value == after[key], (name, key)
+    assert released == list(range(config.text_config.num_hidden_layers))
+    telemetry = json.loads((tmp_path/'shared-capture-cache'/'streamed-calibration-telemetry.json').read_text())
+    assert all(row['capture_policy'] == 'shared-inputs-release-v1' and
+               row['completed_source_released'] for row in telemetry)
+
 
 def test_streamed_bf16_keeps_hf_strict_fp32_source_slots(glm_checkpoint, tmp_path):
     """BF16 forward weights retain HF-declared strict FP32 recurrence state."""
@@ -276,3 +311,16 @@ def test_layer_visit_releases_derived_batch_metadata(glm_checkpoint, tmp_path, m
         runner.visit_layer_batches(tokens, visit)
     finally:
         runner.shutdown()
+
+
+@pytest.mark.parametrize('extra', [[], ['--streaming'],
+    ['--capture-calibration-out', '/unused/capture']])
+def test_shared_capture_policy_refuses_other_routes_before_loading(extra, tmp_path, capsys):
+    from prismaquant.tessera_campaign import main
+    with pytest.raises(SystemExit) as caught:
+        main(['--model', '/missing/source', '--out', str(tmp_path/'unused.pkl'),
+              '--cache-dir', str(tmp_path/'cache'),
+              '--streaming-capture-policy', 'shared-inputs-release-v1', *extra])
+    assert caught.value.code == 2
+    assert '--streaming-capture-policy requires --streaming and --capture-calibration-out' in capsys.readouterr().err
+    assert not (tmp_path/'cache').exists()

--- a/tests/test_tessera_calibration_cache.py
+++ b/tests/test_tessera_calibration_cache.py
@@ -268,3 +268,25 @@ def test_campaign_boundary_coordinates_follow_batched_calibration_ids():
     assert captures[1][1].tolist() == [[2,0],[2,1]]
     assert captures[0][0][:,0].tolist() == [-1,1,1,-1]
     assert all(count == 3 for count in values[2].values())
+
+
+def test_layer_writer_releases_previous_resume_storage_before_next_load(capture, monkeypatch):
+    from torch.multiprocessing.reductions import StorageWeakRef
+    root, path, census, identity, acts, hessians, _record = capture
+    writer = cc.CaptureWriter(root, census_path=path, identity=identity)
+    original_load = torch.load
+    storages, loaded = [], []
+
+    def load(filename, *args, **kwargs):
+        assert all(ref.expired() for ref in storages), 'previous resume entry still owns CPU storage'
+        payload = original_load(filename, *args, **kwargs)
+        storages.extend(StorageWeakRef(payload[key].untyped_storage())
+                        for key in ('inputs', 'hessian'))
+        loaded.append(Path(filename).name)
+        return payload
+
+    monkeypatch.setattr(torch, 'load', load)
+    writer.write(acts=acts, hessians=hessians, counts=census['counts'], maxima=census['max_abs'])
+    assert loaded == ['a.pt', 'b.pt']
+    assert all(ref.expired() for ref in storages)
+    assert set(writer.records) == {'a', 'b'}


### PR DESCRIPTION
The streamed campaign always used the legacy collector, so the existing shared packed-input accumulation and completed-source release could not be selected for a canonical capture. `--streaming-capture-policy shared-inputs-release-v1` now selects that lifecycle for full-scope streamed capture and records the executed policy/release boundary in telemetry. Legacy remains the default; the existing prefetch, storage, canonical identity and conservative reservation are preserved.

A separate fix drops each replay-validation entry and its X/H views before loading the next. Previously those views kept the previous entry alive across the next `torch.load`, exceeding the planner's one-entry allowance. Validation rules and output bytes are unchanged.

Validation through PrismaBuild on DL380 CPU/Python 3.12, one native thread per action:

- 106 tests passed across seven independent shards, including real tiny-GLM CLI census plus legacy/shared capture identity and bytewise tensor/metadata equality, source-storage lifetime, failure cleanup, invalid CLI combinations and documentation gates. No skips.
- The new integration regression failed on the prior implementation at its unrecognized policy argument, after the original census/capture completed (PB `76d19ce67ba6`).
- The replay-storage regression failed before the fix (PB `99dca2b8980d`) because the previous entry's storage was still live at the next load. Afterward, 35 writer/GLM tests passed with no skips; their canonical receipts, payload hashes and exact changed-source comparisons are in `capture-writer-lifetime-root-audit-01.json` beside the earlier audit.
- All four touched Python files passed compilation (PB `c48e699898c2`, `752dcba2b30f`). Full keys, canonical receipts, payload checks and source snapshots: `/mnt/shared/tessera-measurements/glm-canonical-census-20260908/shared-capture-tests-root-audit-01.json`.

This exposes the already qualified collector primitive; it makes no new timing or full-model fit claim. Full GLM capture admission/measurement and served-artifact qualification remain outstanding. `docs/ARCHITECTURE.md` records the policy and limits.

Closes #362.
