### PR TITLE
Bound joint probe candidate residency with deferred operator contractions

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,6 +20,8 @@ residency, GPU saturation, KL, bpp or serving quality. Production integration
 requires separate phase admission and numerical/performance qualification.
 Gate: `tests/test_joint_operator_statistics.py` and existing joint lease/oracle
 and packed-source tests.
+The [primitive measurement](measurements/joint-operator-statistics-2026-09-08.md)
+records the synthetic native before/after profiles and explicit integration limits.
 
 Re-stamped (2026-09-08, `fix/campaign-portable-image-content`) for optional
 campaign container `content_sha256` (issue #371). The existing runtime identity

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,25 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `fix/campaign-portable-image-content`. Stamps
+As of: 2026-09-08 · `research/joint-operator-statistics`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `research/joint-operator-statistics`) for the explicit
+one-probe `JointOperatorStatisticsLease` (issue #374). It extends the existing
+joint-AURA source hooks and packed Linear observers. A finite matrix budget
+admits one FP32 sum(G.T@X) per target and one sum(G.T@dX) per distinct nonidentity
+activation group. After all backwards finish, an observation seal contracts
+activation terms against unchanged source weights and releases this lease's
+source references. Caller-prefetched candidate dW quanta then produce the three
+signed components; each quantum must fit a finite complete-backing-storage
+budget. Unknown, repeated, incomplete, stale-source and nonfinite results
+refuse. Matrix and candidate owners expire at their explicit phase boundaries.
+Matrix accumulation has its own arithmetic identity. The original signed
+per-invocation lease and pipeline defaults remain unchanged. This primitive
+does not schedule source/cache transfers or certify full-model physical
+residency, GPU saturation, KL, bpp or serving quality. Production integration
+requires separate phase admission and numerical/performance qualification.
+Gate: `tests/test_joint_operator_statistics.py` and existing joint lease/oracle
+and packed-source tests.
 
 Re-stamped (2026-09-08, `fix/campaign-portable-image-content`) for optional
 campaign container `content_sha256` (issue #371). The existing runtime identity

--- a/docs/measurements/joint-operator-statistics-2026-09-08.md
+++ b/docs/measurements/joint-operator-statistics-2026-09-08.md
@@ -1,0 +1,101 @@
+# Deferred joint operator contractions — 2026-09-08
+
+Issue #374; implementation `6a2cf9f91399f4a0e2d3ed1d10f795c918f2817b`.
+This is a synthetic primitive qualification at GLM expert dimensions. It does
+not qualify a complete calibration probe, ProductionWeightCache fill, model
+residency, KL, bpp, export, or serving behavior. Pipeline defaults are unchanged.
+
+## Contract
+
+`JointOperatorStatisticsLease` extends the existing joint-AURA source observer.
+For one probe it accumulates FP32 `sum(G.T @ X)` and, per distinct nonidentity
+activation quantizer, `sum(G.T @ dX)`. The observation seal contracts activation
+terms against unchanged source weights, removes hooks, and releases its source
+references. The caller then supplies prefetched candidate deltas in bounded
+quanta. The lease returns signed weight, activation, mixed and total terms and
+never owns candidate deltas beyond a projection call. The finite candidate
+budget charges whole backing storages, including storage hidden behind views.
+
+This changes FP32 contraction order and therefore has a separate arithmetic
+identity. It is not bit-identical to the original per-invocation contractions.
+The original lease remains available. Full integration needs phase admission
+for source weights, statistics, render buffers, cache transfers and physical
+memory; these two tensor budgets alone cannot certify a whole process.
+
+## Matched native measurement
+
+PrismaBuild action
+`438397d5a6c876645a08c6eef7e87c76707fbda9f03c6a2caf83cfa3261525d9`
+ran on Sparklina, NVIDIA GB10, Torch `2.13.0+cu130`, CUDA 13.0, CPUs 5 and 6,
+with two reserved CPUs, 12 GiB physical memory and an 8 GiB GPU subset cap.
+Native threads were bounded to one. The content-qualified producer image has
+content seal `eb8592abd71390231b49aba119e36f02ad91ea867b06df1c67af3833004d07bd`.
+Sparky concurrently ran the independent common capture; both hosts were sampled.
+
+Each shape uses A/B/B/A, ten seconds per arm, with a separate Torch trace after
+each timing arm. Every invocation includes eight synthetic candidate deltas,
+four backwards of 32 tokens each, BF16 source weights/inputs and FP32 delta
+planes. Deltas are constant `(candidate_index+1)/1024`; QDQ rounds `X*8` and
+divides by eight in source dtype. TF32 is disabled. Both arms include delta
+construction. The new lease admits 64 MiB statistics and one 32 MiB delta.
+
+| Projection shape | Legacy latency | Deferred latency | Ratio | Incremental CUDA peak, legacy → deferred | Work/board-joule ratio |
+|---|---:|---:|---:|---:|---:|
+| 2048 × 4096 | 41.881 ms | 16.782 ms | 2.496× | 404,363,776 → 134,219,776 B | 2.365× |
+| 4096 × 2048 | 41.691 ms | 16.756 ms | 2.488× | 404,101,632 → 134,219,776 B | 2.421× |
+
+Latencies are means of the two arm medians, not pooled invocation means.
+All eight arms return to their pre-arm CUDA allocation after profiling.
+The attempt cgroup peaked at 2,754,871,296 bytes, consumed 119.681 CPU seconds,
+exited zero, completed cleanup and left no owned container running.
+
+The profiles explain the gain: for 2048 × 4096, the first legacy/deferred
+traces reduce `aten::mul` from 72 calls/26.908 ms to 21 calls/7.239 ms and
+`aten::sum` from 68 calls/10.482 ms to 17 calls/2.665 ms. Deferred accumulation
+adds six `aten::add_` calls/2.568 ms. Matrix multiplies remain 16 calls, around
+1.94–2.01 ms. Candidate projection now scans each summed operator once rather
+than scanning every candidate during every backward. Times are profiler
+self-device totals and should not be summed with child kernel events.
+
+Existing pqteld 2 Hz samples give 20 power observations per arm. Legacy board
+power spans 22.399–25.736 W; deferred spans 24.656–26.115 W, far below GB10's
+approximately 140 W envelope. There is no saturation claim. Work/joule uses
+completed invocations divided by elapsed time and mean board power, then the
+ratio of paired-arm means; no idle subtraction or whole-system energy is claimed.
+Netdata host CPU means were 7.49–8.22% on Sparklina. Both-host raw Netdata and
+pqteld windows are retained. The automatic PB box window lacked its pqteld CSV;
+the existing host CSVs were copied for these exact intervals and read with the
+published PB window reader. No power value is inferred from GPU utilization.
+
+## Numerical and lifecycle validation
+
+The initial missing-API regression recorded nine failures in PB
+`424b26ef368a132f91eb3fd0ff0eb0802cf37a09c8ff786d1344828115e09d0b`.
+Final CPU action
+`8fe0afac8f716f8ac24403c78198de3f8285aa6581bf06cc7162ea0c842b2b27`
+passed 57 tests, skipped the two CUDA-only shape cases, and compiled both touched
+Python modules. The native action above passed all 46 selected tests with zero
+skips, including independent FP64 output-residual oracles at both full expert
+shapes. Coverage includes signed cancellation, repeated/shared QDQ, real packed
+source slices, never-routed experts, source mutation, missing/duplicate backwards,
+source-owner release, atomic refusal of nonfinite candidate quanta, and complete
+backing-storage accounting. The synthetic timing fixture's maximum component
+change from legacy is 0.000030517578125; this is an arithmetic screen, not a
+model-quality threshold. One intermediate test edit failed collection with a
+syntax error; that failure and its corrected successful run are retained.
+
+## Reproduction and evidence
+
+The committed harness is `experiments/joint_operator_statistics_profile.py`.
+The complete PB command, image/environment declaration and source identity are
+in `native-invocation-01.json` under:
+
+`/mnt/shared/tessera-measurements/glm-canonical-census-20260908/joint-operator-statistics-01/`
+
+That directory contains `cpu-root-audit-01.json`, `native-root-audit-01.json`,
+`native-submission-01.log` and `native-01/{result.json,summary.json,box-windows.json,
+netdata.jsonl,pqteld/,*.trace.json}`. The root audits independently verified
+terminal status, canonical CAS receipt/payload hashes and complete source
+snapshots against the implementation commit; only generated PB closure files
+differ. All eight trace hashes were checked. Native result SHA256:
+`3798d4008715690bbd0885f650e7d0e6e62073ae0e04df0b47cb169105c6d7d0`.

--- a/experiments/joint_operator_statistics_profile.py
+++ b/experiments/joint_operator_statistics_profile.py
@@ -1,0 +1,192 @@
+"""Paired synthetic lease qualification at GLM expert projection dimensions.
+
+This measures source observation plus synthetic resident-delta construction and
+contraction. It does not measure a ProductionWeightCache fill, calibration,
+source streaming, full-model residency, KL, bpp or a serving path.
+"""
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import os
+from pathlib import Path
+import statistics
+import threading
+import time
+import traceback
+
+import torch
+
+from experiments.workspace_netdata import NetdataWriter, sample_netdata
+from prismaquant.format_registry import FormatSpec
+from prismaquant.joint_aura import JointOperatorStatisticsLease, SignedJointProjectionLease
+
+
+def digest(path):
+    with Path(path).open('rb') as stream:
+        return hashlib.file_digest(stream, 'sha256').hexdigest()
+
+
+def memory():
+    torch.cuda.synchronize()
+    return dict(allocated=torch.cuda.memory_allocated(), reserved=torch.cuda.memory_reserved(),
+                peak_allocated=torch.cuda.max_memory_allocated(),
+                peak_reserved=torch.cuda.max_memory_reserved())
+
+
+def invoke(kind, module, specs, draws):
+    shape = tuple(module.weight.shape)
+    plane_bytes = module.weight.numel() * 4
+    kwargs = dict(activation_max_abs={})
+    if kind == 'legacy':
+        deltas = {('u', fmt): torch.full(shape, (index + 1) / 1024, device='cuda')
+                  for index, fmt in enumerate(specs)}
+        lease = SignedJointProjectionLease({'u': module}, {'u': specs}, deltas, **kwargs)
+    else:
+        lease = JointOperatorStatisticsLease({'u': module}, {'u': specs},
+            max_statistics_bytes=2 * plane_bytes, max_candidate_bytes=plane_bytes, **kwargs)
+    with lease:
+        lease.begin_probe()
+        for x, gradient in draws:
+            output = module(x)
+            output.backward(gradient)
+            module.zero_grad(set_to_none=True)
+            del output
+        if kind == 'legacy':
+            result = lease.finish_probe()
+        else:
+            lease.finish_observations()
+            for index, fmt in enumerate(specs):
+                delta = torch.full(shape, (index + 1) / 1024, device='cuda')
+                lease.project({('u', fmt): delta})
+                del delta
+            result = lease.finish_projections()
+    return {f'{name}@{fmt}': values for (name, fmt), values in result.items()}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--out', type=Path, required=True)
+    parser.add_argument('--seconds', type=float, default=10.)
+    args = parser.parse_args()
+    if not 1 <= args.seconds <= 60:
+        parser.error('--seconds must be between 1 and 60')
+    args.out.mkdir(parents=True, exist_ok=False)
+    torch.set_num_threads(1)
+    torch.set_float32_matmul_precision('highest')
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.backends.cudnn.allow_tf32 = False
+    record = dict(schema='prismaquant.joint_operator_statistics_profile.v1', status='running',
+        started_unix=time.time(), torch=str(torch.__version__), cuda=torch.version.cuda,
+        device=torch.cuda.get_device_name(), affinity=sorted(os.sched_getaffinity(0)),
+        candidates=8, draws=4, tokens_per_draw=32, seconds_per_arm=args.seconds,
+        source_dtype='torch.bfloat16', delta_dtype='torch.float32',
+        matmul_precision=torch.get_float32_matmul_precision(), allow_tf32=False,
+        seed=1913, delta_rule='full((rows,cols),(candidate_index+1)/1024,float32)',
+        qdq_rule='round(X*8)/8 in source dtype', shapes=[], telemetry_errors=[])
+    stopped = threading.Event()
+
+    def monitor():
+        try:
+            with (args.out/'netdata.jsonl').open('x') as stream:
+                writer = NetdataWriter(stream)
+                while not stopped.is_set():
+                    for host in ('sparky', 'sparklina'):
+                        writer.write(sample_netdata(host))
+                    stopped.wait(1.)
+        except Exception as exc:
+            record['telemetry_errors'].append(repr(exc))
+
+    monitor_thread = threading.Thread(target=monitor, daemon=True)
+    monitor_thread.start()
+    try:
+        qdq = lambda x: torch.round(x * 8) / 8
+        specs = {f'candidate{i}': FormatSpec(name=f'candidate{i}', weight_bits=8,
+            group_size=0, scale_bits=0, scale_dtype_name='fp32', weight_element_dtype='int8',
+            act_bits=8, activation_quantize_dequantize=qdq) for i in range(8)}
+        for rows, columns in ((2048, 4096), (4096, 2048)):
+            generator = torch.Generator().manual_seed(record['seed'])
+            weight = (torch.randn(rows, columns, generator=generator) / columns**.5).bfloat16()
+            draws = [(torch.randn(32, columns, generator=generator).bfloat16().cuda(),
+                      torch.randn(32, rows, generator=generator).bfloat16().cuda()) for _ in range(4)]
+            module = torch.nn.Linear(columns, rows, bias=False, device='cuda', dtype=torch.bfloat16)
+            with torch.no_grad():
+                module.weight.copy_(weight)
+            del weight
+            shape_row = dict(shape=[rows, columns], arms=[])
+            record['shapes'].append(shape_row)
+            baseline = None
+            for index, kind in enumerate(('legacy', 'statistics', 'statistics', 'legacy')):
+                warm = invoke(kind, module, specs, draws)
+                if baseline is None:
+                    baseline = warm
+                gc.collect()
+                torch.cuda.empty_cache()
+                before = memory()
+                torch.cuda.reset_peak_memory_stats()
+                start = time.time()
+                times = []
+                wall_start = time.perf_counter()
+                while time.perf_counter() - wall_start < args.seconds:
+                    tick = time.perf_counter()
+                    result = invoke(kind, module, specs, draws)
+                    torch.cuda.synchronize()
+                    times.append((time.perf_counter() - tick) * 1000)
+                elapsed = time.perf_counter() - wall_start
+                end = time.time()
+                after = memory()
+                assert after['allocated'] == before['allocated'], 'lease retained CUDA allocations'
+                errors = {key: {term: result[key][term] - baseline[key][term] for term in result[key]}
+                          for key in result}
+                # Native tests separately bind both GLM shapes to an independent
+                # FP64 residual. This row records the old/new arithmetic delta.
+                for key in result:
+                    for term, value in result[key].items():
+                        assert abs(value - baseline[key][term]) <= 1e-4 + abs(baseline[key][term]) * 1e-4
+                with torch.profiler.profile(
+                        activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
+                        record_shapes=True, profile_memory=True) as profile:
+                    with torch.profiler.record_function(f'joint_{kind}_whole_lease'):
+                        invoke(kind, module, specs, draws)
+                    torch.cuda.synchronize()
+                trace = args.out/f'{rows}x{columns}-{index}-{kind}.trace.json'
+                profile.export_chrome_trace(str(trace))
+                events = [dict(key=item.key, calls=item.count,
+                    self_cpu_us=item.self_cpu_time_total,
+                    self_device_us=item.self_device_time_total)
+                    for item in profile.key_averages()]
+                del profile
+                gc.collect()
+                shape_row['arms'].append(dict(kind=kind, index=index, start_unix=start, end_unix=end,
+                    invocations=len(times), elapsed_seconds=elapsed,
+                    median_ms=statistics.median(times), samples_ms=times,
+                    before=before, after=after, after_profile=memory(),
+                    signed_component_delta=errors, trace=dict(path=str(trace), sha256=digest(trace)),
+                    events=sorted(events, key=lambda item: item['self_device_us'], reverse=True)[:30]))
+                (args.out/'progress.json').write_text(json.dumps(record, indent=2)+'\n')
+            del module, draws
+            gc.collect()
+            torch.cuda.empty_cache()
+        record['status'] = 'complete'
+    except BaseException:
+        record.update(status='failed', traceback=traceback.format_exc())
+        raise
+    finally:
+        stopped.set()
+        monitor_thread.join(timeout=15)
+        if monitor_thread.is_alive():
+            record['telemetry_errors'].append('Netdata sampler did not stop')
+        if record['telemetry_errors']:
+            record['status'] = 'failed'
+        record['finished_unix'] = time.time()
+        result_path = args.out/'result.json'
+        result_path.write_text(json.dumps(record, indent=2)+'\n')
+        print(json.dumps(dict(path=str(result_path), sha256=digest(result_path), status=record['status'])))
+    if record['status'] != 'complete':
+        raise RuntimeError('required joint operator qualification evidence is incomplete')
+
+
+if __name__ == '__main__':
+    main()

--- a/prismaquant/joint_aura.py
+++ b/prismaquant/joint_aura.py
@@ -7,6 +7,7 @@ QDQ is the same owner used by PerturbedActivationCache and assignment KL.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from copy import copy
 from dataclasses import dataclass
 import hashlib
 import json
@@ -234,13 +235,7 @@ class SignedJointProjectionLease:
             elif not isinstance(module, nn.Linear):
                 raise TypeError(f"joint AURA target {name} is not Linear")
             self.projection_backend.require_device(module.weight.device)
-            expected = {fmt for qname, fmt in self.deltas if qname == name}
-            if set(self.specs[name]) != expected:
-                raise ValueError(f"joint AURA render/spec coverage mismatch for {name}")
-            for fmt in expected:
-                delta = self.deltas[(name, fmt)]
-                if delta.device != module.weight.device or delta.shape != module.weight.shape:
-                    raise RuntimeError(f"joint AURA dW residency/shape differs for {name}@{fmt}")
+            self._validate_delta_coverage(name, module)
             grouped = {}
             for fmt, spec in self.specs[name].items():
                 receipt = activation_identity(spec, self.activation_max_abs, name)
@@ -255,6 +250,15 @@ class SignedJointProjectionLease:
                 group = (identity_sha256(receipt), callable_key)
                 grouped.setdefault(group, (spec, []))[1].append(fmt)
             self.groups[name] = tuple(grouped.values())
+
+    def _validate_delta_coverage(self, name, module):
+        expected = {fmt for qname, fmt in self.deltas if qname == name}
+        if set(self.specs[name]) != expected:
+            raise ValueError(f"joint AURA render/spec coverage mismatch for {name}")
+        for fmt in expected:
+            delta = self.deltas[(name, fmt)]
+            if delta.device != module.weight.device or delta.shape != module.weight.shape:
+                raise RuntimeError(f"joint AURA dW residency/shape differs for {name}@{fmt}")
 
     def __enter__(self):
         if self.handles or self.forward_originals:
@@ -274,14 +278,17 @@ class SignedJointProjectionLease:
         return self
 
     def __exit__(self, *_args):
+        self._remove_observers()
+        self.terms.clear()
+        self.active = False
+
+    def _remove_observers(self):
         for handle in self.handles:
             handle.remove()
         self.handles.clear()
         for module, original in reversed(self.forward_originals):
             module.forward = original
         self.forward_originals.clear()
-        self.terms.clear()
-        self.active = False
 
     def _install_packed_observer(self, members):
         """Observe the existing per-expert Linear slices without changing them.
@@ -436,6 +443,239 @@ class SignedJointProjectionLease:
             result[key] = {"weight": weight, "activation": activation, "mixed": mixed, "total": total}
         self.terms.clear()
         return result
+
+
+class JointOperatorStatisticsLease(SignedJointProjectionLease):
+    """Opt-in, one-probe deferred contraction using the shared source observers.
+
+    Retain sum(G.T @ X) and sum(G.T @ dX) per activation group, independent
+    of candidate count. After baseline backwards finish, seal observation,
+    release this lease's source references, and project caller-owned resident
+    candidate dW quanta. The caller's ProductionWeightCache owns candidate
+    prefetch and its physical budget. No candidate tensor is retained here.
+
+    ``max_statistics_bytes`` covers FP32 operator matrices only. Baseline
+    source/activations/cotangents, GEMM inputs and temporary matrices, source
+    conversion, projection workspaces, CUDA reservations and allocator overhead
+    still need separate phase admission. This primitive is not a full fit gate.
+    ``max_candidate_bytes`` charges complete backing storages, including any
+    unselected data kept alive by a caller's view, for each projection quantum.
+    Matrix accumulation changes rounding and has a distinct arithmetic identity.
+    """
+
+    def __init__(self, modules, specs_by_qname, *, max_statistics_bytes, max_candidate_bytes,
+                 activation_max_abs=None, projection_backend=None):
+        if type(max_statistics_bytes) is not int or max_statistics_bytes < 0:
+            raise ValueError("joint statistics budget must be a nonnegative integer")
+        if type(max_candidate_bytes) is not int or max_candidate_bytes <= 0:
+            raise ValueError("joint candidate budget must be a positive integer")
+        self.max_candidate_bytes = max_candidate_bytes
+        if not modules or set(modules) != set(specs_by_qname) or any(not specs for specs in specs_by_qname.values()):
+            raise ValueError("joint statistics module/spec coverage differs")
+        # FormatSpec is mutable; freeze its resolved fields for this lease.
+        specs = {name: {fmt: copy(spec) for fmt, spec in choices.items()}
+                 for name, choices in specs_by_qname.items()}
+        super().__init__(modules, specs, {}, activation_max_abs=activation_max_abs,
+                         projection_backend=projection_backend)
+        self._geometry = {name: (tuple(module.weight.shape), module.weight.device)
+                          for name, module in self.modules.items()}
+        self._sources = {name: self._source_fingerprint(module.weight)
+                         for name, module in self.modules.items()}
+        self._format_groups = {(name, fmt): index
+                               for name, groups in self.groups.items()
+                               for index, (_, formats) in enumerate(groups) for fmt in formats}
+        self.statistics_capacity_bytes = sum(
+            module.weight.numel() * 4 * (1 + sum(spec.act_quant_changes_input
+                                                 for spec, _ in self.groups[name]))
+            for name, module in self.modules.items())
+        if self.statistics_capacity_bytes > max_statistics_bytes:
+            raise RuntimeError("joint statistics matrices exceed statistics budget")
+        self._operators = {}
+        self._activation_terms = {}
+        self._results = {}
+        self._pending_backwards = 0
+        self._phase = 'new'
+        self.telemetry.update(statistics_capacity_bytes=self.statistics_capacity_bytes,
+                              peak_statistics_bytes=0, projected_candidates=0,
+                              peak_candidate_storage_bytes=0)
+
+    def _validate_delta_coverage(self, name, module):
+        # The exact candidate roster is sealed now; tensors arrive only after
+        # source observation, through project(), which checks each quantum.
+        if name not in self.specs or not self.specs[name]:
+            raise ValueError(f"joint statistics missing spec coverage for {name}")
+
+    @staticmethod
+    def _source_fingerprint(weight):
+        return (weight.data_ptr(), weight._version, tuple(weight.shape),
+                tuple(weight.stride()), weight.storage_offset(), weight.dtype, weight.device)
+
+    def _require_source(self, name, weight):
+        if self._source_fingerprint(weight) != self._sources[name]:
+            raise RuntimeError(f"joint statistics source weight changed for {name}")
+
+    @property
+    def resident_statistics_bytes(self):
+        return sum(value.numel() * value.element_size() for value in self._operators.values())
+
+    def arithmetic_identity(self, measurement_dtype):
+        identity = arithmetic_identity(measurement_dtype, self.projection_backend)
+        identity.update(
+            weight_projection='summed_output_operator_fp32_gemm',
+            operator_accumulation='sum_fp32_matrices_in_backward_invocation_order',
+            contraction_order='sum_operators_then_project_each_signed_component')
+        return identity
+
+    def begin_probe(self):
+        if self._phase != 'new' or not (self.handles or self.forward_originals):
+            raise RuntimeError("joint statistics requires one new entered lease per probe")
+        for name, module in self.modules.items():
+            self._require_source(name, module.weight)
+        self._phase, self.active = 'observing', True
+
+    def __enter__(self):
+        if self._phase != 'new':
+            raise RuntimeError("joint statistics cannot reenter a consumed lease")
+        return super().__enter__()
+
+    def _accumulate(self, key, matrix):
+        if key in self._operators:
+            self._operators[key].add_(matrix)
+        else:
+            self._operators[key] = matrix
+        self.telemetry['peak_statistics_bytes'] = max(
+            self.telemetry['peak_statistics_bytes'], self.resident_statistics_bytes)
+
+    def _observe(self, name, source_weight, x, output, output_slice=None, row_slice=None):
+        if self._phase != 'observing' or not self.active:
+            raise RuntimeError("joint statistics forward outside active observation")
+        self._require_source(name, source_weight)
+        if not isinstance(x, torch.Tensor) or not isinstance(output, torch.Tensor):
+            raise TypeError(f"joint statistics Linear {name} needs Tensor input/output")
+        x = x.detach()
+        consumed = False
+
+        @torch.no_grad()
+        def collect(gradient):
+            nonlocal consumed
+            if self._phase != 'observing' or not self.active or consumed:
+                raise RuntimeError("joint statistics backward outside active observation")
+            self._require_source(name, source_weight)
+            selected = gradient if row_slice is None else gradient[row_slice]
+            selected = selected if output_slice is None else selected[..., output_slice]
+            if x.device != selected.device or x.device != source_weight.device:
+                raise RuntimeError(f"joint statistics residency mismatch for {name}")
+            if (x.shape[:-1] != selected.shape[:-1] or x.shape[-1] != source_weight.shape[1]
+                    or selected.shape[-1] != source_weight.shape[0]):
+                raise RuntimeError(f"joint statistics Linear geometry/shape mismatch for {name}")
+            x2 = x.reshape(-1, x.shape[-1]).float()
+            g2 = selected.reshape(-1, selected.shape[-1]).float()
+            self._accumulate((name, None), g2.T @ x2)
+            self.telemetry['operator_gemms'] += 1
+            for index, (spec, _) in enumerate(self.groups[name]):
+                if not spec.act_quant_changes_input:
+                    continue
+                quantized = _activation_qdq(x, spec, self.activation_max_abs, name)
+                if (not isinstance(quantized, torch.Tensor) or quantized.shape != x.shape
+                        or quantized.device != x.device or quantized.dtype != x.dtype):
+                    raise RuntimeError(f"joint statistics QDQ changed residency/dtype/shape for {name}")
+                dx = quantized.reshape_as(x2).float() - x2
+                self._accumulate((name, index), g2.T @ dx)
+                self.telemetry['qdq_calls'] += 1
+                self.telemetry['operator_gemms'] += 1
+            consumed = True
+            self._pending_backwards -= 1
+            return gradient
+
+        if output.requires_grad:
+            self._pending_backwards += 1
+            output.register_hook(collect)
+
+    @torch.no_grad()
+    def finish_observations(self):
+        if self._phase != 'observing':
+            raise RuntimeError("joint statistics observations are not active")
+        if self._pending_backwards:
+            raise RuntimeError("joint statistics has pending backward observations")
+        for name, module in self.modules.items():
+            self._require_source(name, module.weight)
+            for index, (spec, _) in enumerate(self.groups[name]):
+                operator = self._operators.get((name, index))
+                value = (float(self._projection_product_sum(operator, module.weight.float()))
+                         if operator is not None else 0.)
+                if not math.isfinite(value):
+                    raise RuntimeError(f"joint statistics nonfinite activation projection for {name}")
+                self._activation_terms[(name, index)] = value
+        self._remove_observers()
+        self.modules.clear()
+        self._phase, self.active = 'ready', False
+
+    @torch.no_grad()
+    def project(self, delta_weights):
+        if self._phase != 'ready':
+            raise RuntimeError("joint statistics is not ready for candidate projection")
+        if not isinstance(delta_weights, Mapping) or not delta_weights:
+            raise ValueError("joint statistics requires a nonempty candidate quantum")
+        storages = {}
+        for key, delta in delta_weights.items():
+            if key not in self._format_groups:
+                raise ValueError(f"joint statistics unknown candidate {key}")
+            if key in self._results:
+                raise ValueError(f"joint statistics duplicate candidate {key}")
+            shape, device = self._geometry[key[0]]
+            if (not isinstance(delta, torch.Tensor) or tuple(delta.shape) != shape
+                    or delta.device != device or not delta.is_floating_point()):
+                raise RuntimeError(f"joint statistics candidate residency/dtype/shape differs for {key}")
+            storage = delta.untyped_storage()
+            storages[(delta.device, storage.data_ptr())] = storage.nbytes()
+        candidate_bytes = sum(storages.values())
+        if candidate_bytes > self.max_candidate_bytes:
+            raise RuntimeError("joint statistics candidate storage exceeds candidate budget")
+        # Commit scalar results only after the whole quantum succeeds.
+        results = {}
+        for key, delta in delta_weights.items():
+            name, fmt = key
+            group = self._format_groups[key]
+            dw = delta.float()
+            gw = self._operators.get((name, None))
+            ga = self._operators.get((name, group))
+            if gw is None and not bool(torch.isfinite(dw).all()):
+                raise RuntimeError(f"joint statistics nonfinite unrouted candidate for {key}")
+            weight = float(self._projection_product_sum(gw, dw)) if gw is not None else 0.
+            activation = self._activation_terms[(name, group)]
+            mixed = float(self._projection_product_sum(ga, dw)) if ga is not None else 0.
+            total = weight + activation + mixed
+            if not all(math.isfinite(value) for value in (weight, activation, mixed, total)):
+                raise RuntimeError(f"joint statistics nonfinite signed projection for {key}")
+            results[key] = dict(weight=weight, activation=activation, mixed=mixed, total=total)
+        self._results.update(results)
+        self.telemetry['projected_candidates'] += len(results)
+        self.telemetry['peak_candidate_storage_bytes'] = max(
+            self.telemetry['peak_candidate_storage_bytes'], candidate_bytes)
+        return {key: dict(value) for key, value in results.items()}
+
+    def finish_projections(self):
+        if self._phase != 'ready':
+            raise RuntimeError("joint statistics is not ready to seal projections")
+        if set(self._results) != set(self._format_groups):
+            raise RuntimeError("joint statistics candidate coverage is incomplete")
+        result = {key: dict(value) for key, value in self._results.items()}
+        self._operators.clear()
+        self._activation_terms.clear()
+        self._results.clear()
+        self._phase = 'complete'
+        return result
+
+    def finish_probe(self):
+        raise RuntimeError("joint statistics requires observation and candidate projection seals")
+
+    def __exit__(self, *_args):
+        super().__exit__(*_args)
+        self.modules.clear()
+        self._operators.clear()
+        self._activation_terms.clear()
+        self._results.clear()
+        self._phase = 'closed'
 
 
 def validate_joint_aura_entry(entry: Mapping) -> bool:

--- a/prismaquant/joint_aura.py
+++ b/prismaquant/joint_aura.py
@@ -494,6 +494,7 @@ class JointOperatorStatisticsLease(SignedJointProjectionLease):
         self._activation_terms = {}
         self._results = {}
         self._pending_backwards = 0
+        self._observation_inputs = {}
         self._phase = 'new'
         self.telemetry.update(statistics_capacity_bytes=self.statistics_capacity_bytes,
                               peak_statistics_bytes=0, projected_candidates=0,
@@ -546,13 +547,18 @@ class JointOperatorStatisticsLease(SignedJointProjectionLease):
         self.telemetry['peak_statistics_bytes'] = max(
             self.telemetry['peak_statistics_bytes'], self.resident_statistics_bytes)
 
+    def _release_observation_inputs(self):
+        for inputs in self._observation_inputs.values():
+            inputs.clear()
+        self._observation_inputs.clear()
+
     def _observe(self, name, source_weight, x, output, output_slice=None, row_slice=None):
         if self._phase != 'observing' or not self.active:
             raise RuntimeError("joint statistics forward outside active observation")
         self._require_source(name, source_weight)
         if not isinstance(x, torch.Tensor) or not isinstance(output, torch.Tensor):
             raise TypeError(f"joint statistics Linear {name} needs Tensor input/output")
-        x = x.detach()
+        inputs = [x.detach(), source_weight]
         consumed = False
 
         @torch.no_grad()
@@ -560,35 +566,50 @@ class JointOperatorStatisticsLease(SignedJointProjectionLease):
             nonlocal consumed
             if self._phase != 'observing' or not self.active or consumed:
                 raise RuntimeError("joint statistics backward outside active observation")
-            self._require_source(name, source_weight)
-            selected = gradient if row_slice is None else gradient[row_slice]
-            selected = selected if output_slice is None else selected[..., output_slice]
-            if x.device != selected.device or x.device != source_weight.device:
-                raise RuntimeError(f"joint statistics residency mismatch for {name}")
-            if (x.shape[:-1] != selected.shape[:-1] or x.shape[-1] != source_weight.shape[1]
-                    or selected.shape[-1] != source_weight.shape[0]):
-                raise RuntimeError(f"joint statistics Linear geometry/shape mismatch for {name}")
-            x2 = x.reshape(-1, x.shape[-1]).float()
-            g2 = selected.reshape(-1, selected.shape[-1]).float()
-            self._accumulate((name, None), g2.T @ x2)
-            self.telemetry['operator_gemms'] += 1
-            for index, (spec, _) in enumerate(self.groups[name]):
-                if not spec.act_quant_changes_input:
-                    continue
-                quantized = _activation_qdq(x, spec, self.activation_max_abs, name)
-                if (not isinstance(quantized, torch.Tensor) or quantized.shape != x.shape
-                        or quantized.device != x.device or quantized.dtype != x.dtype):
-                    raise RuntimeError(f"joint statistics QDQ changed residency/dtype/shape for {name}")
-                dx = quantized.reshape_as(x2).float() - x2
-                self._accumulate((name, index), g2.T @ dx)
-                self.telemetry['qdq_calls'] += 1
+            try:
+                x, source_weight = inputs
+                self._require_source(name, source_weight)
+                selected = gradient if row_slice is None else gradient[row_slice]
+                selected = selected if output_slice is None else selected[..., output_slice]
+                if x.device != selected.device or x.device != source_weight.device:
+                    raise RuntimeError(f"joint statistics residency mismatch for {name}")
+                if (x.shape[:-1] != selected.shape[:-1] or x.shape[-1] != source_weight.shape[1]
+                        or selected.shape[-1] != source_weight.shape[0]):
+                    raise RuntimeError(f"joint statistics Linear geometry/shape mismatch for {name}")
+                x2 = x.reshape(-1, x.shape[-1]).float()
+                g2 = selected.reshape(-1, selected.shape[-1]).float()
+                self._accumulate((name, None), g2.T @ x2)
                 self.telemetry['operator_gemms'] += 1
-            consumed = True
-            self._pending_backwards -= 1
+                for index, (spec, _) in enumerate(self.groups[name]):
+                    if not spec.act_quant_changes_input:
+                        continue
+                    quantized = _activation_qdq(x, spec, self.activation_max_abs, name)
+                    if (not isinstance(quantized, torch.Tensor) or quantized.shape != x.shape
+                            or quantized.device != x.device or quantized.dtype != x.dtype):
+                        raise RuntimeError(f"joint statistics QDQ changed residency/dtype/shape for {name}")
+                    dx = quantized.reshape_as(x2).float() - x2
+                    self._accumulate((name, index), g2.T @ dx)
+                    self.telemetry['qdq_calls'] += 1
+                    self.telemetry['operator_gemms'] += 1
+                consumed = True
+                self._pending_backwards -= 1
+            except BaseException:
+                # A QDQ/GEMM may fail after an earlier operator committed.
+                # Never allow a caught backward failure to become a retry.
+                self._phase, self.active = 'failed', False
+                self._remove_observers()
+                self.modules.clear()
+                self._operators.clear()
+                self._release_observation_inputs()
+                raise
+            finally:
+                inputs.clear()
+                self._observation_inputs.pop(id(inputs), None)
             return gradient
 
         if output.requires_grad:
             self._pending_backwards += 1
+            self._observation_inputs[id(inputs)] = inputs
             output.register_hook(collect)
 
     @torch.no_grad()
@@ -672,6 +693,7 @@ class JointOperatorStatisticsLease(SignedJointProjectionLease):
     def __exit__(self, *_args):
         super().__exit__(*_args)
         self.modules.clear()
+        self._release_observation_inputs()
         self._operators.clear()
         self._activation_terms.clear()
         self._results.clear()

--- a/tests/test_joint_operator_statistics.py
+++ b/tests/test_joint_operator_statistics.py
@@ -1,0 +1,297 @@
+"""Independent residual and ownership gates for deferred joint contractions."""
+import gc
+import weakref
+
+import pytest
+import torch
+
+from prismaquant import joint_aura
+from test_joint_aura_projection import _assert_projection, _linear, _oracle, _spec
+
+
+def _lease(modules, specs, budget=100000, candidate_budget=100000):
+    return joint_aura.JointOperatorStatisticsLease(
+        modules, specs, max_statistics_bytes=budget, max_candidate_bytes=candidate_budget)
+
+
+def _fixture(candidates=12):
+    generator = torch.Generator().manual_seed(1912)
+    weight = torch.randn(4, 3, generator=generator)
+    layer = _linear(weight)
+    qdq = lambda x: torch.round(x * 2) / 2
+    specs = {f'q{i}': _spec(f'q{i}', qdq) for i in range(candidates)}
+    specs['identity'] = _spec('identity', lambda x: x, act_bits=None)
+    draws = [(torch.randn(2, 3, generator=generator),
+              torch.randn(2, 4, generator=generator)) for _ in range(3)]
+    return layer, weight, specs, draws
+
+
+def test_many_candidates_reuse_two_operator_planes_and_match_fp64_residuals():
+    layer, weight, specs, draws = _fixture()
+    before = layer.weight.detach().clone()
+    # 12 candidate deltas would use 576 bytes. One GW plus shared GA uses 96.
+    with _lease({'u': layer}, {'u': specs}, budget=96) as lease:
+        assert lease.statistics_capacity_bytes == 96
+        lease.begin_probe()
+        for x, g in draws:
+            layer(x).backward(g)
+        assert lease.resident_statistics_bytes == 96
+        lease.finish_observations()
+        assert lease.telemetry['qdq_calls'] == len(draws)
+        for index, (fmt, spec) in enumerate(reversed(list(specs.items()))):
+            delta = torch.full_like(weight, (index + 1) / 128)
+            reference = {key: 0. for key in ('weight', 'activation', 'mixed', 'total')}
+            for x, g in draws:
+                terms = _oracle(weight, delta, x,
+                    spec.activation_quantize_dequantize(x), g)
+                for key, value in terms.items():
+                    reference[key] += value
+            actual = lease.project({('u', fmt): delta})
+            _assert_projection(actual[('u', fmt)], reference)
+            ref = weakref.ref(delta)
+            del delta
+            assert ref() is None, 'candidate deltas must stay caller-owned'
+        results = lease.finish_projections()
+        assert len(results) == len(specs)
+        assert lease.resident_statistics_bytes == 0
+    torch.testing.assert_close(layer.weight, before, rtol=0, atol=0)
+
+
+def test_budget_is_enforced_before_observers_or_matrix_allocation():
+    layer, _, specs, _ = _fixture()
+    with pytest.raises(RuntimeError, match='statistics.*budget'):
+        _lease({'u': layer}, {'u': specs}, budget=95)
+    assert not layer._forward_hooks
+
+
+def test_observation_release_drops_source_owners_before_candidate_projection():
+    layer, _, specs, draws = _fixture(2)
+    lease = _lease({'u': layer}, {'u': specs})
+    with lease:
+        lease.begin_probe()
+        x, g = draws[0]
+        layer(x).backward(g)
+        ref = weakref.ref(layer.weight)
+        lease.finish_observations()
+        assert not layer._forward_hooks and not lease.modules
+        del layer
+        gc.collect()
+        assert ref() is None
+        lease.project({('u', fmt): torch.zeros(4, 3) for fmt in specs})
+        lease.finish_projections()
+
+
+def test_incomplete_duplicate_unknown_and_late_projection_refuse():
+    layer, _, specs, _ = _fixture(1)
+    with _lease({'u': layer}, {'u': specs}) as lease:
+        with pytest.raises(RuntimeError, match='ready'):
+            lease.project({('u', 'q0'): torch.zeros(4, 3)})
+        lease.begin_probe()
+        lease.finish_observations()  # never-routed operators produce explicit zeros
+        with pytest.raises(RuntimeError, match='coverage'):
+            lease.finish_projections()
+        with pytest.raises(ValueError, match='unknown'):
+            lease.project({('u', 'bogus'): torch.zeros(4, 3)})
+        lease.project({('u', 'q0'): torch.zeros(4, 3)})
+        with pytest.raises(ValueError, match='duplicate'):
+            lease.project({('u', 'q0'): torch.zeros(4, 3)})
+        lease.project({('u', 'identity'): torch.zeros(4, 3)})
+        assert all(row['total'] == 0 for row in lease.finish_projections().values())
+        with pytest.raises(RuntimeError, match='ready'):
+            lease.project({('u', 'identity'): torch.zeros(4, 3)})
+
+
+def test_unconsumed_backward_refuses_observation_seal_and_cleans_up():
+    layer, _, specs, draws = _fixture(1)
+    lease = _lease({'u': layer}, {'u': specs})
+    with pytest.raises(RuntimeError, match='pending backward'):
+        with lease:
+            lease.begin_probe()
+            output = layer(draws[0][0])
+            lease.finish_observations()
+    assert not layer._forward_hooks and lease.resident_statistics_bytes == 0
+    with pytest.raises(RuntimeError, match='active'):
+        output.sum().backward()
+
+
+@pytest.mark.parametrize('when', ['before_forward', 'before_seal'])
+def test_changed_source_weights_are_refused(when):
+    layer, _, specs, draws = _fixture(1)
+    with _lease({'u': layer}, {'u': specs}) as lease:
+        lease.begin_probe()
+        if when == 'before_seal':
+            layer(draws[0][0]).backward(draws[0][1])
+        with torch.no_grad():
+            layer.weight.add_(1)
+        with pytest.raises(RuntimeError, match='source.*changed'):
+            if when == 'before_forward':
+                layer(draws[0][0])
+            else:
+                lease.finish_observations()
+
+
+def test_cancellation_preserves_three_signed_components_and_new_identity():
+    weight, delta = torch.tensor([[0., -1.]]), torch.tensor([[1., 0.]])
+    layer = _linear(weight)
+    spec = _spec('cancel', lambda x: x + torch.tensor([0., 1.]))
+    with _lease({'u': layer}, {'u': {'cancel': spec}}) as lease:
+        lease.begin_probe()
+        layer(torch.tensor([[1., 0.]])).sum().backward()
+        lease.finish_observations()
+        lease.project({('u', 'cancel'): delta})
+        assert lease.finish_projections()[('u', 'cancel')] == {
+            'weight': 1., 'activation': -1., 'mixed': 0., 'total': 0.}
+        identity = lease.arithmetic_identity(torch.float32)
+        assert identity != joint_aura.arithmetic_identity(torch.float32)
+        assert identity['operator_accumulation'] == 'sum_fp32_matrices_in_backward_invocation_order'
+
+
+def test_bad_candidate_quantum_is_atomic_and_never_retained():
+    layer, _, specs, draws = _fixture(1)
+    with _lease({'u': layer}, {'u': specs}) as lease:
+        lease.begin_probe()
+        layer(draws[0][0]).backward(draws[0][1])
+        lease.finish_observations()
+        with pytest.raises(RuntimeError, match='shape'):
+            lease.project({('u', 'q0'): torch.zeros(4, 3), ('u', 'identity'): torch.zeros(3, 4)})
+        result = lease.project({('u', fmt): torch.zeros(4, 3) for fmt in specs})
+        assert len(result) == 2
+        lease.finish_projections()
+
+
+def test_distinct_dynamic_qdq_callables_are_charged_separately():
+    layer = _linear(torch.ones(4, 3))
+    def quantizer(offset):
+        return lambda x: x + offset
+    specs = {'a': _spec('a', quantizer(1)), 'b': _spec('b', quantizer(2))}
+    # Both closures have the same named identity but different dynamic owners.
+    with _lease({'u': layer}, {'u': specs}, budget=144) as lease:
+        assert lease.statistics_capacity_bytes == 144
+        lease.begin_probe()
+        layer(torch.zeros(2, 3)).sum().backward()
+        lease.finish_observations()
+        lease.project({('u', fmt): torch.ones(4, 3) for fmt in specs})
+        result = lease.finish_projections()
+        assert result[('u', 'b')]['activation'] == 2 * result[('u', 'a')]['activation']
+
+
+def test_invalid_qdq_leaves_no_matrix_owner_after_context_failure():
+    layer = _linear(torch.ones(4, 3))
+    spec = _spec('bad', lambda x: x.double())
+    lease = _lease({'u': layer}, {'u': {'bad': spec}})
+    with pytest.raises(RuntimeError, match='QDQ changed'):
+        with lease:
+            lease.begin_probe()
+            layer(torch.ones(2, 3)).sum().backward()
+    assert not layer._forward_hooks and lease.resident_statistics_bytes == 0
+    with pytest.raises(RuntimeError, match='reenter'):
+        lease.__enter__()
+
+
+def test_second_backward_on_same_observation_refuses_double_counting():
+    layer = _linear(torch.ones(4, 3))
+    spec = _spec('id', lambda x: x, act_bits=None)
+    with _lease({'u': layer}, {'u': {'id': spec}}) as lease:
+        lease.begin_probe()
+        output = layer(torch.ones(2, 3))
+        output.sum().backward(retain_graph=True)
+        with pytest.raises(RuntimeError, match='active observation'):
+            output.sum().backward()
+
+
+@pytest.mark.parametrize('bad', [float('nan'), float('inf')])
+def test_nonfinite_candidate_projection_cannot_publish_partial_quantum(bad):
+    layer, _, specs, draws = _fixture(1)
+    with _lease({'u': layer}, {'u': specs}) as lease:
+        lease.begin_probe()
+        layer(draws[0][0]).backward(draws[0][1])
+        lease.finish_observations()
+        with pytest.raises(RuntimeError, match='nonfinite'):
+            lease.project({('u', 'q0'): torch.zeros(4, 3), ('u', 'identity'): torch.full((4, 3), bad)})
+        lease.project({('u', fmt): torch.zeros(4, 3) for fmt in specs})
+        lease.finish_projections()
+
+
+def test_packed_source_slices_and_unrouted_experts_match_independent_outputs():
+    from test_joint_aura_packed import _fixture as packed_fixture
+
+    model, _, _, _, _, views = packed_fixture()
+    layer = model.model.layers[0]
+    selected = {member.qname: member for member in views
+                if member.qname.startswith('model.layers.0.')}
+    spec = _spec('synthetic', lambda x: torch.round(x * 8) / 8)
+    specs = {name: {'synthetic': spec} for name in selected}
+    source = {name: member.weight.detach().clone() for name, member in selected.items()}
+    delta = {name: torch.full_like(weight, .03125) for name, weight in source.items()}
+    layer.feed_forward.experts.captures = []
+    expected = {name: {key: 0. for key in ('weight', 'activation', 'mixed', 'total')}
+                for name in selected}
+    with _lease(selected, specs) as lease:
+        lease.begin_probe()
+        x = torch.randn(1, 3, 16, requires_grad=True)
+        layer(x).sum().backward()
+        for expert, inputs, gate_up, hidden, down in layer.feed_forward.experts.captures:
+            for role, value, gradient in [('w1', inputs, gate_up.grad[:, :16]),
+                                          ('w3', inputs, gate_up.grad[:, 16:]),
+                                          ('w2', hidden, down.grad)]:
+                name = f'model.layers.0.feed_forward.experts.{expert}.{role}'
+                terms = _oracle(source[name], delta[name], value,
+                    spec.activation_quantize_dequantize(value), gradient)
+                for key, number in terms.items():
+                    expected[name][key] += number
+        lease.finish_observations()
+        assert lease.resident_statistics_bytes < lease.statistics_capacity_bytes
+        for name in reversed(list(selected)):
+            lease.project({(name, 'synthetic'): delta[name]})
+        result = lease.finish_projections()
+        for name, reference in expected.items():
+            _assert_projection(result[(name, 'synthetic')], reference)
+            if '.experts.2.' in name:
+                assert result[(name, 'synthetic')] == {key: 0. for key in reference}
+
+
+def test_candidate_budget_charges_full_storage_behind_small_views():
+    layer, _, specs, _ = _fixture(1)
+    with _lease({'u': layer}, {'u': specs}, candidate_budget=48) as lease:
+        lease.begin_probe()
+        lease.finish_observations()
+        pool = torch.zeros(20, 4, 3)
+        with pytest.raises(RuntimeError, match='candidate storage.*budget'):
+            lease.project({('u', 'q0'): pool[0]})
+        with pytest.raises(RuntimeError, match='candidate storage.*budget'):
+            lease.project({('u', fmt): torch.zeros(4, 3) for fmt in specs})
+        for fmt in specs:
+            lease.project({('u', fmt): torch.zeros(4, 3)})
+        lease.finish_projections()
+        assert lease.telemetry['peak_candidate_storage_bytes'] == 48
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason='native operator statistics needs CUDA')
+@pytest.mark.parametrize('shape', [(2048, 4096), (4096, 2048)])
+def test_native_glm_projection_shapes_match_independent_fp64_outputs(shape):
+    # Synthetic dW and QDQ isolate contraction arithmetic at actual GLM expert
+    # dimensions; they are not trained-model quality or format qualification.
+    rows, columns = shape
+    generator = torch.Generator().manual_seed(1907)
+    weight = (torch.randn(shape, generator=generator) / columns**.5).to('cuda', torch.bfloat16)
+    delta = torch.full(shape, .0009765625, device='cuda')
+    module = torch.nn.Linear(columns, rows, bias=False, device='cuda', dtype=torch.bfloat16)
+    with torch.no_grad():
+        module.weight.copy_(weight)
+    spec = _spec('synthetic', lambda x: torch.round(x * 8) / 8)
+    expected = {key: 0. for key in ('weight', 'activation', 'mixed', 'total')}
+    with _lease({'u': module}, {'u': {'synthetic': spec}},
+                budget=rows * columns * 8, candidate_budget=rows * columns * 4) as lease:
+        lease.begin_probe()
+        for count in (1, 3):
+            x = torch.randn(count, columns, generator=generator).to('cuda', torch.bfloat16)
+            g = torch.randn(count, rows, generator=generator).to('cuda', torch.bfloat16)
+            module(x).backward(g)
+            terms = _oracle(weight, delta, x, spec.activation_quantize_dequantize(x), g)
+            for key, value in terms.items():
+                expected[key] += value
+            module.zero_grad(set_to_none=True)
+        lease.finish_observations()
+        actual = lease.project({('u', 'synthetic'): delta})[('u', 'synthetic')]
+        _assert_projection(actual, expected)
+        lease.finish_projections()

--- a/tests/test_joint_operator_statistics.py
+++ b/tests/test_joint_operator_statistics.py
@@ -295,3 +295,49 @@ def test_native_glm_projection_shapes_match_independent_fp64_outputs(shape):
         actual = lease.project({('u', 'synthetic'): delta})[('u', 'synthetic')]
         _assert_projection(actual, expected)
         lease.finish_projections()
+
+
+def test_caught_backward_qdq_failure_poisoned_observation_cannot_be_retried():
+    layer = _linear(torch.ones(4, 3))
+    fail = True
+    def qdq(x):
+        if fail:
+            raise RuntimeError('transient QDQ failure')
+        return x + 1
+    spec = _spec('transient', qdq)
+    with _lease({'u': layer}, {'u': {'transient': spec}}) as lease:
+        lease.begin_probe()
+        output = layer(torch.ones(2, 3))
+        with pytest.raises(RuntimeError, match='transient QDQ failure'):
+            output.sum().backward(retain_graph=True)
+        fail = False
+        with pytest.raises(RuntimeError, match='active observation'):
+            output.sum().backward()
+        with pytest.raises(RuntimeError, match='not active'):
+            lease.finish_observations()
+        assert lease.resident_statistics_bytes == 0
+        assert not layer._forward_hooks
+
+
+@pytest.mark.parametrize('abort', [False, True])
+def test_retained_output_does_not_retain_observer_input_after_consumption_or_abort(abort):
+    observed = []
+    def qdq(x):
+        observed.append(weakref.ref(x))
+        if abort:
+            raise RuntimeError('abort observation')
+        return x + 1
+    layer = _linear(torch.ones(4, 3))
+    spec = _spec('observed', qdq)
+    with _lease({'u': layer}, {'u': {'observed': spec}}) as lease:
+        lease.begin_probe()
+        output = layer(torch.ones(2, 3))
+        if abort:
+            with pytest.raises(RuntimeError, match='abort observation'):
+                output.sum().backward()
+        else:
+            output.sum().backward()
+            lease.finish_observations()
+        gc.collect()
+        assert observed and observed[0]() is None
+    assert output.shape == (2, 4)


### PR DESCRIPTION
Joint probing currently retains every FP32 candidate delta through every baseline backward. Add an explicit bounded operator-statistics lease: accumulate source operators once, seal observations and release source references, then project caller-prefetched candidate quanta while preserving the three signed components. Full backing-storage accounting, lifecycle/source guards and a distinct FP32 arithmetic identity make the boundaries explicit. Existing pipeline defaults remain unchanged.

PB validation: missing-API regression 9 failures before implementation; final CPU 57 passed/2 CUDA skips plus compile checks; native GB10 46 passed/0 skips, including independent FP64 residuals at GLM expert dimensions. Synthetic A/B/B/A profiles measured 2.49× lower lease latency, incremental CUDA peak about 404 MB→134 MB, and 2.36–2.42× work per board joule. Full source/receipt audits, both-host telemetry and limitations are recorded in `docs/measurements/joint-operator-statistics-2026-09-08.md`. This is a primitive qualification; full-model residency, integration and quality remain unmeasured.

Closes #374.
