### PR TITLE
Submit the campaign rows that fit instead of refusing them all

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,22 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `integrate/capture-followups-20260908`. Stamps
+As of: 2026-09-08 · `triage/dispatch-admissible-partition`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `triage/dispatch-admissible-partition`) for the
+campaign dispatcher's **admissible partition** (§4.10, the campaign fanout's
+rows-per-box paragraph; #391). The fit check was all-or-nothing: one row wider than the
+worker refused every row, so the GLM plan's 864-unit routed stacks, deriving
+124.783 GiB against a 104 GiB worker, blocked the 90 rows that fit beside
+them. `plan` now partitions on the same arithmetic: the manifest holds the
+admissible rows, `plan.json` keeps the whole layout with an `admissible` flag
+per row and an `inadmissible_rows` record carrying each declined row's derived
+demand, multiplier, box and reason, and only a plan with nothing admissible
+refuses. No demand is rewritten to fit, no placement moves: PrismaBuild still
+admits and places on the row's declared demand, and all that changed is which
+rows the dispatcher declines to submit. The merge's gap refusal is untouched,
+so a partitioned plan cannot become a merged scope table. Gates:
+`tests/test_tessera_campaign_fanout.py`, shown failing before the change.
 
 Re-stamped (2026-09-08, `integrate/capture-followups-20260908`) for Hessian
 writer refusal and completed-file page release (#395, #396). A tensor-bearing
@@ -8201,10 +8216,22 @@ the reference row, and two rows that carry different evidence for one
 PrismaBuild admits on the row's declared demand, so the only way to put more
 rows on a box is to make a row hold less; declaring a smaller demand than the
 row holds would reserve less than it uses. `plan --rows-per-box N` therefore
-*checks* rather than sets: it refuses when the spec declares a
-`box_memory_gb` that `N` widest rows do not fit, prints the arithmetic
-otherwise, and records `rows_per_box` and each row's `row_memory_gb` in the
-plan. The dominant term in a row's demand today is `_model_bytes` -- every row
+*checks* rather than sets, and what it decides is which rows the manifest
+holds. When the spec declares a `box_memory_gb`, a row is admissible while
+`row_memory_gb * N` fits that box, and `manifest.json` holds the admissible
+rows alone, so `submit` hands the fleet exactly them. A row that does not fit
+is **declined, not shrunk**: `plan.json` keeps every planned row under an
+explicit `admissible` flag, keeps `row_memory_gb` for all of them, and records
+the declined ones under `inadmissible_rows` with the derived demand, the
+per-box multiplier, the box and the reason, which the run also prints. A spec
+that declares no box budget admits every row and says the check was not made.
+Only a plan with **no** admissible row refuses, naming the widest demand and
+the box, and it writes no manifest. One over-wide row is a demand to report
+and work separately, not a reason to withhold the rows the fleet could already
+be running (#391). A partitioned plan is deliberately not mergeable: `merge`
+still requires every planned row's `cost.pkl`, so the rows that were never
+submitted refuse the merged scope table rather than quietly narrowing it. The
+dominant term in a row's demand today is `_model_bytes` -- every row
 loads the whole checkpoint, because the activations a unit is priced on come
 from a forward pass through the layers above it -- so that term, not the
 selection, is the concurrency ceiling. A quantum that held only its own units'

--- a/tests/test_tessera_campaign_fanout.py
+++ b/tests/test_tessera_campaign_fanout.py
@@ -509,17 +509,169 @@ def test_rows_per_box_is_checked_against_the_box_and_never_shrinks_a_demand():
 
     PrismaBuild admits on the row's declared demand, so the only way to make a
     box hold more rows is to make a row hold less. Declaring a smaller demand
-    than the row holds would reserve less than it uses.
+    than the row holds would reserve less than it uses. A row too wide for the
+    box is declined, and its demand travels with it unchanged.
     """
     import dispatch_tessera_campaign as dispatch
 
-    assert dispatch.require_rows_fit([40, 36], 2, 80) == 40
+    demands = {"row-0000": 40, "row-0001": 36}
+    assert dispatch.partition_rows_by_fit(demands, 2, 80) == (
+        ["row-0000", "row-0001"], [])
     # Unchecked rather than assumed when the spec declares no box.
-    assert dispatch.require_rows_fit([40], 4, None) == 40
+    assert dispatch.partition_rows_by_fit({"row-0000": 40}, 4, None) == (
+        ["row-0000"], [])
+    # The wide row is declined at its own demand, not shrunk to fit.
+    admissible, declined = dispatch.partition_rows_by_fit(demands, 2, 79)
+    assert admissible == ["row-0001"]
+    assert [record["row_id"] for record in declined] == ["row-0000"]
+    assert declined[0]["mem_gb"] == 40
+    assert declined[0]["rows_per_box"] == 2
+    assert declined[0]["box_memory_gb"] == 79
+    assert declined[0]["reason"]
+    # Nothing fits, so there is nothing to submit and the widest demand and the
+    # box are named the way they always were.
     with pytest.raises(RuntimeError, match="at most 2 of these rows"):
-        dispatch.require_rows_fit([40, 36], 3, 80)
+        dispatch.partition_rows_by_fit(demands, 3, 80)
     with pytest.raises(RuntimeError, match="at least 1"):
-        dispatch.require_rows_fit([40], 0, 80)
+        dispatch.partition_rows_by_fit({"row-0000": 40}, 0, 80)
+
+
+# ---------------------------------------------------------------------------
+# The admissible partition
+#
+# One row wider than the worker is a demand to report, not a reason to refuse
+# the rows that fit: on the GLM plan the routed stacks derive 124.783 GiB
+# against a 104 GiB box and used to block the 90 rows that fit with them
+# (RobTand/prismaquant#391).
+# ---------------------------------------------------------------------------
+
+#: Column counts whose derived demand is exact: ``in**2 * 4`` bytes of fp32
+#: Hessian is 1 GiB at 16384 and 64 GiB at 131072, and the retained scoring
+#: rows add the fraction that makes the ceiling 2 GB and 65 GB.
+_NARROW_COLUMNS = 16384
+_WIDE_COLUMNS = 131072
+
+
+def _partition_workspace(tmp_path, *, wide=True, box_memory_gb=104):
+    """A census whose last anchor group is far wider than the others."""
+    model = tmp_path / "model"
+    model.mkdir()
+    groups = {"u:wide": ["wide"]} if not wide else {
+        "u:a": ["a"], "u:b": ["b"], "u:c": ["c"], "u:wide": ["wide"]}
+    shapes = {name: [8, _NARROW_COLUMNS] for names in groups.values()
+              for name in names}
+    shapes["wide"] = [8, _WIDE_COLUMNS]
+    workspace = tmp_path / "campaign"
+    workspace.mkdir()
+    (workspace / "census.json").write_text(json.dumps({
+        "model": str(model), "anchor_groups": groups, "layer_stride": 1,
+        "unit_shapes": shapes}))
+    spec = tmp_path / "spec.json"
+    payload = {"model": str(model), "campaign_argv": [], "cwd": str(tmp_path),
+               "python": "python3", "env": {}, "headroom_gb": 0}
+    if box_memory_gb is not None:
+        payload["box_memory_gb"] = box_memory_gb
+    spec.write_text(json.dumps(payload))
+    return spec, workspace
+
+
+def _plan_args(spec, workspace, **overrides):
+    import types
+
+    args = dict(spec=spec, workspace=workspace, calibration_cache=None,
+                groups_per_row=1, rows_per_box=2, timeout_s=300,
+                stack_sample=None, stack_sample_seed=0, audit_rate=10,
+                probe=None, seed_checkpoint=None, seed_wire_dir=None)
+    args.update(overrides)
+    return types.SimpleNamespace(**args)
+
+
+def test_a_row_too_wide_for_the_box_is_declined_and_the_rest_are_planned(
+        tmp_path, capsys):
+    import dispatch_tessera_campaign as dispatch
+
+    spec, workspace = _partition_workspace(tmp_path)
+    assert dispatch.cmd_plan(_plan_args(spec, workspace)) == 0
+
+    # The manifest is what ``submit`` hands the fleet, so it holds the
+    # admissible rows and nothing else.
+    manifest = json.loads((workspace / "manifest.json").read_text())
+    assert [row["argv"][row["argv"].index("--units") + 1].split("/")[-1]
+            for row in manifest] == ["row-0000.json", "row-0001.json",
+                                     "row-0002.json"]
+    assert {row["demand"]["mem_gb"] for row in manifest} == {2}
+
+    plan = json.loads((workspace / "plan.json").read_text())
+    # The plan is what an auditor reads, so it keeps the whole layout: every
+    # planned row, admissible or not, with its own derived demand.
+    assert [entry["row_id"] for entry in plan["rows"]] == [
+        "row-0000", "row-0001", "row-0002", "row-0003"]
+    assert [entry["admissible"] for entry in plan["rows"]] == [
+        True, True, True, False]
+    assert plan["row_memory_gb"] == {"row-0000": 2, "row-0001": 2,
+                                     "row-0002": 2, "row-0003": 65}
+    declined = plan["inadmissible_rows"]
+    assert [record["row_id"] for record in declined] == ["row-0003"]
+    # The demand is recorded as derived, never rewritten to fit the box.
+    assert declined[0]["mem_gb"] == 65
+    assert declined[0]["rows_per_box"] == 2
+    assert declined[0]["box_memory_gb"] == 104
+    assert declined[0]["members"] == ["wide"]
+    assert declined[0]["reason"]
+
+    out = capsys.readouterr().out
+    assert "3 of 4 rows are admissible" in out
+    assert "1 declined" in out
+    assert "row-0003" in out and "65" in out and "104" in out
+
+
+def test_a_plan_whose_every_row_is_too_wide_refuses(tmp_path):
+    import dispatch_tessera_campaign as dispatch
+
+    spec, workspace = _partition_workspace(tmp_path, wide=False)
+    with pytest.raises(RuntimeError, match="65 GB"):
+        dispatch.cmd_plan(_plan_args(spec, workspace))
+    # Nothing to submit means nothing was written to submit.
+    assert not (workspace / "manifest.json").exists()
+
+
+def test_a_spec_with_no_box_budget_keeps_every_row(tmp_path, capsys):
+    import dispatch_tessera_campaign as dispatch
+
+    spec, workspace = _partition_workspace(tmp_path, box_memory_gb=None)
+    assert dispatch.cmd_plan(_plan_args(spec, workspace)) == 0
+    manifest = json.loads((workspace / "manifest.json").read_text())
+    assert len(manifest) == 4
+    plan = json.loads((workspace / "plan.json").read_text())
+    assert all(entry["admissible"] for entry in plan["rows"])
+    assert plan["inadmissible_rows"] == []
+    assert "the spec declares no box budget, so this is unchecked" in \
+        capsys.readouterr().out
+
+
+def test_submit_hands_the_fleet_the_admissible_rows_only(tmp_path, monkeypatch):
+    import types
+
+    import dispatch_tessera_campaign as dispatch
+
+    spec, workspace = _partition_workspace(tmp_path)
+    assert dispatch.cmd_plan(_plan_args(spec, workspace)) == 0
+
+    seen: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        seen.append(list(command))
+        return types.SimpleNamespace(returncode=0, stdout="")
+
+    monkeypatch.setattr(dispatch.subprocess, "run", fake_run)
+    args = types.SimpleNamespace(workspace=workspace, wait_s=1)
+    assert dispatch.cmd_submit(args) == 0
+
+    assert len(seen) == 1
+    submitted = json.loads(pathlib.Path(seen[0][-1]).read_text())
+    assert [row["argv"][row["argv"].index("--units") + 1].split("/")[-1]
+            for row in submitted] == ["row-0000.json", "row-0001.json",
+                                      "row-0002.json"]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -193,29 +193,54 @@ def _streamed_resource_plan(spec, census, members, *, selected_source=False):
         capture_policy=argument('--streaming-capture-policy', 'legacy', str))
 
 
-def require_rows_fit(mem_gb: "list[int]", per_box: int, budget) -> int:
-    """Check that a box can hold ``per_box`` of these rows, and say so.
+def partition_rows_by_fit(row_memory_gb: "dict[str, int]", per_box: int,
+                          budget) -> "tuple[list[str], list[dict]]":
+    """Split the planned rows into the ones a box holds and the ones it does not.
 
     Concurrency is a property of the row's demand, not a flag: PrismaBuild
     admits as many rows as a box's memory holds.  So this checks rather than
     sets -- shrinking a row's declared demand to force co-residency would be
-    reserving less than the row holds.  Returns the widest demand.
+    reserving less than the row holds.
+
+    A row wider than the box is **declined**, not a reason to refuse the
+    campaign.  The rows that fit are work the fleet can do now, and the ones
+    that do not are a demand to report at the width it was derived at, while
+    the limit they name is worked separately.  Returns the admissible row ids
+    in plan order and one record per declined row.  A plan with nothing
+    admissible refuses: there is no campaign to submit.
     """
     if per_box < 1:
         raise RuntimeError("--rows-per-box must be at least 1")
-    widest = max(mem_gb)
-    if budget is not None and widest * per_box > int(budget):
-        raise RuntimeError(
-            f"--rows-per-box {per_box} does not fit: the widest row demands "
-            f"{widest} GB and the spec declares a {int(budget)} GB box, so at "
-            f"most {int(budget) // widest} of these rows are co-resident. "
-            "Reduce --groups-per-row, or make the quantum hold less than the "
-            "whole checkpoint.")
+    widest = max(row_memory_gb.values())
     print(f"[dispatch] widest row demands {widest} GB; "
           f"--rows-per-box {per_box} needs {widest * per_box} GB per box"
           + (f" (spec declares {int(budget)} GB)" if budget is not None else
              " (the spec declares no box budget, so this is unchecked)"))
-    return widest
+    admissible: list[str] = []
+    declined: list[dict] = []
+    for row_id, mem_gb in row_memory_gb.items():
+        if budget is None or int(mem_gb) * per_box <= int(budget):
+            admissible.append(row_id)
+            continue
+        declined.append({
+            "row_id": row_id, "mem_gb": int(mem_gb), "rows_per_box": per_box,
+            "box_memory_gb": int(budget),
+            "reason": (f"demands {int(mem_gb)} GB, and --rows-per-box "
+                       f"{per_box} needs {int(mem_gb) * per_box} GB, over the "
+                       f"{int(budget)} GB box the spec declares"),
+        })
+    if not admissible:
+        raise RuntimeError(
+            f"--rows-per-box {per_box} fits no planned row: the widest row "
+            f"demands {widest} GB and the spec declares a {int(budget)} GB "
+            f"box, so at most {int(budget) // widest} of these rows are "
+            "co-resident. Reduce --groups-per-row, or make the quantum hold "
+            "less than the whole checkpoint.")
+    print(f"[dispatch] {len(admissible)} of {len(row_memory_gb)} rows are "
+          f"admissible, {len(declined)} declined")
+    for record in declined:
+        print(f"[dispatch]   {record['row_id']} {record['reason']}")
+    return admissible, declined
 
 
 def _row(spec: dict, argv: list[str], *, mem_gb: int, timeout_s: int,
@@ -561,12 +586,25 @@ def cmd_plan(args) -> int:
 
     # PB alone admits and places these independently retryable rows according
     # to their actual source/capture preparation and resident encoding demand.
+    # All this decides is which rows it is handed: a row too wide for the box
+    # is declined here rather than submitted for an admission that cannot
+    # come, and the rest of the plan goes on being work.
     per_box = int(args.rows_per_box)
-    require_rows_fit([int(row["demand"]["mem_gb"]) for row in rows],
-                     per_box, spec.get("box_memory_gb"))
+    row_memory_gb = {entry["row_id"]: int(row["demand"]["mem_gb"])
+                     for entry, row in zip(planned, rows)}
+    admissible, inadmissible = partition_rows_by_fit(
+        row_memory_gb, per_box, spec.get("box_memory_gb"))
+    members_by_row = {entry["row_id"]: entry["members"] for entry in planned}
+    for record in inadmissible:
+        record["members"] = members_by_row[record["row_id"]]
+    admitted = set(admissible)
+    for entry in planned:
+        entry["admissible"] = entry["row_id"] in admitted
 
     manifest = workspace / "manifest.json"
-    manifest.write_text(json.dumps(rows, indent=2) + "\n")
+    manifest.write_text(json.dumps(
+        [row for entry, row in zip(planned, rows) if entry["admissible"]],
+        indent=2) + "\n")
     plan = {
         "schema": PLAN_SCHEMA,
         "model": spec["model"],
@@ -575,9 +613,11 @@ def cmd_plan(args) -> int:
         "manifest": str(manifest),
         "groups_per_row": int(args.groups_per_row),
         "rows_per_box": per_box,
-        "row_memory_gb": {row_id: int(row["demand"]["mem_gb"])
-                          for row_id, row in zip(
-                              (entry["row_id"] for entry in planned), rows)},
+        "row_memory_gb": row_memory_gb,
+        # The rows the manifest does not hold, at the demand they were derived
+        # at. A reader of the plan sees the whole layout; a reader of the
+        # manifest sees only what was submitted.
+        "inadmissible_rows": inadmissible,
         "seed_checkpoint": (None if not args.seed_checkpoint
                             else str(args.seed_checkpoint)),
         # The draw itself, whole: which experts stand for their stack, under
@@ -595,8 +635,8 @@ def cmd_plan(args) -> int:
         "rows": planned,
     }
     (workspace / "plan.json").write_text(json.dumps(plan, indent=2) + "\n")
-    print(f"[dispatch] planned {len(rows)} rows over {len(ordered)} anchor groups "
-          f"-> {manifest}")
+    print(f"[dispatch] planned {len(rows)} rows over {len(ordered)} anchor "
+          f"groups, {len(admissible)} submitted -> {manifest}")
     return 0
 
 
@@ -1209,8 +1249,10 @@ def main(argv=None) -> int:
                            "places on the demand, and shrinking it to force "
                            "co-residency would be reserving less than the row "
                            "holds. It is checked against the spec's "
-                           "'box_memory_gb', when the spec declares one, and "
-                           "recorded in the plan.")
+                           "'box_memory_gb', when the spec declares one: a row "
+                           "that does not fit is left out of the manifest and "
+                           "recorded in the plan, and only a plan with no "
+                           "admissible row at all refuses.")
     plan.add_argument("--timeout-s", type=int, default=14400)
     plan.add_argument("--stack-sample", type=int, default=None,
                       help="price each routed stack from this many experts "


### PR DESCRIPTION
Closes #391.

## What changes

`tools/dispatch_tessera_campaign.py` `plan` no longer refuses the whole campaign when one row is wider than the box. `partition_rows_by_fit` (`tools/dispatch_tessera_campaign.py:196`) splits the planned rows on the same arithmetic the old check used: a row is admissible while `row_memory_gb * rows_per_box` fits the spec's `box_memory_gb`. The manifest holds the admissible rows alone, so `submit` hands the fleet exactly them and is otherwise untouched. `plan.json` keeps every planned row under an explicit `admissible` flag, keeps `row_memory_gb` for all of them, and records the declined rows under `inadmissible_rows` with the derived demand, the per-box multiplier, the box and the reason. The run prints the partition, one line per declined row. Only a plan with no admissible row refuses, naming the widest demand and the box, and it writes no manifest.

No demand is rewritten to fit and no placement moves. PrismaBuild still admits and places on the row's declared demand; all that changed is which rows the dispatcher declines to submit. The merge's gap refusal is untouched: `merge` still requires every planned row's `cost.pkl`, so a partitioned plan cannot become a merged scope table by omission. On the current GLM plan this frees the 90 rows that fit while the 864-unit routed stacks (124.783 GiB derived against a 104 GiB worker) are worked separately under #377 and #379.

`docs/ARCHITECTURE.md` §4.10 states the rule, what the manifest holds, what `plan.json` records, and the zero-admissible refusal; the stamp block is updated.

## Tests

`tests/test_tessera_campaign_fanout.py`: a plan with one over-wide row writes a manifest of the fitting rows and records the declined row; a plan where every row is too wide refuses and writes no manifest; a spec with no box budget keeps every row; `submit` on the partitioned manifest submits the admissible rows only; the never-shrinks-a-demand test is kept and now exercises the partition.

## Receipts (PrismaBuild, priority -10, no GPU)

RED at 4fcd8450b7 (tests only), 4 failed / 34 passed on both tags, identical failure set:
- x86 dl380g10 rc=1 `a7dbca9839fc2bed520c1ef50ae1e4b7a518c51ef278b89029adc0fcb4690a76`
- sparklina rc=1 `d7bbd0aa04229ed6bdaa50efd45dff7d4d99193b40cb724f52a13d9ff8a21a57`

GREEN at b29950184e, all done rc=0:
- x86 dl380g10: fanout 38 passed `a4c8cca6e13fa154a39c2f2ac994eabcae77afbab5e1010ea4c2f202620e382f`; container `a5df6024ed4ecc5a0e44970876bc7cc3093a7a9001fcd85ae5a2fc060c88f83b`; architecture_doc `6d5eb20f9f2f1aa5fe938f6353ee434c5a5abc73452b396674e1cb3eba5cb750`; docs_staleness `d724c9d82f1af2845e1e2e84c85e06f9c0747b484e85666f154b1c7e45b0e897`
- sparklina: fanout 38 passed `318760255e2c6c0091ff5d955129318152b0ea9db177464345920bf2565cea94`; container `6a3922d2ca91d4472269ae48657ad412fd7c796be2e83e6b40e635516e5c4bb1`; architecture_doc `52aa651559b2323102447a917594ac478dccfc8fa4fdee1846f93b1ad31a73f1`; docs_staleness `94ba0a45f59f0bf98c48739e4abb9c024e94c7c36967a05af362353c2ea86674`

The one other `cmd_plan` caller, `tests/test_tessera_stack_driver_integration.py`, plans with no `box_memory_gb`, so every row stays admissible; its x86 receipt is in the first comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsJAfuLU26NWbYpSLrWFHJ
