### PR TITLE
Capture exact AURA boundaries once per source layer

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,24 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `integration/glm-probe-memory`. Stamps
+Re-stamped (2026-09-08, `fix/layer-major-boundary-capture`) for explicit
+`prismaquant.aura.boundary_storage.v2` with `capture_order: "layer_major"`
+(#394). The existing layer visitor installs each baseline source layer once
+and dispatches the original complete batches in order. It keeps each batch's
+original source kwargs/pass state, leases exact input windows from the existing
+activation owner and writes the original output boundary before advancing.
+No full-draw hidden tensor plane is added. Metadata and all live forward/shared
+states remain under the auxiliary cap; physical admission remains separate.
+V1 and default callers preserve batch-major capture. The reverse/probe order,
+source arithmetic, RNG coordinates of Fisher probes, candidate formats and
+serving gates are unchanged. The new capture requires evaluation mode and
+refuses observed Torch CPU or runner-device CUDA RNG consumption during
+preparation/source calls. Other mutable custom-model state is outside this
+qualification; no blanket stateful-model equivalence is claimed. Gates include
+`tests/test_layer_major_boundary_capture.py`, actual shared-state regressions,
+and a paired original-layout GLM source-read/profile qualification with Netdata
+from both hosts. This remains default-off and establishes no full-GLM fit.
+
+As of: 2026-09-08 · `fix/layer-major-boundary-capture`. Stamps
 follow, newest first, each recording its own branch and date.
 
 Re-stamped (2026-09-08, `integration/glm-probe-memory`) for the combined

--- a/docs/design/joint_aura_runtime_allocation.md
+++ b/docs/design/joint_aura_runtime_allocation.md
@@ -280,6 +280,15 @@ as full-draw quality evidence.
 
 ## Exact boundary working storage (opt-in)
 
+For bounded target replay, `SharedStateCotangents.fork_for_replay` accepts a
+mandatory `max_resident_bytes` cap for the fork's newly allocated compact
+adjoint tensors. It requires a quiescent owner after harvest, deep-copies all
+accumulators, and keeps diagnostic lists independent. The original adjoints
+remain separately charged. Earlier target windows may consume/harvest one
+batch's disposable fork and release it; only the final target window may use
+the original owner and commit outgoing cotangents. This helper does not itself
+schedule replay or change reverse-pass behavior.
+
 `compute_aura_cost_streamed(..., boundary_storage=policy)`, CLI
 `--boundary-storage-config policy.json`, or the Tessera joint plan's
 `execution.boundary_storage` accepts the closed policy:

--- a/docs/design/joint_aura_runtime_allocation.md
+++ b/docs/design/joint_aura_runtime_allocation.md
@@ -327,15 +327,33 @@ input. Existing signed cost checkpoints own resume. A completed-checkpoint
 resume skips boundary generation entirely. The policy is checkpoint-bound but
 does not change the probe arithmetic identity or signed samples.
 
+To opt into layer-major baseline capture, use the same fields with
+`schema: "prismaquant.aura.boundary_storage.v2"` and the required additional
+field `capture_order: "layer_major"`. V1 remains closed and unchanged.
+`capture_layer_major_boundaries(input_batches, storage=owner)` consumes the
+existing `visit_layer_batches(..., boundary_storage=owner)` traversal. Source
+layers install/prefetch once, original batches remain in order, exact input
+windows are verified before source calls, and outputs are written immediately.
+All boundary receipts remain available for the ordinary reverse pass.
+
+Global forward order becomes layer/batch; each batch's original layer sequence,
+shape, masks, positions and distinct profile state remain intact. V2 requires
+evaluation mode and prefetched source delivery. It refuses observed Torch CPU
+or active-runner CUDA RNG consumption around preparation, source calls and
+profile state creation/capture. Python/NumPy RNG, other CUDA devices and
+arbitrary mutable custom-model state are not certified; supported source
+identity and equivalence remain qualification gates. Probe RNG and global row
+coordinates are unchanged. All simultaneous live per-batch shared states and
+transient final CPU copies are charged to the auxiliary cap, including
+potential per-probe adjoints.
+
 The exact files and verified page advice make I/O explicit; advice does not
 establish physical release. Profile read/write barriers independently and keep
-actual physical memory checks. The initial implementation preserves the source
-loop to make byte/order parity reviewable. Its batch-major capture still
+actual physical memory checks. V1 preserves the source loop to make
+byte/order parity reviewable. Its batch-major capture still
 traverses all decoder layers per calibration batch. With two source slots,
 512 B1 samples do not get a whole-model resident reuse window: layer-level
 source payload is fetched repeatedly. This source-derived traffic observation
-is unmeasured, not a timing estimate. Production qualification separately needs
-layer-major boundary capture through `StreamedCausalLM.visit_layer_batches`,
-keeping each batch's own source state and per-layer numerical sequence, and
-bounded PWC/delta/diagnostic lifetimes. The mode stays default-off until these
+is unmeasured, not a timing estimate. V2 addresses the initial capture traversal; production qualification still
+needs full-scale physical memory and bounded PWC/delta/diagnostic lifetimes. The mode stays default-off until these
 remaining production gates are satisfied.

--- a/docs/measurements/layer-major-boundary-capture-2026-09-08.md
+++ b/docs/measurements/layer-major-boundary-capture-2026-09-08.md
@@ -1,0 +1,108 @@
+# Exact layer-major boundary capture — 2026-09-08
+
+Issue [#394](https://github.com/RobTand/prismaquant/issues/394),
+PR [#400](https://github.com/RobTand/prismaquant/pull/400).
+Implementation `cf1271fc3d`; native token-device fix and qualified source
+`02ef6a5630`. Shared-cotangent replay forks are the separate `0e8c501cfa`
+commit. All test and GPU execution below used PrismaBuild at priority -10.
+
+The explicit v2 boundary policy extends `StreamedCausalLM.visit_layer_batches`
+with the existing exact activation artifact owner. Each source layer installs
+once and processes original complete batches in order, reading checked input
+windows and immediately writing exact output boundaries. Per-batch source
+kwargs and profile state remain separate. V1/default capture and the reverse
+probe/projection traversal are unchanged. The new policy requires evaluation
+mode, prefetched source residency and bounded auxiliary storage, and refuses
+observed Torch CPU or runner-device CUDA RNG consumption. This does not certify
+arbitrary mutable custom models or other RNG domains.
+
+Evidence root:
+`/mnt/shared/tessera-measurements/glm-canonical-census-20260908/`.
+`layer-major-boundary-implementation-01/` holds terminal/log audits, verified CAS
+receipt/result hashes and `native-evidence-audit.json`. Exact native command and
+container environment are in `layer-major-boundary-native-invocation-02.json`.
+Raw traces, cProfile files, cost panels, tensor digests and both-host telemetry
+are retained in `layer-major-boundary-native-02/`.
+
+| Gate | PB action prefix | Actual result |
+|---|---|---|
+| Before-change source-install regression | `9bf0eecaada7` | Failed: 10 installs, expected 2 |
+| Initial implementation fixtures | `a11184dbf764` | 52 passed, 11 failed: fake context lacked the existing `prefetch_following` argument; fixture corrected |
+| Boundary/state/replay implementation | `e0a3e4bd90c0` | 64 passed in 17.73 s |
+| Broader CPU and four module compile checks | `e81c87c46a25` | 122 passed, no skips, 274.28 s |
+| First native experiment | `14a3ee3087f8` | Baseline arm passed; layer-major refused CPU/CUDA token comparison, fixed in `02ef6a5630` |
+| Native paired qualification | `63dffca2d164` | Exit 0, all four arms passed |
+| Final targeted CPU and independent saved-cost comparison | `b8a94df84c6a` | 45 passed, one CUDA-only skip, 16.59 s; four saved panels matched |
+
+CPU tests used `/home/rob/venvs/pq-cpu312/bin/python` on DL380, with four or
+six physical CPU workers and native threads bounded to one. The broader gate
+included existing collector-source-release and actual GLM campaign/visitor
+tests, plus architecture and staleness checks. The final CPU skip is
+`test_original_cpu_tokens_compare_with_prepared_cuda_tokens`: the CPU worker
+has no CUDA. The genuine CUDA native rerun exercised the same original-CPU /
+prepared-CUDA token path after its recorded regression. Actual Gemma4 shared
+state, probe adjoints, budget refusal, cleanup and quiescent replay forks passed
+in CPU fixtures; the native GLM fixture has no nonempty shared-KV state.
+
+The native experiment used Sparklina GB10, image
+`prismaquant-glm-producer:content-qualified-20260908`, observed image ID
+`sha256:9f9b9f05b17531399ba66dc6415b054cf5d68c82270626d0e9150e75c808435f`,
+content seal `eb8592abd71390231b49aba119e36f02ad91ea867b06df1c67af3833004d07bd`,
+Torch 2.13.0/CUDA 13.0. PB reserved four physical CPUs, 8 GiB total UMA and a
+4 GiB GPU subset with a 600 s ceiling. Actual scope peak was 3,069,296,640
+bytes; terminal exit, scope cleanup and an empty container list were checked.
+
+The genuine original-layout tiny GLM has three layers (one KDA, two DSA), two
+source-cache slots, H=64, mHC=4 and four routed experts. It executes five
+original B1 sequences of length 17 and four probes with IDs 7000–7003 in BF16.
+The upstream Torch reference KDA/conv functions run on CUDA explicitly; this
+is not a fused-kernel qualification. Synthetic source+0.03125 candidate tensors
+cover 33 profile-unpinned dense/packed targets with the same format assignments
+in every arm. No full GLM checkpoint or serving artifact was produced.
+
+| ABBA arm | Capture order | Actual source reads / installs | Materialized source bytes | Capture seconds | Full instrumented call seconds |
+|---|---|---|---|---|---|
+| 0 | batch-major v1 | 15 / 15 | 1,755,300 | 1.218376 | 4.185343 |
+| 1 | layer-major v2 | 3 / 3 | 351,060 | 0.362056 | 3.169947 |
+| 2 | layer-major v2 | 3 / 3 | 351,060 | 0.369237 | 3.145303 |
+| 3 | batch-major v1 | 15 / 15 | 1,755,300 | 0.579450 | 4.739085 |
+
+Source read counts and materialized storage come from actual reader calls,
+not estimated checkpoint traffic or disk-byte counters. V2 reduced these
+capture calls by 80%. All costs and h-trace/Fisher columns matched exactly,
+including an independent PB read of the four saved `.cost.pt` panels. All 80
+propagated cotangent hashes and each batch's input/output/position hashes
+matched; reverse global call order also matched. Initial global forward order
+deliberately changes from batch/layer to layer/batch.
+
+All arms capped owned exact boundary residency at 43,520 bytes, with auxiliary
+peak 4,335 bytes. V2 adds 130,560 logical boundary input bytes during capture:
+whole-call exact reads were 1,218,560 versus 1,088,000 bytes. All arms wrote
+870,400 tensor bytes in 100 entries, retired all 100, ended with zero live
+artifact bytes and recorded zero hot-read misses. This trades explicit bounded
+activation reads for amortized source loading.
+
+Capture-only Torch CPU/CUDA profiles are retained for every arm. Self CPU
+totals were 1.132 s, 316.424 ms, 323.200 ms and 474.330 ms; self CUDA totals
+were 12.736, 11.756, 11.755 and 12.559 ms. Full-call cProfile and process I/O
+snapshots are also retained. Instrumentation, initialization and durable file
+operations dominate this small fixture, so the timing table is not a
+production throughput claim. CUDA allocation peaks were 76,018,688 bytes in
+the cold first arm and 76,449,280 thereafter; reserved peak was 94,371,840
+bytes throughout. No physical-memory reduction is claimed.
+
+Both-host Netdata recorded six samples per host at five-second cadence:
+Sparklina GPU power 4–12 W, CPU nonidle 5.02–7.58%; Sparky 13 W and
+6.13–6.62%. The short capture windows and coarse power cadence cannot support
+work-per-joule ranking. The fixture does not saturate GB10; GPU utilization is
+not used as a saturation diagnostic. Source, candidate, gradient and scratch
+budgets, full-scale physical memory admission and production qualification
+remain independent. The new mode stays default-off.
+
+Successful native CAS receipt:
+`220df31f692a73fe16f497d6c58eaa37e48c00a2031d39dca4aab6c12209392e`;
+result `8730acb55a33231e40014ee54fda44f038a5ffbd48d1cc092452f570b3ddabb7`
+(7,297 bytes). Canonical receipt hash, result length/hash and retained evidence
+file hashes were independently checked. Failed native output remains bounded
+evidence in `layer-major-boundary-native-01/`; it is superseded by the complete
+paired qualification and is not counted as a passing gate.

--- a/experiments/layer_major_boundary_profile.py
+++ b/experiments/layer_major_boundary_profile.py
@@ -1,0 +1,240 @@
+"""Paired exact capture traversal qualification on a tiny original-layout GLM.
+
+Only the changed capture phase uses Torch profiling; cProfile and the existing
+both-host observer cover the whole call. Three source layers exceed the two
+source-cache slots, so actual reader calls expose repeated source loading.
+"""
+from __future__ import annotations
+
+import argparse
+import cProfile
+import json
+from pathlib import Path
+import pstats
+import sys
+import time
+
+import torch
+
+from experiments.glm_full_capture_profile import CaptureObserver
+from experiments.joint_boundary_profile import process_state, tensor_digest
+from prismaquant import aura_cost, streaming_model
+from prismaquant.cost_streaming import (
+    BOUNDARY_STORAGE_SCHEMA, LAYER_MAJOR_BOUNDARY_STORAGE_SCHEMA,
+    build_streamed_causal_lm, build_streamed_model_identity,
+)
+from prismaquant.model_profiles.glm5_next import Glm5NextProfile
+from prismaquant.production_weight_cache import ProductionWeightCache
+from prismaquant.routed_experts import profile_declared_packed_expert_projections
+
+
+def run_arm(source, cache, ids, out, index, order):
+    runner = build_streamed_causal_lm(str(source), device=torch.device('cuda'),
+        dtype=torch.bfloat16, offload_folder=str(out/f'offload-{index}'),
+        profile=Glm5NextProfile(), max_cache_slots=2, prefetch_workers=1,
+        prefetch_min_available_gb=0, cache_headroom_gb=0,
+        prefetch_lookahead=1, require_prefetched_residency=True,
+        attn_implementation='eager')
+    identity = build_streamed_model_identity(runner, str(source))
+    record = dict(index=index, capture_order=order, identity=identity,
+                  source_calls=[], source_reads=[], installs=[], cotangents=[])
+    phase = 'setup'
+    original_read = streaming_model._read_layer_to_device
+    original_install, original_call = runner.context.install, runner._call
+    original_capture, original_major = runner.capture_boundaries, runner.capture_layer_major_boundaries
+    original_tail, original_reverse = runner.tail_logits, runner.isolated_layer
+    tail_calls = reverse_calls = captured_batches = 0
+    profile_active = False
+    profiler = torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU,
+        torch.profiler.ProfilerActivity.CUDA], record_shapes=True, profile_memory=True)
+
+    def read(prefix, *args, **kwargs):
+        started = time.perf_counter()
+        value = original_read(prefix, *args, **kwargs)
+        if prefix.startswith(runner.context.layers_prefix):
+            storages = {(str(t.device), t.untyped_storage().data_ptr()): t.untyped_storage().nbytes()
+                        for t in value.values()}
+            record['source_reads'].append(dict(prefix=prefix, phase=phase,
+                seconds=time.perf_counter()-started, materialized_storage_bytes=sum(storages.values())))
+        return value
+
+    def install(layer, **kwargs):
+        value = original_install(layer, **kwargs)
+        record['installs'].append(dict(layer=layer, phase=phase, delivery=value))
+        return value
+
+    def call(layer, hidden, *, batch, pass_state):
+        incoming = tensor_digest(hidden)
+        value = original_call(layer, hidden, batch=batch, pass_state=pass_state)
+        record['source_calls'].append(dict(layer=layer, batch=int(batch.input_ids[0, 0]),
+            grad=torch.is_grad_enabled(), input=incoming, output=tensor_digest(value),
+            shape=list(hidden.shape), position_ids=tensor_digest(batch.position_ids)))
+        return value
+
+    def begin_capture():
+        nonlocal phase, profile_active
+        phase = 'capture'
+        runner.context.begin_source_initialization_audit()
+        record['capture_before'] = process_state()
+        profiler.__enter__()
+        profile_active = True
+
+    def end_capture():
+        nonlocal phase, profile_active
+        if profile_active:
+            torch.cuda.synchronize()
+            record['capture_after'] = process_state()
+            record['initialization'] = runner.context.source_initialization_contract()
+            profiler.__exit__(None, None, None)
+            profile_active = False
+        phase = 'reverse'
+
+    def capture(*args, **kwargs):
+        nonlocal captured_batches
+        if captured_batches == 0:
+            begin_capture()
+        value = original_capture(*args, **kwargs)
+        captured_batches += 1
+        if captured_batches == len(ids):
+            end_capture()
+        return value
+
+    def major(*args, **kwargs):
+        begin_capture()
+        value = original_major(*args, **kwargs)
+        end_capture()
+        return value
+
+    def gradient(value, probe, batch, layer):
+        record['cotangents'].append(dict(probe=probe, batch=batch, layer=layer,
+            dtype=str(value.dtype), shape=list(value.shape), sha256=tensor_digest(value)))
+
+    def tail(batch, hidden):
+        nonlocal tail_calls
+        b, k = divmod(tail_calls, 4)
+        hidden.register_hook(lambda g, b=b, k=k: gradient(g, k, b, runner.num_layers))
+        tail_calls += 1
+        return original_tail(batch, hidden)
+
+    def reverse(batch, layer, hidden, *, pass_state):
+        nonlocal reverse_calls
+        k, b = divmod(reverse_calls % (4*len(ids)), len(ids))
+        hidden.register_hook(lambda g, k=k, b=b, layer=layer: gradient(g, k, b, layer))
+        reverse_calls += 1
+        return original_reverse(batch, layer, hidden, pass_state=pass_state)
+
+    streaming_model._read_layer_to_device = read
+    runner.context.install, runner._call = install, call
+    runner.capture_boundaries, runner.capture_layer_major_boundaries = capture, major
+    runner.tail_logits, runner.isolated_layer = tail, reverse
+    plane = ids.shape[1]*4*64*2
+    policy = dict(schema=BOUNDARY_STORAGE_SCHEMA, directory=str(out/f'artifacts-{index}'),
+        max_resident_bytes=5*plane, max_auxiliary_bytes=4*1024**2,
+        max_artifact_bytes=32*1024**2, prefetch_batches=2)
+    if order == 'layer_major':
+        policy.update(schema=LAYER_MAJOR_BOUNDARY_STORAGE_SCHEMA, capture_order=order)
+    cpu = cProfile.Profile()
+    torch.cuda.reset_peak_memory_stats()
+    started = time.perf_counter()
+    try:
+        with cpu:
+            payload = aura_cost.compute_aura_cost_streamed(runner, ids,
+                ['FP8_DYNAMIC', 'NVFP4A16', 'BF16'], n_probes=4,
+                probe_microbatch=1, seed_base=7000, min_free_gib=0,
+                production_cache=cache, joint_activation=True, collect_col_energy=True,
+                include_routed_experts=True, model_identity=identity,
+                formats_by_qname={name:['FP8_DYNAMIC','NVFP4A16','BF16'] for name, _ in cache.weights},
+                boundary_storage=policy)
+        record.update(seconds=time.perf_counter()-started, after=process_state(),
+                      storage=payload['provenance']['streamed_boundary_storage'], targets=len(payload['costs']))
+        assert record['storage']['status'] == 'complete'
+        assert record['storage']['telemetry']['live_artifact_bytes'] == 0
+        assert record['storage']['telemetry']['hot_read_misses'] == 0
+        captured = [x for x in record['installs'] if x['phase'] == 'capture']
+        assert len(captured) == (runner.num_layers if order == 'layer_major' else runner.num_layers*len(ids))
+        if order == 'layer_major':
+            assert len([x for x in record['source_reads'] if x['phase'] == 'capture']) == runner.num_layers
+        assert len(record['cotangents']) == 4*len(ids)*(runner.num_layers+1)
+        profiler.export_chrome_trace(str(out/f'arm-{index}.trace.json'))
+        (out/f'arm-{index}.profile.txt').write_text(profiler.key_averages().table(sort_by='self_cuda_time_total', row_limit=80))
+        cpu.dump_stats(str(out/f'arm-{index}.cprofile'))
+        with (out/f'arm-{index}.cprofile.txt').open('w') as handle:
+            pstats.Stats(cpu, stream=handle).sort_stats('cumulative').print_stats(80)
+        torch.save(payload, out/f'arm-{index}.cost.pt')
+        (out/f'arm-{index}.json').write_text(json.dumps(record, indent=2)+'\n')
+        return payload, record
+    finally:
+        if profile_active:
+            profiler.__exit__(None, None, None)
+        runner.shutdown()
+        streaming_model._read_layer_to_device = original_read
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--evidence-out', type=Path, required=True)
+    args = parser.parse_args(argv)
+    if not torch.cuda.is_available():
+        raise RuntimeError('native layer-major qualification requires CUDA')
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]/'tests'))
+    from test_glm5_next_streamed_forward_parity import _build_model, _tiny_config
+    from test_glm_campaign_streaming import write_original_layout_checkpoint
+    from transformers.models.glm5_next import modeling_glm5_next as upstream
+    torch.set_num_threads(1)
+    torch.set_num_interop_threads(1)
+    torch.use_deterministic_algorithms(True)
+    kernels = {}
+    for name in ('causal_conv1d_fn','causal_conv1d_update','chunk_kimi_delta_attention','recurrent_kimi_delta_attention'):
+        reference = getattr(getattr(upstream, name), '__wrapped__', None)
+        if reference is None:
+            raise RuntimeError(f'missing upstream Torch reference {name}')
+        setattr(upstream, name, reference)
+        kernels[name] = reference.__module__+'.'+reference.__name__
+    with CaptureObserver(args.evidence_out, profile_layers=()) as observer:
+        config = _tiny_config()
+        config.text_config.num_hidden_layers = 3
+        config.text_config.layer_types = ['linear_attention','deepseek_sparse_attention','deepseek_sparse_attention']
+        config.text_config.mlp_layer_types = ['dense','sparse','sparse']
+        config.text_config.indexer_types = ['full']*3
+        config = type(config).from_dict(config.to_dict())
+        torch.manual_seed(20260826)
+        model = _build_model(config).to(torch.bfloat16)
+        source = args.evidence_out/'source'
+        write_original_layout_checkpoint(model, source)
+        profile = Glm5NextProfile()
+        weights = {name:module.weight for name,module in model.named_modules()
+                   if isinstance(module,torch.nn.Linear) and '.layers.' in name and not profile.is_pinned_name(name)}
+        weights.update({m.qname:m.weight for m in profile_declared_packed_expert_projections(model,profile)})
+        cache = ProductionWeightCache(weights={(name,fmt):tensor.detach().clone()+0.03125
+            for name,tensor in weights.items() for fmt in ('FP8_E4M3','NVFP4A16')},
+            levers={},activation_max_abs={name:1. for name in weights})
+        del model, weights
+        ids = torch.arange(5*17).remainder(126).add(2).reshape(5,17)
+        observer.result.update(schema='prismaquant.layer_major_boundary_qualification.v1',
+            fixture=dict(layers=3,source_cache_slots=2,hidden=64,hc_mult=4,experts=4,
+                dtype='bfloat16',batches=5,sequence=17,probe_ids=[7000,7001,7002,7003],
+                kernels=kernels,token_sha256=tensor_digest(ids),candidates='synthetic source+0.03125'),
+            claims=dict(full_model_fit=False,full_model_throughput=False,fused_kernel_qualification=False),arms=[])
+        baseline = baseline_record = None
+        for index, order in enumerate(('batch_major','layer_major','layer_major','batch_major')):
+            print(f'BEGIN arm={index} capture={order}',flush=True)
+            payload, record = run_arm(source,cache,ids,args.evidence_out,index,order)
+            if baseline is None:
+                baseline, baseline_record = payload, record
+            else:
+                assert payload['costs'] == baseline['costs']
+                assert record['cotangents'] == baseline_record['cotangents']
+                for b in ids[:,0].tolist():
+                    assert [x for x in record['source_calls'] if x['batch']==b] == [x for x in baseline_record['source_calls'] if x['batch']==b]
+                for name, stats in payload['stats'].items():
+                    assert stats['h_trace'] == baseline['stats'][name]['h_trace']
+                    assert torch.equal(stats['fisher_col'],baseline['stats'][name]['fisher_col'])
+            record['exact_parity'] = True
+            observer.result['arms'].append(record)
+            (args.evidence_out/'progress.json').write_text(json.dumps(observer.result,indent=2)+'\n')
+            print(f'PASS arm={index} capture={order}',flush=True)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/prismaquant/aura_cost.py
+++ b/prismaquant/aura_cost.py
@@ -1907,11 +1907,12 @@ def compute_aura_cost_streamed(
     partitions with versioned global-row probes. Local signed terms and weight
     gradients sum across all partitions before squaring; full-vocabulary GPU
     tensors are bounded by the partition. By default CPU boundaries and shared
-    pass state cover the full calibration. Explicit ``boundary_storage`` v1
+    pass state cover the full calibration. Explicit ``boundary_storage`` v1/v2
     stores exact snapshots and rolling cotangents through the existing
     activation artifact owner, leases bounded resident input windows, and caps
-    metadata/shared-state residency. It preserves the original traversal and
-    scalar projection arithmetic; candidate/gradient and source traffic bounds
+    metadata/shared-state residency. V2 uses layer-major baseline capture with
+    the original per-batch source sequence; v1 preserves batch-major capture.
+    Both preserve scalar projection arithmetic; candidate/gradient bounds
     remain separate admission requirements. Checkpoints bind the execution partition
     because floating-point kernels may round differently with batch shape.
     The resident :func:`compute_aura_cost` path is deliberately unchanged.
@@ -2629,24 +2630,29 @@ def compute_aura_cost_streamed(
     batches = []
     if boundary_storage is not None:
         boundary_storage.watch_auxiliary(batches, [])
-    for batch_index, offset in enumerate(row_offsets):
-        available_gib = _free_gib()
-        if available_gib < min_free_gib:
-            raise RuntimeError(f"free UMA {available_gib:.1f} < floor {min_free_gib:.1f}; "
-                               f"abort before calibration row {offset}")
-        if boundary_storage is None:
-            batches.append(runner.capture_boundaries(calib_ids[offset:offset + batch_rows]))
-        else:
-            def write_boundary(depth, tensor):
-                return boundary_storage.write(tensor, batch_index=batch_index, boundary_index=depth)
+    if boundary_storage is not None and boundary_storage.config.get("capture_order") == "layer_major":
+        batches = runner.capture_layer_major_boundaries(
+            [calib_ids[offset:offset + batch_rows] for offset in row_offsets],
+            storage=boundary_storage)
+    else:
+        for batch_index, offset in enumerate(row_offsets):
+            available_gib = _free_gib()
+            if available_gib < min_free_gib:
+                raise RuntimeError(f"free UMA {available_gib:.1f} < floor {min_free_gib:.1f}; "
+                                   f"abort before calibration row {offset}")
+            if boundary_storage is None:
+                batches.append(runner.capture_boundaries(calib_ids[offset:offset + batch_rows]))
+            else:
+                def write_boundary(depth, tensor):
+                    return boundary_storage.write(tensor, batch_index=batch_index, boundary_index=depth)
 
-            def check_capture_state(current, state):
-                boundary_storage.check_auxiliary([*batches, current], extra=(state,),
-                    shared_extra=state if current.shared_pass_state is None else ())
+                def check_capture_state(current, state):
+                    boundary_storage.check_auxiliary([*batches, current], extra=(state,),
+                        shared_extra=state if current.shared_pass_state is None else ())
 
-            batches.append(runner.capture_boundaries(calib_ids[offset:offset + batch_rows],
-                boundary_writer=write_boundary, resource_check=check_capture_state))
-            boundary_storage.check_auxiliary(batches)
+                batches.append(runner.capture_boundaries(calib_ids[offset:offset + batch_rows],
+                    boundary_writer=write_boundary, resource_check=check_capture_state))
+                boundary_storage.check_auxiliary(batches)
     _log(f"boundary capture done in {(time.time() - capture_started) / 60:.1f} "
          f"min; starting {n_probes}-probe tail cotangents")
     device = runner.device
@@ -3614,7 +3620,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         "routed experts need an empirical/hybrid expert-cost "
                         "path, not silent omission.")
     p.add_argument("--boundary-storage-config", default=None,
-                   help="Explicit v1 JSON policy for exact streamed boundary/cotangent "
+                   help="Explicit v1/v2 JSON policy for exact streamed boundary/cotangent "
                         "artifacts and bounded resident windows; streaming only, default off.")
     p.add_argument(
         "--include-routed-experts",

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -6,7 +6,7 @@ unload all go through the existing streaming-model machinery.
 """
 from __future__ import annotations
 
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 import hashlib
 import json
@@ -53,6 +53,7 @@ class StreamedForwardBoundaries:
 
 
 BOUNDARY_STORAGE_SCHEMA = "prismaquant.aura.boundary_storage.v1"
+LAYER_MAJOR_BOUNDARY_STORAGE_SCHEMA = "prismaquant.aura.boundary_storage.v2"
 
 
 def normalize_boundary_storage(config):
@@ -61,9 +62,17 @@ def normalize_boundary_storage(config):
         return None
     fields = {"schema", "directory", "max_resident_bytes", "max_auxiliary_bytes",
               "max_artifact_bytes", "prefetch_batches"}
-    if not isinstance(config, dict) or set(config) != fields or config.get("schema") != BOUNDARY_STORAGE_SCHEMA:
-        raise ValueError("exact boundary storage requires a complete v1 policy")
-    for key in fields - {"schema", "directory"}:
+    if not isinstance(config, dict):
+        raise ValueError("exact boundary storage requires a complete versioned policy")
+    if config.get("schema") == LAYER_MAJOR_BOUNDARY_STORAGE_SCHEMA:
+        fields.add("capture_order")
+        if config.get("capture_order") != "layer_major":
+            raise ValueError("exact boundary storage v2 requires layer_major capture_order")
+    elif config.get("schema") != BOUNDARY_STORAGE_SCHEMA:
+        raise ValueError("exact boundary storage requires a known policy schema")
+    if set(config) != fields:
+        raise ValueError("exact boundary storage requires a complete closed policy")
+    for key in fields - {"schema", "directory", "capture_order"}:
         if type(config[key]) is not int or config[key] <= 0:
             raise ValueError(f"exact boundary storage requires positive {key}")
     if not isinstance(config["directory"], str) or not config["directory"].strip():
@@ -149,7 +158,7 @@ class StreamedBoundaryArtifacts:
         if self.directory is None:
             return
         from .cost_stage_checkpoint import atomic_write_bytes
-        data = {"schema": BOUNDARY_STORAGE_SCHEMA, "session": self.session,
+        data = {"schema": self.config["schema"], "session": self.session,
                 "policy": self.identity, "status": self._status,
                 "working_artifacts_reusable": False, "telemetry": self.telemetry}
         atomic_write_bytes(self.directory / "generation.json",
@@ -676,63 +685,160 @@ class StreamedCausalLM:
     def shutdown(self) -> None:
         self.context.shutdown()
 
-    def visit_layer_batches(self, input_batches, visitor, *, output_consumer=None):
-        """Visit each resident layer over the original ordered microbatches.
+    def capture_layer_major_boundaries(self, input_batches, *, storage):
+        """Capture exact baseline boundaries through the existing layer visitor."""
+        if storage.config.get("capture_order") != "layer_major":
+            raise ValueError("layer-major boundary capture requires the explicit v2 policy")
+        input_batches = tuple(input_batches)
+        def visit(_layer, forward_batch):
+            for input_ids in input_batches:
+                forward_batch(input_ids)
+        return self.visit_layer_batches(input_batches, visit, boundary_storage=storage)
 
-        ``visitor(layer, forward_batch)`` may install collection hooks, drive
-        the ordinary sample loop through ``forward_batch``, and drain its
-        layer-owned results before returning. The callback must consume every
-        batch exactly once. Only each batch's current hidden state survives;
-        source residency remains owned by this runner's existing context.
-        Derived mask/position kwargs are rebuilt for one original batch at a
-        time through the same preparation path, then released. Masks, mHC adapters and one distinct pass-state per original batch are
-        the same as an ordinary streamed forward. Batches are never combined.
+    def visit_layer_batches(self, input_batches, visitor, *, output_consumer=None,
+                            boundary_storage=None):
+        """Visit one resident source layer over the original ordered batches.
+
+        The original visitor retains one current hidden tensor per batch. With
+        explicit v2 boundary storage, it instead leases exact input windows and
+        writes each original output through the existing activation owner. All
+        per-batch source kwargs/pass-state remain independent and unchanged.
+        The new path requires evaluation mode and observes Torch CPU plus this
+        runner's CUDA RNG state around preparation/source calls. RNG-consuming
+        sources refuse; this is not equivalence for arbitrary stateful models.
         """
         if self._pinned_layer is not None:
             raise RuntimeError("layer-batch traversal cannot start with a pinned layer")
-        states = []
-        with torch.no_grad():
-            for input_ids in input_batches:
-                ids, positions, hidden, embeddings, mask = self._prepare(input_ids)
-                states.append([ids, hidden, self.profile.new_forward_pass_state()])
-                del positions, embeddings, mask
-            if not states:
-                raise ValueError("layer-batch traversal requires calibration batches")
-            for depth in range(min(self.num_layers, self.prefetch_lookahead + 1)):
-                self.context.schedule_prefetch(depth)
-            for layer in range(self.num_layers):
-                self.context.install(layer, require_prefetched=self.require_prefetched_residency)
-                self.context.schedule_prefetch(layer + self.prefetch_lookahead)
-                next_batch = 0
+        exact = boundary_storage is not None
+        if exact:
+            if boundary_storage.config.get("capture_order") != "layer_major":
+                raise ValueError("layer visitor exact storage requires layer_major v2 policy")
+            if not self.require_prefetched_residency:
+                raise RuntimeError("layer-major capture requires prefetched source residency")
+            if any(module.training for module in self.model.modules()):
+                raise RuntimeError("layer-major capture requires evaluation mode")
+        states, batches = [], []
+        if exact:
+            boundary_storage.watch_auxiliary(batches, [])
 
-                def forward_batch(input_ids):
-                    nonlocal next_batch
-                    if next_batch >= len(states):
-                        raise RuntimeError("layer visitor repeated a calibration batch")
-                    ids, hidden, pass_state = states[next_batch]
-                    if not torch.equal(input_ids, ids):
-                        raise RuntimeError("layer visitor changed calibration batch order or tokens")
-                    # Recompute through the ordinary source preparation path:
-                    # position/mask values may depend on the original IDs or
-                    # embeddings. Retain no derived per-B1 tables across layers.
-                    _ids, positions, initial, embeddings, mask = self._prepare(ids)
-                    del initial
-                    batch = StreamedForwardBoundaries(_ids, positions, embeddings, mask, [], None)
-                    states[next_batch][1] = self._call(layer, hidden, batch=batch, pass_state=pass_state)
-                    next_batch += 1
+        def checked(function, *args, **kwargs):
+            if not exact:
+                return function(*args, **kwargs)
+            cpu_rng = torch.get_rng_state()
+            cuda_rng = torch.cuda.get_rng_state(self.device) if self.device.type == "cuda" else None
+            result = function(*args, **kwargs)
+            if (not torch.equal(cpu_rng, torch.get_rng_state()) or
+                    (cuda_rng is not None and not torch.equal(cuda_rng, torch.cuda.get_rng_state(self.device)))):
+                raise RuntimeError("layer-major capture observed source Torch RNG consumption")
+            return result
 
-                try:
-                    visitor(layer, forward_batch)
-                    if next_batch != len(states):
-                        raise RuntimeError("layer visitor omitted calibration batches")
-                finally:
-                    self.context.unload(layer)
-            if output_consumer is not None:
-                for index, (ids, hidden, _pass_state) in enumerate(states):
-                    _ids, positions, initial, embeddings, mask = self._prepare(ids)
-                    del initial
-                    batch = StreamedForwardBoundaries(_ids, positions, embeddings, mask, [], None)
-                    output_consumer(index, self.tail_logits(batch, hidden))
+        def check_state():
+            if exact:
+                boundary_storage.check_auxiliary(batches,
+                    extra=[state[2] for state in states],
+                    shared_extra=[state[2] for batch, state in zip(batches, states)
+                                  if batch.shared_pass_state is None])
+
+        scheduled = set()
+        def prefetch(layer):
+            if 0 <= layer < self.num_layers and layer not in scheduled:
+                self.context.schedule_prefetch(layer)
+                scheduled.add(layer)
+
+        try:
+            with torch.no_grad():
+                for batch_index, input_ids in enumerate(input_batches):
+                    check_state()
+                    ids, positions, hidden, embeddings, mask = checked(self._prepare, input_ids)
+                    pass_state = checked(self.profile.new_forward_pass_state)
+                    if exact:
+                        batch = StreamedForwardBoundaries(ids, positions, embeddings, mask, [], None)
+                        batches.append(batch)
+                        states.append([ids, None, pass_state])
+                        check_state()
+                        batch.activations_cpu.append(boundary_storage.write(hidden,
+                            batch_index=batch_index, boundary_index=0))
+                        del hidden, pass_state
+                    else:
+                        states.append([ids, hidden, pass_state])
+                    del positions, embeddings, mask
+                if not states:
+                    raise ValueError("layer-batch traversal requires calibration batches")
+                if exact:
+                    for depth in range(min(self.num_layers, max(1, self.prefetch_lookahead))):
+                        prefetch(depth)
+                else:
+                    for depth in range(min(self.num_layers, self.prefetch_lookahead + 1)):
+                        self.context.schedule_prefetch(depth)
+                for layer in range(self.num_layers):
+                    if exact:
+                        check_state()
+                        prefetch(layer)
+                        self.context.install(layer, require_prefetched=True, prefetch_following=False)
+                    else:
+                        self.context.install(layer, require_prefetched=self.require_prefetched_residency)
+                    try:
+                        if exact:
+                            prefetch(layer + self.prefetch_lookahead)
+                        else:
+                            self.context.schedule_prefetch(layer + self.prefetch_lookahead)
+                        next_batch = 0
+                        with prefetched_boundary_batches(boundary_storage, batches, layer) if exact else nullcontext() as resident:
+                            def forward_batch(input_ids):
+                                nonlocal next_batch
+                                if next_batch >= len(states):
+                                    raise RuntimeError("layer visitor repeated a calibration batch")
+                                ids, hidden, pass_state = states[next_batch]
+                                if not torch.equal(input_ids, ids):
+                                    raise RuntimeError("layer visitor changed calibration batch order or tokens")
+                                if exact:
+                                    index, batch, cpu_hidden, _unused = next(resident)
+                                    if index != next_batch:
+                                        raise RuntimeError("exact boundary window changed batch order")
+                                    hidden = cpu_hidden.to(device=self.device, dtype=self.dtype)
+                                else:
+                                    _ids, positions, initial, embeddings, mask = self._prepare(ids)
+                                    del initial
+                                    batch = StreamedForwardBoundaries(_ids, positions, embeddings, mask, [], None)
+                                try:
+                                    output = checked(self._call, layer, hidden, batch=batch, pass_state=pass_state)
+                                    if exact:
+                                        check_state()
+                                        batch.activations_cpu.append(boundary_storage.write(output,
+                                            batch_index=next_batch, boundary_index=layer + 1))
+                                    else:
+                                        states[next_batch][1] = output
+                                    next_batch += 1
+                                finally:
+                                    hidden = output = None
+                                    if exact:
+                                        cpu_hidden = None
+                            visitor(layer, forward_batch)
+                            if next_batch != len(states):
+                                raise RuntimeError("layer visitor omitted calibration batches")
+                    finally:
+                        self.context.unload(layer)
+                if exact:
+                    for batch, state in zip(batches, states):
+                        batch.shared_pass_state = checked(self.profile.capture_forward_pass_state, state[2])
+                        check_state()  # Charge the CPU capture and still-live original state together.
+                        state[2] = None
+                    check_state()
+                    if output_consumer is not None:
+                        with prefetched_boundary_batches(boundary_storage, batches, self.num_layers) as resident:
+                            for index, batch, cpu_hidden, _unused in resident:
+                                hidden = cpu_hidden.to(device=self.device, dtype=self.dtype)
+                                output_consumer(index, checked(self.tail_logits, batch, hidden))
+                                del hidden, cpu_hidden
+                    return batches
+                if output_consumer is not None:
+                    for index, (ids, hidden, _pass_state) in enumerate(states):
+                        _ids, positions, initial, embeddings, mask = self._prepare(ids)
+                        del initial
+                        batch = StreamedForwardBoundaries(_ids, positions, embeddings, mask, [], None)
+                        output_consumer(index, self.tail_logits(batch, hidden))
+        finally:
+            states.clear()
 
 
 def build_streamed_causal_lm(

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -789,7 +789,7 @@ class StreamedCausalLM:
                                 if next_batch >= len(states):
                                     raise RuntimeError("layer visitor repeated a calibration batch")
                                 ids, hidden, pass_state = states[next_batch]
-                                if not torch.equal(input_ids, ids):
+                                if not torch.equal(input_ids.to(device=ids.device), ids):
                                     raise RuntimeError("layer visitor changed calibration batch order or tokens")
                                 if exact:
                                     index, batch, cpu_hidden, _unused = next(resident)

--- a/prismaquant/sensitivity_probe.py
+++ b/prismaquant/sensitivity_probe.py
@@ -1834,6 +1834,34 @@ class SharedStateCotangents:
                     yield pos, item
 
     # -- diagnostics ------------------------------------------------------
+    def fork_for_replay(self, *, max_resident_bytes: int) -> "SharedStateCotangents":
+        """Fork completed adjoints for one disposable target replay.
+
+        The budget covers the fork's new compact tensor storages only; the
+        caller still owns and charges this original accumulator. ``graft``,
+        ``produced_roots`` and ``harvest`` may mutate the fork freely. Only a
+        final committed replay should use the original owner. No live graph,
+        mutable accumulator storage or diagnostic list crosses the fork.
+        """
+        if self._live or self._containers or self._live_ids:
+            raise RuntimeError("shared cotangent replay requires a quiescent owner")
+        if type(max_resident_bytes) is not int or max_resident_bytes < 0:
+            raise ValueError("shared cotangent replay requires a nonnegative tensor byte cap")
+        needed = sum(t.numel() * t.element_size() for t in self._acc.values())
+        if needed > max_resident_bytes:
+            raise RuntimeError("shared cotangent replay exceeds its tensor residency budget")
+        fork = type(self)(enabled=self.enabled)
+        try:
+            for slot, tensor in self._acc.items():
+                fork._acc[slot] = tensor.detach().clone(memory_format=torch.contiguous_format)
+            for name in ("n_grafted", "n_harvested", "n_seeded", "n_no_grad"):
+                setattr(fork, name, getattr(self, name))
+            fork.nondifferentiable = list(self.nondifferentiable)
+            return fork
+        except BaseException:
+            fork.release_resident_state()
+            raise
+
     def resident_tensors(self) -> tuple[torch.Tensor, ...]:
         """Expose retained shared adjoints for the streamed owner's byte cap.
 

--- a/tests/test_layer_major_boundary_capture.py
+++ b/tests/test_layer_major_boundary_capture.py
@@ -166,6 +166,20 @@ def test_v2_policy_is_closed_and_v1_default_cannot_change_order(tmp_path):
             normalize_boundary_storage(altered)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason='CUDA token-device regression')
+def test_original_cpu_tokens_compare_with_prepared_cuda_tokens(tmp_path):
+    _, context, runner, _ = fixture()
+    prepare = runner._prepare
+    def prepare_cuda_ids(ids):
+        prepared, positions, hidden, embeddings, mask = prepare(ids)
+        return prepared.cuda(), positions, hidden, embeddings, mask
+    runner._prepare = prepare_cuda_ids
+    with owner(tmp_path) as storage:
+        batches = runner.capture_layer_major_boundaries([draw()[0:1]], storage=storage)
+        assert len(batches) == 1
+    assert context.active == set()
+
+
 def test_actual_shared_state_profile_keeps_every_batch_and_shared_adjoint(tmp_path, monkeypatch):
     from test_streamed_boundary_artifacts import _shared_run
     seen = []

--- a/tests/test_layer_major_boundary_capture.py
+++ b/tests/test_layer_major_boundary_capture.py
@@ -1,0 +1,188 @@
+"""Layer-major baseline capture preserves each original source batch exactly."""
+import hashlib
+from pathlib import Path
+import pytest
+import torch
+
+from prismaquant import aura_cost
+from prismaquant.cost_streaming import (
+    LAYER_MAJOR_BOUNDARY_STORAGE_SCHEMA, StreamedBoundaryArtifacts,
+    normalize_boundary_storage,
+)
+from test_joint_aura_streamed import _fixture
+from test_streamed_boundary_artifacts import _policy
+from test_streamed_cost_checkpoints import _model_identity
+
+
+def policy(path, *, window=2, cap=None):
+    return {**_policy(path, window=window, cap=cap or (2*window+1)*256),
+            'schema': LAYER_MAJOR_BOUNDARY_STORAGE_SCHEMA, 'capture_order': 'layer_major'}
+
+
+def owner(path, **kwargs):
+    value = StreamedBoundaryArtifacts(policy(path, **kwargs))
+    value.bind({'fixture': 'layer-major-source'}, n_probes=4)
+    return value
+
+
+def fixture():
+    model, context, runner, cache = _fixture()
+    install = context.install
+    context.install = lambda layer, *, require_prefetched=False, prefetch_following=True: install(
+        layer, require_prefetched=require_prefetched)
+    runner.require_prefetched_residency = True
+    runner.prefetch_lookahead = 1
+    return model, context, runner, cache
+
+
+def draw():
+    return torch.tensor([[1,2,3,4], [4,3,2,1], [2,3,4,1], [3,4,1,2], [1,3,2,4]])
+
+
+def digest(tensor):
+    return hashlib.sha256(tensor.detach().cpu().contiguous().view(torch.uint8).numpy().tobytes()).hexdigest()
+
+
+def test_source_install_count_is_one_per_layer_for_the_full_draw(tmp_path):
+    _, context, runner, _ = fixture()
+    scheduled = []
+    context.schedule_prefetch = scheduled.append
+    with owner(tmp_path) as storage:
+        batches = runner.capture_layer_major_boundaries([row[None] for row in draw()], storage=storage)
+        assert len(batches) == 5
+        assert all(len(batch.activations_cpu) == runner.num_layers+1 for batch in batches)
+    assert context.install_calls == runner.num_layers
+    assert scheduled == list(range(runner.num_layers))
+    assert context.active == set()
+
+
+@pytest.mark.parametrize('window', [1, 2, 3])
+def test_per_batch_source_tensors_costs_and_cotangents_are_exact(tmp_path, monkeypatch, window):
+    written = []
+    original_write = StreamedBoundaryArtifacts.write
+    def write(self, tensor, **kwargs):
+        coordinates = tuple(kwargs.get(key) for key in ('probe_index','batch_index','boundary_index'))
+        written.append((coordinates, digest(tensor)))
+        return original_write(self, tensor, **kwargs)
+    monkeypatch.setattr(StreamedBoundaryArtifacts, 'write', write)
+    def run(layer_major):
+        written.clear()
+        _, context, runner, cache = fixture()
+        calls = []
+        source = runner._call
+        def call(layer, hidden, *, batch, pass_state):
+            before = digest(hidden)
+            output = source(layer, hidden, batch=batch, pass_state=pass_state)
+            calls.append((tuple(batch.input_ids.flatten().tolist()), layer,
+                          torch.is_grad_enabled(), before, digest(output)))
+            return output
+        runner._call = call
+        settings = policy(tmp_path/str(layer_major), window=window)
+        if not layer_major:
+            settings = _policy(tmp_path/'baseline', window=window, cap=(2*window+1)*256)
+        result = aura_cost.compute_aura_cost_streamed(runner, draw(),
+            ['FP8_DYNAMIC','NVFP4A16','BF16'], n_probes=4, probe_microbatch=1,
+            seed_base=7000, min_free_gib=0, production_cache=cache,
+            joint_activation=True, collect_col_energy=True,
+            model_identity=_model_identity('layer-major-source'), boundary_storage=settings)
+        assert context.active == set()
+        return result, calls, list(written), context.install_calls
+    before, old_calls, old_written, old_installs = run(False)
+    after, new_calls, new_written, new_installs = run(True)
+    assert before['costs'] == after['costs']
+    assert old_installs == 12 and new_installs == 4  # Capture plus unchanged reverse.
+    assert [x for x in old_calls if x[2]] == [x for x in new_calls if x[2]]
+    assert old_calls[:10] != new_calls[:10]  # Intentional global traversal change.
+    for row in map(tuple, draw().tolist()):
+        assert [x for x in old_calls if x[0] == row] == [x for x in new_calls if x[0] == row]
+    assert dict(old_written) == dict(new_written)
+    assert [x for x in old_written if x[0][0] is not None] == [x for x in new_written if x[0][0] is not None]
+    for name, stats in after['stats'].items():
+        assert stats['h_trace'] == before['stats'][name]['h_trace']
+        assert torch.equal(stats['fisher_col'], before['stats'][name]['fisher_col'])
+    assert after['provenance']['probe_identity'] == before['provenance']['probe_identity']
+
+
+@pytest.mark.parametrize('stage', ['prepare', 'forward', 'new_pass', 'capture_pass'])
+def test_layer_major_refuses_observed_torch_rng_consumption_and_cleans(tmp_path, stage):
+    _, context, runner, _ = fixture()
+    obj, name = {'prepare': (runner, '_prepare'), 'forward': (runner, '_call'),
+                 'new_pass': (runner.profile, 'new_forward_pass_state'),
+                 'capture_pass': (runner.profile, 'capture_forward_pass_state')}[stage]
+    original = getattr(obj, name)
+    def consuming(*args, **kwargs):
+        torch.rand(1)
+        return original(*args, **kwargs)
+    setattr(obj, name, consuming)
+    with pytest.raises(RuntimeError, match='RNG consumption'):
+        with owner(tmp_path) as storage:
+            runner.capture_layer_major_boundaries([draw()[0:1]], storage=storage)
+    assert context.active == set()
+    assert not list(tmp_path.rglob('*.pt'))
+
+
+@pytest.mark.parametrize('defect', ['training', 'nonresident', 'window_budget', 'corrupt'])
+def test_capture_refuses_invalid_execution_before_unchecked_forward(tmp_path, defect):
+    model, context, runner, _ = fixture()
+    storage = owner(tmp_path, cap=256 if defect == 'window_budget' else None)
+    if defect == 'training':
+        model.train()
+    if defect == 'nonresident':
+        runner.require_prefetched_residency = False
+    if defect == 'corrupt':
+        install = context.install
+        def corrupt(*args, **kwargs):
+            install(*args, **kwargs)
+            Path(next(iter(storage._references.values())).path).unlink()
+        context.install = corrupt
+    with pytest.raises((RuntimeError, FileNotFoundError)):
+        with storage:
+            runner.capture_layer_major_boundaries([row[None] for row in draw()], storage=storage)
+    assert context.active == set()
+    assert not list(tmp_path.rglob('*.pt'))
+
+
+@pytest.mark.parametrize('defect', ['missing', 'repeat', 'reorder'])
+def test_existing_visitor_checks_apply_to_exact_windows(tmp_path, defect):
+    _, context, runner, _ = fixture()
+    ids = [row[None] for row in draw()]
+    def visit(_layer, forward):
+        selected = ids[:-1] if defect == 'missing' else ids+ids[:1] if defect == 'repeat' else ids[::-1]
+        for batch in selected:
+            forward(batch)
+    with pytest.raises(RuntimeError, match='visitor'):
+        with owner(tmp_path) as storage:
+            runner.visit_layer_batches(ids, visit, boundary_storage=storage)
+    assert context.active == set()
+
+
+def test_v2_policy_is_closed_and_v1_default_cannot_change_order(tmp_path):
+    good = policy(tmp_path)
+    assert normalize_boundary_storage(good) == good
+    for altered in ({**good, 'capture_order': 'batch_major'},
+                    {key:value for key,value in good.items() if key != 'capture_order'},
+                    {**_policy(tmp_path), 'capture_order': 'layer_major'}):
+        with pytest.raises(ValueError):
+            normalize_boundary_storage(altered)
+
+
+def test_actual_shared_state_profile_keeps_every_batch_and_shared_adjoint(tmp_path, monkeypatch):
+    from test_streamed_boundary_artifacts import _shared_run
+    seen = []
+    original_write = StreamedBoundaryArtifacts.write
+    def write(self, tensor, **kwargs):
+        if kwargs.get('probe_index') is not None:
+            seen.append(((kwargs['probe_index'], kwargs['batch_index'], kwargs['boundary_index']), digest(tensor)))
+        return original_write(self, tensor, **kwargs)
+    monkeypatch.setattr(StreamedBoundaryArtifacts, 'write', write)
+    before = _shared_run(tmp_path/'before')
+    original = list(seen)
+    seen.clear()
+    after = _shared_run(tmp_path/'after', layer_major=True)
+    assert after['costs'] == before['costs']
+    assert seen == original
+    telemetry = after['provenance']['streamed_boundary_storage']['telemetry']
+    assert telemetry['peak_shared_cotangent_reservation_bytes'] > 0
+    with pytest.raises(RuntimeError, match='auxiliary/shared-state'):
+        _shared_run(tmp_path/'refused', layer_major=True, aux=1024)
+    assert not list(tmp_path.rglob('*.pt'))

--- a/tests/test_shared_cotangent_replay.py
+++ b/tests/test_shared_cotangent_replay.py
@@ -1,0 +1,76 @@
+"""Temporary target replay must never consume or mutate the original adjoints."""
+import pytest
+import torch
+
+from prismaquant.sensitivity_probe import SharedStateCotangents
+
+
+def accumulated():
+    parent = SharedStateCotangents()
+    state = parent.graft({'kv': {0: torch.ones(2, 3)}})
+    (state['kv'][0] * 3).sum().backward()
+    assert parent.harvest() == 1
+    return parent
+
+
+def test_replay_fork_cannot_consume_parent_producer_roots():
+    parent = accumulated()
+    child = parent.fork_for_replay(max_resident_bytes=24)
+    assert sum(t.untyped_storage().nbytes() for t in child.resident_tensors()) == 24
+    before = parent.resident_tensors()[0].clone()
+    assert child.resident_tensors()[0].data_ptr() != parent.resident_tensors()[0].data_ptr()
+    state = child.graft({'kv': {}})
+    x = torch.ones(2, 3, requires_grad=True)
+    state['kv'][0] = 2 * x
+    roots, gradients = child.produced_roots()
+    torch.autograd.backward(roots, gradients)
+    child.harvest()
+    assert torch.equal(x.grad, torch.full_like(x, 6))
+    assert child.pending_keys() == []
+    assert parent.pending_keys() == [('kv', 0, None)]
+    assert torch.equal(parent.resident_tensors()[0], before)
+
+
+def test_replay_harvest_addition_and_cleanup_do_not_change_parent():
+    parent = accumulated()
+    child = parent.fork_for_replay(max_resident_bytes=24)
+    state = child.graft({'kv': {0: torch.ones(2, 3)}})
+    (state['kv'][0] * 5).sum().backward()
+    child.harvest()
+    assert torch.equal(child.resident_tensors()[0], torch.full((2, 3), 8.))
+    assert torch.equal(parent.resident_tensors()[0], torch.full((2, 3), 3.))
+    child.release_resident_state()
+    assert child.resident_tensors() == ()
+    assert parent.pending_keys() == [('kv', 0, None)]
+    assert parent.n_harvested == 1
+
+
+@pytest.mark.parametrize('enabled', [False, True])
+def test_empty_replay_fork_preserves_flags_without_diagnostic_aliases(enabled):
+    parent = SharedStateCotangents(enabled=enabled)
+    parent.nondifferentiable.append('existing diagnostic')
+    child = parent.fork_for_replay(max_resident_bytes=0)
+    assert child is not parent and child.enabled is enabled
+    assert child.resident_tensors() == ()
+    child.nondifferentiable.append('replay only')
+    assert parent.nondifferentiable == ['existing diagnostic']
+
+
+@pytest.mark.parametrize('live_field', ['_live', '_containers', '_live_ids'])
+def test_replay_refuses_each_nonquiescent_owner(live_field):
+    parent = accumulated()
+    getattr(parent, live_field).add(1) if live_field == '_live_ids' else getattr(parent, live_field).append(None)
+    with pytest.raises(RuntimeError, match='quiescent'):
+        parent.fork_for_replay(max_resident_bytes=24)
+
+
+def test_replay_cap_refuses_before_any_accumulator_clone(monkeypatch):
+    parent = accumulated()
+    original_clone = torch.Tensor.clone
+    def forbidden(tensor, *args, **kwargs):
+        pytest.fail('over-budget replay allocated before refusing')
+    monkeypatch.setattr(torch.Tensor, 'clone', forbidden)
+    with pytest.raises(RuntimeError, match='residency'):
+        parent.fork_for_replay(max_resident_bytes=23)
+    monkeypatch.setattr(torch.Tensor, 'clone', original_clone)
+    assert torch.equal(parent.resident_tensors()[0], torch.full((2, 3), 3.))

--- a/tests/test_streamed_boundary_artifacts.py
+++ b/tests/test_streamed_boundary_artifacts.py
@@ -271,7 +271,7 @@ def test_rank_four_boundaries_keep_all_residual_streams_and_original_dtype(tmp_p
                 del restored
 
 
-def _shared_run(path, *, aux=1 << 20):
+def _shared_run(path, *, aux=1 << 20, layer_major=False):
     from types import SimpleNamespace
     from test_kv_cotangent_path import _ToyModel, SHARED_SPECS
     from test_streamed_cost_checkpoints import _FakeStreamingContext
@@ -285,6 +285,16 @@ def _shared_run(path, *, aux=1 << 20):
     model.lm_head = toy.lm_head
     context = _FakeStreamingContext(model)
     runner = StreamedCausalLM(context, Gemma4Profile())
+    storage_policy = None if path is None else _policy(path, cap=4096, aux=aux)
+    if layer_major:
+        from prismaquant.cost_streaming import LAYER_MAJOR_BOUNDARY_STORAGE_SCHEMA
+        model.eval()
+        runner.require_prefetched_residency = True
+        runner.prefetch_lookahead = 1
+        install = context.install
+        context.install = lambda layer, *, require_prefetched=False, prefetch_following=True: install(
+            layer, require_prefetched=require_prefetched)
+        storage_policy.update(schema=LAYER_MAJOR_BOUNDARY_STORAGE_SCHEMA, capture_order='layer_major')
     weights = {(name, "NVFP4A16"): module.weight.detach().clone() + 0.03125
                for name, module in model.named_modules()
                if isinstance(module, torch.nn.Linear) and ".layers." in name}
@@ -294,7 +304,7 @@ def _shared_run(path, *, aux=1 << 20):
         ["NVFP4A16", "BF16"], n_probes=4, probe_microbatch=1, seed_base=7000,
         min_free_gib=0, joint_activation=True, production_cache=cache,
         model_identity=_model_identity("shared-source"),
-        boundary_storage=None if path is None else _policy(path, cap=4096, aux=aux))
+        boundary_storage=storage_policy)
     return result
 
 


### PR DESCRIPTION
Closes #394.

Initial streamed AURA capture rereads source layers for every original calibration batch. Explicit boundary policy v2 (`capture_order: layer_major`) now extends the existing layer visitor: one source install per layer, original complete batches, verified exact input windows and immediate output artifacts. V1/default capture remains unchanged. Per-batch source state, probe coordinates, reverse traversal and scalar projection arithmetic are preserved. Evaluation mode, observed Torch RNG checks and auxiliary budgets guard the new mode.

The separate shared-cotangent commit adds quiescent bounded deep forks for disposable replay; reverse replay integration remains separate. Native validation also caught and fixed the existing visitor order check comparing original CPU IDs with prepared CUDA IDs. Architecture and runtime allocation docs describe the contracts.

Validation through PrismaBuild:
- The before-change regression failed with 10 source installs versus expected 2.
- Broader CPU gate: 122 passed, no skips, plus four module compile checks. Final targeted gate: 45 passed, one CUDA-only skip; the native rerun exercises that actual CUDA path.
- Genuine three-layer original-layout GLM ABBA with two source slots: source reads/installs 15, 3, 3, 15, an 80% reduction in capture source reads. All 33 target cost/statistic panels, 80 cotangents and per-batch source tensor hashes match exactly. Independent PB reads verified the four saved cost panels.
- Exact boundary residency stays capped at 43,520 bytes. V2 adds 130,560 logical activation input bytes during capture. All 100 artifact entries retire and hot-read misses remain zero.
- Paired capture Torch CPU/CUDA profiles, full-call cProfile, process I/O, both-host Netdata and audited CAS receipts are retained. Native scope peak was 3,069,296,640 bytes under an 8 GiB physical reservation; exit and cleanup verified.

[Full commands, measurements, failures and limitations](docs/measurements/layer-major-boundary-capture-2026-09-08.md). Native action `63dffca2d164ad8579af3f5859da734aa8e83a165281bd08586ba5abb2774190`; evidence under `/mnt/shared/tessera-measurements/glm-canonical-census-20260908/layer-major-boundary-native-02/` and `layer-major-boundary-implementation-01/`.

This remains opt-in. The small instrumented fixture establishes source-load reduction and exact semantics, with no full-model fit, production throughput, serving-format, work-per-joule or fused-kernel claim.
