### PR TITLE
Bound Hessian sidecar pages without changing archive bytes

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,23 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `fix/selected-source-anchors`. Stamps
+As of: 2026-09-08 · `fix/bounded-hessian-sidecar`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `fix/bounded-hessian-sidecar`) for within-file Hessian
+sidecar page ownership (#377). Selected-source export keeps Torch's existing
+path writer, archive record names and serializer, pausing after each tensor
+record to pass its stable visible prefix through the existing inode/size/time
+checks, durability fence and page advice. It changes no tensor, archive byte,
+content seal or publication order; failures retain the previous published pair.
+The v2 selected-anchor resource plan charges one largest H record plus metadata
+as the export file-page window, while all selected H/X/weights and serialization
+scratch remain charged. The physical cgroup guard remains decisive because page
+advice alone is not evidence of release. Resident-source serialization retains
+its previous policy. The bounded writer is byte-qualified against the supported
+Torch runtimes, including shared storage and noncontiguous views; it does not
+establish a full GLM fit or change an exact anchor quantum.
+Gates: `tests/test_bounded_hessian_sidecar.py`, existing capture byte/identity
+checks, and before/after native writer memory traces with both Sparks' Netdata.
 
 Re-stamped (2026-09-08, `fix/selected-source-anchors`) for bounded selected
 encoder-factor ownership (#370). The existing `(unit, scale_plane)` memo in a

--- a/docs/measurements/bounded-hessian-writer-2026-09-08.md
+++ b/docs/measurements/bounded-hessian-writer-2026-09-08.md
@@ -1,0 +1,117 @@
+# Bounded Hessian sidecar writer — 2026-09-08
+
+Issue #377 addresses the remaining whole-file page owner in selected-source
+anchor preparation. The existing writer held all selected source weights,
+Hessians and X prefixes while `torch.save` produced one complete Hessian archive.
+Advice after publication could not bound the within-file peak. The v1 phase
+plan correctly refused a full GLM routed stack at 124.783 GiB.
+
+The selected writer now uses Torch's same path writer and serializer, pausing
+after synchronous tensor-record writes. The existing page helper verifies the
+stable visible file extent, fences durability and advises its pages. Tensor
+storage, pickle protocol, archive record names, CRCs, content seals and the
+atomic publication sequence are unchanged. A file-like substitute was avoided
+because it changes archive names. Resident-source serialization keeps its prior
+policy. The two Torch internal entry points used here are qualified against the
+CPU and native producer runtimes; future runtime changes still require parity.
+
+## Measured before and after
+
+All tests and measurements used PrismaBuild. The native workload contains
+16 resident CUDA FP32 Hessians of shape 4096×4096, totaling 1 GiB, and writes the
+ordinary `hessian_capture.pt` artifact. It is a writer qualification with fixed
+values and provenance, not a canonical model capture or full GLM fit test.
+
+Both actions ran on Sparklina in the same immutable producer image
+`sha256:9f9b9f05b17531399ba66dc6415b054cf5d68c82270626d0e9150e75c808435f`,
+Torch 2.13/CUDA 13.0 and Transformers 5.16.1, with four CPUs, 24 GiB physical
+memory and a 16 GiB GPU subset. Native threads were bounded to one per process;
+a separate thread sampled cgroup memory, anonymous/file/dirty pages and CUDA
+reservation every 20 ms. Torch recorded CPU/CUDA operations and memory, and
+`/proc/self/io` supplied per-process I/O counters. Netdata CPU, RAM, available
+memory and power series cover both Sparks and each measurement window, with
+three seconds of surrounding context. Sparky's coordinating canonical capture
+was external load; Sparklina's measurement window was isolated.
+
+| Observed quantity | Original writer | Prefix-advised writer |
+| --- | ---: | ---: |
+| Cgroup before writer (bytes) | 651,599,872 | 652,439,552 |
+| Sampled peak cgroup (bytes) | 1,746,935,808 | 809,885,696 |
+| Sampled peak file cache (bytes) | 1,120,169,984 | 113,537,024 |
+| Sampled peak dirty file pages (bytes) | 1,006,657,536 | 23,089,152 |
+| CUDA reservation (bytes) | 1,090,519,040 | 1,090,519,040 |
+| Profiled writer wall time (seconds) | 2.707 | 3.036 |
+| File bytes | 1,073,748,005 | 1,073,748,005 |
+
+The identical CUDA reservation is reported separately because GB10 cgroup
+charges can omit GPU allocations. The implementation reduces file ownership;
+this single pair records a small time increase and supports no speedup or
+work-per-joule claim. The original trace has 94 memory samples and the bounded
+trace 130. Netdata has 10/11 one-second samples per chart around these short
+windows; it cannot resolve the 20 ms transient alone.
+
+Both archives have exact SHA-256
+`150346bf06aed6c12d6699252bef4e4990dd91756ce87924e491c990ff90755e`.
+Both return content seal
+`02c6fcec3deee7c75a1aaaf83831070f0acfcb8d2b1cf14908422720325184b8`.
+No bytes were renamed, patched or normalized after writing.
+
+## Validation and disposition
+
+The regression first failed under the unchanged writer (`783031f412d7`): all
+bytes matched, but no tensor prefix was advised before publication. An initial
+implementation attempt omitted Torch's path normalization, so three tests
+failed on a Path object's missing `encode` method (`e259cf8a648a`). Passing
+`os.fspath(path)`, as the public save wrapper does, fixed the actual cause.
+
+The corrected focused CPU suite passed 33 tests with one explicit native
+measurement skip (`51f662ae5e44`). Additional cases passed for FP32, FP64 and
+BF16, shared/noncontiguous storage, ASCII and Unicode paths, and preservation of
+the previous published capture/sidecar when page advice or the memory guard
+fails (`c65629a5d7fe`, eight passed, one measurement skip). After v2 phase
+accounting, four independent CPU shards passed 63 tests with two skips: the
+explicit writer measurement and the CUDA-only memo comparison. CPU execution
+used DL380's pq-cpu312 interpreter, Torch 2.10 and Transformers 5.16.1.
+
+Native baseline `3e6131ae06c5` passed its measurement; native after action
+`ac14c7cf0446` passed 34 cases with no skips including the measurement and capture
+suite. Final native integration `ab7b3c10a237` passed 20 cases with one explicit
+measurement skip, including real tiny GLM original-layout capture, selected
+source preparation, native anchor and resume under the v2 resource plan. The
+measurement was already completed, so it was not repeated in that integration
+run. Each native action exited zero, recorded completed resource cleanup, and
+was followed by an independently empty Docker listing.
+
+Evidence root:
+`/mnt/shared/tessera-measurements/glm-canonical-census-20260908/bounded-hessian-writer-01/`.
+`baseline-invocation.json`, `bounded-invocation.json` and
+`native-final-invocation.json` seal the exact commands and source snapshots.
+`audit.json` verifies terminal hashes, exit statuses, CAS receipts and result
+bytes, including the failed attempts. `baseline-01/` and `bounded-01/` retain the
+original archives, memory/I/O samples, Torch traces, hash-bearing profile
+summaries and both Sparks' Netdata. `before-after-summary.json` compares the
+unchanged artifacts and measured owners. These artifacts are retained as
+bounded evidence; the detached baseline checkout is disposable because its
+exact test-only source is committed as `c635790f8` and snapshotted by PB.
+
+## Admission implication and remaining gate
+
+The v2 selected-anchor resource plan charges one largest tensor record plus
+metadata as the file-page window, while retaining all H/X/source weights and
+serialization scratch. The physical guard remains decisive: advice alone does
+not guarantee page reclamation. No partial capture can become canonical and no
+exact routed-stack group is split or replaced with a sampled estimator.
+
+Resource action `ff10b7324a2a` recomputed the representative GLM stack from the
+same canonical census and source headers: source preparation 68.221 GiB,
+export inputs 84.345 GiB and resident anchors 98.019 GiB. Its maximum is now
+98.019 GiB. Dense fused/singleton maxima remain 28.140/30.141 GiB.
+`resource-inspection-invocation.json` and `full-glm-derived-resources.json`
+record the derivation. This supersedes the writer's old 124.783 GiB phase for
+this implementation; the earlier dated report remains unchanged history.
+
+These are derived admission bounds. A full 864-unit GLM routed stack still
+requires execution from the completed common canonical capture, verified
+physical residency and the unchanged quality/cost/wire gates before any full
+fit claim is made. This change adds no cache, dispatcher, format, serving lane,
+calibration policy or release pin.

--- a/prismaquant/autoscale.py
+++ b/prismaquant/autoscale.py
@@ -330,16 +330,19 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
         source_validation_bytes=sum(source['body_source_file_bytes'][k] for k in layers)+widest_weight)
     export_inputs = dict(common, selected_hessian_bytes=source['full_hessian_bytes'],
         selected_prefix_bytes=source['full_prefix_bytes'],
-        # The existing torch.save writer completes one file before it can
-        # advise its pages. Counts retain the whole census, not this subset.
-        export_input_file_bytes=source['full_hessian_bytes']+len(counts)*16384,
+        # The unchanged Torch serializer pauses after each tensor record;
+        # verified prefix advice bounds visible file pages to one record.
+        # Counts retain the whole census, not this subset. The metadata bound
+        # also covers the writer's small buffered tail and central directory.
+        export_input_page_window_bytes=widest_h+len(counts)*16384,
         serialization_scratch_bytes=2*widest_h)
     phases = dict(source_preparation=preparation, export_inputs=export_inputs,
                   resident_anchors=encoding)
-    return dict(schema='prismaquant.selected_anchor_resources.v1', phases=phases,
+    return dict(schema='prismaquant.selected_anchor_resources.v2', phases=phases,
         memory_bytes=max(sum(phase.values()) for phase in phases.values()),
         selected_source_weight_bytes=weights, selected_layers=layers,
         source_header_sha256=source['source_header_sha256'],
+        export_input_writer_policy='verified-tensor-record-prefix',
         encoder_memo_policy='compatible-anchor-batch-width',
         encoder_memo_capacity=anchor_batch_size,
         source_forward_count=0)

--- a/prismaquant/perturbed_x_cache.py
+++ b/prismaquant/perturbed_x_cache.py
@@ -201,11 +201,14 @@ def write_activation_cache_entry(cache_dir, name, inputs, *, source="perturbed_x
 
 
 def release_activation_cache_file_pages(path, *, expected_stat):
-    """Advise only a completed, unchanged entry after its checksum is checked.
+    """Advise a verified unchanged file extent at a reader/writer boundary.
 
-    This optional capture-writer boundary leaves the artifact and all tensor
-    owners intact. Later consumers still use the ordinary activation prefetch.
-    Advice is not proof of physical release; the caller's guard remains final.
+    Readers check completed-entry hashes first. A serializer may also pause
+    after a synchronous tensor record and advise its stable visible prefix;
+    the same inode, size and timestamp checks and durability fence apply.
+    The artifact and tensor owners remain intact, and final publication still
+    requires the complete seal. Advice is not proof of physical release; the
+    caller's guard remains final.
     """
     import stat
     def identity(value):

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -3331,6 +3331,39 @@ def _require_resumable_anchor(anchor: CampaignAnchor, static_scales) -> None:
         )
 
 
+def _save_hessian_capture_with_page_release(payload, path, *, resource_check=None):
+    """Use Torch's path writer unchanged, advising each stable tensor prefix.
+
+    A file-like torch.save target changes archive record names. Keep the same
+    filename writer and serializer as torch.save, and interpose only after its
+    synchronous storage writes. No storage, pickle or archive byte is rewritten.
+    """
+    import torch.serialization as serialization
+    from .perturbed_x_cache import release_activation_cache_file_pages
+
+    class RecordBoundary:
+        def __init__(self, writer):
+            self.writer = writer
+
+        def __getattr__(self, name):
+            return getattr(self.writer, name)
+
+        def write_record(self, name, *args, **kwargs):
+            result = self.writer.write_record(name, *args, **kwargs)
+            if name.startswith('data/'):
+                # The serializer is paused: the visible file extent cannot
+                # change while the existing helper checks identity and fsyncs.
+                expected = path.stat()
+                release_activation_cache_file_pages(path, expected_stat=expected)
+                if resource_check is not None:
+                    resource_check('after_hessian_tensor_record:'+name)
+            return result
+
+    with serialization._open_zipfile_writer(os.fspath(path)) as writer:
+        serialization._save(payload, RecordBoundary(writer), serialization.pickle,
+                            serialization.DEFAULT_PROTOCOL, False)
+
+
 def write_export_inputs(cache_dir: Path, *, hessians, hessian_rows,
                         hessian_identity, static_scales, static_scale_policy,
                         release_file_pages=False, resource_check=None):
@@ -3383,11 +3416,13 @@ def write_export_inputs(cache_dir: Path, *, hessians, hessian_rows,
             hessian_capture_path.name + ".provenance.json")
         tmp_capture = hessian_capture_path.with_suffix(".pt.tmp")
         tmp_sidecar = sidecar.with_suffix(".json.tmp")
-        torch.save({
-            "H": saved_hessians,
-            "counts": dict(hessian_rows),
-            "provenance": capture_provenance,
-        }, tmp_capture)
+        payload = {"H": saved_hessians, "counts": dict(hessian_rows),
+                   "provenance": capture_provenance}
+        if release_file_pages:
+            _save_hessian_capture_with_page_release(payload, tmp_capture,
+                                                    resource_check=resource_check)
+        else:
+            torch.save(payload, tmp_capture)
         tmp_sidecar.write_text(json.dumps({
             **capture_provenance,
             "capture_sha256": capture_sha256,
@@ -4329,7 +4364,7 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     if selected_guard is not None:
         phase = selected_resources['phases']['export_inputs']
         selected_guard.check('before_selected_export_input_write', reserve_bytes=
-            phase['export_input_file_bytes']+phase['serialization_scratch_bytes'])
+            phase['export_input_page_window_bytes']+phase['serialization_scratch_bytes'])
     hessian_capture_path, input_scales_path, capture_sha256 = write_export_inputs(
         cache_dir,
         hessians=hessians if want_h else None,

--- a/tests/test_bounded_hessian_sidecar.py
+++ b/tests/test_bounded_hessian_sidecar.py
@@ -1,0 +1,115 @@
+"""The existing Torch archive can release completed records without new bytes."""
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def test_export_releases_stable_tensor_prefixes_with_exact_archive_bytes(tmp_path, monkeypatch):
+    from prismaquant import perturbed_x_cache, tessera_campaign as campaign
+    hessians = {f'unit.{index}': torch.arange(128*128, dtype=torch.float32).reshape(128, 128)+index
+                for index in range(4)}
+    hessians['shared.view'] = hessians['unit.0'].t()
+    calls = []
+    original = perturbed_x_cache.release_activation_cache_file_pages
+    def observe(path, *, expected_stat):
+        calls.append((Path(path).name, expected_stat.st_size))
+        return original(path, expected_stat=expected_stat)
+    monkeypatch.setattr(perturbed_x_cache, 'release_activation_cache_file_pages', observe)
+    outcomes = []
+    for bounded in (False, True):
+        directory = tmp_path/str(bounded)
+        directory.mkdir()
+        path, _scales, digest = campaign.write_export_inputs(directory,
+            hessians=hessians, hessian_rows=dict.fromkeys(hessians, 512),
+            hessian_identity={'fit_ids_sha256': 'unchanged-draw'},
+            static_scales={}, static_scale_policy='fixture', release_file_pages=bounded)
+        outcomes.append((path.read_bytes(), digest))
+    assert outcomes[0] == outcomes[1]
+    prefixes = [size for name, size in calls if name == 'hessian_capture.pt.tmp']
+    assert len(prefixes) >= 4, 'the writer retained the whole file until publication'
+    assert prefixes == sorted(prefixes)
+    assert prefixes[0] < len(outcomes[1][0])//2
+    assert calls[-1] == ('hessian_capture.pt', len(outcomes[1][0]))
+
+
+def test_native_hessian_writer_profile(tmp_path, monkeypatch):
+    """Opt-in, attributed writer qualification, never a full-GLM fit claim."""
+    import hashlib
+    import json
+    import os
+    import threading
+    import time
+    from prismaquant import perturbed_x_cache, tessera_campaign as campaign
+    from prismaquant.memory_management import CaptureMemoryGuard
+    destination = os.environ.get('PRISMAQUANT_HESSIAN_WRITER_PROFILE')
+    if not destination:
+        pytest.skip('explicit native writer measurement only')
+    assert torch.cuda.is_available()
+    root = Path(destination)
+    root.mkdir(parents=True, exist_ok=False)
+    hessians = {f'unit.{index}': torch.full((4096, 4096), index/16,
+                device='cuda', dtype=torch.float32) for index in range(16)}
+    torch.cuda.synchronize()
+    guard = CaptureMemoryGuard('cuda')
+    events, samples = [], []
+    original = perturbed_x_cache.release_activation_cache_file_pages
+    def advise(path, *, expected_stat):
+        events.append(dict(name=Path(path).name, bytes=expected_stat.st_size,
+                           before=guard.check('before_prefix_advice')))
+        result = original(path, expected_stat=expected_stat)
+        events[-1]['after'] = guard.check('after_prefix_advice')
+        return result
+    monkeypatch.setattr(perturbed_x_cache, 'release_activation_cache_file_pages', advise)
+    stop = threading.Event()
+    errors = []
+    def sample():
+        while not stop.wait(.02):
+            try:
+                stat = dict(line.split() for line in (guard.scope/'memory.stat').read_text().splitlines())
+                samples.append(dict(time_unix=time.time(),
+                    current_bytes=int((guard.scope/'memory.current').read_text()),
+                    cuda_reserved_bytes=torch.cuda.memory_reserved(),
+                    **{name: int(stat[name]) for name in ('anon', 'file', 'file_dirty', 'file_writeback')}))
+            except Exception as error:
+                errors.append(str(error))
+    def process_io():
+        return dict((key.rstrip(':'), int(value)) for key, value in
+                    (line.split() for line in Path('/proc/self/io').read_text().splitlines()))
+    before = guard.check('before_writer')
+    io_before = process_io()
+    started = time.time()
+    sampler = threading.Thread(target=sample, daemon=True)
+    sampler.start()
+    try:
+        with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA], profile_memory=True,
+                record_shapes=True) as prof:
+            path, _, content_digest = campaign.write_export_inputs(root,
+                hessians=hessians, hessian_rows=dict.fromkeys(hessians, 512),
+                hessian_identity={'fit_ids_sha256': 'writer-qualification-fixed'},
+                static_scales={}, static_scale_policy='fixture', release_file_pages=True,
+                resource_check=guard.check)
+        torch.cuda.synchronize()
+    finally:
+        ended = time.time()
+        stop.set()
+        sampler.join()
+    after = guard.check('after_writer')
+    assert not errors
+    io_after = process_io()
+    prof.export_chrome_trace(str(root/'writer.trace.json'))
+    file_sha = hashlib.sha256()
+    with path.open('rb') as handle:
+        while block := handle.read(8*1024**2):
+            file_sha.update(block)
+    perturbed_x_cache.release_activation_cache_file_pages(path, expected_stat=path.stat())
+    report = dict(start_unix=started, end_unix=ended, elapsed_s=ended-started,
+        workload=dict(tensors=16, shape=[4096,4096], dtype='float32', device='cuda',
+                      tensor_bytes=16*4096*4096*4),
+        before=before, after=after, page_advice=events, memory_samples=samples,
+        io_delta={key: io_after[key]-io_before[key] for key in io_before},
+        file_bytes=path.stat().st_size, file_sha256=file_sha.hexdigest(),
+        content_digest=content_digest, torch=torch.__version__, cuda=torch.version.cuda,
+        claim='writer ownership qualification; no full GLM fit or throughput claim')
+    (root/'measurement.json').write_text(json.dumps(report, indent=2)+'\n')

--- a/tests/test_bounded_hessian_sidecar.py
+++ b/tests/test_bounded_hessian_sidecar.py
@@ -5,9 +5,12 @@ import pytest
 import torch
 
 
-def test_export_releases_stable_tensor_prefixes_with_exact_archive_bytes(tmp_path, monkeypatch):
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float64, torch.bfloat16])
+@pytest.mark.parametrize('directory_name', ['ascii', 'café'])
+def test_export_releases_stable_tensor_prefixes_with_exact_archive_bytes(tmp_path, monkeypatch,
+                                                                        dtype, directory_name):
     from prismaquant import perturbed_x_cache, tessera_campaign as campaign
-    hessians = {f'unit.{index}': torch.arange(128*128, dtype=torch.float32).reshape(128, 128)+index
+    hessians = {f'unit.{index}': torch.arange(128*128, dtype=torch.float32).to(dtype).reshape(128, 128)+index
                 for index in range(4)}
     hessians['shared.view'] = hessians['unit.0'].t()
     calls = []
@@ -18,8 +21,8 @@ def test_export_releases_stable_tensor_prefixes_with_exact_archive_bytes(tmp_pat
     monkeypatch.setattr(perturbed_x_cache, 'release_activation_cache_file_pages', observe)
     outcomes = []
     for bounded in (False, True):
-        directory = tmp_path/str(bounded)
-        directory.mkdir()
+        directory = tmp_path/directory_name/str(bounded)
+        directory.mkdir(parents=True)
         path, _scales, digest = campaign.write_export_inputs(directory,
             hessians=hessians, hessian_rows=dict.fromkeys(hessians, 512),
             hessian_identity={'fit_ids_sha256': 'unchanged-draw'},
@@ -113,3 +116,23 @@ def test_native_hessian_writer_profile(tmp_path, monkeypatch):
         content_digest=content_digest, torch=torch.__version__, cuda=torch.version.cuda,
         claim='writer ownership qualification; no full GLM fit or throughput claim')
     (root/'measurement.json').write_text(json.dumps(report, indent=2)+'\n')
+
+
+@pytest.mark.parametrize('failure', ['page_advice', 'memory_guard'])
+def test_record_failure_preserves_previous_published_capture(tmp_path, monkeypatch, failure):
+    from prismaquant import perturbed_x_cache, tessera_campaign as campaign
+    inputs = dict(hessians={'unit': torch.eye(128)}, hessian_rows={'unit': 512},
+                  hessian_identity={'fit_ids_sha256': 'same-draw'}, static_scales={},
+                  static_scale_policy='fixture')
+    path, _, _ = campaign.write_export_inputs(tmp_path, **inputs)
+    sidecar = path.with_name(path.name+'.provenance.json')
+    previous = (path.read_bytes(), sidecar.read_bytes())
+    inputs['hessians'] = {'unit': torch.eye(128)*2}
+    def refuse(*args, **kwargs):
+        raise RuntimeError('refused at stable record')
+    if failure == 'page_advice':
+        monkeypatch.setattr(perturbed_x_cache, 'release_activation_cache_file_pages', refuse)
+    with pytest.raises(RuntimeError, match='refused at stable record'):
+        campaign.write_export_inputs(tmp_path, **inputs, release_file_pages=True,
+            resource_check=refuse if failure == 'memory_guard' else None)
+    assert (path.read_bytes(), sidecar.read_bytes()) == previous

--- a/tests/test_tessera_calibration_cache.py
+++ b/tests/test_tessera_calibration_cache.py
@@ -95,7 +95,7 @@ def test_export_input_page_release_preserves_existing_file_bytes(capture, monkey
         if bounded:
             assert observed[-1] == 'after_selected_export_input_write'
     assert outcomes[0] == outcomes[1]
-    assert calls == ['hessian_capture.pt']
+    assert calls == ['hessian_capture.pt.tmp']*2+['hessian_capture.pt']
 
 
 @pytest.mark.parametrize('change',['artifact','manifest','source','draw','geometry','scope'])

--- a/tests/test_tessera_selected_source.py
+++ b/tests/test_tessera_selected_source.py
@@ -100,7 +100,9 @@ def test_selected_admission_excludes_unselected_source_and_forward_owners(monkey
     assert source['loader_transient_bytes'] == 200
     assert anchors['selected_hessian_bytes'] == 128
     assert anchors['selected_prefix_bytes'] == 64
-    assert export['export_input_file_bytes'] == 128+2*16384
+    assert export['export_input_page_window_bytes'] == 64+2*16384
+    assert plan['schema'] == 'prismaquant.selected_anchor_resources.v2'
+    assert plan['export_input_writer_policy'] == 'verified-tensor-record-prefix'
     assert export['serialization_scratch_bytes'] == 2*4**2*4
     assert anchors['encoder_memo_bytes'] == 4*4*4+4*8
     assert plan['encoder_memo_capacity'] == 1


### PR DESCRIPTION
Selected-source anchor preparation retained a complete Hessian archive in file cache while H/X/source weights remained resident. This pauses Torch's unchanged path writer after synchronous tensor records and uses the existing identity checks, durability fence and page advice on stable file prefixes. Exact archive names/bytes, storage sharing, content seals and publication order remain unchanged; failure preserves the previous published pair.

Matched native PB measurements wrote the same 1,073,748,005-byte archive with identical SHA-256 and content seal. Sampled file-cache peak fell from 1.120 GB to 0.114 GB and cgroup peak from 1.747 GB to 0.810 GB. The profiled writer took 2.707 versus 3.036 seconds, so this establishes reduced file ownership with an observed time cost. Torch CPU/CUDA traces, 20 ms cgroup/I/O samples and both Sparks' Netdata are retained. No speedup or full GLM fit is claimed.

The v2 selected-anchor plan charges a one-record file-page window plus metadata. The representative GLM stack derives 84.345 GiB export residency and 98.019 GiB overall, still requiring actual full-stack qualification from the completed canonical capture. No partial capture, sampled substitute, new cache, dispatcher, format or serving gate is introduced.

Validation through PrismaBuild: regression reproduced before implementation; exact parity across FP32/FP64/BF16, shared/noncontiguous storage and Unicode paths; failed advice/guard preserves publication. Final CPU shards: 63 passed, two skips. Native matched after measurement/capture suite: 34 passed, no skips. Final native GLM capture→selected anchor→resume integration: 20 passed, one already-measured profile-only skip. Terminal statuses, CAS bytes and container cleanup independently verified. See `docs/measurements/bounded-hessian-writer-2026-09-08.md` for commands, receipt paths, negative trials and scope.

Stacked on #376 solely to keep the review diff focused; retarget to main after #376 merges.

Fixes #377.
