### PR TITLE
Bound streamed AURA exact boundary and cotangent residency

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,40 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `fix/campaign-portable-image-content`. Stamps
+As of: 2026-09-08 · `fix/joint-boundary-residency`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-08, `fix/joint-boundary-residency`) for the explicit
+`prismaquant.aura.boundary_storage.v1` policy (#373). Streamed AURA can store
+exact decoder boundaries and rolling cotangents through the existing
+activation artifact writer, checked page-release helper and bounded prefetch
+window owner. A window validates every complete tensor before source replay;
+lookups never load a missing entry. Source traversal remains batch-major
+capture and layer/probe/batch reverse, with the original B1 RNG coordinates,
+source kwargs, cotangents and signed scalar projection arithmetic. Legacy
+callers keep their in-memory behavior. PWC, full-layer dW and parameter-gradient
+lifetimes are unchanged.
+
+Exact storage uses a fresh isolated working generation per invocation. It binds
+source, calibration, producer and probe identity; immutable receipts bind
+shape, dtype, bytes and coordinates. Successful cotangent writes replace only
+the preceding boundary generation of the same probe/batch slot. Interrupted
+working tensors are never resumed; existing complete cost shards remain the
+only resumable measurement state. The policy has finite tensor-window,
+artifact-storage and auxiliary-state caps. Metadata tensors and potential
+per-probe shared-state adjoints are explicitly charged, with opaque owners
+refused. Completion/failure releases working entries and retains a small
+non-reusable generation receipt.
+
+This memory-lifetime change does not admit a full GLM run. The existing
+batch-major source traversal rereads decoder layers for each calibration
+microbatch, and full candidate/delta/diagnostic planes remain separate limits.
+A production path still needs a separately qualified layer-major boundary
+capture using `visit_layer_batches` and the original per-batch shared state,
+plus bounded candidate/projection lifetimes. No full-draw fit, GPU-bound
+throughput or serving claim follows from the exact-storage mode. Gates include
+`tests/test_streamed_boundary_artifacts.py`, existing joint microbatch/packed/
+lease and shared-state regressions, and a bounded native paired profiler and
+both-host Netdata qualification. The mode remains default-off.
 Re-stamped (2026-09-08, `fix/campaign-portable-image-content`) for optional
 campaign container `content_sha256` (issue #371). The existing runtime identity
 helper binds the inspected OS, architecture, variant, ordered RootFS layers

--- a/docs/design/joint_aura_runtime_allocation.md
+++ b/docs/design/joint_aura_runtime_allocation.md
@@ -301,7 +301,8 @@ writer copy; source replay/gradients, decoded candidates and allocator/runtime
 scratch still need their independent memory reservation and free-memory floor.
 On Spark CPU and GPU ownership share physical memory. The auxiliary cap counts
 all retained input/mask/position/shared-state storage, including full backing
-storages of views, and conservatively reserves one >=FP32 shared-state
+storages of views and tensors in mapping keys as well as values, and
+conservatively reserves one >=FP32 shared-state
 cotangent per captured occurrence per probe. Opaque state owners refuse.
 Nothing samples, reshapes, rounds or reorders a boundary.
 

--- a/docs/design/joint_aura_runtime_allocation.md
+++ b/docs/design/joint_aura_runtime_allocation.md
@@ -276,3 +276,56 @@ parent and subset calibration hashes and sample index in the frozen panel and
 observation; the subset hash is the joint currency. Full-draw probes omit the
 subset receipt and carry null `probe_scope`. A subset screen cannot be reported
 as full-draw quality evidence.
+
+
+## Exact boundary working storage (opt-in)
+
+`compute_aura_cost_streamed(..., boundary_storage=policy)`, CLI
+`--boundary-storage-config policy.json`, or the Tessera joint plan's
+`execution.boundary_storage` accepts the closed policy:
+
+```json
+{
+  "schema": "prismaquant.aura.boundary_storage.v1",
+  "directory": "/run/exact-boundaries",
+  "max_resident_bytes": 1073741824,
+  "max_auxiliary_bytes": 1073741824,
+  "max_artifact_bytes": 536870912000,
+  "prefetch_batches": 2
+}
+```
+
+These illustrative caps are not a GLM admission plan. The resident cap charges
+all exact tensors in the current prefetched CPU window plus one compact CPU
+writer copy; source replay/gradients, decoded candidates and allocator/runtime
+scratch still need their independent memory reservation and free-memory floor.
+On Spark CPU and GPU ownership share physical memory. The auxiliary cap counts
+all retained input/mask/position/shared-state storage, including full backing
+storages of views, and conservatively reserves one >=FP32 shared-state
+cotangent per captured occurrence per probe. Opaque state owners refuse.
+Nothing samples, reshapes, rounds or reorders a boundary.
+
+Each invocation starts a fresh generation only after input/checkpoint identity
+validation. The ordinary atomic activation writer publishes exact tensors and
+immutable receipts. A whole bounded window is loaded and checked before model
+replay; window lookups have no lazy-read path. Outgoing cotangents publish to
+new coordinates before retiring their consumed predecessor. Completed layer
+boundaries retire after all original probes consume them. Working entries are
+removed on normal completion or an ordinary exception; a killed process can
+leave an isolated incomplete generation, which is never accepted as resume
+input. Existing signed cost checkpoints own resume. A completed-checkpoint
+resume skips boundary generation entirely. The policy is checkpoint-bound but
+does not change the probe arithmetic identity or signed samples.
+
+The exact files and verified page advice make I/O explicit; advice does not
+establish physical release. Profile read/write barriers independently and keep
+actual physical memory checks. The initial implementation preserves the source
+loop to make byte/order parity reviewable. Its batch-major capture still
+traverses all decoder layers per calibration batch. With two source slots,
+512 B1 samples do not get a whole-model resident reuse window: layer-level
+source payload is fetched repeatedly. This source-derived traffic observation
+is unmeasured, not a timing estimate. Production qualification separately needs
+layer-major boundary capture through `StreamedCausalLM.visit_layer_batches`,
+keeping each batch's own source state and per-layer numerical sequence, and
+bounded PWC/delta/diagnostic lifetimes. The mode stays default-off until these
+remaining production gates are satisfied.

--- a/docs/measurements/joint-boundary-residency-2026-09-08.md
+++ b/docs/measurements/joint-boundary-residency-2026-09-08.md
@@ -1,0 +1,70 @@
+# Exact streamed AURA boundary residency — 2026-09-08
+
+Issue #373 adds an explicit, default-off exact artifact policy for source
+boundaries and rolling cotangents. The existing activation artifact owner
+writes the original tensor bytes and verifies bounded, fully resident input
+windows before layer execution. Generation metadata owns references, not a
+second tensor cache. Source traversal, signed scalar projection, production
+weight-cache behavior and `dW` arithmetic retain their existing implementation.
+
+The initial CPU regression retained 3,840 boundary bytes against a 1,024-byte
+fixture cap and failed (`c2f15a278645`, exit 1). This was the actual legacy
+full-draw behavior before implementation. The bounded owner passes that case.
+Its explicit cap covers leased exact CPU tensors plus one compact CPU write
+copy. A separate auxiliary cap charges full underlying tensor storage in
+input IDs, positional state, attention masks and shared pass state, plus the
+larger of actual shared cotangents and a conservative per-probe reservation.
+Opaque tensor owners refuse. These caps do not replace total process or GPU
+admission, source prefetch, candidate or gradient budgets.
+
+Nineteen focused owner tests cover full tensor/dtype preservation, GLM-style
+rank-four streams, nonempty Gemma4 shared state, exact propagated cotangents,
+source call order, seeds 7000–7003, uneven prefetch windows, and missing,
+corrupt, stale or oversized entries. A noncontiguous-tensor regression uses
+the CPU profiler's self allocation accounting to require one compact copy.
+Failed and interrupted runs clean their owned tensors and artifacts; resume
+recaptures a fresh generation and can reuse completed cost shards. A complete
+cost checkpoint returns without creating an artifact generation. Hot window
+lookups have no disk-loading branch.
+
+The final CPU gate (`0ad52f784868`, DL380, six physical CPU workers, 18 GiB
+aggregate reservation, one native thread each) passed 145 tests in 19.84 s and
+compiled all seven touched Python modules. One existing Gemma4 sweep-order
+case skipped: the installed Transformers build marks layer 6 KV-shared but
+does not expose `kv_shared_layer_index`. Synthetic shared-state tests using
+the actual Gemma4 profile passed. Earlier gates passed 40, 88 and 107 tests;
+the latter two had the same skip. An initial unsuitable Python 3.14 venv
+lacked `compressed_tensors` (`c924e121d726`), and the first implementation
+snapshot had a syntax error (`61f439f40f1d`); both failures are retained.
+
+The native qualification harness is
+`experiments/joint_boundary_profile.py`. It interleaves legacy/exact/exact/
+legacy over a genuine random tiny GLM original-layout checkpoint: BF16,
+two KDA/DSA layers, hidden size 64, four mHC streams, four routed experts,
+five complete 17-token sequences at B1, four probes, and identical synthetic
+candidate tensors. These candidates are fixtures, not serving artifacts.
+The KDA/short-convolution functions use the upstream Torch reference backend
+on CUDA; this qualifies boundary lifetime and arithmetic parity, not optional
+fused kernels. Each arm records a CPU/CUDA Torch trace, cProfile, process I/O,
+CUDA allocator state, source call order and every cotangent's byte digest.
+The existing observer records Netdata from both Sparks and Python stacks.
+
+Native results are recorded in the evidence directory after qualification.
+No full-model fit or throughput claim follows from this tiny fixture.
+
+The full GLM census still requires a separately qualified source traversal
+that amortizes source reads, bounded candidate/projection lifetimes and an
+aggregate admission model. This change intentionally preserves batch-major
+capture, whose repeated source-layer reads are a remaining limitation; no
+source-read duration or overlap claim has been measured here. Exact artifact
+writes and prefetch are explicit I/O phases outside the checked resident
+windows. Full 512-sequence execution remains subject to its existing gates.
+
+Evidence root:
+`/mnt/shared/tessera-measurements/glm-canonical-census-20260908/`.
+`joint-boundary-implementation-01/` contains commands, logs and canonical
+CAS receipt/result audits. `joint-boundary-native-invocation-*.json` records
+the native producer image content seal, runtime environment and PB demands.
+An early measurement submission (`d6cc0c85238d`) was withdrawn from the ready
+queue with zero tokens to preserve the existing direct-vLLM experiment's
+isolation during its CPU-only container startup gaps.

--- a/docs/measurements/joint-boundary-residency-2026-09-08.md
+++ b/docs/measurements/joint-boundary-residency-2026-09-08.md
@@ -17,11 +17,13 @@ larger of actual shared cotangents and a conservative per-probe reservation.
 Opaque tensor owners refuse. These caps do not replace total process or GPU
 admission, source prefetch, candidate or gradient budgets.
 
-Nineteen focused owner tests cover full tensor/dtype preservation, GLM-style
+Twenty focused owner tests cover full tensor/dtype preservation, GLM-style
 rank-four streams, nonempty Gemma4 shared state, exact propagated cotangents,
 source call order, seeds 7000–7003, uneven prefetch windows, and missing,
 corrupt, stale or oversized entries. A noncontiguous-tensor regression uses
 the CPU profiler's self allocation accounting to require one compact copy.
+Root review added explicit mapping-key inspection: tensor keys are charged and
+opaque keys refuse; all 20 focused cases passed (`62bf4b27e4ec`, 11.24 s).
 Failed and interrupted runs clean their owned tensors and artifacts; resume
 recaptures a fresh generation and can reuse completed cost shards. A complete
 cost checkpoint returns without creating an artifact generation. Hot window
@@ -49,8 +51,42 @@ fused kernels. Each arm records a CPU/CUDA Torch trace, cProfile, process I/O,
 CUDA allocator state, source call order and every cotangent's byte digest.
 The existing observer records Netdata from both Sparks and Python stacks.
 
-Native results are recorded in the evidence directory after qualification.
-No full-model fit or throughput claim follows from this tiny fixture.
+Native PB measurement `f8f2ab675f09` completed on Sparklina with exit 0 and
+verified scope/container cleanup. All four arms passed exact cost/statistic,
+source-order and cotangent parity: 18 profile-unpinned dense/packed targets,
+50 source-layer calls and 60 cotangents per arm. The fixture passes its exact
+per-target format plan through the production plan interface. Two preliminary
+attempts stopped before source forwards because a uniform target list included
+vision units (`6e02875b73cf`) and then pinned attention units with no fixture
+render (`45204e7e83e1`). Their failure logs are retained; neither required a
+production-code change.
+
+| Arm | Profiled call seconds | Retained captured boundary bytes | Exact window + writer peak bytes |
+|---|---:|---:|---:|
+| Legacy 0 | 5.477 | 130,560 | — |
+| Exact 1 | 4.930 | 0 | 43,520 |
+| Exact 2 | 5.657 | 0 | 43,520 |
+| Legacy 3 | 4.269 | 130,560 | — |
+
+The columns describe different ownership phases, not a total process-memory
+ratio. Both exact arms retained only references between windows, observed
+4,335 auxiliary bytes and zero shared-adjoint reservation for this GLM fixture,
+wrote/retired all 75 exact entries, and closed all 27 prefetch windows with
+zero hot misses and zero remaining artifact bytes. Each wrote 652,800 tensor
+bytes and read 739,840; peak working artifact bytes were 336,567. CPU user
+annotations locate the write barriers at 442/1,062 ms and input prefetch at
+125/124 ms in the two exact arms. These I/O phases are outside resident lookup.
+
+CUDA allocated/reserved peaks were identical in all arms: 76,011,008 and
+94,371,840 bytes. Torch profiling and export retain substantially more CPU
+memory than this tiny source; these data do not establish a reduction in
+whole-process physical memory. Twenty Netdata samples from each host cover
+the run: Sparklina GPU power 4–13 W and CPU busy 6.1–7.6%, Sparky power 42–47 W
+and CPU busy 6.5–17.0% with the independent full capture still active. At this
+fixture size the CUDA kernels total roughly 0.1 s and instrumentation/CPU work
+dominate. Timing differences are not a throughput claim, and five-second host
+sampling is too coarse to rank such short calls by work per joule. No
+full-model fit, saturation or serving-kernel claim follows.
 
 The full GLM census still requires a separately qualified source traversal
 that amortizes source reads, bounded candidate/projection lifetimes and an
@@ -63,7 +99,12 @@ windows. Full 512-sequence execution remains subject to its existing gates.
 Evidence root:
 `/mnt/shared/tessera-measurements/glm-canonical-census-20260908/`.
 `joint-boundary-implementation-01/` contains commands, logs and canonical
-CAS receipt/result audits. `joint-boundary-native-invocation-*.json` records
+CAS receipt/result audits; `native-audit.json` independently compares recorded
+cotangent hashes and source order, checks trace markers, and hashes all arm
+artifacts. `joint-boundary-native-03/` contains the successful observations,
+four CPU/CUDA traces (1.58 GB total), cProfile files and both-host Netdata.
+`joint-boundary-native-invocation-04.json` is the successful launch; earlier
+numbered invocations preserve failed/deferred attempts. These files record
 the native producer image content seal, runtime environment and PB demands.
 An early measurement submission (`d6cc0c85238d`) was withdrawn from the ready
 queue with zero tokens to preserve the existing direct-vLLM experiment's

--- a/experiments/joint_boundary_profile.py
+++ b/experiments/joint_boundary_profile.py
@@ -1,0 +1,211 @@
+"""Bounded genuine GLM before/after qualification, never a full-model fit gate.
+
+Run only as an admitted PB measurement in the recorded producer container.
+ABBA preserves the source/checkpoint/calibration/probes and scalar arithmetic.
+The upstream Torch reference KDA/conv kernels deliberately avoid testing the
+separate optional fused-kernel contract on this tiny fixture.
+"""
+from __future__ import annotations
+
+import argparse
+import cProfile
+import gc
+import hashlib
+import json
+from pathlib import Path
+import pstats
+import sys
+import time
+import weakref
+
+import torch
+
+from experiments.glm_full_capture_profile import CaptureObserver
+from prismaquant import aura_cost
+from prismaquant.cost_streaming import (
+    BOUNDARY_STORAGE_SCHEMA, build_streamed_causal_lm,
+    build_streamed_model_identity,
+)
+from prismaquant.model_profiles.glm5_next import Glm5NextProfile
+from prismaquant.production_weight_cache import ProductionWeightCache
+from prismaquant.routed_experts import profile_declared_packed_expert_projections
+
+
+def tensor_digest(value):
+    value = value.detach().to('cpu').contiguous()
+    return hashlib.sha256(value.view(torch.uint8).numpy().tobytes()).hexdigest()
+
+
+def process_state():
+    return dict(time=time.time(), process_io=Path('/proc/self/io').read_text(),
+        process_status=Path('/proc/self/status').read_text(),
+        cuda_allocated=torch.cuda.memory_allocated(),
+        cuda_reserved=torch.cuda.memory_reserved(),
+        cuda_peak_allocated=torch.cuda.max_memory_allocated(),
+        cuda_peak_reserved=torch.cuda.max_memory_reserved())
+
+
+def run_arm(source, cache, ids, out, index, mode):
+    profile = Glm5NextProfile()
+    runner = build_streamed_causal_lm(str(source), device=torch.device('cuda'),
+        dtype=torch.bfloat16, offload_folder=str(out/f'offload-{index}'),
+        profile=profile, max_cache_slots=2, prefetch_workers=1,
+        prefetch_min_available_gb=0, cache_headroom_gb=0,
+        prefetch_lookahead=1, require_prefetched_residency=True,
+        attn_implementation='eager')
+    identity = build_streamed_model_identity(runner, str(source))
+    calls, cotangents, owned = [], [], []
+    capture_peaks = []
+    original_call, original_capture = runner._call, runner.capture_boundaries
+    original_tail, original_reverse = runner.tail_logits, runner.isolated_layer
+    tail_calls = reverse_calls = 0
+
+    def call(layer, hidden, *, batch, pass_state):
+        calls.append((int(batch.input_ids[0, 0]), layer, torch.is_grad_enabled()))
+        return original_call(layer, hidden, batch=batch, pass_state=pass_state)
+
+    def capture(*args, **kwargs):
+        batch = original_capture(*args, **kwargs)
+        owned.extend(weakref.ref(t) for t in batch.activations_cpu if isinstance(t, torch.Tensor))
+        capture_peaks.append(sum(t().untyped_storage().nbytes() for t in owned if t() is not None))
+        return batch
+
+    def observe(gradient, probe, batch, layer):
+        cotangents.append(dict(probe=probe, batch=batch, layer=layer,
+            shape=list(gradient.shape), dtype=str(gradient.dtype),
+            sha256=tensor_digest(gradient)))
+
+    def tail(batch, hidden):
+        nonlocal tail_calls
+        b, k = divmod(tail_calls, 4)
+        hidden.register_hook(lambda g, b=b, k=k: observe(g, k, b, runner.num_layers))
+        tail_calls += 1
+        return original_tail(batch, hidden)
+
+    def reverse(batch, layer, hidden, *, pass_state):
+        nonlocal reverse_calls
+        k, b = divmod(reverse_calls % (4*len(ids)), len(ids))
+        hidden.register_hook(lambda g, k=k, b=b, layer=layer: observe(g, k, b, layer))
+        reverse_calls += 1
+        return original_reverse(batch, layer, hidden, pass_state=pass_state)
+
+    runner._call, runner.capture_boundaries = call, capture
+    runner.tail_logits, runner.isolated_layer = tail, reverse
+    plane = ids.shape[1] * 4 * 64 * 2
+    policy = dict(schema=BOUNDARY_STORAGE_SCHEMA, directory=str(out/f'artifacts-{index}'),
+        max_resident_bytes=5*plane, max_auxiliary_bytes=4*1024**2,
+        max_artifact_bytes=32*1024**2, prefetch_batches=2)
+    gc.collect()
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    record = dict(index=index, mode=mode, before=process_state(),
+        identity=identity, boundary_plane_bytes=plane)
+    cpu_profiler = cProfile.Profile()
+    started = time.perf_counter()
+    try:
+        with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA], record_shapes=True,
+                profile_memory=True) as profiler, cpu_profiler:
+            payload = aura_cost.compute_aura_cost_streamed(runner, ids,
+                ['FP8_DYNAMIC', 'NVFP4A16', 'BF16'], n_probes=4,
+                probe_microbatch=1, seed_base=7000, min_free_gib=0,
+                production_cache=cache, joint_activation=True,
+                collect_col_energy=True, include_routed_experts=True,
+                model_identity=identity, profile=profile,
+                boundary_storage=policy if mode == 'exact' else None)
+            torch.cuda.synchronize()
+        record.update(seconds=time.perf_counter()-started, after=process_state(),
+            source_calls=calls, cotangents=cotangents,
+            legacy_boundary_capture_peak_bytes=max(capture_peaks),
+            storage=payload['provenance'].get('streamed_boundary_storage'),
+            targets=len(payload['costs']))
+        profiler.export_chrome_trace(str(out/f'arm-{index}-{mode}.trace.json'))
+        (out/f'arm-{index}-{mode}.profile.txt').write_text(
+            profiler.key_averages().table(sort_by='self_cuda_time_total', row_limit=80))
+        cpu_profiler.dump_stats(str(out/f'arm-{index}-{mode}.cprofile'))
+        with (out/f'arm-{index}-{mode}.cprofile.txt').open('w') as handle:
+            pstats.Stats(cpu_profiler, stream=handle).sort_stats('cumulative').print_stats(80)
+        assert len(cotangents) == 4*len(ids)*(runner.num_layers+1)
+        assert all(row['probe_ids'] == [7000, 7001, 7002, 7003]
+                   for rows in payload['costs'].values() for row in rows.values())
+        assert any('.experts.' in name for name in payload['costs'])
+        if mode == 'exact':
+            receipt = record['storage']
+            assert receipt['status'] == 'complete'
+            assert receipt['telemetry']['peak_resident_tensor_bytes'] <= 5*plane
+            assert receipt['telemetry']['live_artifact_bytes'] == 0
+            assert receipt['telemetry']['hot_read_misses'] == 0
+            assert not list((out/f'artifacts-{index}').rglob('*.pt'))
+        (out/f'arm-{index}-{mode}.json').write_text(json.dumps(record, indent=2)+'\n')
+        return payload, record
+    finally:
+        runner.shutdown()
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--evidence-out', type=Path, required=True)
+    args = parser.parse_args(argv)
+    if not torch.cuda.is_available():
+        raise RuntimeError('native GLM qualification requires CUDA')
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]/'tests'))
+    from test_glm5_next_streamed_forward_parity import _build_tiny_model
+    from test_glm_campaign_streaming import write_original_layout_checkpoint
+    from transformers.models.glm5_next import modeling_glm5_next as upstream
+    torch.set_num_threads(1)
+    torch.set_num_interop_threads(1)
+    torch.use_deterministic_algorithms(True)
+    kernels = {}
+    for name in ('causal_conv1d_fn', 'causal_conv1d_update',
+                 'chunk_kimi_delta_attention', 'recurrent_kimi_delta_attention'):
+        reference = getattr(getattr(upstream, name), '__wrapped__', None)
+        if reference is None:
+            raise RuntimeError(f'missing upstream Torch reference {name}')
+        setattr(upstream, name, reference)
+        kernels[name] = reference.__module__+'.'+reference.__name__
+    with CaptureObserver(args.evidence_out, profile_layers=()) as observer:
+        out = args.evidence_out
+        model = _build_tiny_model().to(torch.bfloat16)
+        source = out/'source'
+        write_original_layout_checkpoint(model, source)
+        profile = Glm5NextProfile()
+        weights = {name: module.weight for name, module in model.named_modules()
+            if isinstance(module, torch.nn.Linear) and '.layers.' in name
+            and not profile.is_pinned_name(name)}
+        weights.update({m.qname: m.weight for m in profile_declared_packed_expert_projections(model, profile)})
+        cache = ProductionWeightCache(weights={(name, fmt): weight.detach().clone()+0.03125
+            for name, weight in weights.items() for fmt in ('FP8_E4M3', 'NVFP4A16')},
+            levers={}, activation_max_abs={name: 1.0 for name in weights})
+        del weights, model
+        ids = torch.arange(5*17).remainder(126).add(2).reshape(5, 17)
+        observer.result.update(schema='prismaquant.joint_boundary_qualification.v1',
+            fixture=dict(model='genuine random tiny glm5_next original-layout checkpoint',
+                dtype='bfloat16', hidden=64, hc_mult=4, layers=2, routed_experts=4,
+                batches=5, sequence=17, probes=[7000,7001,7002,7003],
+                token_sha256=tensor_digest(ids), kernels=kernels,
+                candidate_weights='synthetic BF16 source +0.03125, not a serving artifact'),
+            claims=dict(full_model_fit=False, full_model_throughput=False,
+                kernel_qualification=False, scalar_arithmetic_changed=False), arms=[])
+        baseline = baseline_record = None
+        for index, mode in enumerate(('legacy', 'exact', 'exact', 'legacy')):
+            print(f'BEGIN arm={index} mode={mode}', flush=True)
+            payload, record = run_arm(source, cache, ids, out, index, mode)
+            if baseline is None:
+                baseline, baseline_record = payload, record
+            else:
+                assert payload['costs'] == baseline['costs'], 'cost arithmetic changed'
+                assert record['source_calls'] == baseline_record['source_calls'], 'source order changed'
+                assert record['cotangents'] == baseline_record['cotangents'], 'cotangent bytes changed'
+                for name, row in payload['stats'].items():
+                    assert row['h_trace'] == baseline['stats'][name]['h_trace']
+                    assert torch.equal(row['fisher_col'], baseline['stats'][name]['fisher_col'])
+            record['exact_parity'] = True
+            observer.result['arms'].append(record)
+            (out/'progress.json').write_text(json.dumps(observer.result, indent=2)+'\n')
+            print(f'PASS arm={index} mode={mode} seconds={record["seconds"]:.3f}', flush=True)
+            del payload
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/experiments/joint_boundary_profile.py
+++ b/experiments/joint_boundary_profile.py
@@ -111,6 +111,8 @@ def run_arm(source, cache, ids, out, index, mode):
                 probe_microbatch=1, seed_base=7000, min_free_gib=0,
                 production_cache=cache, joint_activation=True,
                 collect_col_energy=True, include_routed_experts=True,
+                formats_by_qname={name: ['FP8_DYNAMIC', 'NVFP4A16', 'BF16']
+                                  for name, _fmt in cache.weights},
                 model_identity=identity, profile=profile,
                 boundary_storage=policy if mode == 'exact' else None)
             torch.cuda.synchronize()

--- a/prismaquant/aura_cost.py
+++ b/prismaquant/aura_cost.py
@@ -1844,6 +1844,24 @@ def _assemble_streamed_aura_payload(
     }
 
 
+def _with_boundary_artifacts(function):
+    """Keep temporary activation generations inside the public call lifetime."""
+    from functools import wraps
+
+    @wraps(function)
+    def run(*args, **kwargs):
+        config = kwargs.pop("boundary_storage", None)
+        if config is None:
+            return function(*args, **kwargs)
+        from prismaquant.cost_streaming import StreamedBoundaryArtifacts
+        with StreamedBoundaryArtifacts(config) as storage:
+            result = function(*args, **kwargs, boundary_storage=storage)
+        result["provenance"]["streamed_boundary_storage"] = storage.receipt()
+        return result
+    return run
+
+
+@_with_boundary_artifacts
 def compute_aura_cost_streamed(
     runner,
     calib_ids: torch.Tensor,
@@ -1875,6 +1893,7 @@ def compute_aura_cost_streamed(
     joint_activation: bool = False,
     joint_projection_backend=None,
     source_transition=None,
+    boundary_storage=None,
     profile=None,
 ) -> dict:
     """Layer-streamed KL-adjoint with identity-bound per-Linear shards.
@@ -1887,8 +1906,13 @@ def compute_aura_cost_streamed(
     model. ``probe_microbatch > 0`` opts joint AURA into complete-sequence
     partitions with versioned global-row probes. Local signed terms and weight
     gradients sum across all partitions before squaring; full-vocabulary GPU
-    tensors are bounded by the partition. CPU boundaries and shared pass state
-    still cover the full calibration. Checkpoints bind the execution partition
+    tensors are bounded by the partition. By default CPU boundaries and shared
+    pass state cover the full calibration. Explicit ``boundary_storage`` v1
+    stores exact snapshots and rolling cotangents through the existing
+    activation artifact owner, leases bounded resident input windows, and caps
+    metadata/shared-state residency. It preserves the original traversal and
+    scalar projection arithmetic; candidate/gradient and source traffic bounds
+    remain separate admission requirements. Checkpoints bind the execution partition
     because floating-point kernels may round differently with batch shape.
     The resident :func:`compute_aura_cost` path is deliberately unchanged.
     """
@@ -1902,6 +1926,8 @@ def compute_aura_cost_streamed(
         raise ValueError("probe_microbatch must be a nonnegative integer")
     if calib_ids.ndim != 2 or min(calib_ids.shape) < 1:
         raise ValueError("streamed AURA needs nonempty [rows, sequence] calibration")
+    if boundary_storage is not None and model_identity is None:
+        raise ValueError("exact boundary storage requires exact model_identity")
     if joint_projection_backend is not None and not joint_activation:
         raise ValueError("joint_projection_backend requires joint_activation")
     if probe_microbatch and not joint_activation:
@@ -2333,6 +2359,7 @@ def compute_aura_cost_streamed(
             "streamed_cotangent_rollover",
             "streamed_boundary_release",
             "streamed_microbatch",
+            "streamed_boundary_storage",
         } & set(extra)
         if reserved:
             raise ValueError(
@@ -2342,6 +2369,8 @@ def compute_aura_cost_streamed(
         extra["streaming"] = True
         if execution_partition is not None:
             extra["streamed_microbatch"] = execution_partition
+        if boundary_storage is not None:
+            extra["streamed_boundary_storage"] = boundary_storage.identity
         if joint_activation:
             extra["joint_aura"] = joint_run_identity
         extra["streamed_model_identity"] = exact_model_identity
@@ -2576,55 +2605,95 @@ def compute_aura_cost_streamed(
 
     # Identity validation above is intentionally before the first model
     # forward: a mismatched resume is a refusal, never a recomputation.
+    from prismaquant.cost_streaming import prefetched_boundary_batches
+    if boundary_storage is not None:
+        from prismaquant.cost_streaming import validate_streamed_model_identity
+
+        def check_boundary_memory(label):
+            available = _free_gib()
+            if available < min_free_gib:
+                raise RuntimeError(f"free UMA {available:.1f} < floor {min_free_gib:.1f}; {label}")
+
+        boundary_storage.bind({
+            "source_model": validate_streamed_model_identity(model_identity, where="exact boundary storage"),
+            "producer_source_sha256": _aura_source_sha256(),
+            "calibration_sha256": hashlib.sha256(calib_ids.detach().cpu().contiguous().numpy().tobytes()).hexdigest(),
+            "calibration_shape": list(calib_ids.shape), "calibration_dtype": str(calib_ids.dtype),
+            "n_probes": n_probes, "seed_base": seed_base, "token_scope": token_scope,
+            "temperature": temperature, "execution_partition": execution_partition,
+            "joint_probe_identity": joint_probe_identity,
+        }, n_probes=n_probes, check_memory=check_boundary_memory)
     _log(f"boundary capture: calib {tuple(calib_ids.shape)} in "
          f"{len(row_offsets)} partition(s) across {runner.num_layers} layers ...")
     capture_started = time.time()
     batches = []
-    for offset in row_offsets:
+    if boundary_storage is not None:
+        boundary_storage.watch_auxiliary(batches, [])
+    for batch_index, offset in enumerate(row_offsets):
         available_gib = _free_gib()
         if available_gib < min_free_gib:
             raise RuntimeError(f"free UMA {available_gib:.1f} < floor {min_free_gib:.1f}; "
                                f"abort before calibration row {offset}")
-        batches.append(runner.capture_boundaries(calib_ids[offset:offset + batch_rows]))
+        if boundary_storage is None:
+            batches.append(runner.capture_boundaries(calib_ids[offset:offset + batch_rows]))
+        else:
+            def write_boundary(depth, tensor):
+                return boundary_storage.write(tensor, batch_index=batch_index, boundary_index=depth)
+
+            def check_capture_state(current, state):
+                boundary_storage.check_auxiliary([*batches, current], extra=(state,),
+                    shared_extra=state if current.shared_pass_state is None else ())
+
+            batches.append(runner.capture_boundaries(calib_ids[offset:offset + batch_rows],
+                boundary_writer=write_boundary, resource_check=check_capture_state))
+            boundary_storage.check_auxiliary(batches)
     _log(f"boundary capture done in {(time.time() - capture_started) / 60:.1f} "
          f"min; starting {n_probes}-probe tail cotangents")
     device = runner.device
     dtype = runner.dtype
 
-    # Existing boundary and shared-state mechanisms, one instance per complete
-    # sequence partition. Host boundary/cotangent storage still scales with the
-    # full calibration; only GPU activations and full-vocabulary tensors are
-    # bounded by batch_rows. No second residency or spill cache is introduced.
+    # One existing shared-state instance per complete sequence/probe partition.
+    # Exact-artifact mode additionally caps these retained auxiliary tensors;
+    # the legacy mode keeps its original full-calibration host ownership.
     from prismaquant.sensitivity_probe import (
         SharedStateCotangents,
         kv_cotangent_path_enabled,
     )
     cotangents = [[SharedStateCotangents(enabled=kv_cotangent_path_enabled())
                   for _ in batches] for _ in range(n_probes)]
-    grad_outs: list[list[torch.Tensor]] = [[] for _ in range(n_probes)]
-    for batch_index, batch in enumerate(batches):
-        for probe_index in range(n_probes):
-            tail = batch.activations_cpu[-1].to(
-                device=device, dtype=dtype
-            ).detach().requires_grad_(True)
-            logits = runner.tail_logits(batch, tail)
-            if probe_layout is not None and list(logits.shape) != [
-                len(batch.input_ids), int(calib_ids.shape[1]), probe_layout["vocab_size"]
-            ]:
-                raise RuntimeError("streamed AURA tail differs from bound probe geometry")
-            probe = fisher_probe_scalar(
-                logits, seed=seed_base + probe_index, token_scope=token_scope,
-                temperature=temperature, distribution="rademacher",
-                **({"token_count_override": probe_layout["global_token_count"],
-                    "global_row_offset": row_offsets[batch_index]}
-                   if probe_layout is not None else {}),
-            )
-            probe.backward()
-            if tail.grad is None:
-                raise RuntimeError("streamed AURA tail produced no cotangent")
-            grad_outs[probe_index].append(tail.grad.detach().to("cpu"))
-            del logits, probe, tail
-        batch.activations_cpu[-1] = torch.empty(0)
+    grad_outs = [[] for _ in range(n_probes)]
+    if boundary_storage is not None:
+        boundary_storage.watch_auxiliary(batches, cotangents)
+        boundary_storage.check_auxiliary(batches, cotangents=cotangents)
+    with prefetched_boundary_batches(boundary_storage, batches, runner.num_layers) as tail_batches:
+        for batch_index, batch, tail_cpu, _unused in tail_batches:
+            try:
+                for probe_index in range(n_probes):
+                    tail = tail_cpu.to(device=device, dtype=dtype).detach().requires_grad_(True)
+                    logits = runner.tail_logits(batch, tail)
+                    if probe_layout is not None and list(logits.shape) != [
+                        len(batch.input_ids), int(calib_ids.shape[1]), probe_layout["vocab_size"]
+                    ]:
+                        raise RuntimeError("streamed AURA tail differs from bound probe geometry")
+                    probe = fisher_probe_scalar(
+                        logits, seed=seed_base + probe_index, token_scope=token_scope,
+                        temperature=temperature, distribution="rademacher",
+                        **({"token_count_override": probe_layout["global_token_count"],
+                            "global_row_offset": row_offsets[batch_index]}
+                           if probe_layout is not None else {}),
+                    )
+                    probe.backward()
+                    if tail.grad is None:
+                        raise RuntimeError("streamed AURA tail produced no cotangent")
+                    grad_outs[probe_index].append(tail.grad.detach().to("cpu") if boundary_storage is None
+                        else boundary_storage.write(tail.grad, batch_index=batch_index,
+                            boundary_index=runner.num_layers, probe_index=probe_index))
+                    del logits, probe, tail
+                if boundary_storage is not None:
+                    boundary_storage.retire(batch.activations_cpu[-1])
+                batch.activations_cpu[-1] = torch.empty(0)
+            finally:
+                tail_cpu = logits = probe = tail = None
 
     reverse_started = time.time()
     reverse_layers_done = 0
@@ -2962,57 +3031,68 @@ def compute_aura_cost_streamed(
                     accumulated_gradients.clear()
                     if joint_lease is not None:
                         joint_lease.begin_probe()
-                    for batch_index, batch in enumerate(batches):
-                        available_gib = _free_gib()
-                        if available_gib < min_free_gib:
-                            raise RuntimeError(
-                                f"free UMA {available_gib:.1f} < floor "
-                                f"{min_free_gib:.1f}; abort before streamed "
-                                f"layer {layer} probe {probe_index + 1}"
-                            )
-                        incoming_grad = grad_outs[probe_index][batch_index].to(device)
-                        x_in = batch.activations_cpu[layer].to(
-                            device=device, dtype=dtype
-                        ).detach().requires_grad_(True)
-                        isolated = profile.isolated_layer_pass_state(
-                            batch.shared_pass_state, runner.layers[layer]
-                        )
-                        isolated = cotangents[probe_index][batch_index].graft(isolated)
-                        out = runner.isolated_layer(
-                            batch, layer, x_in, pass_state=isolated
-                        )
-                        roots, root_grads = cotangents[probe_index][batch_index].produced_roots()
-                        if roots:
-                            torch.autograd.backward(
-                                [out, *roots],
-                                [incoming_grad, *root_grads],
-                            )
-                        else:
-                            out.backward(incoming_grad)
-                        cotangents[probe_index][batch_index].harvest()
-                        if x_in.grad is None:
-                            raise RuntimeError(
-                                f"streamed AURA layer {layer} produced no input "
-                                "cotangent"
-                            )
-                        # Replace this probe's consumed incoming cotangent now.
-                        # The former next_grad_outs list retained all 32 incoming
-                        # CPU tensors while growing a second complete outgoing
-                        # plane. In-place rollover bounds the CPU plane to 32
-                        # tensors plus the one result currently being copied.
-                        grad_outs[probe_index][batch_index] = x_in.grad.detach().to("cpu")
-                        for parameter_id, parameter in parameters.items():
-                            gradient = parameter.grad
-                            if gradient is not None:
-                                # Defensive straggler path for a backend that did
-                                # not invoke the post-accumulate hook. It performs
-                                # the identical reduction and still frees the
-                                # gradient before the next probe.
-                                for name in parameter_members[parameter_id]:
-                                    if name not in harvested:
-                                        _consume_streamed_gradient(name, _source_gradient(linears[name], gradient))
-                                parameter.grad = None
-                        del (out, x_in, incoming_grad, isolated, roots, root_grads)
+                    with prefetched_boundary_batches(boundary_storage, batches, layer,
+                            grad_outs[probe_index]) as reverse_batches:
+                        for batch_index, batch, boundary_cpu, incoming_cpu in reverse_batches:
+                            try:
+                                available_gib = _free_gib()
+                                if available_gib < min_free_gib:
+                                    raise RuntimeError(
+                                        f"free UMA {available_gib:.1f} < floor "
+                                        f"{min_free_gib:.1f}; abort before streamed "
+                                        f"layer {layer} probe {probe_index + 1}"
+                                    )
+                                incoming_grad = incoming_cpu.to(device)
+                                x_in = boundary_cpu.to(
+                                    device=device, dtype=dtype
+                                ).detach().requires_grad_(True)
+                                isolated = profile.isolated_layer_pass_state(
+                                    batch.shared_pass_state, runner.layers[layer]
+                                )
+                                isolated = cotangents[probe_index][batch_index].graft(isolated)
+                                out = runner.isolated_layer(
+                                    batch, layer, x_in, pass_state=isolated
+                                )
+                                roots, root_grads = cotangents[probe_index][batch_index].produced_roots()
+                                if roots:
+                                    torch.autograd.backward(
+                                        [out, *roots],
+                                        [incoming_grad, *root_grads],
+                                    )
+                                else:
+                                    out.backward(incoming_grad)
+                                cotangents[probe_index][batch_index].harvest()
+                                if x_in.grad is None:
+                                    raise RuntimeError(
+                                        f"streamed AURA layer {layer} produced no input "
+                                        "cotangent"
+                                    )
+                                # Replace this probe's consumed incoming cotangent now.
+                                # The former next_grad_outs list retained all 32 incoming
+                                # CPU tensors while growing a second complete outgoing
+                                # plane. In-place rollover bounds the CPU plane to 32
+                                # tensors plus the one result currently being copied.
+                                grad_outs[probe_index][batch_index] = (x_in.grad.detach().to("cpu")
+                                    if boundary_storage is None else boundary_storage.write(x_in.grad,
+                                        batch_index=batch_index, boundary_index=layer, probe_index=probe_index,
+                                        previous=grad_outs[probe_index][batch_index]))
+                                if boundary_storage is not None:
+                                    boundary_storage.check_auxiliary(batches, cotangents=cotangents)
+                                for parameter_id, parameter in parameters.items():
+                                    gradient = parameter.grad
+                                    if gradient is not None:
+                                        # Defensive straggler path for a backend that did
+                                        # not invoke the post-accumulate hook. It performs
+                                        # the identical reduction and still frees the
+                                        # gradient before the next probe.
+                                        for name in parameter_members[parameter_id]:
+                                            if name not in harvested:
+                                                _consume_streamed_gradient(name, _source_gradient(linears[name], gradient))
+                                        parameter.grad = None
+                                del (out, x_in, incoming_grad, isolated, roots, root_grads)
+                            finally:
+                                boundary_cpu = incoming_cpu = None
+                                out = x_in = incoming_grad = isolated = roots = root_grads = None
                     for name in list(accumulated_gradients):
                         _harvest_streamed_gradient(name, accumulated_gradients.pop(name))
                     for name in pending:
@@ -3066,6 +3146,8 @@ def compute_aura_cost_streamed(
             # Release it progressively instead of retaining all 44 DSv4
             # hc_mult=4 boundary snapshots to the end.
             for batch in batches:
+                if boundary_storage is not None:
+                    boundary_storage.retire(batch.activations_cpu[layer])
                 batch.activations_cpu[layer] = torch.empty(0)
 
             if checkpoint_root is not None:
@@ -3151,6 +3233,7 @@ def run_streamed_production_anchor_aura(
     collect_col_energy: bool = False,
     joint_activation: bool = False,
     joint_projection_backend=None,
+    boundary_storage=None,
     profile=None,
 ) -> dict:
     """Run one streamed KL adjoint over an exact production-anchor plan.
@@ -3339,6 +3422,7 @@ def run_streamed_production_anchor_aura(
         collect_col_energy=collect_col_energy,
         joint_activation=joint_activation,
         joint_projection_backend=joint_projection_backend,
+        boundary_storage=boundary_storage,
         checkpoint_dir=checkpoint_dir,
         resume=resume,
         model_identity=model_identity,
@@ -3529,6 +3613,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                         "artifact compatibility. Default is fail-fast because "
                         "routed experts need an empirical/hybrid expert-cost "
                         "path, not silent omission.")
+    p.add_argument("--boundary-storage-config", default=None,
+                   help="Explicit v1 JSON policy for exact streamed boundary/cotangent "
+                        "artifacts and bounded resident windows; streaming only, default off.")
     p.add_argument(
         "--include-routed-experts",
         action="store_true",
@@ -3548,6 +3635,13 @@ def main(argv: Sequence[str] | None = None) -> int:
                    help="Pipeline COST_MODE stamped into "
                         "provenance['cost_mode'] (re-vet R2).")
     args = p.parse_args(argv)
+    boundary_storage_config = None
+    if args.boundary_storage_config:
+        if not args.streaming:
+            p.error("--boundary-storage-config requires --streaming")
+        from prismaquant.cost_streaming import normalize_boundary_storage
+        boundary_storage_config = normalize_boundary_storage(
+            json.loads(Path(args.boundary_storage_config).read_text()))
     if bool(args.calibration_input) != bool(args.calibration_input_sha256):
         p.error("--calibration-input and --calibration-input-sha256 are required together")
     if args.calibration_input and args.dataset:
@@ -3691,7 +3785,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if streamed_runner is not None:
         try:
             streamed_model_identity = None
-            if args.checkpoint_dir or args.joint_activation:
+            if args.checkpoint_dir or args.joint_activation or boundary_storage_config is not None:
                 from prismaquant.cost_streaming import (
                     build_streamed_model_identity,
                 )
@@ -3710,6 +3804,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 requested_formats,
                 n_probes=args.n_probes,
                 probe_microbatch=args.probe_microbatch,
+                boundary_storage=boundary_storage_config,
                 token_scope=args.token_scope,
                 temperature=args.temperature,
                 production_cache=cache,

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -79,7 +79,8 @@ def _state_tensors(value):
             raise TypeError("exact boundary storage cannot account this state tensor")
         yield value
     elif isinstance(value, Mapping):
-        for item in value.values():
+        for key, item in value.items():
+            yield from _state_tensors(key)
             yield from _state_tensors(item)
     elif isinstance(value, (tuple, list)):
         for item in value:

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -46,8 +46,316 @@ class StreamedForwardBoundaries:
     position_ids: torch.Tensor
     position_embeddings: object
     attention_mask: object
-    activations_cpu: list[torch.Tensor]
+    # Explicit artifact mode stores ExactActivationReference receipts here;
+    # all legacy callers continue to receive their original CPU tensors.
+    activations_cpu: list[Any]
     shared_pass_state: object
+
+
+BOUNDARY_STORAGE_SCHEMA = "prismaquant.aura.boundary_storage.v1"
+
+
+def normalize_boundary_storage(config):
+    """Validate the explicit exact-artifact policy without touching storage."""
+    if config is None:
+        return None
+    fields = {"schema", "directory", "max_resident_bytes", "max_auxiliary_bytes",
+              "max_artifact_bytes", "prefetch_batches"}
+    if not isinstance(config, dict) or set(config) != fields or config.get("schema") != BOUNDARY_STORAGE_SCHEMA:
+        raise ValueError("exact boundary storage requires a complete v1 policy")
+    for key in fields - {"schema", "directory"}:
+        if type(config[key]) is not int or config[key] <= 0:
+            raise ValueError(f"exact boundary storage requires positive {key}")
+    if not isinstance(config["directory"], str) or not config["directory"].strip():
+        raise ValueError("exact boundary storage requires an artifact directory")
+    return {**config, "directory": str(Path(config["directory"]).resolve())}
+
+
+def _state_tensors(value):
+    """Closed source-metadata grammar: opaque tensor owners must refuse."""
+    from collections.abc import Mapping
+    if isinstance(value, torch.Tensor):
+        if value.is_meta or value.layout != torch.strided:
+            raise TypeError("exact boundary storage cannot account this state tensor")
+        yield value
+    elif isinstance(value, Mapping):
+        for item in value.values():
+            yield from _state_tensors(item)
+    elif isinstance(value, (tuple, list)):
+        for item in value:
+            yield from _state_tensors(item)
+    elif value is not None and type(value) not in (str, bool, int, float, complex):
+        raise TypeError(f"exact boundary storage cannot account opaque state {type(value).__name__}")
+
+
+def _state_storage_bytes(values):
+    storages = {}
+    for tensor in _state_tensors(values):
+        storage = tensor.untyped_storage()
+        key = (str(tensor.device), storage.data_ptr(), storage.nbytes())
+        storages[key] = storage.nbytes()
+    return sum(storages.values())
+
+
+class StreamedBoundaryArtifacts:
+    """Own exact-boundary receipts and generations, never a second tensor cache.
+
+    Tensor writing, page release and each bounded resident window are delegated
+    to the existing activation artifact owner in ``perturbed_x_cache``. Working
+    generations are deliberately not checkpoint inputs: an interrupted cost
+    resume recaptures into a fresh generation, as the legacy producer already
+    does. Only completed signed cost shards are resumable measurement state.
+    """
+
+    def __init__(self, config):
+        self.config = normalize_boundary_storage(config)
+        self.identity = {key: value for key, value in self.config.items() if key != "directory"}
+        self.session = None
+        self.directory = None
+        self._references = {}
+        self._slots = {}
+        self._active_window = None
+        self._check_memory = None
+        self._n_probes = 0
+        self._batches = None
+        self._cotangents = None
+        self._status = "unused"
+        self.telemetry = {"resident_tensor_bytes": 0, "peak_resident_tensor_bytes": 0,
+            "peak_auxiliary_bytes": 0, "peak_shared_cotangent_reservation_bytes": 0,
+            "live_artifact_bytes": 0, "peak_artifact_bytes": 0,
+            "written_tensor_bytes": 0, "read_tensor_bytes": 0,
+            "written_entries": 0, "retired_entries": 0, "prefetch_windows": 0,
+            "hot_read_misses": 0}
+
+    def __enter__(self):
+        return self
+
+    def bind(self, identity, *, n_probes, check_memory=None):
+        import uuid
+        from .cost_stage_checkpoint import canonical_json_sha256
+        if self.session is not None:
+            raise RuntimeError("exact boundary generation is already bound")
+        self._n_probes = n_probes
+        self._check_memory = check_memory
+        self.session = {"generation": uuid.uuid4().hex,
+            "run_identity_sha256": canonical_json_sha256(identity, where="exact boundary source")}
+        self.directory = Path(self.config["directory"]) / self.session["generation"]
+        self.directory.mkdir(parents=True, exist_ok=False)
+        self._status = "running"
+        self._publish_status()
+
+    def _publish_status(self):
+        if self.directory is None:
+            return
+        from .cost_stage_checkpoint import atomic_write_bytes
+        data = {"schema": BOUNDARY_STORAGE_SCHEMA, "session": self.session,
+                "policy": self.identity, "status": self._status,
+                "working_artifacts_reusable": False, "telemetry": self.telemetry}
+        atomic_write_bytes(self.directory / "generation.json",
+            (json.dumps(data, sort_keys=True, indent=2, allow_nan=False) + "\n").encode())
+
+    def _reserve(self, delta):
+        value = self.telemetry["resident_tensor_bytes"] + delta
+        if value < 0 or value > self.config["max_resident_bytes"]:
+            raise RuntimeError("exact boundary tensor residency budget exceeded")
+        if delta > 0 and self._check_memory is not None:
+            self._check_memory("exact activation allocation")
+        self.telemetry["resident_tensor_bytes"] = value
+        self.telemetry["peak_resident_tensor_bytes"] = max(
+            value, self.telemetry["peak_resident_tensor_bytes"])
+
+    def check_auxiliary(self, batches, *, cotangents=(), extra=(), shared_extra=()):
+        """Bound retained metadata plus all potential per-probe shared adjoints.
+
+        Shared state remains under the profile's original ownership/precision.
+        We conservatively reserve one >=FP32 cotangent per captured occurrence
+        per probe, including aliases at different shared-state keys; actual
+        accumulators are checked too. No hidden tensor plane is called metadata.
+        """
+        metadata = [(batch.input_ids, batch.position_ids, batch.position_embeddings,
+                     batch.attention_mask, batch.shared_pass_state) for batch in batches]
+        actual_accumulators = [cotangent.resident_tensors() for row in cotangents for cotangent in row]
+        shared = [batch.shared_pass_state for batch in batches] + [shared_extra]
+        reserved_shared = self._n_probes * sum(
+            tensor.numel() * max(4, tensor.element_size())
+            for tensor in _state_tensors(shared)
+            if tensor.is_floating_point() or tensor.is_complex())
+        actual_shared = _state_storage_bytes(actual_accumulators)
+        total = _state_storage_bytes((metadata, extra)) + max(actual_shared, reserved_shared)
+        if total > self.config["max_auxiliary_bytes"]:
+            raise RuntimeError("exact boundary auxiliary/shared-state residency budget exceeded")
+        self.telemetry["peak_auxiliary_bytes"] = max(total, self.telemetry["peak_auxiliary_bytes"])
+        self.telemetry["peak_shared_cotangent_reservation_bytes"] = max(
+            reserved_shared, self.telemetry["peak_shared_cotangent_reservation_bytes"])
+        if self._check_memory is not None:
+            self._check_memory("exact boundary auxiliary state")
+
+    def watch_auxiliary(self, batches, cotangents):
+        """Register existing owners for deterministic end-of-call cleanup."""
+        self._batches = batches
+        self._cotangents = cotangents
+
+    def _entry_identity(self, reference):
+        from .perturbed_x_cache import ExactActivationReference
+        if (not isinstance(reference, ExactActivationReference)
+                or self._references.get(reference.name) != reference):
+            raise RuntimeError("exact boundary reference is stale or belongs to another generation")
+        identity = json.loads(reference.metadata_json)["identity"]
+        if identity["session"] != self.session or self._slots.get(identity["slot"]) != reference:
+            raise RuntimeError("exact boundary reference has a stale generation")
+        return identity
+
+    def write(self, tensor, *, batch_index, boundary_index, probe_index=None, previous=None):
+        from .perturbed_x_cache import write_exact_activation_cache_entry
+        if self._status != "running":
+            raise RuntimeError("exact boundary generation is not running")
+        kind = "boundary" if probe_index is None else "cotangent"
+        coordinates = {"batch": batch_index, "boundary": boundary_index, "probe": probe_index}
+        if any(type(v) is not int or v < 0 for v in (batch_index, boundary_index)):
+            raise ValueError("exact boundary coordinates must be nonnegative integers")
+        if probe_index is not None and (type(probe_index) is not int or not 0 <= probe_index < self._n_probes):
+            raise ValueError("exact cotangent probe coordinate is outside the run")
+        slot = f"boundary-{batch_index}-{boundary_index}" if probe_index is None else f"cotangent-{probe_index}-{batch_index}"
+        if previous is not None:
+            old = self._entry_identity(previous)
+            if (kind != "cotangent" or old["slot"] != slot
+                    or old["coordinates"]["boundary"] != boundary_index + 1):
+                raise RuntimeError("exact cotangent rollover changed its original coordinates")
+        elif slot in self._slots:
+            raise RuntimeError("exact boundary slot already exists")
+        nbytes = tensor.numel() * tensor.element_size()
+        # A bounded envelope for the exact writer's small PyTorch zip header.
+        # Actual file length is checked before the entry can be published.
+        file_limit = nbytes + 65536
+        if self.telemetry["live_artifact_bytes"] + file_limit > self.config["max_artifact_bytes"]:
+            raise RuntimeError("exact boundary artifact budget exceeded")
+        name = f"{slot}-at-{boundary_index}"
+        identity = {"session": self.session, "slot": slot, "kind": kind, "coordinates": coordinates}
+        self._reserve(nbytes)
+        try:
+            with torch.profiler.record_function("aura.exact_activation.write"):
+                reference = write_exact_activation_cache_entry(self.directory / "entries", name, tensor,
+                    identity=identity, max_tensor_bytes=nbytes, max_file_bytes=file_limit)
+        finally:
+            self._reserve(-nbytes)
+        self._references[name] = reference
+        self._slots[slot] = reference
+        self.telemetry["written_entries"] += 1
+        self.telemetry["written_tensor_bytes"] += nbytes
+        self.telemetry["live_artifact_bytes"] += reference.file_bytes
+        self.telemetry["peak_artifact_bytes"] = max(
+            self.telemetry["live_artifact_bytes"], self.telemetry["peak_artifact_bytes"])
+        if previous is not None:
+            self._retire(previous)
+        if self._check_memory is not None:
+            self._check_memory("exact activation publication")
+        return reference
+
+    def _retire(self, reference, *, missing_ok=False):
+        if self._references.get(reference.name) != reference:
+            raise RuntimeError("exact boundary retirement has a stale reference")
+        Path(reference.path).unlink(missing_ok=missing_ok)
+        del self._references[reference.name]
+        self.telemetry["live_artifact_bytes"] -= reference.file_bytes
+        self.telemetry["retired_entries"] += 1
+
+    def retire(self, reference):
+        identity = self._entry_identity(reference)
+        del self._slots[identity["slot"]]
+        self._retire(reference)
+
+    @contextmanager
+    def prefetch(self, references):
+        from .perturbed_x_cache import prefetch_exact_activation_cache_entries
+        if self._active_window is not None:
+            raise RuntimeError("exact boundary windows may not overlap")
+        references = tuple(references)
+        for reference in references:
+            self._entry_identity(reference)
+        with torch.profiler.record_function("aura.exact_activation.prefetch"):
+            context = prefetch_exact_activation_cache_entries(references,
+                expected_session=self.session, max_tensor_bytes=self.config["max_resident_bytes"],
+                residency_check=self._reserve)
+            window = context.__enter__()
+        self._active_window = window
+        self.telemetry["prefetch_windows"] += 1
+        self.telemetry["read_tensor_bytes"] += sum(ref.tensor_bytes for ref in references)
+        try:
+            yield window
+        finally:
+            self._active_window = None
+            context.__exit__(None, None, None)
+
+    def get(self, window, reference):
+        self._entry_identity(reference)
+        if window is not self._active_window:
+            raise RuntimeError("exact boundary lookup has no active resident window")
+        try:
+            return window.get(reference)
+        except RuntimeError:
+            self.telemetry["hot_read_misses"] += 1
+            raise
+
+    def __exit__(self, exc_type, exc, traceback):
+        # No working tensor reference is resumable. Cost checkpoint shards own
+        # successful measurements; a new attempt always uses a new generation.
+        self._status = "failed" if exc_type is not None else ("complete" if self.session else "unused")
+        try:
+            if self._active_window is not None or self.telemetry["resident_tensor_bytes"]:
+                raise RuntimeError("exact boundary generation closed with a live window")
+            for reference in list(self._references.values()):
+                self._retire(reference, missing_ok=True)
+            self._slots.clear()
+        except BaseException:
+            self._status = "failed"
+            raise
+        finally:
+            for batch in self._batches or ():
+                batch.activations_cpu.clear()
+                batch.input_ids = batch.position_ids = None
+                batch.position_embeddings = batch.attention_mask = batch.shared_pass_state = None
+            for row in self._cotangents or ():
+                for cotangent in row:
+                    cotangent.release_resident_state()
+                row.clear()
+            if self._batches is not None:
+                self._batches.clear()
+            if self._cotangents is not None:
+                self._cotangents.clear()
+            self._batches = self._cotangents = None
+            self._check_memory = None
+            self._publish_status()
+
+    def receipt(self):
+        return {"policy": self.identity, "session": self.session, "status": self._status,
+                "generation_manifest": str(self.directory / "generation.json") if self.directory else None,
+                "working_artifacts_reusable": False, "telemetry": dict(self.telemetry)}
+
+
+@contextmanager
+def prefetched_boundary_batches(storage, batches, boundary_index, incoming=None):
+    """Preserve original batch order while leasing exact tensors in windows."""
+    def iterate():
+        size = len(batches) if storage is None else storage.config["prefetch_batches"]
+        for start in range(0, len(batches), size):
+            indices = range(start, min(start + size, len(batches)))
+            if storage is None:
+                for index in indices:
+                    yield index, batches[index], batches[index].activations_cpu[boundary_index], (
+                        None if incoming is None else incoming[index])
+            else:
+                references = [batches[index].activations_cpu[boundary_index] for index in indices]
+                if incoming is not None:
+                    references.extend(incoming[index] for index in indices)
+                with storage.prefetch(references) as window:
+                    for index in indices:
+                        yield index, batches[index], storage.get(window, batches[index].activations_cpu[boundary_index]), (
+                            None if incoming is None else storage.get(window, incoming[index]))
+    iterator = iterate()
+    try:
+        yield iterator
+    finally:
+        iterator.close()
 
 
 class StreamedCausalLM:
@@ -173,7 +481,7 @@ class StreamedCausalLM:
         return self._head()(hidden)
 
     def capture_boundaries(
-        self, input_ids: torch.Tensor
+        self, input_ids: torch.Tensor, *, boundary_writer=None, resource_check=None,
     ) -> StreamedForwardBoundaries:
         """Stream a no-grad source forward and retain only boundary acts."""
         ids, position_ids, hidden, position_embeddings, attention_mask = (
@@ -188,7 +496,10 @@ class StreamedCausalLM:
             shared_pass_state=None,
         )
         pass_state = self.profile.new_forward_pass_state()
-        batch.activations_cpu.append(hidden.detach().to("cpu"))
+        if resource_check is not None:
+            resource_check(batch, pass_state)
+        batch.activations_cpu.append(hidden.detach().to("cpu") if boundary_writer is None
+                                     else boundary_writer(0, hidden))
         for depth in range(self.prefetch_lookahead):
             self.context.schedule_prefetch(depth)
         for layer in range(self.num_layers):
@@ -203,13 +514,18 @@ class StreamedCausalLM:
                     hidden = self._call(
                         layer, hidden, batch=batch, pass_state=pass_state
                     )
-                batch.activations_cpu.append(hidden.detach().to("cpu"))
+                if resource_check is not None:
+                    resource_check(batch, pass_state)
+                batch.activations_cpu.append(hidden.detach().to("cpu") if boundary_writer is None
+                                             else boundary_writer(layer + 1, hidden))
             finally:
                 if self._pinned_layer != layer:
                     self.context.unload(layer)
         batch.shared_pass_state = self.profile.capture_forward_pass_state(
             pass_state
         )
+        if resource_check is not None:
+            resource_check(batch, pass_state)
         return batch
 
     def isolated_layer(

--- a/prismaquant/perturbed_x_cache.py
+++ b/prismaquant/perturbed_x_cache.py
@@ -226,6 +226,162 @@ def release_activation_cache_file_pages(path, *, expected_stat):
         os.close(descriptor)
 
 
+EXACT_ACTIVATION_SCHEMA = "prismaquant.exact_activation_entry.v1"
+
+
+@dataclass(frozen=True)
+class ExactActivationReference:
+    """An immutable exact tensor receipt, never an activation sample/cache."""
+
+    path: str
+    name: str
+    metadata_json: str
+    shape: tuple[int, ...]
+    dtype: str
+    tensor_bytes: int
+    file_bytes: int
+    sha256: str
+
+
+def _exact_activation_json(value):
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+def _activation_file_signature(path):
+    import stat
+    value = Path(path).lstat()
+    if not stat.S_ISREG(value.st_mode):
+        raise RuntimeError("exact activation entry is not a regular file")
+    return (value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns, value.st_ctime_ns)
+
+
+def write_exact_activation_cache_entry(cache_dir, name, inputs, *, identity,
+                                       max_tensor_bytes, max_file_bytes,
+                                       release_file_pages=True):
+    """Extend the ordinary atomic writer with an exact tensor/identity receipt.
+
+    The caller reserves the one compact CPU copy before entering. No dtype,
+    row selection or shape change is allowed. Compact copying also prevents a
+    narrow view from serializing its entire source backing storage.
+    """
+    if not isinstance(inputs, torch.Tensor) or inputs.layout != torch.strided or inputs.is_meta:
+        raise TypeError("exact activation entry requires a materialized strided Tensor")
+    nbytes = inputs.numel() * inputs.element_size()
+    if not 0 < nbytes <= max_tensor_bytes:
+        raise RuntimeError("exact activation entry exceeds tensor residency budget")
+    metadata = {"schema": EXACT_ACTIVATION_SCHEMA, "identity": identity,
+                "shape": list(inputs.shape), "dtype": str(inputs.dtype), "tensor_bytes": nbytes}
+    encoded = _exact_activation_json(metadata)
+    path = Path(cache_dir) / activation_cache_filename(name)
+    if path.exists() or path.with_suffix(".pt.tmp").exists():
+        raise RuntimeError("exact activation entry already exists")
+    compact = None
+    try:
+        compact = inputs.detach().to(device="cpu", copy=True,
+            memory_format=torch.contiguous_format)
+        path = write_activation_cache_entry(cache_dir, name, compact,
+            source="exact_activation", durable=True, exact=metadata)
+        del compact
+        compact = None
+        published_stat = path.lstat()
+        signature = _activation_file_signature(path)
+        if signature[2] > max_file_bytes:
+            raise RuntimeError("exact activation entry exceeds file budget")
+        with path.open("rb") as handle:
+            digest = hashlib.file_digest(handle, "sha256").hexdigest()
+        if _activation_file_signature(path) != signature:
+            raise RuntimeError("exact activation entry changed during publication")
+        if release_file_pages:
+            release_activation_cache_file_pages(path, expected_stat=published_stat)
+        return ExactActivationReference(str(path), name, encoded, tuple(inputs.shape),
+            str(inputs.dtype), nbytes, signature[2], digest)
+    except BaseException:
+        path.unlink(missing_ok=True)
+        path.with_suffix(".pt.tmp").unlink(missing_ok=True)
+        raise
+    finally:
+        compact = None
+
+
+class _ExactActivationPrefetch:
+    """One borrowed, closed resident window; lookups never perform I/O."""
+
+    def __init__(self):
+        self._tensors = {}
+        self.active = False
+
+    def get(self, reference):
+        if not self.active or reference not in self._tensors:
+            raise RuntimeError("exact activation window is not ready for this entry")
+        return self._tensors[reference]
+
+
+@contextmanager
+def prefetch_exact_activation_cache_entries(references, *, max_tensor_bytes,
+                                            expected_session, residency_check=None,
+                                            release_file_pages=True):
+    """Read/verify the entire bounded window before exposing any tensor.
+
+    This is the existing activation artifact owner's exact-input read seam.
+    The consumer owns no additional cache and receives no lazy-loading path.
+    ``residency_check`` reserves/releases these tensors in its aggregate owner.
+    """
+    references = tuple(references)
+    if any(not isinstance(ref, ExactActivationReference) for ref in references):
+        raise TypeError("exact activation prefetch requires immutable references")
+    if len(set(references)) != len(references):
+        raise ValueError("exact activation window repeats an entry")
+    nbytes = sum(ref.tensor_bytes for ref in references)
+    if nbytes > max_tensor_bytes:
+        raise RuntimeError("exact activation prefetch exceeds tensor residency budget")
+    window = _ExactActivationPrefetch()
+    reserved = False
+    payload = tensor = None
+    try:
+        if residency_check is not None:
+            residency_check(nbytes)
+            reserved = True
+        for ref in references:
+            metadata = json.loads(ref.metadata_json)
+            if (metadata.get("schema") != EXACT_ACTIVATION_SCHEMA
+                    or metadata.get("identity", {}).get("session") != expected_session):
+                raise RuntimeError("exact activation reference has a different session identity")
+            path = Path(ref.path)
+            prefetched_stat = path.lstat()
+            signature = _activation_file_signature(path)
+            if signature[2] != ref.file_bytes:
+                raise RuntimeError("exact activation entry size changed")
+            with path.open("rb") as handle:
+                digest = hashlib.file_digest(handle, "sha256").hexdigest()
+            if digest != ref.sha256 or _activation_file_signature(path) != signature:
+                raise RuntimeError("exact activation entry checksum changed")
+            payload = torch.load(path, map_location="cpu", weights_only=True)
+            tensor = payload.get("inputs") if isinstance(payload, dict) else None
+            if (not isinstance(tensor, torch.Tensor) or tensor.layout != torch.strided
+                    or set(payload) != {"inputs", "name", "source", "exact"}
+                    or payload["name"] != ref.name or payload["source"] != "exact_activation"
+                    or _exact_activation_json(payload["exact"]) != ref.metadata_json
+                    or tuple(tensor.shape) != ref.shape or str(tensor.dtype) != ref.dtype
+                    or tensor.numel() * tensor.element_size() != ref.tensor_bytes
+                    or tensor.untyped_storage().nbytes() != ref.tensor_bytes
+                    or not tensor.is_contiguous() or tensor.requires_grad):
+                raise RuntimeError("exact activation entry tensor/metadata differs from its receipt")
+            if _activation_file_signature(path) != signature:
+                raise RuntimeError("exact activation entry changed during prefetch")
+            window._tensors[ref] = tensor
+            payload = tensor = None
+            if release_file_pages:
+                release_activation_cache_file_pages(path, expected_stat=prefetched_stat)
+        window.active = True
+        yield window
+    finally:
+        window.active = False
+        window._tensors.clear()
+        payload = tensor = None
+        if reserved:
+            residency_check(-nbytes)
+
+
 def _tensor_hash_update(h: "hashlib._Hash", tensor: torch.Tensor) -> None:
     t = tensor.detach().to("cpu").contiguous()
     h.update(str(tuple(t.shape)).encode())

--- a/prismaquant/sensitivity_probe.py
+++ b/prismaquant/sensitivity_probe.py
@@ -1834,6 +1834,23 @@ class SharedStateCotangents:
                     yield pos, item
 
     # -- diagnostics ------------------------------------------------------
+    def resident_tensors(self) -> tuple[torch.Tensor, ...]:
+        """Expose retained shared adjoints for the streamed owner's byte cap.
+
+        Call at layer boundaries after harvest; a live graft belongs to the
+        current autograd graph, so treating it as completed state must refuse.
+        """
+        if self._live or self._containers:
+            raise RuntimeError("shared cotangent residency queried before harvest")
+        return tuple(self._acc.values())
+
+    def release_resident_state(self) -> None:
+        """Release adjoints/graph references when their entire sweep closes."""
+        self._acc.clear()
+        self._live.clear()
+        self._live_ids.clear()
+        self._containers.clear()
+
     def pending_keys(self) -> list[tuple]:
         """Accumulated cotangents no producer ever claimed. Non-empty means the
         sweep never forwarded the producing layer (or it stopped writing the

--- a/prismaquant/tessera_joint_aura.py
+++ b/prismaquant/tessera_joint_aura.py
@@ -439,6 +439,8 @@ def _load_plan(path, digest):
     execution = config["execution"]
     from .joint_projection_backend import normalize_projection_backend
     normalize_projection_backend(execution.get("projection_backend"))
+    from .cost_streaming import normalize_boundary_storage
+    normalize_boundary_storage(execution.get("boundary_storage"))
     _require(type(config.get("file_hash_workers", 1)) is int and config.get("file_hash_workers", 1) > 0,
              "positive file_hash_workers required")
     for name, minimum in (("n_calib_samples", 1), ("calib_seqlen", 1),
@@ -616,6 +618,7 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False, source
                 seed_base=execution["seed_base"], token_scope="all", temperature=1.0,
                 production_cache=cache, require_production_cache=True, joint_activation=True,
                 joint_projection_backend=projection_backend,
+                boundary_storage=execution.get("boundary_storage"),
                 **({"source_transition": source_transition} if source_transition is not None else {}),
                 include_routed_experts=True, include_lm_head=False, dw_dtype="float32",
                 min_free_gib=config["min_free_gib"], formats_by_qname=data.formats_by_qname,

--- a/tests/test_streamed_boundary_artifacts.py
+++ b/tests/test_streamed_boundary_artifacts.py
@@ -1,0 +1,364 @@
+"""Exact source boundary residency and rolling cotangent regressions."""
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+from pathlib import Path
+import weakref
+
+import pytest
+import torch
+
+import prismaquant.aura_cost as aura
+from prismaquant.cost_streaming import (
+    BOUNDARY_STORAGE_SCHEMA, StreamedBoundaryArtifacts, normalize_boundary_storage,
+)
+from prismaquant.perturbed_x_cache import ExactActivationReference
+from test_joint_aura_streamed import _fixture
+from test_streamed_cost_checkpoints import _model_identity
+
+
+def _policy(path, *, window=2, cap=1280, aux=1 << 20, disk=1 << 24):
+    return {"schema": BOUNDARY_STORAGE_SCHEMA, "directory": str(path),
+            "max_resident_bytes": cap, "max_auxiliary_bytes": aux,
+            "max_artifact_bytes": disk, "prefetch_batches": window}
+
+
+def _bound(path, **kwargs):
+    owner = StreamedBoundaryArtifacts(_policy(path, **kwargs))
+    owner.bind({"fixture": "exact-source"}, n_probes=4)
+    return owner
+
+
+def _run(path, *, window=2, checkpoint=None, resume=False, owner_events=None):
+    _, context, runner, cache = _fixture()
+    source_events = []
+    original_call = runner._call
+    def call(layer, hidden, *, batch, pass_state):
+        source_events.append((int(batch.input_ids[0, 0]), layer, torch.is_grad_enabled()))
+        return original_call(layer, hidden, batch=batch, pass_state=pass_state)
+    runner._call = call
+    ids = torch.tensor([[1, 2, 3, 4], [4, 3, 2, 1], [2, 3, 4, 1],
+                        [3, 4, 1, 2], [1, 3, 2, 4]])
+    if owner_events is not None:
+        tail_call = runner.tail_logits
+        tail_calls = 0
+        def tail(batch, hidden):
+            nonlocal tail_calls
+            batch_index, probe_index = divmod(tail_calls, 4)
+            hidden.register_hook(lambda gradient, b=batch_index, k=probe_index:
+                owner_events.append((k, b, runner.num_layers, gradient.detach().clone())))
+            tail_calls += 1
+            return tail_call(batch, hidden)
+        runner.tail_logits = tail
+        reverse_call = runner.isolated_layer
+        reverse_calls = 0
+        def reverse(batch, layer, hidden, *, pass_state):
+            nonlocal reverse_calls
+            probe_index, batch_index = divmod(reverse_calls % 20, 5)
+            hidden.register_hook(lambda gradient, b=batch_index, k=probe_index, depth=layer:
+                owner_events.append((k, b, depth, gradient.detach().clone())))
+            reverse_calls += 1
+            return reverse_call(batch, layer, hidden, pass_state=pass_state)
+        runner.isolated_layer = reverse
+    payload = aura.compute_aura_cost_streamed(
+        runner, ids, ["FP8_DYNAMIC", "NVFP4A16", "BF16"], n_probes=4,
+        probe_microbatch=1, seed_base=7000, min_free_gib=0,
+        production_cache=cache, joint_activation=True, collect_col_energy=True,
+        model_identity=_model_identity("joint-source"), checkpoint_dir=checkpoint,
+        resume=resume, boundary_storage=(None if path is None else
+            _policy(path, window=window, cap=(2 * window + 1) * 256)),
+    )
+    return payload, source_events, context
+
+
+def test_full_draw_boundary_residency_is_bounded(tmp_path):
+    _, _, runner, _ = _fixture()
+    ids = torch.tensor([[1, 2, 3, 4]] * 5)
+    cap = 4 * 4 * 16 * 4
+    with _bound(tmp_path, cap=cap) as owner:
+        batches = [runner.capture_boundaries(row[None],
+            boundary_writer=lambda layer, tensor, batch=index: owner.write(
+                tensor, batch_index=batch, boundary_index=layer))
+            for index, row in enumerate(ids)]
+        assert all(isinstance(ref, ExactActivationReference)
+                   for batch in batches for ref in batch.activations_cpu)
+        resident = sum(t.untyped_storage().nbytes()
+                       for batch in batches for t in batch.activations_cpu
+                       if isinstance(t, torch.Tensor))
+        assert resident <= cap
+        assert owner.telemetry["peak_resident_tensor_bytes"] <= cap
+        refs = [batch.activations_cpu[0] for batch in batches]
+        with owner.prefetch(refs[:4]) as window:
+            assert all(owner.get(window, ref).shape == (1, 4, 16) for ref in refs[:4])
+        assert owner.telemetry["resident_tensor_bytes"] == 0
+    assert not list(tmp_path.rglob("*.pt"))
+    assert json.loads(next(tmp_path.rglob("generation.json")).read_text())["status"] == "complete"
+
+
+@pytest.mark.parametrize("window", [1, 2, 3])
+def test_exact_streamed_costs_cotangents_and_source_order_match_legacy(tmp_path, monkeypatch, window):
+    # Audit every propagated cotangent separately from final cost agreement.
+    seen = []
+    original_write = StreamedBoundaryArtifacts.write
+    def observe(self, tensor, **kwargs):
+        if kwargs.get("probe_index") is not None:
+            seen.append((kwargs["probe_index"], kwargs["batch_index"],
+                         kwargs["boundary_index"], tensor.detach().clone()))
+        return original_write(self, tensor, **kwargs)
+    monkeypatch.setattr(StreamedBoundaryArtifacts, "write", observe)
+    expected_gradients = []
+    expected, expected_events, _ = _run(None, owner_events=expected_gradients)
+    actual, actual_events, context = _run(tmp_path / "bounded", window=window)
+    assert actual_events == expected_events
+    assert actual["costs"] == expected["costs"]
+    assert context.active == set()
+    assert len(seen) == 4 * 5 * 3
+    assert {key[0] for key in seen} == {0, 1, 2, 3}
+    assert len(expected_gradients) == len(seen)
+    for expected_gradient, actual_gradient in zip(expected_gradients, seen):
+        assert actual_gradient[:3] == expected_gradient[:3]
+        assert torch.equal(actual_gradient[3], expected_gradient[3])
+    for name, row in actual["stats"].items():
+        assert row["h_trace"] == expected["stats"][name]["h_trace"]
+        assert torch.equal(row["fisher_col"], expected["stats"][name]["fisher_col"])
+    receipt = actual["provenance"]["streamed_boundary_storage"]
+    assert receipt["status"] == "complete"
+    assert receipt["telemetry"]["peak_resident_tensor_bytes"] <= (2 * window + 1) * 256
+    assert receipt["telemetry"]["live_artifact_bytes"] == 0
+    assert receipt["telemetry"]["hot_read_misses"] == 0
+    assert not list(tmp_path.rglob("*.pt"))
+    for rows in actual["costs"].values():
+        assert all(row["probe_ids"] == [7000, 7001, 7002, 7003] for row in rows.values())
+
+
+def test_exact_window_cannot_lazy_load_or_outlive_lease(tmp_path, monkeypatch):
+    import prismaquant.perturbed_x_cache as cache
+    with _bound(tmp_path) as owner:
+        first = owner.write(torch.randn(1, 4, 16), batch_index=0, boundary_index=0)
+        second = owner.write(torch.randn(1, 4, 16), batch_index=1, boundary_index=0)
+        with owner.prefetch([first]) as window:
+            def forbidden(*args, **kwargs):
+                raise AssertionError("disk read in active exact window")
+            monkeypatch.setattr(cache.torch, "load", forbidden)
+            assert owner.get(window, first).shape == (1, 4, 16)
+            with pytest.raises(RuntimeError, match="not ready"):
+                owner.get(window, second)
+            ref = weakref.ref(owner.get(window, first))
+        assert ref() is None
+        with pytest.raises(RuntimeError, match="active resident window"):
+            owner.get(window, first)
+
+
+def test_noncontiguous_snapshot_uses_one_compact_tensor_allocation(tmp_path):
+    # Transpose would preserve strides in ordinary Tensor.to(copy=True), then
+    # require a second full allocation for contiguous(). Both copies matter to
+    # a strict one-write-copy envelope; profiler self memory avoids double
+    # counting parent/child operators.
+    original = torch.arange(256, dtype=torch.float32).reshape(16, 16).T
+    nbytes = original.numel() * original.element_size()
+    with _bound(tmp_path, cap=nbytes) as owner:
+        with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU],
+                                    profile_memory=True) as profiler:
+            ref = owner.write(original, batch_index=0, boundary_index=0)
+        allocated = sum(max(0, event.self_cpu_memory_usage) for event in profiler.events())
+        assert allocated <= nbytes
+        with owner.prefetch([ref]) as window:
+            restored = owner.get(window, ref)
+            assert restored.is_contiguous()
+            assert restored.untyped_storage().nbytes() == nbytes
+            assert torch.equal(restored, original)
+            del restored
+
+
+@pytest.mark.parametrize("fault", ["missing", "checksum", "shape", "identity"])
+def test_exact_window_refuses_bad_receipts_before_exposing_tensors(tmp_path, fault):
+    with _bound(tmp_path) as owner:
+        ref = owner.write(torch.randn(1, 4, 16), batch_index=0, boundary_index=0)
+        if fault == "missing":
+            Path(ref.path).unlink()
+        elif fault == "checksum":
+            data = bytearray(Path(ref.path).read_bytes()); data[-1] ^= 1
+            Path(ref.path).write_bytes(data)
+        else:
+            bad = replace(ref, shape=(1, 8, 8)) if fault == "shape" else replace(ref, metadata_json='{}')
+            owner._references[ref.name] = bad
+            owner._slots["boundary-0-0"] = bad
+            ref = bad
+        with pytest.raises((RuntimeError, FileNotFoundError, KeyError)):
+            with owner.prefetch([ref]):
+                pytest.fail("bad entry exposed as ready")
+        assert owner.telemetry["resident_tensor_bytes"] == 0
+
+
+def test_rollover_refuses_stale_or_skipped_boundary_and_retires_only_previous(tmp_path):
+    with _bound(tmp_path) as owner:
+        old = owner.write(torch.ones(1, 4, 16), batch_index=0, boundary_index=2, probe_index=0)
+        with pytest.raises(RuntimeError, match="coordinates"):
+            owner.write(torch.zeros(1, 4, 16), batch_index=0, boundary_index=0, probe_index=0, previous=old)
+        new = owner.write(torch.zeros(1, 4, 16), batch_index=0, boundary_index=1, probe_index=0, previous=old)
+        assert not Path(old.path).exists() and Path(new.path).exists()
+        with pytest.raises(RuntimeError, match="stale"):
+            owner.write(torch.ones(1, 4, 16), batch_index=0, boundary_index=0, probe_index=0, previous=old)
+        with owner.prefetch([new]) as window:
+            assert torch.equal(owner.get(window, new), torch.zeros(1, 4, 16))
+
+
+def test_limits_refuse_before_copy_and_failure_cleans_owned_files(tmp_path, monkeypatch):
+    with _bound(tmp_path, cap=256) as owner:
+        with pytest.raises(RuntimeError, match="residency"):
+            owner.write(torch.zeros(2, 4, 16), batch_index=0, boundary_index=0)
+        ref = owner.write(torch.zeros(1, 4, 16), batch_index=0, boundary_index=0)
+        with owner.prefetch([ref]):
+            with pytest.raises(RuntimeError, match="residency"):
+                owner.write(torch.zeros(1, 4, 16), batch_index=1, boundary_index=0)
+    assert not list(tmp_path.rglob("*.pt*"))
+    with pytest.raises(RuntimeError, match="fixture write failure"):
+        with _bound(tmp_path) as owner:
+            import prismaquant.perturbed_x_cache as cache
+            original = cache.write_activation_cache_entry
+            def interrupted(*args, **kwargs):
+                result = original(*args, **kwargs)
+                raise RuntimeError("fixture write failure")
+            monkeypatch.setattr(cache, "write_activation_cache_entry", interrupted)
+            owner.write(torch.zeros(1, 4, 16), batch_index=0, boundary_index=0)
+    assert not list(tmp_path.rglob("*.pt*"))
+    assert {json.loads(p.read_text())["status"] for p in tmp_path.rglob("generation.json")} == {"complete", "failed"}
+
+
+def test_exact_storage_policy_is_closed_and_complete(tmp_path):
+    good = _policy(tmp_path)
+    assert normalize_boundary_storage(good) == good
+    for key in good:
+        with pytest.raises(ValueError):
+            normalize_boundary_storage({k: v for k, v in good.items() if k != key})
+    with pytest.raises(ValueError):
+        normalize_boundary_storage({**good, "prefetch_batches": True})
+
+
+def test_rank_four_boundaries_keep_all_residual_streams_and_original_dtype(tmp_path):
+    from prismaquant.model_profiles.default import DefaultProfile
+    class FourStreams(DefaultProfile):
+        def expand_hidden_for_layers(self, hidden, base_model):
+            return hidden.unsqueeze(2).expand(-1, -1, 4, -1).contiguous()
+        def collapse_hidden_after_layers(self, hidden, base_model):
+            return hidden.mean(dim=2)
+    _, _, runner, _ = _fixture()
+    runner.profile = FourStreams()
+    ids = torch.tensor([[1, 2, 3, 4]])
+    expected = runner.capture_boundaries(ids)
+    with _bound(tmp_path, cap=4096) as owner:
+        actual = runner.capture_boundaries(ids, boundary_writer=lambda layer, tensor:
+            owner.write(tensor, batch_index=0, boundary_index=layer))
+        for ref, tensor in zip(actual.activations_cpu, expected.activations_cpu):
+            with owner.prefetch([ref]) as window:
+                restored = owner.get(window, ref)
+                assert restored.shape == (1, 4, 4, 16)
+                assert restored.dtype == tensor.dtype
+                assert torch.equal(restored.view(torch.uint8), tensor.view(torch.uint8))
+                del restored
+
+
+def _shared_run(path, *, aux=1 << 20):
+    from types import SimpleNamespace
+    from test_kv_cotangent_path import _ToyModel, SHARED_SPECS
+    from test_streamed_cost_checkpoints import _FakeStreamingContext
+    from prismaquant.cost_streaming import StreamedCausalLM
+    from prismaquant.model_profiles.gemma4 import Gemma4Profile
+    from prismaquant.production_weight_cache import ProductionWeightCache
+    toy = _ToyModel(SHARED_SPECS, hidden=16, seed=91)
+    toy.config = SimpleNamespace(layer_types=())
+    model = torch.nn.Module()
+    model.model = toy
+    model.lm_head = toy.lm_head
+    context = _FakeStreamingContext(model)
+    runner = StreamedCausalLM(context, Gemma4Profile())
+    weights = {(name, "NVFP4A16"): module.weight.detach().clone() + 0.03125
+               for name, module in model.named_modules()
+               if isinstance(module, torch.nn.Linear) and ".layers." in name}
+    cache = ProductionWeightCache(weights=weights, levers={})
+    result = aura.compute_aura_cost_streamed(runner,
+        torch.tensor([[1, 2, 3, 4], [4, 3, 2, 1], [2, 1, 4, 3]]),
+        ["NVFP4A16", "BF16"], n_probes=4, probe_microbatch=1, seed_base=7000,
+        min_free_gib=0, joint_activation=True, production_cache=cache,
+        model_identity=_model_identity("shared-source"),
+        boundary_storage=None if path is None else _policy(path, cap=4096, aux=aux))
+    return result
+
+
+def test_shared_state_and_its_probe_cotangents_are_preserved_and_budgeted(tmp_path):
+    expected = _shared_run(None)
+    actual = _shared_run(tmp_path / "bounded")
+    assert actual["costs"] == expected["costs"]
+    telemetry = actual["provenance"]["streamed_boundary_storage"]["telemetry"]
+    assert telemetry["peak_shared_cotangent_reservation_bytes"] > 0
+    assert telemetry["peak_auxiliary_bytes"] > telemetry["peak_shared_cotangent_reservation_bytes"]
+    with pytest.raises(RuntimeError, match="auxiliary/shared-state"):
+        _shared_run(tmp_path / "refused", aux=1024)
+    assert not list((tmp_path / "refused").rglob("*.pt*"))
+    assert json.loads(next((tmp_path / "refused").rglob("generation.json")).read_text())["status"] == "failed"
+
+
+def test_opaque_shared_state_refuses_instead_of_hiding_tensor_ownership(tmp_path):
+    from types import SimpleNamespace
+    from prismaquant.cost_streaming import StreamedForwardBoundaries
+    batch = StreamedForwardBoundaries(torch.ones(1, 4, dtype=torch.int64), None,
+        None, None, [], SimpleNamespace(hidden=torch.ones(1024)))
+    with _bound(tmp_path) as owner:
+        with pytest.raises(TypeError, match="opaque state"):
+            owner.check_auxiliary([batch])
+
+
+def test_completed_resume_skips_generation_and_policy_change_refuses(tmp_path, monkeypatch):
+    monkeypatch.setattr(aura, "_checkpoint_git_commit", lambda: "1" * 40)
+    first, _, _ = _run(tmp_path / "working", checkpoint=tmp_path / "checkpoints")
+    actual, events, context = _run(tmp_path / "working", checkpoint=tmp_path / "checkpoints", resume=True)
+    assert actual["costs"] == first["costs"]
+    assert events == [] and context.install_calls == 0
+    assert actual["provenance"]["streamed_boundary_storage"]["status"] == "unused"
+    assert len(list((tmp_path / "working").iterdir())) == 1
+    with pytest.raises(RuntimeError, match="identity mismatch"):
+        _run(tmp_path / "working", window=1, checkpoint=tmp_path / "checkpoints", resume=True)
+
+
+def test_interrupted_cost_resume_uses_new_generation_and_original_signed_samples(tmp_path, monkeypatch):
+    monkeypatch.setattr(aura, "_checkpoint_git_commit", lambda: "1" * 40)
+    expected, _, _ = _run(None)
+    writer = aura._write_aura_unit_checkpoint
+    def interrupt(*args, **kwargs):
+        writer(*args, **kwargs)
+        raise RuntimeError("fixture interrupted cost checkpoint")
+    monkeypatch.setattr(aura, "_write_aura_unit_checkpoint", interrupt)
+    with pytest.raises(RuntimeError, match="fixture interrupted"):
+        _run(tmp_path / "working", checkpoint=tmp_path / "checkpoints")
+    assert not list((tmp_path / "working").rglob("*.pt*"))
+    failed = json.loads(next((tmp_path / "working").rglob("generation.json")).read_text())
+    assert failed["status"] == "failed" and failed["working_artifacts_reusable"] is False
+    monkeypatch.setattr(aura, "_write_aura_unit_checkpoint", writer)
+    actual, _, _ = _run(tmp_path / "working", checkpoint=tmp_path / "checkpoints", resume=True)
+    assert actual["costs"] == expected["costs"]
+    completed = actual["provenance"]["streamed_boundary_storage"]
+    assert completed["session"]["generation"] != failed["session"]["generation"]
+    assert not list((tmp_path / "working").rglob("*.pt*"))
+
+
+def test_failed_reverse_releases_windows_shared_state_and_hooks(tmp_path, monkeypatch):
+    seen_windows = []
+    import prismaquant.perturbed_x_cache as cache
+    original_get = cache._ExactActivationPrefetch.get
+    def get(self, reference):
+        value = original_get(self, reference)
+        seen_windows.append(weakref.ref(value))
+        return value
+    monkeypatch.setattr(cache._ExactActivationPrefetch, "get", get)
+    from prismaquant.cost_streaming import StreamedCausalLM
+    def fail(*args, **kwargs):
+        raise RuntimeError("fixture reverse refusal")
+    monkeypatch.setattr(StreamedCausalLM, "isolated_layer", fail)
+    with pytest.raises(RuntimeError, match="fixture reverse refusal"):
+        _run(tmp_path)
+    assert seen_windows and all(ref() is None for ref in seen_windows)
+    assert not list(tmp_path.rglob("*.pt*"))
+    record = json.loads(next(tmp_path.rglob("generation.json")).read_text())
+    assert record["status"] == "failed"
+    assert record["telemetry"]["resident_tensor_bytes"] == 0

--- a/tests/test_streamed_boundary_artifacts.py
+++ b/tests/test_streamed_boundary_artifacts.py
@@ -236,6 +236,18 @@ def test_exact_storage_policy_is_closed_and_complete(tmp_path):
         normalize_boundary_storage({**good, "prefetch_batches": True})
 
 
+def test_shared_state_mapping_keys_cannot_hide_tensor_or_opaque_owners(tmp_path):
+    from prismaquant.cost_streaming import StreamedForwardBoundaries
+    with _bound(tmp_path, aux=64) as owner:
+        key = torch.zeros(32)
+        batch = StreamedForwardBoundaries(None, None, None, None, [], {key: None})
+        with pytest.raises(RuntimeError, match="auxiliary/shared-state"):
+            owner.check_auxiliary([batch])
+        batch.shared_pass_state = {object(): None}
+        with pytest.raises(TypeError, match="opaque state"):
+            owner.check_auxiliary([batch])
+
+
 def test_rank_four_boundaries_keep_all_residual_streams_and_original_dtype(tmp_path):
     from prismaquant.model_profiles.default import DefaultProfile
     class FourStreams(DefaultProfile):


### PR DESCRIPTION
Streamed AURA's full calibration boundaries and incoming cotangents remain resident across the reverse pass, so B1 alone cannot bound their host footprint. Add an explicit versioned exact-artifact policy through the existing activation owner: immutable identity-bound references, one compact CPU write copy, checked bounded resident input windows, rolling cotangent retirement, and separate auxiliary/shared-state accounting (including mapping keys). Missing, corrupt, stale, oversized or opaque state refuses; interrupted cost resume uses a new nonreusable artifact generation.

Legacy callers remain default-off. Source traversal, complete sequence order, seeds, scalar projection arithmetic, PWC/dW and source-prefetch behavior are preserved. This does not establish full-GLM fit or GPU-bound throughput: batch-major source capture and candidate/gradient lifetimes remain separately gated. Architecture and design contracts are updated in the implementation commit.

Validation: initial legacy residency regression failed at 3,840 bytes against 1,024. PB CPU gate `0ad52f784868` passed 145 tests and seven module compile checks; one existing Gemma4 sweep-order case skipped because installed Transformers metadata lacks `kv_shared_layer_index`. The final mapping-key regression passed with all 20 focused owner tests (`62bf4b27e4ec`). Coverage includes byte-exact propagated cotangents and cost rows, uneven windows, rank-four streams, nonempty actual-profile shared state, failure/cleanup and checkpoint resume, plus a profiler-backed one-copy bound for noncontiguous input.

Native PB measurement `f8f2ab675f09` passed legacy/exact/exact/legacy on a genuine BF16 tiny GLM original-layout checkpoint, B1 five 17-token sequences, K4 seeds7000–7003, two KDA/DSA layers, four mHC streams and four routed experts. All 18 profile-unpinned dense/packed targets, 50 source calls and 60 cotangents per arm matched exactly. Captured CPU boundary ownership was 130,560 bytes in legacy and references only in exact mode; exact resident window plus write-copy peak was 43,520 bytes, with all 75 artifacts retired and no hot misses. CUDA allocated/reserved peaks were identical. Upstream Torch reference KDA/conv kernels, short calls, CPU instrumentation overhead and 4–13 W sampled device power make this a lifetime/parity qualification, not a speed or saturation claim.

Both-host Netdata, four CPU/CUDA traces, cProfile, source order, cotangent hashes and process I/O are retained in `/mnt/shared/tessera-measurements/glm-canonical-census-20260908/joint-boundary-native-03/`; verified terminal exit0, scope/container cleanup, canonical CAS receipts and hashed artifacts are audited in `joint-boundary-implementation-01/`. Failed fixture setup attempts and the deliberately deferred measurement remain recorded. The checked-in measurement report documents commands, skips, evidence and limits: `docs/measurements/joint-boundary-residency-2026-09-08.md`.

Closes #373.
