### PR TITLE
test: set the bounded-capture environment before the selected-source CLI check

### DIFF
--- a/tests/test_tessera_selected_source.py
+++ b/tests/test_tessera_selected_source.py
@@ -234,8 +234,13 @@ def test_native_bounded_encoder_memo_keeps_wire_and_price_bytes(tmp_path, monkey
 def test_selected_capture_cli_reaches_existing_streamed_source(monkeypatch, tmp_path):
     from test_tessera_campaign_resume import _main_fixture
     from prismaquant import cost_streaming
+    from prismaquant.autoscale import BOUNDED_CAPTURE_ENV
     campaign, _, argv, _, _ = _main_fixture(monkeypatch, tmp_path)
     argv[argv.index('--hessian') + 1] = 'require'
+    # On a CUDA host the CLI checks the bounded-capture release policy before
+    # it reaches the streamed source; the dispatcher sets this for real runs.
+    for name, value in BOUNDED_CAPTURE_ENV.items():
+        monkeypatch.setenv(name, value)
 
     class SelectedSourceReached(Exception):
         pass


### PR DESCRIPTION
Closes #398. Test-only.

**Defect.** `test_selected_capture_cli_reaches_existing_streamed_source` calls `campaign.main` with a selected source and never sets the bounded-capture release policy. On a CUDA host `main` checks that policy before it reaches the streamed source, so the test passed on CPU and failed on every GPU host with:

```
RuntimeError: bounded CUDA capture requires PRISMAQUANT_RELEASE_SOURCE_PAGES=1 before process startup
```

**Fix.** The test sets the gate's variables through `monkeypatch.setenv` from `autoscale.BOUNDED_CAPTURE_ENV`, the same way the dispatcher does for real runs. No production code changes.

**Receipts** (PrismaBuild, priority -10, sealed parent verified):

| commit | box | receipt | result |
|---|---|---|---|
| 695439cb37 main, control | sparklina GPU | 5d53e29e3fa8 (failed row) | 1 failed, 10 passed: the defect on main |
| 54d0b6c8de fix | sparklina GPU | 242b22b88cf5 | 11 passed |
| 54d0b6c8de fix | dl380g10 x86 | 43cb914bedb9 | 10 passed, 1 skipped (the CUDA-only memo qualification) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsJAfuLU26NWbYpSLrWFHJ