### PR TITLE
Add checked phase admission for shared calibration capture

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,38 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `feat/streamed-shared-capture`. Stamps
+As of: 2026-09-08 · `feat/streamed-capture-admission`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `feat/streamed-capture-admission`) for experimental
+`--streaming-capture-policy shared-inputs-bounded-v1`. The legacy and prior
+shared-input policies keep their conservative v1 reservation. The bounded
+policy uses a v2 resource plan with separate source-validation, forward and
+materialization phases; their maximum determines admission. Expected packed
+input groups come from the profile and must equal actual collector groups
+before any forward. Device prefixes reserve the full row capacity, including
+short draws; independent CPU sibling outputs remain fully charged. The
+existing prefetch futures settle before capture growth and again before
+completed-source release, retaining successor cache/delivery ownership.
+
+CUDA execution requires `PRISMAQUANT_RELEASE_SOURCE_PAGES=1` and a finite
+cgroup v2 budget. The shared memory guard adds the entire CUDA reservation to
+the cgroup charge conservatively, preserves a 2 GiB margin and 8 GiB host
+available-memory floor, and reserves upcoming growth before allocation.
+It checks bounded source-hash reads, source projection checks, original
+forwards, output materialization, writes and sealing. A refusal latches.
+Completed source-hash pages and byte-verified projection payload pages receive
+kernel advice through their existing readers; completed capture files are
+advised only after durability and unchanged-file checks. Kernel advice never
+certifies release: observed counters decide whether capture can continue.
+The existing per-unit capture writer, source/census identities, numerical
+calibration and downstream prefetch remain authoritative. CPU qualification
+exercises ownership and byte parity; CUDA qualification additionally exercises
+the physical guard. No full-GLM fit or throughput improvement follows from the
+formula or tiny-model parity alone. Full-model capture remains a measurement
+gate before this policy can become a default. Gates:
+`tests/test_streamed_capture_admission.py`,
+`tests/test_glm_campaign_streaming.py`, and
+`tests/test_tessera_calibration_cache.py`.
 
 Re-stamped (2026-09-08, `feat/streamed-shared-capture`) for the experimental
 campaign `--streaming-capture-policy shared-inputs-release-v1`. Only full-scope

--- a/prismaquant/autoscale.py
+++ b/prismaquant/autoscale.py
@@ -57,7 +57,8 @@ DEFAULT_FIXED_OVERHEAD_GB = 15.0   # HF transformers + tokenizer + Python heap f
 
 def streamed_calibration_resources(model_path, *, unit_shapes, counts,
                                    nsamples, seqlen, max_act_rows, cache_slots,
-                                   prefetch_workers, headroom_gb):
+                                   prefetch_workers, headroom_gb,
+                                   capture_policy='legacy'):
     """Bound canonical capture using the shared loader's actual source layout.
 
     Headers and profile mappings determine source residency. Capture owns one
@@ -71,6 +72,8 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
     import math
     from .artifact_completeness import read_artifact_header
     from .model_profiles import detect_profile
+    if capture_policy not in ('legacy', 'shared-inputs-release-v1', 'shared-inputs-bounded-v1'):
+        raise ValueError('unknown streamed capture resource policy')
     if (any(type(v) is not int or v < 1 for v in
             (nsamples, seqlen, max_act_rows, cache_slots, prefetch_workers)) or
             cache_slots < 2 or not math.isfinite(headroom_gb) or headroom_gb < 0):
@@ -103,6 +106,7 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
         raise ValueError('profile cannot map the decoder prefix for resource admission')
     live_prefix = live_probe.rsplit('.0.', 1)[0]+'.'
     body, fixed, pack, concat = {}, 0, {}, {}
+    raw_body, max_element_bytes = {}, 4
     packed_regex = profile.per_expert_moe_regex()
     packed_pattern = (re.compile(packed_regex.removeprefix('re:')) if packed_regex else None)
     for key, meta in header.items():
@@ -133,6 +137,8 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
             raise ValueError(f'out-of-body source tensor is still live: {name}')
         layer = int(index)
         body[layer] = body.get(layer, 0)+size
+        raw_body[layer] = raw_body.get(layer, 0)+stored
+        max_element_bytes = max(max_element_bytes, math.ceil(size/max(numel, 1)), floating or 0)
         leaf = name.removesuffix('.weight')
         if packed_pattern is not None and (packed_pattern.match(leaf) or
                 packed_pattern.match(profile.to_vllm_internal_name(leaf))):
@@ -187,13 +193,65 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
     # One new entry may coexist with the old one during atomic replacement;
     # metadata/journals have an explicit per-unit serialization allowance.
     disk = total_h+total_x+widest_unit+len(unit_shapes)*16384
-    return dict(schema='prismaquant.streamed_calibration_resources.v1',
+    result = dict(schema='prismaquant.streamed_calibration_resources.v1',
         source_header_sha256=hashlib.sha256(json.dumps(header, sort_keys=True,
             separators=(',', ':')).encode()).hexdigest(),
         terms=terms, memory_bytes=sum(terms.values()), disk_bytes=disk,
         full_hessian_bytes=total_h, full_prefix_bytes=total_x,
         body_layer_bytes={str(k): v for k, v in sorted(body.items())},
         transient_status='conservative physical allocator bound for direct final-slab packer')
+    if capture_policy != 'shared-inputs-bounded-v1':
+        return result
+
+    from .routed_experts import declared_shared_capture_groups
+    groups = declared_shared_capture_groups(unit_shapes, profile)
+    forward_h, forward_x, drain = {}, {}, {}
+    for members in groups.values():
+        if any(type(counts[name]) is not int or counts[name] <= 0 for name in members):
+            raise ValueError('shared capture admission requires positive census counts')
+        if len({counts[name] for name in members}) != 1:
+            raise ValueError('shared capture siblings disagree on census input count')
+        name = members[0]
+        layer = int(name[len(live_prefix):].split('.', 1)[0])
+        columns = unit_shapes[name][1]
+        h = columns*columns*4
+        # The device buffer reserves max_act_rows even for a shorter draw.
+        device_x = max_act_rows*columns*4
+        output_x = min(counts[name], max_act_rows)*columns*4
+        forward_h[layer] = forward_h.get(layer, 0)+h
+        forward_x[layer] = forward_x.get(layer, 0)+device_x
+        # Each group drains before its independent CPU siblings are cloned.
+        # At every group boundary charge its larger device/output footprint;
+        # one transfer may additionally coexist within the active group.
+        drain[layer] = drain.get(layer, 0)+max(h+device_x, len(members)*(h+output_x))
+    common = {key: value for key, value in terms.items() if key not in
+              ('source_window_bytes', 'loader_transient_bytes',
+               'layer_hessian_bytes', 'layer_prefix_bytes')}
+    forward = dict(common, source_window_bytes=terms['source_window_bytes'],
+        loader_transient_bytes=loader_transient,
+        layer_hessian_bytes=max(forward_h.values(), default=0),
+        layer_prefix_bytes=max(forward_x.values(), default=0))
+    materialization = dict(common,
+        source_window_bytes=sum(sorted(body.values(), reverse=True)[:cache_slots-1]),
+        loader_transient_bytes=0,
+        layer_materialization_bytes=max(drain.values(), default=0),
+        finite_validation_mask_bytes=max((max(shape[1]**2,
+            min(counts[name], max_act_rows)*shape[1])
+            for name, shape in unit_shapes.items()), default=0))
+    source_validation = dict(common, source_window_bytes=terms['source_window_bytes'],
+        loader_transient_bytes=loader_transient,
+        source_validation_file_bytes=max(raw_body.values(), default=0),
+        source_validation_cpu_copy_bytes=max(
+            (math.prod(shape)*max_element_bytes for shape in unit_shapes.values()), default=0))
+    phases = dict(source_validation=source_validation, forward=forward, materialization=materialization)
+    result.update(schema='prismaquant.streamed_calibration_resources.v2',
+        capture_policy=capture_policy, input_groups=groups, phases=phases,
+        memory_bytes=max(sum(phase.values()) for phase in phases.values()),
+        transient_status='checked shared input groups; settled prefetch window and completed source release before materialization')
+    # v1's additive terms are retained only in its own schema. v2 carries two
+    # mutually exclusive phase maps, with the maximum defining admission.
+    del result['terms']
+    return result
 
 
 def _num_layers(cfg: dict) -> int:

--- a/prismaquant/autoscale.py
+++ b/prismaquant/autoscale.py
@@ -248,7 +248,7 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
         capture_policy=capture_policy, input_groups=groups, phases=phases,
         memory_bytes=max(sum(phase.values()) for phase in phases.values()),
         transient_status='checked shared input groups; settled prefetch window and completed source release before materialization')
-    # v1's additive terms are retained only in its own schema. v2 carries two
+    # v1's additive terms are retained only in its own schema. v2 carries three
     # mutually exclusive phase maps, with the maximum defining admission.
     del result['terms']
     return result

--- a/prismaquant/memory_management.py
+++ b/prismaquant/memory_management.py
@@ -5,6 +5,7 @@ import gc
 import os
 import sys
 import weakref
+from pathlib import Path
 from typing import Iterable
 
 import torch
@@ -15,6 +16,90 @@ _BUDGET_EVICTORS: "weakref.WeakSet[object]" = weakref.WeakSet()
 
 class GPUMemoryBudgetExceeded(RuntimeError):
     """Raised when cache eviction cannot bring CUDA memory under budget."""
+
+
+class CaptureMemoryGuard:
+    """Fail closed on the conservative cgroup-plus-CUDA capture footprint.
+
+    CUDA can be absent from GB10's cgroup charge. Adding the entire allocator
+    reservation is deliberately conservative even where charges overlap. The
+    guard never changes a cache policy or drops system-wide page caches.
+    """
+
+    def __init__(self, device, *, cgroup_root=Path('/sys/fs/cgroup'),
+                 membership=Path('/proc/self/cgroup')):
+        self.device = torch.device(device)
+        root = Path(cgroup_root)
+        entries = [line.split(':', 2)[2] for line in Path(membership).read_text().splitlines()
+                   if line.startswith('0::')]
+        if len(entries) != 1 or not entries[0].startswith('/') or '..' in Path(entries[0]).parts:
+            raise RuntimeError('capture memory guard requires a cgroup v2 membership')
+        current = root/entries[0].lstrip('/')
+        limits = []
+        for scope in [current, *current.parents]:
+            if scope != root and root not in scope.parents:
+                break
+            limit_path = scope/'memory.max'
+            if not limit_path.is_file():
+                if scope == root:
+                    break  # The host's root cgroup has no configurable limit.
+                raise RuntimeError('capture memory guard cannot inspect its cgroup ancestors')
+            raw = limit_path.read_text().strip()
+            if raw != 'max':
+                limits.append((int(raw), scope))
+            if scope == root:
+                break
+        if not limits:
+            raise RuntimeError('bounded capture requires a finite cgroup memory budget')
+        self.cap_bytes, self.scope = min(limits, key=lambda pair: pair[0])
+        self.margin_bytes = 2*1024**3
+        self.host_floor_bytes = 8*1024**3
+        if self.cap_bytes <= self.margin_bytes:
+            raise RuntimeError('capture budget cannot hold its physical safety margin')
+        self.failure = None
+        self.peak_bytes = 0
+        self.min_available_bytes = None
+        self.last = None
+
+    def check(self, label, *, reserve_bytes=0):
+        if self.failure is not None:
+            raise RuntimeError(self.failure)
+        try:
+            if type(reserve_bytes) is not int or reserve_bytes < 0:
+                raise ValueError('capture future allocation reservation must be nonnegative bytes')
+            raw = (self.scope/'memory.max').read_text().strip()
+            cap = self.cap_bytes if raw == 'max' else min(self.cap_bytes, int(raw))
+            current = int((self.scope/'memory.current').read_text())
+            reserved = int(torch.cuda.memory_reserved(self.device))
+            host = _host_memory_info()
+            if host is None or current < 0 or reserved < 0:
+                raise RuntimeError('capture memory observations are unavailable')
+            available, total = host
+            if not 0 <= available <= total:
+                raise RuntimeError('capture host memory observations are invalid')
+            self.last = dict(label=str(label), cgroup_current_bytes=current,
+                cuda_reserved_bytes=reserved,
+                conservative_cgroup_plus_cuda_reserved_bytes=current+reserved,
+                host_mem_available_bytes=available, cap_bytes=cap,
+                future_allocation_bytes=reserve_bytes,
+                refusal_threshold_bytes=cap-self.margin_bytes)
+            self.peak_bytes = max(self.peak_bytes, current+reserved)
+            self.min_available_bytes = (available if self.min_available_bytes is None
+                                       else min(self.min_available_bytes, available))
+            if (current+reserved+reserve_bytes > cap-self.margin_bytes or
+                    available < self.host_floor_bytes+reserve_bytes):
+                raise RuntimeError(f'capture physical memory refusal: {self.last}')
+        except Exception as error:
+            self.failure = str(error)
+            raise
+        return dict(self.last)
+
+    def snapshot(self):
+        return dict(scope=str(self.scope), budget_bytes=self.cap_bytes,
+            margin_bytes=self.margin_bytes, host_floor_bytes=self.host_floor_bytes,
+            peak_conservative_bytes=self.peak_bytes,
+            min_host_available_bytes=self.min_available_bytes,
+            last_checkpoint=None if self.last is None else dict(self.last))
 
 
 def env_flag_enabled(name: str, *, default: bool = True) -> bool:

--- a/prismaquant/perturbed_x_cache.py
+++ b/prismaquant/perturbed_x_cache.py
@@ -200,6 +200,32 @@ def write_activation_cache_entry(cache_dir, name, inputs, *, source="perturbed_x
     return path
 
 
+def release_activation_cache_file_pages(path, *, expected_stat):
+    """Advise only a completed, unchanged entry after its checksum is checked.
+
+    This optional capture-writer boundary leaves the artifact and all tensor
+    owners intact. Later consumers still use the ordinary activation prefetch.
+    Advice is not proof of physical release; the caller's guard remains final.
+    """
+    import stat
+    def identity(value):
+        return (value.st_dev, value.st_ino, value.st_size,
+                value.st_mtime_ns, value.st_ctime_ns)
+    flags = os.O_RDONLY | os.O_NOFOLLOW
+    descriptor = os.open(path, flags)
+    try:
+        actual = os.fstat(descriptor)
+        if not stat.S_ISREG(actual.st_mode) or identity(actual) != identity(expected_stat):
+            raise RuntimeError('capture entry changed before page advice')
+        os.fsync(descriptor)
+        if (identity(os.fstat(descriptor)) != identity(expected_stat) or
+                identity(os.stat(path, follow_symlinks=False)) != identity(expected_stat)):
+            raise RuntimeError('capture entry changed while completing durability')
+        os.posix_fadvise(descriptor, 0, 0, os.POSIX_FADV_DONTNEED)
+    finally:
+        os.close(descriptor)
+
+
 def _tensor_hash_update(h: "hashlib._Hash", tensor: torch.Tensor) -> None:
     t = tensor.detach().to("cpu").contiguous()
     h.update(str(tuple(t.shape)).encode())

--- a/prismaquant/routed_experts.py
+++ b/prismaquant/routed_experts.py
@@ -295,6 +295,43 @@ def profile_declared_unpacked_expert_linears(
     return sorted(out, key=lambda member: member.qname)
 
 
+def packed_activation_input_kind(param_name: str) -> str:
+    """Input names owned by the existing packed activation derivation."""
+    kinds = {"gate_up_proj": "gate_up", "down_proj": "down"}
+    if param_name not in kinds:
+        raise RuntimeError(f"packed activation derivation does not support {param_name!r}")
+    return kinds[param_name]
+
+
+def declared_shared_capture_groups(unit_shapes, profile):
+    """Plan input ownership from profile declarations, for checked admission.
+
+    This is an expectation, not evidence of the live representation. A
+    collector using the resulting memory bound must compare its actual groups
+    with these groups before forwarding. In particular, declared experts that
+    are ordinary unpacked Linears cannot claim packed gate/up sharing.
+    """
+    classifier = ProfileRoutedExpertClassifier(profile)
+    groups = {}
+    for name, shape in sorted(unit_shapes.items()):
+        if (not isinstance(name, str) or not name or len(shape) != 2 or
+                any(type(value) is not int or value <= 0 for value in shape)):
+            raise ValueError('capture input grouping requires named positive 2-D unit shapes')
+        match = classifier.classify(name)
+        key = ('dense', name)
+        if match is not None:
+            parts = name.rsplit('.', 2)
+            if len(parts) != 3 or not parts[1].isdigit() or not match.regex_declared:
+                raise RuntimeError(f'capture unit has no declared per-expert representation: {name}')
+            parent = profile.packed_expert_parent_for_projection(match.projection_name)
+            key = ('packed', parts[0], int(parts[1]), packed_activation_input_kind(parent))
+        groups.setdefault(key, []).append(name)
+    for members in groups.values():
+        if len({unit_shapes[name][1] for name in members}) != 1:
+            raise RuntimeError(f'shared capture inputs have different widths: {members}')
+    return {members[0]: members for members in sorted(groups.values())}
+
+
 @dataclass(frozen=True)
 class PackedExpertProjection:
     """One profile-declared 2-D view of a live packed expert parameter.

--- a/prismaquant/streaming_model.py
+++ b/prismaquant/streaming_model.py
@@ -907,6 +907,35 @@ class StreamingContext:
         if self.device.type == 'cuda':
             torch.cuda.empty_cache()
 
+    def settle_prefetched_layers(self, layer_indices):
+        """Await an already scheduled window without claiming its owners.
+
+        Capture may exclude loader temporaries only after every remaining
+        prefetch is complete. Missing, refused, failed or unexpected loads
+        fail closed; this boundary never schedules a cold read, installs a
+        layer, changes an LRU pin or removes a delivery future.
+        """
+        indices = tuple(layer_indices)
+        if (len(set(indices)) != len(indices) or any(
+                type(index) is not int or not 0 <= index < self.num_layers for index in indices)):
+            raise ValueError('prefetch settlement requires unique in-scope layers')
+        with self._inflight_lock:
+            futures = dict(self._inflight)
+        if set(futures) - set(indices):
+            raise RuntimeError('capture prefetch window has unexpected source owners')
+        settled = []
+        for index in indices:
+            future = futures.get(index)
+            if future is not None:
+                if not future.result():
+                    raise RuntimeError(f'capture successor {index} prefetch was refused')
+                settled.append(dict(layer=index, owner='prefetch_future'))
+            elif self.layer_cache.peek(index):
+                settled.append(dict(layer=index, owner='layer_cache'))
+            else:
+                raise RuntimeError(f'capture successor {index} has no resident prefetch')
+        return settled
+
     def source_residency_snapshot(self, layer_indices):
         """Describe existing layer owners without retaining any tensor views.
 

--- a/prismaquant/tessera_calibration_cache.py
+++ b/prismaquant/tessera_calibration_cache.py
@@ -18,8 +18,39 @@ STAGE = 'tessera_calibration_capture'
 SOURCE = 'tessera_campaign_prefix_f32_v1'
 
 
-def sha256(path):
+def sha256(path, *, resource_check=None, release_read_pages=False):
     with Path(path).open('rb') as handle:
+        if resource_check is not None or release_read_pages:
+            import os
+            import stat
+            original = os.fstat(handle.fileno())
+            if release_read_pages and not stat.S_ISREG(original.st_mode):
+                raise RuntimeError('source hash page release requires a regular file')
+            digest = hashlib.sha256()
+            consumed = advised = 0
+            while True:
+                if resource_check is not None:
+                    resource_check(f'before_capture_hash:{Path(path).name}')
+                block = handle.read(16*1024**2)
+                if not block:
+                    after = os.fstat(handle.fileno())
+                    named = Path(path).stat()
+                    if any(getattr(original, key) != getattr(actual, key)
+                           for actual in (after, named) for key in
+                           ('st_dev', 'st_ino', 'st_size', 'st_mtime_ns', 'st_ctime_ns')):
+                        raise RuntimeError('source changed during guarded capture hashing')
+                    return digest.hexdigest()
+                digest.update(block)
+                consumed += len(block)
+                del block
+                if release_read_pages:
+                    page = os.sysconf('SC_PAGE_SIZE')
+                    end = consumed//page*page
+                    if end > advised:
+                        os.posix_fadvise(handle.fileno(), advised, end-advised, os.POSIX_FADV_DONTNEED)
+                        advised = end
+                if resource_check is not None:
+                    resource_check(f'after_capture_hash:{Path(path).name}')
         return hashlib.file_digest(handle, 'sha256').hexdigest()
 
 
@@ -29,7 +60,8 @@ def _json(path, value):
 
 
 def capture_identity(census_path, *, calibration, max_act_rows,
-                     model_load_contract, attention_implementation):
+                     model_load_contract, attention_implementation,
+                     resource_check=None, release_read_pages=False):
     """Hash source bytes on every invocation; mtimes never authorize reuse."""
     import importlib.metadata
     import torch
@@ -51,7 +83,9 @@ def capture_identity(census_path, *, calibration, max_act_rows,
                     *root.glob('*.model'), *root.glob('*.txt')})
     if not files or not (root / 'config.json').is_file():
         raise RuntimeError('calibration capture needs a complete local source checkpoint')
-    source = {p.name:sha256(p) for p in files if p.is_file()}
+    def source_digest(path):
+        return sha256(path, resource_check=resource_check, release_read_pages=release_read_pages)
+    source = {p.name:source_digest(p) for p in files if p.is_file()}
     # The census already seals the producer's complete source/auxiliary
     # roster (including non-JSON tokenizer assets such as chat_template.jinja).
     # Check those bytes too, without inventing another producer identity.
@@ -61,7 +95,7 @@ def capture_identity(census_path, *, calibration, max_act_rows,
     if declared.get('config_sha256'):
         expected['config.json'] = declared['config_sha256']
     for name,digest in expected.items():
-        actual = source[name] if name in source else sha256(root/name)
+        actual = source[name] if name in source else source_digest(root/name)
         if actual != digest:
             raise RuntimeError(f'calibration source differs from census producer: {name}')
     if not any(name.endswith('.safetensors') for name in source):
@@ -95,7 +129,8 @@ def _validate_tensors(name, payload, census, max_rows):
 
 
 def publish_capture(root, *, census_path, identity, acts=None, hessians=None,
-                    counts=None, maxima=None, existing_entries=None):
+                    counts=None, maxima=None, existing_entries=None,
+                    release_file_pages=False, resource_check=None):
     """Seal a complete capture, journalling per-unit file receipts atomically.
 
     ``existing_entries`` seals a previously measured raw capture without another
@@ -119,6 +154,8 @@ def publish_capture(root, *, census_path, identity, acts=None, hessians=None,
         resume=True, identity=identity, qnames=names)
     records = {}
     for name in names:
+        if resource_check is not None:
+            resource_check(f'before_capture_seal:{name}')
         expected_path = Path('inputs') / activation_cache_filename(name)
         record = completed.get(name) or (existing_entries or {}).get(name)
         if record is None:
@@ -127,18 +164,25 @@ def publish_capture(root, *, census_path, identity, acts=None, hessians=None,
             _validate_tensors(name,payload,census,identity['max_act_rows'])
             path = write_activation_cache_entry(root/'inputs',name,acts[name],
                 source=SOURCE,durable=True,hessian=hessians[name],count=counts[name],max_abs=maxima[name])
+            file_stat = path.stat() if release_file_pages else None
             record = dict(path=str(expected_path),sha256=sha256(path))
         else:
             if record.get('path') != str(expected_path):
                 raise RuntimeError(f'{name}: capture file is outside its canonical location')
             path = root/expected_path
+            file_stat = path.stat() if release_file_pages else None
             if sha256(path) != record['sha256']:
                 raise RuntimeError(f'{name}: capture artifact checksum mismatch')
             _validate_tensors(name,torch.load(path,map_location='cpu',weights_only=True),
                               census,identity['max_act_rows'])
+        if release_file_pages:
+            from .perturbed_x_cache import release_activation_cache_file_pages
+            release_activation_cache_file_pages(path, expected_stat=file_stat)
         if name not in completed:
             write_unit(journal,stage=STAGE,qname=name,identity_sha256=digest,state=record)
         records[name] = record
+        if resource_check is not None:
+            resource_check(f'after_capture_seal:{name}')
     manifest = dict(schema=SCHEMA,status='complete',identity=identity,entries=records)
     path = root/'capture_manifest.json'
     if path.exists() and json.loads(path.read_text()) != manifest:
@@ -156,11 +200,14 @@ class CaptureWriter:
     witness from that traversal, not only the census's expected descriptor.
     """
 
-    def __init__(self, root, *, census_path, identity):
+    def __init__(self, root, *, census_path, identity,
+                 release_file_pages=False, resource_check=None):
         self.root = Path(root).resolve()
         self.census_path = census_path
         self.census = json.loads(Path(census_path).read_text())
         self.identity = identity
+        self.release_file_pages = release_file_pages
+        self.resource_check = resource_check
         self.names = sorted(identity['units'])
         if set(self.names) != set(self.census['counts']):
             raise RuntimeError('calibration writer scope differs from census')
@@ -191,6 +238,8 @@ class CaptureWriter:
                 any(set(values) != names for values in (hessians, counts, maxima))):
             raise RuntimeError('calibration writer has repeated or inconsistent layer scope')
         for name in sorted(names):
+            if self.resource_check is not None:
+                self.resource_check(f'before_capture_write:{name}')
             payload = dict(inputs=acts[name], hessian=hessians[name], count=counts[name],
                            max_abs=maxima[name], name=name, source=SOURCE)
             _validate_tensors(name, payload, self.census, self.identity['max_act_rows'])
@@ -199,6 +248,7 @@ class CaptureWriter:
                 import torch
                 expected = str(Path('inputs')/activation_cache_filename(name))
                 path = self.root/expected
+                file_stat = path.stat() if self.release_file_pages else None
                 if previous.get('path') != expected or sha256(path) != previous.get('sha256'):
                     raise RuntimeError(f'{name}: interrupted capture entry changed')
                 old = torch.load(path, map_location='cpu', weights_only=True)
@@ -213,10 +263,17 @@ class CaptureWriter:
                 path = write_activation_cache_entry(self.root/'inputs', name, acts[name],
                     source=SOURCE, durable=True, hessian=hessians[name],
                     count=counts[name], max_abs=maxima[name])
+                file_stat = path.stat() if self.release_file_pages else None
                 record = dict(path=str(Path('inputs')/activation_cache_filename(name)), sha256=sha256(path))
+            if self.release_file_pages:
+                from .perturbed_x_cache import release_activation_cache_file_pages
+                release_activation_cache_file_pages(path, expected_stat=file_stat)
+            if previous is None:
                 write_unit(self.journal, stage=STAGE, qname=name,
                            identity_sha256=self.digest, state=record)
             self.records[name] = record
+            if self.resource_check is not None:
+                self.resource_check(f'after_capture_write:{name}')
 
     def finish(self, *, model_load_contract):
         from prismaquant import validate_source_initialization_contract
@@ -224,7 +281,9 @@ class CaptureWriter:
         if actual != self.identity['model_load_contract']:
             raise RuntimeError('actual capture initialization differs from the census')
         return publish_capture(self.root, census_path=self.census_path,
-                               identity=self.identity, existing_entries=self.records)
+                               identity=self.identity, existing_entries=self.records,
+                               release_file_pages=self.release_file_pages,
+                               resource_check=self.resource_check)
 
 
 def require_capture_contract(path, expected_sha256=None):

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -1792,7 +1792,8 @@ def _link_seed_wire(seed_wire: Path, wire_dir: Path, filename) -> None:
 def _collect_activations(model, targets, tokens, max_rows: int, device,
                          *, want_hessian: bool = False, profile=None,
                          boundary_consumer=None, forward_batch=None, resource_check=None,
-                         shared_packed_inputs: bool = False, on_forwards_complete=None):
+                         shared_packed_inputs: bool = False, on_forwards_complete=None,
+                         expected_shared_input_groups=None):
     """One model forward per batch, for dense and declared packed projections.
 
     Returns ``(rows, hessians, token_counts, max_abs)``. Counts describe every
@@ -1944,12 +1945,12 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
         selected_by_module = {}
         # These are the input kinds published by the existing derivation,
         # not a mapping to the producer's served role/group vocabulary.
-        input_kind = {"gate_up_proj": "gate_up", "down_proj": "down"}
+        from .routed_experts import packed_activation_input_kind
+        input_kind = {}
         for name in sorted(missing_modules):
             member = by_name[name]
             if member.param_name not in input_kind:
-                raise RuntimeError(
-                    f"packed activation derivation does not support {member.packed_qname!r}")
+                input_kind[member.param_name] = packed_activation_input_kind(member.param_name)
             selected_by_module.setdefault(member.module_qname, []).append(member)
             routed_seen[name] = 0
         parents = {name: _packed_experts_parent_module(model, name)
@@ -1993,6 +1994,11 @@ def _collect_activations(model, targets, tokens, max_rows: int, device,
             boundary_consumer=(consume_boundary if boundary_consumer is not None else None),
         )
     try:
+        if expected_shared_input_groups is not None:
+            actual = sorted(sorted(names) for names in group_members.values())
+            expected = sorted(sorted(names) for names in expected_shared_input_groups.values())
+            if not shared_packed_inputs or actual != expected:
+                raise RuntimeError('actual capture input groups differ from memory admission')
         for name in targets:
             if name not in missing_modules:
                 handles.append(modules[name].register_forward_pre_hook(make_hook(name)))
@@ -3069,7 +3075,8 @@ def _project_expert_population(population: ExpertPopulation, *, weights, menus,
 
 
 def _checked_projected_units(bound, *, weights, model_path, source,
-                             measured=None) -> dict[str, dict]:
+                             measured=None, resource_check=None,
+                             release_source_pages=False) -> dict[str, dict]:
     """The producer's unit records for the units this run prices, bytes checked.
 
     Each unit's source tensor is read from the shard the producer hashed and
@@ -3084,11 +3091,17 @@ def _checked_projected_units(bound, *, weights, model_path, source,
 
     projected: dict[str, dict] = {}
     mismatched: list[str] = []
+    consumed, source_stats = {}, {}
     for _stack, units in sorted(bound.items()):
         for name, unit in sorted(units.items()):
             if measured is not None and name not in measured:
                 continue
+            if resource_check is not None:
+                resource_check(f'before_source_projection_check:{name}')
             try:
+                if release_source_pages:
+                    path = Path(model_path)/source['tensors'][unit['source_tensor']]
+                    source_stats.setdefault(str(path), path.stat())
                 weight = source_unit_weight(model_path, source, unit)
             except ExpertProjectionError as exc:
                 raise RuntimeError(
@@ -3099,14 +3112,27 @@ def _checked_projected_units(bound, *, weights, model_path, source,
                 mismatched.append(
                     f"{name} (live {tuple(live.shape)} {live.dtype} vs source "
                     f"{unit['source_tensor']} {tuple(weight.shape)} {weight.dtype})")
+                if resource_check is not None:
+                    del weight, live
+                    resource_check(f'after_source_projection_check:{name}')
                 continue
             projected[name] = unit
+            if release_source_pages:
+                consumed.setdefault(str(path), []).append(unit['source_tensor'])
+            if resource_check is not None or release_source_pages:
+                del weight, live
+            if resource_check is not None:
+                resource_check(f'after_source_projection_check:{name}')
     if mismatched:
         raise RuntimeError(
             "Tessera campaign's live expert view disagrees byte-for-byte with the "
             "producer's source tensor for " + ", ".join(mismatched)
             + "; the exporter would encode bytes this table did not price. "
             "Refusing (PrismaQuant #183).")
+    if release_source_pages:
+        from .layer_streaming import _advise_consumed_safetensors_pages
+        for path, keys in consumed.items():
+            _advise_consumed_safetensors_pages(path, keys, source_stats[path])
     return projected
 
 
@@ -3387,6 +3413,14 @@ def _run_streamed_calibration(args, runner, profile, *, mode, population,
             measured=set(), projection=None if census is None else census.get('expert_projection'))
     del weights
 
+    capture_policy = getattr(args, 'streaming_capture_policy', 'legacy')
+    shared_capture = capture_policy in ('shared-inputs-release-v1', 'shared-inputs-bounded-v1')
+    bounded_capture = capture_policy == 'shared-inputs-bounded-v1'
+    guard = None
+    if bounded_capture and runner.device.type == 'cuda':
+        from .memory_management import CaptureMemoryGuard
+        guard = CaptureMemoryGuard(runner.device)
+        guard.check('before_capture_identity')
     writer = None
     if census is not None:
         if (census.get('model_load_contract') or {}).get('schema') != 'prismaquant.streaming_initialization.v1':
@@ -3401,40 +3435,82 @@ def _run_streamed_calibration(args, runner, profile, *, mode, population,
         # as an already completed checkpoint load before it runs.
         identity = store.capture_identity(args.calibration_census, calibration=calibration,
             max_act_rows=args.max_act_rows, model_load_contract=census['model_load_contract'],
-            attention_implementation=attention_implementation)
+            attention_implementation=attention_implementation,
+            resource_check=None if guard is None else guard.check,
+            release_read_pages=guard is not None)
         writer = store.CaptureWriter(args.capture_calibration_out,
-            census_path=args.calibration_census, identity=identity)
+            census_path=args.calibration_census, identity=identity,
+            release_file_pages=bounded_capture,
+            resource_check=None if guard is None else guard.check)
 
-    capture_policy = getattr(args, 'streaming_capture_policy', 'legacy')
-    shared_capture = capture_policy == 'shared-inputs-release-v1'
     if shared_capture and writer is None:
         raise RuntimeError('shared-inputs-release-v1 requires streamed calibration capture')
     counts, maxima, telemetry = {}, {}, []
+    if guard is not None:
+        from .autoscale import streamed_calibration_resources
+        resources = streamed_calibration_resources(args.model, unit_shapes=shapes,
+            counts=census['counts'], nsamples=args.nsamples, seqlen=args.seqlen,
+            max_act_rows=args.max_act_rows, cache_slots=args.streaming_cache_slots,
+            prefetch_workers=args.streaming_prefetch_workers,
+            headroom_gb=args.streaming_cache_headroom_gb, capture_policy=capture_policy)
+        if resources['memory_bytes'] > guard.cap_bytes:
+            raise RuntimeError('capture cgroup budget is smaller than its checked phase plan')
+        additional = max(sum(value for key, value in phase.items() if key not in
+            ('nonbody_source_bytes', 'declared_headroom_bytes'))
+            for phase in resources['phases'].values())
+        guard.check('before_capture_source_traversal', reserve_bytes=additional)
     runner.context.begin_source_initialization_audit()
 
     def visit(layer, forward_batch):
         names = names_by_layer.get(layer, [])
+        if bounded_capture:
+            # No loader allocation can race with growing capture tensors.
+            runner.context.settle_prefetched_layers(range(
+                layer+1, min(runner.num_layers, layer+1+runner.prefetch_lookahead)))
         members = [m for m in population.members if m.qname in names]
         live = refresh_packed_expert_projections(members, profile)
         if live:
             _checked_projected_units(projection['stacks'],
                 weights={m.qname: m.weight for m in live}, model_path=args.model,
-                source=projection['producer']['source'], measured={m.qname for m in live})
+                source=projection['producer']['source'], measured={m.qname for m in live},
+                resource_check=None if guard is None else guard.check,
+                release_source_pages=guard is not None)
         # The source identity check is complete. The collector creates its own
         # live views; this caller must not pin old packed storage through return.
         del live
         completed_source_released = False
+        settled_prefetch = None
         def release_completed_source():
-            nonlocal completed_source_released
+            nonlocal completed_source_released, settled_prefetch
+            if bounded_capture:
+                settled_prefetch = runner.context.settle_prefetched_layers(range(
+                    layer+1, min(runner.num_layers, layer+1+runner.prefetch_lookahead)))
             runner.context.release_completed_layer(layer)
             completed_source_released = True
+
+        expected_groups = None
+        if bounded_capture:
+            from .routed_experts import declared_shared_capture_groups
+            expected_groups = declared_shared_capture_groups({name: shapes[name] for name in names}, profile)
+            if guard is not None:
+                capture_bytes = sum(4*(shapes[name][1]**2+args.max_act_rows*shapes[name][1])
+                                    for name in expected_groups)
+                guard.check('before_capture_tensor_growth', reserve_bytes=capture_bytes)
+        def checked_forward(batch):
+            guard.check('before_capture_forward')
+            value = forward_batch(batch)
+            guard.check('after_capture_forward')
+            return value
 
         before = time.perf_counter()
         acts, hessians, rows, amax = _collect_activations(runner.model, names, tokens,
             args.max_act_rows if writer is not None else 0, runner.device,
-            want_hessian=writer is not None, profile=profile, forward_batch=forward_batch,
+            want_hessian=writer is not None, profile=profile,
+            forward_batch=forward_batch if guard is None else checked_forward,
             shared_packed_inputs=shared_capture,
-            on_forwards_complete=release_completed_source if shared_capture else None)
+            on_forwards_complete=release_completed_source if shared_capture else None,
+            expected_shared_input_groups=expected_groups,
+            resource_check=None if guard is None else guard.check)
         collected = time.perf_counter()
         counts.update(rows)
         maxima.update(amax)
@@ -3446,13 +3522,24 @@ def _run_streamed_calibration(args, runner, profile, *, mode, population,
             flush_seconds=flushed-collected,
             capture_tensor_bytes=sum(t.numel()*t.element_size()
                 for t in [*acts.values(), *hessians.values()] if t is not None))
+        if bounded_capture:
+            record['settled_prefetch'] = settled_prefetch
+            record['physical_memory_guard'] = None if guard is None else guard.snapshot()
         telemetry.append(record)
         print(json.dumps({'streamed_calibration_layer': record}), flush=True)
         del acts, hessians
         if runner.device.type == 'cuda':
             torch.cuda.empty_cache()
 
-    runner.visit_layer_batches(tokens, visit)
+    try:
+        runner.visit_layer_batches(tokens, visit)
+    except BaseException:
+        if guard is not None:
+            from .cost_stage_checkpoint import atomic_write_bytes
+            failure = dict(completed_layers=telemetry, physical_memory_guard=guard.snapshot())
+            atomic_write_bytes(Path(args.cache_dir)/'capture-memory-refusal.json',
+                (json.dumps(failure, indent=2, sort_keys=True)+'\n').encode())
+        raise
     contract = runner.context.source_initialization_contract()
     if set(counts) != set(targets) or any(value <= 0 for value in counts.values()):
         raise RuntimeError('streamed calibration did not observe every in-scope unit')
@@ -3597,8 +3684,8 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     ap.add_argument("--streaming-prefetch-workers", type=int, default=1)
     ap.add_argument("--streaming-cache-headroom-gb", type=float, default=24)
     ap.add_argument("--streaming-capture-policy", default="legacy",
-                    choices=("legacy", "shared-inputs-release-v1"),
-                    help="Opt-in shared packed inputs and completed-source release for capture.")
+                    choices=("legacy", "shared-inputs-release-v1", "shared-inputs-bounded-v1"),
+                    help="Opt-in shared capture; bounded also checks phase ownership and physical memory.")
     ap.add_argument("--capture-calibration-out", default=None,
                     help="Capture full-census float32 prefix X and uncapped H once, then exit.")
     ap.add_argument("--calibration-cache", default=None,
@@ -3645,6 +3732,9 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             "H-aware encoder branch is merged."
         )
     device = "cuda" if torch.cuda.is_available() else "cpu"
+    if (args.streaming_capture_policy == "shared-inputs-bounded-v1" and device == "cuda"
+            and os.environ.get("PRISMAQUANT_RELEASE_SOURCE_PAGES") != "1"):
+        raise RuntimeError("bounded CUDA capture requires PRISMAQUANT_RELEASE_SOURCE_PAGES=1")
     cache_dir = Path(args.cache_dir)
     cache_dir.mkdir(parents=True, exist_ok=True)
     wire_dir = cache_dir / "wire"

--- a/tests/test_glm_campaign_streaming.py
+++ b/tests/test_glm_campaign_streaming.py
@@ -166,7 +166,8 @@ def test_streamed_resource_plan_prices_layer_capture_and_packer_transients(glm_c
     assert result['disk_bytes'] > result['full_hessian_bytes']+result['full_prefix_bytes']
 
 
-def test_streamed_campaign_publishes_original_layout_census_and_capture(glm_checkpoint, tmp_path, monkeypatch):
+@pytest.mark.parametrize('capture_policy', ['shared-inputs-release-v1', 'shared-inputs-bounded-v1'])
+def test_streamed_campaign_publishes_original_layout_census_and_capture(glm_checkpoint, tmp_path, monkeypatch, capture_policy):
     """The CLI publishes a complete capture from real GLM source forwards."""
     import json
     from pathlib import Path
@@ -223,7 +224,7 @@ def test_streamed_campaign_publishes_original_layout_census_and_capture(glm_chec
     shared_root = tmp_path/'shared-capture'
     campaign.main([*common, '--cache-dir', str(tmp_path/'shared-capture-cache'),
         '--calibration-census', str(census), '--capture-calibration-out', str(shared_root),
-        '--streaming-capture-policy', 'shared-inputs-release-v1'])
+        '--streaming-capture-policy', capture_policy])
     shared_manifest = shared_root/'capture_manifest.json'
     capture.require_capture_contract(shared_manifest)
     baseline = json.loads(manifest.read_text())
@@ -241,8 +242,18 @@ def test_streamed_campaign_publishes_original_layout_census_and_capture(glm_chec
                 assert value == after[key], (name, key)
     assert released == list(range(config.text_config.num_hidden_layers))
     telemetry = json.loads((tmp_path/'shared-capture-cache'/'streamed-calibration-telemetry.json').read_text())
-    assert all(row['capture_policy'] == 'shared-inputs-release-v1' and
+    assert all(row['capture_policy'] == capture_policy and
                row['completed_source_released'] for row in telemetry)
+    if capture_policy == 'shared-inputs-bounded-v1':
+        assert [[entry['layer'] for entry in row['settled_prefetch']] for row in telemetry] == [[1], []]
+        for row in telemetry:
+            guard = row['physical_memory_guard']
+            if torch.cuda.is_available():
+                assert guard['peak_conservative_bytes'] <= guard['budget_bytes']-guard['margin_bytes']
+                assert guard['min_host_available_bytes'] >= guard['host_floor_bytes']
+                assert guard['last_checkpoint']['cuda_reserved_bytes'] > 0
+            else:
+                assert guard is None
 
 
 def test_streamed_bf16_keeps_hf_strict_fp32_source_slots(glm_checkpoint, tmp_path):

--- a/tests/test_streamed_capture_admission.py
+++ b/tests/test_streamed_capture_admission.py
@@ -1,0 +1,220 @@
+"""Phase admission must follow the collector and prefetch ownership contracts."""
+from concurrent.futures import Future, ThreadPoolExecutor
+from threading import Event, Lock
+from types import SimpleNamespace
+
+import pytest
+
+from prismaquant.streaming_model import StreamingContext
+from test_glm_campaign_streaming import glm_checkpoint
+
+
+def context(futures, cached=()):
+    value = object.__new__(StreamingContext)
+    value.num_layers = 4
+    value._inflight_lock = Lock()
+    value._inflight = futures
+    value.layer_cache = SimpleNamespace(peek=lambda layer: layer in cached)
+    return value
+
+
+def test_settlement_awaits_existing_future_without_claiming_or_reloading():
+    release = Event()
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(lambda: release.wait(timeout=2) and {'source': 'resident'})
+        value = context({1: future}, cached={2})
+        original_result = future.result
+        def result(*args, **kwargs):
+            assert not future.done()
+            release.set()
+            return original_result(*args, **kwargs)
+        future.result = result
+        records = value.settle_prefetched_layers([1, 2])
+        assert records == [{'layer': 1, 'owner': 'prefetch_future'},
+                           {'layer': 2, 'owner': 'layer_cache'}]
+        assert value._inflight == {1: future}
+        assert future.done() and not future.cancelled()
+
+
+@pytest.mark.parametrize('failure', ['missing', 'refused', 'error', 'unexpected'])
+def test_settlement_refuses_an_unproven_loader_boundary(failure):
+    futures = {}
+    if failure != 'missing':
+        future = Future()
+        if failure == 'error':
+            future.set_exception(RuntimeError('source load failed'))
+        else:
+            future.set_result(None if failure == 'refused' else {'source': 'resident'})
+        futures[3 if failure == 'unexpected' else 1] = future
+    value = context(dict(futures))
+    with pytest.raises(RuntimeError):
+        value.settle_prefetched_layers([1])
+    assert value._inflight == futures
+
+
+@pytest.mark.parametrize('indices', [[-1], [4], [1, 1], [True]])
+def test_settlement_rejects_invalid_windows(indices):
+    with pytest.raises(ValueError):
+        context({}).settle_prefetched_layers(indices)
+
+
+def test_shared_plan_prices_full_device_prefix_and_each_independent_cpu_output(glm_checkpoint):
+    from prismaquant.autoscale import streamed_calibration_resources
+    from prismaquant.model_profiles.glm5_next import Glm5NextProfile
+    from prismaquant.routed_experts import profile_declared_packed_expert_projections
+    model, source = glm_checkpoint
+    members = profile_declared_packed_expert_projections(model, Glm5NextProfile())
+    shapes = {member.qname: list(member.weight.shape) for member in members}
+    counts = {name: 2 for name in shapes}  # deliberately shorter than the buffer
+    common = dict(unit_shapes=shapes, counts=counts, nsamples=1, seqlen=2,
+                  max_act_rows=7, cache_slots=2, prefetch_workers=1, headroom_gb=1)
+    legacy = streamed_calibration_resources(source, **common)
+    plan = streamed_calibration_resources(source, **common,
+                                          capture_policy='shared-inputs-bounded-v1')
+    assert legacy['schema'].endswith('.v1') and plan['schema'].endswith('.v2')
+    assert 'terms' in legacy and 'terms' not in plan
+    # Derive the actual owners from live packed module handles and expert IDs,
+    # independently of the planner's profile/name classification.
+    actual = {}
+    for member in members:
+        actual.setdefault((id(member.module), member.expert_id, member.param_name), []).append(member.qname)
+    assert {tuple(sorted(names)) for names in plan['input_groups'].values()} == {
+        tuple(sorted(names)) for names in actual.values()}
+    device_h = device_x = drain = 0
+    for names in actual.values():
+        columns = shapes[names[0]][1]
+        h, x, output_x = 4*columns**2, 4*7*columns, 4*2*columns
+        device_h += h
+        device_x += x
+        drain += max(h+x, len(names)*(h+output_x))
+    forward, output = plan['phases']['forward'], plan['phases']['materialization']
+    assert forward['layer_hessian_bytes'] == device_h
+    assert forward['layer_prefix_bytes'] == device_x
+    assert output['layer_materialization_bytes'] == drain
+    assert forward['loader_transient_bytes'] == legacy['terms']['loader_transient_bytes'] > 0
+    assert output['loader_transient_bytes'] == 0
+    assert output['source_window_bytes'] == max(plan['body_layer_bytes'].values())
+    assert plan['memory_bytes'] == max(sum(phase.values()) for phase in plan['phases'].values())
+    assert plan['disk_bytes'] == legacy['disk_bytes']
+    assert plan['full_hessian_bytes'] == legacy['full_hessian_bytes']
+
+
+@pytest.fixture
+def memory_guard(tmp_path, monkeypatch):
+    from prismaquant import memory_management as memory
+    gib = 1024**3
+    root = tmp_path/'cgroup'
+    child = root/'job'
+    child.mkdir(parents=True)
+    (root/'memory.max').write_text(str(16*gib))
+    (root/'memory.current').write_text(str(gib))
+    (child/'memory.max').write_text('max')
+    membership = tmp_path/'membership'
+    membership.write_text('0::/job\n')
+    monkeypatch.setattr(memory.torch.cuda, 'memory_reserved', lambda _device: 2*gib)
+    monkeypatch.setattr(memory, '_host_memory_info', lambda: (20*gib, 32*gib))
+    guard = memory.CaptureMemoryGuard('cuda', cgroup_root=root, membership=membership)
+    return guard, root, memory
+
+
+def test_guard_prices_the_bounded_ancestor_and_the_entire_cuda_reservation(memory_guard):
+    guard, root, _memory = memory_guard
+    observed = guard.check('start')
+    assert observed['conservative_cgroup_plus_cuda_reserved_bytes'] == 3*1024**3
+    assert observed['refusal_threshold_bytes'] == 14*1024**3
+    assert guard.scope == root
+    assert guard.snapshot()['peak_conservative_bytes'] == 3*1024**3
+
+
+@pytest.mark.parametrize('failure', ['sum', 'host_floor', 'missing', 'tightened_cap'])
+def test_guard_latches_physical_refusal(memory_guard, monkeypatch, failure):
+    guard, root, memory = memory_guard
+    guard.check('start')
+    if failure == 'sum':
+        (root/'memory.current').write_text(str(13*1024**3))
+    elif failure == 'host_floor':
+        monkeypatch.setattr(memory, '_host_memory_info', lambda: (7*1024**3, 32*1024**3))
+    elif failure == 'missing':
+        (root/'memory.current').unlink()
+    else:
+        (root/'memory.max').write_text(str(4*1024**3))
+    with pytest.raises((RuntimeError, OSError)):
+        guard.check('refuse')
+    (root/'memory.current').write_text('0')
+    (root/'memory.max').write_text(str(100*1024**3))
+    monkeypatch.setattr(memory, '_host_memory_info', lambda: (20*1024**3, 32*1024**3))
+    with pytest.raises(RuntimeError):
+        guard.check('must not recover after a latched refusal')
+
+
+def test_guard_refuses_unbounded_cuda_capture(tmp_path):
+    from prismaquant.memory_management import CaptureMemoryGuard
+    root = tmp_path/'cgroup'
+    root.mkdir()
+    membership = tmp_path/'membership'
+    membership.write_text('0::/\n')
+    with pytest.raises(RuntimeError, match='finite cgroup memory budget'):
+        CaptureMemoryGuard('cuda', cgroup_root=root, membership=membership)
+
+
+def test_actual_collector_refuses_unproven_sharing_before_forward(glm_checkpoint, monkeypatch):
+    import torch
+    from prismaquant.tessera_campaign import _collect_activations
+    from prismaquant.model_profiles.glm5_next import Glm5NextProfile
+    model, _source = glm_checkpoint
+    targets = [name for name, module in model.named_modules()
+               if isinstance(module, torch.nn.Linear) and '.mlp.' in name][:2]
+    assert len(targets) == 2
+    called = []
+    with pytest.raises(RuntimeError, match='actual capture input groups'):
+        _collect_activations(model, targets, [torch.ones(1, 2, dtype=torch.long)], 1, 'cpu',
+            profile=Glm5NextProfile(), want_hessian=True, shared_packed_inputs=True,
+            expected_shared_input_groups={targets[0]: targets},
+            forward_batch=lambda _batch: called.append(True), on_forwards_complete=lambda: None)
+    assert not called
+    assert all(not module._forward_pre_hooks for module in model.modules())
+
+
+def test_guard_reserves_future_allocations_before_they_begin(memory_guard):
+    guard, root, _memory = memory_guard
+    with pytest.raises(RuntimeError, match='physical memory refusal'):
+        guard.check('before growth', reserve_bytes=12*1024**3)
+    assert int((root/'memory.current').read_text()) == 1024**3
+    assert guard.last['future_allocation_bytes'] == 12*1024**3
+
+
+def test_projected_source_advice_waits_for_byte_check_and_mapping_release(tmp_path, monkeypatch):
+    import torch
+    from safetensors.torch import save_file
+    from torch.multiprocessing.reductions import StorageWeakRef
+    from prismaquant import tessera_campaign as campaign
+    from prismaquant import tessera_expert_projection as projection
+    from prismaquant import layer_streaming
+    weight = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+    save_file({'expert.weight': weight}, str(tmp_path/'source.safetensors'))
+    unit = {'source_tensor': 'expert.weight', 'rows': 3, 'cols': 4}
+    bound = {'stack': {'expert': unit}}
+    source = {'tensors': {'expert.weight': 'source.safetensors'}}
+    original_read = projection.source_unit_weight
+    storage = []
+    calls = []
+    def read(*args, **kwargs):
+        value = original_read(*args, **kwargs)
+        storage.append(StorageWeakRef(value.untyped_storage()))
+        return value
+    def advise(path, keys, expected):
+        assert all(ref.expired() for ref in storage)
+        assert str(path) == str(tmp_path/'source.safetensors')
+        assert keys == ['expert.weight']
+        assert expected.st_size == (tmp_path/'source.safetensors').stat().st_size
+        calls.append(True)
+    monkeypatch.setattr(projection, 'source_unit_weight', read)
+    monkeypatch.setattr(layer_streaming, '_advise_consumed_safetensors_pages', advise)
+    assert campaign._checked_projected_units(bound, weights={'expert': weight},
+        model_path=tmp_path, source=source, release_source_pages=True) == {'expert': unit}
+    assert calls == [True]
+    calls.clear()
+    with pytest.raises(RuntimeError, match='disagrees byte-for-byte'):
+        campaign._checked_projected_units(bound, weights={'expert': weight+1},
+            model_path=tmp_path, source=source, release_source_pages=True)
+    assert not calls

--- a/tests/test_tessera_calibration_cache.py
+++ b/tests/test_tessera_calibration_cache.py
@@ -290,3 +290,88 @@ def test_layer_writer_releases_previous_resume_storage_before_next_load(capture,
     assert loaded == ['a.pt', 'b.pt']
     assert all(ref.expired() for ref in storages)
     assert set(writer.records) == {'a', 'b'}
+
+
+def test_bounded_writer_advises_only_verified_durable_entries_and_guards_sealing(capture, monkeypatch):
+    from prismaquant import perturbed_x_cache as cache
+    root, path, census, identity, acts, hessians, _record = capture
+    events = []
+    def advise(filename, *, expected_stat):
+        assert Path(filename).stat() == expected_stat
+        events.append(('advice', Path(filename).name))
+    monkeypatch.setattr(cache, 'release_activation_cache_file_pages', advise)
+    writer = cc.CaptureWriter(root, census_path=path, identity=identity,
+        release_file_pages=True, resource_check=lambda label: events.append(('check', label)))
+    writer.write(acts=acts, hessians=hessians, counts=census['counts'], maxima=census['max_abs'])
+    writer.finish(model_load_contract=identity['model_load_contract'])
+    assert events == [
+        ('check', 'before_capture_write:a'), ('advice', 'a.pt'), ('check', 'after_capture_write:a'),
+        ('check', 'before_capture_write:b'), ('advice', 'b.pt'), ('check', 'after_capture_write:b'),
+        ('check', 'before_capture_seal:a'), ('advice', 'a.pt'), ('check', 'after_capture_seal:a'),
+        ('check', 'before_capture_seal:b'), ('advice', 'b.pt'), ('check', 'after_capture_seal:b')]
+    events.clear()
+    (root/'inputs/a.pt').write_bytes(b'corrupt')
+    writer = cc.CaptureWriter(root, census_path=path, identity=identity, release_file_pages=True)
+    with pytest.raises(RuntimeError, match='entry changed'):
+        writer.write(acts=acts, hessians=hessians, counts=census['counts'], maxima=census['max_abs'])
+    assert not events
+
+
+def test_guarded_source_hash_matches_legacy_and_refuses_between_bounded_reads(tmp_path):
+    path = tmp_path/'source.bin'
+    path.write_bytes(b'a'*(17*1024**2))
+    events = []
+    assert cc.sha256(path, resource_check=events.append) == cc.sha256(path)
+    assert sum(label.startswith('after_') for label in events) == 2
+    def refuse(label):
+        if label.startswith('after_'):
+            raise RuntimeError('physical hash refusal')
+    with pytest.raises(RuntimeError, match='physical hash refusal'):
+        cc.sha256(path, resource_check=refuse)
+
+
+def test_page_advice_fences_durability_and_refuses_changed_files(tmp_path, monkeypatch):
+    import os
+    from prismaquant.perturbed_x_cache import release_activation_cache_file_pages
+    path = tmp_path/'entry.pt'
+    path.write_bytes(b'complete entry')
+    expected = path.stat()
+    events = []
+    original_fsync = os.fsync
+    def fsync(fd):
+        events.append('fsync')
+        original_fsync(fd)
+    monkeypatch.setattr(os, 'fsync', fsync)
+    monkeypatch.setattr(os, 'posix_fadvise', lambda fd, start, size, mode:
+                        events.append(('advice', start, size, mode)))
+    release_activation_cache_file_pages(path, expected_stat=expected)
+    assert events == ['fsync', ('advice', 0, 0, os.POSIX_FADV_DONTNEED)]
+    assert path.read_bytes() == b'complete entry'
+    events.clear()
+    path.write_bytes(b'changed entry')
+    with pytest.raises(RuntimeError, match='changed before page advice'):
+        release_activation_cache_file_pages(path, expected_stat=expected)
+    assert not events
+
+
+def test_guarded_hash_advises_only_consumed_pages_and_keeps_the_content_digest(tmp_path, monkeypatch):
+    import os
+    path = tmp_path/'source.bin'
+    path.write_bytes(b'z'*(17*1024**2+3))
+    expected = cc.sha256(path)
+    advice = []
+    def advise(fd, start, size, mode):
+        assert start+size <= os.lseek(fd, 0, os.SEEK_CUR)
+        advice.append((start, size, mode))
+    monkeypatch.setattr(os, 'posix_fadvise', advise)
+    assert cc.sha256(path, release_read_pages=True) == expected
+    assert advice == [(0, 16*1024**2, os.POSIX_FADV_DONTNEED),
+                      (16*1024**2, 1024**2, os.POSIX_FADV_DONTNEED)]
+    changed = []
+    def change(label):
+        if label.startswith('after_') and not changed:
+            with path.open('r+b') as handle:
+                handle.write(b'x')
+            changed.append(True)
+    with pytest.raises(RuntimeError, match='changed during guarded capture hashing'):
+        cc.sha256(path, resource_check=change)

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -183,7 +183,8 @@ def _streamed_resource_plan(spec, census, members):
         cache_slots=argument('--streaming-cache-slots', 2),
         prefetch_workers=argument('--streaming-prefetch-workers', 1),
         headroom_gb=max(float(spec.get('headroom_gb', 24)),
-                        argument('--streaming-cache-headroom-gb', 24., float)))
+                        argument('--streaming-cache-headroom-gb', 24., float)),
+        capture_policy=argument('--streaming-capture-policy', 'legacy', str))
 
 
 def require_rows_fit(mem_gb: "list[int]", per_box: int, budget) -> int:


### PR DESCRIPTION
Canonical shared capture needs an admission contract that follows its actual source and capture lifetimes. The new experimental `--streaming-capture-policy shared-inputs-bounded-v1` derives separate source-validation, forward and output-materialization phases from checkpoint headers, profile declarations and census counts. The existing legacy and shared-release policies retain their reservations.

- Actual collector input groups must match the planner before forwarding. Full device prefix capacity and independent CPU sibling outputs remain charged. Existing prefetch futures settle before capture growth and completed-source release without losing successor ownership.
- CUDA execution requires the existing source-page option and a finite cgroup budget. The shared guard conservatively adds cgroup charge and CUDA reservation, retains the 2 GiB margin and 8 GiB host floor, and reserves future growth before traversal/collection. Hash chunks, source checks, forwards, materialization, writes and sealing have refusal boundaries.
- Fully consumed source reads and completed capture files receive page advice through existing readers/writers. Source identity, byte comparisons, durability and unchanged-file checks remain mandatory; advice cannot certify physical release. The existing capture storage, canonical numerical identity and downstream prefetch are preserved. Architecture documentation records the contract and limits.

Validation through PrismaBuild:

- Final targeted CPU set: 149 passed. The initial eight-shard run had 142 passed/7 skipped because its producer path was unset; rerunning the entire packed-campaign module with the pinned producer passed all 16 tests, including those seven.
- Existing collector sharing/release/refusal regressions: another 53 passed before the final source-boundary additions; those collector changes remained unchanged.
- Native CUDA tiny-GLM CLI census, legacy capture and bounded capture passed in the exact GLM producer image on Sparky. Canonical identity and all per-unit tensor bytes/metadata matched; successor settlement and actual physical-guard observations were checked. PB `31f99a76b2de`, pinned image `cf3f7f83e682`.
- All 11 touched Python files compiled. Root independently verified successful terminals/cleanup, canonical receipts, payload hashes and all 12 changed files against each of 11 complete CAS source bundles. Audit: `/mnt/shared/tessera-measurements/glm-canonical-census-20260908/capture-admission-root-audit-03.json`.

This remains opt-in. No full-GLM fit, throughput improvement or served-artifact qualification is claimed. Full-scale capture still needs its own profiler and host telemetry before promotion; the resource formula and tiny-model equality do not establish that result.

Closes #364.
