### PR TITLE
Release completed anchor and sidecar pages without hashing the bytes again

### DIFF
--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -517,13 +517,13 @@ def _finish_anchor(*, qname, weight, activations, format_name, cache, wire_dir,
     if getattr(cache, 'metadata', {}).get('release_completed_anchor_file_pages'):
         # The existing PWC entry is already disk-backed. Completed anchor
         # files must not accumulate an unbounded page-cache owner across rungs.
+        # The bytes were sealed in memory before the write, and the release
+        # helper checks the entry's identity, fsyncs and advises it from its
+        # own descriptor: nothing here reads the entry back.
         from .perturbed_x_cache import release_activation_cache_file_pages
-        from .tessera_calibration_cache import sha256
         rendered_path = Path(cache.cache_dir)/cache.weights[(qname, format_name)]
         for path in (rendered_path, wire_path):
-            expected = path.stat()
-            sha256(path, release_read_pages=True)
-            release_activation_cache_file_pages(path, expected_stat=expected)
+            release_activation_cache_file_pages(path, expected_stat=path.stat())
 
     bits = spec.bits_for_shape(tuple(weight.shape))
     return CampaignAnchor(
@@ -3433,11 +3433,13 @@ def write_export_inputs(cache_dir: Path, *, hessians, hessian_rows,
         os.replace(tmp_capture, hessian_capture_path)
         os.replace(tmp_sidecar, sidecar)
         if release_file_pages:
+            # ``capture_sha256`` was sealed from the in-memory bytes above;
+            # the release helper checks identity, fsyncs and advises from its
+            # own descriptor. Reading the archive back here would be a full
+            # pass over the Hessian sidecar per row with no consumer.
             from .perturbed_x_cache import release_activation_cache_file_pages
-            from .tessera_calibration_cache import sha256
-            expected = hessian_capture_path.stat()
-            sha256(hessian_capture_path, resource_check=resource_check, release_read_pages=True)
-            release_activation_cache_file_pages(hessian_capture_path, expected_stat=expected)
+            release_activation_cache_file_pages(
+                hessian_capture_path, expected_stat=hessian_capture_path.stat())
         if resource_check is not None:
             resource_check('after_selected_export_input_write')
         print(f"[campaign] wrote {hessian_capture_path} "

--- a/tests/test_tessera_calibration_cache.py
+++ b/tests/test_tessera_calibration_cache.py
@@ -98,6 +98,76 @@ def test_export_input_page_release_preserves_existing_file_bytes(capture, monkey
     assert calls == ['hessian_capture.pt.tmp']*2+['hessian_capture.pt']
 
 
+def test_export_input_page_release_does_not_reread_the_archive(capture, monkeypatch, tmp_path):
+    """Releasing a completed archive's pages must not read the archive again.
+
+    The capture seal is computed in memory before the write, and
+    ``release_activation_cache_file_pages`` fsyncs and advises the whole file
+    from its descriptor. A hashing pass over the written bytes has no
+    consumer, and on a routed GLM stack it is a full read of a 44 GB sidecar
+    per row (PR #376 audit, finding 1).
+    """
+    from prismaquant import tessera_campaign as campaign, tessera_calibration_cache
+    _root, _path, census, identity, _acts, hessians, _record = capture
+    hashed = []
+    original = tessera_calibration_cache.sha256
+    def counting_sha256(path, **kwargs):
+        hashed.append(Path(path).name)
+        return original(path, **kwargs)
+    monkeypatch.setattr(tessera_calibration_cache, 'sha256', counting_sha256)
+    observed = []
+    root = tmp_path/'bounded'
+    root.mkdir()
+    path, _scales, _digest = campaign.write_export_inputs(root, hessians=hessians,
+        hessian_rows=census['counts'], hessian_identity=identity['calibration'],
+        static_scales={}, static_scale_policy='fixture', release_file_pages=True,
+        resource_check=lambda label, **kwargs: observed.append(label))
+    assert path.name not in hashed
+    assert not [label for label in observed if 'capture_hash' in label]
+
+
+def test_completed_anchor_page_release_does_not_reread_the_entries(monkeypatch, tmp_path):
+    """The rendered shard and the wire are advised out, never hashed again."""
+    import types
+    import torch
+    from prismaquant import tessera_campaign as campaign
+    from prismaquant import perturbed_x_cache, tessera_calibration_cache
+
+    def refuse_reread(path, **kwargs):
+        raise AssertionError(f'completed anchor entry was re-read: {Path(path).name}')
+    monkeypatch.setattr(tessera_calibration_cache, 'sha256', refuse_reread)
+    released = []
+    original = perturbed_x_cache.release_activation_cache_file_pages
+    def release(path, *, expected_stat):
+        released.append(Path(path).name)
+        return original(path, expected_stat=expected_stat)
+    monkeypatch.setattr(perturbed_x_cache, 'release_activation_cache_file_pages', release)
+
+    cache_dir = tmp_path/'cache'
+    wire_dir = tmp_path/'wire'
+    cache_dir.mkdir()
+    wire_dir.mkdir()
+    cache = types.SimpleNamespace(weights={}, cache_dir=str(cache_dir),
+                                  metadata={'release_completed_anchor_file_pages': True})
+    weight = torch.arange(64, dtype=torch.float32).reshape(8, 8) / 64
+    activations = torch.ones(4, 8)
+    spec = types.SimpleNamespace(
+        bits_for_shape=lambda shape: 4 * shape[0] * shape[1],
+        memory_bytes_for_shape=lambda shape: shape[0] * shape[1] // 2,
+        act_dtype_name=None)
+    prepared = dict(spec=spec, family=types.SimpleNamespace(name='fixture'),
+                    rung=1024, activation_qdq=lambda x: x, input_scale=None,
+                    activation_kwargs={})
+    anchor = campaign._finish_anchor(qname='layers.0.q_proj', weight=weight,
+        activations=activations, format_name='FIXTURE_R4', cache=cache,
+        wire_dir=wire_dir, prepared=prepared, render=weight.clone(),
+        blob=b'wire-bytes', elapsed=0.0)
+    rendered = cache.weights[('layers.0.q_proj', 'FIXTURE_R4')]
+    assert sorted(released) == sorted([Path(rendered).name,
+                                       'layers__0__q_proj__FIXTURE_R4.tessera'])
+    assert anchor.wire_bytes == len(b'wire-bytes')
+
+
 @pytest.mark.parametrize('change',['artifact','manifest','source','draw','geometry','scope'])
 def test_prefetch_refuses_drift(capture,change):
     root,path,census,identity,acts,hessians,record = capture


### PR DESCRIPTION
Closes #395. Refs #370. Finding 1 of the PR #376 post-merge audit (https://github.com/RobTand/prismaquant/pull/376#issuecomment-5584543796).

`_finish_anchor` and `write_export_inputs` hashed every completed file a second time before advising its pages out, and discarded the digest. The seal is computed from the in-memory bytes before the write, and `release_activation_cache_file_pages` checks the entry's identity, fsyncs and advises it from its own descriptor, so the extra pass had no consumer. On a routed GLM stack it was a full read of the 44 GB Hessian sidecar per row and of every rendered shard and wire per rung, plus one guard poll per 16 MiB read. Archive names, bytes, seals and the release itself are unchanged; the only behavioural change is that nothing reads a completed entry back.

Two regressions demonstrate it: `test_export_input_page_release_does_not_reread_the_archive` counts hash calls on the capture path with `release_file_pages=True`, and `test_completed_anchor_page_release_does_not_reread_the_entries` drives `_finish_anchor` with `release_completed_anchor_file_pages` set and a hash helper that refuses any read. The `resource_check` labels `before_capture_hash` and `after_capture_hash` no longer appear on the export-input path.

PrismaBuild, x86 (`/home/rob/venvs/pq-cpu312`), priority -10:

- Red at the test-only commit 1efbc09f4: `49801762d3c7953ec6ecfe53ceb2cafdebc94a8d96ab8ea090fa54d802ee1181`, rc 1, exactly the two new tests fail, 32 pass.
- Green at 6923fabf3, four shards: `62837a808dc5fb8fbb56f9f6adfb2bf536b4802fa09cb6b7cdb33fa6fbe444e9`, `d1d75c3ea8709771934f2e590e791e86d9543c0362f8bd8ac367dda7fb62d045`, `75195ff81c4bf63a3327d0c586fa848b13b4e76084cf41b47b214147bc48654e`, `04af35f60d7902acab23f3b2a36436e546c88c3e5e82732031d2840dbd923a6a`; `test_tessera_calibration_cache.py` 34 passed, `test_tessera_selected_source.py` 10 passed 1 skipped, `test_tessera_materialization.py` 25 passed 1 skipped, `test_allocator_tessera_priced_inputs.py` 5 passed.
- `test_glm_campaign_streaming.py` at 16 GiB: `970f8ee6a4df`, 12 passed, on the content-identical runtime tree 8ea2dfc48 (differs from 6923fabf3 in the test fixture only).

No speedup is claimed: the removed pass is one full read of each completed file, and the fixture files are too small for a receipt-level I/O delta. A before/after profile on a real selected GLM row belongs with #388, which is the same row's other full-source read.

**Rebase.** Rebased onto `695439cb37` after #386 merged. Both call sites were still present on the integration tree, so nothing here is superseded; re-test receipts at the rebased head follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsJAfuLU26NWbYpSLrWFHJ
