### PR TITLE
Bound research candidate residency through ProductionWeightCache windows

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,26 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `fix/joint-boundary-residency`. Stamps
+As of: 2026-09-08 · `codex/pwc-resident-windows`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `codex/pwc-resident-windows`) for opt-in candidate
+windows through `ProductionWeightCache` (#381). `plan_resident_windows`
+resolves aliases in input order and bounds each finite quantum by a declared
+byte cap and loader count. `resident_window` uses the existing prefetch pool;
+`get_resident` refuses missing or evicted entries and preserves CB integrity
+and active file-load receipts. Whole backing storages count, including views,
+aliases and unrelated resident entries. Incoming standard uncompressed Torch
+archives have a conservative file-size bound plus storage-record preflight;
+opaque/compressed inputs refuse. Serialized load buffers have a separate
+aggregate cap. Nested windows and LRU eviction of other entries refuse.
+Context completion or failure releases the selected disk-backed cache owners
+through the existing release mechanism. Optional checked file-page advice
+follows the verified load, without changing artifact bytes or promising
+physical reclaim. Callers still admit allocator overhead, borrowed references
+and projection workspaces separately. Legacy cache defaults, pipeline order,
+quantization arithmetic and serving gates are unchanged. CPU lifecycle and
+budget gates are in `tests/test_pwc_resident_windows.py`; this API is not a
+full-model fit or throughput qualification.
 
 Re-stamped (2026-09-08, `fix/joint-boundary-residency`) for the explicit
 `prismaquant.aura.boundary_storage.v1` policy (#373). Streamed AURA can store

--- a/docs/measurements/pwc-resident-windows-2026-09-08.md
+++ b/docs/measurements/pwc-resident-windows-2026-09-08.md
@@ -1,0 +1,93 @@
+# Production weight-cache resident windows — 2026-09-08
+
+Issue #381; implementation `d2a9218f08`. This is an opt-in cache API and CPU
+lifecycle qualification. It changes no pipeline default, source traversal,
+quantization arithmetic, cache artifact, format menu or serving gate. No GPU
+throughput, whole-process memory fit, KL or bpp claim is made.
+
+## API and ownership
+
+`ProductionWeightCache.plan_resident_windows(keys, *, max_resident_bytes,
+max_workers)` resolves aliases, removes duplicates in first-occurrence order,
+and returns finite tuples of concrete cache keys. Each quantum has at most
+`max_workers` entries. This bounds the existing `prefetch` pool's submitted
+futures and loaded results without adding another cache or dispatcher.
+
+`resident_window(keys, *, max_resident_bytes, max_workers,
+max_load_buffer_bytes=None, release_file_pages=False)` admits exactly one
+nonempty quantum, prefetches it, checks residency and yields a key/scalar-only
+receipt. All existing PWC tensor backing storages count against the resident
+cap, including unrelated entries and storage hidden behind small views.
+Storage aliases count once. Incoming files use the existing conservative file
+estimate and uncompressed Torch archive storage-record preflight. Compressed,
+opaque and symlink inputs refuse; sparse/meta tensor storages refuse. Loaded
+storage is checked against the archive bound and complete cache storage is
+checked before exposing a window. The LRU must have room for the incoming
+storage without evicting another resident entry. Nested windows refuse.
+
+Serialized buffers have a separate aggregate cap, defaulting to the resident
+cap. The context reports both caps and `load_buffer_capacity_bytes`. An active
+window uses the existing exact-byte file-load receipt path, checking the file
+stat identity before/during the read and recording SHA-256 of the actual bytes.
+Optional page advice runs through `release_activation_cache_file_pages` after
+the checked load; the helper rechecks file identity. Advice is not evidence of
+physical reclaim.
+
+`get_resident(name, fmt)` resolves the existing aliases, preserves CB producer
+identity and loaded-tensor validation, and checks an enabled file-load receipt
+against its exact tensor/file lifetime. A missing or evicted key raises instead
+of invoking a disk load. A failed receipt check cannot be bypassed by repeating
+the lookup during an active window.
+
+On context completion or failure, `release_resident_tensors(keys)` drops the
+selected disk-backed owners and their receipts through the existing cache
+release mechanism. It preserves unrelated entries and in-memory values with
+no recorded load path. A same-named file alone is not adopted as proof that an
+in-memory value is safely releasable. The existing no-argument whole-cache
+release/compaction behavior remains unchanged.
+
+Callers must drop borrowed tensor references at the boundary and separately
+admit device copies, candidate deltas, source/statistics buffers, allocator
+overhead and consumer workspaces. These cache caps do not certify a complete
+candidate projection phase or physical memory fit.
+
+## Validation and evidence
+
+All execution used PrismaBuild, CPU-only on DL380G10, with the existing
+`/home/rob/venvs/pq-cpu312/bin/python` interpreter. Native math threads were
+bounded to one. No tests or GPU probes ran outside admission.
+
+| Action | Result | Reservation |
+|---|---|---|
+| `036495496825` | Seven expected missing-API failures before implementation | 2 CPUs, 3 GiB |
+| `6f3f7c225ca8` | 16 window/file-receipt tests passed | 2 CPUs, 3 GiB |
+| `b23326e12a2f` | 85 expanded window and existing-cache tests passed | 4 CPUs, 6 GiB |
+| `70db9cbf929a` | Final 108 tests passed, zero skips | 4 CPUs, 6 GiB |
+| `f6a1a7322df1` | Both touched Python files compiled successfully | 1 CPU, 1 GiB |
+
+The final suite used two xdist workers, each permitted at most two loader
+threads. It covers full backing storages and aliases, unrelated resident
+owners, LRU refusal before load, strict missing/evicted lookup, existing CB
+validators, optional receipts, repeated lookup after receipt invalidation,
+file drift, bounded serialized buffers, malformed input refusal, checked page
+advice, selected release, normal/exception cleanup and legacy cache behavior.
+It also ran the architecture and documentation-staleness checks.
+
+The final test command, following `pbrun.py --tag x86 --cpus 4 --demand mem_gb=6
+--priority -10` and `OMP_NUM_THREADS=MKL_NUM_THREADS=OPENBLAS_NUM_THREADS=1`, was:
+
+```text
+/home/rob/venvs/pq-cpu312/bin/python -m pytest -q -n 2
+  tests/test_pwc_resident_windows.py tests/test_pwc_file_load_receipts.py
+  tests/test_production_weight_cache.py tests/test_docs_staleness.py
+  tests/test_architecture_doc.py
+```
+
+Complete commands, raw logs, the read-only audit script and `pb-audit.json` are
+under `/mnt/shared/tessera-measurements/glm-canonical-census-20260908/pwc-resident-windows-01/`.
+The audit checked all five terminal exit statuses and scope cleanup, four
+canonical CAS receipt hashes and their actual payload hashes, and all source
+snapshot bundle hashes. The final test and compilation source trees match the
+implementation commit across every tracked path; their only extra files are
+generated PrismaBuild closure records. No successful receipt is inferred from
+the submission acknowledgement.

--- a/prismaquant/production_weight_cache.py
+++ b/prismaquant/production_weight_cache.py
@@ -79,6 +79,7 @@ import re
 import subprocess
 import stat
 import time
+import zipfile
 
 import torch
 import torch.nn as nn
@@ -376,7 +377,7 @@ class ProductionWeightCache:
         self._file_load_receipts = None
         return compacted
 
-    def release_resident_tensors(self) -> int:
+    def release_resident_tensors(self, keys: Sequence[tuple[str, str]] | None = None) -> int:
         """Drop disk-backed resident tensors, keeping every key resolvable.
 
         Same operation as :meth:`compact_for_pickle` — that one is named for
@@ -389,8 +390,198 @@ class ProductionWeightCache:
         Entries that were never disk-backed are left resident, because dropping
         those would lose data rather than free a re-readable copy. A later
         ``get()`` on a released key simply reloads it from disk.
+
+        ``keys`` limits release to entries with a recorded load path. It never
+        adopts an unrelated same-named file as backing for an in-memory tensor.
+        Omitting ``keys`` preserves the legacy whole-cache compaction behavior.
         """
-        return self.compact_for_pickle()
+        if keys is None:
+            return self.compact_for_pickle()
+        released = 0
+        for key in dict.fromkeys(keys):
+            value = self.weights.get(key)
+            if not isinstance(value, torch.Tensor):
+                continue
+            path = (self._lru_paths or {}).get(key)
+            if path is None:
+                continue  # A non-disk-backed value remains its only owner.
+            self.weights[key] = path
+            if self._lru_order is not None and key in self._lru_order:
+                self._lru_order.remove(key)
+                self._lru_bytes -= value.numel() * value.element_size()
+            if self._cb_verified_keys is not None:
+                self._cb_verified_keys.discard(key)
+            if self._file_load_receipts is not None:
+                self._file_load_receipts.pop(key, None)
+            released += 1
+        return released
+
+    @staticmethod
+    def _window_storage(tensor):
+        if (type(tensor) not in (torch.Tensor, nn.Parameter)
+                or tensor.layout != torch.strided or tensor.device.type == 'meta'):
+            raise RuntimeError('PWC resident window has unaccountable tensor storage')
+        storage = tensor.untyped_storage()
+        return (tensor.device, storage.data_ptr()), storage.nbytes()
+
+    def _window_resident_storages(self):
+        storages = {}
+        for value in self.weights.values():
+            if isinstance(value, torch.Tensor):
+                identity, nbytes = self._window_storage(value)
+                storages[identity] = max(storages.get(identity, 0), nbytes)
+        return storages
+
+    @staticmethod
+    def _window_archive_storage_bytes(source):
+        """Only ordinary uncompressed Torch archives have accountable loads."""
+        try:
+            with zipfile.ZipFile(source) as archive:
+                entries = archive.infolist()
+                names = [entry.filename for entry in entries]
+                roots = {name.split('/')[0] for name in names}
+                if (len(roots) != 1 or len(set(names)) != len(names)
+                        or not any(name.endswith('/data.pkl') for name in names)
+                        or any(entry.compress_type != zipfile.ZIP_STORED or entry.flag_bits & 1
+                               or entry.file_size != entry.compress_size for entry in entries)):
+                    raise RuntimeError('PWC window requires an uncompressed Torch archive')
+                return sum(entry.file_size for entry in entries
+                           if re.fullmatch(r'[^/]+/data/[0-9]+', entry.filename))
+        except (OSError, zipfile.BadZipFile) as exc:
+            raise RuntimeError('PWC window has an unaccountable Torch archive') from exc
+
+    def _window_keys(self, keys):
+        if not isinstance(keys, Sequence) or isinstance(keys, (str, bytes)):
+            raise TypeError('PWC window keys must be a finite sequence')
+        resolved, seen = [], set()
+        for pair in keys:
+            if (not isinstance(pair, (tuple, list)) or len(pair) != 2
+                    or any(not isinstance(part, str) or not part for part in pair)):
+                raise ValueError('PWC window needs (name, format) keys')
+            key = self.resolve_key(*pair)
+            if key is None:
+                raise RuntimeError(f'PWC window missing cache entry {pair}')
+            if key not in seen:
+                resolved.append(key)
+                seen.add(key)
+        return tuple(resolved)
+
+    @staticmethod
+    def _window_limits(max_resident_bytes, max_workers):
+        if type(max_resident_bytes) is not int or max_resident_bytes <= 0:
+            raise ValueError('PWC window requires a positive resident byte budget')
+        if (type(max_workers) is not int or max_workers <= 0
+                or max_workers > len(os.sched_getaffinity(0))):
+            raise ValueError('PWC window workers exceed assigned CPU affinity')
+
+    def _window_file(self, key):
+        value = self.weights[key]
+        if not isinstance(value, (str, Path)):
+            raise RuntimeError('PWC window has an unaccountable cache input')
+        path = Path(self._path_for_value(value)).absolute()
+        before = path.lstat()
+        if not stat.S_ISREG(before.st_mode):
+            raise RuntimeError('PWC window requires a regular file, not a symlink')
+        storage_bytes = self._window_archive_storage_bytes(path)
+        if self._file_signature(path.lstat()) != self._file_signature(before):
+            raise RuntimeError('PWC window file changed during preflight')
+        estimate = self.estimate_nbytes([key])
+        if estimate != before.st_size or storage_bytes > estimate:
+            raise RuntimeError('PWC window file storage estimate changed')
+        return path, before, estimate, storage_bytes
+
+    def plan_resident_windows(self, keys, *, max_resident_bytes: int, max_workers: int):
+        """Plan finite research quanta in input order without loading tensors.
+
+        All existing PWC tensor backing storages count, including unrelated
+        entries and storage hidden behind views; aliases count once. Incoming
+        standard uncompressed Torch files use the existing conservative file
+        estimate. Each quantum has at most ``max_workers`` keys, bounding the
+        existing prefetch pool's futures as well as its loader concurrency.
+        Plans are key-only hints; ``resident_window`` revalidates each entry.
+        """
+        self._window_limits(max_resident_bytes, max_workers)
+        keys = self._window_keys(keys)
+        baseline = sum(self._window_resident_storages().values())
+        if baseline > max_resident_bytes:
+            raise RuntimeError('PWC existing resident storage exceeds window budget')
+        windows, window, nbytes = [], [], baseline
+        for key in keys:
+            value = self.weights[key]
+            incoming = 0 if isinstance(value, torch.Tensor) else self._window_file(key)[2]
+            if baseline + incoming > max_resident_bytes:
+                raise RuntimeError(f'PWC single entry exceeds resident window budget: {key}')
+            if window and (len(window) == max_workers or nbytes + incoming > max_resident_bytes):
+                windows.append(tuple(window))
+                window, nbytes = [], baseline
+            window.append(key)
+            nbytes += incoming
+        if window:
+            windows.append(tuple(window))
+        return tuple(windows)
+
+    @contextmanager
+    def resident_window(self, keys, *, max_resident_bytes: int, max_workers: int,
+                        max_load_buffer_bytes: int | None = None, release_file_pages: bool = False):
+        """Prefetch one research quantum, then expose strict resident lookups.
+
+        This owns no tensor dictionary. PWC remains the only cache; selected
+        disk-backed entries are released on success/failure. Callers must drop
+        their borrowed tensor references at the boundary. Nested windows refuse.
+        The resident cap covers all cache backing storages. Serialized loader
+        buffers have a separate aggregate cap (default: resident cap); both
+        caps, allocator overhead and consumer workspaces need phase admission.
+        Page-release advice is optional and is not a physical-memory guarantee.
+        """
+        if getattr(self, '_resident_window_files', None) is not None:
+            raise RuntimeError('PWC resident windows cannot be nested')
+        if type(release_file_pages) is not bool:
+            raise ValueError('PWC window page release must be boolean')
+        buffer_cap = max_resident_bytes if max_load_buffer_bytes is None else max_load_buffer_bytes
+        if type(buffer_cap) is not int or buffer_cap <= 0:
+            raise ValueError('PWC window needs a positive serialized buffer budget')
+        windows = self.plan_resident_windows(keys, max_resident_bytes=max_resident_bytes,
+                                             max_workers=max_workers)
+        if len(windows) != 1:
+            raise RuntimeError('PWC resident_window requires one nonempty planned quantum')
+        keys = windows[0]
+        files = {}
+        for key in keys:
+            value = self.weights[key]
+            if not isinstance(value, torch.Tensor):
+                path, observed, estimate, storage_bytes = self._window_file(key)
+                files[str(path)] = (observed, estimate, storage_bytes)
+        # Different keys reading one file still allocate separate load buffers.
+        buffer_bytes = sum(files[str(Path(self._path_for_value(self.weights[key])).absolute())][1]
+                           for key in keys if not isinstance(self.weights[key], torch.Tensor))
+        if buffer_bytes > buffer_cap:
+            raise RuntimeError('PWC serialized load buffers exceed window budget')
+        incoming_storage = sum(files[str(Path(self._path_for_value(self.weights[key])).absolute())][2]
+                               for key in keys if not isinstance(self.weights[key], torch.Tensor))
+        if (self._lru_order is not None and self._lru_max_bytes > 0
+                and self._lru_bytes + incoming_storage > self._lru_max_bytes):
+            raise RuntimeError('PWC resident window exceeds available LRU budget')
+        self._resident_window_files = files
+        self._resident_window_receipt_keys = frozenset(
+            key for key in keys if not isinstance(self.weights[key], torch.Tensor))
+        try:
+            loaded = self.prefetch(keys, max_workers=max_workers)
+            for key in keys:
+                self.get_resident(*key)
+            actual = sum(self._window_resident_storages().values())
+            if actual > max_resident_bytes:
+                raise RuntimeError('PWC actual backing storage exceeds resident window budget')
+            if release_file_pages:
+                from .perturbed_x_cache import release_activation_cache_file_pages
+                for path, (observed, _, _) in files.items():
+                    release_activation_cache_file_pages(path, expected_stat=observed)
+            yield {'keys': keys, 'loaded': loaded, 'resident_bytes': actual,
+                   'budget_bytes': max_resident_bytes, 'load_buffer_capacity_bytes': buffer_bytes,
+                   'load_buffer_budget_bytes': buffer_cap, 'file_pages_advised': len(files) if release_file_pages else 0}
+        finally:
+            self.release_resident_tensors(keys)
+            self._resident_window_files = None
+            self._resident_window_receipt_keys = frozenset()
 
     def _path_for_value(self, value: object) -> str:
         path = str(value)
@@ -772,6 +963,13 @@ class ProductionWeightCache:
     def _load_file_tensor(self, value):
         path = Path(self._path_for_value(value)).absolute()
         limit = getattr(self, "_file_load_max_bytes", 0)
+        window_files = getattr(self, '_resident_window_files', None)
+        window_entry = None
+        if window_files is not None:
+            window_entry = window_files.get(str(path))
+            if window_entry is None:
+                raise RuntimeError('PWC load is outside the active resident window')
+            limit = min(limit, window_entry[1]) if limit else window_entry[1]
         if not limit:
             return torch.load(path, map_location="cpu", weights_only=True), None
         before = path.lstat()
@@ -780,6 +978,8 @@ class ProductionWeightCache:
         if before.st_size > limit:
             raise RuntimeError("PWC file exceeds the explicit read buffer bound")
         signature = self._file_signature(before)
+        if window_entry is not None and signature != self._file_signature(window_entry[0]):
+            raise RuntimeError('PWC window file changed before its content read')
         with path.open("rb") as handle:
             if self._file_signature(os.fstat(handle.fileno())) != signature:
                 raise RuntimeError("PWC file changed before its content read")
@@ -790,9 +990,14 @@ class ProductionWeightCache:
         # The temporary serialized buffer is per loader worker and is released
         # before its result enters the existing LRU. No whole-cache byte store.
         receipt = {"path": str(path), "bytes": len(raw), "sha256": hashlib.sha256(raw).hexdigest()}
+        if window_entry is not None:
+            if self._window_archive_storage_bytes(io.BytesIO(raw)) != window_entry[2]:
+                raise RuntimeError('PWC window archive storage changed during its read')
         tensor = torch.load(io.BytesIO(raw), map_location="cpu", weights_only=True)
         if not isinstance(tensor, torch.Tensor):
             raise RuntimeError("PWC file receipt requires a tensor shard")
+        if window_entry is not None and self._window_storage(tensor)[1] > window_entry[2]:
+            raise RuntimeError('PWC loaded backing storage exceeds its archive bound')
         return tensor, (receipt, signature, self._file_tensor_guard(tensor))
 
     def _record_file_load(self, key, tensor, observed) -> None:
@@ -867,16 +1072,22 @@ class ProductionWeightCache:
                 loaded_count += 1
         return loaded_count
 
-    def _resolve_to_tensor(self, key: tuple[str, str]) -> torch.Tensor | None:
+    def _resolve_to_tensor(self, key: tuple[str, str], *, resident_only=False) -> torch.Tensor | None:
         """Return the tensor at ``key`` (lazy-load from disk if needed).
         With LRU enabled, the freshly-loaded tensor is bookkept and the
         oldest entries get evicted back to filenames when the byte budget
         is exceeded.  Returns None if the key isn't present."""
         v = self.weights.get(key)
+        if resident_only and not isinstance(v, torch.Tensor):
+            raise RuntimeError(f'PWC cache entry is not resident: {key}')
         if v is None:
             return None
         if isinstance(v, torch.Tensor):
             self._validate_loaded_cb_pair_tensor(key, v)
+            if resident_only and (getattr(self, '_file_load_max_bytes', 0)
+                                  or key in (self._file_load_receipts or {})
+                                  or key in getattr(self, '_resident_window_receipt_keys', ())):
+                self.file_load_receipt(key, v)
             # Refresh LRU position.
             if self._lru_order is not None:
                 if key in self._lru_order:
@@ -891,7 +1102,7 @@ class ProductionWeightCache:
         self._record_file_load(key, loaded, receipt)
         return loaded
 
-    def get(self, name: str, fmt: str) -> torch.Tensor | None:
+    def get(self, name: str, fmt: str, *, resident_only=False) -> torch.Tensor | None:
         key = self.resolve_key(name, fmt)
         if key is not None:
             if _is_cb_format_name(key[1]):
@@ -900,8 +1111,14 @@ class ProductionWeightCache:
                     require_for_formats=[key[1]],
                     where=f"ProductionWeightCache get({key[0]}@{key[1]})",
                 )
-            return self._resolve_to_tensor(key)
+            return self._resolve_to_tensor(key, resident_only=resident_only)
+        if resident_only:
+            raise RuntimeError(f'PWC missing cache entry: {name}@{fmt}')
         return None
+
+    def get_resident(self, name: str, fmt: str) -> torch.Tensor:
+        """Return a resident tensor with CB/receipt guards; never load a file."""
+        return self.get(name, fmt, resident_only=True)
 
     def relocate(self, new_cache_dir: str | Path) -> None:
         """Point the cache at a new on-disk directory of .pt shards.

--- a/tests/test_pwc_resident_windows.py
+++ b/tests/test_pwc_resident_windows.py
@@ -1,0 +1,276 @@
+"""Finite research windows reuse PWC loads and never fault on consumption."""
+import weakref
+import zipfile
+
+import pytest
+import torch
+
+from prismaquant.production_weight_cache import ProductionWeightCache
+from test_pwc_file_load_receipts import make_cache
+
+
+def test_plan_resolves_aliases_and_bounds_existing_prefetch(tmp_path, monkeypatch):
+    cache, paths, expected = make_cache(tmp_path, 5, budget=100000)
+    keys = tuple(paths)
+    bound = 2 * max(path.stat().st_size for path in paths.values())
+    aliases = [(name + '.weight', fmt) for name, fmt in keys]
+    windows = cache.plan_resident_windows(aliases + [aliases[0]],
+        max_resident_bytes=bound, max_workers=2)
+    assert windows == (keys[:2], keys[2:4], keys[4:])
+    original = cache.prefetch
+    calls = []
+    def bounded(keys, max_workers):
+        calls.append(tuple(keys))
+        assert len(keys) <= max_workers == 2
+        return original(keys, max_workers=max_workers)
+    monkeypatch.setattr(cache, 'prefetch', bounded)
+    refs = []
+    for window in windows:
+        with cache.resident_window(window, max_resident_bytes=bound, max_workers=2) as receipt:
+            assert receipt['keys'] == window and receipt['loaded'] == len(window)
+            assert receipt['resident_bytes'] == 32 * len(window)
+            for key in window:
+                value = cache.get_resident(*key)
+                torch.testing.assert_close(value, expected[key])
+                refs.append(weakref.ref(value))
+                del value
+        assert all(ref() is None for ref in refs)
+        assert all(isinstance(cache.weights[key], str) for key in window)
+    assert calls == list(windows)
+
+
+def test_resident_lookup_refuses_missing_or_evicted_without_load(tmp_path, monkeypatch):
+    cache, paths, _ = make_cache(tmp_path, 2, budget=32)
+    a, b = paths
+    cache.get(*a)
+    cache.get(*b)
+    monkeypatch.setattr(cache, '_load_file_tensor', lambda *args: pytest.fail('hidden load'))
+    with pytest.raises(RuntimeError, match='resident'):
+        cache.get_resident(*a)
+    with pytest.raises(RuntimeError, match='missing'):
+        cache.get_resident('unknown', a[1])
+    assert cache.get_resident(*b) is cache.weights[b]
+
+
+def test_full_backing_storage_and_aliases_are_accounted():
+    pool = torch.zeros(100)
+    keys = [('a', 'FP8'), ('b', 'FP8')]
+    cache = ProductionWeightCache(dict(zip(keys, (pool[:2], pool[2:4]))), {})
+    with pytest.raises(RuntimeError, match='budget'):
+        cache.plan_resident_windows(keys, max_resident_bytes=399, max_workers=2)
+    assert cache.plan_resident_windows(keys, max_resident_bytes=400, max_workers=2) == (tuple(keys),)
+    with cache.resident_window(keys, max_resident_bytes=400, max_workers=2) as receipt:
+        assert receipt['resident_bytes'] == 400
+    assert all(isinstance(cache.weights[key], torch.Tensor) for key in keys)
+
+
+def test_invalid_roster_or_oversize_refuses_before_loading(tmp_path, monkeypatch):
+    cache, paths, _ = make_cache(tmp_path)
+    key, path = next(iter(paths.items()))
+    monkeypatch.setattr(cache, '_load_file_tensor', lambda *args: pytest.fail('hidden load'))
+    with pytest.raises(RuntimeError, match='budget'):
+        cache.plan_resident_windows([key], max_resident_bytes=path.stat().st_size - 1, max_workers=1)
+    with pytest.raises(RuntimeError, match='missing'):
+        cache.plan_resident_windows([key, ('missing', key[1])], max_resident_bytes=10000, max_workers=1)
+    with pytest.raises((TypeError, ValueError), match='finite|sequence'):
+        cache.plan_resident_windows(iter([key]), max_resident_bytes=10000, max_workers=1)
+
+
+def test_selected_release_preserves_unrelated_residents_and_receipts(tmp_path):
+    cache, paths, _ = make_cache(tmp_path, 2)
+    a, b = paths
+    cache.enable_file_load_receipts(max_file_bytes=10000)
+    cache.prefetch([a, b], max_workers=2)
+    retained = cache.get_resident(*b)
+    assert cache.release_resident_tensors([a]) == 1
+    assert isinstance(cache.weights[a], str)
+    assert cache.get_resident(*b) is retained
+    cache.file_load_receipt(b, retained)
+    assert cache._lru_bytes == 32 and cache._lru_order == [b]
+
+
+def test_window_releases_on_consumer_failure_and_receipt_checks_mutation(tmp_path):
+    cache, paths, _ = make_cache(tmp_path)
+    key = next(iter(paths))
+    cache.enable_file_load_receipts(max_file_bytes=10000)
+    with pytest.raises(RuntimeError, match='changed'):
+        with cache.resident_window([key], max_resident_bytes=10000, max_workers=1):
+            value = cache.get_resident(*key)
+            value.add_(1)
+            cache.get_resident(*key)
+    assert isinstance(cache.weights[key], str)
+    assert not cache._file_load_receipts
+
+
+def test_lru_eviction_cannot_yield_partial_window(tmp_path):
+    cache, paths, _ = make_cache(tmp_path, 2, budget=32)
+    with pytest.raises(RuntimeError, match='resident|LRU|budget'):
+        with cache.resident_window(tuple(paths), max_resident_bytes=10000, max_workers=2):
+            pytest.fail('partial resident window exposed')
+    assert all(isinstance(value, str) for value in cache.weights.values())
+
+
+def test_unrelated_resident_storage_is_in_the_budget_before_load(tmp_path, monkeypatch):
+    cache, paths, _ = make_cache(tmp_path)
+    key, path = next(iter(paths.items()))
+    cache.weights[('unrelated', 'FP8')] = torch.zeros(100)[:1]
+    monkeypatch.setattr(cache, '_load_file_tensor', lambda *args: pytest.fail('hidden load'))
+    with pytest.raises(RuntimeError, match='budget'):
+        with cache.resident_window([key], max_resident_bytes=path.stat().st_size + 399, max_workers=1):
+            pytest.fail('unrelated backing storage was omitted')
+
+
+def test_nested_window_refuses_without_releasing_outer_owners(tmp_path):
+    cache, paths, _ = make_cache(tmp_path, 2)
+    a, b = paths
+    with cache.resident_window([a], max_resident_bytes=10000, max_workers=1):
+        outer = cache.get_resident(*a)
+        with pytest.raises(RuntimeError, match='nested'):
+            with cache.resident_window([b], max_resident_bytes=10000, max_workers=1):
+                pytest.fail('nested window')
+        with pytest.raises(RuntimeError, match='outside'):
+            cache.get(*b)
+        assert cache.get_resident(*a) is outer
+    assert all(isinstance(value, str) for value in cache.weights.values())
+
+
+def test_existing_lru_owner_cannot_be_evicted_by_window(tmp_path, monkeypatch):
+    cache, paths, _ = make_cache(tmp_path, 2, budget=32)
+    a, b = paths
+    old = cache.get(*a)
+    monkeypatch.setattr(cache, '_load_file_tensor', lambda *args: pytest.fail('hidden load'))
+    with pytest.raises(RuntimeError, match='LRU budget'):
+        with cache.resident_window([b], max_resident_bytes=10000, max_workers=1):
+            pytest.fail('unrelated LRU owner evicted')
+    assert cache.get_resident(*a) is old
+
+
+@pytest.mark.parametrize('kind', ['compressed', 'opaque', 'legacy', 'symlink'])
+def test_unaccountable_disk_inputs_refuse_without_deserializing(tmp_path, monkeypatch, kind):
+    cache, paths, _ = make_cache(tmp_path)
+    key, path = next(iter(paths.items()))
+    if kind == 'compressed':
+        with zipfile.ZipFile(path) as archive:
+            entries = {name: archive.read(name) for name in archive.namelist()}
+        with zipfile.ZipFile(path, 'w', compression=zipfile.ZIP_DEFLATED) as archive:
+            for name, value in entries.items():
+                archive.writestr(name, value)
+    elif kind == 'opaque':
+        cache.weights[key] = object()
+    elif kind == 'legacy':
+        torch.save(torch.zeros(4), path, _use_new_zipfile_serialization=False)
+    else:
+        target = path.with_suffix('.target'); path.rename(target); path.symlink_to(target)
+    monkeypatch.setattr(cache, '_load_file_tensor', lambda *args: pytest.fail('hidden load'))
+    with pytest.raises(RuntimeError, match='archive|unaccountable|regular'):
+        cache.plan_resident_windows([key], max_resident_bytes=10000, max_workers=1)
+
+
+@pytest.mark.parametrize('value', [torch.empty(1, device='meta'), torch.sparse_coo_tensor([[0]], [1.], (1,))])
+def test_unaccountable_tensor_storages_refuse(value):
+    cache = ProductionWeightCache({('a', 'FP8'): value}, {})
+    with pytest.raises(RuntimeError, match='unaccountable'):
+        cache.plan_resident_windows([('a', 'FP8')], max_resident_bytes=10000, max_workers=1)
+
+
+def test_serialized_buffers_have_a_separate_aggregate_limit(tmp_path, monkeypatch):
+    cache, paths, _ = make_cache(tmp_path, 2)
+    size = sum(path.stat().st_size for path in paths.values())
+    monkeypatch.setattr(cache, '_load_file_tensor', lambda *args: pytest.fail('hidden load'))
+    with pytest.raises(RuntimeError, match='serialized'):
+        with cache.resident_window(tuple(paths), max_resident_bytes=10000, max_workers=2,
+                                   max_load_buffer_bytes=size - 1):
+            pytest.fail('oversize buffers')
+
+
+def test_page_advice_uses_verified_load_stat_and_cleanup(tmp_path, monkeypatch):
+    from prismaquant import perturbed_x_cache
+    cache, paths, _ = make_cache(tmp_path)
+    key, path = next(iter(paths.items()))
+    seen = []
+    def advice(candidate, *, expected_stat):
+        value = cache.get_resident(*key)
+        assert cache.file_load_receipt(key, value)['bytes'] == expected_stat.st_size
+        assert str(path) == candidate
+        seen.append(candidate)
+    monkeypatch.setattr(perturbed_x_cache, 'release_activation_cache_file_pages', advice)
+    with cache.resident_window([key], max_resident_bytes=10000, max_workers=1,
+                               release_file_pages=True) as receipt:
+        assert receipt['file_pages_advised'] == 1
+    assert seen == [str(path)] and not cache._file_load_receipts
+
+
+def test_window_load_failure_cleans_partial_prefetch_and_allows_fresh_context(tmp_path, monkeypatch):
+    cache, paths, _ = make_cache(tmp_path, 2)
+    a, b = paths
+    original = cache._validate_loaded_cb_pair_tensor
+    def refused(key, tensor):
+        if key == b:
+            raise RuntimeError('synthetic integrity refusal')
+        return original(key, tensor)
+    monkeypatch.setattr(cache, '_validate_loaded_cb_pair_tensor', refused)
+    with pytest.raises(RuntimeError, match='integrity'):
+        with cache.resident_window(tuple(paths), max_resident_bytes=10000, max_workers=2):
+            pytest.fail('partial load exposed')
+    assert all(isinstance(value, str) for value in cache.weights.values())
+    assert not cache._file_load_receipts
+    monkeypatch.setattr(cache, '_validate_loaded_cb_pair_tensor', original)
+    with cache.resident_window([a], max_resident_bytes=10000, max_workers=1):
+        assert isinstance(cache.get_resident(*a), torch.Tensor)
+
+
+def test_resident_cb_lookup_preserves_both_existing_validators(monkeypatch):
+    key = ('a', 'FP8_CB_K28')
+    cache = ProductionWeightCache({key: torch.zeros(2, 2)}, {})
+    calls = []
+    monkeypatch.setattr('prismaquant.production_weight_cache._is_cb_format_name', lambda fmt: True)
+    monkeypatch.setattr(cache, 'validate_cb_render_identity', lambda **kwargs: calls.append('identity'))
+    monkeypatch.setattr(cache, '_validate_loaded_cb_pair_tensor', lambda *args: calls.append('tensor'))
+    assert cache.get_resident(*key) is cache.weights[key]
+    assert calls == ['identity', 'tensor']
+
+
+def test_existing_disk_loaded_tensor_can_enter_without_enabling_receipts(tmp_path):
+    cache, paths, _ = make_cache(tmp_path)
+    key = next(iter(paths))
+    tensor = cache.get(*key)
+    assert not cache._file_load_receipts
+    with cache.resident_window([key], max_resident_bytes=32, max_workers=1) as receipt:
+        assert receipt['loaded'] == 0
+        assert cache.get_resident(*key) is tensor
+    assert isinstance(cache.weights[key], str)
+
+
+def test_invalidated_window_receipt_cannot_be_bypassed_by_a_second_lookup(tmp_path):
+    cache, paths, _ = make_cache(tmp_path)
+    key = next(iter(paths))
+    with cache.resident_window([key], max_resident_bytes=10000, max_workers=1):
+        cache.get_resident(*key).add_(1)
+        for _ in range(2):
+            with pytest.raises(RuntimeError, match='receipt|changed'):
+                cache.get_resident(*key)
+
+
+def test_window_load_rejects_file_drift_after_preflight(tmp_path, monkeypatch):
+    cache, paths, _ = make_cache(tmp_path)
+    key, path = next(iter(paths.items()))
+    original = cache.prefetch
+    def altered(keys, max_workers):
+        with path.open('ab') as stream:
+            stream.write(b'changed')
+        return original(keys, max_workers=max_workers)
+    monkeypatch.setattr(cache, 'prefetch', altered)
+    with pytest.raises(RuntimeError, match='bound|changed'):
+        with cache.resident_window([key], max_resident_bytes=10000, max_workers=1):
+            pytest.fail('changed file admitted')
+    assert isinstance(cache.weights[key], str) and not cache._file_load_receipts
+
+
+def test_selected_release_does_not_adopt_same_named_unverified_file(tmp_path):
+    from prismaquant.production_weight_cache import _cache_weight_filename
+    key = ('unit', 'FP8')
+    tensor = torch.ones(4)
+    torch.save(torch.zeros(4), tmp_path / _cache_weight_filename(*key))
+    cache = ProductionWeightCache({key: tensor}, {}, cache_dir=str(tmp_path))
+    assert cache.release_resident_tensors([key]) == 0
+    assert cache.get_resident(*key) is tensor


### PR DESCRIPTION
ProductionWeightCache previously offered whole-list prefetch and lazy `get`, so a research candidate phase could retain unbounded loader results or silently reload an evicted tensor. Add explicit finite resident windows through the existing cache: deterministic alias-resolved planning, strict resident lookup, and selected-key release on context success or failure.

The resident cap charges complete backing storages across every existing cache tensor plus incoming entries; aliases count once. Standard uncompressed Torch archive preflight bounds incoming storage, serialized loader buffers have a separate aggregate cap, nested windows and LRU eviction of another owner refuse, and optional checked file-page advice follows exact-byte loading. CB validation and file-load receipts remain active. Legacy defaults are unchanged. Callers still own borrowed references and must separately admit device copies, deltas and consumer workspaces; this is not a full-model fit or throughput qualification.

Validation through PrismaBuild on DL380G10: seven expected missing-API failures before implementation; final **108 passed, zero skips**, including existing cache/receipt and architecture checks; both touched Python files compiled. Four canonical CAS receipts/payloads and all five terminal records were independently audited. Final test and compile source snapshots match implementation `d2a9218f08` across every tracked path, with only generated PB closure additions. Commands, ownership limits and receipt locations are recorded in `docs/measurements/pwc-resident-windows-2026-09-08.md`.

Closes #381
