### PR TITLE
Bind portable campaign images to executable content

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,18 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `feat/streamed-capture-admission`. Stamps
+As of: 2026-09-08 · `fix/capture-memory-lifetime`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `fix/capture-memory-lifetime`) for the bounded capture
+allocator contract (issue #366). The dispatcher seals `MIMALLOC_PURGE_DELAY=0`
+and source-page release into both the PB action and its container environment
+before Python starts; an explicitly conflicting setting refuses. Direct bounded
+CUDA capture requires the same environment. This releases completed CPU H/X
+from Torch wheels with statically linked mimalloc, whose delayed purge can
+otherwise retain an entire layer after all tensor owners expire. The physical
+guard also samples after output deletion, before the next layer is installed.
+Admission limits, source prefetch, per-unit tensor bytes and canonical calibration
+identity retain their contracts. This remains the opt-in bounded policy.
 
 Re-stamped (2026-09-08, `feat/streamed-capture-admission`) for experimental
 `--streaming-capture-policy shared-inputs-bounded-v1`. The legacy and prior
@@ -14,8 +25,8 @@ short draws; independent CPU sibling outputs remain fully charged. The
 existing prefetch futures settle before capture growth and again before
 completed-source release, retaining successor cache/delivery ownership.
 
-CUDA execution requires `PRISMAQUANT_RELEASE_SOURCE_PAGES=1` and a finite
-cgroup v2 budget. The shared memory guard adds the entire CUDA reservation to
+CUDA execution requires `PRISMAQUANT_RELEASE_SOURCE_PAGES=1`,
+`MIMALLOC_PURGE_DELAY=0` at process startup, and a finite cgroup v2 budget. The shared memory guard adds the entire CUDA reservation to
 the cgroup charge conservatively, preserves a 2 GiB margin and 8 GiB host
 available-memory floor, and reserves upcoming growth before allocation.
 It checks bounded source-hash reads, source projection checks, original

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,19 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `perf/tessera-layout-pricing`. Stamps
+As of: 2026-09-08 · `fix/campaign-portable-image-content`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `fix/campaign-portable-image-content`) for optional
+campaign container `content_sha256` (issue #371). The existing runtime identity
+helper binds the inspected OS, architecture, variant, ordered RootFS layers
+and complete runtime Config using `prismaquant.container_image_content.v1`.
+The adapter resolves a requested reference once, compares a declared content
+seal before launch, records both content and local image identity, and executes
+the resolved immutable ID. A shared tag with this seal permits identical images
+in different Docker stores while refusing changed layers or runtime settings.
+Existing digest-reference specs remain supported. This changes no serving gate,
+model/calibration identity, PB placement rule, cache or production default.
+Gate: `tests/test_campaign_image_content.py` plus existing container identity tests.
 
 Re-stamped (2026-09-08, `perf/tessera-layout-pricing`) for producer-owned
 payload-free pricing. `tessera_footprint` uses Tessera's paired
@@ -675,8 +687,9 @@ Re-stamped (2026-09-07, `codex/first-model-integration-20260907`) for
 **campaign quanta in the declared Docker runtime** (§4.10). The shared fanout
 spec accepts an optional `container` block with `image` and explicit absolute
 `mounts` (`source`, `target`, optional `readonly`). The worker resolves the image
-once, logs its immutable ID and executes that ID; use a digest in versioned
-specs when retries must retain the same runtime. The existing environment is
+once, logs its immutable ID and content digest, and executes that ID; use an
+immutable reference or an explicit `content_sha256` seal in versioned specs
+when retries must retain the same runtime. The existing environment is
 passed into the container. Its source is the PB worker's sealed checkout at
 `/workspace`, read-only; data mounts cannot hide that source. The container
 runs with the worker's UID/GID so shared output remains writable under NFS root

--- a/docs/measurements/campaign-portable-image-2026-09-08.md
+++ b/docs/measurements/campaign-portable-image-2026-09-08.md
@@ -1,0 +1,47 @@
+# Portable campaign image identity — 2026-09-08
+
+The qualified producer image has different local IDs on the two Sparks after
+Docker save/load. Sparky reports OCI index
+`sha256:cf3f7f83e6820fa75aae249393e8fa4840af4562192203a1aed3f2082f3ea2f9`;
+Sparklina reports
+`sha256:9f9b9f05b17531399ba66dc6415b054cf5d68c82270626d0e9150e75c808435f`.
+Their complete ordered RootFS layers and runtime Config match. A local ID
+alone therefore cannot name both installations for portable PB placement.
+
+The existing container identity helper now derives an optional content seal
+from OS, architecture, variant, RootFS and complete runtime Config. The campaign
+adapter checks it before launch and executes the resolved immutable ID. A
+changed tag, layer, platform or runtime setting cannot silently substitute for
+the reviewed content. External source/data mounts retain their own identities.
+The common alias is `prismaquant-glm-producer:content-qualified-20260908` and
+its content SHA256 is
+`eb8592abd71390231b49aba119e36f02ad91ea867b06df1c67af3833004d07bd`.
+No runtime serving cell, pin, menu or scheduler policy changes (issue #371).
+
+## Validation
+
+Fifteen regression cases failed before implementation (`079006c010b7`): no
+shared content identity existed and the adapter refused the new declaration.
+After source `d6652ed91`, 40 CPU cases passed in 7.42 seconds on DL380
+(`815d8742956c`), including the existing container/runtime identity and
+architecture tests. Four workers used four reserved CPUs, 8 GiB total memory
+and one native thread each. No cases skipped.
+
+A portable `gb10` PB action selected Sparklina and launched the common alias
+with the declared seal. Its recorded observed seal matched before execution;
+22 adapter/content cases passed inside the actual producer image in 8.87
+seconds (`1df8bafab834`, no skips). The action reserved two CPUs, 12 GiB total
+physical memory and an 8 GiB GPU subset. It proves runtime preflight and
+execution, not GPU numerical fit or speed. The prior second-worker capture
+qualification covered native CUDA/tiny-GLM parity separately (`24e642c1bb11`,
+34 passed; see the capture allocator report).
+
+Evidence root: `/mnt/shared/tessera-measurements/glm-canonical-census-20260908/`.
+`producer-second-box-image-inspection.json` records both complete inspections;
+`producer-portable-image-content-01.json` binds their common seal.
+`producer-portable-image-native-invocation-01.json` records the exact launch.
+`portable-image-cpu-root-audit-01.json` and
+`portable-image-native-root-audit-01.json` verify canonical CAS receipts,
+payloads, zero exit status, cleanup, and full checkout snapshots against the
+implementation commit; only PB closure files differ. Read-only pytest cache
+warnings were retained. No repeated benchmark or performance claim is involved.

--- a/docs/measurements/capture-allocator-lifetime-2026-09-08.md
+++ b/docs/measurements/capture-allocator-lifetime-2026-09-08.md
@@ -106,3 +106,25 @@ Root: `/mnt/shared/tessera-measurements/glm-canonical-census-20260908/`.
   canonical success CAS receipts and actual test output.
 - `full-capture-retry-invocation-02.json` and `full-capture-profile-02/`:
   retry declaration and live profiler/host evidence.
+
+## Second worker and merged-source qualification
+
+After merging the menu-pricing change from PR #368, source `f65c117e6`
+passed 34 native tests on Sparklina (`24e642c1bb11`, 35.48 seconds, no skips).
+The selection covers tiny-GLM source/census/capture parity, the original CUDA
+profiler windows, bounded launch environment and architecture. PB reserved four
+CPUs, 24 GiB total physical memory and a 16 GiB GPU subset; two pytest workers
+ran with native threads limited to one. Actual affinity was `[5,6,7,8]`, scope
+peak 4,311,883,776 bytes, exit zero, no OOM, and containment cleanup completed.
+This is environment/integration qualification, not a throughput comparison.
+
+Docker's source image uses OCI index identity `cf3f7f83e682...`; the second
+worker's legacy image store reports configuration identity `9f9b9f05b175...`
+after `docker save`/`load`. The complete ordered RootFS layer hashes and runtime
+configuration match. Both inspection records are retained in
+`producer-second-box-image-inspection.json`; the invocation binds the full
+second-worker identity. `producer-second-box-native-root-audit-01.json` verifies
+the canonical CAS receipt and payload, and the full checkout snapshot against
+`f65c117e6` (only the PB closure differs). The separate observer final-state
+regression also has an independently checked receipt/source record in
+`capture-observer-final-state-root-audit-01.json`.

--- a/docs/measurements/capture-allocator-lifetime-2026-09-08.md
+++ b/docs/measurements/capture-allocator-lifetime-2026-09-08.md
@@ -1,0 +1,108 @@
+# Bounded capture CPU allocator lifetime — 2026-09-08
+
+The full canonical GLM capture completed and durably wrote layers 0–3, then
+refused before layer 4 at its physical memory guard. The retained prefix is
+876 entries, 52,007,061,660 file bytes. Every journal envelope and entry SHA256
+was independently verified before retry; no complete capture manifest exists
+for that failed attempt. PB action `cbd010f53bd2` exited one with complete scope
+cleanup and no OOM. It is not a successful capture.
+
+At the refusal, the cgroup charge was 59,080,269,824 bytes, CUDA reservation
+56,637,784,064 bytes, and host available memory 7,659,896,832 bytes. The guard
+correctly refused its conservative 115,718,053,888-byte sum and the host floor.
+The completed layer’s CPU tensor objects had been deleted; object lifetime
+alone did not establish physical release.
+
+## Reproduction and cause
+
+A bounded diagnostic in the exact producer image creates 32 representative
+shared-input groups: 4096-column gate/up Hessians, 2048-column down Hessians,
+and 512 retained rows per unit. It materializes independent CPU siblings,
+uses the existing durable activation writer and completed-file page advice,
+then releases all output owners. Storage weak references, cgroup memory.stat,
+process smaps, CUDA/pinned allocator counters, cProfile and both Sparks’ raw
+Netdata series record the boundary. No model forward or calibration change is
+involved in this diagnostic.
+
+All 192 output storages expire. The original configuration nevertheless
+retains about 5.4 GiB of anonymous host pages. Python GC, libc malloc_trim,
+Torch pinned-host emptyCache and accelerator empty_host_cache leave that charge
+in place; the outputs are not pinned and the pinned allocator counters are zero.
+These negative attempts rule out those release mechanisms for this image.
+
+Independent disassembly of the image’s libc10.so shows `c10::alloc_cpu` calling
+its statically linked `mi_malloc_aligned`, and `c10::free_cpu` calling `mi_free`.
+The allocator is mimalloc, even though no separate mimalloc library or
+LD_PRELOAD entry appears in process maps. This agrees with Torch’s
+[allocator source at the image’s build commit](https://github.com/pytorch/pytorch/blob/cf30153c4c131c8164ee7798e5022d810682e2cb/c10/core/impl/alloc_cpu.cpp).
+
+The final before/after pair differs only in the explicit
+`MIMALLOC_PURGE_DELAY=0` child environment and evidence directory. Full source
+snapshots compare identically apart from PB closure metadata. The setting makes
+mimalloc purge freed pages immediately, as described in its
+[environment options](https://github.com/microsoft/mimalloc#environment-options).
+
+| Physical checkpoint | Original configuration | Immediate purge |
+| --- | ---: | ---: |
+| Initial cgroup bytes | 541,822,976 | 541,433,856 |
+| After durable writes | 6,441,553,920 | 6,441,926,656 |
+| After output deletion | 6,441,537,536 | 632,369,152 |
+| Live output storages after deletion | 0 | 0 |
+
+This establishes physical release after a completed layer. It does not reduce
+the live output footprint, discount admission, establish full-model fit, or
+claim faster encoding/serving. Each short diagnostic has cProfile, process
+memory snapshots and two samples from each Spark’s Netdata at the configured
+five-second interval. No GPU saturation or work-per-joule improvement is claimed.
+
+## Contract and validation
+
+The existing bounded-capture dispatcher seals immediate purge and source-page
+release into the PB environment and its inner container specification before
+Python starts. Explicit incompatible settings refuse. Direct bounded CUDA
+capture requires the same environment. The physical guard additionally samples
+after deleting completed outputs, before installing the next layer. Existing
+budget, source prefetch, tensor bytes and numerical identities remain unchanged.
+The legacy and prior shared-input policies retain their environments.
+
+Seven new launch-contract regressions failed before implementation, while the
+legacy case passed (`3e5f626dd5d5`). After implementation, 47 CPU cases passed
+(`6e477a80af44`), followed by 50 native cases with no skips (`b4b544f94479`),
+including tiny GLM streamed-capture tensor parity and actual CUDA profiler
+coverage. The CPU run used four workers, Torch 2.11 CPU and pytest 9.1.1 on
+DL380. Native validation used the exact Torch 2.13/CUDA 13 producer image on
+Sparky, two xdist workers, four reserved CPU cores, native threads one, and a
+24 GiB physical budget. The first native launch failed before collection because
+xdist was absent (`61bb25eb028a`); scoped pytest-xdist 3.8.0 and execnet 2.1.2
+were installed and the corrected run supplied them explicitly. Read-only pytest
+cache warnings do not hide missing tests.
+
+A separate observer fix publishes final status to progress.json as well as
+result.json. The regression demonstrated that progress retained `running`
+after failure (`ec0f61ac138b`); the corrected case passed (`f8af63d37005`).
+Terminal PB state and actual result files remain the completion authority.
+
+The full retry, action `63992d4c42ad`, uses source `0ec032210c`, the same census,
+source checkpoint, producer, image, 512×512 B1 token draw, output journal,
+104 GiB physical reservation, 92 GiB GPU cap and 24-hour deadline. It changes
+the allocator environment and adds the checked release boundary. It must replay
+the completed prefix to recover hidden states and requires exact equality to
+all preserved entries. Its outcome is recorded separately; submission alone
+establishes no full-capture success.
+
+## Evidence
+
+Root: `/mnt/shared/tessera-measurements/glm-canonical-census-20260908/`.
+
+- `full-capture-failure-root-audit-01.json`: failed terminal, complete source,
+  all 876 journal/file checksums, original profiler artifacts and memory refusal.
+- `capture-allocator-lifetime-root-audit-01.json`: all four diagnostic CAS
+  receipts/payloads, full source snapshots, isolated pair and artifact hashes.
+- `capture-lifetime-01/` through `capture-lifetime-04/`: original diagnostic
+  outputs; the final pair is 03/04 (`e041d1c5669c`, `2c4bea45a57f`).
+- `capture-libc10-allocator-disassembly.txt`: actual allocator call targets;
+  the binary hash accompanies the audit.
+- `capture-allocator-tests-root-audit-01.json`: complete CPU/native source,
+  canonical success CAS receipts and actual test output.
+- `full-capture-retry-invocation-02.json` and `full-capture-profile-02/`:
+  retry declaration and live profiler/host evidence.

--- a/experiments/capture_memory_lifetime.py
+++ b/experiments/capture_memory_lifetime.py
@@ -1,0 +1,84 @@
+"""Bounded diagnostic of the capture materialization/write/release boundary."""
+import cProfile
+import ctypes
+import gc
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import time
+
+import torch
+from torch.multiprocessing.reductions import StorageWeakRef
+from experiments.glm_full_capture_profile import CaptureObserver
+from prismaquant.perturbed_x_cache import write_activation_cache_entry, release_activation_cache_file_pages
+
+
+def main():
+    out = Path(sys.argv[1])
+    with CaptureObserver(out, profile_layers=()) as observer:
+        records = []
+        (out/'torch-config.txt').write_text(torch.__config__.show())
+        (out/'process-maps.txt').write_text(Path('/proc/self/maps').read_text())
+        (out/'memory-api.json').write_text(json.dumps([n for n in dir(torch._C) if any(k in n.lower() for k in ('cache','alloc','malloc','host'))]))
+        def snapshot(label, refs=()):
+            stats = dict(line.split() for line in Path('/sys/fs/cgroup/memory.stat').read_text().splitlines())
+            result = dict(label=label, time=time.time(), cgroup_bytes=int(Path('/sys/fs/cgroup/memory.current').read_text()),
+                          memory_stat={k:int(v) for k,v in stats.items()},
+                          smaps=Path('/proc/self/smaps_rollup').read_text(),
+                          cuda_allocated=torch.cuda.memory_allocated(), cuda_reserved=torch.cuda.memory_reserved(),
+                          live_storage_count=sum(not ref.expired() for ref in refs),
+                          gc_count=gc.get_count(), host_allocator=torch.cuda.memory.host_memory_stats())
+            records.append(result)
+            print(json.dumps(result), flush=True)
+            (out/'memory.json').write_text(json.dumps(records, indent=2)+'\n')
+        def materialize():
+            groups = {f'{i}.{kind}': torch.ones((cols,cols),device='cuda')
+                      for i in range(32) for kind,cols in [('gate',4096),('down',2048)]}
+            snapshot('device_groups')
+            acts, hess = {}, {}
+            for name in list(groups):
+                value = groups.pop(name).cpu()
+                hess[name] = value
+                acts[name] = torch.ones((512,value.shape[0]))
+                if name.endswith('gate'):
+                    hess[name+'.up'] = value.clone()
+                    acts[name+'.up'] = acts[name].clone()
+                del value
+                torch.cuda.empty_cache()
+            return acts,hess
+        snapshot('initial')
+        profiler = cProfile.Profile()
+        with profiler:
+            acts,hess = materialize()
+            refs = [StorageWeakRef(v.untyped_storage()) for d in (acts,hess) for v in d.values()]
+            snapshot('materialized',refs)
+            observer.result['pinned_outputs'] = {name: value.is_pinned() for name,value in hess.items()}
+            with tempfile.TemporaryDirectory(prefix='capture-lifetime-') as tmp:
+                for name in sorted(acts):
+                    path = write_activation_cache_entry(tmp,name,acts[name],hessian=hess[name],durable=True)
+                    with path.open('rb') as handle:
+                        hashlib.file_digest(handle,'sha256')
+                    release_activation_cache_file_pages(path, expected_stat=path.stat())
+                snapshot('written',refs)
+                del acts,hess
+                torch.cuda.empty_cache()
+                snapshot('outputs_deleted',refs)
+                gc.collect()
+                torch.cuda.empty_cache()
+                snapshot('cycles_collected',refs)
+                ctypes.CDLL(None).malloc_trim(0)
+                snapshot('heap_trimmed',refs)
+                torch._C._host_emptyCache()
+                snapshot('torch_host_cache_released',refs)
+                torch._C._accelerator_emptyHostCache()
+                snapshot('torch_accelerator_host_cache_released',refs)
+        profiler.dump_stats(out/'lifetime.pstats')
+        observer.result['memory_stages'] = records
+        observer.result['serialization_sha256'] = hashlib.sha256(Path(torch.serialization.__file__).read_bytes()).hexdigest()
+
+
+if __name__ == '__main__':
+    main()

--- a/experiments/glm_full_capture_profile.py
+++ b/experiments/glm_full_capture_profile.py
@@ -141,7 +141,9 @@ class CaptureObserver:
         self.result.update(finished_unix=time.time(),
             status='failed' if error or self.result['errors'] else 'complete',
             campaign_error=None if error is None else repr(error))
-        (self.out/'result.json').write_text(json.dumps(self.result, indent=2)+'\n')
+        final = json.dumps(self.result, indent=2)+'\n'
+        (self.out/'result.json').write_text(final)
+        (self.out/'progress.json').write_text(final)
         if error is None and self.result['errors']:
             raise RuntimeError('capture completed but required profiler evidence is incomplete')
 

--- a/experiments/glm_full_capture_profile.py
+++ b/experiments/glm_full_capture_profile.py
@@ -1,0 +1,172 @@
+"""Observe the original campaign traversal; no extra forwards or scheduling.
+
+This is experiment instrumentation, not an alternate capture implementation.
+Python stacks cover the main thread at 1 Hz; selected original forward windows
+use torch.profiler. Both Sparks' host series use the existing Netdata contract
+at 5-second intervals, with explicit disk caps suitable for a 24-hour action.
+"""
+from __future__ import annotations
+
+import argparse
+from contextlib import nullcontext
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+import threading
+import time
+import traceback
+
+import torch
+
+from experiments.workspace_netdata import NetdataWriter, sample_netdata
+
+
+class CaptureObserver:
+    def __init__(self, out, *, profile_layers=(0, 3, 4, 23, 44)):
+        self.out = Path(out)
+        self.out.mkdir(parents=True, exist_ok=False)
+        self.profile_layers = set(profile_layers)
+        self.stopped = threading.Event()
+        self.main_thread = threading.get_ident()
+        self.index = 0
+        self.result = dict(schema='prismaquant.glm_full_capture_profile.v1',
+            status='running', started_unix=time.time(), collections=[], errors=[],
+            torch=torch.__version__, cuda=torch.version.cuda,
+            cpu_affinity=sorted(os.sched_getaffinity(0)),
+            kernel=os.uname().release,
+            netdata=dict(hosts=['sparky', 'sparklina'], interval_seconds=5,
+                         byte_cap=3*1024**3),
+            python_sampler=dict(scope='main_thread_only', interval_seconds=1,
+                                byte_cap=512*1024**2),
+            profile_layers=sorted(self.profile_layers),
+            forward_windows_zero_based=[[0, 1], [31, 32]])
+        for name in ('srcversion', 'parameters/delegation_watermark'):
+            path = Path('/sys/module/nfsv4')/name
+            self.result['nfsv4_'+name.replace('/', '_')] = (
+                path.read_text().strip() if path.exists() else None)
+        self.threads = []
+
+    def monitor(self, kind):
+        try:
+            cap = self.result[kind]['byte_cap']
+            with (self.out/(kind+'.jsonl')).open('x') as handle:
+                writer = NetdataWriter(handle, max_bytes=cap)
+                while not self.stopped.is_set():
+                    if kind == 'netdata':
+                        for host in self.result[kind]['hosts']:
+                            writer.write(sample_netdata(host))
+                    else:
+                        frame = sys._current_frames().get(self.main_thread)
+                        frames = traceback.extract_stack(frame)
+                        del frame
+                        writer.write(dict(time=time.time(),
+                            frames=[dict(file=x.filename, line=x.lineno, function=x.name)
+                                    for x in frames],
+                            process_io=Path('/proc/self/io').read_text()))
+                    self.result[kind]['bytes_written'] = writer.bytes_written
+                    self.result[kind]['samples'] = self.result[kind].get('samples', 0)+1
+                    self.stopped.wait(self.result[kind]['interval_seconds'])
+        except BaseException as error:
+            self.result['errors'].append(dict(instrument=kind, error=repr(error)))
+
+    def wrap_collector(self, original):
+        def collect(*args, **kwargs):
+            index = self.index
+            self.index += 1
+            record = dict(collection_index=index, started_unix=time.time(), batches=0,
+                          traces=[], status='running')
+            self.result['collections'].append(record)
+            forward = kwargs['forward_batch']
+            profiler = None
+
+            def observed_forward(batch):
+                value = forward(batch)
+                record['batches'] += 1
+                if profiler is not None:
+                    profiler.step()
+                return value
+
+            def schedule(step):
+                if step in (1, 32):
+                    return torch.profiler.ProfilerAction.RECORD_AND_SAVE
+                if step in (0, 31):
+                    return torch.profiler.ProfilerAction.RECORD
+                return torch.profiler.ProfilerAction.NONE
+
+            def ready(prof):
+                stem = f'collection-{index:02d}-window-{len(record["traces"]):02d}'
+                path = self.out/(stem+'.trace.json')
+                prof.export_chrome_trace(str(path))
+                (self.out/(stem+'.profile.txt')).write_text(
+                    prof.key_averages().table(sort_by='self_cuda_time_total', row_limit=60))
+                with path.open('rb') as handle:
+                    digest = hashlib.file_digest(handle, 'sha256').hexdigest()
+                record['traces'].append(dict(path=path.name, bytes=path.stat().st_size,
+                                             sha256=digest, after_batches=record['batches']))
+
+            context = (torch.profiler.profile(
+                activities=[torch.profiler.ProfilerActivity.CPU,
+                            torch.profiler.ProfilerActivity.CUDA],
+                schedule=schedule, record_shapes=True, profile_memory=True,
+                on_trace_ready=ready) if index in self.profile_layers else nullcontext())
+            kwargs['forward_batch'] = observed_forward
+            try:
+                with context as profiler:
+                    value = original(*args, **kwargs)
+                record['status'] = 'complete'
+                return value
+            except BaseException as error:
+                record.update(status='failed', error=repr(error))
+                raise
+            finally:
+                record['finished_unix'] = time.time()
+                (self.out/'progress.json').write_text(json.dumps(self.result, indent=2)+'\n')
+        return collect
+
+    def __enter__(self):
+        for kind in ('netdata', 'python_sampler'):
+            thread = threading.Thread(target=self.monitor, args=(kind,), daemon=True)
+            thread.start()
+            self.threads.append(thread)
+        return self
+
+    def __exit__(self, error_type, error, tb):
+        self.stopped.set()
+        for thread in self.threads:
+            thread.join(timeout=12)
+            if thread.is_alive():
+                self.result['errors'].append(dict(instrument='shutdown', error='monitor did not stop'))
+        self.result.update(finished_unix=time.time(),
+            status='failed' if error or self.result['errors'] else 'complete',
+            campaign_error=None if error is None else repr(error))
+        (self.out/'result.json').write_text(json.dumps(self.result, indent=2)+'\n')
+        if error is None and self.result['errors']:
+            raise RuntimeError('capture completed but required profiler evidence is incomplete')
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--evidence-out', type=Path, required=True)
+    parser.add_argument('campaign_argv', nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    command = args.campaign_argv
+    if command[:1] == ['--']:
+        command = command[1:]
+    if '--capture-calibration-out' not in command or '--streaming' not in command:
+        parser.error('observer requires the streamed canonical capture action')
+    if not torch.cuda.is_available():
+        raise RuntimeError('full capture profiler requires CUDA')
+    from prismaquant import tessera_campaign as campaign
+    original = campaign._collect_activations
+    with CaptureObserver(args.evidence_out) as observer:
+        campaign._collect_activations = observer.wrap_collector(original)
+        try:
+            return campaign.main(command)
+        finally:
+            campaign._collect_activations = original
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/prismaquant/autoscale.py
+++ b/prismaquant/autoscale.py
@@ -55,6 +55,23 @@ DEFAULT_FULL_GRAPH_ACT_MULT = 48   # 64 layers × sqrt ≈ 8 × 6 (per-layer-mix
 DEFAULT_FIXED_OVERHEAD_GB = 15.0   # HF transformers + tokenizer + Python heap floor
 
 
+# Bounded capture reuses one layer's physical CPU budget. Torch wheels may
+# statically link mimalloc, whose delayed purge otherwise retains completed H/X
+# even after every tensor owner is gone. Set this in the child environment before
+# importing Torch; libc trimming and pinned-host cache release do not reach it.
+BOUNDED_CAPTURE_ENV = {
+    'PRISMAQUANT_RELEASE_SOURCE_PAGES': '1',
+    'MIMALLOC_PURGE_DELAY': '0',
+}
+
+
+def require_bounded_capture_environment(environ):
+    """Require the release policy underlying the bounded physical phase plan."""
+    for name, expected in BOUNDED_CAPTURE_ENV.items():
+        if environ.get(name) != expected:
+            raise RuntimeError(f'bounded CUDA capture requires {name}={expected} before process startup')
+
+
 def streamed_calibration_resources(model_path, *, unit_shapes, counts,
                                    nsamples, seqlen, max_act_rows, cache_slots,
                                    prefetch_workers, headroom_gb,

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -3526,10 +3526,12 @@ def _run_streamed_calibration(args, runner, profile, *, mode, population,
             record['settled_prefetch'] = settled_prefetch
             record['physical_memory_guard'] = None if guard is None else guard.snapshot()
         telemetry.append(record)
-        print(json.dumps({'streamed_calibration_layer': record}), flush=True)
         del acts, hessians
         if runner.device.type == 'cuda':
             torch.cuda.empty_cache()
+        if guard is not None:
+            record['released_capture_memory'] = guard.check('after_capture_output_release')
+        print(json.dumps({'streamed_calibration_layer': record}), flush=True)
 
     try:
         runner.visit_layer_batches(tokens, visit)
@@ -3732,9 +3734,9 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             "H-aware encoder branch is merged."
         )
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    if (args.streaming_capture_policy == "shared-inputs-bounded-v1" and device == "cuda"
-            and os.environ.get("PRISMAQUANT_RELEASE_SOURCE_PAGES") != "1"):
-        raise RuntimeError("bounded CUDA capture requires PRISMAQUANT_RELEASE_SOURCE_PAGES=1")
+    if args.streaming_capture_policy == "shared-inputs-bounded-v1" and device == "cuda":
+        from .autoscale import require_bounded_capture_environment
+        require_bounded_capture_environment(os.environ)
     cache_dir = Path(args.cache_dir)
     cache_dir.mkdir(parents=True, exist_ok=True)
     wire_dir = cache_dir / "wire"

--- a/tests/test_campaign_image_content.py
+++ b/tests/test_campaign_image_content.py
@@ -1,0 +1,81 @@
+"""A portable tag may resolve differently, but its executable content is fixed."""
+from copy import deepcopy
+import json
+
+import pytest
+
+from tools import container_runtime_identity as identity
+from tools import tessera_campaign_container as runner
+
+
+def inspection():
+    return {"Id": "sha256:" + "1" * 64, "Os": "linux", "Architecture": "arm64",
+            "RootFS": {"Type": "layers", "Layers": ["sha256:" + "2" * 64]},
+            "Config": {"Env": ["PATH=/bin"], "Entrypoint": ["/entry"], "Cmd": []}}
+
+
+def test_content_identity_survives_backend_ids_and_local_tags():
+    original = inspection()
+    copied = deepcopy(original)
+    copied.update(Id="sha256:" + "3" * 64, RepoTags=["qualified:copy"], Size=123,
+                  GraphDriver={"Name": "overlay2"})
+    assert identity.image_content_sha256(original) == identity.image_content_sha256(copied)
+
+
+@pytest.mark.parametrize("field,value", [
+    ("RootFS", {"Type": "layers", "Layers": ["sha256:" + "4" * 64]}),
+    ("Config", {"Env": ["PATH=/changed"], "Entrypoint": ["/entry"], "Cmd": []}),
+    ("Architecture", "amd64"), ("Os", "windows"), ("Variant", "v8"),
+])
+def test_executable_content_changes_the_seal(field, value):
+    changed = {**inspection(), field: value}
+    assert identity.image_content_sha256(changed) != identity.image_content_sha256(inspection())
+
+
+@pytest.mark.parametrize("field,value", [("Config", None), ("RootFS", {}),
+                                        ("Architecture", ""), ("Os", None)])
+def test_incomplete_inspection_cannot_mint_content_identity(field, value):
+    with pytest.raises(identity.RuntimeIdentityError):
+        identity.image_content_sha256({**inspection(), field: value})
+
+
+def test_resolved_image_is_executed_after_content_check(monkeypatch, capsys):
+    observed = inspection()
+    digest = identity.image_content_sha256(observed)
+    inspected, executed = [], []
+    def inspect(argv, **kwargs):
+        inspected.append(argv)
+        return json.dumps([observed])
+    def execute(binary, argv):
+        executed.append(argv)
+        raise SystemExit(0)
+    monkeypatch.setattr(runner.subprocess, "check_output", inspect)
+    monkeypatch.setattr(runner.os, "execvp", execute)
+    spec = {"container": {"image": "qualified:portable", "content_sha256": digest}}
+    with pytest.raises(SystemExit) as stopped:
+        runner.main(["--spec", json.dumps(spec), "--", "python3", "task.py"])
+    assert stopped.value.code == 0
+    assert inspected == [["docker", "image", "inspect", "qualified:portable"]]
+    assert executed[0][-3:] == [observed["Id"], "python3", "task.py"]
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["image_id"] == observed["Id"]
+    assert receipt["image_content_sha256"] == digest
+
+
+def test_changed_portable_tag_refuses_before_container_launch(monkeypatch):
+    expected = identity.image_content_sha256(inspection())
+    observed = inspection()
+    observed["Config"]["Env"] = ["PATH=/changed"]
+    monkeypatch.setattr(runner.subprocess, "check_output", lambda *a, **k: json.dumps([observed]))
+    def forbidden(*args):
+        pytest.fail("changed runtime reached container launch")
+    monkeypatch.setattr(runner.os, "execvp", forbidden)
+    spec = {"container": {"image": "qualified:portable", "content_sha256": expected}}
+    with pytest.raises(RuntimeError, match="content.*differs"):
+        runner.main(["--spec", json.dumps(spec), "--", "python3", "task.py"])
+
+
+@pytest.mark.parametrize("value", [None, "short", "A" * 64])
+def test_malformed_declared_seal_refuses(value):
+    with pytest.raises(RuntimeError, match="content_sha256"):
+        runner.validate_container({"container": {"image": "qualified:portable", "content_sha256": value}})

--- a/tests/test_capture_allocator_environment.py
+++ b/tests/test_capture_allocator_environment.py
@@ -1,0 +1,50 @@
+"""A bounded capture must release completed CPU allocations before its next layer."""
+import json
+
+import pytest
+
+from test_tessera_campaign_container import dispatch, spec
+
+
+@pytest.mark.parametrize('container', [False, True])
+@pytest.mark.parametrize('flags', [
+    ['--streaming-capture-policy', 'shared-inputs-bounded-v1'],
+    ['--streaming-capture-policy=shared-inputs-bounded-v1'],
+])
+def test_capture_manifest_seals_immediate_host_purge_before_python_starts(container, flags):
+    data = spec()
+    if not container:
+        del data['container']
+    original_env = dict(data['env'])
+    row = dispatch._row(data, ['--streaming', '--capture-calibration-out', '/capture', *flags],
+                        mem_gb=104, timeout_s=86400)
+    assert row['env']['MIMALLOC_PURGE_DELAY'] == '0'
+    assert row['env']['PRISMAQUANT_RELEASE_SOURCE_PAGES'] == '1'
+    assert data['env'] == original_env
+    if container:
+        assert json.loads(row['argv'][4])['env'] == row['env']
+
+
+@pytest.mark.parametrize('name,value', [('MIMALLOC_PURGE_DELAY', '10'),
+                                       ('PRISMAQUANT_RELEASE_SOURCE_PAGES', '0')])
+def test_explicit_incompatible_capture_environment_refuses(name, value):
+    data = spec()
+    data['env'][name] = value
+    with pytest.raises(RuntimeError, match=name):
+        dispatch._row(data, ['--streaming-capture-policy', 'shared-inputs-bounded-v1'],
+                      mem_gb=104, timeout_s=86400)
+
+
+def test_direct_cuda_capture_cannot_claim_missing_allocator_policy(monkeypatch):
+    from prismaquant.autoscale import require_bounded_capture_environment
+    with pytest.raises(RuntimeError, match='MIMALLOC_PURGE_DELAY'):
+        require_bounded_capture_environment({'PRISMAQUANT_RELEASE_SOURCE_PAGES': '1'})
+    require_bounded_capture_environment({'PRISMAQUANT_RELEASE_SOURCE_PAGES': '1',
+                                        'MIMALLOC_PURGE_DELAY': '0'})
+
+
+def test_legacy_manifest_keeps_explicit_allocator_environment():
+    data = spec()
+    data['env']['MIMALLOC_PURGE_DELAY'] = '10'
+    row = dispatch._row(data, ['--streaming-capture-policy', 'legacy'], mem_gb=104, timeout_s=60)
+    assert row['env'] == data['env']

--- a/tests/test_glm_full_capture_profile.py
+++ b/tests/test_glm_full_capture_profile.py
@@ -52,3 +52,5 @@ def test_observer_preserves_forward_return_and_partial_failure(tmp_path):
     assert result['status'] == 'failed'
     assert result['collections'][0]['batches'] == 1
     assert 'original forward failure' in result['campaign_error']
+
+    assert json.loads((tmp_path/'partial/progress.json').read_text()) == result

--- a/tests/test_glm_full_capture_profile.py
+++ b/tests/test_glm_full_capture_profile.py
@@ -1,0 +1,54 @@
+import json
+
+import pytest
+import torch
+
+from experiments.glm_full_capture_profile import CaptureObserver
+from prismaquant.tessera_campaign import _collect_activations
+
+
+def test_observer_keeps_exact_cuda_capture_and_original_batch_order(tmp_path):
+    if not torch.cuda.is_available():
+        pytest.skip('native CUDA profiler qualification')
+    torch.manual_seed(917)
+    model = torch.nn.Sequential(torch.nn.Linear(4, 3)).cuda()
+    batches = [torch.randn(1, 7, 4) for _ in range(34)]
+    baseline = _collect_activations(model, ['0'], batches, 11, 'cuda',
+                                    want_hessian=True, forward_batch=model)
+    seen = []
+    def forward(batch):
+        seen.append(batch.detach().cpu().clone())
+        return model(batch)
+    with CaptureObserver(tmp_path/'observed', profile_layers=(0,)) as observer:
+        actual = observer.wrap_collector(_collect_activations)(
+            model, ['0'], batches, 11, 'cuda', want_hessian=True,
+            forward_batch=forward)
+    assert len(seen) == len(batches)
+    assert all(torch.equal(a, b) for a, b in zip(seen, batches))
+    for old, new in zip(baseline[:2], actual[:2]):
+        assert set(old) == set(new)
+        assert all(torch.equal(old[name], new[name]) for name in old)
+    assert baseline[2:] == actual[2:]
+    result = json.loads((tmp_path/'observed/result.json').read_text())
+    assert result['status'] == 'complete'
+    assert result['netdata']['samples'] >= 1
+    assert result['python_sampler']['samples'] >= 1
+    assert [t['after_batches'] for t in result['collections'][0]['traces']] == [2, 33]
+    assert all(t['bytes'] > 0 for t in result['collections'][0]['traces'])
+
+
+def test_observer_preserves_forward_return_and_partial_failure(tmp_path):
+    observer = CaptureObserver(tmp_path/'partial', profile_layers=())
+    token = object()
+    def forward(batch):
+        return token
+    def broken(*args, forward_batch):
+        assert forward_batch(None) is token
+        raise ValueError('original forward failure')
+    with pytest.raises(ValueError, match='original forward failure'):
+        with observer:
+            observer.wrap_collector(broken)(forward_batch=forward)
+    result = json.loads((tmp_path/'partial/result.json').read_text())
+    assert result['status'] == 'failed'
+    assert result['collections'][0]['batches'] == 1
+    assert 'original forward failure' in result['campaign_error']

--- a/tools/container_runtime_identity.py
+++ b/tools/container_runtime_identity.py
@@ -47,6 +47,39 @@ class RuntimeIdentityError(ValueError):
     """The producer runtime cannot be identified exactly."""
 
 
+def image_content_sha256(image: Mapping[str, Any]) -> str:
+    """Bind executable image content independently of the local Docker store.
+
+    Containerd may report an OCI index/manifest ID where the legacy store
+    reports the configuration ID. Ordered unpacked layer digests, platform
+    and the complete runtime configuration remain the content authority.
+    Tags, storage paths, compression sizes and build history are not inputs.
+    """
+    if not isinstance(image, Mapping):
+        raise RuntimeIdentityError("Docker image inspection must be an object")
+    for field in ("Os", "Architecture"):
+        if not isinstance(image.get(field), str) or not image[field]:
+            raise RuntimeIdentityError(f"Docker image has no {field}")
+    variant = image.get("Variant", "")
+    if not isinstance(variant, str):
+        raise RuntimeIdentityError("Docker image has invalid Variant")
+    rootfs = image.get("RootFS")
+    if (not isinstance(rootfs, dict) or rootfs.get("Type") != "layers"
+            or not isinstance(rootfs.get("Layers"), list)
+            or not all(isinstance(layer, str) and _IMAGE_ID_RE.fullmatch(layer)
+                       for layer in rootfs["Layers"])):
+        raise RuntimeIdentityError("Docker image has no exact RootFS layer list")
+    config = image.get("Config")
+    if not isinstance(config, dict):
+        raise RuntimeIdentityError("Docker image has no runtime Config")
+    content = {"schema": "prismaquant.container_image_content.v1",
+               "os": image["Os"], "architecture": image["Architecture"],
+               "variant": variant, "rootfs": rootfs, "config": config}
+    raw = json.dumps(content, sort_keys=True, separators=(",", ":"),
+                     ensure_ascii=False, allow_nan=False).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
 def _reject_duplicate_members(pairs: Sequence[tuple[str, Any]]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, value in pairs:

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -214,17 +214,26 @@ def require_rows_fit(mem_gb: "list[int]", per_box: int, budget) -> int:
 
 def _row(spec: dict, argv: list[str], *, mem_gb: int, timeout_s: int,
          module: str = "prismaquant.tessera_campaign") -> dict:
+    env = dict(spec['env'])
+    policy_flag = '--streaming-capture-policy'
+    bounded = (policy_flag+'=shared-inputs-bounded-v1' in argv or
+               (policy_flag in argv and
+                argv[argv.index(policy_flag)+1] == 'shared-inputs-bounded-v1'))
+    if bounded:
+        from prismaquant.autoscale import BOUNDED_CAPTURE_ENV, require_bounded_capture_environment
+        env = {**BOUNDED_CAPTURE_ENV, **env}
+        require_bounded_capture_environment(env)
     command = [spec["python"], "-u", "-m", module, *argv]
     if "container" in spec:
         validate_container(spec)
         command = ["python3", "-m", "tools.tessera_campaign_container", "--spec",
-                   json.dumps({"container": spec["container"], "env": spec["env"]},
+                   json.dumps({"container": spec["container"], "env": env},
                               sort_keys=True), "--", *command]
     row = {
         "argv": command,
         "cwd": spec["cwd"],
         "demand": {"gpu": 1, "cpu": int(spec.get("cpus", 4)), "mem_gb": int(mem_gb)},
-        "env": dict(spec["env"]),
+        "env": env,
         "tags": list(spec.get("tags", ["gb10"])),
         "timeout_s": int(timeout_s),
         # A row is one memoized action and a retry re-runs the same argv over

--- a/tools/tessera_campaign_container.py
+++ b/tools/tessera_campaign_container.py
@@ -9,16 +9,23 @@ import argparse
 import json
 import os
 from pathlib import Path, PurePosixPath
+import re
 import subprocess
+
+from tools.container_runtime_identity import image_content_sha256
 
 
 def validate_container(spec: dict) -> None:
     container = spec.get("container")
-    if not isinstance(container, dict) or set(container) - {"image", "mounts"}:
-        raise RuntimeError("container must declare image and optional mounts only")
+    if not isinstance(container, dict) or set(container) - {"image", "mounts", "content_sha256"}:
+        raise RuntimeError("container must declare image and optional mounts/content_sha256 only")
     image = container.get("image")
     if not isinstance(image, str) or not image or image.startswith("-"):
         raise RuntimeError("container.image must name a Docker image")
+    if "content_sha256" in container:
+        digest = container["content_sha256"]
+        if not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+            raise RuntimeError("container.content_sha256 must be a lowercase SHA256 digest")
     mounts = container.get("mounts", [])
     if not isinstance(mounts, list):
         raise RuntimeError("container.mounts must be a list")
@@ -76,12 +83,22 @@ def main(argv=None) -> int:
     if not command:
         parser.error("a container command is required")
     requested = spec["container"]["image"]
-    image_id = subprocess.check_output(
-        ["docker", "image", "inspect", requested, "--format", "{{.Id}}"], text=True).strip()
-    if not image_id.startswith("sha256:") or len(image_id) != 71:
+    inspected = json.loads(subprocess.check_output(
+        ["docker", "image", "inspect", requested], text=True))
+    if not isinstance(inspected, list) or len(inspected) != 1 or not isinstance(inspected[0], dict):
+        raise RuntimeError("Docker returned no unique image inspection")
+    image_id = inspected[0].get("Id")
+    if not isinstance(image_id, str) or re.fullmatch(r"sha256:[0-9a-f]{64}", image_id) is None:
         raise RuntimeError("Docker returned no immutable image ID")
+    content_digest = image_content_sha256(inspected[0])
+    declared = spec["container"].get("content_sha256")
+    if declared is not None and declared != content_digest:
+        raise RuntimeError(f"Docker image content differs for {requested!r}: "
+                           f"expected {declared}, observed {content_digest}")
     print(json.dumps({"schema": "prismaquant.tessera_campaign_container.v1",
                       "requested_image": requested, "image_id": image_id,
+                      "image_content_sha256": content_digest,
+                      "declared_content_sha256": declared,
                       "uid": os.getuid(), "gid": os.getgid()}), flush=True)
     docker = docker_command(spec, command, cwd=str(Path.cwd()),
                             uid=os.getuid(), gid=os.getgid(), image_id=image_id)


### PR DESCRIPTION
Identical producer images receive different local IDs in the two Sparks’ Docker stores, preventing one immutable-ID spec from using either worker. Add an optional `container.content_sha256` seal through the existing runtime identity helper. The adapter checks platform, ordered RootFS layers and complete runtime Config before executing the locally resolved immutable ID, so a common tag can serve portable PB work while changed content refuses.

Validation: 15 regressions failed before implementation; 40 CPU cases passed after, including existing container/runtime identity and architecture coverage. A portable PB action selected Sparklina, verified the common seal, and passed 22 cases inside the actual producer image. No skips. Canonical CAS receipts, logs, cleanup and full source snapshots were independently checked. The two complete image inspections and exact invocation are retained in the linked measurement document. No serving pin, production eligibility or placement policy changes.

Closes #371
