### PR TITLE
Coalesce consumed source spans to release retained file-cache folios

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,18 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `fix/joint-boundary-residency`. Stamps
+As of: 2026-09-08 · `fix/coalesced-source-page-release`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `fix/coalesced-source-page-release`) for consumed
+source-page release (#380). The existing CUDA reader chunk validates selected
+safetensors spans, merges adjacent or overlapping consumed bytes, then advises
+only complete pages of each union. This releases internal tensor-boundary
+pages while preserving headers, unread gaps and outer partial pages. The
+existing completed-copy fence, mapping lifetime and source-identity checks
+remain unchanged. No global page drop, admission allowance or source cache is
+introduced; advice remains best effort. Gates cover adjacency, unread gaps,
+invalid-span refusal, CUDA lifecycle and a bounded real-checkpoint native
+profile. A full canonical capture still requires its own successful receipt.
 
 Re-stamped (2026-09-08, `fix/joint-boundary-residency`) for the explicit
 `prismaquant.aura.boundary_storage.v1` policy (#373). Streamed AURA can store

--- a/docs/measurements/coalesced-source-page-release-2026-09-08.md
+++ b/docs/measurements/coalesced-source-page-release-2026-09-08.md
@@ -1,0 +1,81 @@
+# Consumed source-page coalescing — 2026-09-08
+
+Issue #380. This fixes the opt-in CUDA source-reader page-advice range, without
+changing checkpoint bytes, selected tensors, copy/map lifetime fences, source
+identity, admission thresholds or the canonical calibration contract.
+
+The common GLM capture stopped at its physical memory guard before layer 11.
+Its retired cgroup retained 18,513,117,184 file-cache bytes, including
+18,111,004,672 `file_thp` bytes, with anonymous memory zero. The old helper
+aligned every tensor individually, leaving a partial page at every adjacent
+consumed tensor boundary. Large file-cache folios containing those pages
+remained resident. The corrected helper validates all selected spans, unions
+adjacent/overlapping consumed bytes, then aligns each union inward. Headers,
+unread gaps and outer partial pages remain protected. There is no global cache
+drop, separate source cache or new allowance to pass the physical guard.
+
+A failing pre-fix CPU regression (`f8baf61182b3`) reproduced two advice ranges
+where one contiguous consumed range was required. The corrected focused suite
+passed 24 tests (`1de1d672fc9f`); source-page, architecture and staleness checks
+passed 43 tests with no skips (`0c3924531a25`). These tests include unread gaps,
+invalid later spans refusing before any advice, source mutation, nonregular
+files, CPU mapping ownership and mocked CUDA copy/map lifecycle.
+
+The native measurement is PB action
+`2f7d0b024d3c39b632c005b0a5e2411b7702d4f7b07731eaf362ba884769cc2d`:
+`--measurement --host-class gb10`, placed on Sparky, 2 CPUs, 12 GiB physical
+memory and a 6 GiB GPU subset. Native library threads and the existing source
+read pool each used one thread. The content-qualified producer image seal is
+`eb8592abd71390231b49aba119e36f02ad91ea867b06df1c67af3833004d07bd`,
+Torch 2.13.0+cu130, CUDA 13.0, NVIDIA driver 595.84.
+
+`experiments/source_page_release_profile.py` reads the same 64 contiguous BF16
+GLM layer-20 expert tensors from the actual checkpoint, totaling 1 GiB, in one
+admitted ABBA experiment. The old-control arm invokes the shared helper once
+per key, reproducing its original page ranges. The corrected arm calls it once
+per completed reader chunk. Both are profiled with CPU/CUDA `torch.profiler`,
+memory events and shape recording. A 20 ms sampler records cgroup memory,
+`file_thp` and CUDA reservations. `mincore` reads residency without faulting in
+the selected payload. A completed warm read supplies exact GPU reference
+values; each arm must compare equal for every tensor. Between arms only the
+already consumed byte union receives advice, so every initial payload residency
+is the same 2,093,056 bytes. No source or unrelated cache bytes are modified.
+
+| Arm | Payload pages retained | Cgroup `file_thp` after read | Profiled wall time |
+| --- | ---: | ---: | ---: |
+| Old per-key 1 | 134,213,632 B | 136,314,880 B | 0.5704 s |
+| Coalesced 1 | 2,093,056 B | 4,194,304 B | 0.3270 s |
+| Coalesced 2 | 2,093,056 B | 4,194,304 B | 0.3988 s |
+| Old per-key 2 | 134,213,632 B | 136,314,880 B | 0.4257 s |
+
+The measured memory reduction is 126 MiB of retained payload/cache-folio
+storage per 64 adjacent expert tensors in this workload. All four GPU results
+are byte-exact. The protected outer edge still retains roughly 2 MiB; advice
+is best effort and cannot authorize a general zero-residency assumption.
+The first arm also allocates its second GPU output plane; later arms reuse that
+allocator reservation. The control reparses the small header for each key.
+These short timings therefore do not establish a production speedup or work
+per joule. Each trace records 64 HtoD copies. This experiment qualifies memory
+release, and does not establish GPU-bound source loading or a full-capture fit.
+
+Both-host Netdata CPU, RAM, available-memory and GPU-power charts have ten
+samples spanning the experiment plus three seconds of context on either side.
+Their resolution is too coarse for per-arm energy comparison. GPU utilization
+is not used as a saturation claim. PB ended with exit 0, no OOM, complete
+scope cleanup and independently empty local Docker process listing.
+
+Attributable artifacts are under
+`/mnt/shared/tessera-measurements/glm-canonical-census-20260908/coalesced-source-pages-01/`:
+
+- `native-invocation.json` records the complete command and sealed container.
+- `native-abba-01/measurement.json` records every arm, source stat, exact keys,
+  span, samples, advice boundaries and exact GPU equality.
+- `native-abba-01/{0-per_key,1-coalesced,2-coalesced,3-per_key}.trace.json`
+  and `profile-summary.json` provide before/after in-process profiles.
+- `native-abba-01/netdata-*.json` preserves both boxes' eight chart series.
+- `audit.json` checks actual terminal status, cleanup, source snapshot and CAS
+  payload bytes; `artifact-seals.json` binds measurement files by SHA-256.
+- Prefix-named logs preserve the failed regression and passing checks.
+
+The previous full capture remains a failed, partial artifact. Only a separately
+completed canonical capture can establish full-model progress after this fix.

--- a/experiments/source_page_release_profile.py
+++ b/experiments/source_page_release_profile.py
@@ -1,0 +1,137 @@
+"""Bounded native paired qualification of consumed safetensors page release.
+
+Run only inside an admitted PB action. Reads the same real checkpoint subset
+with original per-key advice and coalesced advice, retaining exact GPU bytes.
+"""
+import argparse
+import ctypes
+import json
+import mmap
+import os
+from pathlib import Path
+import threading
+import time
+
+import torch
+from prismaquant import layer_streaming as ls
+from prismaquant.memory_management import CaptureMemoryGuard
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--model', required=True)
+    parser.add_argument('--output', required=True)
+    args = parser.parse_args()
+    root = Path(args.output)
+    root.mkdir(parents=True, exist_ok=False)
+    model = Path(args.model)
+    weights = json.loads((model/'model.safetensors.index.json').read_text())['weight_map']
+    available = sorted(k for k in weights if 'layers.20.mlp.experts.' in k)
+    shard = model/weights[available[0]]
+    with shard.open('rb') as handle:
+        length = int.from_bytes(handle.read(8), 'little')
+        header = json.loads(handle.read(length))
+    keys = sorted((k for k in available if weights[k] == shard.name),
+                  key=lambda k: header[k]['data_offsets'][0])[:64]
+    assert len(keys) == 64
+    assert all(header[k]['dtype'] == 'BF16' for k in keys)
+    assert all(header[a]['data_offsets'][1] == header[b]['data_offsets'][0]
+               for a,b in zip(keys, keys[1:]))
+    base = length+8
+    begin = base+header[keys[0]]['data_offsets'][0]
+    end = base+header[keys[-1]]['data_offsets'][1]
+    page = os.sysconf('SC_PAGE_SIZE')
+    first, last = (begin+page-1)//page*page, end//page*page
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.mincore.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_void_p]
+    libc.mincore.restype = ctypes.c_int
+    def residency():
+        with shard.open('rb') as handle:
+            region = mmap.mmap(handle.fileno(), last-first, access=mmap.ACCESS_COPY, offset=first)
+            address = ctypes.addressof(ctypes.c_char.from_buffer(region))
+            vector = (ctypes.c_ubyte*((last-first)//page))()
+            result = libc.mincore(address, last-first, vector)
+            if result:
+                raise OSError(ctypes.get_errno(), 'mincore')
+            resident = sum(bool(value & 1) for value in vector)*page
+            region.close()
+        return resident
+    guard = CaptureMemoryGuard('cuda')
+    def memory():
+        stats = dict(line.split() for line in (guard.scope/'memory.stat').read_text().splitlines())
+        return dict(time_unix=time.time(), current_bytes=int((guard.scope/'memory.current').read_text()),
+                    cuda_reserved_bytes=torch.cuda.memory_reserved(),
+                    **{k:int(stats[k]) for k in ('anon','file','file_thp','file_dirty','file_writeback')})
+    mapping = dict.fromkeys(keys, str(shard))
+    names = {k:k for k in keys}
+    original = ls._advise_consumed_safetensors_pages
+    source_stat = shard.stat()
+    def read():
+        return ls._read_layer_to_device('', mapping, names, torch.bfloat16, torch.device('cuda:0'))
+    reference = read()
+    torch.cuda.synchronize()
+    assert sum(t.numel()*t.element_size() for t in reference.values()) == 1024**3
+    arms = []
+    for index, mode in enumerate(('per_key','coalesced','coalesced','per_key')):
+        # All advised bytes were consumed by this action's completed warm/read.
+        # This changes no header, unread neighbor, outer edge or global cache.
+        original(str(shard), keys, source_stat)
+        events, samples, errors = [], [], []
+        stop = threading.Event()
+        def sample():
+            while not stop.wait(.02):
+                try:
+                    samples.append(memory())
+                except Exception as exc:
+                    errors.append(str(exc))
+        def advice(path, selected, expected_stat=None):
+            before = memory()
+            started = time.perf_counter()
+            if mode == 'per_key':
+                for key in sorted(set(selected)):
+                    original(path, [key], expected_stat)
+            else:
+                original(path, selected, expected_stat)
+            events.append(dict(keys=len(selected), elapsed_s=time.perf_counter()-started,
+                               before=before, after=memory()))
+        ls._advise_consumed_safetensors_pages = advice
+        initial = dict(memory=memory(), resident_payload_bytes=residency())
+        worker = threading.Thread(target=sample, daemon=True)
+        worker.start()
+        started = time.time()
+        try:
+            with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU,
+                    torch.profiler.ProfilerActivity.CUDA], profile_memory=True,
+                    record_shapes=True) as prof:
+                with torch.profiler.record_function('source_read_and_page_release'):
+                    values = read()
+                    torch.cuda.synchronize()
+            ended = time.time()
+        finally:
+            stop.set()
+            worker.join()
+            ls._advise_consumed_safetensors_pages = original
+        final = dict(memory=memory(), resident_payload_bytes=residency())
+        assert not errors
+        equal = all(torch.equal(values[key], reference[key]) for key in keys)
+        assert equal
+        del values
+        prof.export_chrome_trace(str(root/f'{index}-{mode}.trace.json'))
+        arms.append(dict(mode=mode, start_unix=started, end_unix=ended, elapsed_s=ended-started,
+                         initial=initial, final=final, exact_gpu_bytes=equal,
+                         page_advice=events, memory_samples=samples))
+        (root/'measurement.json').write_text(json.dumps(dict(arms=arms), indent=2)+'\n')
+    original(str(shard), keys, source_stat)
+    current = shard.stat()
+    assert all(getattr(current,k) == getattr(source_stat,k) for k in
+               ('st_dev','st_ino','st_size','st_mtime_ns','st_ctime_ns'))
+    report = dict(arms=arms, source=str(shard), keys=keys, tensor_bytes=end-begin,
+        payload_begin=begin, payload_end=end, advised_begin=first, advised_end=last,
+        source_stat={k:getattr(source_stat,k) for k in ('st_dev','st_ino','st_size','st_mtime_ns','st_ctime_ns')},
+        torch=torch.__version__, cuda=torch.version.cuda,
+        contract='Same 64 contiguous real BF16 expert tensors; ABBA original per-key vs coalesced consumed-page advice; exact GPU equality. No full-capture fit claim.')
+    (root/'measurement.json').write_text(json.dumps(report, indent=2)+'\n')
+    print(json.dumps({k:report[k] for k in ('tensor_bytes','contract')}), flush=True)
+
+if __name__ == '__main__':
+    main()

--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -1394,13 +1394,25 @@ def _advise_consumed_safetensors_pages(shard: str, keys: list[str],
         header = json.loads(os.pread(fd, header_size, 8))
         base = 8 + header_size
         page = os.sysconf('SC_PAGE_SIZE')
+        spans = []
         for key in sorted(set(keys)):
             begin, end = header[key]['data_offsets']
             if (type(begin) is not int or type(end) is not int
                     or not 0 <= begin <= end <= source_stat.st_size - base):
                 raise ValueError('invalid tensor span for consumed-page release')
-            first = ((base + begin + page - 1) // page) * page
-            last = ((base + end) // page) * page
+            spans.append((base + begin, base + end))
+        # Merge bytes before page alignment: a page shared by two consumed
+        # tensors is consumed in full. Per-tensor alignment would retain each
+        # boundary page (and potentially its entire large file-cache folio).
+        merged = []
+        for begin, end in sorted(spans):
+            if merged and begin <= merged[-1][1]:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+            else:
+                merged.append((begin, end))
+        for begin, end in merged:
+            first = ((begin + page - 1) // page) * page
+            last = (end // page) * page
             if first < last:
                 os.posix_fadvise(fd, first, last - first, os.POSIX_FADV_DONTNEED)
     finally:

--- a/tests/test_streaming_source_pages.py
+++ b/tests/test_streaming_source_pages.py
@@ -250,3 +250,45 @@ def test_changed_source_identity_refuses_advice(tmp_path, monkeypatch):
     monkeypatch.setattr(os, 'posix_fadvise', lambda *args: pytest.fail('replacement source advised'))
     with pytest.raises(RuntimeError, match='source changed'):
         ls._advise_consumed_safetensors_pages(str(path), ['selected'], expected)
+
+
+def test_adjacent_consumed_payloads_coalesce_before_page_alignment(tmp_path, monkeypatch):
+    path, tensors, header, base, page = checkpoint(tmp_path)
+    selected = sorted(header, key=lambda name: header[name]['data_offsets'][0])[:2]
+    calls = []
+    monkeypatch.setattr(os, 'posix_fadvise', lambda fd, start, size, mode:
+                        calls.append((start, size, mode)))
+    ls._advise_consumed_safetensors_pages(str(path), list(reversed(selected))+selected)
+    begin = base+header[selected[0]]['data_offsets'][0]
+    end = base+header[selected[-1]]['data_offsets'][1]
+    first = (begin+page-1)//page*page
+    last = end//page*page
+    assert calls == [(first, last-first, os.POSIX_FADV_DONTNEED)]
+    assert last <= base+header['unread_after']['data_offsets'][0]
+
+
+def test_nonadjacent_consumed_payloads_preserve_unread_gap(tmp_path, monkeypatch):
+    path, tensors, header, base, page = checkpoint(tmp_path)
+    ordered = sorted(header, key=lambda name: header[name]['data_offsets'][0])
+    calls = []
+    monkeypatch.setattr(os, 'posix_fadvise', lambda fd, start, size, mode:
+                        calls.append((start, size)))
+    ls._advise_consumed_safetensors_pages(str(path), [ordered[0], ordered[2]])
+    assert len(calls) == 2
+    unread_begin, unread_end = (base+x for x in header[ordered[1]]['data_offsets'])
+    assert all(start+size <= unread_begin or start >= unread_end for start, size in calls)
+
+
+def test_invalid_later_span_refuses_before_any_advice(tmp_path, monkeypatch):
+    path, tensors, header, base, page = checkpoint(tmp_path)
+    calls = []
+    monkeypatch.setattr(os, 'posix_fadvise', lambda *args: calls.append(args))
+    real_loads = json.loads
+    def malformed(raw):
+        h = real_loads(raw)
+        h['unread_after']['data_offsets'][1] = path.stat().st_size
+        return h
+    monkeypatch.setattr(json, 'loads', malformed)
+    with pytest.raises(ValueError, match='invalid tensor span'):
+        ls._advise_consumed_safetensors_pages(str(path), list(header))
+    assert calls == []


### PR DESCRIPTION
Canonical GLM capture retained a large file-cache folio at each adjacent tensor boundary and stopped at the physical guard before layer 11. Merge validated consumed byte spans before page alignment so internal consumed boundary pages are released while headers, unread gaps, outer edges and existing copy/map lifetime checks remain protected.

Real 1 GiB checkpoint ABBA measurement on GB10 reduced retained payload pages from 134,213,632 to 2,093,056 bytes in both paired arms; all GPU tensors remained byte-exact. CPU/CUDA traces, cgroup file_thp and both-host Netdata are retained. No full-capture fit or speedup claim.

Validation through PrismaBuild: pre-fix regression failed; 43 focused source-page/architecture/staleness tests passed, zero skips (0c3924531a25); native measurement2f7d0b024d3c exited0 with complete cleanup. Source-page tests include preserved unread gaps and invalid-span refusal before any advice. Full evidence: docs/measurements/coalesced-source-page-release-2026-09-08.md.

Fixes #380
