### PR TITLE
Integrate bounded GLM probe memory primitives

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,23 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `fix/selected-source-anchors`. Stamps
+As of: 2026-09-08 · `fix/bounded-hessian-sidecar`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `fix/bounded-hessian-sidecar`) for within-file Hessian
+sidecar page ownership (#377). Selected-source export keeps Torch's existing
+path writer, archive record names and serializer, pausing after each tensor
+record to pass its stable visible prefix through the existing inode/size/time
+checks, durability fence and page advice. It changes no tensor, archive byte,
+content seal or publication order; failures retain the previous published pair.
+The v2 selected-anchor resource plan charges one largest H record plus metadata
+as the export file-page window, while all selected H/X/weights and serialization
+scratch remain charged. The physical cgroup guard remains decisive because page
+advice alone is not evidence of release. Resident-source serialization retains
+its previous policy. The bounded writer is byte-qualified against the supported
+Torch runtimes, including shared storage and noncontiguous views; it does not
+establish a full GLM fit or change an exact anchor quantum.
+Gates: `tests/test_bounded_hessian_sidecar.py`, existing capture byte/identity
+checks, and before/after native writer memory traces with both Sparks' Netdata.
 
 Re-stamped (2026-09-08, `fix/selected-source-anchors`) for bounded selected
 encoder-factor ownership (#370). The existing `(unit, scale_plane)` memo in a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,26 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `fix/joint-boundary-residency`. Stamps
+As of: 2026-09-08 · `codex/pwc-resident-windows`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `codex/pwc-resident-windows`) for opt-in candidate
+windows through `ProductionWeightCache` (#381). `plan_resident_windows`
+resolves aliases in input order and bounds each finite quantum by a declared
+byte cap and loader count. `resident_window` uses the existing prefetch pool;
+`get_resident` refuses missing or evicted entries and preserves CB integrity
+and active file-load receipts. Whole backing storages count, including views,
+aliases and unrelated resident entries. Incoming standard uncompressed Torch
+archives have a conservative file-size bound plus storage-record preflight;
+opaque/compressed inputs refuse. Serialized load buffers have a separate
+aggregate cap. Nested windows and LRU eviction of other entries refuse.
+Context completion or failure releases the selected disk-backed cache owners
+through the existing release mechanism. Optional checked file-page advice
+follows the verified load, without changing artifact bytes or promising
+physical reclaim. Callers still admit allocator overhead, borrowed references
+and projection workspaces separately. Legacy cache defaults, pipeline order,
+quantization arithmetic and serving gates are unchanged. CPU lifecycle and
+budget gates are in `tests/test_pwc_resident_windows.py`; this API is not a
+full-model fit or throughput qualification.
 
 Re-stamped (2026-09-08, `fix/joint-boundary-residency`) for the explicit
 `prismaquant.aura.boundary_storage.v1` policy (#373). Streamed AURA can store

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,6 +20,8 @@ residency, GPU saturation, KL, bpp or serving quality. Production integration
 requires separate phase admission and numerical/performance qualification.
 Gate: `tests/test_joint_operator_statistics.py` and existing joint lease/oracle
 and packed-source tests.
+The [primitive measurement](measurements/joint-operator-statistics-2026-09-08.md)
+records the synthetic native before/after profiles and explicit integration limits.
 
 Re-stamped (2026-09-08, `fix/campaign-portable-image-content`) for optional
 campaign container `content_sha256` (issue #371). The existing runtime identity

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,14 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `fix/bounded-hessian-sidecar`. Stamps
+As of: 2026-09-08 · `integration/glm-probe-memory`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `integration/glm-probe-memory`) for the combined
+integration of issues #374, #377, #380 and #381. The reviewed operator-statistics,
+Hessian writer, consumed-source-page and PWC window changes retain their
+individual contracts and measurement scopes below. This integration resolves
+architecture stamps only; it does not enable the experimental policies or claim
+that a complete GLM capture, joint probe or served artifact has passed.
 
 Re-stamped (2026-09-08, `fix/bounded-hessian-sidecar`) for within-file Hessian
 sidecar page ownership (#377). Selected-source export keeps Torch's existing

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,25 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `fix/campaign-portable-image-content`. Stamps
+As of: 2026-09-08 · `research/joint-operator-statistics`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `research/joint-operator-statistics`) for the explicit
+one-probe `JointOperatorStatisticsLease` (issue #374). It extends the existing
+joint-AURA source hooks and packed Linear observers. A finite matrix budget
+admits one FP32 sum(G.T@X) per target and one sum(G.T@dX) per distinct nonidentity
+activation group. After all backwards finish, an observation seal contracts
+activation terms against unchanged source weights and releases this lease's
+source references. Caller-prefetched candidate dW quanta then produce the three
+signed components; each quantum must fit a finite complete-backing-storage
+budget. Unknown, repeated, incomplete, stale-source and nonfinite results
+refuse. Matrix and candidate owners expire at their explicit phase boundaries.
+Matrix accumulation has its own arithmetic identity. The original signed
+per-invocation lease and pipeline defaults remain unchanged. This primitive
+does not schedule source/cache transfers or certify full-model physical
+residency, GPU saturation, KL, bpp or serving quality. Production integration
+requires separate phase admission and numerical/performance qualification.
+Gate: `tests/test_joint_operator_statistics.py` and existing joint lease/oracle
+and packed-source tests.
 
 Re-stamped (2026-09-08, `fix/campaign-portable-image-content`) for optional
 campaign container `content_sha256` (issue #371). The existing runtime identity

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,18 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `fix/joint-boundary-residency`. Stamps
+As of: 2026-09-08 · `fix/coalesced-source-page-release`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `fix/coalesced-source-page-release`) for consumed
+source-page release (#380). The existing CUDA reader chunk validates selected
+safetensors spans, merges adjacent or overlapping consumed bytes, then advises
+only complete pages of each union. This releases internal tensor-boundary
+pages while preserving headers, unread gaps and outer partial pages. The
+existing completed-copy fence, mapping lifetime and source-identity checks
+remain unchanged. No global page drop, admission allowance or source cache is
+introduced; advice remains best effort. Gates cover adjacency, unread gaps,
+invalid-span refusal, CUDA lifecycle and a bounded real-checkpoint native
+profile. A full canonical capture still requires its own successful receipt.
 
 Re-stamped (2026-09-08, `fix/joint-boundary-residency`) for the explicit
 `prismaquant.aura.boundary_storage.v1` policy (#373). Streamed AURA can store

--- a/docs/measurements/bounded-hessian-writer-2026-09-08.md
+++ b/docs/measurements/bounded-hessian-writer-2026-09-08.md
@@ -1,0 +1,117 @@
+# Bounded Hessian sidecar writer — 2026-09-08
+
+Issue #377 addresses the remaining whole-file page owner in selected-source
+anchor preparation. The existing writer held all selected source weights,
+Hessians and X prefixes while `torch.save` produced one complete Hessian archive.
+Advice after publication could not bound the within-file peak. The v1 phase
+plan correctly refused a full GLM routed stack at 124.783 GiB.
+
+The selected writer now uses Torch's same path writer and serializer, pausing
+after synchronous tensor-record writes. The existing page helper verifies the
+stable visible file extent, fences durability and advises its pages. Tensor
+storage, pickle protocol, archive record names, CRCs, content seals and the
+atomic publication sequence are unchanged. A file-like substitute was avoided
+because it changes archive names. Resident-source serialization keeps its prior
+policy. The two Torch internal entry points used here are qualified against the
+CPU and native producer runtimes; future runtime changes still require parity.
+
+## Measured before and after
+
+All tests and measurements used PrismaBuild. The native workload contains
+16 resident CUDA FP32 Hessians of shape 4096×4096, totaling 1 GiB, and writes the
+ordinary `hessian_capture.pt` artifact. It is a writer qualification with fixed
+values and provenance, not a canonical model capture or full GLM fit test.
+
+Both actions ran on Sparklina in the same immutable producer image
+`sha256:9f9b9f05b17531399ba66dc6415b054cf5d68c82270626d0e9150e75c808435f`,
+Torch 2.13/CUDA 13.0 and Transformers 5.16.1, with four CPUs, 24 GiB physical
+memory and a 16 GiB GPU subset. Native threads were bounded to one per process;
+a separate thread sampled cgroup memory, anonymous/file/dirty pages and CUDA
+reservation every 20 ms. Torch recorded CPU/CUDA operations and memory, and
+`/proc/self/io` supplied per-process I/O counters. Netdata CPU, RAM, available
+memory and power series cover both Sparks and each measurement window, with
+three seconds of surrounding context. Sparky's coordinating canonical capture
+was external load; Sparklina's measurement window was isolated.
+
+| Observed quantity | Original writer | Prefix-advised writer |
+| --- | ---: | ---: |
+| Cgroup before writer (bytes) | 651,599,872 | 652,439,552 |
+| Sampled peak cgroup (bytes) | 1,746,935,808 | 809,885,696 |
+| Sampled peak file cache (bytes) | 1,120,169,984 | 113,537,024 |
+| Sampled peak dirty file pages (bytes) | 1,006,657,536 | 23,089,152 |
+| CUDA reservation (bytes) | 1,090,519,040 | 1,090,519,040 |
+| Profiled writer wall time (seconds) | 2.707 | 3.036 |
+| File bytes | 1,073,748,005 | 1,073,748,005 |
+
+The identical CUDA reservation is reported separately because GB10 cgroup
+charges can omit GPU allocations. The implementation reduces file ownership;
+this single pair records a small time increase and supports no speedup or
+work-per-joule claim. The original trace has 94 memory samples and the bounded
+trace 130. Netdata has 10/11 one-second samples per chart around these short
+windows; it cannot resolve the 20 ms transient alone.
+
+Both archives have exact SHA-256
+`150346bf06aed6c12d6699252bef4e4990dd91756ce87924e491c990ff90755e`.
+Both return content seal
+`02c6fcec3deee7c75a1aaaf83831070f0acfcb8d2b1cf14908422720325184b8`.
+No bytes were renamed, patched or normalized after writing.
+
+## Validation and disposition
+
+The regression first failed under the unchanged writer (`783031f412d7`): all
+bytes matched, but no tensor prefix was advised before publication. An initial
+implementation attempt omitted Torch's path normalization, so three tests
+failed on a Path object's missing `encode` method (`e259cf8a648a`). Passing
+`os.fspath(path)`, as the public save wrapper does, fixed the actual cause.
+
+The corrected focused CPU suite passed 33 tests with one explicit native
+measurement skip (`51f662ae5e44`). Additional cases passed for FP32, FP64 and
+BF16, shared/noncontiguous storage, ASCII and Unicode paths, and preservation of
+the previous published capture/sidecar when page advice or the memory guard
+fails (`c65629a5d7fe`, eight passed, one measurement skip). After v2 phase
+accounting, four independent CPU shards passed 63 tests with two skips: the
+explicit writer measurement and the CUDA-only memo comparison. CPU execution
+used DL380's pq-cpu312 interpreter, Torch 2.10 and Transformers 5.16.1.
+
+Native baseline `3e6131ae06c5` passed its measurement; native after action
+`ac14c7cf0446` passed 34 cases with no skips including the measurement and capture
+suite. Final native integration `ab7b3c10a237` passed 20 cases with one explicit
+measurement skip, including real tiny GLM original-layout capture, selected
+source preparation, native anchor and resume under the v2 resource plan. The
+measurement was already completed, so it was not repeated in that integration
+run. Each native action exited zero, recorded completed resource cleanup, and
+was followed by an independently empty Docker listing.
+
+Evidence root:
+`/mnt/shared/tessera-measurements/glm-canonical-census-20260908/bounded-hessian-writer-01/`.
+`baseline-invocation.json`, `bounded-invocation.json` and
+`native-final-invocation.json` seal the exact commands and source snapshots.
+`audit.json` verifies terminal hashes, exit statuses, CAS receipts and result
+bytes, including the failed attempts. `baseline-01/` and `bounded-01/` retain the
+original archives, memory/I/O samples, Torch traces, hash-bearing profile
+summaries and both Sparks' Netdata. `before-after-summary.json` compares the
+unchanged artifacts and measured owners. These artifacts are retained as
+bounded evidence; the detached baseline checkout is disposable because its
+exact test-only source is committed as `c635790f8` and snapshotted by PB.
+
+## Admission implication and remaining gate
+
+The v2 selected-anchor resource plan charges one largest tensor record plus
+metadata as the file-page window, while retaining all H/X/source weights and
+serialization scratch. The physical guard remains decisive: advice alone does
+not guarantee page reclamation. No partial capture can become canonical and no
+exact routed-stack group is split or replaced with a sampled estimator.
+
+Resource action `ff10b7324a2a` recomputed the representative GLM stack from the
+same canonical census and source headers: source preparation 68.221 GiB,
+export inputs 84.345 GiB and resident anchors 98.019 GiB. Its maximum is now
+98.019 GiB. Dense fused/singleton maxima remain 28.140/30.141 GiB.
+`resource-inspection-invocation.json` and `full-glm-derived-resources.json`
+record the derivation. This supersedes the writer's old 124.783 GiB phase for
+this implementation; the earlier dated report remains unchanged history.
+
+These are derived admission bounds. A full 864-unit GLM routed stack still
+requires execution from the completed common canonical capture, verified
+physical residency and the unchanged quality/cost/wire gates before any full
+fit claim is made. This change adds no cache, dispatcher, format, serving lane,
+calibration policy or release pin.

--- a/docs/measurements/coalesced-source-page-release-2026-09-08.md
+++ b/docs/measurements/coalesced-source-page-release-2026-09-08.md
@@ -1,0 +1,81 @@
+# Consumed source-page coalescing — 2026-09-08
+
+Issue #380. This fixes the opt-in CUDA source-reader page-advice range, without
+changing checkpoint bytes, selected tensors, copy/map lifetime fences, source
+identity, admission thresholds or the canonical calibration contract.
+
+The common GLM capture stopped at its physical memory guard before layer 11.
+Its retired cgroup retained 18,513,117,184 file-cache bytes, including
+18,111,004,672 `file_thp` bytes, with anonymous memory zero. The old helper
+aligned every tensor individually, leaving a partial page at every adjacent
+consumed tensor boundary. Large file-cache folios containing those pages
+remained resident. The corrected helper validates all selected spans, unions
+adjacent/overlapping consumed bytes, then aligns each union inward. Headers,
+unread gaps and outer partial pages remain protected. There is no global cache
+drop, separate source cache or new allowance to pass the physical guard.
+
+A failing pre-fix CPU regression (`f8baf61182b3`) reproduced two advice ranges
+where one contiguous consumed range was required. The corrected focused suite
+passed 24 tests (`1de1d672fc9f`); source-page, architecture and staleness checks
+passed 43 tests with no skips (`0c3924531a25`). These tests include unread gaps,
+invalid later spans refusing before any advice, source mutation, nonregular
+files, CPU mapping ownership and mocked CUDA copy/map lifecycle.
+
+The native measurement is PB action
+`2f7d0b024d3c39b632c005b0a5e2411b7702d4f7b07731eaf362ba884769cc2d`:
+`--measurement --host-class gb10`, placed on Sparky, 2 CPUs, 12 GiB physical
+memory and a 6 GiB GPU subset. Native library threads and the existing source
+read pool each used one thread. The content-qualified producer image seal is
+`eb8592abd71390231b49aba119e36f02ad91ea867b06df1c67af3833004d07bd`,
+Torch 2.13.0+cu130, CUDA 13.0, NVIDIA driver 595.84.
+
+`experiments/source_page_release_profile.py` reads the same 64 contiguous BF16
+GLM layer-20 expert tensors from the actual checkpoint, totaling 1 GiB, in one
+admitted ABBA experiment. The old-control arm invokes the shared helper once
+per key, reproducing its original page ranges. The corrected arm calls it once
+per completed reader chunk. Both are profiled with CPU/CUDA `torch.profiler`,
+memory events and shape recording. A 20 ms sampler records cgroup memory,
+`file_thp` and CUDA reservations. `mincore` reads residency without faulting in
+the selected payload. A completed warm read supplies exact GPU reference
+values; each arm must compare equal for every tensor. Between arms only the
+already consumed byte union receives advice, so every initial payload residency
+is the same 2,093,056 bytes. No source or unrelated cache bytes are modified.
+
+| Arm | Payload pages retained | Cgroup `file_thp` after read | Profiled wall time |
+| --- | ---: | ---: | ---: |
+| Old per-key 1 | 134,213,632 B | 136,314,880 B | 0.5704 s |
+| Coalesced 1 | 2,093,056 B | 4,194,304 B | 0.3270 s |
+| Coalesced 2 | 2,093,056 B | 4,194,304 B | 0.3988 s |
+| Old per-key 2 | 134,213,632 B | 136,314,880 B | 0.4257 s |
+
+The measured memory reduction is 126 MiB of retained payload/cache-folio
+storage per 64 adjacent expert tensors in this workload. All four GPU results
+are byte-exact. The protected outer edge still retains roughly 2 MiB; advice
+is best effort and cannot authorize a general zero-residency assumption.
+The first arm also allocates its second GPU output plane; later arms reuse that
+allocator reservation. The control reparses the small header for each key.
+These short timings therefore do not establish a production speedup or work
+per joule. Each trace records 64 HtoD copies. This experiment qualifies memory
+release, and does not establish GPU-bound source loading or a full-capture fit.
+
+Both-host Netdata CPU, RAM, available-memory and GPU-power charts have ten
+samples spanning the experiment plus three seconds of context on either side.
+Their resolution is too coarse for per-arm energy comparison. GPU utilization
+is not used as a saturation claim. PB ended with exit 0, no OOM, complete
+scope cleanup and independently empty local Docker process listing.
+
+Attributable artifacts are under
+`/mnt/shared/tessera-measurements/glm-canonical-census-20260908/coalesced-source-pages-01/`:
+
+- `native-invocation.json` records the complete command and sealed container.
+- `native-abba-01/measurement.json` records every arm, source stat, exact keys,
+  span, samples, advice boundaries and exact GPU equality.
+- `native-abba-01/{0-per_key,1-coalesced,2-coalesced,3-per_key}.trace.json`
+  and `profile-summary.json` provide before/after in-process profiles.
+- `native-abba-01/netdata-*.json` preserves both boxes' eight chart series.
+- `audit.json` checks actual terminal status, cleanup, source snapshot and CAS
+  payload bytes; `artifact-seals.json` binds measurement files by SHA-256.
+- Prefix-named logs preserve the failed regression and passing checks.
+
+The previous full capture remains a failed, partial artifact. Only a separately
+completed canonical capture can establish full-model progress after this fix.

--- a/docs/measurements/joint-operator-statistics-2026-09-08.md
+++ b/docs/measurements/joint-operator-statistics-2026-09-08.md
@@ -1,0 +1,101 @@
+# Deferred joint operator contractions — 2026-09-08
+
+Issue #374; implementation `6a2cf9f91399f4a0e2d3ed1d10f795c918f2817b`.
+This is a synthetic primitive qualification at GLM expert dimensions. It does
+not qualify a complete calibration probe, ProductionWeightCache fill, model
+residency, KL, bpp, export, or serving behavior. Pipeline defaults are unchanged.
+
+## Contract
+
+`JointOperatorStatisticsLease` extends the existing joint-AURA source observer.
+For one probe it accumulates FP32 `sum(G.T @ X)` and, per distinct nonidentity
+activation quantizer, `sum(G.T @ dX)`. The observation seal contracts activation
+terms against unchanged source weights, removes hooks, and releases its source
+references. The caller then supplies prefetched candidate deltas in bounded
+quanta. The lease returns signed weight, activation, mixed and total terms and
+never owns candidate deltas beyond a projection call. The finite candidate
+budget charges whole backing storages, including storage hidden behind views.
+
+This changes FP32 contraction order and therefore has a separate arithmetic
+identity. It is not bit-identical to the original per-invocation contractions.
+The original lease remains available. Full integration needs phase admission
+for source weights, statistics, render buffers, cache transfers and physical
+memory; these two tensor budgets alone cannot certify a whole process.
+
+## Matched native measurement
+
+PrismaBuild action
+`438397d5a6c876645a08c6eef7e87c76707fbda9f03c6a2caf83cfa3261525d9`
+ran on Sparklina, NVIDIA GB10, Torch `2.13.0+cu130`, CUDA 13.0, CPUs 5 and 6,
+with two reserved CPUs, 12 GiB physical memory and an 8 GiB GPU subset cap.
+Native threads were bounded to one. The content-qualified producer image has
+content seal `eb8592abd71390231b49aba119e36f02ad91ea867b06df1c67af3833004d07bd`.
+Sparky concurrently ran the independent common capture; both hosts were sampled.
+
+Each shape uses A/B/B/A, ten seconds per arm, with a separate Torch trace after
+each timing arm. Every invocation includes eight synthetic candidate deltas,
+four backwards of 32 tokens each, BF16 source weights/inputs and FP32 delta
+planes. Deltas are constant `(candidate_index+1)/1024`; QDQ rounds `X*8` and
+divides by eight in source dtype. TF32 is disabled. Both arms include delta
+construction. The new lease admits 64 MiB statistics and one 32 MiB delta.
+
+| Projection shape | Legacy latency | Deferred latency | Ratio | Incremental CUDA peak, legacy → deferred | Work/board-joule ratio |
+|---|---:|---:|---:|---:|---:|
+| 2048 × 4096 | 41.881 ms | 16.782 ms | 2.496× | 404,363,776 → 134,219,776 B | 2.365× |
+| 4096 × 2048 | 41.691 ms | 16.756 ms | 2.488× | 404,101,632 → 134,219,776 B | 2.421× |
+
+Latencies are means of the two arm medians, not pooled invocation means.
+All eight arms return to their pre-arm CUDA allocation after profiling.
+The attempt cgroup peaked at 2,754,871,296 bytes, consumed 119.681 CPU seconds,
+exited zero, completed cleanup and left no owned container running.
+
+The profiles explain the gain: for 2048 × 4096, the first legacy/deferred
+traces reduce `aten::mul` from 72 calls/26.908 ms to 21 calls/7.239 ms and
+`aten::sum` from 68 calls/10.482 ms to 17 calls/2.665 ms. Deferred accumulation
+adds six `aten::add_` calls/2.568 ms. Matrix multiplies remain 16 calls, around
+1.94–2.01 ms. Candidate projection now scans each summed operator once rather
+than scanning every candidate during every backward. Times are profiler
+self-device totals and should not be summed with child kernel events.
+
+Existing pqteld 2 Hz samples give 20 power observations per arm. Legacy board
+power spans 22.399–25.736 W; deferred spans 24.656–26.115 W, far below GB10's
+approximately 140 W envelope. There is no saturation claim. Work/joule uses
+completed invocations divided by elapsed time and mean board power, then the
+ratio of paired-arm means; no idle subtraction or whole-system energy is claimed.
+Netdata host CPU means were 7.49–8.22% on Sparklina. Both-host raw Netdata and
+pqteld windows are retained. The automatic PB box window lacked its pqteld CSV;
+the existing host CSVs were copied for these exact intervals and read with the
+published PB window reader. No power value is inferred from GPU utilization.
+
+## Numerical and lifecycle validation
+
+The initial missing-API regression recorded nine failures in PB
+`424b26ef368a132f91eb3fd0ff0eb0802cf37a09c8ff786d1344828115e09d0b`.
+Final CPU action
+`8fe0afac8f716f8ac24403c78198de3f8285aa6581bf06cc7162ea0c842b2b27`
+passed 57 tests, skipped the two CUDA-only shape cases, and compiled both touched
+Python modules. The native action above passed all 46 selected tests with zero
+skips, including independent FP64 output-residual oracles at both full expert
+shapes. Coverage includes signed cancellation, repeated/shared QDQ, real packed
+source slices, never-routed experts, source mutation, missing/duplicate backwards,
+source-owner release, atomic refusal of nonfinite candidate quanta, and complete
+backing-storage accounting. The synthetic timing fixture's maximum component
+change from legacy is 0.000030517578125; this is an arithmetic screen, not a
+model-quality threshold. One intermediate test edit failed collection with a
+syntax error; that failure and its corrected successful run are retained.
+
+## Reproduction and evidence
+
+The committed harness is `experiments/joint_operator_statistics_profile.py`.
+The complete PB command, image/environment declaration and source identity are
+in `native-invocation-01.json` under:
+
+`/mnt/shared/tessera-measurements/glm-canonical-census-20260908/joint-operator-statistics-01/`
+
+That directory contains `cpu-root-audit-01.json`, `native-root-audit-01.json`,
+`native-submission-01.log` and `native-01/{result.json,summary.json,box-windows.json,
+netdata.jsonl,pqteld/,*.trace.json}`. The root audits independently verified
+terminal status, canonical CAS receipt/payload hashes and complete source
+snapshots against the implementation commit; only generated PB closure files
+differ. All eight trace hashes were checked. Native result SHA256:
+`3798d4008715690bbd0885f650e7d0e6e62073ae0e04df0b47cb169105c6d7d0`.

--- a/docs/measurements/pwc-resident-windows-2026-09-08.md
+++ b/docs/measurements/pwc-resident-windows-2026-09-08.md
@@ -1,0 +1,93 @@
+# Production weight-cache resident windows — 2026-09-08
+
+Issue #381; implementation `d2a9218f08`. This is an opt-in cache API and CPU
+lifecycle qualification. It changes no pipeline default, source traversal,
+quantization arithmetic, cache artifact, format menu or serving gate. No GPU
+throughput, whole-process memory fit, KL or bpp claim is made.
+
+## API and ownership
+
+`ProductionWeightCache.plan_resident_windows(keys, *, max_resident_bytes,
+max_workers)` resolves aliases, removes duplicates in first-occurrence order,
+and returns finite tuples of concrete cache keys. Each quantum has at most
+`max_workers` entries. This bounds the existing `prefetch` pool's submitted
+futures and loaded results without adding another cache or dispatcher.
+
+`resident_window(keys, *, max_resident_bytes, max_workers,
+max_load_buffer_bytes=None, release_file_pages=False)` admits exactly one
+nonempty quantum, prefetches it, checks residency and yields a key/scalar-only
+receipt. All existing PWC tensor backing storages count against the resident
+cap, including unrelated entries and storage hidden behind small views.
+Storage aliases count once. Incoming files use the existing conservative file
+estimate and uncompressed Torch archive storage-record preflight. Compressed,
+opaque and symlink inputs refuse; sparse/meta tensor storages refuse. Loaded
+storage is checked against the archive bound and complete cache storage is
+checked before exposing a window. The LRU must have room for the incoming
+storage without evicting another resident entry. Nested windows refuse.
+
+Serialized buffers have a separate aggregate cap, defaulting to the resident
+cap. The context reports both caps and `load_buffer_capacity_bytes`. An active
+window uses the existing exact-byte file-load receipt path, checking the file
+stat identity before/during the read and recording SHA-256 of the actual bytes.
+Optional page advice runs through `release_activation_cache_file_pages` after
+the checked load; the helper rechecks file identity. Advice is not evidence of
+physical reclaim.
+
+`get_resident(name, fmt)` resolves the existing aliases, preserves CB producer
+identity and loaded-tensor validation, and checks an enabled file-load receipt
+against its exact tensor/file lifetime. A missing or evicted key raises instead
+of invoking a disk load. A failed receipt check cannot be bypassed by repeating
+the lookup during an active window.
+
+On context completion or failure, `release_resident_tensors(keys)` drops the
+selected disk-backed owners and their receipts through the existing cache
+release mechanism. It preserves unrelated entries and in-memory values with
+no recorded load path. A same-named file alone is not adopted as proof that an
+in-memory value is safely releasable. The existing no-argument whole-cache
+release/compaction behavior remains unchanged.
+
+Callers must drop borrowed tensor references at the boundary and separately
+admit device copies, candidate deltas, source/statistics buffers, allocator
+overhead and consumer workspaces. These cache caps do not certify a complete
+candidate projection phase or physical memory fit.
+
+## Validation and evidence
+
+All execution used PrismaBuild, CPU-only on DL380G10, with the existing
+`/home/rob/venvs/pq-cpu312/bin/python` interpreter. Native math threads were
+bounded to one. No tests or GPU probes ran outside admission.
+
+| Action | Result | Reservation |
+|---|---|---|
+| `036495496825` | Seven expected missing-API failures before implementation | 2 CPUs, 3 GiB |
+| `6f3f7c225ca8` | 16 window/file-receipt tests passed | 2 CPUs, 3 GiB |
+| `b23326e12a2f` | 85 expanded window and existing-cache tests passed | 4 CPUs, 6 GiB |
+| `70db9cbf929a` | Final 108 tests passed, zero skips | 4 CPUs, 6 GiB |
+| `f6a1a7322df1` | Both touched Python files compiled successfully | 1 CPU, 1 GiB |
+
+The final suite used two xdist workers, each permitted at most two loader
+threads. It covers full backing storages and aliases, unrelated resident
+owners, LRU refusal before load, strict missing/evicted lookup, existing CB
+validators, optional receipts, repeated lookup after receipt invalidation,
+file drift, bounded serialized buffers, malformed input refusal, checked page
+advice, selected release, normal/exception cleanup and legacy cache behavior.
+It also ran the architecture and documentation-staleness checks.
+
+The final test command, following `pbrun.py --tag x86 --cpus 4 --demand mem_gb=6
+--priority -10` and `OMP_NUM_THREADS=MKL_NUM_THREADS=OPENBLAS_NUM_THREADS=1`, was:
+
+```text
+/home/rob/venvs/pq-cpu312/bin/python -m pytest -q -n 2
+  tests/test_pwc_resident_windows.py tests/test_pwc_file_load_receipts.py
+  tests/test_production_weight_cache.py tests/test_docs_staleness.py
+  tests/test_architecture_doc.py
+```
+
+Complete commands, raw logs, the read-only audit script and `pb-audit.json` are
+under `/mnt/shared/tessera-measurements/glm-canonical-census-20260908/pwc-resident-windows-01/`.
+The audit checked all five terminal exit statuses and scope cleanup, four
+canonical CAS receipt hashes and their actual payload hashes, and all source
+snapshot bundle hashes. The final test and compilation source trees match the
+implementation commit across every tracked path; their only extra files are
+generated PrismaBuild closure records. No successful receipt is inferred from
+the submission acknowledgement.

--- a/experiments/joint_operator_statistics_profile.py
+++ b/experiments/joint_operator_statistics_profile.py
@@ -1,0 +1,192 @@
+"""Paired synthetic lease qualification at GLM expert projection dimensions.
+
+This measures source observation plus synthetic resident-delta construction and
+contraction. It does not measure a ProductionWeightCache fill, calibration,
+source streaming, full-model residency, KL, bpp or a serving path.
+"""
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import os
+from pathlib import Path
+import statistics
+import threading
+import time
+import traceback
+
+import torch
+
+from experiments.workspace_netdata import NetdataWriter, sample_netdata
+from prismaquant.format_registry import FormatSpec
+from prismaquant.joint_aura import JointOperatorStatisticsLease, SignedJointProjectionLease
+
+
+def digest(path):
+    with Path(path).open('rb') as stream:
+        return hashlib.file_digest(stream, 'sha256').hexdigest()
+
+
+def memory():
+    torch.cuda.synchronize()
+    return dict(allocated=torch.cuda.memory_allocated(), reserved=torch.cuda.memory_reserved(),
+                peak_allocated=torch.cuda.max_memory_allocated(),
+                peak_reserved=torch.cuda.max_memory_reserved())
+
+
+def invoke(kind, module, specs, draws):
+    shape = tuple(module.weight.shape)
+    plane_bytes = module.weight.numel() * 4
+    kwargs = dict(activation_max_abs={})
+    if kind == 'legacy':
+        deltas = {('u', fmt): torch.full(shape, (index + 1) / 1024, device='cuda')
+                  for index, fmt in enumerate(specs)}
+        lease = SignedJointProjectionLease({'u': module}, {'u': specs}, deltas, **kwargs)
+    else:
+        lease = JointOperatorStatisticsLease({'u': module}, {'u': specs},
+            max_statistics_bytes=2 * plane_bytes, max_candidate_bytes=plane_bytes, **kwargs)
+    with lease:
+        lease.begin_probe()
+        for x, gradient in draws:
+            output = module(x)
+            output.backward(gradient)
+            module.zero_grad(set_to_none=True)
+            del output
+        if kind == 'legacy':
+            result = lease.finish_probe()
+        else:
+            lease.finish_observations()
+            for index, fmt in enumerate(specs):
+                delta = torch.full(shape, (index + 1) / 1024, device='cuda')
+                lease.project({('u', fmt): delta})
+                del delta
+            result = lease.finish_projections()
+    return {f'{name}@{fmt}': values for (name, fmt), values in result.items()}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--out', type=Path, required=True)
+    parser.add_argument('--seconds', type=float, default=10.)
+    args = parser.parse_args()
+    if not 1 <= args.seconds <= 60:
+        parser.error('--seconds must be between 1 and 60')
+    args.out.mkdir(parents=True, exist_ok=False)
+    torch.set_num_threads(1)
+    torch.set_float32_matmul_precision('highest')
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.backends.cudnn.allow_tf32 = False
+    record = dict(schema='prismaquant.joint_operator_statistics_profile.v1', status='running',
+        started_unix=time.time(), torch=str(torch.__version__), cuda=torch.version.cuda,
+        device=torch.cuda.get_device_name(), affinity=sorted(os.sched_getaffinity(0)),
+        candidates=8, draws=4, tokens_per_draw=32, seconds_per_arm=args.seconds,
+        source_dtype='torch.bfloat16', delta_dtype='torch.float32',
+        matmul_precision=torch.get_float32_matmul_precision(), allow_tf32=False,
+        seed=1913, delta_rule='full((rows,cols),(candidate_index+1)/1024,float32)',
+        qdq_rule='round(X*8)/8 in source dtype', shapes=[], telemetry_errors=[])
+    stopped = threading.Event()
+
+    def monitor():
+        try:
+            with (args.out/'netdata.jsonl').open('x') as stream:
+                writer = NetdataWriter(stream)
+                while not stopped.is_set():
+                    for host in ('sparky', 'sparklina'):
+                        writer.write(sample_netdata(host))
+                    stopped.wait(1.)
+        except Exception as exc:
+            record['telemetry_errors'].append(repr(exc))
+
+    monitor_thread = threading.Thread(target=monitor, daemon=True)
+    monitor_thread.start()
+    try:
+        qdq = lambda x: torch.round(x * 8) / 8
+        specs = {f'candidate{i}': FormatSpec(name=f'candidate{i}', weight_bits=8,
+            group_size=0, scale_bits=0, scale_dtype_name='fp32', weight_element_dtype='int8',
+            act_bits=8, activation_quantize_dequantize=qdq) for i in range(8)}
+        for rows, columns in ((2048, 4096), (4096, 2048)):
+            generator = torch.Generator().manual_seed(record['seed'])
+            weight = (torch.randn(rows, columns, generator=generator) / columns**.5).bfloat16()
+            draws = [(torch.randn(32, columns, generator=generator).bfloat16().cuda(),
+                      torch.randn(32, rows, generator=generator).bfloat16().cuda()) for _ in range(4)]
+            module = torch.nn.Linear(columns, rows, bias=False, device='cuda', dtype=torch.bfloat16)
+            with torch.no_grad():
+                module.weight.copy_(weight)
+            del weight
+            shape_row = dict(shape=[rows, columns], arms=[])
+            record['shapes'].append(shape_row)
+            baseline = None
+            for index, kind in enumerate(('legacy', 'statistics', 'statistics', 'legacy')):
+                warm = invoke(kind, module, specs, draws)
+                if baseline is None:
+                    baseline = warm
+                gc.collect()
+                torch.cuda.empty_cache()
+                before = memory()
+                torch.cuda.reset_peak_memory_stats()
+                start = time.time()
+                times = []
+                wall_start = time.perf_counter()
+                while time.perf_counter() - wall_start < args.seconds:
+                    tick = time.perf_counter()
+                    result = invoke(kind, module, specs, draws)
+                    torch.cuda.synchronize()
+                    times.append((time.perf_counter() - tick) * 1000)
+                elapsed = time.perf_counter() - wall_start
+                end = time.time()
+                after = memory()
+                assert after['allocated'] == before['allocated'], 'lease retained CUDA allocations'
+                errors = {key: {term: result[key][term] - baseline[key][term] for term in result[key]}
+                          for key in result}
+                # Native tests separately bind both GLM shapes to an independent
+                # FP64 residual. This row records the old/new arithmetic delta.
+                for key in result:
+                    for term, value in result[key].items():
+                        assert abs(value - baseline[key][term]) <= 1e-4 + abs(baseline[key][term]) * 1e-4
+                with torch.profiler.profile(
+                        activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
+                        record_shapes=True, profile_memory=True) as profile:
+                    with torch.profiler.record_function(f'joint_{kind}_whole_lease'):
+                        invoke(kind, module, specs, draws)
+                    torch.cuda.synchronize()
+                trace = args.out/f'{rows}x{columns}-{index}-{kind}.trace.json'
+                profile.export_chrome_trace(str(trace))
+                events = [dict(key=item.key, calls=item.count,
+                    self_cpu_us=item.self_cpu_time_total,
+                    self_device_us=item.self_device_time_total)
+                    for item in profile.key_averages()]
+                del profile
+                gc.collect()
+                shape_row['arms'].append(dict(kind=kind, index=index, start_unix=start, end_unix=end,
+                    invocations=len(times), elapsed_seconds=elapsed,
+                    median_ms=statistics.median(times), samples_ms=times,
+                    before=before, after=after, after_profile=memory(),
+                    signed_component_delta=errors, trace=dict(path=str(trace), sha256=digest(trace)),
+                    events=sorted(events, key=lambda item: item['self_device_us'], reverse=True)[:30]))
+                (args.out/'progress.json').write_text(json.dumps(record, indent=2)+'\n')
+            del module, draws
+            gc.collect()
+            torch.cuda.empty_cache()
+        record['status'] = 'complete'
+    except BaseException:
+        record.update(status='failed', traceback=traceback.format_exc())
+        raise
+    finally:
+        stopped.set()
+        monitor_thread.join(timeout=15)
+        if monitor_thread.is_alive():
+            record['telemetry_errors'].append('Netdata sampler did not stop')
+        if record['telemetry_errors']:
+            record['status'] = 'failed'
+        record['finished_unix'] = time.time()
+        result_path = args.out/'result.json'
+        result_path.write_text(json.dumps(record, indent=2)+'\n')
+        print(json.dumps(dict(path=str(result_path), sha256=digest(result_path), status=record['status'])))
+    if record['status'] != 'complete':
+        raise RuntimeError('required joint operator qualification evidence is incomplete')
+
+
+if __name__ == '__main__':
+    main()

--- a/experiments/source_page_release_profile.py
+++ b/experiments/source_page_release_profile.py
@@ -1,0 +1,137 @@
+"""Bounded native paired qualification of consumed safetensors page release.
+
+Run only inside an admitted PB action. Reads the same real checkpoint subset
+with original per-key advice and coalesced advice, retaining exact GPU bytes.
+"""
+import argparse
+import ctypes
+import json
+import mmap
+import os
+from pathlib import Path
+import threading
+import time
+
+import torch
+from prismaquant import layer_streaming as ls
+from prismaquant.memory_management import CaptureMemoryGuard
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--model', required=True)
+    parser.add_argument('--output', required=True)
+    args = parser.parse_args()
+    root = Path(args.output)
+    root.mkdir(parents=True, exist_ok=False)
+    model = Path(args.model)
+    weights = json.loads((model/'model.safetensors.index.json').read_text())['weight_map']
+    available = sorted(k for k in weights if 'layers.20.mlp.experts.' in k)
+    shard = model/weights[available[0]]
+    with shard.open('rb') as handle:
+        length = int.from_bytes(handle.read(8), 'little')
+        header = json.loads(handle.read(length))
+    keys = sorted((k for k in available if weights[k] == shard.name),
+                  key=lambda k: header[k]['data_offsets'][0])[:64]
+    assert len(keys) == 64
+    assert all(header[k]['dtype'] == 'BF16' for k in keys)
+    assert all(header[a]['data_offsets'][1] == header[b]['data_offsets'][0]
+               for a,b in zip(keys, keys[1:]))
+    base = length+8
+    begin = base+header[keys[0]]['data_offsets'][0]
+    end = base+header[keys[-1]]['data_offsets'][1]
+    page = os.sysconf('SC_PAGE_SIZE')
+    first, last = (begin+page-1)//page*page, end//page*page
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.mincore.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_void_p]
+    libc.mincore.restype = ctypes.c_int
+    def residency():
+        with shard.open('rb') as handle:
+            region = mmap.mmap(handle.fileno(), last-first, access=mmap.ACCESS_COPY, offset=first)
+            address = ctypes.addressof(ctypes.c_char.from_buffer(region))
+            vector = (ctypes.c_ubyte*((last-first)//page))()
+            result = libc.mincore(address, last-first, vector)
+            if result:
+                raise OSError(ctypes.get_errno(), 'mincore')
+            resident = sum(bool(value & 1) for value in vector)*page
+            region.close()
+        return resident
+    guard = CaptureMemoryGuard('cuda')
+    def memory():
+        stats = dict(line.split() for line in (guard.scope/'memory.stat').read_text().splitlines())
+        return dict(time_unix=time.time(), current_bytes=int((guard.scope/'memory.current').read_text()),
+                    cuda_reserved_bytes=torch.cuda.memory_reserved(),
+                    **{k:int(stats[k]) for k in ('anon','file','file_thp','file_dirty','file_writeback')})
+    mapping = dict.fromkeys(keys, str(shard))
+    names = {k:k for k in keys}
+    original = ls._advise_consumed_safetensors_pages
+    source_stat = shard.stat()
+    def read():
+        return ls._read_layer_to_device('', mapping, names, torch.bfloat16, torch.device('cuda:0'))
+    reference = read()
+    torch.cuda.synchronize()
+    assert sum(t.numel()*t.element_size() for t in reference.values()) == 1024**3
+    arms = []
+    for index, mode in enumerate(('per_key','coalesced','coalesced','per_key')):
+        # All advised bytes were consumed by this action's completed warm/read.
+        # This changes no header, unread neighbor, outer edge or global cache.
+        original(str(shard), keys, source_stat)
+        events, samples, errors = [], [], []
+        stop = threading.Event()
+        def sample():
+            while not stop.wait(.02):
+                try:
+                    samples.append(memory())
+                except Exception as exc:
+                    errors.append(str(exc))
+        def advice(path, selected, expected_stat=None):
+            before = memory()
+            started = time.perf_counter()
+            if mode == 'per_key':
+                for key in sorted(set(selected)):
+                    original(path, [key], expected_stat)
+            else:
+                original(path, selected, expected_stat)
+            events.append(dict(keys=len(selected), elapsed_s=time.perf_counter()-started,
+                               before=before, after=memory()))
+        ls._advise_consumed_safetensors_pages = advice
+        initial = dict(memory=memory(), resident_payload_bytes=residency())
+        worker = threading.Thread(target=sample, daemon=True)
+        worker.start()
+        started = time.time()
+        try:
+            with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU,
+                    torch.profiler.ProfilerActivity.CUDA], profile_memory=True,
+                    record_shapes=True) as prof:
+                with torch.profiler.record_function('source_read_and_page_release'):
+                    values = read()
+                    torch.cuda.synchronize()
+            ended = time.time()
+        finally:
+            stop.set()
+            worker.join()
+            ls._advise_consumed_safetensors_pages = original
+        final = dict(memory=memory(), resident_payload_bytes=residency())
+        assert not errors
+        equal = all(torch.equal(values[key], reference[key]) for key in keys)
+        assert equal
+        del values
+        prof.export_chrome_trace(str(root/f'{index}-{mode}.trace.json'))
+        arms.append(dict(mode=mode, start_unix=started, end_unix=ended, elapsed_s=ended-started,
+                         initial=initial, final=final, exact_gpu_bytes=equal,
+                         page_advice=events, memory_samples=samples))
+        (root/'measurement.json').write_text(json.dumps(dict(arms=arms), indent=2)+'\n')
+    original(str(shard), keys, source_stat)
+    current = shard.stat()
+    assert all(getattr(current,k) == getattr(source_stat,k) for k in
+               ('st_dev','st_ino','st_size','st_mtime_ns','st_ctime_ns'))
+    report = dict(arms=arms, source=str(shard), keys=keys, tensor_bytes=end-begin,
+        payload_begin=begin, payload_end=end, advised_begin=first, advised_end=last,
+        source_stat={k:getattr(source_stat,k) for k in ('st_dev','st_ino','st_size','st_mtime_ns','st_ctime_ns')},
+        torch=torch.__version__, cuda=torch.version.cuda,
+        contract='Same 64 contiguous real BF16 expert tensors; ABBA original per-key vs coalesced consumed-page advice; exact GPU equality. No full-capture fit claim.')
+    (root/'measurement.json').write_text(json.dumps(report, indent=2)+'\n')
+    print(json.dumps({k:report[k] for k in ('tensor_bytes','contract')}), flush=True)
+
+if __name__ == '__main__':
+    main()

--- a/prismaquant/autoscale.py
+++ b/prismaquant/autoscale.py
@@ -330,16 +330,19 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
         source_validation_bytes=sum(source['body_source_file_bytes'][k] for k in layers)+widest_weight)
     export_inputs = dict(common, selected_hessian_bytes=source['full_hessian_bytes'],
         selected_prefix_bytes=source['full_prefix_bytes'],
-        # The existing torch.save writer completes one file before it can
-        # advise its pages. Counts retain the whole census, not this subset.
-        export_input_file_bytes=source['full_hessian_bytes']+len(counts)*16384,
+        # The unchanged Torch serializer pauses after each tensor record;
+        # verified prefix advice bounds visible file pages to one record.
+        # Counts retain the whole census, not this subset. The metadata bound
+        # also covers the writer's small buffered tail and central directory.
+        export_input_page_window_bytes=widest_h+len(counts)*16384,
         serialization_scratch_bytes=2*widest_h)
     phases = dict(source_preparation=preparation, export_inputs=export_inputs,
                   resident_anchors=encoding)
-    return dict(schema='prismaquant.selected_anchor_resources.v1', phases=phases,
+    return dict(schema='prismaquant.selected_anchor_resources.v2', phases=phases,
         memory_bytes=max(sum(phase.values()) for phase in phases.values()),
         selected_source_weight_bytes=weights, selected_layers=layers,
         source_header_sha256=source['source_header_sha256'],
+        export_input_writer_policy='verified-tensor-record-prefix',
         encoder_memo_policy='compatible-anchor-batch-width',
         encoder_memo_capacity=anchor_batch_size,
         source_forward_count=0)

--- a/prismaquant/joint_aura.py
+++ b/prismaquant/joint_aura.py
@@ -7,6 +7,7 @@ QDQ is the same owner used by PerturbedActivationCache and assignment KL.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from copy import copy
 from dataclasses import dataclass
 import hashlib
 import json
@@ -234,13 +235,7 @@ class SignedJointProjectionLease:
             elif not isinstance(module, nn.Linear):
                 raise TypeError(f"joint AURA target {name} is not Linear")
             self.projection_backend.require_device(module.weight.device)
-            expected = {fmt for qname, fmt in self.deltas if qname == name}
-            if set(self.specs[name]) != expected:
-                raise ValueError(f"joint AURA render/spec coverage mismatch for {name}")
-            for fmt in expected:
-                delta = self.deltas[(name, fmt)]
-                if delta.device != module.weight.device or delta.shape != module.weight.shape:
-                    raise RuntimeError(f"joint AURA dW residency/shape differs for {name}@{fmt}")
+            self._validate_delta_coverage(name, module)
             grouped = {}
             for fmt, spec in self.specs[name].items():
                 receipt = activation_identity(spec, self.activation_max_abs, name)
@@ -255,6 +250,15 @@ class SignedJointProjectionLease:
                 group = (identity_sha256(receipt), callable_key)
                 grouped.setdefault(group, (spec, []))[1].append(fmt)
             self.groups[name] = tuple(grouped.values())
+
+    def _validate_delta_coverage(self, name, module):
+        expected = {fmt for qname, fmt in self.deltas if qname == name}
+        if set(self.specs[name]) != expected:
+            raise ValueError(f"joint AURA render/spec coverage mismatch for {name}")
+        for fmt in expected:
+            delta = self.deltas[(name, fmt)]
+            if delta.device != module.weight.device or delta.shape != module.weight.shape:
+                raise RuntimeError(f"joint AURA dW residency/shape differs for {name}@{fmt}")
 
     def __enter__(self):
         if self.handles or self.forward_originals:
@@ -274,14 +278,17 @@ class SignedJointProjectionLease:
         return self
 
     def __exit__(self, *_args):
+        self._remove_observers()
+        self.terms.clear()
+        self.active = False
+
+    def _remove_observers(self):
         for handle in self.handles:
             handle.remove()
         self.handles.clear()
         for module, original in reversed(self.forward_originals):
             module.forward = original
         self.forward_originals.clear()
-        self.terms.clear()
-        self.active = False
 
     def _install_packed_observer(self, members):
         """Observe the existing per-expert Linear slices without changing them.
@@ -436,6 +443,239 @@ class SignedJointProjectionLease:
             result[key] = {"weight": weight, "activation": activation, "mixed": mixed, "total": total}
         self.terms.clear()
         return result
+
+
+class JointOperatorStatisticsLease(SignedJointProjectionLease):
+    """Opt-in, one-probe deferred contraction using the shared source observers.
+
+    Retain sum(G.T @ X) and sum(G.T @ dX) per activation group, independent
+    of candidate count. After baseline backwards finish, seal observation,
+    release this lease's source references, and project caller-owned resident
+    candidate dW quanta. The caller's ProductionWeightCache owns candidate
+    prefetch and its physical budget. No candidate tensor is retained here.
+
+    ``max_statistics_bytes`` covers FP32 operator matrices only. Baseline
+    source/activations/cotangents, GEMM inputs and temporary matrices, source
+    conversion, projection workspaces, CUDA reservations and allocator overhead
+    still need separate phase admission. This primitive is not a full fit gate.
+    ``max_candidate_bytes`` charges complete backing storages, including any
+    unselected data kept alive by a caller's view, for each projection quantum.
+    Matrix accumulation changes rounding and has a distinct arithmetic identity.
+    """
+
+    def __init__(self, modules, specs_by_qname, *, max_statistics_bytes, max_candidate_bytes,
+                 activation_max_abs=None, projection_backend=None):
+        if type(max_statistics_bytes) is not int or max_statistics_bytes < 0:
+            raise ValueError("joint statistics budget must be a nonnegative integer")
+        if type(max_candidate_bytes) is not int or max_candidate_bytes <= 0:
+            raise ValueError("joint candidate budget must be a positive integer")
+        self.max_candidate_bytes = max_candidate_bytes
+        if not modules or set(modules) != set(specs_by_qname) or any(not specs for specs in specs_by_qname.values()):
+            raise ValueError("joint statistics module/spec coverage differs")
+        # FormatSpec is mutable; freeze its resolved fields for this lease.
+        specs = {name: {fmt: copy(spec) for fmt, spec in choices.items()}
+                 for name, choices in specs_by_qname.items()}
+        super().__init__(modules, specs, {}, activation_max_abs=activation_max_abs,
+                         projection_backend=projection_backend)
+        self._geometry = {name: (tuple(module.weight.shape), module.weight.device)
+                          for name, module in self.modules.items()}
+        self._sources = {name: self._source_fingerprint(module.weight)
+                         for name, module in self.modules.items()}
+        self._format_groups = {(name, fmt): index
+                               for name, groups in self.groups.items()
+                               for index, (_, formats) in enumerate(groups) for fmt in formats}
+        self.statistics_capacity_bytes = sum(
+            module.weight.numel() * 4 * (1 + sum(spec.act_quant_changes_input
+                                                 for spec, _ in self.groups[name]))
+            for name, module in self.modules.items())
+        if self.statistics_capacity_bytes > max_statistics_bytes:
+            raise RuntimeError("joint statistics matrices exceed statistics budget")
+        self._operators = {}
+        self._activation_terms = {}
+        self._results = {}
+        self._pending_backwards = 0
+        self._phase = 'new'
+        self.telemetry.update(statistics_capacity_bytes=self.statistics_capacity_bytes,
+                              peak_statistics_bytes=0, projected_candidates=0,
+                              peak_candidate_storage_bytes=0)
+
+    def _validate_delta_coverage(self, name, module):
+        # The exact candidate roster is sealed now; tensors arrive only after
+        # source observation, through project(), which checks each quantum.
+        if name not in self.specs or not self.specs[name]:
+            raise ValueError(f"joint statistics missing spec coverage for {name}")
+
+    @staticmethod
+    def _source_fingerprint(weight):
+        return (weight.data_ptr(), weight._version, tuple(weight.shape),
+                tuple(weight.stride()), weight.storage_offset(), weight.dtype, weight.device)
+
+    def _require_source(self, name, weight):
+        if self._source_fingerprint(weight) != self._sources[name]:
+            raise RuntimeError(f"joint statistics source weight changed for {name}")
+
+    @property
+    def resident_statistics_bytes(self):
+        return sum(value.numel() * value.element_size() for value in self._operators.values())
+
+    def arithmetic_identity(self, measurement_dtype):
+        identity = arithmetic_identity(measurement_dtype, self.projection_backend)
+        identity.update(
+            weight_projection='summed_output_operator_fp32_gemm',
+            operator_accumulation='sum_fp32_matrices_in_backward_invocation_order',
+            contraction_order='sum_operators_then_project_each_signed_component')
+        return identity
+
+    def begin_probe(self):
+        if self._phase != 'new' or not (self.handles or self.forward_originals):
+            raise RuntimeError("joint statistics requires one new entered lease per probe")
+        for name, module in self.modules.items():
+            self._require_source(name, module.weight)
+        self._phase, self.active = 'observing', True
+
+    def __enter__(self):
+        if self._phase != 'new':
+            raise RuntimeError("joint statistics cannot reenter a consumed lease")
+        return super().__enter__()
+
+    def _accumulate(self, key, matrix):
+        if key in self._operators:
+            self._operators[key].add_(matrix)
+        else:
+            self._operators[key] = matrix
+        self.telemetry['peak_statistics_bytes'] = max(
+            self.telemetry['peak_statistics_bytes'], self.resident_statistics_bytes)
+
+    def _observe(self, name, source_weight, x, output, output_slice=None, row_slice=None):
+        if self._phase != 'observing' or not self.active:
+            raise RuntimeError("joint statistics forward outside active observation")
+        self._require_source(name, source_weight)
+        if not isinstance(x, torch.Tensor) or not isinstance(output, torch.Tensor):
+            raise TypeError(f"joint statistics Linear {name} needs Tensor input/output")
+        x = x.detach()
+        consumed = False
+
+        @torch.no_grad()
+        def collect(gradient):
+            nonlocal consumed
+            if self._phase != 'observing' or not self.active or consumed:
+                raise RuntimeError("joint statistics backward outside active observation")
+            self._require_source(name, source_weight)
+            selected = gradient if row_slice is None else gradient[row_slice]
+            selected = selected if output_slice is None else selected[..., output_slice]
+            if x.device != selected.device or x.device != source_weight.device:
+                raise RuntimeError(f"joint statistics residency mismatch for {name}")
+            if (x.shape[:-1] != selected.shape[:-1] or x.shape[-1] != source_weight.shape[1]
+                    or selected.shape[-1] != source_weight.shape[0]):
+                raise RuntimeError(f"joint statistics Linear geometry/shape mismatch for {name}")
+            x2 = x.reshape(-1, x.shape[-1]).float()
+            g2 = selected.reshape(-1, selected.shape[-1]).float()
+            self._accumulate((name, None), g2.T @ x2)
+            self.telemetry['operator_gemms'] += 1
+            for index, (spec, _) in enumerate(self.groups[name]):
+                if not spec.act_quant_changes_input:
+                    continue
+                quantized = _activation_qdq(x, spec, self.activation_max_abs, name)
+                if (not isinstance(quantized, torch.Tensor) or quantized.shape != x.shape
+                        or quantized.device != x.device or quantized.dtype != x.dtype):
+                    raise RuntimeError(f"joint statistics QDQ changed residency/dtype/shape for {name}")
+                dx = quantized.reshape_as(x2).float() - x2
+                self._accumulate((name, index), g2.T @ dx)
+                self.telemetry['qdq_calls'] += 1
+                self.telemetry['operator_gemms'] += 1
+            consumed = True
+            self._pending_backwards -= 1
+            return gradient
+
+        if output.requires_grad:
+            self._pending_backwards += 1
+            output.register_hook(collect)
+
+    @torch.no_grad()
+    def finish_observations(self):
+        if self._phase != 'observing':
+            raise RuntimeError("joint statistics observations are not active")
+        if self._pending_backwards:
+            raise RuntimeError("joint statistics has pending backward observations")
+        for name, module in self.modules.items():
+            self._require_source(name, module.weight)
+            for index, (spec, _) in enumerate(self.groups[name]):
+                operator = self._operators.get((name, index))
+                value = (float(self._projection_product_sum(operator, module.weight.float()))
+                         if operator is not None else 0.)
+                if not math.isfinite(value):
+                    raise RuntimeError(f"joint statistics nonfinite activation projection for {name}")
+                self._activation_terms[(name, index)] = value
+        self._remove_observers()
+        self.modules.clear()
+        self._phase, self.active = 'ready', False
+
+    @torch.no_grad()
+    def project(self, delta_weights):
+        if self._phase != 'ready':
+            raise RuntimeError("joint statistics is not ready for candidate projection")
+        if not isinstance(delta_weights, Mapping) or not delta_weights:
+            raise ValueError("joint statistics requires a nonempty candidate quantum")
+        storages = {}
+        for key, delta in delta_weights.items():
+            if key not in self._format_groups:
+                raise ValueError(f"joint statistics unknown candidate {key}")
+            if key in self._results:
+                raise ValueError(f"joint statistics duplicate candidate {key}")
+            shape, device = self._geometry[key[0]]
+            if (not isinstance(delta, torch.Tensor) or tuple(delta.shape) != shape
+                    or delta.device != device or not delta.is_floating_point()):
+                raise RuntimeError(f"joint statistics candidate residency/dtype/shape differs for {key}")
+            storage = delta.untyped_storage()
+            storages[(delta.device, storage.data_ptr())] = storage.nbytes()
+        candidate_bytes = sum(storages.values())
+        if candidate_bytes > self.max_candidate_bytes:
+            raise RuntimeError("joint statistics candidate storage exceeds candidate budget")
+        # Commit scalar results only after the whole quantum succeeds.
+        results = {}
+        for key, delta in delta_weights.items():
+            name, fmt = key
+            group = self._format_groups[key]
+            dw = delta.float()
+            gw = self._operators.get((name, None))
+            ga = self._operators.get((name, group))
+            if gw is None and not bool(torch.isfinite(dw).all()):
+                raise RuntimeError(f"joint statistics nonfinite unrouted candidate for {key}")
+            weight = float(self._projection_product_sum(gw, dw)) if gw is not None else 0.
+            activation = self._activation_terms[(name, group)]
+            mixed = float(self._projection_product_sum(ga, dw)) if ga is not None else 0.
+            total = weight + activation + mixed
+            if not all(math.isfinite(value) for value in (weight, activation, mixed, total)):
+                raise RuntimeError(f"joint statistics nonfinite signed projection for {key}")
+            results[key] = dict(weight=weight, activation=activation, mixed=mixed, total=total)
+        self._results.update(results)
+        self.telemetry['projected_candidates'] += len(results)
+        self.telemetry['peak_candidate_storage_bytes'] = max(
+            self.telemetry['peak_candidate_storage_bytes'], candidate_bytes)
+        return {key: dict(value) for key, value in results.items()}
+
+    def finish_projections(self):
+        if self._phase != 'ready':
+            raise RuntimeError("joint statistics is not ready to seal projections")
+        if set(self._results) != set(self._format_groups):
+            raise RuntimeError("joint statistics candidate coverage is incomplete")
+        result = {key: dict(value) for key, value in self._results.items()}
+        self._operators.clear()
+        self._activation_terms.clear()
+        self._results.clear()
+        self._phase = 'complete'
+        return result
+
+    def finish_probe(self):
+        raise RuntimeError("joint statistics requires observation and candidate projection seals")
+
+    def __exit__(self, *_args):
+        super().__exit__(*_args)
+        self.modules.clear()
+        self._operators.clear()
+        self._activation_terms.clear()
+        self._results.clear()
+        self._phase = 'closed'
 
 
 def validate_joint_aura_entry(entry: Mapping) -> bool:

--- a/prismaquant/joint_aura.py
+++ b/prismaquant/joint_aura.py
@@ -494,6 +494,7 @@ class JointOperatorStatisticsLease(SignedJointProjectionLease):
         self._activation_terms = {}
         self._results = {}
         self._pending_backwards = 0
+        self._observation_inputs = {}
         self._phase = 'new'
         self.telemetry.update(statistics_capacity_bytes=self.statistics_capacity_bytes,
                               peak_statistics_bytes=0, projected_candidates=0,
@@ -546,13 +547,18 @@ class JointOperatorStatisticsLease(SignedJointProjectionLease):
         self.telemetry['peak_statistics_bytes'] = max(
             self.telemetry['peak_statistics_bytes'], self.resident_statistics_bytes)
 
+    def _release_observation_inputs(self):
+        for inputs in self._observation_inputs.values():
+            inputs.clear()
+        self._observation_inputs.clear()
+
     def _observe(self, name, source_weight, x, output, output_slice=None, row_slice=None):
         if self._phase != 'observing' or not self.active:
             raise RuntimeError("joint statistics forward outside active observation")
         self._require_source(name, source_weight)
         if not isinstance(x, torch.Tensor) or not isinstance(output, torch.Tensor):
             raise TypeError(f"joint statistics Linear {name} needs Tensor input/output")
-        x = x.detach()
+        inputs = [x.detach(), source_weight]
         consumed = False
 
         @torch.no_grad()
@@ -560,35 +566,50 @@ class JointOperatorStatisticsLease(SignedJointProjectionLease):
             nonlocal consumed
             if self._phase != 'observing' or not self.active or consumed:
                 raise RuntimeError("joint statistics backward outside active observation")
-            self._require_source(name, source_weight)
-            selected = gradient if row_slice is None else gradient[row_slice]
-            selected = selected if output_slice is None else selected[..., output_slice]
-            if x.device != selected.device or x.device != source_weight.device:
-                raise RuntimeError(f"joint statistics residency mismatch for {name}")
-            if (x.shape[:-1] != selected.shape[:-1] or x.shape[-1] != source_weight.shape[1]
-                    or selected.shape[-1] != source_weight.shape[0]):
-                raise RuntimeError(f"joint statistics Linear geometry/shape mismatch for {name}")
-            x2 = x.reshape(-1, x.shape[-1]).float()
-            g2 = selected.reshape(-1, selected.shape[-1]).float()
-            self._accumulate((name, None), g2.T @ x2)
-            self.telemetry['operator_gemms'] += 1
-            for index, (spec, _) in enumerate(self.groups[name]):
-                if not spec.act_quant_changes_input:
-                    continue
-                quantized = _activation_qdq(x, spec, self.activation_max_abs, name)
-                if (not isinstance(quantized, torch.Tensor) or quantized.shape != x.shape
-                        or quantized.device != x.device or quantized.dtype != x.dtype):
-                    raise RuntimeError(f"joint statistics QDQ changed residency/dtype/shape for {name}")
-                dx = quantized.reshape_as(x2).float() - x2
-                self._accumulate((name, index), g2.T @ dx)
-                self.telemetry['qdq_calls'] += 1
+            try:
+                x, source_weight = inputs
+                self._require_source(name, source_weight)
+                selected = gradient if row_slice is None else gradient[row_slice]
+                selected = selected if output_slice is None else selected[..., output_slice]
+                if x.device != selected.device or x.device != source_weight.device:
+                    raise RuntimeError(f"joint statistics residency mismatch for {name}")
+                if (x.shape[:-1] != selected.shape[:-1] or x.shape[-1] != source_weight.shape[1]
+                        or selected.shape[-1] != source_weight.shape[0]):
+                    raise RuntimeError(f"joint statistics Linear geometry/shape mismatch for {name}")
+                x2 = x.reshape(-1, x.shape[-1]).float()
+                g2 = selected.reshape(-1, selected.shape[-1]).float()
+                self._accumulate((name, None), g2.T @ x2)
                 self.telemetry['operator_gemms'] += 1
-            consumed = True
-            self._pending_backwards -= 1
+                for index, (spec, _) in enumerate(self.groups[name]):
+                    if not spec.act_quant_changes_input:
+                        continue
+                    quantized = _activation_qdq(x, spec, self.activation_max_abs, name)
+                    if (not isinstance(quantized, torch.Tensor) or quantized.shape != x.shape
+                            or quantized.device != x.device or quantized.dtype != x.dtype):
+                        raise RuntimeError(f"joint statistics QDQ changed residency/dtype/shape for {name}")
+                    dx = quantized.reshape_as(x2).float() - x2
+                    self._accumulate((name, index), g2.T @ dx)
+                    self.telemetry['qdq_calls'] += 1
+                    self.telemetry['operator_gemms'] += 1
+                consumed = True
+                self._pending_backwards -= 1
+            except BaseException:
+                # A QDQ/GEMM may fail after an earlier operator committed.
+                # Never allow a caught backward failure to become a retry.
+                self._phase, self.active = 'failed', False
+                self._remove_observers()
+                self.modules.clear()
+                self._operators.clear()
+                self._release_observation_inputs()
+                raise
+            finally:
+                inputs.clear()
+                self._observation_inputs.pop(id(inputs), None)
             return gradient
 
         if output.requires_grad:
             self._pending_backwards += 1
+            self._observation_inputs[id(inputs)] = inputs
             output.register_hook(collect)
 
     @torch.no_grad()
@@ -672,6 +693,7 @@ class JointOperatorStatisticsLease(SignedJointProjectionLease):
     def __exit__(self, *_args):
         super().__exit__(*_args)
         self.modules.clear()
+        self._release_observation_inputs()
         self._operators.clear()
         self._activation_terms.clear()
         self._results.clear()

--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -1394,13 +1394,25 @@ def _advise_consumed_safetensors_pages(shard: str, keys: list[str],
         header = json.loads(os.pread(fd, header_size, 8))
         base = 8 + header_size
         page = os.sysconf('SC_PAGE_SIZE')
+        spans = []
         for key in sorted(set(keys)):
             begin, end = header[key]['data_offsets']
             if (type(begin) is not int or type(end) is not int
                     or not 0 <= begin <= end <= source_stat.st_size - base):
                 raise ValueError('invalid tensor span for consumed-page release')
-            first = ((base + begin + page - 1) // page) * page
-            last = ((base + end) // page) * page
+            spans.append((base + begin, base + end))
+        # Merge bytes before page alignment: a page shared by two consumed
+        # tensors is consumed in full. Per-tensor alignment would retain each
+        # boundary page (and potentially its entire large file-cache folio).
+        merged = []
+        for begin, end in sorted(spans):
+            if merged and begin <= merged[-1][1]:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+            else:
+                merged.append((begin, end))
+        for begin, end in merged:
+            first = ((begin + page - 1) // page) * page
+            last = (end // page) * page
             if first < last:
                 os.posix_fadvise(fd, first, last - first, os.POSIX_FADV_DONTNEED)
     finally:

--- a/prismaquant/perturbed_x_cache.py
+++ b/prismaquant/perturbed_x_cache.py
@@ -201,11 +201,14 @@ def write_activation_cache_entry(cache_dir, name, inputs, *, source="perturbed_x
 
 
 def release_activation_cache_file_pages(path, *, expected_stat):
-    """Advise only a completed, unchanged entry after its checksum is checked.
+    """Advise a verified unchanged file extent at a reader/writer boundary.
 
-    This optional capture-writer boundary leaves the artifact and all tensor
-    owners intact. Later consumers still use the ordinary activation prefetch.
-    Advice is not proof of physical release; the caller's guard remains final.
+    Readers check completed-entry hashes first. A serializer may also pause
+    after a synchronous tensor record and advise its stable visible prefix;
+    the same inode, size and timestamp checks and durability fence apply.
+    The artifact and tensor owners remain intact, and final publication still
+    requires the complete seal. Advice is not proof of physical release; the
+    caller's guard remains final.
     """
     import stat
     def identity(value):

--- a/prismaquant/production_weight_cache.py
+++ b/prismaquant/production_weight_cache.py
@@ -79,6 +79,7 @@ import re
 import subprocess
 import stat
 import time
+import zipfile
 
 import torch
 import torch.nn as nn
@@ -376,7 +377,7 @@ class ProductionWeightCache:
         self._file_load_receipts = None
         return compacted
 
-    def release_resident_tensors(self) -> int:
+    def release_resident_tensors(self, keys: Sequence[tuple[str, str]] | None = None) -> int:
         """Drop disk-backed resident tensors, keeping every key resolvable.
 
         Same operation as :meth:`compact_for_pickle` — that one is named for
@@ -389,8 +390,198 @@ class ProductionWeightCache:
         Entries that were never disk-backed are left resident, because dropping
         those would lose data rather than free a re-readable copy. A later
         ``get()`` on a released key simply reloads it from disk.
+
+        ``keys`` limits release to entries with a recorded load path. It never
+        adopts an unrelated same-named file as backing for an in-memory tensor.
+        Omitting ``keys`` preserves the legacy whole-cache compaction behavior.
         """
-        return self.compact_for_pickle()
+        if keys is None:
+            return self.compact_for_pickle()
+        released = 0
+        for key in dict.fromkeys(keys):
+            value = self.weights.get(key)
+            if not isinstance(value, torch.Tensor):
+                continue
+            path = (self._lru_paths or {}).get(key)
+            if path is None:
+                continue  # A non-disk-backed value remains its only owner.
+            self.weights[key] = path
+            if self._lru_order is not None and key in self._lru_order:
+                self._lru_order.remove(key)
+                self._lru_bytes -= value.numel() * value.element_size()
+            if self._cb_verified_keys is not None:
+                self._cb_verified_keys.discard(key)
+            if self._file_load_receipts is not None:
+                self._file_load_receipts.pop(key, None)
+            released += 1
+        return released
+
+    @staticmethod
+    def _window_storage(tensor):
+        if (type(tensor) not in (torch.Tensor, nn.Parameter)
+                or tensor.layout != torch.strided or tensor.device.type == 'meta'):
+            raise RuntimeError('PWC resident window has unaccountable tensor storage')
+        storage = tensor.untyped_storage()
+        return (tensor.device, storage.data_ptr()), storage.nbytes()
+
+    def _window_resident_storages(self):
+        storages = {}
+        for value in self.weights.values():
+            if isinstance(value, torch.Tensor):
+                identity, nbytes = self._window_storage(value)
+                storages[identity] = max(storages.get(identity, 0), nbytes)
+        return storages
+
+    @staticmethod
+    def _window_archive_storage_bytes(source):
+        """Only ordinary uncompressed Torch archives have accountable loads."""
+        try:
+            with zipfile.ZipFile(source) as archive:
+                entries = archive.infolist()
+                names = [entry.filename for entry in entries]
+                roots = {name.split('/')[0] for name in names}
+                if (len(roots) != 1 or len(set(names)) != len(names)
+                        or not any(name.endswith('/data.pkl') for name in names)
+                        or any(entry.compress_type != zipfile.ZIP_STORED or entry.flag_bits & 1
+                               or entry.file_size != entry.compress_size for entry in entries)):
+                    raise RuntimeError('PWC window requires an uncompressed Torch archive')
+                return sum(entry.file_size for entry in entries
+                           if re.fullmatch(r'[^/]+/data/[0-9]+', entry.filename))
+        except (OSError, zipfile.BadZipFile) as exc:
+            raise RuntimeError('PWC window has an unaccountable Torch archive') from exc
+
+    def _window_keys(self, keys):
+        if not isinstance(keys, Sequence) or isinstance(keys, (str, bytes)):
+            raise TypeError('PWC window keys must be a finite sequence')
+        resolved, seen = [], set()
+        for pair in keys:
+            if (not isinstance(pair, (tuple, list)) or len(pair) != 2
+                    or any(not isinstance(part, str) or not part for part in pair)):
+                raise ValueError('PWC window needs (name, format) keys')
+            key = self.resolve_key(*pair)
+            if key is None:
+                raise RuntimeError(f'PWC window missing cache entry {pair}')
+            if key not in seen:
+                resolved.append(key)
+                seen.add(key)
+        return tuple(resolved)
+
+    @staticmethod
+    def _window_limits(max_resident_bytes, max_workers):
+        if type(max_resident_bytes) is not int or max_resident_bytes <= 0:
+            raise ValueError('PWC window requires a positive resident byte budget')
+        if (type(max_workers) is not int or max_workers <= 0
+                or max_workers > len(os.sched_getaffinity(0))):
+            raise ValueError('PWC window workers exceed assigned CPU affinity')
+
+    def _window_file(self, key):
+        value = self.weights[key]
+        if not isinstance(value, (str, Path)):
+            raise RuntimeError('PWC window has an unaccountable cache input')
+        path = Path(self._path_for_value(value)).absolute()
+        before = path.lstat()
+        if not stat.S_ISREG(before.st_mode):
+            raise RuntimeError('PWC window requires a regular file, not a symlink')
+        storage_bytes = self._window_archive_storage_bytes(path)
+        if self._file_signature(path.lstat()) != self._file_signature(before):
+            raise RuntimeError('PWC window file changed during preflight')
+        estimate = self.estimate_nbytes([key])
+        if estimate != before.st_size or storage_bytes > estimate:
+            raise RuntimeError('PWC window file storage estimate changed')
+        return path, before, estimate, storage_bytes
+
+    def plan_resident_windows(self, keys, *, max_resident_bytes: int, max_workers: int):
+        """Plan finite research quanta in input order without loading tensors.
+
+        All existing PWC tensor backing storages count, including unrelated
+        entries and storage hidden behind views; aliases count once. Incoming
+        standard uncompressed Torch files use the existing conservative file
+        estimate. Each quantum has at most ``max_workers`` keys, bounding the
+        existing prefetch pool's futures as well as its loader concurrency.
+        Plans are key-only hints; ``resident_window`` revalidates each entry.
+        """
+        self._window_limits(max_resident_bytes, max_workers)
+        keys = self._window_keys(keys)
+        baseline = sum(self._window_resident_storages().values())
+        if baseline > max_resident_bytes:
+            raise RuntimeError('PWC existing resident storage exceeds window budget')
+        windows, window, nbytes = [], [], baseline
+        for key in keys:
+            value = self.weights[key]
+            incoming = 0 if isinstance(value, torch.Tensor) else self._window_file(key)[2]
+            if baseline + incoming > max_resident_bytes:
+                raise RuntimeError(f'PWC single entry exceeds resident window budget: {key}')
+            if window and (len(window) == max_workers or nbytes + incoming > max_resident_bytes):
+                windows.append(tuple(window))
+                window, nbytes = [], baseline
+            window.append(key)
+            nbytes += incoming
+        if window:
+            windows.append(tuple(window))
+        return tuple(windows)
+
+    @contextmanager
+    def resident_window(self, keys, *, max_resident_bytes: int, max_workers: int,
+                        max_load_buffer_bytes: int | None = None, release_file_pages: bool = False):
+        """Prefetch one research quantum, then expose strict resident lookups.
+
+        This owns no tensor dictionary. PWC remains the only cache; selected
+        disk-backed entries are released on success/failure. Callers must drop
+        their borrowed tensor references at the boundary. Nested windows refuse.
+        The resident cap covers all cache backing storages. Serialized loader
+        buffers have a separate aggregate cap (default: resident cap); both
+        caps, allocator overhead and consumer workspaces need phase admission.
+        Page-release advice is optional and is not a physical-memory guarantee.
+        """
+        if getattr(self, '_resident_window_files', None) is not None:
+            raise RuntimeError('PWC resident windows cannot be nested')
+        if type(release_file_pages) is not bool:
+            raise ValueError('PWC window page release must be boolean')
+        buffer_cap = max_resident_bytes if max_load_buffer_bytes is None else max_load_buffer_bytes
+        if type(buffer_cap) is not int or buffer_cap <= 0:
+            raise ValueError('PWC window needs a positive serialized buffer budget')
+        windows = self.plan_resident_windows(keys, max_resident_bytes=max_resident_bytes,
+                                             max_workers=max_workers)
+        if len(windows) != 1:
+            raise RuntimeError('PWC resident_window requires one nonempty planned quantum')
+        keys = windows[0]
+        files = {}
+        for key in keys:
+            value = self.weights[key]
+            if not isinstance(value, torch.Tensor):
+                path, observed, estimate, storage_bytes = self._window_file(key)
+                files[str(path)] = (observed, estimate, storage_bytes)
+        # Different keys reading one file still allocate separate load buffers.
+        buffer_bytes = sum(files[str(Path(self._path_for_value(self.weights[key])).absolute())][1]
+                           for key in keys if not isinstance(self.weights[key], torch.Tensor))
+        if buffer_bytes > buffer_cap:
+            raise RuntimeError('PWC serialized load buffers exceed window budget')
+        incoming_storage = sum(files[str(Path(self._path_for_value(self.weights[key])).absolute())][2]
+                               for key in keys if not isinstance(self.weights[key], torch.Tensor))
+        if (self._lru_order is not None and self._lru_max_bytes > 0
+                and self._lru_bytes + incoming_storage > self._lru_max_bytes):
+            raise RuntimeError('PWC resident window exceeds available LRU budget')
+        self._resident_window_files = files
+        self._resident_window_receipt_keys = frozenset(
+            key for key in keys if not isinstance(self.weights[key], torch.Tensor))
+        try:
+            loaded = self.prefetch(keys, max_workers=max_workers)
+            for key in keys:
+                self.get_resident(*key)
+            actual = sum(self._window_resident_storages().values())
+            if actual > max_resident_bytes:
+                raise RuntimeError('PWC actual backing storage exceeds resident window budget')
+            if release_file_pages:
+                from .perturbed_x_cache import release_activation_cache_file_pages
+                for path, (observed, _, _) in files.items():
+                    release_activation_cache_file_pages(path, expected_stat=observed)
+            yield {'keys': keys, 'loaded': loaded, 'resident_bytes': actual,
+                   'budget_bytes': max_resident_bytes, 'load_buffer_capacity_bytes': buffer_bytes,
+                   'load_buffer_budget_bytes': buffer_cap, 'file_pages_advised': len(files) if release_file_pages else 0}
+        finally:
+            self.release_resident_tensors(keys)
+            self._resident_window_files = None
+            self._resident_window_receipt_keys = frozenset()
 
     def _path_for_value(self, value: object) -> str:
         path = str(value)
@@ -772,6 +963,13 @@ class ProductionWeightCache:
     def _load_file_tensor(self, value):
         path = Path(self._path_for_value(value)).absolute()
         limit = getattr(self, "_file_load_max_bytes", 0)
+        window_files = getattr(self, '_resident_window_files', None)
+        window_entry = None
+        if window_files is not None:
+            window_entry = window_files.get(str(path))
+            if window_entry is None:
+                raise RuntimeError('PWC load is outside the active resident window')
+            limit = min(limit, window_entry[1]) if limit else window_entry[1]
         if not limit:
             return torch.load(path, map_location="cpu", weights_only=True), None
         before = path.lstat()
@@ -780,6 +978,8 @@ class ProductionWeightCache:
         if before.st_size > limit:
             raise RuntimeError("PWC file exceeds the explicit read buffer bound")
         signature = self._file_signature(before)
+        if window_entry is not None and signature != self._file_signature(window_entry[0]):
+            raise RuntimeError('PWC window file changed before its content read')
         with path.open("rb") as handle:
             if self._file_signature(os.fstat(handle.fileno())) != signature:
                 raise RuntimeError("PWC file changed before its content read")
@@ -790,9 +990,14 @@ class ProductionWeightCache:
         # The temporary serialized buffer is per loader worker and is released
         # before its result enters the existing LRU. No whole-cache byte store.
         receipt = {"path": str(path), "bytes": len(raw), "sha256": hashlib.sha256(raw).hexdigest()}
+        if window_entry is not None:
+            if self._window_archive_storage_bytes(io.BytesIO(raw)) != window_entry[2]:
+                raise RuntimeError('PWC window archive storage changed during its read')
         tensor = torch.load(io.BytesIO(raw), map_location="cpu", weights_only=True)
         if not isinstance(tensor, torch.Tensor):
             raise RuntimeError("PWC file receipt requires a tensor shard")
+        if window_entry is not None and self._window_storage(tensor)[1] > window_entry[2]:
+            raise RuntimeError('PWC loaded backing storage exceeds its archive bound')
         return tensor, (receipt, signature, self._file_tensor_guard(tensor))
 
     def _record_file_load(self, key, tensor, observed) -> None:
@@ -867,16 +1072,22 @@ class ProductionWeightCache:
                 loaded_count += 1
         return loaded_count
 
-    def _resolve_to_tensor(self, key: tuple[str, str]) -> torch.Tensor | None:
+    def _resolve_to_tensor(self, key: tuple[str, str], *, resident_only=False) -> torch.Tensor | None:
         """Return the tensor at ``key`` (lazy-load from disk if needed).
         With LRU enabled, the freshly-loaded tensor is bookkept and the
         oldest entries get evicted back to filenames when the byte budget
         is exceeded.  Returns None if the key isn't present."""
         v = self.weights.get(key)
+        if resident_only and not isinstance(v, torch.Tensor):
+            raise RuntimeError(f'PWC cache entry is not resident: {key}')
         if v is None:
             return None
         if isinstance(v, torch.Tensor):
             self._validate_loaded_cb_pair_tensor(key, v)
+            if resident_only and (getattr(self, '_file_load_max_bytes', 0)
+                                  or key in (self._file_load_receipts or {})
+                                  or key in getattr(self, '_resident_window_receipt_keys', ())):
+                self.file_load_receipt(key, v)
             # Refresh LRU position.
             if self._lru_order is not None:
                 if key in self._lru_order:
@@ -891,7 +1102,7 @@ class ProductionWeightCache:
         self._record_file_load(key, loaded, receipt)
         return loaded
 
-    def get(self, name: str, fmt: str) -> torch.Tensor | None:
+    def get(self, name: str, fmt: str, *, resident_only=False) -> torch.Tensor | None:
         key = self.resolve_key(name, fmt)
         if key is not None:
             if _is_cb_format_name(key[1]):
@@ -900,8 +1111,14 @@ class ProductionWeightCache:
                     require_for_formats=[key[1]],
                     where=f"ProductionWeightCache get({key[0]}@{key[1]})",
                 )
-            return self._resolve_to_tensor(key)
+            return self._resolve_to_tensor(key, resident_only=resident_only)
+        if resident_only:
+            raise RuntimeError(f'PWC missing cache entry: {name}@{fmt}')
         return None
+
+    def get_resident(self, name: str, fmt: str) -> torch.Tensor:
+        """Return a resident tensor with CB/receipt guards; never load a file."""
+        return self.get(name, fmt, resident_only=True)
 
     def relocate(self, new_cache_dir: str | Path) -> None:
         """Point the cache at a new on-disk directory of .pt shards.

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -3331,6 +3331,39 @@ def _require_resumable_anchor(anchor: CampaignAnchor, static_scales) -> None:
         )
 
 
+def _save_hessian_capture_with_page_release(payload, path, *, resource_check=None):
+    """Use Torch's path writer unchanged, advising each stable tensor prefix.
+
+    A file-like torch.save target changes archive record names. Keep the same
+    filename writer and serializer as torch.save, and interpose only after its
+    synchronous storage writes. No storage, pickle or archive byte is rewritten.
+    """
+    import torch.serialization as serialization
+    from .perturbed_x_cache import release_activation_cache_file_pages
+
+    class RecordBoundary:
+        def __init__(self, writer):
+            self.writer = writer
+
+        def __getattr__(self, name):
+            return getattr(self.writer, name)
+
+        def write_record(self, name, *args, **kwargs):
+            result = self.writer.write_record(name, *args, **kwargs)
+            if name.startswith('data/'):
+                # The serializer is paused: the visible file extent cannot
+                # change while the existing helper checks identity and fsyncs.
+                expected = path.stat()
+                release_activation_cache_file_pages(path, expected_stat=expected)
+                if resource_check is not None:
+                    resource_check('after_hessian_tensor_record:'+name)
+            return result
+
+    with serialization._open_zipfile_writer(os.fspath(path)) as writer:
+        serialization._save(payload, RecordBoundary(writer), serialization.pickle,
+                            serialization.DEFAULT_PROTOCOL, False)
+
+
 def write_export_inputs(cache_dir: Path, *, hessians, hessian_rows,
                         hessian_identity, static_scales, static_scale_policy,
                         release_file_pages=False, resource_check=None):
@@ -3383,11 +3416,13 @@ def write_export_inputs(cache_dir: Path, *, hessians, hessian_rows,
             hessian_capture_path.name + ".provenance.json")
         tmp_capture = hessian_capture_path.with_suffix(".pt.tmp")
         tmp_sidecar = sidecar.with_suffix(".json.tmp")
-        torch.save({
-            "H": saved_hessians,
-            "counts": dict(hessian_rows),
-            "provenance": capture_provenance,
-        }, tmp_capture)
+        payload = {"H": saved_hessians, "counts": dict(hessian_rows),
+                   "provenance": capture_provenance}
+        if release_file_pages:
+            _save_hessian_capture_with_page_release(payload, tmp_capture,
+                                                    resource_check=resource_check)
+        else:
+            torch.save(payload, tmp_capture)
         tmp_sidecar.write_text(json.dumps({
             **capture_provenance,
             "capture_sha256": capture_sha256,
@@ -4329,7 +4364,7 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     if selected_guard is not None:
         phase = selected_resources['phases']['export_inputs']
         selected_guard.check('before_selected_export_input_write', reserve_bytes=
-            phase['export_input_file_bytes']+phase['serialization_scratch_bytes'])
+            phase['export_input_page_window_bytes']+phase['serialization_scratch_bytes'])
     hessian_capture_path, input_scales_path, capture_sha256 = write_export_inputs(
         cache_dir,
         hessians=hessians if want_h else None,

--- a/tests/test_bounded_hessian_sidecar.py
+++ b/tests/test_bounded_hessian_sidecar.py
@@ -1,0 +1,115 @@
+"""The existing Torch archive can release completed records without new bytes."""
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def test_export_releases_stable_tensor_prefixes_with_exact_archive_bytes(tmp_path, monkeypatch):
+    from prismaquant import perturbed_x_cache, tessera_campaign as campaign
+    hessians = {f'unit.{index}': torch.arange(128*128, dtype=torch.float32).reshape(128, 128)+index
+                for index in range(4)}
+    hessians['shared.view'] = hessians['unit.0'].t()
+    calls = []
+    original = perturbed_x_cache.release_activation_cache_file_pages
+    def observe(path, *, expected_stat):
+        calls.append((Path(path).name, expected_stat.st_size))
+        return original(path, expected_stat=expected_stat)
+    monkeypatch.setattr(perturbed_x_cache, 'release_activation_cache_file_pages', observe)
+    outcomes = []
+    for bounded in (False, True):
+        directory = tmp_path/str(bounded)
+        directory.mkdir()
+        path, _scales, digest = campaign.write_export_inputs(directory,
+            hessians=hessians, hessian_rows=dict.fromkeys(hessians, 512),
+            hessian_identity={'fit_ids_sha256': 'unchanged-draw'},
+            static_scales={}, static_scale_policy='fixture', release_file_pages=bounded)
+        outcomes.append((path.read_bytes(), digest))
+    assert outcomes[0] == outcomes[1]
+    prefixes = [size for name, size in calls if name == 'hessian_capture.pt.tmp']
+    assert len(prefixes) >= 4, 'the writer retained the whole file until publication'
+    assert prefixes == sorted(prefixes)
+    assert prefixes[0] < len(outcomes[1][0])//2
+    assert calls[-1] == ('hessian_capture.pt', len(outcomes[1][0]))
+
+
+def test_native_hessian_writer_profile(tmp_path, monkeypatch):
+    """Opt-in, attributed writer qualification, never a full-GLM fit claim."""
+    import hashlib
+    import json
+    import os
+    import threading
+    import time
+    from prismaquant import perturbed_x_cache, tessera_campaign as campaign
+    from prismaquant.memory_management import CaptureMemoryGuard
+    destination = os.environ.get('PRISMAQUANT_HESSIAN_WRITER_PROFILE')
+    if not destination:
+        pytest.skip('explicit native writer measurement only')
+    assert torch.cuda.is_available()
+    root = Path(destination)
+    root.mkdir(parents=True, exist_ok=False)
+    hessians = {f'unit.{index}': torch.full((4096, 4096), index/16,
+                device='cuda', dtype=torch.float32) for index in range(16)}
+    torch.cuda.synchronize()
+    guard = CaptureMemoryGuard('cuda')
+    events, samples = [], []
+    original = perturbed_x_cache.release_activation_cache_file_pages
+    def advise(path, *, expected_stat):
+        events.append(dict(name=Path(path).name, bytes=expected_stat.st_size,
+                           before=guard.check('before_prefix_advice')))
+        result = original(path, expected_stat=expected_stat)
+        events[-1]['after'] = guard.check('after_prefix_advice')
+        return result
+    monkeypatch.setattr(perturbed_x_cache, 'release_activation_cache_file_pages', advise)
+    stop = threading.Event()
+    errors = []
+    def sample():
+        while not stop.wait(.02):
+            try:
+                stat = dict(line.split() for line in (guard.scope/'memory.stat').read_text().splitlines())
+                samples.append(dict(time_unix=time.time(),
+                    current_bytes=int((guard.scope/'memory.current').read_text()),
+                    cuda_reserved_bytes=torch.cuda.memory_reserved(),
+                    **{name: int(stat[name]) for name in ('anon', 'file', 'file_dirty', 'file_writeback')}))
+            except Exception as error:
+                errors.append(str(error))
+    def process_io():
+        return dict((key.rstrip(':'), int(value)) for key, value in
+                    (line.split() for line in Path('/proc/self/io').read_text().splitlines()))
+    before = guard.check('before_writer')
+    io_before = process_io()
+    started = time.time()
+    sampler = threading.Thread(target=sample, daemon=True)
+    sampler.start()
+    try:
+        with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA], profile_memory=True,
+                record_shapes=True) as prof:
+            path, _, content_digest = campaign.write_export_inputs(root,
+                hessians=hessians, hessian_rows=dict.fromkeys(hessians, 512),
+                hessian_identity={'fit_ids_sha256': 'writer-qualification-fixed'},
+                static_scales={}, static_scale_policy='fixture', release_file_pages=True,
+                resource_check=guard.check)
+        torch.cuda.synchronize()
+    finally:
+        ended = time.time()
+        stop.set()
+        sampler.join()
+    after = guard.check('after_writer')
+    assert not errors
+    io_after = process_io()
+    prof.export_chrome_trace(str(root/'writer.trace.json'))
+    file_sha = hashlib.sha256()
+    with path.open('rb') as handle:
+        while block := handle.read(8*1024**2):
+            file_sha.update(block)
+    perturbed_x_cache.release_activation_cache_file_pages(path, expected_stat=path.stat())
+    report = dict(start_unix=started, end_unix=ended, elapsed_s=ended-started,
+        workload=dict(tensors=16, shape=[4096,4096], dtype='float32', device='cuda',
+                      tensor_bytes=16*4096*4096*4),
+        before=before, after=after, page_advice=events, memory_samples=samples,
+        io_delta={key: io_after[key]-io_before[key] for key in io_before},
+        file_bytes=path.stat().st_size, file_sha256=file_sha.hexdigest(),
+        content_digest=content_digest, torch=torch.__version__, cuda=torch.version.cuda,
+        claim='writer ownership qualification; no full GLM fit or throughput claim')
+    (root/'measurement.json').write_text(json.dumps(report, indent=2)+'\n')

--- a/tests/test_bounded_hessian_sidecar.py
+++ b/tests/test_bounded_hessian_sidecar.py
@@ -5,9 +5,12 @@ import pytest
 import torch
 
 
-def test_export_releases_stable_tensor_prefixes_with_exact_archive_bytes(tmp_path, monkeypatch):
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float64, torch.bfloat16])
+@pytest.mark.parametrize('directory_name', ['ascii', 'café'])
+def test_export_releases_stable_tensor_prefixes_with_exact_archive_bytes(tmp_path, monkeypatch,
+                                                                        dtype, directory_name):
     from prismaquant import perturbed_x_cache, tessera_campaign as campaign
-    hessians = {f'unit.{index}': torch.arange(128*128, dtype=torch.float32).reshape(128, 128)+index
+    hessians = {f'unit.{index}': torch.arange(128*128, dtype=torch.float32).to(dtype).reshape(128, 128)+index
                 for index in range(4)}
     hessians['shared.view'] = hessians['unit.0'].t()
     calls = []
@@ -18,8 +21,8 @@ def test_export_releases_stable_tensor_prefixes_with_exact_archive_bytes(tmp_pat
     monkeypatch.setattr(perturbed_x_cache, 'release_activation_cache_file_pages', observe)
     outcomes = []
     for bounded in (False, True):
-        directory = tmp_path/str(bounded)
-        directory.mkdir()
+        directory = tmp_path/directory_name/str(bounded)
+        directory.mkdir(parents=True)
         path, _scales, digest = campaign.write_export_inputs(directory,
             hessians=hessians, hessian_rows=dict.fromkeys(hessians, 512),
             hessian_identity={'fit_ids_sha256': 'unchanged-draw'},
@@ -113,3 +116,23 @@ def test_native_hessian_writer_profile(tmp_path, monkeypatch):
         content_digest=content_digest, torch=torch.__version__, cuda=torch.version.cuda,
         claim='writer ownership qualification; no full GLM fit or throughput claim')
     (root/'measurement.json').write_text(json.dumps(report, indent=2)+'\n')
+
+
+@pytest.mark.parametrize('failure', ['page_advice', 'memory_guard'])
+def test_record_failure_preserves_previous_published_capture(tmp_path, monkeypatch, failure):
+    from prismaquant import perturbed_x_cache, tessera_campaign as campaign
+    inputs = dict(hessians={'unit': torch.eye(128)}, hessian_rows={'unit': 512},
+                  hessian_identity={'fit_ids_sha256': 'same-draw'}, static_scales={},
+                  static_scale_policy='fixture')
+    path, _, _ = campaign.write_export_inputs(tmp_path, **inputs)
+    sidecar = path.with_name(path.name+'.provenance.json')
+    previous = (path.read_bytes(), sidecar.read_bytes())
+    inputs['hessians'] = {'unit': torch.eye(128)*2}
+    def refuse(*args, **kwargs):
+        raise RuntimeError('refused at stable record')
+    if failure == 'page_advice':
+        monkeypatch.setattr(perturbed_x_cache, 'release_activation_cache_file_pages', refuse)
+    with pytest.raises(RuntimeError, match='refused at stable record'):
+        campaign.write_export_inputs(tmp_path, **inputs, release_file_pages=True,
+            resource_check=refuse if failure == 'memory_guard' else None)
+    assert (path.read_bytes(), sidecar.read_bytes()) == previous

--- a/tests/test_joint_operator_statistics.py
+++ b/tests/test_joint_operator_statistics.py
@@ -1,0 +1,297 @@
+"""Independent residual and ownership gates for deferred joint contractions."""
+import gc
+import weakref
+
+import pytest
+import torch
+
+from prismaquant import joint_aura
+from test_joint_aura_projection import _assert_projection, _linear, _oracle, _spec
+
+
+def _lease(modules, specs, budget=100000, candidate_budget=100000):
+    return joint_aura.JointOperatorStatisticsLease(
+        modules, specs, max_statistics_bytes=budget, max_candidate_bytes=candidate_budget)
+
+
+def _fixture(candidates=12):
+    generator = torch.Generator().manual_seed(1912)
+    weight = torch.randn(4, 3, generator=generator)
+    layer = _linear(weight)
+    qdq = lambda x: torch.round(x * 2) / 2
+    specs = {f'q{i}': _spec(f'q{i}', qdq) for i in range(candidates)}
+    specs['identity'] = _spec('identity', lambda x: x, act_bits=None)
+    draws = [(torch.randn(2, 3, generator=generator),
+              torch.randn(2, 4, generator=generator)) for _ in range(3)]
+    return layer, weight, specs, draws
+
+
+def test_many_candidates_reuse_two_operator_planes_and_match_fp64_residuals():
+    layer, weight, specs, draws = _fixture()
+    before = layer.weight.detach().clone()
+    # 12 candidate deltas would use 576 bytes. One GW plus shared GA uses 96.
+    with _lease({'u': layer}, {'u': specs}, budget=96) as lease:
+        assert lease.statistics_capacity_bytes == 96
+        lease.begin_probe()
+        for x, g in draws:
+            layer(x).backward(g)
+        assert lease.resident_statistics_bytes == 96
+        lease.finish_observations()
+        assert lease.telemetry['qdq_calls'] == len(draws)
+        for index, (fmt, spec) in enumerate(reversed(list(specs.items()))):
+            delta = torch.full_like(weight, (index + 1) / 128)
+            reference = {key: 0. for key in ('weight', 'activation', 'mixed', 'total')}
+            for x, g in draws:
+                terms = _oracle(weight, delta, x,
+                    spec.activation_quantize_dequantize(x), g)
+                for key, value in terms.items():
+                    reference[key] += value
+            actual = lease.project({('u', fmt): delta})
+            _assert_projection(actual[('u', fmt)], reference)
+            ref = weakref.ref(delta)
+            del delta
+            assert ref() is None, 'candidate deltas must stay caller-owned'
+        results = lease.finish_projections()
+        assert len(results) == len(specs)
+        assert lease.resident_statistics_bytes == 0
+    torch.testing.assert_close(layer.weight, before, rtol=0, atol=0)
+
+
+def test_budget_is_enforced_before_observers_or_matrix_allocation():
+    layer, _, specs, _ = _fixture()
+    with pytest.raises(RuntimeError, match='statistics.*budget'):
+        _lease({'u': layer}, {'u': specs}, budget=95)
+    assert not layer._forward_hooks
+
+
+def test_observation_release_drops_source_owners_before_candidate_projection():
+    layer, _, specs, draws = _fixture(2)
+    lease = _lease({'u': layer}, {'u': specs})
+    with lease:
+        lease.begin_probe()
+        x, g = draws[0]
+        layer(x).backward(g)
+        ref = weakref.ref(layer.weight)
+        lease.finish_observations()
+        assert not layer._forward_hooks and not lease.modules
+        del layer
+        gc.collect()
+        assert ref() is None
+        lease.project({('u', fmt): torch.zeros(4, 3) for fmt in specs})
+        lease.finish_projections()
+
+
+def test_incomplete_duplicate_unknown_and_late_projection_refuse():
+    layer, _, specs, _ = _fixture(1)
+    with _lease({'u': layer}, {'u': specs}) as lease:
+        with pytest.raises(RuntimeError, match='ready'):
+            lease.project({('u', 'q0'): torch.zeros(4, 3)})
+        lease.begin_probe()
+        lease.finish_observations()  # never-routed operators produce explicit zeros
+        with pytest.raises(RuntimeError, match='coverage'):
+            lease.finish_projections()
+        with pytest.raises(ValueError, match='unknown'):
+            lease.project({('u', 'bogus'): torch.zeros(4, 3)})
+        lease.project({('u', 'q0'): torch.zeros(4, 3)})
+        with pytest.raises(ValueError, match='duplicate'):
+            lease.project({('u', 'q0'): torch.zeros(4, 3)})
+        lease.project({('u', 'identity'): torch.zeros(4, 3)})
+        assert all(row['total'] == 0 for row in lease.finish_projections().values())
+        with pytest.raises(RuntimeError, match='ready'):
+            lease.project({('u', 'identity'): torch.zeros(4, 3)})
+
+
+def test_unconsumed_backward_refuses_observation_seal_and_cleans_up():
+    layer, _, specs, draws = _fixture(1)
+    lease = _lease({'u': layer}, {'u': specs})
+    with pytest.raises(RuntimeError, match='pending backward'):
+        with lease:
+            lease.begin_probe()
+            output = layer(draws[0][0])
+            lease.finish_observations()
+    assert not layer._forward_hooks and lease.resident_statistics_bytes == 0
+    with pytest.raises(RuntimeError, match='active'):
+        output.sum().backward()
+
+
+@pytest.mark.parametrize('when', ['before_forward', 'before_seal'])
+def test_changed_source_weights_are_refused(when):
+    layer, _, specs, draws = _fixture(1)
+    with _lease({'u': layer}, {'u': specs}) as lease:
+        lease.begin_probe()
+        if when == 'before_seal':
+            layer(draws[0][0]).backward(draws[0][1])
+        with torch.no_grad():
+            layer.weight.add_(1)
+        with pytest.raises(RuntimeError, match='source.*changed'):
+            if when == 'before_forward':
+                layer(draws[0][0])
+            else:
+                lease.finish_observations()
+
+
+def test_cancellation_preserves_three_signed_components_and_new_identity():
+    weight, delta = torch.tensor([[0., -1.]]), torch.tensor([[1., 0.]])
+    layer = _linear(weight)
+    spec = _spec('cancel', lambda x: x + torch.tensor([0., 1.]))
+    with _lease({'u': layer}, {'u': {'cancel': spec}}) as lease:
+        lease.begin_probe()
+        layer(torch.tensor([[1., 0.]])).sum().backward()
+        lease.finish_observations()
+        lease.project({('u', 'cancel'): delta})
+        assert lease.finish_projections()[('u', 'cancel')] == {
+            'weight': 1., 'activation': -1., 'mixed': 0., 'total': 0.}
+        identity = lease.arithmetic_identity(torch.float32)
+        assert identity != joint_aura.arithmetic_identity(torch.float32)
+        assert identity['operator_accumulation'] == 'sum_fp32_matrices_in_backward_invocation_order'
+
+
+def test_bad_candidate_quantum_is_atomic_and_never_retained():
+    layer, _, specs, draws = _fixture(1)
+    with _lease({'u': layer}, {'u': specs}) as lease:
+        lease.begin_probe()
+        layer(draws[0][0]).backward(draws[0][1])
+        lease.finish_observations()
+        with pytest.raises(RuntimeError, match='shape'):
+            lease.project({('u', 'q0'): torch.zeros(4, 3), ('u', 'identity'): torch.zeros(3, 4)})
+        result = lease.project({('u', fmt): torch.zeros(4, 3) for fmt in specs})
+        assert len(result) == 2
+        lease.finish_projections()
+
+
+def test_distinct_dynamic_qdq_callables_are_charged_separately():
+    layer = _linear(torch.ones(4, 3))
+    def quantizer(offset):
+        return lambda x: x + offset
+    specs = {'a': _spec('a', quantizer(1)), 'b': _spec('b', quantizer(2))}
+    # Both closures have the same named identity but different dynamic owners.
+    with _lease({'u': layer}, {'u': specs}, budget=144) as lease:
+        assert lease.statistics_capacity_bytes == 144
+        lease.begin_probe()
+        layer(torch.zeros(2, 3)).sum().backward()
+        lease.finish_observations()
+        lease.project({('u', fmt): torch.ones(4, 3) for fmt in specs})
+        result = lease.finish_projections()
+        assert result[('u', 'b')]['activation'] == 2 * result[('u', 'a')]['activation']
+
+
+def test_invalid_qdq_leaves_no_matrix_owner_after_context_failure():
+    layer = _linear(torch.ones(4, 3))
+    spec = _spec('bad', lambda x: x.double())
+    lease = _lease({'u': layer}, {'u': {'bad': spec}})
+    with pytest.raises(RuntimeError, match='QDQ changed'):
+        with lease:
+            lease.begin_probe()
+            layer(torch.ones(2, 3)).sum().backward()
+    assert not layer._forward_hooks and lease.resident_statistics_bytes == 0
+    with pytest.raises(RuntimeError, match='reenter'):
+        lease.__enter__()
+
+
+def test_second_backward_on_same_observation_refuses_double_counting():
+    layer = _linear(torch.ones(4, 3))
+    spec = _spec('id', lambda x: x, act_bits=None)
+    with _lease({'u': layer}, {'u': {'id': spec}}) as lease:
+        lease.begin_probe()
+        output = layer(torch.ones(2, 3))
+        output.sum().backward(retain_graph=True)
+        with pytest.raises(RuntimeError, match='active observation'):
+            output.sum().backward()
+
+
+@pytest.mark.parametrize('bad', [float('nan'), float('inf')])
+def test_nonfinite_candidate_projection_cannot_publish_partial_quantum(bad):
+    layer, _, specs, draws = _fixture(1)
+    with _lease({'u': layer}, {'u': specs}) as lease:
+        lease.begin_probe()
+        layer(draws[0][0]).backward(draws[0][1])
+        lease.finish_observations()
+        with pytest.raises(RuntimeError, match='nonfinite'):
+            lease.project({('u', 'q0'): torch.zeros(4, 3), ('u', 'identity'): torch.full((4, 3), bad)})
+        lease.project({('u', fmt): torch.zeros(4, 3) for fmt in specs})
+        lease.finish_projections()
+
+
+def test_packed_source_slices_and_unrouted_experts_match_independent_outputs():
+    from test_joint_aura_packed import _fixture as packed_fixture
+
+    model, _, _, _, _, views = packed_fixture()
+    layer = model.model.layers[0]
+    selected = {member.qname: member for member in views
+                if member.qname.startswith('model.layers.0.')}
+    spec = _spec('synthetic', lambda x: torch.round(x * 8) / 8)
+    specs = {name: {'synthetic': spec} for name in selected}
+    source = {name: member.weight.detach().clone() for name, member in selected.items()}
+    delta = {name: torch.full_like(weight, .03125) for name, weight in source.items()}
+    layer.feed_forward.experts.captures = []
+    expected = {name: {key: 0. for key in ('weight', 'activation', 'mixed', 'total')}
+                for name in selected}
+    with _lease(selected, specs) as lease:
+        lease.begin_probe()
+        x = torch.randn(1, 3, 16, requires_grad=True)
+        layer(x).sum().backward()
+        for expert, inputs, gate_up, hidden, down in layer.feed_forward.experts.captures:
+            for role, value, gradient in [('w1', inputs, gate_up.grad[:, :16]),
+                                          ('w3', inputs, gate_up.grad[:, 16:]),
+                                          ('w2', hidden, down.grad)]:
+                name = f'model.layers.0.feed_forward.experts.{expert}.{role}'
+                terms = _oracle(source[name], delta[name], value,
+                    spec.activation_quantize_dequantize(value), gradient)
+                for key, number in terms.items():
+                    expected[name][key] += number
+        lease.finish_observations()
+        assert lease.resident_statistics_bytes < lease.statistics_capacity_bytes
+        for name in reversed(list(selected)):
+            lease.project({(name, 'synthetic'): delta[name]})
+        result = lease.finish_projections()
+        for name, reference in expected.items():
+            _assert_projection(result[(name, 'synthetic')], reference)
+            if '.experts.2.' in name:
+                assert result[(name, 'synthetic')] == {key: 0. for key in reference}
+
+
+def test_candidate_budget_charges_full_storage_behind_small_views():
+    layer, _, specs, _ = _fixture(1)
+    with _lease({'u': layer}, {'u': specs}, candidate_budget=48) as lease:
+        lease.begin_probe()
+        lease.finish_observations()
+        pool = torch.zeros(20, 4, 3)
+        with pytest.raises(RuntimeError, match='candidate storage.*budget'):
+            lease.project({('u', 'q0'): pool[0]})
+        with pytest.raises(RuntimeError, match='candidate storage.*budget'):
+            lease.project({('u', fmt): torch.zeros(4, 3) for fmt in specs})
+        for fmt in specs:
+            lease.project({('u', fmt): torch.zeros(4, 3)})
+        lease.finish_projections()
+        assert lease.telemetry['peak_candidate_storage_bytes'] == 48
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason='native operator statistics needs CUDA')
+@pytest.mark.parametrize('shape', [(2048, 4096), (4096, 2048)])
+def test_native_glm_projection_shapes_match_independent_fp64_outputs(shape):
+    # Synthetic dW and QDQ isolate contraction arithmetic at actual GLM expert
+    # dimensions; they are not trained-model quality or format qualification.
+    rows, columns = shape
+    generator = torch.Generator().manual_seed(1907)
+    weight = (torch.randn(shape, generator=generator) / columns**.5).to('cuda', torch.bfloat16)
+    delta = torch.full(shape, .0009765625, device='cuda')
+    module = torch.nn.Linear(columns, rows, bias=False, device='cuda', dtype=torch.bfloat16)
+    with torch.no_grad():
+        module.weight.copy_(weight)
+    spec = _spec('synthetic', lambda x: torch.round(x * 8) / 8)
+    expected = {key: 0. for key in ('weight', 'activation', 'mixed', 'total')}
+    with _lease({'u': module}, {'u': {'synthetic': spec}},
+                budget=rows * columns * 8, candidate_budget=rows * columns * 4) as lease:
+        lease.begin_probe()
+        for count in (1, 3):
+            x = torch.randn(count, columns, generator=generator).to('cuda', torch.bfloat16)
+            g = torch.randn(count, rows, generator=generator).to('cuda', torch.bfloat16)
+            module(x).backward(g)
+            terms = _oracle(weight, delta, x, spec.activation_quantize_dequantize(x), g)
+            for key, value in terms.items():
+                expected[key] += value
+            module.zero_grad(set_to_none=True)
+        lease.finish_observations()
+        actual = lease.project({('u', 'synthetic'): delta})[('u', 'synthetic')]
+        _assert_projection(actual, expected)
+        lease.finish_projections()

--- a/tests/test_joint_operator_statistics.py
+++ b/tests/test_joint_operator_statistics.py
@@ -295,3 +295,49 @@ def test_native_glm_projection_shapes_match_independent_fp64_outputs(shape):
         actual = lease.project({('u', 'synthetic'): delta})[('u', 'synthetic')]
         _assert_projection(actual, expected)
         lease.finish_projections()
+
+
+def test_caught_backward_qdq_failure_poisoned_observation_cannot_be_retried():
+    layer = _linear(torch.ones(4, 3))
+    fail = True
+    def qdq(x):
+        if fail:
+            raise RuntimeError('transient QDQ failure')
+        return x + 1
+    spec = _spec('transient', qdq)
+    with _lease({'u': layer}, {'u': {'transient': spec}}) as lease:
+        lease.begin_probe()
+        output = layer(torch.ones(2, 3))
+        with pytest.raises(RuntimeError, match='transient QDQ failure'):
+            output.sum().backward(retain_graph=True)
+        fail = False
+        with pytest.raises(RuntimeError, match='active observation'):
+            output.sum().backward()
+        with pytest.raises(RuntimeError, match='not active'):
+            lease.finish_observations()
+        assert lease.resident_statistics_bytes == 0
+        assert not layer._forward_hooks
+
+
+@pytest.mark.parametrize('abort', [False, True])
+def test_retained_output_does_not_retain_observer_input_after_consumption_or_abort(abort):
+    observed = []
+    def qdq(x):
+        observed.append(weakref.ref(x))
+        if abort:
+            raise RuntimeError('abort observation')
+        return x + 1
+    layer = _linear(torch.ones(4, 3))
+    spec = _spec('observed', qdq)
+    with _lease({'u': layer}, {'u': {'observed': spec}}) as lease:
+        lease.begin_probe()
+        output = layer(torch.ones(2, 3))
+        if abort:
+            with pytest.raises(RuntimeError, match='abort observation'):
+                output.sum().backward()
+        else:
+            output.sum().backward()
+            lease.finish_observations()
+        gc.collect()
+        assert observed and observed[0]() is None
+    assert output.shape == (2, 4)

--- a/tests/test_pwc_resident_windows.py
+++ b/tests/test_pwc_resident_windows.py
@@ -1,0 +1,276 @@
+"""Finite research windows reuse PWC loads and never fault on consumption."""
+import weakref
+import zipfile
+
+import pytest
+import torch
+
+from prismaquant.production_weight_cache import ProductionWeightCache
+from test_pwc_file_load_receipts import make_cache
+
+
+def test_plan_resolves_aliases_and_bounds_existing_prefetch(tmp_path, monkeypatch):
+    cache, paths, expected = make_cache(tmp_path, 5, budget=100000)
+    keys = tuple(paths)
+    bound = 2 * max(path.stat().st_size for path in paths.values())
+    aliases = [(name + '.weight', fmt) for name, fmt in keys]
+    windows = cache.plan_resident_windows(aliases + [aliases[0]],
+        max_resident_bytes=bound, max_workers=2)
+    assert windows == (keys[:2], keys[2:4], keys[4:])
+    original = cache.prefetch
+    calls = []
+    def bounded(keys, max_workers):
+        calls.append(tuple(keys))
+        assert len(keys) <= max_workers == 2
+        return original(keys, max_workers=max_workers)
+    monkeypatch.setattr(cache, 'prefetch', bounded)
+    refs = []
+    for window in windows:
+        with cache.resident_window(window, max_resident_bytes=bound, max_workers=2) as receipt:
+            assert receipt['keys'] == window and receipt['loaded'] == len(window)
+            assert receipt['resident_bytes'] == 32 * len(window)
+            for key in window:
+                value = cache.get_resident(*key)
+                torch.testing.assert_close(value, expected[key])
+                refs.append(weakref.ref(value))
+                del value
+        assert all(ref() is None for ref in refs)
+        assert all(isinstance(cache.weights[key], str) for key in window)
+    assert calls == list(windows)
+
+
+def test_resident_lookup_refuses_missing_or_evicted_without_load(tmp_path, monkeypatch):
+    cache, paths, _ = make_cache(tmp_path, 2, budget=32)
+    a, b = paths
+    cache.get(*a)
+    cache.get(*b)
+    monkeypatch.setattr(cache, '_load_file_tensor', lambda *args: pytest.fail('hidden load'))
+    with pytest.raises(RuntimeError, match='resident'):
+        cache.get_resident(*a)
+    with pytest.raises(RuntimeError, match='missing'):
+        cache.get_resident('unknown', a[1])
+    assert cache.get_resident(*b) is cache.weights[b]
+
+
+def test_full_backing_storage_and_aliases_are_accounted():
+    pool = torch.zeros(100)
+    keys = [('a', 'FP8'), ('b', 'FP8')]
+    cache = ProductionWeightCache(dict(zip(keys, (pool[:2], pool[2:4]))), {})
+    with pytest.raises(RuntimeError, match='budget'):
+        cache.plan_resident_windows(keys, max_resident_bytes=399, max_workers=2)
+    assert cache.plan_resident_windows(keys, max_resident_bytes=400, max_workers=2) == (tuple(keys),)
+    with cache.resident_window(keys, max_resident_bytes=400, max_workers=2) as receipt:
+        assert receipt['resident_bytes'] == 400
+    assert all(isinstance(cache.weights[key], torch.Tensor) for key in keys)
+
+
+def test_invalid_roster_or_oversize_refuses_before_loading(tmp_path, monkeypatch):
+    cache, paths, _ = make_cache(tmp_path)
+    key, path = next(iter(paths.items()))
+    monkeypatch.setattr(cache, '_load_file_tensor', lambda *args: pytest.fail('hidden load'))
+    with pytest.raises(RuntimeError, match='budget'):
+        cache.plan_resident_windows([key], max_resident_bytes=path.stat().st_size - 1, max_workers=1)
+    with pytest.raises(RuntimeError, match='missing'):
+        cache.plan_resident_windows([key, ('missing', key[1])], max_resident_bytes=10000, max_workers=1)
+    with pytest.raises((TypeError, ValueError), match='finite|sequence'):
+        cache.plan_resident_windows(iter([key]), max_resident_bytes=10000, max_workers=1)
+
+
+def test_selected_release_preserves_unrelated_residents_and_receipts(tmp_path):
+    cache, paths, _ = make_cache(tmp_path, 2)
+    a, b = paths
+    cache.enable_file_load_receipts(max_file_bytes=10000)
+    cache.prefetch([a, b], max_workers=2)
+    retained = cache.get_resident(*b)
+    assert cache.release_resident_tensors([a]) == 1
+    assert isinstance(cache.weights[a], str)
+    assert cache.get_resident(*b) is retained
+    cache.file_load_receipt(b, retained)
+    assert cache._lru_bytes == 32 and cache._lru_order == [b]
+
+
+def test_window_releases_on_consumer_failure_and_receipt_checks_mutation(tmp_path):
+    cache, paths, _ = make_cache(tmp_path)
+    key = next(iter(paths))
+    cache.enable_file_load_receipts(max_file_bytes=10000)
+    with pytest.raises(RuntimeError, match='changed'):
+        with cache.resident_window([key], max_resident_bytes=10000, max_workers=1):
+            value = cache.get_resident(*key)
+            value.add_(1)
+            cache.get_resident(*key)
+    assert isinstance(cache.weights[key], str)
+    assert not cache._file_load_receipts
+
+
+def test_lru_eviction_cannot_yield_partial_window(tmp_path):
+    cache, paths, _ = make_cache(tmp_path, 2, budget=32)
+    with pytest.raises(RuntimeError, match='resident|LRU|budget'):
+        with cache.resident_window(tuple(paths), max_resident_bytes=10000, max_workers=2):
+            pytest.fail('partial resident window exposed')
+    assert all(isinstance(value, str) for value in cache.weights.values())
+
+
+def test_unrelated_resident_storage_is_in_the_budget_before_load(tmp_path, monkeypatch):
+    cache, paths, _ = make_cache(tmp_path)
+    key, path = next(iter(paths.items()))
+    cache.weights[('unrelated', 'FP8')] = torch.zeros(100)[:1]
+    monkeypatch.setattr(cache, '_load_file_tensor', lambda *args: pytest.fail('hidden load'))
+    with pytest.raises(RuntimeError, match='budget'):
+        with cache.resident_window([key], max_resident_bytes=path.stat().st_size + 399, max_workers=1):
+            pytest.fail('unrelated backing storage was omitted')
+
+
+def test_nested_window_refuses_without_releasing_outer_owners(tmp_path):
+    cache, paths, _ = make_cache(tmp_path, 2)
+    a, b = paths
+    with cache.resident_window([a], max_resident_bytes=10000, max_workers=1):
+        outer = cache.get_resident(*a)
+        with pytest.raises(RuntimeError, match='nested'):
+            with cache.resident_window([b], max_resident_bytes=10000, max_workers=1):
+                pytest.fail('nested window')
+        with pytest.raises(RuntimeError, match='outside'):
+            cache.get(*b)
+        assert cache.get_resident(*a) is outer
+    assert all(isinstance(value, str) for value in cache.weights.values())
+
+
+def test_existing_lru_owner_cannot_be_evicted_by_window(tmp_path, monkeypatch):
+    cache, paths, _ = make_cache(tmp_path, 2, budget=32)
+    a, b = paths
+    old = cache.get(*a)
+    monkeypatch.setattr(cache, '_load_file_tensor', lambda *args: pytest.fail('hidden load'))
+    with pytest.raises(RuntimeError, match='LRU budget'):
+        with cache.resident_window([b], max_resident_bytes=10000, max_workers=1):
+            pytest.fail('unrelated LRU owner evicted')
+    assert cache.get_resident(*a) is old
+
+
+@pytest.mark.parametrize('kind', ['compressed', 'opaque', 'legacy', 'symlink'])
+def test_unaccountable_disk_inputs_refuse_without_deserializing(tmp_path, monkeypatch, kind):
+    cache, paths, _ = make_cache(tmp_path)
+    key, path = next(iter(paths.items()))
+    if kind == 'compressed':
+        with zipfile.ZipFile(path) as archive:
+            entries = {name: archive.read(name) for name in archive.namelist()}
+        with zipfile.ZipFile(path, 'w', compression=zipfile.ZIP_DEFLATED) as archive:
+            for name, value in entries.items():
+                archive.writestr(name, value)
+    elif kind == 'opaque':
+        cache.weights[key] = object()
+    elif kind == 'legacy':
+        torch.save(torch.zeros(4), path, _use_new_zipfile_serialization=False)
+    else:
+        target = path.with_suffix('.target'); path.rename(target); path.symlink_to(target)
+    monkeypatch.setattr(cache, '_load_file_tensor', lambda *args: pytest.fail('hidden load'))
+    with pytest.raises(RuntimeError, match='archive|unaccountable|regular'):
+        cache.plan_resident_windows([key], max_resident_bytes=10000, max_workers=1)
+
+
+@pytest.mark.parametrize('value', [torch.empty(1, device='meta'), torch.sparse_coo_tensor([[0]], [1.], (1,))])
+def test_unaccountable_tensor_storages_refuse(value):
+    cache = ProductionWeightCache({('a', 'FP8'): value}, {})
+    with pytest.raises(RuntimeError, match='unaccountable'):
+        cache.plan_resident_windows([('a', 'FP8')], max_resident_bytes=10000, max_workers=1)
+
+
+def test_serialized_buffers_have_a_separate_aggregate_limit(tmp_path, monkeypatch):
+    cache, paths, _ = make_cache(tmp_path, 2)
+    size = sum(path.stat().st_size for path in paths.values())
+    monkeypatch.setattr(cache, '_load_file_tensor', lambda *args: pytest.fail('hidden load'))
+    with pytest.raises(RuntimeError, match='serialized'):
+        with cache.resident_window(tuple(paths), max_resident_bytes=10000, max_workers=2,
+                                   max_load_buffer_bytes=size - 1):
+            pytest.fail('oversize buffers')
+
+
+def test_page_advice_uses_verified_load_stat_and_cleanup(tmp_path, monkeypatch):
+    from prismaquant import perturbed_x_cache
+    cache, paths, _ = make_cache(tmp_path)
+    key, path = next(iter(paths.items()))
+    seen = []
+    def advice(candidate, *, expected_stat):
+        value = cache.get_resident(*key)
+        assert cache.file_load_receipt(key, value)['bytes'] == expected_stat.st_size
+        assert str(path) == candidate
+        seen.append(candidate)
+    monkeypatch.setattr(perturbed_x_cache, 'release_activation_cache_file_pages', advice)
+    with cache.resident_window([key], max_resident_bytes=10000, max_workers=1,
+                               release_file_pages=True) as receipt:
+        assert receipt['file_pages_advised'] == 1
+    assert seen == [str(path)] and not cache._file_load_receipts
+
+
+def test_window_load_failure_cleans_partial_prefetch_and_allows_fresh_context(tmp_path, monkeypatch):
+    cache, paths, _ = make_cache(tmp_path, 2)
+    a, b = paths
+    original = cache._validate_loaded_cb_pair_tensor
+    def refused(key, tensor):
+        if key == b:
+            raise RuntimeError('synthetic integrity refusal')
+        return original(key, tensor)
+    monkeypatch.setattr(cache, '_validate_loaded_cb_pair_tensor', refused)
+    with pytest.raises(RuntimeError, match='integrity'):
+        with cache.resident_window(tuple(paths), max_resident_bytes=10000, max_workers=2):
+            pytest.fail('partial load exposed')
+    assert all(isinstance(value, str) for value in cache.weights.values())
+    assert not cache._file_load_receipts
+    monkeypatch.setattr(cache, '_validate_loaded_cb_pair_tensor', original)
+    with cache.resident_window([a], max_resident_bytes=10000, max_workers=1):
+        assert isinstance(cache.get_resident(*a), torch.Tensor)
+
+
+def test_resident_cb_lookup_preserves_both_existing_validators(monkeypatch):
+    key = ('a', 'FP8_CB_K28')
+    cache = ProductionWeightCache({key: torch.zeros(2, 2)}, {})
+    calls = []
+    monkeypatch.setattr('prismaquant.production_weight_cache._is_cb_format_name', lambda fmt: True)
+    monkeypatch.setattr(cache, 'validate_cb_render_identity', lambda **kwargs: calls.append('identity'))
+    monkeypatch.setattr(cache, '_validate_loaded_cb_pair_tensor', lambda *args: calls.append('tensor'))
+    assert cache.get_resident(*key) is cache.weights[key]
+    assert calls == ['identity', 'tensor']
+
+
+def test_existing_disk_loaded_tensor_can_enter_without_enabling_receipts(tmp_path):
+    cache, paths, _ = make_cache(tmp_path)
+    key = next(iter(paths))
+    tensor = cache.get(*key)
+    assert not cache._file_load_receipts
+    with cache.resident_window([key], max_resident_bytes=32, max_workers=1) as receipt:
+        assert receipt['loaded'] == 0
+        assert cache.get_resident(*key) is tensor
+    assert isinstance(cache.weights[key], str)
+
+
+def test_invalidated_window_receipt_cannot_be_bypassed_by_a_second_lookup(tmp_path):
+    cache, paths, _ = make_cache(tmp_path)
+    key = next(iter(paths))
+    with cache.resident_window([key], max_resident_bytes=10000, max_workers=1):
+        cache.get_resident(*key).add_(1)
+        for _ in range(2):
+            with pytest.raises(RuntimeError, match='receipt|changed'):
+                cache.get_resident(*key)
+
+
+def test_window_load_rejects_file_drift_after_preflight(tmp_path, monkeypatch):
+    cache, paths, _ = make_cache(tmp_path)
+    key, path = next(iter(paths.items()))
+    original = cache.prefetch
+    def altered(keys, max_workers):
+        with path.open('ab') as stream:
+            stream.write(b'changed')
+        return original(keys, max_workers=max_workers)
+    monkeypatch.setattr(cache, 'prefetch', altered)
+    with pytest.raises(RuntimeError, match='bound|changed'):
+        with cache.resident_window([key], max_resident_bytes=10000, max_workers=1):
+            pytest.fail('changed file admitted')
+    assert isinstance(cache.weights[key], str) and not cache._file_load_receipts
+
+
+def test_selected_release_does_not_adopt_same_named_unverified_file(tmp_path):
+    from prismaquant.production_weight_cache import _cache_weight_filename
+    key = ('unit', 'FP8')
+    tensor = torch.ones(4)
+    torch.save(torch.zeros(4), tmp_path / _cache_weight_filename(*key))
+    cache = ProductionWeightCache({key: tensor}, {}, cache_dir=str(tmp_path))
+    assert cache.release_resident_tensors([key]) == 0
+    assert cache.get_resident(*key) is tensor

--- a/tests/test_streaming_source_pages.py
+++ b/tests/test_streaming_source_pages.py
@@ -250,3 +250,45 @@ def test_changed_source_identity_refuses_advice(tmp_path, monkeypatch):
     monkeypatch.setattr(os, 'posix_fadvise', lambda *args: pytest.fail('replacement source advised'))
     with pytest.raises(RuntimeError, match='source changed'):
         ls._advise_consumed_safetensors_pages(str(path), ['selected'], expected)
+
+
+def test_adjacent_consumed_payloads_coalesce_before_page_alignment(tmp_path, monkeypatch):
+    path, tensors, header, base, page = checkpoint(tmp_path)
+    selected = sorted(header, key=lambda name: header[name]['data_offsets'][0])[:2]
+    calls = []
+    monkeypatch.setattr(os, 'posix_fadvise', lambda fd, start, size, mode:
+                        calls.append((start, size, mode)))
+    ls._advise_consumed_safetensors_pages(str(path), list(reversed(selected))+selected)
+    begin = base+header[selected[0]]['data_offsets'][0]
+    end = base+header[selected[-1]]['data_offsets'][1]
+    first = (begin+page-1)//page*page
+    last = end//page*page
+    assert calls == [(first, last-first, os.POSIX_FADV_DONTNEED)]
+    assert last <= base+header['unread_after']['data_offsets'][0]
+
+
+def test_nonadjacent_consumed_payloads_preserve_unread_gap(tmp_path, monkeypatch):
+    path, tensors, header, base, page = checkpoint(tmp_path)
+    ordered = sorted(header, key=lambda name: header[name]['data_offsets'][0])
+    calls = []
+    monkeypatch.setattr(os, 'posix_fadvise', lambda fd, start, size, mode:
+                        calls.append((start, size)))
+    ls._advise_consumed_safetensors_pages(str(path), [ordered[0], ordered[2]])
+    assert len(calls) == 2
+    unread_begin, unread_end = (base+x for x in header[ordered[1]]['data_offsets'])
+    assert all(start+size <= unread_begin or start >= unread_end for start, size in calls)
+
+
+def test_invalid_later_span_refuses_before_any_advice(tmp_path, monkeypatch):
+    path, tensors, header, base, page = checkpoint(tmp_path)
+    calls = []
+    monkeypatch.setattr(os, 'posix_fadvise', lambda *args: calls.append(args))
+    real_loads = json.loads
+    def malformed(raw):
+        h = real_loads(raw)
+        h['unread_after']['data_offsets'][1] = path.stat().st_size
+        return h
+    monkeypatch.setattr(json, 'loads', malformed)
+    with pytest.raises(ValueError, match='invalid tensor span'):
+        ls._advise_consumed_safetensors_pages(str(path), list(header))
+    assert calls == []

--- a/tests/test_tessera_calibration_cache.py
+++ b/tests/test_tessera_calibration_cache.py
@@ -95,7 +95,7 @@ def test_export_input_page_release_preserves_existing_file_bytes(capture, monkey
         if bounded:
             assert observed[-1] == 'after_selected_export_input_write'
     assert outcomes[0] == outcomes[1]
-    assert calls == ['hessian_capture.pt']
+    assert calls == ['hessian_capture.pt.tmp']*2+['hessian_capture.pt']
 
 
 @pytest.mark.parametrize('change',['artifact','manifest','source','draw','geometry','scope'])

--- a/tests/test_tessera_selected_source.py
+++ b/tests/test_tessera_selected_source.py
@@ -100,7 +100,9 @@ def test_selected_admission_excludes_unselected_source_and_forward_owners(monkey
     assert source['loader_transient_bytes'] == 200
     assert anchors['selected_hessian_bytes'] == 128
     assert anchors['selected_prefix_bytes'] == 64
-    assert export['export_input_file_bytes'] == 128+2*16384
+    assert export['export_input_page_window_bytes'] == 64+2*16384
+    assert plan['schema'] == 'prismaquant.selected_anchor_resources.v2'
+    assert plan['export_input_writer_policy'] == 'verified-tensor-record-prefix'
     assert export['serialization_scratch_bytes'] == 2*4**2*4
     assert anchors['encoder_memo_bytes'] == 4*4*4+4*8
     assert plan['encoder_memo_capacity'] == 1


### PR DESCRIPTION
Large GLM layers can retain source file pages, a whole Hessian output archive, all candidate renders and per-candidate projection work at the same time. This integrates the reviewed changes from #378, #379, #382 and #384: consumed-span page advice, byte-identical bounded Hessian writing, an opt-in operator-statistics lease, and finite ProductionWeightCache windows. Existing defaults and serving gates remain unchanged.

All runtime files exactly match the individually reviewed PR heads; integration resolves architecture stamps only. Their measurement reports retain native profiler, host telemetry, byte parity, test counts and limitations. Combined PrismaBuild regression: 145 passed, four explicit native-only skips across four CPU shards. Root verified all canonical receipts, payload hashes and exact source snapshots. Full CI: 6,657 passed, 200 skipped, three expected failures and 192 subtests passed (run 34221065704). Complete GLM capture, phased joint-probe integration and served artifacts remain separate unfinished gates.

Closes #374. Closes #377. Closes #380. Closes #381.
