### PR TITLE
Refuse a Hessian capture write that produced no stable tensor record

### DIFF
--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -3338,12 +3338,14 @@ def _save_hessian_capture_with_page_release(payload, path, *, resource_check=Non
     filename writer and serializer as torch.save, and interpose only after its
     synchronous storage writes. No storage, pickle or archive byte is rewritten.
     """
+    import torch
     import torch.serialization as serialization
     from .perturbed_x_cache import release_activation_cache_file_pages
 
     class RecordBoundary:
         def __init__(self, writer):
             self.writer = writer
+            self.stable_records = 0
 
         def __getattr__(self, name):
             return getattr(self.writer, name)
@@ -3353,15 +3355,34 @@ def _save_hessian_capture_with_page_release(payload, path, *, resource_check=Non
             if name.startswith('data/'):
                 # The serializer is paused: the visible file extent cannot
                 # change while the existing helper checks identity and fsyncs.
+                self.stable_records += 1
                 expected = path.stat()
                 release_activation_cache_file_pages(path, expected_stat=expected)
                 if resource_check is not None:
                     resource_check('after_hessian_tensor_record:'+name)
             return result
 
+    def holds_tensor(value):
+        if isinstance(value, torch.Tensor):
+            return True
+        if isinstance(value, dict):
+            return any(holds_tensor(item) for item in value.values())
+        if isinstance(value, (list, tuple)):
+            return any(holds_tensor(item) for item in value)
+        return False
+
     with serialization._open_zipfile_writer(os.fspath(path)) as writer:
-        serialization._save(payload, RecordBoundary(writer), serialization.pickle,
+        boundary = RecordBoundary(writer)
+        serialization._save(payload, boundary, serialization.pickle,
                             serialization.DEFAULT_PROTOCOL, False)
+    if holds_tensor(payload) and boundary.stable_records == 0:
+        # Fail closed: a torch archive layout that files tensor bytes under
+        # another prefix would otherwise turn this writer into a plain
+        # torch.save with the whole sidecar left resident and no signal.
+        raise RuntimeError(
+            'hessian capture writer saw no stable tensor record (data/*) for a '
+            'payload holding tensors; the torch archive layout changed and the '
+            'page release would be silently skipped (RobTand/prismaquant#396)')
 
 
 def write_export_inputs(cache_dir: Path, *, hessians, hessian_rows,
@@ -3418,11 +3439,17 @@ def write_export_inputs(cache_dir: Path, *, hessians, hessian_rows,
         tmp_sidecar = sidecar.with_suffix(".json.tmp")
         payload = {"H": saved_hessians, "counts": dict(hessian_rows),
                    "provenance": capture_provenance}
-        if release_file_pages:
-            _save_hessian_capture_with_page_release(payload, tmp_capture,
-                                                    resource_check=resource_check)
-        else:
-            torch.save(payload, tmp_capture)
+        try:
+            if release_file_pages:
+                _save_hessian_capture_with_page_release(payload, tmp_capture,
+                                                        resource_check=resource_check)
+            else:
+                torch.save(payload, tmp_capture)
+        except BaseException:
+            # The previously published capture and sidecar stay untouched;
+            # do not leave a half-written .pt.tmp beside them.
+            tmp_capture.unlink(missing_ok=True)
+            raise
         tmp_sidecar.write_text(json.dumps({
             **capture_provenance,
             "capture_sha256": capture_sha256,

--- a/tests/test_bounded_hessian_sidecar.py
+++ b/tests/test_bounded_hessian_sidecar.py
@@ -136,3 +136,43 @@ def test_record_failure_preserves_previous_published_capture(tmp_path, monkeypat
         campaign.write_export_inputs(tmp_path, **inputs, release_file_pages=True,
             resource_check=refuse if failure == 'memory_guard' else None)
     assert (path.read_bytes(), sidecar.read_bytes()) == previous
+
+
+def test_writer_refuses_when_no_stable_tensor_record_is_written(tmp_path, monkeypatch):
+    """A serializer that files tensor bytes under another prefix must refuse, not degrade."""
+    import torch.serialization as serialization
+    from prismaquant import tessera_campaign as campaign
+    inputs = dict(hessians={'unit': torch.eye(128)}, hessian_rows={'unit': 512},
+                  hessian_identity={'fit_ids_sha256': 'same-draw'}, static_scales={},
+                  static_scale_policy='fixture')
+    path, _, _ = campaign.write_export_inputs(tmp_path, **inputs)
+    sidecar = path.with_name(path.name+'.provenance.json')
+    previous = (path.read_bytes(), sidecar.read_bytes())
+    original = serialization._save
+    class Relocated:
+        def __init__(self, writer):
+            self.writer = writer
+        def __getattr__(self, name):
+            return getattr(self.writer, name)
+        def write_record(self, name, *args, **kwargs):
+            if name.startswith('data/'):
+                name = 'storage/'+name[len('data/'):]
+            return self.writer.write_record(name, *args, **kwargs)
+    def relocated_save(obj, zip_file, *args, **kwargs):
+        return original(obj, Relocated(zip_file), *args, **kwargs)
+    monkeypatch.setattr(serialization, '_save', relocated_save)
+    inputs['hessians'] = {'unit': torch.eye(128)*2}
+    with pytest.raises(RuntimeError, match='no stable tensor record'):
+        campaign.write_export_inputs(tmp_path, **inputs, release_file_pages=True)
+    assert (path.read_bytes(), sidecar.read_bytes()) == previous
+    assert sorted(entry.name for entry in tmp_path.iterdir()) == sorted([path.name, sidecar.name])
+
+
+def test_writer_accepts_a_capture_with_no_tensors(tmp_path):
+    """No tensor, no stable record expected: the check must not refuse an empty table."""
+    from prismaquant import tessera_campaign as campaign
+    path, _, digest = campaign.write_export_inputs(tmp_path, hessians={'unit': None},
+        hessian_rows={}, hessian_identity={'fit_ids_sha256': 'same-draw'}, static_scales={},
+        static_scale_policy='fixture', release_file_pages=True)
+    assert path.exists() and digest
+    assert torch.load(path, weights_only=False)['H'] == {}


### PR DESCRIPTION
Closes #396. Fix-forward for the #379 review item that #386 merged without.

**Defect.** `_save_hessian_capture_with_page_release` advises archive pages only for records named `data/*` and never checks that any matched. A torch archive layout that files tensor bytes under another prefix turns the writer into a plain `torch.save` with the whole sidecar left resident and no signal.

**Fix.** `RecordBoundary` counts the stable records it advised. After `serialization._save` returns, a payload holding tensors with zero matched records raises. `write_export_inputs` removes the half-written `.pt.tmp` on any failure, so the previously published capture and its sidecar are the only files left. No archive byte changes on the success path.

**Tests.** `test_writer_refuses_when_no_stable_tensor_record_is_written` drives the writer through a serializer that relocates `data/*` to `storage/*` and asserts the refusal, the untouched previous capture, and no temporary file. `test_writer_accepts_a_capture_with_no_tensors` covers the empty table, which must still write.

**Receipts** (PrismaBuild, x86 `pq-cpu312`, priority -10, sealed parent verified on each row):

| commit | run | receipt | result |
|---|---|---|---|
| adad67e1c9 tests only | red | 182ce135adfc (failed row) | 1 failed, 9 passed, 1 skipped: the new refusal test fails, the empty-table test already passes |
| d8cae87445 fix | green | a326b99c339f | test_bounded_hessian_sidecar.py 10 passed, 1 skipped |
| d8cae87445 fix | green | 7257a91c0a18 | test_tessera_calibration_cache.py 32 passed |
| d8cae87445 fix | green | b29ac32d84c0 | test_tessera_priced_export_inputs.py 39 passed, 1 skipped |
| d8cae87445 fix | green | be988be1d615 | test_tessera_input_handoff.py 10 skipped |

The skip in the sidecar file is the opt-in native writer profile. No `docs/ARCHITECTURE.md` change: no default, stage, format or gate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsJAfuLU26NWbYpSLrWFHJ