### PR TITLE
Enable selected-source Tessera anchors from canonical capture

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,23 @@
 As of: 2026-09-08 · `fix/selected-source-anchors`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-08, `fix/selected-source-anchors`) for bounded selected
+encoder-factor ownership (#370). The existing `(unit, scale_plane)` memo in a
+selected-source row retains at most `--anchor-batch-size` entries. Evicted
+factors are recomputed from the same resident uncapped H and producer settings;
+their values, wire bytes, scores and checkpoint identities remain unchanged.
+Admission charges that bounded memo plus a separate factorization transient.
+The existing export-input writer has its own phase: all selected H, X and
+weights remain resident while one complete Hessian sidecar and one tensor
+serialization temporary may coexist. Completed sidecar, rendered-weight and
+wire files receive verified page advice through the existing helper before
+encoding continues. This does not bound the sidecar writer's within-file peak;
+an indivisible full routed stack can therefore remain above admission.
+Selected weight bytes follow the loader's HF dtype plan, including strict FP32
+parameters; the skeleton's initial dtype does not authorize a cast or a budget.
+Resident-source campaign behavior remains unchanged. This establishes an
+ownership bound, not a throughput gain or full-GLM fit claim.
+
 Re-stamped (2026-09-08, `fix/selected-source-anchors`) for selected Tessera
 anchor preparation from a complete canonical capture (#370). `--streaming`
 with `--units` requires the capture manifest and its expected SHA-256. Scope,
@@ -14,16 +31,22 @@ cache and a finite selected-layer prefetch sequence, requires resident delivery,
 and copies selected logical expert views into independent storage. Completed
 source layers and fixed source state are released before selected X/H prefetch.
 
-The campaign planner reserves the larger of selected source preparation and
-resident anchor encoding, using source headers and the existing loader dtype
+The campaign planner reserves the largest of selected source preparation,
+export-input serialization and resident anchor encoding, using source headers and the existing loader dtype
 policy. It records the selected layers and phase terms in each planned row;
 PrismaBuild continues to own placement and admission. CUDA execution requires
-source-page advice and the existing finite-cgroup physical memory guard. The
-encoder memo is currently charged for every selected unit and all scale planes;
-a large selected stack may still exceed admission. This introduces no new
+source-page advice, immediate host allocator purge, and the existing
+finite-cgroup physical memory guard. Source weights and all selected H/X remain
+charged even with bounded encoder factors, so a selected stack may still exceed
+admission. This introduces no new
 capture, sampling policy, joint scope, serving format or numerical calibration.
 Gates: `tests/test_tessera_selected_source.py`,
 `tests/test_glm_campaign_streaming.py`, and existing capture/fanout/resume tests.
+With `--groups-per-row 1`, the canonical GLM census becomes 132 independent PB
+rows whose deterministic union covers all 36,423 units. Its 42 routed-stack
+groups each contain 864 logical units. The current planner cannot subdivide an
+exact full-stack group into smaller independently measured rows; statistical
+stack sampling is a different contract and does not fill that gap.
 
 Re-stamped (2026-09-08, `fix/capture-memory-lifetime`) for the bounded capture
 allocator contract (issue #366). The dispatcher seals `MIMALLOC_PURGE_DELAY=0`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,29 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `perf/tessera-layout-pricing`. Stamps
+As of: 2026-09-08 · `fix/selected-source-anchors`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `fix/selected-source-anchors`) for selected Tessera
+anchor preparation from a complete canonical capture (#370). `--streaming`
+with `--units` requires the capture manifest and its expected SHA-256. Scope,
+geometry, calibration draw, runtime, initialization witness and current source
+hashes remain bound to the full census. The initialization witness describes
+the historical capture; sparse preparation does not certify a new full-source
+forward. `StreamedCausalLM.snapshot_selected_weights` uses the existing layer
+cache and a finite selected-layer prefetch sequence, requires resident delivery,
+and copies selected logical expert views into independent storage. Completed
+source layers and fixed source state are released before selected X/H prefetch.
+
+The campaign planner reserves the larger of selected source preparation and
+resident anchor encoding, using source headers and the existing loader dtype
+policy. It records the selected layers and phase terms in each planned row;
+PrismaBuild continues to own placement and admission. CUDA execution requires
+source-page advice and the existing finite-cgroup physical memory guard. The
+encoder memo is currently charged for every selected unit and all scale planes;
+a large selected stack may still exceed admission. This introduces no new
+capture, sampling policy, joint scope, serving format or numerical calibration.
+Gates: `tests/test_tessera_selected_source.py`,
+`tests/test_glm_campaign_streaming.py`, and existing capture/fanout/resume tests.
 
 Re-stamped (2026-09-08, `perf/tessera-layout-pricing`) for producer-owned
 payload-free pricing. `tessera_footprint` uses Tessera's paired

--- a/docs/measurements/selected-source-anchors-2026-09-08.md
+++ b/docs/measurements/selected-source-anchors-2026-09-08.md
@@ -1,0 +1,96 @@
+# Selected-source Tessera anchors — 2026-09-08
+
+A complete canonical capture could previously be reused only after loading the
+whole model: `--streaming --units` exited before source preparation. Issue #370
+adds selected source preparation through the existing streaming layer cache.
+It verifies the complete census geometry, draw, source hashes, runtime and
+capture manifest, then snapshots only selected dense or declared logical-expert
+weights. Required layers arrive through resident prefetch; cloned expert views
+retain no packed parent storage. Source preparation performs zero forwards and
+releases the source model before selected uncapped H and retained X are loaded.
+The recorded initialization witness belongs to the completed canonical capture;
+it does not claim a new full-source initialization audit.
+
+The existing encoder memo retains at most the compatible anchor batch width
+for this path. Its deterministic eviction changes ownership, not producer
+inputs. Resident-source execution retains its prior policy. Admission derives
+source, export-input and encoder phase peaks from source headers and the shared
+loader dtype policy, including strict FP32 parameters. The existing physical
+cgroup guard checks selected CUDA execution; source page advice and immediate
+host allocator purge are required. Completed sidecar and PWC files use the
+existing verified page-release helper. The whole-file writer remains unchanged.
+
+## Qualification and evidence
+
+All tests ran through PrismaBuild. The evidence root is
+`/mnt/shared/tessera-measurements/glm-canonical-census-20260908/selected-source-anchors-01/`.
+`regression-before.json` records the original CLI regression failing at the
+streaming selection guard (action `d1f5a9da1405`). A separate strict-dtype test
+failed before correction (`38ae4c6fbd4d`): the meta skeleton incorrectly charged
+8 bytes for a strict FP32 plus ordinary BF16 pair requiring 6 bytes. The corrected
+shared loader snapshot preserves the original FP32 value exactly and passes the
+6-byte budget (`05c4e8d9ac25`, 7 passed). Its temporary regression worktree was
+retired after preserving `dtype-before-regression.patch` and the PB snapshot.
+
+The first native CUDA qualification on Sparklina used the immutable producer
+image `sha256:9f9b9f05b17531399ba66dc6415b054cf5d68c82270626d0e9150e75c808435f`,
+Torch 2.13/CUDA 13.0 and Transformers 5.16.1, reserving four CPUs, 24 GiB physical
+memory and a 16 GiB GPU subset. Action `40dba33a6fe0` passed 52 tests with no
+skips in 44.75 seconds. It covers a real tiny GLM original-layout checkpoint,
+full canonical capture, selected source reuse, a native Tessera anchor and
+resume identity, plus native wire/price equality for three units at two rungs.
+This preceded the final dtype-budget and export-page accounting additions.
+
+The memo comparison retained 786,432 bytes of owned factor tensors with three
+unbounded entries versus 262,144 bytes with capacity one, with identical native
+wire bytes and quality/cost rows. `native-bounded-01/memo-parity.json` records the
+comparison. Both `native-control-01/` and `native-bounded-01/` contain Torch
+CPU/CUDA memory traces, hash-bearing summaries, source receipts, and Netdata CPU,
+RAM, available-memory and power series from both Sparks. The parent canonical
+capture was external load on Sparky. These tiny cases establish ownership and
+numerical parity; their timings establish no speed or work-per-joule claim.
+
+The control attempt had one synthetic fixture failure caused by mocking its
+resource plan while allowing CUDA detection; real GLM tests passed. The fixture
+was explicitly made CPU-only before the 52-test native pass. An earlier CPU
+collection environment lacked compressed-tensors; the qualified pq-cpu312
+installation was used thereafter. The retained failure logs distinguish these
+setup errors from regressions.
+
+After the export-phase changes, five independent CPU PB shards passed 66 tests
+with two native-only skips (`cpu-export-phase.json`). The complete capture suite,
+including exact legacy/selected Hessian sidecar byte equality, passed 32 tests
+with no skips (`ced399e32b0e`). Earlier resume/fanout checks passed 61 tests;
+profile/header and packed-expert checks are recorded in `cpu-audit.json`.
+`final-audit.json` independently verifies terminal records, checkout snapshots,
+exit status and CAS result bytes for the final focused checks and the native
+qualification. Pytest used one native thread per process on DL380 with CPU Torch
+2.10 and Transformers 5.16.1; CUDA-only comparisons were covered on Sparklina.
+
+## Full GLM admission remains constrained
+
+The canonical census has 36,423 units. The existing planner with
+`--groups-per-row 1` yields 132 independent rows: 45 fused dense groups,
+45 dense singletons and 42 routed stacks. Each routed stack has 864 logical
+units and remains indivisible under the exact full-group contract. Statistical
+expert sampling is a different estimator and cannot stand in for exact coverage.
+
+Using the canonical census SHA-256
+`b63f7bf6c4320714b4ceb38fbd6996e032e0f0c9b82ac2a30a8337d846e358fd`,
+source headers and current dtype policy, action `8449e462362c` derived these
+phase maxima (GiB):
+
+| Representative group | Source preparation | Export inputs | Resident anchors | Admission |
+| --- | ---: | ---: | ---: | ---: |
+| Layer 0 fused gate/up | 28.140 | 25.134 | 26.258 | 28.140 |
+| Layer 0 down | 28.047 | 26.923 | 30.141 | 30.141 |
+| Layer 10 routed stack | 68.221 | 124.783 | 98.019 | 124.783 |
+
+`resource-inspection-invocation.json` and `full-glm-derived-resources.json`
+record the exact derivation. These are conservative bounds, not a full GLM
+execution or fit measurement. The earlier 98.019 GiB stack estimate omitted the
+Hessian writer's whole-file page owner and is superseded. The current writer
+can retain a full 40.5 GiB sidecar while H/X/weights remain resident, so this row
+must refuse a 104 GiB worker. Within-file bounded serialization and/or a supported
+exact smaller quantum require separate work. No partial capture becomes
+canonical, no joint scope is narrowed, and no serving format, menu or pin changes.

--- a/docs/measurements/selected-source-anchors-2026-09-08.md
+++ b/docs/measurements/selected-source-anchors-2026-09-08.md
@@ -94,3 +94,18 @@ can retain a full 40.5 GiB sidecar while H/X/weights remain resident, so this ro
 must refuse a 104 GiB worker. Within-file bounded serialization and/or a supported
 exact smaller quantum require separate work. No partial capture becomes
 canonical, no joint scope is narrowed, and no serving format, menu or pin changes.
+
+## Final integration qualification
+
+After dtype-budget, whole-file export accounting and completed-page advice
+changes, action `61a9da5bbf86` passed 60 native cases with no skips in 39.65
+seconds on Sparklina under the same image and reservation. This included the
+strict FP32 source regression, exact Hessian sidecar byte parity, real GLM
+selected-source/capture/anchor/resume and native memo wire/price comparisons.
+The PB terminal and CAS result both report exit zero, cleanup completed, and an
+independent Docker listing was empty. `native-final-invocation.json` binds the
+launch to source `ff839e4cf`; `final-audit.json` verifies its receipt and payload.
+
+After merging the portable-image adapter from main, action `ad8f283959ed`
+passed all 34 architecture, staleness and image-content cases on CPU. The final
+report addition is prose only. The full GLM fit limitation above is unchanged.

--- a/prismaquant/autoscale.py
+++ b/prismaquant/autoscale.py
@@ -126,6 +126,10 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
     raw_body, max_element_bytes = {}, 4
     packed_regex = profile.per_expert_moe_regex()
     packed_pattern = (re.compile(packed_regex.removeprefix('re:')) if packed_regex else None)
+    def resident_element_bytes(name):
+        match = None if dtype_pattern is None else dtype_pattern.search(name)
+        return (2 if match is None else torch.empty((), dtype=
+            dtype_plan[dtype_groups[match.lastgroup]]).element_size())
     for key, meta in header.items():
         name = profile.checkpoint_to_live_name(key, multimodal=multimodal)
         if name is None:
@@ -140,8 +144,7 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
             for suffix in sources:
                 if name.endswith(suffix):
                     target_name = name[:-len(suffix)]+target
-        match = None if dtype_pattern is None else dtype_pattern.search(target_name)
-        target_bytes = 2 if match is None else torch.empty((), dtype=dtype_plan[dtype_groups[match.lastgroup]]).element_size()
+        target_bytes = resident_element_bytes(target_name)
         size = max(stored, numel*target_bytes) if floating is not None else stored
         if (fp4_experts and str(meta['dtype']).upper() in _PACKED_BYTE_DTYPES
                 and declared_expert_dtype_covers(key)):
@@ -178,13 +181,22 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
                  for layer in range(layers)]
     loader_transient = min(prefetch_workers, cache_slots) * (
         max(pack_peak, default=0)+max(concat.values(), default=0))
-    h_by_layer, x_by_layer = {}, {}
+    h_by_layer, x_by_layer, unit_source_weight_bytes = {}, {}, {}
     total_h, total_x, widest_unit = 0, 0, 0
     for name, shape in unit_shapes.items():
         if not name.startswith(live_prefix):
             raise ValueError(f'capture unit is outside the decoder source scope: {name}')
         layer = int(name[len(live_prefix):].split('.', 1)[0])
         columns = int(shape[1])
+        parameter_name = name+'.weight'
+        if packed_pattern is not None and (packed_pattern.match(name) or
+                packed_pattern.match(profile.to_vllm_internal_name(name))):
+            owner, projection = name.rsplit('.', 1)
+            expert_path, expert = owner.rsplit('.', 1)
+            parent = profile.packed_expert_parent_for_projection(projection)
+            if parent is not None and expert.isdigit():
+                parameter_name = expert_path+'.'+parent
+        unit_source_weight_bytes[name] = math.prod(shape)*resident_element_bytes(parameter_name)
         h = columns*columns*4
         x = min(int(counts[name]), max_act_rows)*columns*4
         h_by_layer[layer] = h_by_layer.get(layer, 0)+h
@@ -215,6 +227,7 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
             separators=(',', ':')).encode()).hexdigest(),
         terms=terms, memory_bytes=sum(terms.values()), disk_bytes=disk,
         full_hessian_bytes=total_h, full_prefix_bytes=total_x,
+        unit_source_weight_bytes=unit_source_weight_bytes,
         body_layer_bytes={str(k): v for k, v in sorted(body.items())},
         body_loader_transient_bytes={str(k): pack_peak[k]+max(
             (size for key, size in concat.items() if key[0] == k), default=0)
@@ -282,8 +295,8 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
     """Bound selected-source preparation separately from resident encoding.
 
     This extends the source loader's header/dtype accounting. No source
-    forward or calibration accumulation occurs. Encoder factors currently
-    remain memoized for every selected unit and all three scale planes.
+    forward or calibration accumulation occurs. The existing plane-keyed
+    encoder memo retains at most one compatible batch's factors.
     """
     import math
     if not unit_shapes or type(anchor_batch_size) is not int or anchor_batch_size < 1:
@@ -294,7 +307,7 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
         headroom_gb=headroom_gb)
     prefix = source['live_layer_prefix']
     layers = sorted({str(int(name[len(prefix):].split('.', 1)[0])) for name in unit_shapes}, key=int)
-    weights = sum(math.prod(shape)*4 for shape in unit_shapes.values())
+    weights = sum(source['unit_source_weight_bytes'].values())
     widest_weight = max(math.prod(shape)*4 for shape in unit_shapes.values())
     widest_h = max(shape[1]**2*4 for shape in unit_shapes.values())
     widest_x = max(min(counts[name], max_act_rows)*shape[1]*4
@@ -309,18 +322,26 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
                                           reverse=True)[:min(prefetch_workers, cache_slots)]))
     encoding = dict(common, selected_hessian_bytes=source['full_hessian_bytes'],
         selected_prefix_bytes=source['full_prefix_bytes'],
-        encoder_memo_bytes=3*(source['full_hessian_bytes']+
-                            sum(shape[1]*4 for shape in unit_shapes.values())),
+        encoder_memo_bytes=anchor_batch_size*max(
+            shape[1]**2*4+shape[1]*8 for shape in unit_shapes.values()),
         factorization_scratch_bytes=4*widest_h,
         compatible_batch_weight_bytes=anchor_batch_size*widest_weight*4,
         entry_validation_bytes=2*(widest_h+widest_x),
         source_validation_bytes=sum(source['body_source_file_bytes'][k] for k in layers)+widest_weight)
-    phases = dict(source_preparation=preparation, resident_anchors=encoding)
+    export_inputs = dict(common, selected_hessian_bytes=source['full_hessian_bytes'],
+        selected_prefix_bytes=source['full_prefix_bytes'],
+        # The existing torch.save writer completes one file before it can
+        # advise its pages. Counts retain the whole census, not this subset.
+        export_input_file_bytes=source['full_hessian_bytes']+len(counts)*16384,
+        serialization_scratch_bytes=2*widest_h)
+    phases = dict(source_preparation=preparation, export_inputs=export_inputs,
+                  resident_anchors=encoding)
     return dict(schema='prismaquant.selected_anchor_resources.v1', phases=phases,
         memory_bytes=max(sum(phase.values()) for phase in phases.values()),
         selected_source_weight_bytes=weights, selected_layers=layers,
         source_header_sha256=source['source_header_sha256'],
-        encoder_memo_policy='all-selected-units-all-scale-planes',
+        encoder_memo_policy='compatible-anchor-batch-width',
+        encoder_memo_capacity=anchor_batch_size,
         source_forward_count=0)
 
 

--- a/prismaquant/autoscale.py
+++ b/prismaquant/autoscale.py
@@ -199,6 +199,11 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
         terms=terms, memory_bytes=sum(terms.values()), disk_bytes=disk,
         full_hessian_bytes=total_h, full_prefix_bytes=total_x,
         body_layer_bytes={str(k): v for k, v in sorted(body.items())},
+        body_loader_transient_bytes={str(k): pack_peak[k]+max(
+            (size for key, size in concat.items() if key[0] == k), default=0)
+            for k in range(layers)},
+        body_source_file_bytes={str(k): v for k, v in sorted(raw_body.items())},
+        live_layer_prefix=live_prefix,
         transient_status='conservative physical allocator bound for direct final-slab packer')
     if capture_policy != 'shared-inputs-bounded-v1':
         return result
@@ -252,6 +257,54 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
     # mutually exclusive phase maps, with the maximum defining admission.
     del result['terms']
     return result
+
+
+def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
+                              cache_slots, prefetch_workers, headroom_gb,
+                              anchor_batch_size=1):
+    """Bound selected-source preparation separately from resident encoding.
+
+    This extends the source loader's header/dtype accounting. No source
+    forward or calibration accumulation occurs. Encoder factors currently
+    remain memoized for every selected unit and all three scale planes.
+    """
+    import math
+    if not unit_shapes or type(anchor_batch_size) is not int or anchor_batch_size < 1:
+        raise ValueError('selected anchors require nonempty units and a positive batch size')
+    source = streamed_calibration_resources(model_path, unit_shapes=unit_shapes,
+        counts=counts, nsamples=1, seqlen=1, max_act_rows=max_act_rows,
+        cache_slots=cache_slots, prefetch_workers=prefetch_workers,
+        headroom_gb=headroom_gb)
+    prefix = source['live_layer_prefix']
+    layers = sorted({str(int(name[len(prefix):].split('.', 1)[0])) for name in unit_shapes}, key=int)
+    weights = sum(math.prod(shape)*4 for shape in unit_shapes.values())
+    widest_weight = max(math.prod(shape)*4 for shape in unit_shapes.values())
+    widest_h = max(shape[1]**2*4 for shape in unit_shapes.values())
+    widest_x = max(min(counts[name], max_act_rows)*shape[1]*4
+                   for name, shape in unit_shapes.items())
+    terms = source['terms']
+    common = dict(selected_source_weight_bytes=weights,
+                  declared_headroom_bytes=terms['declared_headroom_bytes'])
+    preparation = dict(common, nonbody_source_bytes=terms['nonbody_source_bytes'],
+        source_window_bytes=sum(sorted((source['body_layer_bytes'][k] for k in layers),
+                                       reverse=True)[:cache_slots]),
+        loader_transient_bytes=sum(sorted((source['body_loader_transient_bytes'][k] for k in layers),
+                                          reverse=True)[:min(prefetch_workers, cache_slots)]))
+    encoding = dict(common, selected_hessian_bytes=source['full_hessian_bytes'],
+        selected_prefix_bytes=source['full_prefix_bytes'],
+        encoder_memo_bytes=3*(source['full_hessian_bytes']+
+                            sum(shape[1]*4 for shape in unit_shapes.values())),
+        factorization_scratch_bytes=4*widest_h,
+        compatible_batch_weight_bytes=anchor_batch_size*widest_weight*4,
+        entry_validation_bytes=2*(widest_h+widest_x),
+        source_validation_bytes=sum(source['body_source_file_bytes'][k] for k in layers)+widest_weight)
+    phases = dict(source_preparation=preparation, resident_anchors=encoding)
+    return dict(schema='prismaquant.selected_anchor_resources.v1', phases=phases,
+        memory_bytes=max(sum(phase.values()) for phase in phases.values()),
+        selected_source_weight_bytes=weights, selected_layers=layers,
+        source_header_sha256=source['source_header_sha256'],
+        encoder_memo_policy='all-selected-units-all-scale-planes',
+        source_forward_count=0)
 
 
 def _num_layers(cfg: dict) -> int:

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -102,6 +102,84 @@ class StreamedCausalLM:
             )
         return layer
 
+    def snapshot_selected_weights(self, names, *, max_resident_bytes: int,
+                                  resource_check=None):
+        """Copy selected source Linears from the existing resident layer cache.
+
+        This is preparation for a consumer that already owns its ``weights``
+        mapping and needs no source forward. The finite layer sequence is
+        prefetched through StreamingContext; ordinary adjacent-layer top-up
+        is disabled so a sparse selection never reads unrelated layers.
+        Independent copies prevent an expert view from pinning its complete
+        packed parent after the source layer has been released.
+        """
+        from .routed_experts import (
+            profile_declared_packed_expert_projections,
+            refresh_packed_expert_projections,
+        )
+
+        names = tuple(names)
+        if not names or len(set(names)) != len(names):
+            raise ValueError("selected source requires unique nonempty unit names")
+        if type(max_resident_bytes) is not int or max_resident_bytes <= 0:
+            raise ValueError("selected source requires a positive resident byte budget")
+        if self._pinned_layer is not None:
+            raise RuntimeError("selected source cannot start with a pinned layer")
+        modules = dict(self.model.named_modules())
+        projected = {member.qname: member for member in
+                     profile_declared_packed_expert_projections(self.model, self.profile)}
+        shapes, layers = {}, {}
+        for name in sorted(names):
+            layer = self.layer_index_for_qname(name)
+            if name in projected:
+                weight = projected[name].weight
+            elif isinstance(modules.get(name), torch.nn.Linear):
+                weight = modules[name].weight
+            else:
+                raise RuntimeError(f"selected source unit is not a declared Linear: {name}")
+            shapes[name] = (tuple(weight.shape), weight.dtype, weight.numel() * weight.element_size())
+            layers.setdefault(layer, []).append(name)
+        del weight
+        required = sum(shape[2] for shape in shapes.values())
+        if required > max_resident_bytes:
+            raise RuntimeError("selected source weights exceed their resident byte budget")
+
+        ordered = sorted(layers)
+        window = max(1, min(self.prefetch_lookahead, self.context.max_cache_slots - 1))
+        weights, records = {}, []
+        for layer in ordered[:window]:
+            self.context.schedule_prefetch(layer)
+        for index, layer in enumerate(ordered):
+            source = self.context.install(layer, require_prefetched=True,
+                                          prefetch_following=False)
+            if index + window < len(ordered):
+                self.context.schedule_prefetch(ordered[index + window])
+            live = {}
+            try:
+                live = {member.qname: member for member in refresh_packed_expert_projections(
+                    [projected[name] for name in layers[layer] if name in projected], self.profile)}
+                with torch.no_grad():
+                    for name in layers[layer]:
+                        value = live[name].weight if name in live else modules[name].weight
+                        shape, dtype, nbytes = shapes[name]
+                        if value.is_meta or tuple(value.shape) != shape or value.dtype != dtype:
+                            raise RuntimeError(f"selected source has wrong resident tensor: {name}")
+                        if resource_check is not None:
+                            resource_check(f"before_selected_source_copy:{name}", reserve_bytes=nbytes)
+                        weights[name] = value.detach().clone(memory_format=torch.contiguous_format)
+                        del value
+                if self.device.type == "cuda":
+                    torch.cuda.synchronize(self.device)
+            finally:
+                live.clear()
+                self.context.release_completed_layer(layer)
+            records.append(dict(layer=layer, units=layers[layer], source=source))
+            if resource_check is not None:
+                resource_check(f"after_selected_source_release:{layer}")
+        return weights, dict(schema="prismaquant.selected_source_weights.v1",
+            units=sorted(weights), layers=records, resident_bytes=required,
+            source_forward_count=0, packed_parent_storage_retained=False)
+
     @contextmanager
     def pin_layer(self, layer: int) -> Iterator[None]:
         layer = int(layer)

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -133,11 +133,15 @@ class StreamedCausalLM:
             layer = self.layer_index_for_qname(name)
             if name in projected:
                 weight = projected[name].weight
+                parameter_name = projected[name].module_qname+'.'+projected[name].param_name
             elif isinstance(modules.get(name), torch.nn.Linear):
                 weight = modules[name].weight
+                parameter_name = name+'.weight'
             else:
                 raise RuntimeError(f"selected source unit is not a declared Linear: {name}")
-            shapes[name] = (tuple(weight.shape), weight.dtype, weight.numel() * weight.element_size())
+            dtype = getattr(self.context, 'buffer_dtypes', {}).get(parameter_name, self.dtype)
+            shapes[name] = (tuple(weight.shape), dtype,
+                            weight.numel()*torch.empty((), dtype=dtype).element_size())
             layers.setdefault(layer, []).append(name)
         del weight
         required = sum(shape[2] for shape in shapes.values())

--- a/prismaquant/streaming_model.py
+++ b/prismaquant/streaming_model.py
@@ -852,7 +852,8 @@ class StreamingContext:
         self.layer_cache.put(L, tensors)
         return tensors, "cold"
 
-    def install(self, L: int, *, require_prefetched: bool = False):
+    def install(self, L: int, *, require_prefetched: bool = False,
+                prefetch_following: bool = True):
         tensors, src = self.ensure_loaded(
             L, require_prefetched=require_prefetched,
         )
@@ -861,7 +862,8 @@ class StreamingContext:
         if audit is not None:
             audit.observe_layer(L, tensors)
         # Re-derive the lookahead window now that this layer's slot is free.
-        self._top_up_prefetch(L)
+        if prefetch_following:
+            self._top_up_prefetch(L)
         # v20 step 3+4: value-aware retention. The historical
         # one-way-stream assumption (discard immediately after install)
         # is wrong for multi-shard workloads where every phase-3 shard

--- a/prismaquant/tessera_calibration_cache.py
+++ b/prismaquant/tessera_calibration_cache.py
@@ -312,7 +312,8 @@ def require_capture_contract(path, expected_sha256=None):
 
 
 def prefetch_capture(path, *, expected_identity, census, names, device,
-                     expected_sha256=None):
+                     expected_sha256=None, resource_check=None,
+                     release_file_pages=False):
     """Verify selected files and make all selected X/H resident before encoding."""
     import torch
     from .perturbed_x_cache import activation_cache_filename
@@ -334,12 +335,26 @@ def prefetch_capture(path, *, expected_identity, census, names, device,
         if record.get('path') != relative:
             raise RuntimeError(f'{name}: noncanonical capture artifact path')
         artifact = path.parent/relative
-        if sha256(artifact) != record.get('sha256'):
+        file_stat = artifact.stat() if release_file_pages else None
+        if sha256(artifact, resource_check=resource_check,
+                  release_read_pages=release_file_pages) != record.get('sha256'):
             raise RuntimeError(f'{name}: capture artifact checksum mismatch')
+        if resource_check is not None:
+            columns = int(census['unit_shapes'][name][1])
+            resource_check(f'before_capture_prefetch:{name}', reserve_bytes=8*(
+                columns**2+min(census['counts'][name], expected_identity['max_act_rows'])*columns))
         payload = torch.load(artifact,map_location='cpu',weights_only=True)
         x,h = _validate_tensors(name,payload,census,expected_identity['max_act_rows'])
         acts[name],hessians[name] = x.to(device),h.to(device)
         counts[name],maxima[name] = payload['count'],payload['max_abs']
+        if release_file_pages:
+            from .perturbed_x_cache import release_activation_cache_file_pages
+            if str(device).startswith('cuda'):
+                torch.cuda.synchronize(device)
+            del payload, x, h
+            release_activation_cache_file_pages(artifact, expected_stat=file_stat)
+        if resource_check is not None:
+            resource_check(f'after_capture_prefetch:{name}')
     if str(device).startswith('cuda'):
         torch.cuda.synchronize(device)
     resident = sum(t.numel()*t.element_size() for t in (*acts.values(),*hessians.values()))

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -335,6 +335,26 @@ def _encode_and_render(weight, format_name: str, *, activation_kwargs=None,
     )
 
 
+def _activation_kwargs_memo(source, weights, device, *, max_entries=None,
+                            resource_check=None, factor_scratch_bytes=0):
+    """The campaign's existing plane-keyed memo, with an explicit owner bound."""
+    if max_entries is not None and (type(max_entries) is not int or max_entries < 1):
+        raise ValueError('encoder memo capacity must be positive or unbounded')
+
+    @functools.lru_cache(maxsize=max_entries)
+    def for_unit(name, scale_plane):
+        if resource_check is not None:
+            resource_check('before_selected_encoder_factors:'+name,
+                           reserve_bytes=factor_scratch_bytes)
+        kwargs = th.encoder_kwargs(source, name, int(weights[name].shape[1]),
+                                   device, scale_plane=scale_plane)
+        if resource_check is not None:
+            resource_check('after_selected_encoder_factors:'+name)
+        return kwargs
+
+    return for_unit
+
+
 def _measure_anchor(
     *, qname: str, weight, activations, format_name: str, cache, wire_dir: Path,
     activation_kwargs_for=None, hessian_required: bool = True,
@@ -358,7 +378,8 @@ def _measure_anchor(
     wasteful: no rate reaches that call, and a twelve-anchor surface would
     otherwise factorise the same Hessian twelve times.  The plane is constant
     across every rung of a family and differs between families, so the bound is
-    one factorisation per unit per family-plane.
+    one factorisation per unit per family-plane while retained. Selected
+    source campaigns bound the memo to the compatible anchor batch width.
 
     A **missing key is a hard failure**, never a silently H-free encode: this
     codebase has already been bitten once by a render whose activation lookup
@@ -493,6 +514,16 @@ def _finish_anchor(*, qname, weight, activations, format_name, cache, wire_dir,
     tmp = wire_path.with_suffix(".tessera.tmp")
     tmp.write_bytes(blob)
     os.replace(tmp, wire_path)
+    if getattr(cache, 'metadata', {}).get('release_completed_anchor_file_pages'):
+        # The existing PWC entry is already disk-backed. Completed anchor
+        # files must not accumulate an unbounded page-cache owner across rungs.
+        from .perturbed_x_cache import release_activation_cache_file_pages
+        from .tessera_calibration_cache import sha256
+        rendered_path = Path(cache.cache_dir)/cache.weights[(qname, format_name)]
+        for path in (rendered_path, wire_path):
+            expected = path.stat()
+            sha256(path, release_read_pages=True)
+            release_activation_cache_file_pages(path, expected_stat=expected)
 
     bits = spec.bits_for_shape(tuple(weight.shape))
     return CampaignAnchor(
@@ -3301,7 +3332,8 @@ def _require_resumable_anchor(anchor: CampaignAnchor, static_scales) -> None:
 
 
 def write_export_inputs(cache_dir: Path, *, hessians, hessian_rows,
-                        hessian_identity, static_scales, static_scale_policy):
+                        hessian_identity, static_scales, static_scale_policy,
+                        release_file_pages=False, resource_check=None):
     """Write the exporter's ``--hessian`` and ``--input-scales`` inputs.
 
     ``(hessian_capture_path | None, input_scales_path | None,
@@ -3365,6 +3397,14 @@ def write_export_inputs(cache_dir: Path, *, hessians, hessian_rows,
             sidecar.unlink()
         os.replace(tmp_capture, hessian_capture_path)
         os.replace(tmp_sidecar, sidecar)
+        if release_file_pages:
+            from .perturbed_x_cache import release_activation_cache_file_pages
+            from .tessera_calibration_cache import sha256
+            expected = hessian_capture_path.stat()
+            sha256(hessian_capture_path, resource_check=resource_check, release_read_pages=True)
+            release_activation_cache_file_pages(hessian_capture_path, expected_stat=expected)
+        if resource_check is not None:
+            resource_check('after_selected_export_input_write')
         print(f"[campaign] wrote {hessian_capture_path} "
               f"({len(saved_hessians)} Hessians, capture_sha256 "
               f"{capture_sha256[:12]})", flush=True)
@@ -4061,8 +4101,10 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     # keys the refit objective by plane (the exact quadratic on a CHANNEL row
     # scale, a diagonal power on the LUT plane's coupled blocks) and the two
     # measured answers disagree. The plane is a property of the family, not of
-    # the rung, so the memo is keyed by (unit, plane) and the bound is one
-    # factorisation per unit per family-plane. The source is built from the
+    # the rung, so the memo is keyed by (unit, plane). Selected-source rows
+    # retain at most one compatible batch's factors and deterministically
+    # recompute evicted entries; resident-source rows keep the historical
+    # memo. The source is built from the
     # same functions the production render calls (``tessera_hessian``), so the
     # campaign's price and the cache's render are one rendering of one draw
     # (principle 8).
@@ -4070,22 +4112,17 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     if want_h:
         calibration_source = th.activation_source(hessians, hessian_identity)
 
-    @functools.lru_cache(maxsize=None)
-    def _activation_kwargs_for(name: str, scale_plane) -> dict:
-        if selected_guard is not None:
-            selected_guard.check('before_selected_encoder_factors:'+name,
-                reserve_bytes=selected_resources['phases']['resident_anchors']['factorization_scratch_bytes'])
-        kwargs = th.encoder_kwargs(
-            calibration_source, name,
-            int(weights[name].shape[1]), device, scale_plane=scale_plane)
-        if selected_guard is not None:
-            selected_guard.check('after_selected_encoder_factors:'+name)
-        return kwargs
+    _activation_kwargs_for = _activation_kwargs_memo(calibration_source, weights, device,
+        max_entries=args.anchor_batch_size if selected_source else None,
+        resource_check=None if selected_guard is None else selected_guard.check,
+        factor_scratch_bytes=(selected_resources['phases']['resident_anchors']['factorization_scratch_bytes']
+                              if selected_source else 0))
 
     cache = ProductionWeightCache(
         weights={}, levers={"tessera_campaign": True},
         cache_dir=str(cache_dir),
-        metadata={"schema": SCHEMA, "menu_mode": mode},
+        metadata={"schema": SCHEMA, "menu_mode": mode,
+                  **({'release_completed_anchor_file_pages': True} if selected_source else {})},
     )
     menus = expand_menus_for_targets(
         weights, targets, mode=mode, tp_degree=args.tp_degree,
@@ -4289,6 +4326,10 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     # capture is then the whole scope's H under the whole scope's counts --
     # exactly the object a whole-scope run writes -- and the merge can prove it
     # by recomputing the digest.
+    if selected_guard is not None:
+        phase = selected_resources['phases']['export_inputs']
+        selected_guard.check('before_selected_export_input_write', reserve_bytes=
+            phase['export_input_file_bytes']+phase['serialization_scratch_bytes'])
     hessian_capture_path, input_scales_path, capture_sha256 = write_export_inputs(
         cache_dir,
         hessians=hessians if want_h else None,
@@ -4296,6 +4337,9 @@ def main(argv: "Sequence[str] | None" = None) -> int:
         hessian_identity=hessian_identity,
         static_scales=static_scales,
         static_scale_policy=static_scale_policy,
+        **(dict(release_file_pages=True,
+                resource_check=None if selected_guard is None else selected_guard.check)
+           if selected_source else {}),
     )
 
     # PrismaQuant #291 (filed here first as #288). A narrowing menu mode --

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -2939,7 +2939,8 @@ def _require_campaign_population(model, profile, layer_stride: int) -> ExpertPop
 
 def _project_expert_population(population: ExpertPopulation, *, weights, menus,
                                model_path, cache_dir: Path, measured=None,
-                               projection=None) -> tuple[dict, dict]:
+                               projection=None, resource_check=None,
+                               release_source_pages=False) -> tuple[dict, dict]:
     """Ask the producer to project every in-scope stack; bind it; check the bytes.
 
     Each request covers the whole campaign (the producer hashes the checkpoint
@@ -2994,7 +2995,8 @@ def _project_expert_population(population: ExpertPopulation, *, weights, menus,
         return carried, _checked_projected_units(
             bound, weights=weights, model_path=model_path,
             source=carried["producer"]["source"],
-            measured=measured)
+            measured=measured, resource_check=resource_check,
+            release_source_pages=release_source_pages)
 
     ladders: dict[str, list[tuple[str, int]]] = {}
     for stack, units in sorted(population.declared.items()):
@@ -3071,7 +3073,8 @@ def _project_expert_population(population: ExpertPopulation, *, weights, menus,
     carried["plan_attempts"] = attempts
     return carried, _checked_projected_units(
         bound, weights=weights, model_path=model_path,
-        source=answer["source"], measured=measured)
+        source=answer["source"], measured=measured,
+        resource_check=resource_check, release_source_pages=release_source_pages)
 
 
 def _checked_projected_units(bound, *, weights, model_path, source,
@@ -3679,7 +3682,7 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     ap.add_argument("--attention-implementation", choices=("eager", "sdpa"), default=None,
                     help="Explicit HF attention backend required for canonical census/capture.")
     ap.add_argument("--streaming", action="store_true",
-                    help="Use the existing source layer cache for canonical census/capture.")
+                    help="Use the source layer cache for census/capture or selected anchors from a complete capture.")
     ap.add_argument("--streaming-cache-slots", type=int, default=2)
     ap.add_argument("--streaming-prefetch-workers", type=int, default=1)
     ap.add_argument("--streaming-cache-headroom-gb", type=float, default=24)
@@ -3695,8 +3698,12 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     args = ap.parse_args(argv)
     if args.streaming_capture_policy != "legacy" and not (args.streaming and args.capture_calibration_out):
         ap.error("--streaming-capture-policy requires --streaming and --capture-calibration-out")
-    if args.streaming and (not (args.census_out or args.capture_calibration_out) or args.units):
-        ap.error("--streaming currently requires full-scope --census-out or --capture-calibration-out")
+    selected_source = bool(args.streaming and args.units and args.calibration_cache
+                           and args.calibration_cache_sha256
+                           and not (args.census_out or args.capture_calibration_out))
+    if args.streaming and not selected_source and (
+            not (args.census_out or args.capture_calibration_out) or args.units):
+        ap.error("--streaming requires full-scope census/capture or --units with a hash-bound complete calibration cache")
     if args.streaming and (args.streaming_cache_slots < 2 or args.streaming_prefetch_workers < 1):
         ap.error("streaming calibration requires at least two cache slots and one prefetch worker")
     if (args.census_out or args.capture_calibration_out or args.calibration_cache) and not args.attention_implementation:
@@ -3732,9 +3739,9 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             "H-aware encoder branch is merged."
         )
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    if (args.streaming_capture_policy == "shared-inputs-bounded-v1" and device == "cuda"
+    if ((args.streaming_capture_policy == "shared-inputs-bounded-v1" or selected_source) and device == "cuda"
             and os.environ.get("PRISMAQUANT_RELEASE_SOURCE_PAGES") != "1"):
-        raise RuntimeError("bounded CUDA capture requires PRISMAQUANT_RELEASE_SOURCE_PAGES=1")
+        raise RuntimeError("bounded CUDA source preparation requires PRISMAQUANT_RELEASE_SOURCE_PAGES=1")
     cache_dir = Path(args.cache_dir)
     cache_dir.mkdir(parents=True, exist_ok=True)
     wire_dir = cache_dir / "wire"
@@ -3796,6 +3803,7 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             pinned.append(name)
             continue
         all_dense.append(name)
+    del module  # Do not retain the final non-body module after source teardown.
     dense_targets = _campaign_layer_scope(all_dense, args.layer_stride)
     expert_targets = population.qnames
     expert_members = {member.qname: member for member in population.members}
@@ -3890,6 +3898,9 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     want_h = args.hessian == "require" and not census_only
     calibration_cache = None
     capture_identity = None
+    selected_source_preparation = None
+    selected_weights = None
+    selected_guard = None
     if census is not None:
         # Validate the whole scope before a selected unit's artifact is read.
         if (set(census["counts"]) != set(census_targets) or
@@ -3901,7 +3912,7 @@ def main(argv: "Sequence[str] | None" = None) -> int:
                              for member in population.members})
         if census["unit_shapes"] != scope_shapes:
             raise RuntimeError("calibration census geometry differs from the loaded model")
-    if runner is not None:
+    if runner is not None and not selected_source:
         try:
             return _run_streamed_calibration(args, runner, profile, mode=mode, population=population,
                 dense_targets=census_dense_targets, expert_targets=census_expert_targets,
@@ -3910,6 +3921,26 @@ def main(argv: "Sequence[str] | None" = None) -> int:
                 capture_runtime=capture_runtime)
         finally:
             runner.shutdown()
+    if selected_source:
+        from .autoscale import selected_anchor_resources
+        if (census.get('model_load_contract') or {}).get('schema') != 'prismaquant.streaming_initialization.v1':
+            raise RuntimeError('selected source requires the qualified streaming census witness')
+        # This describes the historical complete capture. This sparse source
+        # preparation makes no claim to repeat the full initialization audit.
+        model_load_contract = census['model_load_contract']
+        selected_resources = selected_anchor_resources(args.model,
+            unit_shapes={name: census['unit_shapes'][name] for name in targets},
+            counts=census['counts'], max_act_rows=args.max_act_rows,
+            cache_slots=args.streaming_cache_slots,
+            prefetch_workers=args.streaming_prefetch_workers,
+            headroom_gb=args.streaming_cache_headroom_gb,
+            anchor_batch_size=args.anchor_batch_size)
+        if device == 'cuda':
+            from .memory_management import CaptureMemoryGuard
+            selected_guard = CaptureMemoryGuard(device)
+            if selected_resources['memory_bytes'] > selected_guard.cap_bytes:
+                raise RuntimeError('selected anchor cgroup budget is smaller than its checked phase plan')
+            selected_guard.check('before_selected_capture_identity')
     if args.capture_calibration_out or args.calibration_cache:
         from . import tessera_calibration_cache as calibration_store
         hi, lo = census_token_counts(census, {})
@@ -3922,7 +3953,34 @@ def main(argv: "Sequence[str] | None" = None) -> int:
         capture_identity = calibration_store.capture_identity(
             args.calibration_census, calibration=bound_calibration,
             max_act_rows=args.max_act_rows, model_load_contract=model_load_contract,
-            attention_implementation=attention_implementation)
+            attention_implementation=attention_implementation,
+            **(dict(resource_check=None if selected_guard is None else selected_guard.check,
+                    release_read_pages=True) if selected_source else {}))
+    if selected_source:
+        manifest = calibration_store.require_capture_contract(args.calibration_cache,
+            expected_sha256=args.calibration_cache_sha256)
+        if manifest['identity'] != capture_identity:
+            raise RuntimeError('selected source capture identity differs from the canonical census')
+        try:
+            selected_weights, selected_source_preparation = runner.snapshot_selected_weights(
+                targets, max_resident_bytes=selected_resources['selected_source_weight_bytes'],
+                resource_check=None if selected_guard is None else selected_guard.check)
+        finally:
+            runner.shutdown()
+        selected_source_preparation.update(resources=selected_resources,
+            initialization_witness_origin='complete-canonical-capture',
+            full_source_initialization_repeated=False)
+        # Release fixed non-body state and the source context before selected
+        # H/X become resident. Packed members now reference only meta tensors.
+        del model, runner
+        runner = None
+        import gc
+        gc.collect()
+        torch.cuda.empty_cache()
+        if selected_guard is not None:
+            selected_guard.check('before_selected_capture_prefetch', reserve_bytes=
+                selected_resources['phases']['resident_anchors']['selected_hessian_bytes']+
+                selected_resources['phases']['resident_anchors']['selected_prefix_bytes'])
     if args.capture_calibration_out:
         completed_capture = Path(args.capture_calibration_out) / "capture_manifest.json"
         if completed_capture.exists():
@@ -3935,8 +3993,12 @@ def main(argv: "Sequence[str] | None" = None) -> int:
         values, calibration_cache = calibration_store.prefetch_capture(
             args.calibration_cache, expected_identity=capture_identity,
             census=census, names=targets, device=device,
-            expected_sha256=args.calibration_cache_sha256)
+            expected_sha256=args.calibration_cache_sha256,
+            **(dict(resource_check=None if selected_guard is None else selected_guard.check,
+                    release_file_pages=True) if selected_source else {}))
         acts, hessians, hessian_rows, act_max_abs = values
+        if selected_guard is not None:
+            selected_guard.check('after_selected_capture_prefetch')
     else:
         acts, hessians, hessian_rows, act_max_abs = _collect_activations(
             model, targets, tokens, 0 if census_only else args.max_act_rows, device,
@@ -3979,13 +4041,14 @@ def main(argv: "Sequence[str] | None" = None) -> int:
         act_max_abs if census is None else census_max_abs(census, act_max_abs),
         profile=profile)
 
-    weights = {name: dict(model.named_modules())[name].weight.detach()
-               for name in dense_targets}
-    for name, member in expert_members.items():
-        # The profile-declared 2-D view of the live packed parameter; checked
-        # byte-for-byte against the producer's source tensor below.
-        weights[name] = member.weight.detach()
-    del model
+    if selected_weights is not None:
+        weights = selected_weights
+    else:
+        weights = {name: dict(model.named_modules())[name].weight.detach()
+                   for name in dense_targets}
+        for name, member in expert_members.items():
+            weights[name] = member.weight.detach()
+        del model
     torch.cuda.empty_cache()
 
     # ONE ActivationSource for the whole campaign, and ONE set of encoder
@@ -4007,9 +4070,15 @@ def main(argv: "Sequence[str] | None" = None) -> int:
 
     @functools.lru_cache(maxsize=None)
     def _activation_kwargs_for(name: str, scale_plane) -> dict:
-        return th.encoder_kwargs(
+        if selected_guard is not None:
+            selected_guard.check('before_selected_encoder_factors:'+name,
+                reserve_bytes=selected_resources['phases']['resident_anchors']['factorization_scratch_bytes'])
+        kwargs = th.encoder_kwargs(
             calibration_source, name,
             int(weights[name].shape[1]), device, scale_plane=scale_plane)
+        if selected_guard is not None:
+            selected_guard.check('after_selected_encoder_factors:'+name)
+        return kwargs
 
     cache = ProductionWeightCache(
         weights={}, levers={"tessera_campaign": True},
@@ -4052,7 +4121,9 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             population, weights=weights, menus=menus,
             model_path=args.model, cache_dir=cache_dir,
             measured=set(expert_targets),
-            projection=(None if census is None else census.get("expert_projection")))
+            projection=(None if census is None else census.get("expert_projection")),
+            **(dict(resource_check=None if selected_guard is None else selected_guard.check,
+                    release_source_pages=True) if selected_source else {}))
         print(f"[campaign] producer projected {len(expert_projection['stacks'])} stacks; "
               f"{len(projected_units)} expert units priced here", flush=True)
 
@@ -4469,9 +4540,13 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             except (HessianContractError, ActivationScaleContractError):
                 raise
             except Exception as exc:
+                if selected_guard is not None and selected_guard.failure is not None:
+                    raise  # A physical memory refusal must stop the action.
                 print(f"[campaign] {names} {fmt}: FAILED {type(exc).__name__}: "
                       f"{exc}", flush=True)
                 continue
+            if selected_guard is not None:
+                selected_guard.check('after_selected_anchor_batch')
             for anchor in anchors:
                 name = anchor.qname
                 identity = _checkpoint_anchor_identity(
@@ -4636,6 +4711,9 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             # module (trellis_input_global_scale), so this block is what makes
             # "the priced A side is the served A side" checkable downstream.
             "calibration_cache": calibration_cache,
+            **({"selected_source_preparation": dict(selected_source_preparation,
+                  memory_guard=None if selected_guard is None else selected_guard.snapshot())}
+               if selected_source else {}),
             "activation_static_scales": {
                 "policy": str(static_scale_policy),
                 "source": "campaign_calibration_amax_fused_unified",

--- a/tests/test_glm_campaign_streaming.py
+++ b/tests/test_glm_campaign_streaming.py
@@ -255,6 +255,52 @@ def test_streamed_campaign_publishes_original_layout_census_and_capture(glm_chec
             else:
                 assert guard is None
 
+        # Reuse that actual complete capture through the selected-source CLI,
+        # including one real pinned-producer anchor and a checkpoint resume.
+        import pickle
+        dense_group = next(key for key in result['anchor_groups']
+                           if key.startswith('u:') and '.experts.' not in key)
+        names = result['anchor_groups'][dense_group]
+        selection_path = tmp_path/'selected-units.json'
+        selection_path.write_text(json.dumps(dict(schema=campaign.UNITS_SCHEMA,
+            model=str(source), layer_stride=1,
+            groups=[dict(key=dense_group, members=names)])))
+        def no_forward(*args, **kwargs):
+            pytest.fail('selected anchor reuse repeated calibration')
+        monkeypatch.setattr(campaign, '_collect_activations', no_forward)
+        original_menus = campaign.expand_menus_for_targets
+        def one_rung(weights, targets, **kwargs):
+            assert set(weights) == set(names)
+            assert all(not value.is_meta for value in weights.values())
+            menus = original_menus(weights, targets, **kwargs)
+            narrowed = {name: [row for row in rows
+                if row.format_name == 'TESSERA_E4M3_K1_R1024'] for name, rows in menus.items()}
+            assert all(narrowed.values()), 'native fixture must admit the measured rung'
+            return narrowed
+        monkeypatch.setattr(campaign, 'expand_menus_for_targets', one_rung)
+        selected_out = tmp_path/'selected-cost.pkl'
+        selected_argv = [*common, '--out', str(selected_out),
+            '--cache-dir', str(tmp_path/'selected-cache'), '--units', str(selection_path),
+            '--calibration-census', str(census), '--calibration-cache', str(shared_manifest),
+            '--calibration-cache-sha256', capture.sha256(shared_manifest),
+            '--max-rounds', '1']
+        assert campaign.main(selected_argv) == 0
+        with selected_out.open('rb') as handle:
+            selected = pickle.load(handle)
+        assert set(selected['costs']) == set(names)
+        receipt = selected['provenance']['selected_source_preparation']
+        assert receipt['source_forward_count'] == 0
+        assert receipt['full_source_initialization_repeated'] is False
+        assert all(row['source'] != 'cold' for row in receipt['layers'])
+        journal = selected_out.with_suffix('.anchors.json')
+        first = json.loads(journal.read_text())
+        assert campaign.main(selected_argv) == 0
+        second = json.loads(journal.read_text())
+        assert first['identity_sha256'] == second['identity_sha256']
+        with selected_out.open('rb') as handle:
+            resumed = pickle.load(handle)
+        assert selected['costs'] == resumed['costs']
+
 
 def test_streamed_bf16_keeps_hf_strict_fp32_source_slots(glm_checkpoint, tmp_path):
     """BF16 forward weights retain HF-declared strict FP32 recurrence state."""
@@ -284,6 +330,43 @@ def test_streamed_bf16_keeps_hf_strict_fp32_source_slots(glm_checkpoint, tmp_pat
             runner.context.unload(layer)
         assert any(name.endswith('conv1d.weight') for name in observed)
         assert any(name.endswith('e_score_correction_bias') for name in observed)
+    finally:
+        runner.shutdown()
+
+
+def test_selected_glm_source_copies_dense_and_logical_expert_without_forward(glm_checkpoint, tmp_path, monkeypatch):
+    from prismaquant.routed_experts import profile_declared_packed_expert_projections
+    from prismaquant.autoscale import selected_anchor_resources
+    reference, source = glm_checkpoint
+    profile = Glm5NextProfile()
+    expert = profile_declared_packed_expert_projections(reference, profile)[0]
+    dense = next(name for name, module in reference.named_modules()
+                 if isinstance(module, torch.nn.Linear) and '.layers.0.mlp.' in name)
+    expected = {dense: dict(reference.named_modules())[dense].weight, expert.qname: expert.weight}
+    shapes = {name: list(value.shape) for name, value in expected.items()}
+    resources = selected_anchor_resources(source, unit_shapes=shapes,
+        counts={name: 257 for name in shapes}, max_act_rows=7,
+        cache_slots=2, prefetch_workers=1, headroom_gb=0)
+    runner = build_streamed_causal_lm(str(source), device=torch.device('cpu'),
+        dtype=torch.float32, offload_folder=str(tmp_path/'selected-offload'),
+        profile=profile, max_cache_slots=2, prefetch_workers=1,
+        prefetch_min_available_gb=0, cache_headroom_gb=0,
+        prefetch_lookahead=1, require_prefetched_residency=True,
+        attn_implementation='eager')
+    def no_forward(*args, **kwargs):
+        pytest.fail('selected source must not run a calibration forward')
+    monkeypatch.setattr(runner.model, 'forward', no_forward)
+    try:
+        weights, receipt = runner.snapshot_selected_weights(list(expected),
+            max_resident_bytes=resources['selected_source_weight_bytes'])
+        for name in expected:
+            assert torch.equal(weights[name], expected[name])
+            assert weights[name].untyped_storage().nbytes() == weights[name].numel()*weights[name].element_size()
+        assert receipt['source_forward_count'] == 0
+        assert [row['layer'] for row in receipt['layers']] == sorted({runner.layer_index_for_qname(n) for n in expected})
+        assert all(p.is_meta for layer in runner.layers for p in layer.parameters())
+        assert runner.context.layer_cache._cache == {}
+        assert runner.context._inflight == {}
     finally:
         runner.shutdown()
 

--- a/tests/test_glm_campaign_streaming.py
+++ b/tests/test_glm_campaign_streaming.py
@@ -284,11 +284,31 @@ def test_streamed_campaign_publishes_original_layout_census_and_capture(glm_chec
             '--calibration-census', str(census), '--calibration-cache', str(shared_manifest),
             '--calibration-cache-sha256', capture.sha256(shared_manifest),
             '--max-rounds', '1']
-        assert campaign.main(selected_argv) == 0
+        profile_root = os.environ.get('PRISMAQUANT_SELECTED_SOURCE_PROFILE')
+        if profile_root:
+            import time
+            profile_root = Path(profile_root)
+            profile_root.mkdir(parents=True, exist_ok=True)
+            activities = [torch.profiler.ProfilerActivity.CPU]
+            if torch.cuda.is_available():
+                activities.append(torch.profiler.ProfilerActivity.CUDA)
+                torch.cuda.reset_peak_memory_stats()
+            started = time.time()
+            with torch.profiler.profile(activities=activities, profile_memory=True,
+                                       record_shapes=True) as prof:
+                assert campaign.main(selected_argv) == 0
+            prof.export_chrome_trace(str(profile_root/'selected-anchor.trace.json'))
+            (profile_root/'window.json').write_text(json.dumps(dict(start_unix=started,
+                end_unix=time.time(), cuda_max_allocated_bytes=(
+                    torch.cuda.max_memory_allocated() if torch.cuda.is_available() else None))))
+        else:
+            assert campaign.main(selected_argv) == 0
         with selected_out.open('rb') as handle:
             selected = pickle.load(handle)
         assert set(selected['costs']) == set(names)
         receipt = selected['provenance']['selected_source_preparation']
+        if profile_root:
+            (profile_root/'selected-source-receipt.json').write_text(json.dumps(receipt, indent=2)+'\n')
         assert receipt['source_forward_count'] == 0
         assert receipt['full_source_initialization_repeated'] is False
         assert all(row['source'] != 'cold' for row in receipt['layers'])
@@ -342,13 +362,14 @@ def test_selected_glm_source_copies_dense_and_logical_expert_without_forward(glm
     expert = profile_declared_packed_expert_projections(reference, profile)[0]
     dense = next(name for name, module in reference.named_modules()
                  if isinstance(module, torch.nn.Linear) and '.layers.0.mlp.' in name)
-    expected = {dense: dict(reference.named_modules())[dense].weight, expert.qname: expert.weight}
+    expected = {dense: dict(reference.named_modules())[dense].weight.to(torch.bfloat16),
+                expert.qname: expert.weight.to(torch.bfloat16)}
     shapes = {name: list(value.shape) for name, value in expected.items()}
     resources = selected_anchor_resources(source, unit_shapes=shapes,
         counts={name: 257 for name in shapes}, max_act_rows=7,
         cache_slots=2, prefetch_workers=1, headroom_gb=0)
     runner = build_streamed_causal_lm(str(source), device=torch.device('cpu'),
-        dtype=torch.float32, offload_folder=str(tmp_path/'selected-offload'),
+        dtype=torch.bfloat16, offload_folder=str(tmp_path/'selected-offload'),
         profile=profile, max_cache_slots=2, prefetch_workers=1,
         prefetch_min_available_gb=0, cache_headroom_gb=0,
         prefetch_lookahead=1, require_prefetched_residency=True,

--- a/tests/test_streaming_buffer_precision.py
+++ b/tests/test_streaming_buffer_precision.py
@@ -73,8 +73,8 @@ def test_streaming_cache_preserves_declared_buffer_precision(tmp_path, prefetch)
         context.shutdown()
 
 
-@pytest.mark.parametrize('mode', ['resident', 'cold', 'prefetch'])
-def test_checkpoint_strict_fp32_parameters_keep_source_bytes(tmp_path, mode):
+@pytest.mark.parametrize('mode', ['resident', 'cold', 'prefetch', 'selected'])
+def test_checkpoint_strict_fp32_parameters_keep_source_bytes(tmp_path, mode, monkeypatch):
     from transformers import PreTrainedModel
 
     class PolicyModel(nn.Module):
@@ -92,7 +92,7 @@ def test_checkpoint_strict_fp32_parameters_keep_source_bytes(tmp_path, mode):
     with torch.no_grad():
         layer.strict.weight.copy_(value)
         layer.ordinary.weight.copy_(value)
-    path = tmp_path / 'strict.safetensors'
+    path = tmp_path / 'model.safetensors'
     save_file(model.state_dict(), str(path))
     keys = {name: name for name in model.state_dict()}
     shards = dict.fromkeys(keys, str(path))
@@ -112,9 +112,37 @@ def test_checkpoint_strict_fp32_parameters_keep_source_bytes(tmp_path, mode):
         layers_prefix='layers.', num_layers=1,
         install_resolvers=[_build_install_resolver(model, 'layers.0')],
         weight_shard=shards, weight_ckpt=keys,
-        layer_cache=LayerCache(max_bytes=1024), prefetch_pool=ThreadPoolExecutor(max_workers=1),
+        layer_cache=LayerCache(max_bytes=1024, max_entries=2), prefetch_pool=ThreadPoolExecutor(max_workers=1),
         device=torch.device('cpu'), dtype=torch.bfloat16, offload_folder=str(tmp_path))
     try:
+        if mode == 'selected':
+            import json
+            from prismaquant import autoscale, model_profiles, streaming_model
+            from prismaquant.cost_streaming import StreamedCausalLM
+            from prismaquant.model_profiles import DefaultProfile
+            profile = DefaultProfile()
+            monkeypatch.setattr(profile, 'body_layer_prefix', lambda: 'layers')
+            monkeypatch.setattr(model_profiles, 'detect_profile', lambda _: profile)
+            monkeypatch.setattr(streaming_model, '_resolve_declared_model_cls', lambda *_: PolicyModel)
+            (tmp_path/'config.json').write_text(json.dumps(dict(model_type='llama',
+                hidden_size=1, num_hidden_layers=1, num_attention_heads=1,
+                num_key_value_heads=1, intermediate_size=1, vocab_size=8)))
+            shapes = {'layers.0.strict': [1, 1], 'layers.0.ordinary': [1, 1]}
+            plan = autoscale.selected_anchor_resources(tmp_path, unit_shapes=shapes,
+                counts=dict.fromkeys(shapes, 1), max_act_rows=1, cache_slots=2,
+                prefetch_workers=1, headroom_gb=0)
+            assert plan['selected_source_weight_bytes'] == 6
+            runner = StreamedCausalLM(context, profile, prefetch_lookahead=1,
+                                     require_prefetched_residency=True)
+            weights, receipt = runner.snapshot_selected_weights(
+                ['layers.0.strict', 'layers.0.ordinary'],
+                max_resident_bytes=plan['selected_source_weight_bytes'])
+            assert receipt['resident_bytes'] == 6
+            assert weights['layers.0.strict'].dtype == torch.float32
+            assert torch.equal(weights['layers.0.strict'], value)
+            assert weights['layers.0.ordinary'].dtype == torch.bfloat16
+            assert all(parameter.is_meta for parameter in layer.parameters())
+            return
         if mode == 'prefetch':
             context.schedule_prefetch(0)
         context.install(0, require_prefetched=mode == 'prefetch')

--- a/tests/test_tessera_calibration_cache.py
+++ b/tests/test_tessera_calibration_cache.py
@@ -57,6 +57,22 @@ def test_prefetch_only_selected_and_preserves_full_h_and_prefix_precision(captur
     assert values[2] == {'a':5}
 
 
+def test_selected_prefetch_guards_and_advises_verified_files(capture, monkeypatch):
+    from prismaquant import perturbed_x_cache
+    root, path, census, identity, acts, hessians, record = capture
+    observed, advised = [], []
+    monkeypatch.setattr(perturbed_x_cache, 'release_activation_cache_file_pages',
+        lambda path, *, expected_stat: advised.append((path.name, expected_stat.st_size)))
+    values, _ = cc.prefetch_capture(record['path'], expected_identity=identity,
+        census=census, names=['a'], device='cpu', expected_sha256=record['sha256'],
+        release_file_pages=True, resource_check=lambda label, **kwargs: observed.append((label, kwargs)))
+    assert advised == [('a.pt', (root/'inputs/a.pt').stat().st_size)]
+    assert ('before_capture_prefetch:a', {'reserve_bytes': 64}) in observed
+    assert observed[-1] == ('after_capture_prefetch:a', {})
+    assert torch.equal(values[0]['a'], acts['a'])
+    assert torch.equal(values[1]['a'], hessians['a'])
+
+
 @pytest.mark.parametrize('change',['artifact','manifest','source','draw','geometry','scope'])
 def test_prefetch_refuses_drift(capture,change):
     root,path,census,identity,acts,hessians,record = capture
@@ -134,11 +150,20 @@ def test_layer_writer_refuses_insufficient_disk(capture, tmp_path, monkeypatch):
         cc.CaptureWriter(tmp_path/'no-space', census_path=path, identity=identity)
 
 
-def test_cli_capture_then_reuse_never_repeats_forward(monkeypatch,tmp_path):
+@pytest.mark.parametrize('streamed_selection', [False, True])
+def test_cli_capture_then_reuse_never_repeats_forward(monkeypatch,tmp_path,streamed_selection):
     from test_tessera_campaign_resume import _main_fixture,UNIT
     tc,_,argv,model,inputs = _main_fixture(monkeypatch,tmp_path)
     model.config = SimpleNamespace(_attn_implementation='eager')
-    monkeypatch.setattr(prismaquant,'pretrained_initialization_contract',lambda model:canonical_fields()['model_load_contract'])
+    fields = canonical_fields()
+    if streamed_selection:
+        fields['model_load_contract'] = dict(schema='prismaquant.streaming_initialization.v1',
+            scope='streamed_text_source_forward', status='completed',
+            transformers_version=importlib.metadata.version('transformers'),
+            model_class='SyntheticSource', dtype='torch.bfloat16', layers_prefix='model.layers.',
+            num_layers=1, persistent_tensors=1, derived_buffers=0,
+            state_sha256='a'*64, source_map_sha256='b'*64)
+    monkeypatch.setattr(prismaquant,'pretrained_initialization_contract',lambda model:fields['model_load_contract'])
     argv += ['--attention-implementation','eager']
     source = tmp_path/'source'
     source.mkdir()
@@ -151,7 +176,7 @@ def test_cli_capture_then_reuse_never_repeats_forward(monkeypatch,tmp_path):
         seed=0,nsamples=32,seqlen=512,fit_tokens_min=4)
     census = tc.calibration_census({UNIT:4},{UNIT:3.},args=SimpleNamespace(model=str(source),
         nsamples=32,seqlen=512,seed=0,layer_stride=1),groups={'u:'+UNIT:[UNIT]},
-        dense_targets=[UNIT],expert_targets=[],shapes={UNIT:[32,256]},identity=calibration,**canonical_fields())
+        dense_targets=[UNIT],expert_targets=[],shapes={UNIT:[32,256]},identity=calibration,**fields)
     census_path = tmp_path/'census.json'
     census_path.write_text(json.dumps(census))
     argv += ['--nsamples','32','--seqlen','512','--layer-stride','1',
@@ -160,7 +185,26 @@ def test_cli_capture_then_reuse_never_repeats_forward(monkeypatch,tmp_path):
     assert tc.main([*argv,'--capture-calibration-out',str(root)]) == 0
     monkeypatch.setattr(tc,'_collect_activations',lambda *a,**k: pytest.fail('repeated forward'))
     assert tc.main([*argv,'--capture-calibration-out',str(root)]) == 0
+    if streamed_selection:
+        from prismaquant import cost_streaming, autoscale
+        source_calls = []
+        def snapshot(names, **kwargs):
+            source_calls.append(list(names))
+            return {UNIT: model.model.layers[0].proj.weight.detach().clone()}, dict(
+                schema='prismaquant.selected_source_weights.v1', source_forward_count=0)
+        runner = SimpleNamespace(model=model, snapshot_selected_weights=snapshot,
+            shutdown=lambda: source_calls.append('shutdown'))
+        monkeypatch.setattr(cost_streaming, 'build_streamed_causal_lm', lambda *a, **k: runner)
+        monkeypatch.setattr(autoscale, 'selected_anchor_resources', lambda *a, **k: dict(
+            memory_bytes=1024**3, selected_source_weight_bytes=32768))
+        selection = tmp_path/'units.json'
+        selection.write_text(json.dumps(dict(schema=tc.UNITS_SCHEMA,
+            groups=[dict(key='u:'+UNIT, members=[UNIT])])))
+        argv += ['--streaming', '--units', str(selection),
+                 '--calibration-cache-sha256', cc.sha256(root/'capture_manifest.json')]
     assert tc.main([*argv,'--calibration-cache',str(root/'capture_manifest.json')]) == tc.EXIT_EMPTY_MENU
+    if streamed_selection:
+        assert source_calls == [[UNIT], 'shutdown']
 
 
 def test_driver_capture_and_plan_bind_one_complete_capture(capture):

--- a/tests/test_tessera_calibration_cache.py
+++ b/tests/test_tessera_calibration_cache.py
@@ -73,6 +73,31 @@ def test_selected_prefetch_guards_and_advises_verified_files(capture, monkeypatc
     assert torch.equal(values[1]['a'], hessians['a'])
 
 
+def test_export_input_page_release_preserves_existing_file_bytes(capture, monkeypatch, tmp_path):
+    from prismaquant import tessera_campaign as campaign, perturbed_x_cache
+    _root, _path, census, identity, _acts, hessians, _record = capture
+    calls = []
+    original = perturbed_x_cache.release_activation_cache_file_pages
+    def release(path, *, expected_stat):
+        calls.append(path.name)
+        return original(path, expected_stat=expected_stat)
+    monkeypatch.setattr(perturbed_x_cache, 'release_activation_cache_file_pages', release)
+    outcomes = []
+    for bounded in (False, True):
+        root = tmp_path/str(bounded)
+        root.mkdir()
+        observed = []
+        path, _scales, digest = campaign.write_export_inputs(root, hessians=hessians,
+            hessian_rows=census['counts'], hessian_identity=identity['calibration'],
+            static_scales={}, static_scale_policy='fixture', release_file_pages=bounded,
+            resource_check=(lambda label, **kwargs: observed.append(label)) if bounded else None)
+        outcomes.append((path.read_bytes(), digest))
+        if bounded:
+            assert observed[-1] == 'after_selected_export_input_write'
+    assert outcomes[0] == outcomes[1]
+    assert calls == ['hessian_capture.pt']
+
+
 @pytest.mark.parametrize('change',['artifact','manifest','source','draw','geometry','scope'])
 def test_prefetch_refuses_drift(capture,change):
     root,path,census,identity,acts,hessians,record = capture
@@ -152,6 +177,9 @@ def test_layer_writer_refuses_insufficient_disk(capture, tmp_path, monkeypatch):
 
 @pytest.mark.parametrize('streamed_selection', [False, True])
 def test_cli_capture_then_reuse_never_repeats_forward(monkeypatch,tmp_path,streamed_selection):
+    # This synthetic orchestration fixture has no source CUDA allocations;
+    # the real GLM test exercises the finite-cgroup guard on the native lane.
+    monkeypatch.setattr(torch.cuda, 'is_available', lambda: False)
     from test_tessera_campaign_resume import _main_fixture,UNIT
     tc,_,argv,model,inputs = _main_fixture(monkeypatch,tmp_path)
     model.config = SimpleNamespace(_attn_implementation='eager')
@@ -196,7 +224,8 @@ def test_cli_capture_then_reuse_never_repeats_forward(monkeypatch,tmp_path,strea
             shutdown=lambda: source_calls.append('shutdown'))
         monkeypatch.setattr(cost_streaming, 'build_streamed_causal_lm', lambda *a, **k: runner)
         monkeypatch.setattr(autoscale, 'selected_anchor_resources', lambda *a, **k: dict(
-            memory_bytes=1024**3, selected_source_weight_bytes=32768))
+            memory_bytes=1024**3, selected_source_weight_bytes=32768,
+            phases={'resident_anchors': {'factorization_scratch_bytes': 4*256**2*4}}))
         selection = tmp_path/'units.json'
         selection.write_text(json.dumps(dict(schema=tc.UNITS_SCHEMA,
             groups=[dict(key='u:'+UNIT, members=[UNIT])])))

--- a/tests/test_tessera_selected_source.py
+++ b/tests/test_tessera_selected_source.py
@@ -88,17 +88,22 @@ def test_selected_admission_excludes_unselected_source_and_forward_owners(monkey
         body_layer_bytes={'0': 1000, '1': 10000, '2': 2000},
         body_loader_transient_bytes={'0': 100, '1': 1000, '2': 200},
         body_source_file_bytes={'0': 900, '1': 9000, '2': 1800},
+        unit_source_weight_bytes={'layers.0.proj': 24, 'layers.2.proj': 24},
         full_hessian_bytes=128, full_prefix_bytes=64, source_header_sha256='a'*64))
     plan = autoscale.selected_anchor_resources('/source',
         unit_shapes={'layers.0.proj': [3, 4], 'layers.2.proj': [3, 4]},
         counts={'layers.0.proj': 9, 'layers.2.proj': 9}, max_act_rows=2,
         cache_slots=2, prefetch_workers=1, headroom_gb=0)
     assert plan['selected_layers'] == ['0', '2']
-    source, anchors = plan['phases'].values()
+    source, export, anchors = plan['phases'].values()
     assert source['source_window_bytes'] == 3000
     assert source['loader_transient_bytes'] == 200
     assert anchors['selected_hessian_bytes'] == 128
     assert anchors['selected_prefix_bytes'] == 64
+    assert export['export_input_file_bytes'] == 128+2*16384
+    assert export['serialization_scratch_bytes'] == 2*4**2*4
+    assert anchors['encoder_memo_bytes'] == 4*4*4+4*8
+    assert plan['encoder_memo_capacity'] == 1
     assert 'nonbody_source_bytes' not in anchors
     assert all('boundary' not in key for phase in plan['phases'].values() for key in phase)
     assert plan['memory_bytes'] == max(map(lambda phase: sum(phase.values()), plan['phases'].values()))
@@ -129,6 +134,99 @@ def test_streaming_planner_requires_capture_and_stamps_selected_phase_plan(monke
     assert '--calibration-cache-sha256' in rows[0]['argv']
     plan = json.loads((tmp_path/'plan.json').read_text())
     assert plan['rows'][0]['resources']['selected_layers'] == ['0']
+
+
+def test_bounded_encoder_memo_releases_evicted_factors_and_recomputes_identically(monkeypatch):
+    import weakref
+    import torch
+    from prismaquant import tessera_campaign as campaign
+    refs = []
+    def encoder(source, name, columns, device, *, scale_plane):
+        result = dict(ldl=torch.eye(columns)*(int(name)+1),
+                      refit_metric=torch.full((columns,), float(scale_plane)))
+        refs.append(weakref.ref(result['ldl']))
+        return result
+    monkeypatch.setattr(campaign.th, 'encoder_kwargs', encoder)
+    weights = {str(i): torch.empty(2, 4) for i in range(6)}
+    results = []
+    for capacity, expected_live in ((None, 12), (2, 2)):
+        memo = campaign._activation_kwargs_memo(None, weights, 'cpu', max_entries=capacity)
+        outputs = []
+        for repeat in range(2):
+            for plane in (1, 2):
+                for name in weights:
+                    kwargs = memo(name, plane)
+                    outputs.append((kwargs['ldl'].tolist(), kwargs['refit_metric'].tolist()))
+                    del kwargs
+                    assert sum(ref() is not None for ref in refs) <= (12 if capacity is None else 2)
+        assert sum(ref() is not None for ref in refs) == expected_live
+        results.append(outputs)
+        memo.cache_clear()
+        assert all(ref() is None for ref in refs)
+        del memo
+    assert results[0] == results[1]
+
+
+@pytest.mark.skipif(not __import__('torch').cuda.is_available(), reason='real encoder memo qualification requires CUDA')
+def test_native_bounded_encoder_memo_keeps_wire_and_price_bytes(tmp_path, monkeypatch):
+    import json
+    import os
+    import weakref
+    from pathlib import Path
+    import torch
+    from types import SimpleNamespace
+    from prismaquant import tessera_campaign as campaign
+    generator = torch.Generator().manual_seed(370)
+    weights = {f'unit{i}': torch.randn(16, 256, generator=generator).to('cuda', torch.bfloat16)
+               for i in range(3)}
+    acts = {name: torch.randn(7, 256, generator=generator).cuda() for name in weights}
+    hs = {name: torch.eye(256, device='cuda')*(i+1) for i, name in enumerate(weights)}
+    identity = campaign.th.calibration_identity('bounded memo', [torch.ones(1, 256, dtype=torch.long)],
+                                               fit_tokens=256)
+    source = campaign.th.activation_source(hs, identity)
+    original = campaign.th.encoder_kwargs
+    shared = {value.untyped_storage().data_ptr() for value in hs.values()}
+    refs = []
+    def tracked(*args, **kwargs):
+        result = original(*args, **kwargs)
+        refs.extend(weakref.ref(value) for value in result.values()
+                    if isinstance(value, torch.Tensor) and value.untyped_storage().data_ptr() not in shared)
+        return result
+    monkeypatch.setattr(campaign.th, 'encoder_kwargs', tracked)
+    outputs = []
+    measurements = []
+    for capacity in (None, 1):
+        memo = campaign._activation_kwargs_memo(source, weights, 'cuda', max_entries=capacity)
+        root = tmp_path/str(capacity)
+        root.mkdir()
+        cache = SimpleNamespace(weights={}, cache_dir=str(root))
+        rows = []
+        peak_owned_bytes = 0
+        for fmt in ('TESSERA_E4M3_K1_R1024', 'TESSERA_E4M3_K1_R1280'):
+            for name, weight in weights.items():
+                anchor = campaign._measure_anchor(qname=name, weight=weight, activations=acts[name],
+                    format_name=fmt, cache=cache, wire_dir=root,
+                    activation_kwargs_for=memo, hessian_required=True)
+                row = vars(anchor).copy()
+                row.pop('seconds')
+                rows.append(row)
+                alive = [ref() for ref in refs]
+                live = {value.untyped_storage().data_ptr(): value.untyped_storage().nbytes()
+                        for value in alive if value is not None}
+                peak_owned_bytes = max(peak_owned_bytes, sum(live.values()))
+                del alive, live
+        wires = {path.name: path.read_bytes() for path in root.glob('*.tessera')}
+        outputs.append((rows, wires))
+        assert memo.cache_info().currsize == (3 if capacity is None else 1)
+        measurements.append(dict(capacity=capacity, retained_entries=memo.cache_info().currsize,
+                                 peak_owned_factor_bytes_after_anchor=peak_owned_bytes))
+        memo.cache_clear()
+    assert outputs[0] == outputs[1]
+    assert measurements[1]['peak_owned_factor_bytes_after_anchor'] < measurements[0]['peak_owned_factor_bytes_after_anchor']
+    if os.environ.get('PRISMAQUANT_SELECTED_SOURCE_PROFILE'):
+        path = Path(os.environ['PRISMAQUANT_SELECTED_SOURCE_PROFILE'])/'memo-parity.json'
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(dict(measurements=measurements, wire_and_price_parity=True), indent=2)+'\n')
 
 
 def test_selected_capture_cli_reaches_existing_streamed_source(monkeypatch, tmp_path):

--- a/tests/test_tessera_selected_source.py
+++ b/tests/test_tessera_selected_source.py
@@ -1,0 +1,151 @@
+"""Selected anchors reuse canonical inputs without loading the whole source."""
+import pytest
+
+
+@pytest.mark.parametrize('extra', [[], ['--calibration-cache', '/capture'],
+    ['--calibration-cache-sha256', 'a'*64]])
+def test_selected_source_requires_complete_hash_bound_capture_before_loading(tmp_path, extra):
+    from prismaquant.tessera_campaign import main
+    with pytest.raises(SystemExit) as caught:
+        main(['--model', '/missing', '--out', str(tmp_path/'out'),
+            '--cache-dir', str(tmp_path/'cache'), '--streaming',
+            '--units', '/units', *extra])
+    assert caught.value.code == 2
+    assert not (tmp_path/'cache').exists()
+
+
+@pytest.fixture
+def selected_runner(monkeypatch):
+    import torch
+    from types import SimpleNamespace
+    from prismaquant.cost_streaming import StreamedCausalLM
+    from prismaquant import routed_experts
+    model = torch.nn.Module()
+    model.layers = torch.nn.ModuleList([torch.nn.Module() for _ in range(4)])
+    for layer in model.layers:
+        layer.proj = torch.nn.Linear(4, 3, bias=False, device='meta')
+    calls, pending = [], set()
+    source = {i: torch.arange(12, dtype=torch.float32).reshape(3, 4)+i for i in range(4)}
+    def schedule(layer):
+        calls.append(('schedule', layer)); pending.add(layer)
+    def install(layer, *, require_prefetched, prefetch_following):
+        assert require_prefetched and not prefetch_following
+        assert layer in pending
+        pending.remove(layer)
+        model.layers[layer].proj.weight = torch.nn.Parameter(source[layer])
+        calls.append(('install', layer))
+        return 'wait'
+    def release(layer):
+        model.layers[layer].proj.weight = torch.nn.Parameter(torch.empty(3, 4, device='meta'))
+        calls.append(('release', layer))
+    context = SimpleNamespace(model=model, base_model=model, layers=model.layers,
+        layers_prefix='layers.', num_layers=4, device='cpu', dtype=torch.float32,
+        max_cache_slots=2, schedule_prefetch=schedule, install=install,
+        release_completed_layer=release)
+    monkeypatch.setattr(routed_experts, 'profile_declared_packed_expert_projections', lambda *_: [])
+    monkeypatch.setattr(routed_experts, 'refresh_packed_expert_projections', lambda *_: [])
+    runner = StreamedCausalLM(context, profile=SimpleNamespace(),
+        prefetch_lookahead=1, require_prefetched_residency=True)
+    return runner, calls, source
+
+
+def test_selected_source_prefetches_only_selected_layers_and_releases_them(selected_runner):
+    import torch
+    runner, calls, source = selected_runner
+    values, receipt = runner.snapshot_selected_weights(['layers.3.proj', 'layers.1.proj'],
+                                                       max_resident_bytes=96)
+    assert [layer for kind, layer in calls if kind == 'schedule'] == [1, 3]
+    assert [layer for kind, layer in calls if kind == 'release'] == [1, 3]
+    assert receipt['resident_bytes'] == 96 and receipt['source_forward_count'] == 0
+    for i in (1, 3):
+        assert torch.equal(values[f'layers.{i}.proj'], source[i])
+        assert values[f'layers.{i}.proj'].untyped_storage().data_ptr() != source[i].untyped_storage().data_ptr()
+    assert all(p.is_meta for p in runner.model.parameters())
+
+
+def test_selected_source_refuses_budget_before_any_source_read(selected_runner):
+    runner, calls, _source = selected_runner
+    with pytest.raises(RuntimeError, match='resident byte budget'):
+        runner.snapshot_selected_weights(['layers.1.proj'], max_resident_bytes=47)
+    assert calls == []
+
+
+def test_selected_source_releases_layer_when_copy_guard_refuses(selected_runner):
+    runner, calls, _source = selected_runner
+    def refuse(*args, **kwargs):
+        raise RuntimeError('budget refusal')
+    with pytest.raises(RuntimeError, match='budget refusal'):
+        runner.snapshot_selected_weights(['layers.1.proj'], max_resident_bytes=48,
+                                         resource_check=refuse)
+    assert calls[-1] == ('release', 1)
+    assert all(p.is_meta for p in runner.model.parameters())
+
+
+def test_selected_admission_excludes_unselected_source_and_forward_owners(monkeypatch):
+    from prismaquant import autoscale
+    monkeypatch.setattr(autoscale, 'streamed_calibration_resources', lambda *a, **k: dict(
+        live_layer_prefix='layers.', terms=dict(nonbody_source_bytes=100, declared_headroom_bytes=200),
+        body_layer_bytes={'0': 1000, '1': 10000, '2': 2000},
+        body_loader_transient_bytes={'0': 100, '1': 1000, '2': 200},
+        body_source_file_bytes={'0': 900, '1': 9000, '2': 1800},
+        full_hessian_bytes=128, full_prefix_bytes=64, source_header_sha256='a'*64))
+    plan = autoscale.selected_anchor_resources('/source',
+        unit_shapes={'layers.0.proj': [3, 4], 'layers.2.proj': [3, 4]},
+        counts={'layers.0.proj': 9, 'layers.2.proj': 9}, max_act_rows=2,
+        cache_slots=2, prefetch_workers=1, headroom_gb=0)
+    assert plan['selected_layers'] == ['0', '2']
+    source, anchors = plan['phases'].values()
+    assert source['source_window_bytes'] == 3000
+    assert source['loader_transient_bytes'] == 200
+    assert anchors['selected_hessian_bytes'] == 128
+    assert anchors['selected_prefix_bytes'] == 64
+    assert 'nonbody_source_bytes' not in anchors
+    assert all('boundary' not in key for phase in plan['phases'].values() for key in phase)
+    assert plan['memory_bytes'] == max(map(lambda phase: sum(phase.values()), plan['phases'].values()))
+
+
+def test_streaming_planner_requires_capture_and_stamps_selected_phase_plan(monkeypatch, tmp_path):
+    import json
+    from tools import dispatch_tessera_campaign as dispatch
+    census = dict(model='/source', anchor_groups={'u:layers.0.proj': ['layers.0.proj']},
+        layer_stride=1, unit_shapes={'layers.0.proj': [3, 4]}, counts={'layers.0.proj': 9})
+    (tmp_path/'census.json').write_text(json.dumps(census))
+    spec = dict(model='/source', campaign_argv=['--streaming'], cwd=str(tmp_path),
+                python='python3', env={}, cpus=1)
+    (tmp_path/'spec.json').write_text(json.dumps(spec))
+    common = ['plan', '--spec', str(tmp_path/'spec.json'), '--workspace', str(tmp_path)]
+    with pytest.raises(RuntimeError, match='complete calibration cache'):
+        dispatch.main(common)
+    monkeypatch.setattr(dispatch, '_calibration_cache_binding', lambda *a: dict(path='/capture', sha256='a'*64))
+    def resources(spec, census, members, *, selected_source):
+        assert selected_source and members == ['layers.0.proj']
+        return dict(memory_bytes=3*1024**3, selected_layers=['0'])
+    monkeypatch.setattr(dispatch, '_streamed_resource_plan', resources)
+    assert dispatch.main([*common, '--calibration-cache', '/capture']) == 0
+    rows = json.loads((tmp_path/'manifest.json').read_text())
+    assert rows[0]['demand']['mem_gb'] == 3
+    assert '--calibration-cache-sha256' in rows[0]['argv']
+    plan = json.loads((tmp_path/'plan.json').read_text())
+    assert plan['rows'][0]['resources']['selected_layers'] == ['0']
+
+
+def test_selected_capture_cli_reaches_existing_streamed_source(monkeypatch, tmp_path):
+    from test_tessera_campaign_resume import _main_fixture
+    from prismaquant import cost_streaming
+    campaign, _, argv, _, _ = _main_fixture(monkeypatch, tmp_path)
+    argv[argv.index('--hessian') + 1] = 'require'
+
+    class SelectedSourceReached(Exception):
+        pass
+
+    def build(*args, **kwargs):
+        assert kwargs['require_prefetched_residency'] is True
+        raise SelectedSourceReached
+
+    monkeypatch.setattr(cost_streaming, 'build_streamed_causal_lm', build)
+    with pytest.raises(SelectedSourceReached):
+        campaign.main([*argv, '--streaming', '--units', str(tmp_path/'units.json'),
+            '--calibration-census', str(tmp_path/'census.json'),
+            '--calibration-cache', str(tmp_path/'capture_manifest.json'),
+            '--calibration-cache-sha256', 'a'*64,
+            '--attention-implementation', 'eager'])

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -144,7 +144,7 @@ def _model_bytes(model: str) -> int:
     return sum(path.stat().st_size for path in root.glob("*.safetensors"))
 
 
-def _row_memory_gb(spec: dict, members: list[str], census: dict) -> int:
+def _row_memory_gb(spec: dict, members: list[str], census: dict, *, selected_source=False) -> int:
     """The row's memory demand, from what the row actually holds.
 
     Three terms, each a measured quantity rather than a guess:
@@ -159,7 +159,7 @@ def _row_memory_gb(spec: dict, members: list[str], census: dict) -> int:
     """
     gib = 1024 ** 3
     if "--streaming" in spec['campaign_argv']:
-        resource = _streamed_resource_plan(spec, census, members)
+        resource = _streamed_resource_plan(spec, census, members, selected_source=selected_source)
         return int(math.ceil(resource['memory_bytes']/gib))
     shapes = census.get("unit_shapes") or {}
     hessian = sum(int(shapes.get(name, [0, 0])[1]) ** 2 * 4 for name in members)
@@ -169,21 +169,25 @@ def _row_memory_gb(spec: dict, members: list[str], census: dict) -> int:
     return int(math.ceil(total / gib)) + int(spec.get("headroom_gb", 24))
 
 
-def _streamed_resource_plan(spec, census, members):
-    from prismaquant.autoscale import streamed_calibration_resources
+def _streamed_resource_plan(spec, census, members, *, selected_source=False):
+    from prismaquant.autoscale import streamed_calibration_resources, selected_anchor_resources
     argv = spec['campaign_argv']
     def argument(name, default, convert=int):
         return convert(argv[argv.index(name)+1]) if name in argv else default
     shapes = census.get('unit_shapes') or {}
     counts = census.get('counts') or {}
-    return streamed_calibration_resources(spec['model'],
+    options = dict(
         unit_shapes={n: shapes[n] for n in members}, counts=counts,
-        nsamples=argument('--nsamples', 8), seqlen=argument('--seqlen', 512),
         max_act_rows=argument('--max-act-rows', int(spec.get('max_act_rows', 512))),
         cache_slots=argument('--streaming-cache-slots', 2),
         prefetch_workers=argument('--streaming-prefetch-workers', 1),
         headroom_gb=max(float(spec.get('headroom_gb', 24)),
-                        argument('--streaming-cache-headroom-gb', 24., float)),
+                        argument('--streaming-cache-headroom-gb', 24., float)))
+    if selected_source:
+        return selected_anchor_resources(spec['model'], **options,
+            anchor_batch_size=argument('--anchor-batch-size', 1))
+    return streamed_calibration_resources(spec['model'], **options,
+        nsamples=argument('--nsamples', 8), seqlen=argument('--seqlen', 512),
         capture_policy=argument('--streaming-capture-policy', 'legacy', str))
 
 
@@ -465,6 +469,9 @@ def cmd_plan(args) -> int:
             f"{spec['model']!r}")
     calibration_cache = _calibration_cache_binding(
         getattr(args, "calibration_cache", None), workspace / "census.json")
+    selected_source = '--streaming' in spec['campaign_argv']
+    if selected_source and calibration_cache is None:
+        raise RuntimeError('streaming anchor rows require a hash-bound complete calibration cache')
     groups = census["anchor_groups"]
     if not groups:
         raise RuntimeError("census reports no anchor group to price")
@@ -532,14 +539,15 @@ def cmd_plan(args) -> int:
             if args.seed_wire_dir:
                 argv += ["--seed-wire-dir", str(args.seed_wire_dir)]
         rows.append(_row(spec, argv,
-                         mem_gb=_row_memory_gb(spec, members, census),
+                         mem_gb=_row_memory_gb(spec, members, census, selected_source=selected_source),
                          timeout_s=int(args.timeout_s)))
         planned.append({"row_id": row_id, "groups": bundle, "members": sorted(members),
-                        "dir": str(row_dir), "units": str(units_path)})
+                        "dir": str(row_dir), "units": str(units_path),
+                        **({'resources': _streamed_resource_plan(spec, census, members,
+                            selected_source=True)} if selected_source else {})})
 
-    # The dominant term in a row's demand today is the whole checkpoint every
-    # row loads, which is what a quantum holding only its own units' weights
-    # would remove; until then that term is the concurrency ceiling.
+    # PB alone admits and places these independently retryable rows according
+    # to their actual source/capture preparation and resident encoding demand.
     per_box = int(args.rows_per_box)
     require_rows_fit([int(row["demand"]["mem_gb"]) for row in rows],
                      per_box, spec.get("box_memory_gb"))


### PR DESCRIPTION
A selected Tessera anchor row could reuse a complete capture only after loading the whole model: `--streaming --units` was rejected. This enables that path through the existing resident layer prefetch/cache, copies only selected dense or logical-expert weights, releases source state before H/X prefetch, and binds the full canonical census/capture/runtime/source identity without rerunning calibration.

A separate implementation commit bounds the existing encoder memo to the compatible anchor batch width and derives PB admission from source preparation, export-input serialization and resident encoding. Loader dtype rules preserve strict FP32 bytes. Existing guard and page-release helpers bound completed owners; no new cache, dispatcher, calibration or serving format is introduced.

Validation through PrismaBuild: original CLI and strict-dtype regressions reproduced; native tiny-GLM capture → selected source → producer anchor → resume passed (52 tests). Native memo eviction preserved wire bytes and price rows while retained factor storage fell from 786,432 to 262,144 bytes. Torch CPU/CUDA traces and Netdata from both Sparks are recorded. Final CPU changes passed 66 tests in five shards (two CUDA skips), plus 32 capture/sidecar byte-parity tests. Final focused native rerun after dtype/export-phase edits passed all 60 cases with no skips (PB `61a9da5bbf86`); terminal/CAS success and empty Docker state independently verified. Post-merge architecture/image checks passed 34 cases. See `docs/measurements/selected-source-anchors-2026-09-08.md` for exact actions, environments, negative results and artifact receipts.

The full GLM routed stack still refuses a 104 GiB worker: the current whole-file Hessian writer drives a conservative 124.783 GiB peak. The 132 exact group rows cover 36,423 units, but each 864-unit routed stack is currently indivisible. This PR makes that limit truthful; it does not claim full GLM fit or speed. Within-file bounded writing is separate follow-up work.

Fixes #370.
