### PR TITLE
Price Tessera menus without placeholder payloads

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,19 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `feat/streamed-capture-admission`. Stamps
+As of: 2026-09-08 · `perf/tessera-layout-pricing`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `perf/tessera-layout-pricing`) for producer-owned
+payload-free pricing. `tessera_footprint` uses Tessera's paired
+`build_plane_extents` / `build_terminal_extent` APIs when the installed
+producer exposes them. The existing pinned producer remains supported through
+its writer-based byte calculation. Both paths use the same declared geometry,
+recipe, plane counts, alignment and terminal arithmetic; returned footprint
+and recipe identities remain identical. This adds no probe, cache, format,
+serving admission, or pin change. The older producer still incurs placeholder
+payload construction. Gates: `tests/test_tessera_footprint_extents.py` and the
+existing footprint/menu tests; the modern producer path additionally requires
+validation against a Tessera revision exposing the extent APIs.
 
 Re-stamped (2026-09-08, `feat/streamed-capture-admission`) for experimental
 `--streaming-capture-policy shared-inputs-bounded-v1`. The legacy and prior

--- a/docs/measurements/glm-menu-extents-2026-09-08.md
+++ b/docs/measurements/glm-menu-extents-2026-09-08.md
@@ -1,0 +1,75 @@
+# GLM menu pricing through Tessera extents — 2026-09-08
+
+The PrismaQuant footprint accountant uses Tessera’s paired extent builders when
+both are present. Older installed producers keep the existing writer-based
+path. Exact arithmetic remains owned by Tessera. Runtime pins, menu eligibility,
+calibration and wire recipes do not change (PrismaQuant issue #367; Tessera PR #421).
+
+## Paired measurement
+
+The workload is the complete readable menu for a GLM routed gate projection,
+shape `(2048,4096)`, TP=1, no parallel split: 5,635 rows. One PrismaBuild CPU
+measurement on DL380 ran fresh processes in before/after/after/before order,
+with cProfile in every arm. Affinity was `[0,1]`, native threads one, physical
+reservation 8 GiB; the action’s observed cgroup peak was 536,391,680 bytes.
+The interpreter was CPython 3.12.11. Baseline PrismaQuant is `42e9f19a58`,
+optimized source is `341b4345da`; both use the same Tessera producer `af2c20360`.
+
+| Arm | Seconds |
+| --- | --- |
+| Before 1 | 183.7279 |
+| After 1 | 86.3785 |
+| After 2 | 85.9021 |
+| Before 2 | 182.5634 |
+
+Mean time fell from 183.1456 to 86.1403 seconds (52.97%, 2.126×). All four
+serialized menus have SHA256
+`6c896618f982c0c0a6a573e5d7c5adc5a745847a5a37f7af65ae6bb7b179ab67`.
+SHA256 calls fell from 56,353 (95.039/95.013 seconds of self time) to 5,638
+(0.018/0.017 seconds). The remaining hashes have purposes outside placeholder
+payload pricing. This is menu construction, not capture, encoding, allocation
+quality, served latency or GPU energy efficiency.
+
+Netdata covers the exact 555-second paired window on both Sparks and DL380.
+DL380 averaged 1.611% user CPU, 0.411% system CPU and 0.043% I/O wait across
+its CPUs, with no swap I/O. Sparky/Sparklina averaged 4.151/3.964 W GPU power;
+these GPUs did not execute the timed menu. Their raw swap, memory, CPU and load
+series are retained, including background swap reads on the Sparks.
+
+**Retained failure:** action `a24c36f97753` completed all four arms, then exited
+one when the Netdata hostname lookup failed. It has no success CAS receipt.
+The historical telemetry was recovered separately over the exact arm timestamps
+using explicit endpoints (`192.168.1.180`, `.110`, `.107`). Timings were not
+repeated. The helper now requires explicit endpoints before starting a paired
+measurement, so the source of each host series is reviewable.
+
+## Validation and evidence
+
+The two new consumer regressions failed before implementation (`46cd6bb2d677`)
+and passed afterward. The initial targeted footprint/architecture run passed all
+57 cases (`62cc58b5838e`). A broader menu run passed 154 cases and failed four
+allocation cases because the historical table named a source model directory
+missing on DL380 (`e2550f91fc6c`). The existing complete Qwen3-0.6B checkpoint
+was staged at that recorded path; all ten tests in the affected file then passed
+(`60cad850c2c8`). These are separate executions, with no missing collection or
+skips in their reported populations. CI with the repository’s older pinned
+producer supplies the compatibility lane; its final result is recorded on the PR.
+The comparison test also calls the legacy writer fallback with the modern
+producer and requires the exact same footprint report.
+
+Evidence root: `/mnt/shared/tessera-measurements/glm-canonical-census-20260908/`.
+
+- `extents-menu-root-audit-01.json`: failed terminal and cleanup, full measured
+  PrismaQuant snapshot, 1,141 producer file bytes/modes, four exact menus,
+  profiles, source-module hashes and telemetry recovery.
+- `extents-menu-profile-01/`: original four arm outputs and cProfile files.
+- `extents-menu-telemetry-recovery-01.json`: explicit URLs, raw historical host
+  series, exact window and descriptive statistics.
+- `extents-consumer-tests-root-audit-01.json` and
+  `extents-consumer-correction-root-audit-01.json`: canonical success CAS
+  receipts/payloads and complete snapshot comparisons for the passing tests.
+
+The upstream Tessera extent change separately qualified 43 identical byte-audit
+rows and the complete native suite; see Tessera’s
+`docs/measurements/layout-extents-2026-09-08.md`. No runtime release pin is moved
+by this consumer change.

--- a/experiments/glm_menu_extent_profile.py
+++ b/experiments/glm_menu_extent_profile.py
@@ -62,6 +62,8 @@ def main():
     parser.add_argument("--tessera-source", type=Path, required=True)
     parser.add_argument("--base")
     parser.add_argument("--arm-source", type=Path)
+    parser.add_argument("--netdata-endpoints", type=json.loads,
+                        help="JSON mapping of sparky, sparklina and the measured hostname to reachable hosts/IPs")
     args = parser.parse_args()
     producer = args.tessera_source.resolve()
     if args.arm_source:
@@ -69,6 +71,10 @@ def main():
         return
     if not args.base:
         parser.error("--base is required for paired profiling")
+    hosts = ("sparky", "sparklina", socket.gethostname())
+    if (not isinstance(args.netdata_endpoints, dict) or set(args.netdata_endpoints) != set(hosts)
+            or not all(isinstance(v, str) and v for v in args.netdata_endpoints.values())):
+        parser.error("paired profiles require explicit --netdata-endpoints for both Sparks and this host")
     args.out.mkdir(parents=True, exist_ok=False)
     source = Path(__file__).resolve().parents[1]
     baseline = subprocess.check_output(["git", "rev-parse", args.base], cwd=source, text=True).strip()
@@ -96,7 +102,7 @@ def main():
                for context, dims in SERIES if host in ("sparky", "sparklina") or not context.startswith("nvidia_smi.")]
     def fetch(query):
         host, context, dims = query
-        return host, context, _fetch(host, context, dims, after, before, before - after)
+        return host, context, _fetch(args.netdata_endpoints[host], context, dims, after, before, before - after)
     with ThreadPoolExecutor(max_workers=4) as pool:
         records = list(pool.map(fetch, queries))
     telemetry = {host: {context: data for h, context, data in records if h == host}
@@ -107,7 +113,7 @@ def main():
     assert all(row["rows"] == 5635 for row in results), "unexpected menu population"
     result = dict(scope="complete readable GLM expert menu at 2048x4096, TP1; no forwards or encodes",
                   baseline_commit=baseline, producer_commit=producer_commit,
-                  arms=results, menus_identical=True)
+                  arms=results, menus_identical=True, netdata_endpoints=args.netdata_endpoints)
     (args.out / "result.json").write_text(json.dumps(result, indent=2) + "\n")
 
 

--- a/experiments/glm_menu_extent_profile.py
+++ b/experiments/glm_menu_extent_profile.py
@@ -1,0 +1,115 @@
+"""Interleaved profiles of the complete GLM expert menu, with identical producer inputs."""
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+import cProfile
+from dataclasses import asdict
+from fractions import Fraction
+import hashlib
+import json
+import os
+from pathlib import Path
+import pstats
+import socket
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+from types import SimpleNamespace
+
+
+def json_default(value):
+    if isinstance(value, Fraction):
+        return dict(numerator=value.numerator, denominator=value.denominator)
+    raise TypeError(type(value).__name__)
+
+
+def arm(source, producer, out):
+    sys.path[:0] = [str(source), str(producer / "src")]
+    from prismaquant.tessera_campaign import expand_menus_for_targets
+    from prismaquant.tessera_menu import PARALLEL_NONE
+
+    out.mkdir()
+    name = "model.language_model.layers.4.mlp.experts.0.gate_proj"
+    weights = {name: SimpleNamespace(shape=(2048, 4096))}
+    profile = cProfile.Profile()
+    start_unix, start = time.time(), time.perf_counter()
+    with profile:
+        menus = expand_menus_for_targets(weights, [name], mode="readable",
+                                        tp_degree=1, parallel_kind=PARALLEL_NONE)
+    seconds, end_unix = time.perf_counter() - start, time.time()
+    profile.dump_stats(out / "menu.pstats")
+    with (out / "profile.txt").open("w") as stream:
+        pstats.Stats(profile, stream=stream).strip_dirs().sort_stats("cumulative").print_stats(60)
+    raw = json.dumps([asdict(row) for row in menus[name]], sort_keys=True,
+                     separators=(",", ":"), default=json_default).encode()
+    (out / "menu.json").write_bytes(raw)
+    result = dict(start_unix=start_unix, end_unix=end_unix, seconds=seconds,
+                  rows=len(menus[name]), menu_sha256=hashlib.sha256(raw).hexdigest(),
+                  host=socket.gethostname(), python=sys.version,
+                  affinity=sorted(os.sched_getaffinity(0)),
+                  sources={name: hashlib.sha256((source / "prismaquant" / name).read_bytes()).hexdigest()
+                           for name in ("tessera_footprint.py", "tessera_menu.py", "tessera_campaign.py")})
+    (out / "result.json").write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps(result), flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--tessera-source", type=Path, required=True)
+    parser.add_argument("--base")
+    parser.add_argument("--arm-source", type=Path)
+    args = parser.parse_args()
+    producer = args.tessera_source.resolve()
+    if args.arm_source:
+        arm(args.arm_source.resolve(), producer, args.out)
+        return
+    if not args.base:
+        parser.error("--base is required for paired profiling")
+    args.out.mkdir(parents=True, exist_ok=False)
+    source = Path(__file__).resolve().parents[1]
+    baseline = subprocess.check_output(["git", "rev-parse", args.base], cwd=source, text=True).strip()
+    producer_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=producer, text=True).strip()
+    assert not subprocess.check_output(["git", "status", "--porcelain"], cwd=producer), "dirty producer"
+    results = []
+    with tempfile.TemporaryDirectory(prefix="pq-menu-baseline-") as temp:
+        base = Path(temp)
+        archive = base / "source.tar"
+        subprocess.run(["git", "archive", "--format=tar", "--output", str(archive), baseline], cwd=source, check=True)
+        with tarfile.open(archive) as tar:
+            tar.extractall(base, filter="data")
+        for index, label in enumerate(("before", "after", "after", "before")):
+            output = args.out / f"{index}-{label}"
+            subprocess.run([sys.executable, str(Path(__file__).resolve()), "--out", str(output),
+                            "--tessera-source", str(producer), "--arm-source",
+                            str(base if label == "before" else source)], check=True)
+            results.append(dict(label=label, **json.loads((output / "result.json").read_text())))
+    sys.path.insert(0, str(producer / "experiments"))
+    from box_power_window import SERIES, _fetch
+
+    after = int(min(row["start_unix"] for row in results))
+    before = int(max(row["end_unix"] for row in results)) + 1
+    queries = [(host, context, dims) for host in ("sparky", "sparklina", socket.gethostname())
+               for context, dims in SERIES if host in ("sparky", "sparklina") or not context.startswith("nvidia_smi.")]
+    def fetch(query):
+        host, context, dims = query
+        return host, context, _fetch(host, context, dims, after, before, before - after)
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        records = list(pool.map(fetch, queries))
+    telemetry = {host: {context: data for h, context, data in records if h == host}
+                 for host in {h for h, _, _ in records}}
+    (args.out / "netdata.json").write_text(json.dumps(telemetry, indent=2) + "\n")
+    assert all(data["doc"]["result"]["data"] for _, _, data in records), "missing Netdata series"
+    assert len({row["menu_sha256"] for row in results}) == 1, "menu changed"
+    assert all(row["rows"] == 5635 for row in results), "unexpected menu population"
+    result = dict(scope="complete readable GLM expert menu at 2048x4096, TP1; no forwards or encodes",
+                  baseline_commit=baseline, producer_commit=producer_commit,
+                  arms=results, menus_identical=True)
+    (args.out / "result.json").write_text(json.dumps(result, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/prismaquant/tessera_footprint.py
+++ b/prismaquant/tessera_footprint.py
@@ -9,9 +9,11 @@ alignment and block-offset rules -- and Tessera has a different wire
 byte count here from Gridbook's model would produce a number that no exporter
 would ever write.
 
-So nothing here counts bytes.  ``tessera.layout`` does, through the same
-``build_planes`` / ``build_terminal`` path the artifact writer uses, and this
-module arranges the call and reports the result.  That is deliberate: the
+So nothing here counts bytes. ``tessera.layout`` does, through the shared
+plane/terminal extent arithmetic used by the artifact writer. Older producers
+expose that arithmetic through ``build_planes`` / ``build_terminal``; newer
+ones also expose payload-free extent builders. This module arranges the call
+and reports the result. That is deliberate: the
 allocator's byte budget, the accountant's figures and the exported artifact
 have to be one number, and the only way to guarantee that is to have one
 implementation of it.
@@ -63,6 +65,7 @@ GROUP_WEIGHTS = 32
 HALF_WEIGHTS = 16
 
 try:  # pragma: no cover
+    from tessera import layout as _layout
     from tessera.grammar import forest_plane_bytes
     from tessera.layout import TerminalSpec, build_planes, build_terminal
     from tessera.manifest import BodyKind, Geometry
@@ -71,6 +74,12 @@ except ImportError as exc:  # pragma: no cover
         "prismaquant.tessera_footprint requires the `tessera` package, which "
         "owns the plane layout these byte counts come from."
     ) from exc
+
+
+# The existing reviewed producer pin remains supported. Newer producer inputs
+# can price directly from extents without allocating or hashing payload bytes.
+_build_plane_extents = getattr(_layout, "build_plane_extents", None)
+_build_terminal_extent = getattr(_layout, "build_terminal_extent", None)
 
 
 #: What the recipe digest covers.  Named because a content address is only
@@ -357,17 +366,7 @@ def tessera_tensor_payload_breakdown(
             f"{spec.name}: a CHANNEL plane *is* the DIAG_SV field; segment 2a "
             "cannot be fitted under it (tessera.encode.encode_unit)"
         )
-    # Zero-filled blobs of the wire's own lengths: `build_planes` charges a
-    # plane by its extent and the contents never reach the byte count.  Routed
-    # through it rather than added afterwards so any alignment the descriptors
-    # impose is charged too -- the same thing `tessera.calculator.terminal_rate`
-    # does under `with_forest=True`.  The second argument was a hardcoded `b""`
-    # until 2026-09-03, which charged zero DESCENDANT bytes on every rung.
-    planes = build_planes(
-        geometry,
-        rates,
-        bytes(alphabet_bytes),
-        bytes(descendant_bytes),
+    layout_kwargs = dict(
         with_diagonals=with_diagonals,
         cap=cap,
         arity=spec.arity,
@@ -375,10 +374,20 @@ def tessera_tensor_payload_breakdown(
         span=span,
         with_row_scale=plane == "channel",
     )
-    record = build_terminal(
-        geometry, rates, terminal_spec, planes, alphabet_bytes, descendant_bytes,
-        cap=cap, arity=spec.arity, span=span,
-    )
+    if _build_plane_extents is not None and _build_terminal_extent is not None:
+        planes = _build_plane_extents(
+            geometry, rates, alphabet_bytes, descendant_bytes, **layout_kwargs)
+        terminal_builder = _build_terminal_extent
+    else:
+        # Compatibility with the pinned producer: its writer remains the
+        # byte authority, including blob extents and plane alignment.
+        planes = build_planes(
+            geometry, rates, bytes(alphabet_bytes), bytes(descendant_bytes),
+            **layout_kwargs)
+        terminal_builder = build_terminal
+    record = terminal_builder(geometry, rates, terminal_spec, planes,
+                              alphabet_bytes, descendant_bytes,
+                              cap=cap, arity=spec.arity, span=span)
 
     route = tessera_serving_route(spec, wire, rung)
     total_bytes = record.exact_bytes + sidecar_header_bytes

--- a/tests/test_tessera_footprint_extents.py
+++ b/tests/test_tessera_footprint_extents.py
@@ -1,0 +1,32 @@
+"""Use the producer's payload-free API when the installed producer supplies it."""
+import pytest
+
+from prismaquant import tessera_footprint as footprint
+from tessera import layout
+
+
+def test_modern_producer_pricing_never_materializes_payloads(monkeypatch):
+    if not hasattr(layout, "build_plane_extents"):
+        pytest.skip("installed Tessera predates the payload-free extent API")
+
+    def forbid(*args, **kwargs):
+        raise AssertionError("pricing allocated or hashed a placeholder payload")
+
+    monkeypatch.setattr(footprint, "bytes", forbid, raising=False)
+    monkeypatch.setattr(layout, "bytes", forbid, raising=False)
+    monkeypatch.setattr(footprint, "build_planes", forbid)
+    monkeypatch.setattr(footprint, "build_terminal", forbid)
+    result = footprint.tessera_tensor_payload_breakdown(
+        (2048, 4096), family="TESSERA_E4M3_K1", body_rate_q256=1024)
+    assert result["payload_bytes"] > 0
+    assert result["plane_elements"]
+
+
+def test_older_producer_path_preserves_exact_report(monkeypatch):
+    if not hasattr(layout, "build_plane_extents"):
+        pytest.skip("comparison needs both producer pricing interfaces")
+    kwargs = dict(family="TESSERA_E4M3_K1", body_rate_q256=1024)
+    expected = footprint.tessera_tensor_payload_breakdown((2048, 4096), **kwargs)
+    monkeypatch.setattr(footprint, "_build_plane_extents", None)
+    monkeypatch.setattr(footprint, "_build_terminal_extent", None)
+    assert footprint.tessera_tensor_payload_breakdown((2048, 4096), **kwargs) == expected


### PR DESCRIPTION
GLM menu expansion allocates and hashes placeholder payloads to price each rung. Use Tessera’s paired payload-free extent APIs when available, with the authoritative writer fallback for older installed producers. The runtime pins, menu and wire recipes retain their contracts.

A paired cProfile run over the complete 5,635-choice GLM expert menu measured 183.146 → 86.140 seconds on DL380 (52.97% less CPU wall time); all four serialized menus matched exactly. The original action failed only when retrieving Netdata through an unresolved hostname. The exact historical window was recovered with explicit endpoints for both Sparks and DL380; the failed action is retained and is not claimed as a success CAS receipt. This measures menu construction, not capture or serving.

Validation: two new regressions failed before implementation; 57 targeted footprint/architecture cases passed. Broader menu validation passed 154 cases with four missing-model-path failures; after staging the existing historical model, all ten affected-file cases passed. Complete source snapshots, CAS payloads and profile/menu hashes were independently checked. CI supplies the older pinned-producer lane. Full commands, environment and evidence are in docs/measurements/glm-menu-extents-2026-09-08.md.

Closes #367
