### PR TITLE
Plan bounded joint-statistics windows using shared activation requirements

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,21 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `research/joint-operator-statistics`. Stamps
+As of: 2026-09-08 · `feat/joint-statistics-target-windows`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `feat/joint-statistics-target-windows`) for whole-target
+operator-statistics planning (#385). The planner and both existing joint
+projection leases share one target-validation and activation-group requirement
+calculation. A target charges one FP32 GW matrix plus one FP32 GA matrix per
+distinct executed nonidentity QDQ group. Sorted target names form deterministic
+whole-target windows under an explicit statistics cap; oversize targets refuse
+before hooks or allocation. Plans retain names, shapes, ordered format groups
+and activation receipts, never source tensors, specs or callable pointers.
+Dynamic callable distinctions remain separate groups, while static served
+contracts retain their shared QDQ owner. Existing lease insertion order and
+projection arithmetic remain unchanged. The planner does not execute replay or
+admit source, boundary, graph, candidate or allocator memory. Gates:
+`tests/test_joint_statistics_plan.py` plus existing joint lease/projection tests.
 
 Re-stamped (2026-09-08, `research/joint-operator-statistics`) for the explicit
 one-probe `JointOperatorStatisticsLease` (issue #374). It extends the existing

--- a/docs/measurements/joint-statistics-target-windows-2026-09-08.md
+++ b/docs/measurements/joint-statistics-target-windows-2026-09-08.md
@@ -1,0 +1,52 @@
+# Whole-target joint-statistics planner — 2026-09-08
+
+Issue #385. `plan_joint_statistics_target_windows` uses the same extracted
+module validation, activation grouping and FP32 matrix requirements as both
+joint projection leases. It emits immutable target-name windows under an
+explicit statistics cap. It neither installs observers nor executes replay.
+Source/cotangent/graph/PWC/transient admission remains a separate obligation.
+No probe arithmetic, format gate or production default changes here.
+
+Grouping retains the lease's original format insertion order. Equal activation
+receipts with different dynamic callable objects remain different groups;
+static served QDQ ignores the unused dynamic callable. Plans persist ordered
+format rosters and activation receipts with group indexes, never Python IDs,
+callables, FormatSpecs, modules or tensors. Target names sort lexicographically
+for deterministic greedy whole-target windows. Invalid coverage, module/spec
+types, aliases, static scale/geometry, backend, cap and oversized targets refuse
+before hooks or statistics allocation.
+
+The CPU geometry test uses meta Linear modules with the actual largest GLM
+layer's 289 `[4096,2048]` and 578 `[2048,4096]` projections. Static A4 plus
+dynamic A8 and identity candidate groups charge 96 MiB per target:
+87,275,077,632 bytes total (81.28125 GiB). A 32 GiB cap yields windows of
+341, 341 and 185 names. The widest first-three-layer dense target
+`[4096,12288]` requires 576 MiB with those groups and refuses a one-byte-smaller
+cap. These are geometry/contract derivations, not actual GPU allocation or a
+full-model fit measurement.
+
+PrismaBuild CPU validation on dl380g10 passed 146 tests, with two explicit
+native-only skips, across four independently admitted shards (two workers,
+six GiB per shard, native threads one). This includes planner policy, source
+retention, packed projections, existing operator and signed leases, streamed
+and microbatch arithmetic, projection backend, architecture and staleness:
+
+- `ecb9f254c210`: 43 passed.
+- `b7b27d72a8a7`: 44 passed, 2 skipped.
+- `d0754432b1ff`: 29 passed.
+- `853c0aa04442`: 30 passed.
+- Compile action `bdae96797f33520bd8a64170aee3cc8cc0ea885ab621341bdd233f14f5c7687c`
+  compiled the three changed Python modules successfully.
+
+The first run `0d476f86d1a1` passed 90 tests and skipped two native-only tests,
+with one new test incorrectly expecting ValueError for the existing
+ActivationScaleContractError. The test was corrected to the established
+exception; implementation behavior did not change for that failure. An initial
+pbtest client command rejected unsupported `-q` report forwarding before any
+submission; the accepted fanout used its ordinary report options.
+
+All validation artifacts are retained under
+`/mnt/shared/tessera-measurements/glm-canonical-census-20260908/joint-statistics-target-windows-01/`.
+`cpu-final.json` gives file populations and per-shard output; `audit.json` binds
+actual terminal state, source snapshot, CAS payload bytes and cleanup. No GPU
+benchmark, latency, energy or throughput claim follows from this planner.

--- a/prismaquant/joint_aura.py
+++ b/prismaquant/joint_aura.py
@@ -193,6 +193,86 @@ def prefetch_joint_cache(cache, names, formats_by_qname, *, max_resident_bytes, 
     return {"entries": len(keys), "resident_bytes": nbytes, "loaded": loaded, "misses": 0}
 
 
+@dataclass(frozen=True)
+class _JointActivationGroup:
+    spec: object
+    formats: tuple[str, ...]
+    activation_identity_json: str
+
+
+@dataclass(frozen=True)
+class _JointTargetRequirements:
+    shape: tuple[int, int]
+    groups: tuple[_JointActivationGroup, ...]
+    statistics_bytes: int
+
+
+def _joint_projection_requirements(modules, specs_by_qname, *, activation_max_abs=None,
+                                   projection_backend=None):
+    """Resolve shared lease/planner admission without hooks or tensor allocation.
+
+    Preserve target and format insertion order. Callable identity distinguishes
+    dynamic groups only in this process; no pointer becomes persisted identity.
+    Returned specs are borrowed for lease construction, never a tensor plan.
+    """
+    from .format_registry import FormatSpec
+    from .joint_projection_backend import require_prewarmed_projection
+
+    if (not isinstance(modules, Mapping) or not isinstance(specs_by_qname, Mapping)
+            or set(modules) != set(specs_by_qname)):
+        raise ValueError("joint AURA module/spec coverage differs")
+    device = next((module.weight.device for module in modules.values()
+                   if isinstance(module, (nn.Linear, PackedExpertProjection))), torch.device("cpu"))
+    backend = require_prewarmed_projection(projection_backend, device=device)
+    maxima = dict(activation_max_abs or {})
+    dense_modules = [mod for mod in modules.values() if isinstance(mod, nn.Linear)]
+    if len({id(mod) for mod in dense_modules}) != len(dense_modules):
+        raise ValueError("joint AURA refuses aliased Linear modules")
+    packed_aliases, requirements = set(), {}
+    for name, module in modules.items():
+        if not isinstance(name, str) or not name:
+            raise ValueError("joint AURA target name must be nonempty text")
+        if isinstance(module, PackedExpertProjection):
+            if module.qname != name:
+                raise ValueError(f"joint AURA packed projection name differs for {name}")
+            rows = module.output_slice
+            alias = (id(module.parameter), module.expert_id, rows.start, rows.stop)
+            if alias in packed_aliases:
+                raise ValueError("joint AURA refuses aliased packed projection views")
+            packed_aliases.add(alias)
+        elif not isinstance(module, nn.Linear):
+            raise TypeError(f"joint AURA target {name} is not Linear")
+        weight = module.weight
+        if (not isinstance(weight, torch.Tensor) or weight.ndim != 2
+                or any(size <= 0 for size in weight.shape) or not weight.is_floating_point()):
+            raise ValueError(f"joint AURA target {name} requires a floating nonempty matrix")
+        backend.require_device(weight.device)
+        choices = specs_by_qname[name]
+        if not isinstance(choices, Mapping) or not choices:
+            raise ValueError(f"joint AURA missing spec coverage for {name}")
+        grouped = {}
+        for fmt, spec in choices.items():
+            if not isinstance(fmt, str) or not fmt or not isinstance(spec, FormatSpec):
+                raise ValueError(f"joint AURA invalid resolved format for {name}")
+            receipt = activation_identity(spec, maxima, name)
+            if receipt["input_global_scale"] is not None:
+                if weight.shape[1] % spec.static_activation_contract.group_size:
+                    raise ValueError(f"joint AURA static activation group geometry differs for {name}")
+                # Static served QDQ owns this path, regardless of the unused
+                # dynamic callable that a registry row happens to carry.
+                callable_key = 0
+            else:
+                callable_key = id(spec.activation_quantize_dequantize)
+            group = (identity_sha256(receipt), callable_key)
+            grouped.setdefault(group, (spec, [], json.dumps(receipt, sort_keys=True,
+                separators=(",", ":"), allow_nan=False)))[1].append(fmt)
+        groups = tuple(_JointActivationGroup(spec, tuple(formats), receipt)
+                       for spec, formats, receipt in grouped.values())
+        requirements[name] = _JointTargetRequirements(tuple(weight.shape), groups,
+            weight.numel() * 4 * (1 + sum(group.spec.act_quant_changes_input for group in groups)))
+    return backend, requirements
+
+
 class SignedJointProjectionLease:
     """Observe a resident layer and retain only signed scalar probe terms.
 
@@ -203,12 +283,10 @@ class SignedJointProjectionLease:
 
     def __init__(self, modules, specs_by_qname, delta_weights, *, activation_max_abs=None,
                  projection_backend=None):
-        from .joint_projection_backend import require_prewarmed_projection
-
         self.modules = dict(modules)
-        device = next((module.weight.device for module in self.modules.values()
-                       if isinstance(module, (nn.Linear, PackedExpertProjection))), torch.device("cpu"))
-        self.projection_backend = require_prewarmed_projection(projection_backend, device=device)
+        self.projection_backend, requirements = _joint_projection_requirements(
+            self.modules, specs_by_qname, activation_max_abs=activation_max_abs,
+            projection_backend=projection_backend)
         self._projection_product_sum = self.projection_backend.product_sum
         self.specs = specs_by_qname
         self.deltas = delta_weights
@@ -218,38 +296,12 @@ class SignedJointProjectionLease:
         self.active = False
         self.terms = {}
         self.groups = {}
+        self._statistics_capacity_bytes = sum(row.statistics_bytes for row in requirements.values())
         self.telemetry = {"qdq_calls": 0, "operator_gemms": 0, "persistent_cache_entries": 0}
-        dense_modules = [mod for mod in self.modules.values() if isinstance(mod, nn.Linear)]
-        if len({id(mod) for mod in dense_modules}) != len(dense_modules):
-            raise ValueError("joint AURA refuses aliased Linear modules")
-        packed_aliases = set()
         for name, module in self.modules.items():
-            if isinstance(module, PackedExpertProjection):
-                if module.qname != name:
-                    raise ValueError(f"joint AURA packed projection name differs for {name}")
-                rows = module.output_slice
-                alias = (id(module.parameter), module.expert_id, rows.start, rows.stop)
-                if alias in packed_aliases:
-                    raise ValueError("joint AURA refuses aliased packed projection views")
-                packed_aliases.add(alias)
-            elif not isinstance(module, nn.Linear):
-                raise TypeError(f"joint AURA target {name} is not Linear")
-            self.projection_backend.require_device(module.weight.device)
             self._validate_delta_coverage(name, module)
-            grouped = {}
-            for fmt, spec in self.specs[name].items():
-                receipt = activation_identity(spec, self.activation_max_abs, name)
-                if receipt["input_global_scale"] is not None:
-                    if module.weight.shape[1] % spec.static_activation_contract.group_size:
-                        raise ValueError(f"joint AURA static activation group geometry differs for {name}")
-                    # A static served contract owns QDQ; different dynamic
-                    # registry lambdas are never executed on this path.
-                    callable_key = 0
-                else:
-                    callable_key = id(spec.activation_quantize_dequantize)
-                group = (identity_sha256(receipt), callable_key)
-                grouped.setdefault(group, (spec, []))[1].append(fmt)
-            self.groups[name] = tuple(grouped.values())
+            self.groups[name] = tuple((group.spec, list(group.formats))
+                                      for group in requirements[name].groups)
 
     def _validate_delta_coverage(self, name, module):
         expected = {fmt for qname, fmt in self.deltas if qname == name}
@@ -484,10 +536,7 @@ class JointOperatorStatisticsLease(SignedJointProjectionLease):
         self._format_groups = {(name, fmt): index
                                for name, groups in self.groups.items()
                                for index, (_, formats) in enumerate(groups) for fmt in formats}
-        self.statistics_capacity_bytes = sum(
-            module.weight.numel() * 4 * (1 + sum(spec.act_quant_changes_input
-                                                 for spec, _ in self.groups[name]))
-            for name, module in self.modules.items())
+        self.statistics_capacity_bytes = self._statistics_capacity_bytes
         if self.statistics_capacity_bytes > max_statistics_bytes:
             raise RuntimeError("joint statistics matrices exceed statistics budget")
         self._operators = {}

--- a/prismaquant/joint_statistics_plan.py
+++ b/prismaquant/joint_statistics_plan.py
@@ -1,0 +1,97 @@
+"""Whole-target statistics windows, derived from the joint lease's own groups.
+
+This plan owns names and immutable scalar metadata only. It does not schedule
+replay, load candidates, install observers or change probe arithmetic. Source,
+activation, cotangent, graph, PWC and transient memory need separate admission.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+
+from .joint_aura import _joint_projection_requirements, identity_sha256
+
+SCHEMA = 'prismaquant.joint_statistics_target_windows.v1'
+
+
+@dataclass(frozen=True)
+class JointStatisticsGroup:
+    formats: tuple[str, ...]
+    activation_identity_json: str
+
+    def as_dict(self):
+        return dict(formats=list(self.formats), activation=json.loads(self.activation_identity_json))
+
+
+@dataclass(frozen=True)
+class JointStatisticsTarget:
+    name: str
+    shape: tuple[int, int]
+    statistics_bytes: int
+    groups: tuple[JointStatisticsGroup, ...]
+
+    def as_dict(self):
+        return dict(name=self.name, shape=list(self.shape), statistics_bytes=self.statistics_bytes,
+                    groups=[dict(index=index, **group.as_dict()) for index, group in enumerate(self.groups)])
+
+
+@dataclass(frozen=True)
+class JointStatisticsTargetPlan:
+    max_statistics_bytes: int
+    targets: tuple[JointStatisticsTarget, ...]
+    windows: tuple[tuple[str, ...], ...]
+    window_statistics_bytes: tuple[int, ...]
+    projection_backend_identity_json: str
+
+    @property
+    def total_statistics_bytes(self):
+        return sum(target.statistics_bytes for target in self.targets)
+
+    def as_dict(self):
+        return dict(schema=SCHEMA, max_statistics_bytes=self.max_statistics_bytes,
+            target_order='lexicographic', grouping_order='original_format_insertion_order',
+            targets=[target.as_dict() for target in self.targets],
+            windows=[dict(names=list(names), statistics_bytes=size)
+                     for names, size in zip(self.windows, self.window_statistics_bytes)],
+            projection_backend=json.loads(self.projection_backend_identity_json))
+
+    @property
+    def identity_sha256(self):
+        return identity_sha256(self.as_dict())
+
+
+def plan_joint_statistics_target_windows(modules, specs_by_qname, *, max_statistics_bytes,
+                                         activation_max_abs=None, projection_backend=None):
+    """Validate all targets and pack deterministic whole-target windows.
+
+    Meta Linear modules are supported by the torch reference backend for
+    geometry-only CPU planning. A fused backend still requires its actual
+    prewarmed device. Neither mode certifies source residency or a full fit.
+    Dynamic callable distinctions become separate ordered format groups; raw
+    callable IDs never leave the shared in-process grouping calculation.
+    """
+    if type(max_statistics_bytes) is not int or max_statistics_bytes <= 0:
+        raise ValueError('joint statistics planning requires a positive integer statistics budget')
+    if not modules:
+        raise ValueError('joint statistics planning requires nonempty target coverage')
+    backend, requirements = _joint_projection_requirements(modules, specs_by_qname,
+        activation_max_abs=activation_max_abs, projection_backend=projection_backend)
+    targets = tuple(JointStatisticsTarget(name, row.shape, row.statistics_bytes,
+        tuple(JointStatisticsGroup(group.formats, group.activation_identity_json) for group in row.groups))
+        for name, row in sorted(requirements.items()))
+    for target in targets:
+        if target.statistics_bytes > max_statistics_bytes:
+            raise RuntimeError(f'joint statistics target {target.name} requires {target.statistics_bytes} '
+                               f'bytes, exceeding statistics budget {max_statistics_bytes}')
+    windows, sizes, current, used = [], [], [], 0
+    for target in targets:
+        if current and used + target.statistics_bytes > max_statistics_bytes:
+            windows.append(tuple(current))
+            sizes.append(used)
+            current, used = [], 0
+        current.append(target.name)
+        used += target.statistics_bytes
+    windows.append(tuple(current))
+    sizes.append(used)
+    return JointStatisticsTargetPlan(max_statistics_bytes, targets, tuple(windows), tuple(sizes),
+        json.dumps(backend.identity, sort_keys=True, separators=(',', ':'), allow_nan=False))

--- a/tests/test_joint_statistics_plan.py
+++ b/tests/test_joint_statistics_plan.py
@@ -1,0 +1,193 @@
+"""CPU policy/geometry gates; plans never allocate statistics or retain source."""
+from dataclasses import FrozenInstanceError, replace
+import gc
+import json
+import weakref
+
+import pytest
+import torch
+from torch import nn
+
+from prismaquant import format_registry as fr
+from prismaquant.joint_aura import JointOperatorStatisticsLease, SignedJointProjectionLease
+from prismaquant.joint_projection_backend import prewarm_projection_backend
+from prismaquant.joint_statistics_plan import plan_joint_statistics_target_windows as plan
+from prismaquant.nvfp4_activation_contract import (
+    ActivationScaleContractError, NVFP4_SERVED_ACTIVATION_CONTRACT)
+from prismaquant.routed_experts import PackedExpertProjection
+from test_joint_aura_projection import _spec
+
+
+def linear(rows=4, columns=16):
+    return nn.Linear(columns, rows, bias=False, device='meta')
+
+
+def choices():
+    contract = replace(NVFP4_SERVED_ACTIVATION_CONTRACT, measured_as_served=True)
+    a4 = replace(fr.get_format('NVFP4'), name='a4', static_activation_contract=contract)
+    return {'a4': a4, 'a8': fr.get_format('FP8_E4M3'), 'identity': fr.get_format('BF16')}
+
+
+def test_whole_target_greedy_windows_have_complete_deterministic_coverage():
+    modules = {name: linear(rows) for name, rows in [('z', 2), ('a', 1), ('m', 3)]}
+    specs = {name: {'identity': fr.get_format('BF16')} for name in modules}
+    result = plan(modules, specs, max_statistics_bytes=256)
+    assert result.windows == (('a', 'm'), ('z',))
+    assert result.window_statistics_bytes == (256, 128)
+    assert result.total_statistics_bytes == 384
+    other = plan(dict(reversed(list(modules.items()))), specs, max_statistics_bytes=256)
+    assert other.as_dict() == result.as_dict()
+    assert other.identity_sha256 == result.identity_sha256
+    assert [name for window in result.windows for name in window] == ['a', 'm', 'z']
+    assert result.as_dict()['projection_backend']['name'] == 'torch'
+
+
+def test_actual_glm_shapes_two_qdq_groups_produce_three_windows_without_allocation(monkeypatch):
+    # Full routed+shared layer census: 289 down and 578 gate/up projections.
+    modules = {f'unit.{index:04}': linear(4096 if index < 289 else 2048,
+                                        2048 if index < 289 else 4096)
+               for index in range(867)}
+    specs = {name: choices() for name in modules}
+    maxima = dict.fromkeys(modules, 1.0)
+    backend = prewarm_projection_backend({'name': 'torch'}, device='meta')
+    monkeypatch.setattr(torch, 'empty', lambda *a, **k: pytest.fail('planner allocated a tensor'))
+    monkeypatch.setattr(nn.Module, 'register_forward_hook', lambda *a, **k: pytest.fail('planner installed hook'))
+    result = plan(modules, specs, max_statistics_bytes=32*1024**3,
+                  activation_max_abs=maxima, projection_backend=backend)
+    assert list(map(len, result.windows)) == [341, 341, 185]
+    assert result.total_statistics_bytes == 87_275_077_632
+    assert all(target.statistics_bytes == 96*1024**2 for target in result.targets)
+    assert all(len(target.groups) == 3 for target in result.targets)
+    assert result.window_statistics_bytes == (341*96*1024**2, 341*96*1024**2, 185*96*1024**2)
+
+
+def test_widest_glm_dense_target_remains_indivisible():
+    module = linear(4096, 12288)
+    specs = {'unit': choices()}
+    kwargs = dict(activation_max_abs={'unit': 1.0})
+    with pytest.raises(RuntimeError, match='target unit.*exceeding statistics budget'):
+        plan({'unit': module}, specs, max_statistics_bytes=576*1024**2-1, **kwargs)
+    result = plan({'unit': module}, specs, max_statistics_bytes=576*1024**2, **kwargs)
+    assert result.windows == (('unit',),)
+    assert result.total_statistics_bytes == 576*1024**2
+
+
+def test_static_owner_shares_group_despite_distinct_unused_dynamic_callables():
+    source = choices()['a4']
+    specs = {'second': replace(source, activation_quantize_dequantize=lambda x: x),
+             'first': replace(source, activation_quantize_dequantize=lambda x: x*0)}
+    result = plan({'unit': linear()}, {'unit': specs}, max_statistics_bytes=512,
+                  activation_max_abs={'unit': 1.0})
+    assert result.total_statistics_bytes == 512
+    assert result.targets[0].groups[0].formats == ('second', 'first')
+    assert result.targets[0].groups[0].as_dict()['activation']['input_global_scale'] is not None
+
+
+def test_dynamic_callable_distinctions_survive_equal_receipts_without_pointer_identity():
+    def factory():
+        return lambda x: x
+    left, right = factory(), factory()
+    specs = {'left': _spec('left', left), 'left_alias': _spec('left_alias', left),
+             'right': _spec('right', right), 'identity': _spec('identity', left, act_bits=None)}
+    result = plan({'unit': linear()}, {'unit': specs}, max_statistics_bytes=768)
+    groups = result.targets[0].groups
+    assert [group.formats for group in groups] == [('left', 'left_alias'), ('right',), ('identity',)]
+    assert groups[0].activation_identity_json == groups[1].activation_identity_json
+    assert result.total_statistics_bytes == 768
+    # Recreated callable objects preserve equality partition and persisted identity.
+    newer_left, newer_right = factory(), factory()
+    newer = {fmt: replace(spec, activation_quantize_dequantize=(newer_right if fmt=='right' else newer_left))
+             for fmt, spec in specs.items()}
+    again = plan({'unit': linear()}, {'unit': newer}, max_statistics_bytes=768)
+    assert again.identity_sha256 == result.identity_sha256
+    encoded = json.dumps(result.as_dict())
+    assert str(id(left)) not in encoded and str(id(right)) not in encoded
+
+
+def test_plan_and_both_leases_share_requirements_and_preserve_group_order():
+    module = nn.Linear(16, 4, bias=False)
+    specs = choices()
+    result = plan({'unit': module}, {'unit': specs}, max_statistics_bytes=768,
+                  activation_max_abs={'unit': 1.0})
+    operator = JointOperatorStatisticsLease({'unit': module}, {'unit': specs},
+        max_statistics_bytes=768, max_candidate_bytes=256, activation_max_abs={'unit': 1.0})
+    signed = SignedJointProjectionLease({'unit': module}, {'unit': specs},
+        {('unit', fmt): torch.zeros_like(module.weight) for fmt in specs}, activation_max_abs={'unit': 1.0})
+    assert operator.statistics_capacity_bytes == result.total_statistics_bytes
+    expected = [group.formats for group in result.targets[0].groups]
+    assert [tuple(formats) for _,formats in operator.groups['unit']] == expected
+    assert [tuple(formats) for _,formats in signed.groups['unit']] == expected
+    assert not module._forward_hooks
+
+
+def test_plan_does_not_retain_modules_specs_tensors_or_callables():
+    def construct():
+        module = linear()
+        tensor = torch.ones(1)
+        def quantizer(x):
+            return x*tensor
+        spec = _spec('q', quantizer)
+        refs = [weakref.ref(value) for value in (module, module.weight, tensor, quantizer, spec)]
+        return plan({'unit': module}, {'unit': {'q': spec}}, max_statistics_bytes=512), refs
+    result, refs = construct()
+    gc.collect()
+    assert all(ref() is None for ref in refs)
+    original = result.identity_sha256
+    exported = result.as_dict()
+    exported['targets'][0]['groups'][0]['activation']['act_bits'] = 1
+    assert result.identity_sha256 == original
+    with pytest.raises(FrozenInstanceError):
+        result.windows = ()
+
+
+@pytest.mark.parametrize('cap', [None, 0, -1, True, 1.0, float('inf')])
+def test_invalid_caps_refuse_before_source_access(cap):
+    with pytest.raises(ValueError, match='positive integer'):
+        plan({'unit': object()}, {'unit': {}}, max_statistics_bytes=cap)
+
+
+@pytest.mark.parametrize('case', ['empty','missing','extra','no_specs','unknown_spec','unknown_module','alias'])
+def test_unknown_coverage_types_and_aliases_refuse(case):
+    module = linear()
+    modules, specs = {'unit': module}, {'unit': {'BF16': fr.get_format('BF16')}}
+    if case == 'empty': modules, specs = {}, {}
+    elif case == 'missing': specs = {}
+    elif case == 'extra': specs['extra'] = specs['unit']
+    elif case == 'no_specs': specs['unit'] = {}
+    elif case == 'unknown_spec': specs['unit'] = {'bad': object()}
+    elif case == 'unknown_module': modules['unit'] = object()
+    else:
+        modules['alias'] = module
+        specs['alias'] = specs['unit']
+    with pytest.raises((ValueError, TypeError)):
+        plan(modules, specs, max_statistics_bytes=1024)
+    assert not module._forward_hooks
+
+
+def test_unprewarmed_backend_refuses():
+    with pytest.raises(RuntimeError, match='prewarmed'):
+        plan({'unit': linear()}, {'unit': choices()}, max_statistics_bytes=1024,
+             activation_max_abs={'unit': 1.0}, projection_backend={'name': 'torch'})
+
+
+def test_static_scale_and_geometry_refuse():
+    with pytest.raises(ActivationScaleContractError):
+        plan({'unit': linear()}, {'unit': choices()}, max_statistics_bytes=1024)
+    with pytest.raises(ValueError, match='geometry'):
+        plan({'unit': linear(columns=15)}, {'unit': choices()}, max_statistics_bytes=1024,
+             activation_max_abs={'unit': 1.0})
+
+
+def test_distinct_packed_experts_are_counted_but_exact_alias_refuses():
+    owner = nn.Module()
+    owner.weight = nn.Parameter(torch.empty(2, 4, 16, device='meta'))
+    def target(name, expert):
+        return PackedExpertProjection(name, 'experts.weight', 'experts', owner,
+                                      'weight', expert, 'down_proj', owner.weight[expert])
+    modules = {'one': target('one', 0), 'two': target('two', 1)}
+    specs = {name: {'BF16': fr.get_format('BF16')} for name in modules}
+    result = plan(modules, specs, max_statistics_bytes=256)
+    assert result.windows == (('one',), ('two',))
+    modules['two'] = target('two', 0)
+    with pytest.raises(ValueError, match='aliased packed'):
+        plan(modules, specs, max_statistics_bytes=512)


### PR DESCRIPTION
A full GLM layer can require 81.28125 GiB of GW/GA statistics before its source weights or activations. Add deterministic whole-target windows under an explicit statistics cap, deriving activation grouping and matrix bytes from the same helper consumed by both existing projection leases. Plans retain only names and immutable identity metadata; invalid coverage, aliases, static contracts, backends and oversized targets refuse before hooks/allocation.

The planner preserves lease group insertion order and signed arithmetic. It performs no source replay or full-model admission. CPU geometry validation for 867 actual GLM-shaped targets yields 341/341/185 target windows under 32 GiB; existing dense, packed, streamed, microbatch and operator projection tests pass unchanged.

PrismaBuild validation: 146 passed, 2 explicit native-only skips across 4 shards; compile checks passed. Actual terminal/source/CAS audits and commands are recorded under joint-statistics-target-windows-01, with the dated report in docs/measurements/joint-statistics-target-windows-2026-09-08.md.

GitHub CI on the frozen post-merge head: 6680 passed, 200 skipped, 3 xfailed, and 192 subtests passed; import surface and linked-issue policy also passed. Run: https://github.com/RobTand/prismaquant/actions/runs/34224069522.

Runtime integration is separate from this planner.

Fixes #385
