### PR TITLE
Byte-verify only the shards a selected-source row reads

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,8 +23,15 @@ row refuses when the roster is missing, a read shard is not on disk or not
 sealed, a read shard's bytes differ from the roster, or an on-disk shard is
 neither read nor sealed. The roster is absent whenever the census declares no
 packed expert projection (`expert_projection` is `null` for a dense-only
-model), so a dense-only streamed selected row refuses until its census carries
-a producer source roster. What each row verified is stamped into its payload,
+model); a dense-only selected row then has nothing to inherit and falls back
+to hashing the whole source root exactly as the canonical capture did, stamped
+`mode="full-root"`, `roster_present=false` (the roster path stamps
+`mode="roster-inherit"`, `roster_present=true`). Inheriting is attested only
+by identity equality with the canonical manifest, so the roster path refuses
+when that manifest is not pinned by `calibration_cache_sha256`. Bound on the
+real GLM-5.3-Flash census: the fixed state spans 2 of 120 shards (9.5 GB,
+shards 00001 and 00120), so a typical row reads 5 shards / 25.6 GB of the
+642.7 GB source instead of hashing all of it. What each row verified is stamped into its payload,
 not its identity: `selected_source_preparation.source_verification` lists
 `byte_verified`, `inherited_from_census_roster`, `byte_verified_auxiliary`,
 `roster_origin`, `canonical_manifest_sha256`, `selected_layers`,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,43 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `integrate/capture-followups-20260908`. Stamps
+As of: 2026-09-08 · `triage/selected-row-shard-identity`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `triage/selected-row-shard-identity`) for selected
+rows that byte-verify only the shards they read (#388). A selected-source row
+(`--streaming` with `--units`) still recomputes the capture identity against
+the current source, but `tessera_campaign.prepare_selected_source` now passes
+`verify_shards` to `tessera_calibration_cache.capture_identity_with_verification`:
+every small file (`*.json`, `*.model`, `*.txt`, and whatever the roster seals
+that is not a shard) is hashed, and only the shards in the row's read set are
+read. The read set is `StreamedCausalLM.selected_source_shards`: every shard
+holding any tensor of a layer that holds a selected unit (whole-layer install)
+plus every shard holding a tensor outside the decoder layers, which the
+streamed model materialises at construction. `selected_source_read_set`
+cross-checks that set, tensor by tensor, against the census-sealed
+`expert_projection.producer.source.tensors` map and refuses on disagreement.
+Every other on-disk shard inherits its digest from `source.files`, so the
+identity equals the canonical manifest's; that equality remains the row's
+attestation, because the canonical capture byte-verified those digests. The
+row refuses when the roster is missing, a read shard is not on disk or not
+sealed, a read shard's bytes differ from the roster, or an on-disk shard is
+neither read nor sealed. The roster is absent whenever the census declares no
+packed expert projection (`expert_projection` is `null` for a dense-only
+model), so a dense-only streamed selected row refuses until its census carries
+a producer source roster. What each row verified is stamped into its payload,
+not its identity: `selected_source_preparation.source_verification` lists
+`byte_verified`, `inherited_from_census_roster`, `byte_verified_auxiliary`,
+`roster_origin`, `canonical_manifest_sha256`, `selected_layers`,
+`layer_shards` and `fixed_state_shards`. Unset `verify_shards` (the canonical
+capture, `tessera_materialization`, `tessera_joint_aura`) hashes exactly the
+previous file set and returns the same dict. Gates:
+`tests/test_selected_source_shard_identity.py` (default-path file set,
+inheritance, every refusal), `tests/test_selected_source_glm_row.py` (an
+instrumented selected row on a re-sharded tiny glm5_next checkpoint reads
+tensor data only from byte-verified shards; the same row hashed all three
+shards before this change), `tests/test_tessera_selected_source.py`. This
+establishes no at-scale measurement; the GLM before/after NFS read profile is
+a separate follow-up.
 
 Re-stamped (2026-09-08, `integrate/capture-followups-20260908`) for Hessian
 writer refusal and completed-file page release (#395, #396). A tensor-bearing
@@ -210,7 +246,9 @@ Re-stamped (2026-09-08, `fix/selected-source-anchors`) for selected Tessera
 anchor preparation from a complete canonical capture (#370). `--streaming`
 with `--units` requires the capture manifest and its expected SHA-256. Scope,
 geometry, calibration draw, runtime, initialization witness and current source
-hashes remain bound to the full census. The initialization witness describes
+hashes remain bound to the full census (since #388 a row byte-verifies only the
+shards it reads and inherits the rest from the sealed roster; see the
+`triage/selected-row-shard-identity` stamp). The initialization witness describes
 the historical capture; sparse preparation does not certify a new full-source
 forward. `StreamedCausalLM.snapshot_selected_weights` uses the existing layer
 cache and a finite selected-layer prefetch sequence, requires resident delivery,

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -420,6 +420,47 @@ class StreamedCausalLM:
             )
         return layer
 
+    def selected_source_shards(self, names):
+        """Shard basenames a selected-source row reads for ``names``.
+
+        Whole layers install through the StreamingContext, so the set holds
+        every shard carrying any tensor of a layer that holds a selected unit,
+        plus every shard carrying a tensor outside the decoder layers (embed,
+        final norm, lm_head, visual tower, ...) which the streamed model
+        materialises at construction. Derived from the runner's own weight map;
+        ``tensors`` maps each checkpoint tensor name in the read set to its
+        shard so the caller can cross-check the census-sealed roster.
+        """
+        names = tuple(names)
+        if not names or len(set(names)) != len(names):
+            raise ValueError("selected source requires unique nonempty unit names")
+        layers = sorted({self.layer_index_for_qname(name) for name in names})
+        wanted = set(layers)
+        pattern = re.compile(rf"^{re.escape(self.layers_prefix)}([0-9]+)\.")
+        layer_tensors: dict[int, dict[str, str]] = {layer: {} for layer in layers}
+        fixed_tensors: dict[str, str] = {}
+        for model_key, path in self.context.weight_shard.items():
+            checkpoint_key = self.context.weight_ckpt[model_key]
+            shard = Path(path).name
+            match = pattern.match(model_key)
+            if match is None:
+                fixed_tensors[checkpoint_key] = shard
+            elif int(match.group(1)) in wanted:
+                layer_tensors[int(match.group(1))][checkpoint_key] = shard
+        for layer in layers:
+            if not layer_tensors[layer]:
+                raise RuntimeError(f"no source tensors for selected layer {layer}")
+        tensors = dict(fixed_tensors)
+        for layer in layers:
+            tensors.update(layer_tensors[layer])
+        if len(tensors) != len(fixed_tensors) + sum(len(t) for t in layer_tensors.values()):
+            raise RuntimeError("selected source checkpoint tensor names collide across shards")
+        return dict(layers=layers,
+                    layer_shards=sorted({shard for per_layer in layer_tensors.values()
+                                         for shard in per_layer.values()}),
+                    fixed_state_shards=sorted(set(fixed_tensors.values())),
+                    tensors=tensors)
+
     def snapshot_selected_weights(self, names, *, max_resident_bytes: int,
                                   resource_check=None):
         """Copy selected source Linears from the existing resident layer cache.

--- a/prismaquant/tessera_calibration_cache.py
+++ b/prismaquant/tessera_calibration_cache.py
@@ -59,10 +59,41 @@ def _json(path, value):
                                               allow_nan=False) + '\n').encode())
 
 
+ROSTER_ORIGIN = 'expert_projection.producer.source'
+
+
 def capture_identity(census_path, *, calibration, max_act_rows,
                      model_load_contract, attention_implementation,
-                     resource_check=None, release_read_pages=False):
-    """Hash source bytes on every invocation; mtimes never authorize reuse."""
+                     resource_check=None, release_read_pages=False,
+                     verify_shards=None):
+    """Hash source bytes on every invocation; mtimes never authorize reuse.
+
+    ``verify_shards`` is opt-in for a selected-source row: see
+    :func:`capture_identity_with_verification`. Unset, every globbed file is
+    hashed and the returned identity is the canonical one.
+    """
+    return capture_identity_with_verification(census_path, calibration=calibration,
+        max_act_rows=max_act_rows, model_load_contract=model_load_contract,
+        attention_implementation=attention_implementation, resource_check=resource_check,
+        release_read_pages=release_read_pages, verify_shards=verify_shards)[0]
+
+
+def capture_identity_with_verification(census_path, *, calibration, max_act_rows,
+                                       model_load_contract, attention_implementation,
+                                       resource_check=None, release_read_pages=False,
+                                       verify_shards=None):
+    """Return ``(identity, verification)``; ``verification`` is None unless opted in.
+
+    With ``verify_shards`` set, every small file (``*.json``, ``*.model``,
+    ``*.txt`` and whatever the roster seals that is not a shard) is still
+    hashed, but only the named safetensors shards are read. Every other shard
+    on disk takes its digest from the census-sealed producer roster
+    ``expert_projection.producer.source.files`` so the identity equals the
+    canonical capture's; the caller's comparison against the canonical manifest
+    is what attests those inherited digests. It refuses when the roster is
+    missing, a named shard is not on disk or not sealed, a named shard's bytes
+    differ from the roster, or an on-disk shard is neither read nor sealed.
+    """
     import importlib.metadata
     import torch
     census_path = Path(census_path)
@@ -83,14 +114,43 @@ def capture_identity(census_path, *, calibration, max_act_rows,
                     *root.glob('*.model'), *root.glob('*.txt')})
     if not files or not (root / 'config.json').is_file():
         raise RuntimeError('calibration capture needs a complete local source checkpoint')
+    hashed = []
     def source_digest(path):
+        hashed.append(Path(path).name)
         return sha256(path, resource_check=resource_check, release_read_pages=release_read_pages)
-    source = {p.name:source_digest(p) for p in files if p.is_file()}
     # The census already seals the producer's complete source/auxiliary
     # roster (including non-JSON tokenizer assets such as chat_template.jinja).
     # Check those bytes too, without inventing another producer identity.
     producer = (census.get('expert_projection') or {}).get('producer') or {}
     declared = producer.get('source') or {}
+    verification = None
+    if verify_shards is None:
+        source = {p.name:source_digest(p) for p in files if p.is_file()}
+    else:
+        verify = {str(name) for name in verify_shards}
+        roster = declared.get('files')
+        if not isinstance(roster, dict) or not roster:
+            raise RuntimeError('selected source verification needs the census producer shard roster')
+        on_disk = {p.name for p in files if p.is_file() and p.name.endswith('.safetensors')}
+        missing = sorted(verify - on_disk)
+        if missing:
+            raise RuntimeError(f'selected source shards are not on disk: {missing[:8]}')
+        unsealed = sorted(verify - set(roster))
+        if unsealed:
+            raise RuntimeError('selected source shards are absent from the census producer '
+                               f'roster: {unsealed[:8]}')
+        orphaned = sorted(on_disk - verify - set(roster))
+        if orphaned:
+            raise RuntimeError('source shards are neither read nor sealed by the census '
+                               f'producer roster: {orphaned[:8]}')
+        source = {}
+        for p in files:
+            if not p.is_file():
+                continue
+            if p.name.endswith('.safetensors') and p.name not in verify:
+                source[p.name] = roster[p.name]
+            else:
+                source[p.name] = source_digest(p)
     expected = {**declared.get('files',{}),**declared.get('auxiliary_sha256',{})}
     if declared.get('config_sha256'):
         expected['config.json'] = declared['config_sha256']
@@ -100,12 +160,19 @@ def capture_identity(census_path, *, calibration, max_act_rows,
             raise RuntimeError(f'calibration source differs from census producer: {name}')
     if not any(name.endswith('.safetensors') for name in source):
         raise RuntimeError('calibration capture source has no safetensors weights')
-    return dict(schema=SCHEMA, model_load_contract=contract,
+    if verify_shards is not None:
+        verification = dict(byte_verified=sorted(verify),
+            inherited_from_census_roster=sorted(on_disk - verify),
+            byte_verified_auxiliary=sorted(name for name in set(hashed)
+                                           if not name.endswith('.safetensors')),
+            roster_origin=ROSTER_ORIGIN)
+    identity = dict(schema=SCHEMA, model_load_contract=contract,
                 attention_implementation=attention_implementation,
                 census_sha256=sha256(census_path),capture_runtime=runtime,
                 source_files=source, calibration=dict(calibration),
                 max_act_rows=int(max_act_rows), storage_source=SOURCE,
                 units={name:list(shape) for name,shape in sorted(census['unit_shapes'].items())})
+    return identity, verification
 
 
 def _validate_tensors(name, payload, census, max_rows):

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -3674,6 +3674,40 @@ def _run_streamed_calibration(args, runner, profile, *, mode, population,
     return 0
 
 
+def prepare_selected_source(runner, targets, *, census_path, calibration,
+                            max_act_rows, model_load_contract,
+                            attention_implementation, calibration_cache,
+                            calibration_cache_sha256, selected_resources,
+                            resource_check=None):
+    """Bind a selected-source row to the canonical capture and copy its weights.
+
+    Returns ``(capture_identity, selected_weights, selected_source_preparation)``.
+    The identity is recomputed against the current source bytes and must equal
+    the pinned canonical manifest's identity before any selected layer installs.
+    ``runner`` is shut down once the selected weights are copied.
+    """
+    from . import tessera_calibration_cache as calibration_store
+    capture_identity = calibration_store.capture_identity(
+        census_path, calibration=calibration,
+        max_act_rows=max_act_rows, model_load_contract=model_load_contract,
+        attention_implementation=attention_implementation,
+        resource_check=resource_check, release_read_pages=True)
+    manifest = calibration_store.require_capture_contract(calibration_cache,
+        expected_sha256=calibration_cache_sha256)
+    if manifest['identity'] != capture_identity:
+        raise RuntimeError('selected source capture identity differs from the canonical census')
+    try:
+        selected_weights, selected_source_preparation = runner.snapshot_selected_weights(
+            targets, max_resident_bytes=selected_resources['selected_source_weight_bytes'],
+            resource_check=resource_check)
+    finally:
+        runner.shutdown()
+    selected_source_preparation.update(resources=selected_resources,
+        initialization_witness_origin='complete-canonical-capture',
+        full_source_initialization_repeated=False)
+    return capture_identity, selected_weights, selected_source_preparation
+
+
 def main(argv: "Sequence[str] | None" = None) -> int:
     import torch
 
@@ -4056,26 +4090,22 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             model=str(args.model), seed=int(args.seed), nsamples=int(args.nsamples),
             seqlen=int(args.seqlen), fit_tokens_min=lo)
         require_census_draw(census, bound_calibration, where="calibration capture")
-        capture_identity = calibration_store.capture_identity(
-            args.calibration_census, calibration=bound_calibration,
-            max_act_rows=args.max_act_rows, model_load_contract=model_load_contract,
-            attention_implementation=attention_implementation,
-            **(dict(resource_check=None if selected_guard is None else selected_guard.check,
-                    release_read_pages=True) if selected_source else {}))
+        if selected_source:
+            capture_identity, selected_weights, selected_source_preparation = (
+                prepare_selected_source(runner, targets,
+                    census_path=args.calibration_census, calibration=bound_calibration,
+                    max_act_rows=args.max_act_rows, model_load_contract=model_load_contract,
+                    attention_implementation=attention_implementation,
+                    calibration_cache=args.calibration_cache,
+                    calibration_cache_sha256=args.calibration_cache_sha256,
+                    selected_resources=selected_resources,
+                    resource_check=None if selected_guard is None else selected_guard.check))
+        else:
+            capture_identity = calibration_store.capture_identity(
+                args.calibration_census, calibration=bound_calibration,
+                max_act_rows=args.max_act_rows, model_load_contract=model_load_contract,
+                attention_implementation=attention_implementation)
     if selected_source:
-        manifest = calibration_store.require_capture_contract(args.calibration_cache,
-            expected_sha256=args.calibration_cache_sha256)
-        if manifest['identity'] != capture_identity:
-            raise RuntimeError('selected source capture identity differs from the canonical census')
-        try:
-            selected_weights, selected_source_preparation = runner.snapshot_selected_weights(
-                targets, max_resident_bytes=selected_resources['selected_source_weight_bytes'],
-                resource_check=None if selected_guard is None else selected_guard.check)
-        finally:
-            runner.shutdown()
-        selected_source_preparation.update(resources=selected_resources,
-            initialization_witness_origin='complete-canonical-capture',
-            full_source_initialization_repeated=False)
         # Release fixed non-body state and the source context before selected
         # H/X become resident. Packed members now reference only meta tensors.
         del model, runner

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -3702,7 +3702,7 @@ def selected_source_read_set(runner, targets, *, census):
     return derived
 
 
-def prepare_selected_source(runner, targets, *, census_path, calibration,
+def prepare_selected_source(runner, targets, *, census, census_path, calibration,
                             max_act_rows, model_load_contract,
                             attention_implementation, calibration_cache,
                             calibration_cache_sha256, selected_resources,
@@ -3710,26 +3710,56 @@ def prepare_selected_source(runner, targets, *, census_path, calibration,
     """Bind a selected-source row to the canonical capture and copy its weights.
 
     Returns ``(capture_identity, selected_weights, selected_source_preparation)``.
-    The row byte-verifies only the shards it reads (#388): the selected layers'
-    shards and the fixed-state shards, derived by :func:`selected_source_read_set`.
-    Every other shard's digest is inherited from the census-sealed roster, and
-    the recomputed identity must still equal the pinned canonical manifest's
-    identity before any selected layer installs; that equality is the
-    attestation that the canonical capture byte-verified the inherited digests.
-    ``selected_source_preparation['source_verification']`` records what this row
-    verified and what it inherited. ``runner`` is shut down once the selected
-    weights are copied.
+    ``census`` is the already-parsed census dict and ``census_path`` its file,
+    which the identity hashes. The row's verification mode follows the census:
+
+    * ``roster-inherit`` when the census seals a producer source roster
+      (``expert_projection.producer.source``): the row byte-verifies only the
+      shards it reads (#388), the selected layers' shards and the fixed-state
+      shards, derived by :func:`selected_source_read_set`. Every other shard's
+      digest is inherited from the roster, so the recomputed identity must equal
+      the canonical manifest's identity before any selected layer installs, and
+      that manifest must be hash-pinned (``calibration_cache_sha256``): identity
+      equality with the pinned manifest is the only attestation of the inherited
+      digests, so an unpinned manifest refuses.
+    * ``full-root`` when the census seals no roster (dense-only models declare
+      no packed expert projection): nothing can be inherited, so the row hashes
+      the whole source root exactly as the canonical capture did.
+
+    ``selected_source_preparation['source_verification']`` records the mode and
+    what this row verified or inherited. ``runner`` is shut down once the
+    selected weights are copied.
     """
     from . import tessera_calibration_cache as calibration_store
-    census = json.loads(Path(census_path).read_text())
-    read_set = selected_source_read_set(runner, targets, census=census)
-    verify_shards = frozenset(read_set['layer_shards']) | frozenset(read_set['fixed_state_shards'])
-    capture_identity, verification = calibration_store.capture_identity_with_verification(
-        census_path, calibration=calibration,
-        max_act_rows=max_act_rows, model_load_contract=model_load_contract,
-        attention_implementation=attention_implementation,
-        resource_check=resource_check, release_read_pages=True,
-        verify_shards=verify_shards)
+    source = ((census.get('expert_projection') or {}).get('producer') or {}).get('source') or {}
+    roster_present = bool(isinstance(source.get('files'), Mapping) and source['files'] and
+                          isinstance(source.get('tensors'), Mapping) and source['tensors'])
+    if roster_present:
+        if calibration_cache_sha256 is None:
+            raise RuntimeError('selected source inherits shard digests from the census roster; '
+                               'the canonical capture manifest must be pinned by sha256')
+        read_set = selected_source_read_set(runner, targets, census=census)
+        verify_shards = frozenset(read_set['layer_shards']) | frozenset(read_set['fixed_state_shards'])
+        capture_identity, verification = calibration_store.capture_identity_with_verification(
+            census_path, calibration=calibration,
+            max_act_rows=max_act_rows, model_load_contract=model_load_contract,
+            attention_implementation=attention_implementation,
+            resource_check=resource_check, release_read_pages=True,
+            verify_shards=verify_shards)
+        verification = dict(mode='roster-inherit', roster_present=True, **verification)
+    else:
+        read_set = runner.selected_source_shards(targets)
+        capture_identity = calibration_store.capture_identity(
+            census_path, calibration=calibration,
+            max_act_rows=max_act_rows, model_load_contract=model_load_contract,
+            attention_implementation=attention_implementation,
+            resource_check=resource_check, release_read_pages=True)
+        hashed = sorted(capture_identity['source_files'])
+        verification = dict(mode='full-root', roster_present=False,
+            byte_verified=[name for name in hashed if name.endswith('.safetensors')],
+            inherited_from_census_roster=[],
+            byte_verified_auxiliary=[name for name in hashed if not name.endswith('.safetensors')],
+            roster_origin=SELECTED_SOURCE_ROSTER_ORIGIN)
     manifest = calibration_store.require_capture_contract(calibration_cache,
         expected_sha256=calibration_cache_sha256)
     if manifest['identity'] != capture_identity:
@@ -4134,7 +4164,7 @@ def main(argv: "Sequence[str] | None" = None) -> int:
         require_census_draw(census, bound_calibration, where="calibration capture")
         if selected_source:
             capture_identity, selected_weights, selected_source_preparation = (
-                prepare_selected_source(runner, targets,
+                prepare_selected_source(runner, targets, census=census,
                     census_path=args.calibration_census, calibration=bound_calibration,
                     max_act_rows=args.max_act_rows, model_load_contract=model_load_contract,
                     attention_implementation=attention_implementation,

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -3674,6 +3674,34 @@ def _run_streamed_calibration(args, runner, profile, *, mode, population,
     return 0
 
 
+SELECTED_SOURCE_ROSTER_ORIGIN = 'expert_projection.producer.source'
+
+
+def selected_source_read_set(runner, targets, *, census):
+    """The shards a selected row reads, cross-checked against the sealed roster.
+
+    The runner derives the set from its own weight map (whole selected layers
+    plus the fixed state materialised at construction). Every tensor in that
+    set must map to the same shard in the census-sealed
+    ``expert_projection.producer.source.tensors`` roster, and every shard must
+    be sealed in ``source.files``; any disagreement refuses before a byte is
+    hashed or installed.
+    """
+    derived = runner.selected_source_shards(targets)
+    source = ((census.get('expert_projection') or {}).get('producer') or {}).get('source') or {}
+    sealed_tensors, sealed_files = source.get('tensors'), source.get('files')
+    if not isinstance(sealed_tensors, Mapping) or not sealed_tensors or \
+            not isinstance(sealed_files, Mapping) or not sealed_files:
+        raise RuntimeError('selected source requires the census-sealed producer source roster')
+    for tensor, shard in sorted(derived['tensors'].items()):
+        if sealed_tensors.get(tensor) != shard:
+            raise RuntimeError('selected source shard index disagrees with the census '
+                               f'producer roster: {tensor} -> {shard}')
+        if shard not in sealed_files:
+            raise RuntimeError(f'selected source shard is not sealed by the census producer roster: {shard}')
+    return derived
+
+
 def prepare_selected_source(runner, targets, *, census_path, calibration,
                             max_act_rows, model_load_contract,
                             attention_implementation, calibration_cache,
@@ -3682,16 +3710,26 @@ def prepare_selected_source(runner, targets, *, census_path, calibration,
     """Bind a selected-source row to the canonical capture and copy its weights.
 
     Returns ``(capture_identity, selected_weights, selected_source_preparation)``.
-    The identity is recomputed against the current source bytes and must equal
-    the pinned canonical manifest's identity before any selected layer installs.
-    ``runner`` is shut down once the selected weights are copied.
+    The row byte-verifies only the shards it reads (#388): the selected layers'
+    shards and the fixed-state shards, derived by :func:`selected_source_read_set`.
+    Every other shard's digest is inherited from the census-sealed roster, and
+    the recomputed identity must still equal the pinned canonical manifest's
+    identity before any selected layer installs; that equality is the
+    attestation that the canonical capture byte-verified the inherited digests.
+    ``selected_source_preparation['source_verification']`` records what this row
+    verified and what it inherited. ``runner`` is shut down once the selected
+    weights are copied.
     """
     from . import tessera_calibration_cache as calibration_store
-    capture_identity = calibration_store.capture_identity(
+    census = json.loads(Path(census_path).read_text())
+    read_set = selected_source_read_set(runner, targets, census=census)
+    verify_shards = frozenset(read_set['layer_shards']) | frozenset(read_set['fixed_state_shards'])
+    capture_identity, verification = calibration_store.capture_identity_with_verification(
         census_path, calibration=calibration,
         max_act_rows=max_act_rows, model_load_contract=model_load_contract,
         attention_implementation=attention_implementation,
-        resource_check=resource_check, release_read_pages=True)
+        resource_check=resource_check, release_read_pages=True,
+        verify_shards=verify_shards)
     manifest = calibration_store.require_capture_contract(calibration_cache,
         expected_sha256=calibration_cache_sha256)
     if manifest['identity'] != capture_identity:
@@ -3704,7 +3742,11 @@ def prepare_selected_source(runner, targets, *, census_path, calibration,
         runner.shutdown()
     selected_source_preparation.update(resources=selected_resources,
         initialization_witness_origin='complete-canonical-capture',
-        full_source_initialization_repeated=False)
+        full_source_initialization_repeated=False,
+        source_verification=dict(verification,
+            canonical_manifest_sha256=calibration_cache_sha256,
+            selected_layers=read_set['layers'], layer_shards=read_set['layer_shards'],
+            fixed_state_shards=read_set['fixed_state_shards']))
     return capture_identity, selected_weights, selected_source_preparation
 
 

--- a/tests/test_selected_source_glm_row.py
+++ b/tests/test_selected_source_glm_row.py
@@ -142,7 +142,7 @@ def test_selected_glm_row_byte_verifies_only_the_shards_it_reads(tmp_path, monke
         attn_implementation='eager')
     events.append(('row', 'prepare_selected_source', None))
     identity, weights, preparation = campaign.prepare_selected_source(runner, targets,
-        census_path=census_path, calibration=calibration, max_act_rows=4,
+        census=census, census_path=census_path, calibration=calibration, max_act_rows=4,
         model_load_contract=contract, attention_implementation='eager',
         calibration_cache=record['path'], calibration_cache_sha256=record['sha256'],
         selected_resources=resources)
@@ -169,6 +169,7 @@ def test_selected_glm_row_byte_verifies_only_the_shards_it_reads(tmp_path, monke
         f'expected only {sorted([layer1, fixed])}')
     assert sum(hashed.values()) == sum((source/name).stat().st_size for name in (layer1, fixed))
     assert preparation['source_verification'] == dict(
+        mode='roster-inherit', roster_present=True,
         byte_verified=[layer1, fixed], inherited_from_census_roster=[layer0],
         byte_verified_auxiliary=sorted(name for name in identity['source_files']
                                        if not name.endswith('.safetensors')),

--- a/tests/test_selected_source_glm_row.py
+++ b/tests/test_selected_source_glm_row.py
@@ -1,0 +1,177 @@
+"""An instrumented selected GLM row reads only shards it byte-verified (#388).
+
+The tiny glm5_next checkpoint is re-sharded into one shard per decoder layer
+plus one shard of fixed state (embeddings, final norm, lm_head, visual tower).
+A row that selects a layer-1 unit must hash the layer-1 shard and the fixed
+shard, inherit the layer-0 digest from the census roster, reproduce the
+canonical identity, and read tensor data only from shards it hashed.
+"""
+import json
+import re
+from pathlib import Path
+
+import pytest
+import torch
+
+from test_glm5_next_streamed_forward_parity import (  # noqa: F401  (autouse shim)
+    _build_tiny_model, _torch_only_causal_conv1d,
+)
+from test_glm_campaign_streaming import write_original_layout_checkpoint
+from test_selected_source_shard_identity import (
+    ROSTER_ORIGIN, producer_roster, runtime, streaming_contract,
+)
+from prismaquant import tessera_calibration_cache as cc
+from prismaquant import tessera_campaign as campaign
+from prismaquant.autoscale import selected_anchor_resources
+from prismaquant.cost_streaming import build_streamed_causal_lm
+from prismaquant.model_profiles.glm5_next import Glm5NextProfile
+
+LAYERS_PREFIX = 'model.language_model.layers.'
+
+
+def reshard_checkpoint(source, *, layers_prefix, num_layers):
+    """Split `model.safetensors` into one shard per layer plus one fixed shard."""
+    from safetensors import safe_open
+    from safetensors.torch import save_file
+    single = source/'model.safetensors'
+    pattern = re.compile(rf'^{re.escape(layers_prefix)}(\d+)\.')
+    total = num_layers+1
+    groups = {}
+    with safe_open(str(single), framework='pt') as handle:
+        for key in handle.keys():
+            match = pattern.match(key)
+            index = int(match.group(1))+1 if match else total
+            shard = f'model-{index:05d}-of-{total:05d}.safetensors'
+            groups.setdefault(shard, {})[key] = handle.get_tensor(key)
+    single.unlink()
+    weight_map = {}
+    for shard, tensors in groups.items():
+        save_file(tensors, str(source/shard), metadata={'format': 'pt'})
+        weight_map.update({key: shard for key in tensors})
+    (source/'model.safetensors.index.json').write_text(
+        json.dumps(dict(metadata={}, weight_map=weight_map), indent=1, sort_keys=True))
+    return weight_map
+
+
+def instrument(monkeypatch, source):
+    """Log ('hash'|'open'|'read', file, bytes-or-tensor) for files under `source`."""
+    import safetensors
+    from prismaquant import layer_streaming, streaming_model
+    events = []
+    root = source.resolve()
+    real_open = safetensors.safe_open
+
+    class Handle:
+        def __init__(self, inner, shard):
+            self._inner, self._shard = inner, shard
+        def __enter__(self):
+            self._inner.__enter__()
+            return self
+        def __exit__(self, *exc):
+            return self._inner.__exit__(*exc)
+        def get_tensor(self, name):
+            events.append(('read', self._shard, name))
+            return self._inner.get_tensor(name)
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    def opened(path, *args, **kwargs):
+        resolved = Path(path).resolve()
+        inner = real_open(path, *args, **kwargs)
+        if resolved.parent != root:
+            return inner
+        events.append(('open', resolved.name, None))
+        return Handle(inner, resolved.name)
+
+    for module in (safetensors, layer_streaming, streaming_model):
+        monkeypatch.setattr(module, 'safe_open', opened)
+    real_sha256 = cc.sha256
+    def hashed(path, **kwargs):
+        digest = real_sha256(path, **kwargs)
+        events.append(('hash', Path(path).name, Path(path).stat().st_size))
+        return digest
+    monkeypatch.setattr(cc, 'sha256', hashed)
+    return events
+
+
+def test_selected_glm_row_byte_verifies_only_the_shards_it_reads(tmp_path, monkeypatch):
+    monkeypatch.setenv('PRISMAQUANT_TMPDIR', str(tmp_path/'staging'))
+    source = tmp_path/'source'
+    model = _build_tiny_model()
+    write_original_layout_checkpoint(model, source)
+    num_layers = len(model.model.language_model.layers)
+    assert num_layers == 2
+    weight_map = reshard_checkpoint(source, layers_prefix=LAYERS_PREFIX, num_layers=num_layers)
+    layer0, layer1, fixed = sorted(set(weight_map.values()))
+    modules = dict(model.named_modules())
+    def linear_in(layer):
+        return next(name for name, module in modules.items()
+                    if isinstance(module, torch.nn.Linear) and
+                    name.startswith(f'{LAYERS_PREFIX}{layer}.'))
+    units = [linear_in(0), linear_in(1)]
+    targets = [units[1]]
+    unit_shapes = {name: list(modules[name].weight.shape) for name in units}
+    counts = {name: 9 for name in units}
+    max_abs = {name: 1.0 for name in units}
+    contract = streaming_contract(layers_prefix=LAYERS_PREFIX, num_layers=num_layers,
+                                  model_class=type(model).__name__)
+    census = dict(model=str(source), model_load_contract=contract, capture_runtime=runtime(),
+        attention_implementation='eager', unit_shapes=unit_shapes, counts=counts,
+        max_abs=max_abs,
+        expert_projection=dict(producer=dict(source=producer_roster(source, weight_map))))
+    census_path = tmp_path/'census.json'
+    census_path.write_text(json.dumps(census))
+    calibration = {'fit_ids_sha256': 'draw'}
+    canonical = cc.capture_identity(census_path, calibration=calibration, max_act_rows=4,
+        model_load_contract=contract, attention_implementation='eager')
+    record = cc.publish_capture(tmp_path/'capture', census_path=census_path, identity=canonical,
+        acts={name: torch.zeros(4, unit_shapes[name][1]) for name in units},
+        hessians={name: torch.eye(unit_shapes[name][1]) for name in units},
+        counts=counts, maxima=max_abs)
+    del model, modules
+
+    events = instrument(monkeypatch, source)
+    resources = selected_anchor_resources(source,
+        unit_shapes={name: unit_shapes[name] for name in targets}, counts=counts,
+        max_act_rows=4, cache_slots=2, prefetch_workers=1, headroom_gb=0)
+    runner = build_streamed_causal_lm(str(source), device=torch.device('cpu'),
+        dtype=torch.bfloat16, offload_folder=str(tmp_path/'selected-offload'),
+        profile=Glm5NextProfile(), max_cache_slots=2, prefetch_workers=1,
+        prefetch_min_available_gb=0, cache_headroom_gb=0,
+        prefetch_lookahead=1, require_prefetched_residency=True,
+        attn_implementation='eager')
+    events.append(('row', 'prepare_selected_source', None))
+    identity, weights, preparation = campaign.prepare_selected_source(runner, targets,
+        census_path=census_path, calibration=calibration, max_act_rows=4,
+        model_load_contract=contract, attention_implementation='eager',
+        calibration_cache=record['path'], calibration_cache_sha256=record['sha256'],
+        selected_resources=resources)
+
+    assert identity == canonical
+    assert set(weights) == set(targets)
+    hashed = {name: size for kind, name, size in events
+              if kind == 'hash' and name.endswith('.safetensors')}
+    read = {name for kind, name, _ in events if kind == 'read'}
+    print(f'[#388 fixture] hashed {sum(hashed.values())} shard bytes across '
+          f'{sorted(hashed)}; tensor data read from {sorted(read)}', flush=True)
+    # The whole-layer install of layer 1 plus the fixed state the streamed
+    # model materialises at construction: exactly the layer-1 and fixed shards.
+    assert read == {layer1, fixed}
+    assert read <= set(hashed), 'a shard was read without being byte-verified'
+    start = events.index(('row', 'prepare_selected_source', None))
+    for position, (kind, name, _) in enumerate(events):
+        if kind == 'read' and position > start:
+            assert any(kind_ == 'hash' and name_ == name
+                       for kind_, name_, _ in events[start:position]), (
+                f'{name} was read by the row before it was byte-verified')
+    assert set(hashed) == {layer1, fixed}, (
+        f'row hashed {sum(hashed.values())} shard bytes: {dict(sorted(hashed.items()))}; '
+        f'expected only {sorted([layer1, fixed])}')
+    assert sum(hashed.values()) == sum((source/name).stat().st_size for name in (layer1, fixed))
+    assert preparation['source_verification'] == dict(
+        byte_verified=[layer1, fixed], inherited_from_census_roster=[layer0],
+        byte_verified_auxiliary=sorted(name for name in identity['source_files']
+                                       if not name.endswith('.safetensors')),
+        roster_origin=ROSTER_ORIGIN, canonical_manifest_sha256=record['sha256'],
+        selected_layers=[1], layer_shards=[layer1], fixed_state_shards=[fixed])
+    assert preparation['initialization_witness_origin'] == 'complete-canonical-capture'

--- a/tests/test_selected_source_shard_identity.py
+++ b/tests/test_selected_source_shard_identity.py
@@ -189,3 +189,85 @@ def test_verify_shards_refuses_without_a_sealed_roster(sharded_source):
         identity_with_verification(path, census, verify_shards={SHARDS[1]})
     # The default path is unchanged by the missing roster: it still hashes everything.
     assert set(identity(path, census)['source_files']) == {*SHARDS, *GLOBBED_SMALL}
+
+
+def fake_runner(targets, *, tensors):
+    """A runner whose read set is layer 1 plus the fixed-state shard."""
+    from types import SimpleNamespace
+    calls = []
+    read_set = dict(layers=[1], layer_shards=[SHARDS[1]], fixed_state_shards=[SHARDS[2]],
+        tensors={k: v for k, v in tensors.items() if k != 'model.layers.0.proj.weight'})
+    return SimpleNamespace(calls=calls,
+        selected_source_shards=lambda names: read_set,
+        snapshot_selected_weights=lambda names, **kw: ({name: None for name in names},
+            dict(schema='prismaquant.selected_source_weights.v1', source_forward_count=0)),
+        shutdown=lambda: calls.append('shutdown')), read_set
+
+
+def canonical_manifest(tmp_path, path, census):
+    import torch
+    canonical = identity(path, census)
+    units = sorted(census['counts'])
+    return canonical, cc.publish_capture(tmp_path/'capture', census_path=path, identity=canonical,
+        acts={name: torch.zeros(2, census['unit_shapes'][name][1]) for name in units},
+        hessians={name: torch.eye(census['unit_shapes'][name][1]) for name in units},
+        counts=census['counts'], maxima=census['max_abs'])
+
+
+def prepare(runner, path, census, record, **extra):
+    from prismaquant import tessera_campaign as campaign
+    kwargs = dict(census=census, census_path=path, calibration={'fit_ids_sha256': 'draw'},
+        max_act_rows=2, model_load_contract=census['model_load_contract'],
+        attention_implementation='eager', calibration_cache=record['path'],
+        calibration_cache_sha256=record['sha256'],
+        selected_resources=dict(selected_source_weight_bytes=1))
+    return campaign.prepare_selected_source(runner, ['model.layers.1.proj'], **(kwargs | extra))
+
+
+def test_prepare_selected_source_stamps_roster_inherit_when_the_census_seals_a_roster(
+        sharded_source, tmp_path, monkeypatch):
+    source, path, census = sharded_source
+    canonical, record = canonical_manifest(tmp_path, path, census)
+    tensors = census['expert_projection']['producer']['source']['tensors']
+    runner, read_set = fake_runner(['model.layers.1.proj'], tensors=tensors)
+    log = HashLog(monkeypatch)
+    result, _weights, preparation = prepare(runner, path, census, record)
+    assert result == canonical and runner.calls == ['shutdown']
+    assert [n for n in log.names() if n.endswith('.safetensors')] == [SHARDS[1], SHARDS[2]]
+    assert preparation['source_verification'] == dict(mode='roster-inherit', roster_present=True,
+        byte_verified=[SHARDS[1], SHARDS[2]], inherited_from_census_roster=[SHARDS[0]],
+        byte_verified_auxiliary=sorted(SMALL), roster_origin=ROSTER_ORIGIN,
+        canonical_manifest_sha256=record['sha256'], selected_layers=[1],
+        layer_shards=[SHARDS[1]], fixed_state_shards=[SHARDS[2]])
+
+
+def test_prepare_selected_source_refuses_to_inherit_from_an_unpinned_manifest(
+        sharded_source, tmp_path, monkeypatch):
+    source, path, census = sharded_source
+    _canonical, record = canonical_manifest(tmp_path, path, census)
+    tensors = census['expert_projection']['producer']['source']['tensors']
+    runner, _read_set = fake_runner(['model.layers.1.proj'], tensors=tensors)
+    log = HashLog(monkeypatch)
+    with pytest.raises(RuntimeError, match='must be pinned by sha256'):
+        prepare(runner, path, census, record, calibration_cache_sha256=None)
+    assert log.events == [] and runner.calls == []
+
+
+def test_prepare_selected_source_hashes_the_full_root_without_a_roster(
+        sharded_source, tmp_path, monkeypatch):
+    """Dense-only censuses seal no roster: nothing to inherit, so hash every shard."""
+    source, path, census = sharded_source
+    tensors = census['expert_projection']['producer']['source']['tensors']
+    census = rewrite_census(path, census, lambda c: c.update(expert_projection=None))
+    canonical, record = canonical_manifest(tmp_path, path, census)
+    runner, _read_set = fake_runner(['model.layers.1.proj'], tensors=tensors)
+    log = HashLog(monkeypatch)
+    result, _weights, preparation = prepare(runner, path, census, record)
+    assert result == canonical
+    assert [n for n in log.names() if n.endswith('.safetensors')] == list(SHARDS)
+    assert log.shard_bytes() == sum((source/name).stat().st_size for name in SHARDS)
+    assert preparation['source_verification'] == dict(mode='full-root', roster_present=False,
+        byte_verified=list(SHARDS), inherited_from_census_roster=[],
+        byte_verified_auxiliary=list(GLOBBED_SMALL), roster_origin=ROSTER_ORIGIN,
+        canonical_manifest_sha256=record['sha256'], selected_layers=[1],
+        layer_shards=[SHARDS[1]], fixed_state_shards=[SHARDS[2]])

--- a/tests/test_selected_source_shard_identity.py
+++ b/tests/test_selected_source_shard_identity.py
@@ -1,0 +1,191 @@
+"""Selected-source rows byte-verify only the shards they read (#388).
+
+`capture_identity` hashes every source file it globs and returns the digests
+inside the identity, so a selected row that never installs most layers still
+re-hashed the whole checkpoint. With `verify_shards` set, the row hashes every
+small file and only the named shards; every other on-disk shard inherits its
+digest from the census-sealed producer roster, and the identity must still equal
+the canonical capture's. Whatever cannot be inherited or checked refuses.
+"""
+import hashlib
+import importlib.metadata
+import json
+from pathlib import Path
+
+import pytest
+
+from prismaquant import tessera_calibration_cache as cc
+
+SHARDS = ('model-00001-of-00003.safetensors', 'model-00002-of-00003.safetensors',
+          'model-00003-of-00003.safetensors')
+SMALL = ('chat_template.jinja', 'config.json', 'notes.txt', 'tokenizer.json',
+         'tokenizer.model')
+GLOBBED_SMALL = ('config.json', 'notes.txt', 'tokenizer.json', 'tokenizer.model')
+ROSTER_ORIGIN = 'expert_projection.producer.source'
+
+
+def runtime():
+    import torch
+    return dict(torch=torch.__version__, cuda=torch.version.cuda,
+                transformers=importlib.metadata.version('transformers'))
+
+
+def streaming_contract(*, layers_prefix='model.layers.', num_layers=2,
+                       model_class='SyntheticSource'):
+    return dict(schema='prismaquant.streaming_initialization.v1',
+        scope='streamed_text_source_forward', status='completed',
+        transformers_version=importlib.metadata.version('transformers'),
+        model_class=model_class, dtype='torch.bfloat16', layers_prefix=layers_prefix,
+        num_layers=num_layers, persistent_tensors=1, derived_buffers=0,
+        state_sha256='a'*64, source_map_sha256='b'*64)
+
+
+def file_sha256(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def producer_roster(source, tensors):
+    """The census-sealed `expert_projection.producer.source` for a fixture root."""
+    shards = sorted(p.name for p in source.glob('*.safetensors'))
+    auxiliary = sorted(p.name for p in source.iterdir() if p.is_file() and
+                       not p.name.endswith(('.safetensors', '.bin')) and p.name != 'config.json')
+    return dict(files={name: file_sha256(source/name) for name in shards},
+                auxiliary_sha256={name: file_sha256(source/name) for name in auxiliary},
+                config_sha256=file_sha256(source/'config.json'), tensors=dict(tensors))
+
+
+class HashLog:
+    """Record every `tessera_calibration_cache.sha256` call: (name, bytes)."""
+
+    def __init__(self, monkeypatch):
+        self.events = []
+        real = cc.sha256
+        def wrapped(path, **kwargs):
+            digest = real(path, **kwargs)
+            self.events.append((Path(path).name, Path(path).stat().st_size))
+            return digest
+        monkeypatch.setattr(cc, 'sha256', wrapped)
+
+    def names(self):
+        return sorted({name for name, _ in self.events})
+
+    def shard_bytes(self):
+        return sum(size for name, size in self.events if name.endswith('.safetensors'))
+
+
+@pytest.fixture
+def sharded_source(tmp_path):
+    source = tmp_path/'source'
+    source.mkdir()
+    (source/'config.json').write_text('{"architectures": ["SyntheticSource"]}')
+    (source/'tokenizer.json').write_text('{}')
+    (source/'tokenizer.model').write_bytes(b'spm')
+    (source/'notes.txt').write_text('notes')
+    (source/'chat_template.jinja').write_text('{{ messages }}')  # sealed, outside the glob
+    (source/'weights.bin').write_bytes(b'outside the glob and the roster')
+    for index, name in enumerate(SHARDS):
+        (source/name).write_bytes(bytes([index+1])*(64*(index+1)))
+    tensors = {'model.layers.0.proj.weight': SHARDS[0], 'model.layers.1.proj.weight': SHARDS[1],
+               'model.embed_tokens.weight': SHARDS[2], 'lm_head.weight': SHARDS[2]}
+    census = dict(model=str(source), model_load_contract=streaming_contract(),
+        capture_runtime=runtime(), attention_implementation='eager',
+        unit_shapes={'model.layers.0.proj': [3, 2], 'model.layers.1.proj': [3, 2]},
+        counts={'model.layers.0.proj': 5, 'model.layers.1.proj': 5},
+        max_abs={'model.layers.0.proj': 1.0, 'model.layers.1.proj': 1.0},
+        expert_projection=dict(producer=dict(source=producer_roster(source, tensors))))
+    path = tmp_path/'census.json'
+    path.write_text(json.dumps(census))
+    return source, path, census
+
+
+def identity(path, census, **extra):
+    return cc.capture_identity(path, calibration={'fit_ids_sha256': 'draw'}, max_act_rows=2,
+        model_load_contract=census['model_load_contract'], attention_implementation='eager',
+        **extra)
+
+
+def identity_with_verification(path, census, **extra):
+    return cc.capture_identity_with_verification(path, calibration={'fit_ids_sha256': 'draw'},
+        max_act_rows=2, model_load_contract=census['model_load_contract'],
+        attention_implementation='eager', **extra)
+
+
+def rewrite_census(path, census, mutate):
+    census = json.loads(json.dumps(census))
+    mutate(census)
+    path.write_text(json.dumps(census))
+    return census
+
+
+def test_unset_verify_shards_hashes_exactly_the_globbed_roster(sharded_source, monkeypatch):
+    """Design A: the default path hashes today's file set, no more and no less."""
+    source, path, census = sharded_source
+    log = HashLog(monkeypatch)
+    result = identity(path, census)
+    assert log.names() == sorted([*SHARDS, *SMALL, 'census.json'])
+    assert set(result['source_files']) == {*SHARDS, *GLOBBED_SMALL}
+    assert log.shard_bytes() == sum((source/name).stat().st_size for name in SHARDS)
+
+
+def test_verify_shards_reads_only_named_shards_and_reproduces_the_canonical_identity(
+        sharded_source, monkeypatch):
+    source, path, census = sharded_source
+    canonical = identity(path, census)
+    log = HashLog(monkeypatch)
+    result, verification = identity_with_verification(path, census, verify_shards={SHARDS[1]})
+    assert result == canonical
+    assert log.names() == sorted([SHARDS[1], *SMALL, 'census.json'])
+    assert log.shard_bytes() == (source/SHARDS[1]).stat().st_size
+    assert verification == dict(byte_verified=[SHARDS[1]],
+        inherited_from_census_roster=[SHARDS[0], SHARDS[2]],
+        byte_verified_auxiliary=sorted(SMALL), roster_origin=ROSTER_ORIGIN)
+    assert identity(path, census, verify_shards=frozenset({SHARDS[1]})) == canonical
+
+
+def test_empty_verify_shards_hashes_only_small_files_without_refusing(sharded_source, monkeypatch):
+    source, path, census = sharded_source
+    canonical = identity(path, census)
+    log = HashLog(monkeypatch)
+    result, verification = identity_with_verification(path, census, verify_shards=frozenset())
+    assert result == canonical
+    assert log.shard_bytes() == 0
+    assert verification['byte_verified'] == []
+    assert verification['inherited_from_census_roster'] == list(SHARDS)
+
+
+def test_verify_shards_refuses_an_unsealed_unread_shard_on_disk(sharded_source):
+    source, path, census = sharded_source
+    (source/'model-00004-of-00003.safetensors').write_bytes(b'unsealed')
+    with pytest.raises(RuntimeError, match='neither read nor sealed.*model-00004'):
+        identity_with_verification(path, census, verify_shards={SHARDS[1]})
+
+
+def test_verify_shards_refuses_a_tampered_read_shard(sharded_source):
+    source, path, census = sharded_source
+    (source/SHARDS[1]).write_bytes(b'tampered')
+    with pytest.raises(RuntimeError, match=f'differs from census producer: {SHARDS[1]}'):
+        identity_with_verification(path, census, verify_shards={SHARDS[1]})
+
+
+def test_verify_shards_refuses_a_read_shard_the_roster_never_sealed(sharded_source):
+    source, path, census = sharded_source
+    census = rewrite_census(path, census, lambda c: c['expert_projection']['producer']
+                            ['source']['files'].pop(SHARDS[1]))
+    with pytest.raises(RuntimeError, match=f'absent from the census producer roster.*{SHARDS[1]}'):
+        identity_with_verification(path, census, verify_shards={SHARDS[1]})
+
+
+def test_verify_shards_refuses_a_read_shard_missing_on_disk(sharded_source):
+    source, path, census = sharded_source
+    with pytest.raises(RuntimeError, match='not on disk.*model-00009'):
+        identity_with_verification(path, census,
+                                   verify_shards={'model-00009-of-00003.safetensors'})
+
+
+def test_verify_shards_refuses_without_a_sealed_roster(sharded_source):
+    source, path, census = sharded_source
+    census = rewrite_census(path, census, lambda c: c.pop('expert_projection'))
+    with pytest.raises(RuntimeError, match='producer shard roster'):
+        identity_with_verification(path, census, verify_shards={SHARDS[1]})
+    # The default path is unchanged by the missing roster: it still hashes everything.
+    assert set(identity(path, census)['source_files']) == {*SHARDS, *GLOBBED_SMALL}

--- a/tests/test_tessera_calibration_cache.py
+++ b/tests/test_tessera_calibration_cache.py
@@ -272,6 +272,12 @@ def test_cli_capture_then_reuse_never_repeats_forward(monkeypatch,tmp_path,strea
     calibration = tc.th.calibration_identity(inputs['text'],inputs['tokens'],fit_tokens=4,
         source='wikitext-2-raw-v1/train',split_role='calibration',model=str(source),
         seed=0,nsamples=32,seqlen=512,fit_tokens_min=4)
+    if streamed_selection:
+        # A selected row inherits unread shard digests from the sealed roster (#388).
+        fields['expert_projection'] = dict(producer=dict(source=dict(
+            files={'model.safetensors': cc.sha256(source/'model.safetensors')},
+            auxiliary_sha256={}, config_sha256=cc.sha256(source/'config.json'),
+            tensors={UNIT+'.weight': 'model.safetensors'})))
     census = tc.calibration_census({UNIT:4},{UNIT:3.},args=SimpleNamespace(model=str(source),
         nsamples=32,seqlen=512,seed=0,layer_stride=1),groups={'u:'+UNIT:[UNIT]},
         dense_targets=[UNIT],expert_targets=[],shapes={UNIT:[32,256]},identity=calibration,**fields)
@@ -291,7 +297,9 @@ def test_cli_capture_then_reuse_never_repeats_forward(monkeypatch,tmp_path,strea
             return {UNIT: model.model.layers[0].proj.weight.detach().clone()}, dict(
                 schema='prismaquant.selected_source_weights.v1', source_forward_count=0)
         runner = SimpleNamespace(model=model, snapshot_selected_weights=snapshot,
-            shutdown=lambda: source_calls.append('shutdown'))
+            shutdown=lambda: source_calls.append('shutdown'),
+            selected_source_shards=lambda names: dict(layers=[0], layer_shards=['model.safetensors'],
+                fixed_state_shards=[], tensors={UNIT+'.weight': 'model.safetensors'}))
         monkeypatch.setattr(cost_streaming, 'build_streamed_causal_lm', lambda *a, **k: runner)
         monkeypatch.setattr(autoscale, 'selected_anchor_resources', lambda *a, **k: dict(
             memory_bytes=1024**3, selected_source_weight_bytes=32768,

--- a/tests/test_tessera_calibration_cache.py
+++ b/tests/test_tessera_calibration_cache.py
@@ -272,12 +272,6 @@ def test_cli_capture_then_reuse_never_repeats_forward(monkeypatch,tmp_path,strea
     calibration = tc.th.calibration_identity(inputs['text'],inputs['tokens'],fit_tokens=4,
         source='wikitext-2-raw-v1/train',split_role='calibration',model=str(source),
         seed=0,nsamples=32,seqlen=512,fit_tokens_min=4)
-    if streamed_selection:
-        # A selected row inherits unread shard digests from the sealed roster (#388).
-        fields['expert_projection'] = dict(producer=dict(source=dict(
-            files={'model.safetensors': cc.sha256(source/'model.safetensors')},
-            auxiliary_sha256={}, config_sha256=cc.sha256(source/'config.json'),
-            tensors={UNIT+'.weight': 'model.safetensors'})))
     census = tc.calibration_census({UNIT:4},{UNIT:3.},args=SimpleNamespace(model=str(source),
         nsamples=32,seqlen=512,seed=0,layer_stride=1),groups={'u:'+UNIT:[UNIT]},
         dense_targets=[UNIT],expert_targets=[],shapes={UNIT:[32,256]},identity=calibration,**fields)
@@ -309,9 +303,29 @@ def test_cli_capture_then_reuse_never_repeats_forward(monkeypatch,tmp_path,strea
             groups=[dict(key='u:'+UNIT, members=[UNIT])])))
         argv += ['--streaming', '--units', str(selection),
                  '--calibration-cache-sha256', cc.sha256(root/'capture_manifest.json')]
+        # This synthetic census seals no producer roster (dense-only: no packed
+        # experts), so the row cannot inherit digests and must hash every shard
+        # under the source root (#388 full-root fallback), and say so.
+        prepared, hashed_shards = [], []
+        real_prepare, real_sha256 = tc.prepare_selected_source, cc.sha256
+        def prepare(*a, **k):
+            result = real_prepare(*a, **k)
+            prepared.append(result[2])
+            return result
+        monkeypatch.setattr(tc, 'prepare_selected_source', prepare)
+        def sha256(path, **k):
+            if str(path).endswith('.safetensors'):
+                hashed_shards.append(Path(path).name)
+            return real_sha256(path, **k)
+        monkeypatch.setattr(cc, 'sha256', sha256)
     assert tc.main([*argv,'--calibration-cache',str(root/'capture_manifest.json')]) == tc.EXIT_EMPTY_MENU
     if streamed_selection:
         assert source_calls == [[UNIT], 'shutdown']
+        verification = prepared[0]['source_verification']
+        assert verification['mode'] == 'full-root' and verification['roster_present'] is False
+        assert verification['byte_verified'] == ['model.safetensors']
+        assert verification['inherited_from_census_roster'] == []
+        assert set(hashed_shards) == {p.name for p in source.glob('*.safetensors')} == {'model.safetensors'}
 
 
 def test_driver_capture_and_plan_bind_one_complete_capture(capture):

--- a/tests/test_tessera_selected_source.py
+++ b/tests/test_tessera_selected_source.py
@@ -256,3 +256,52 @@ def test_selected_capture_cli_reaches_existing_streamed_source(monkeypatch, tmp_
             '--calibration-cache', str(tmp_path/'capture_manifest.json'),
             '--calibration-cache-sha256', 'a'*64,
             '--attention-implementation', 'eager'])
+
+
+def test_selected_source_shards_cover_selected_layers_and_fixed_state(selected_runner):
+    """The read set is whole layers holding selected units plus every non-layer shard."""
+    runner, _calls, _source = selected_runner
+    runner.context.weight_shard = {
+        'layers.0.proj.weight': '/src/a.safetensors', 'layers.1.proj.weight': '/src/b.safetensors',
+        'layers.2.proj.weight': '/src/b.safetensors', 'layers.3.proj.weight': '/src/c.safetensors',
+        'embed_tokens.weight': '/src/d.safetensors', 'norm.weight': '/src/a.safetensors'}
+    runner.context.weight_ckpt = {key: 'ckpt.'+key for key in runner.context.weight_shard}
+    shards = runner.selected_source_shards(['layers.3.proj', 'layers.1.proj'])
+    assert shards == dict(layers=[1, 3], layer_shards=['b.safetensors', 'c.safetensors'],
+        fixed_state_shards=['a.safetensors', 'd.safetensors'],
+        tensors={'ckpt.layers.1.proj.weight': 'b.safetensors',
+                 'ckpt.layers.3.proj.weight': 'c.safetensors',
+                 'ckpt.embed_tokens.weight': 'd.safetensors',
+                 'ckpt.norm.weight': 'a.safetensors'})
+    with pytest.raises(ValueError, match='unique nonempty'):
+        runner.selected_source_shards([])
+    del runner.context.weight_shard['layers.1.proj.weight']
+    with pytest.raises(RuntimeError, match='no source tensors for selected layer 1'):
+        runner.selected_source_shards(['layers.1.proj'])
+
+
+def test_selected_source_read_set_must_agree_with_the_census_roster(selected_runner):
+    from prismaquant.tessera_campaign import selected_source_read_set
+    runner, _calls, _source = selected_runner
+    runner.context.weight_shard = {'layers.1.proj.weight': '/src/b.safetensors',
+                                   'embed_tokens.weight': '/src/d.safetensors'}
+    runner.context.weight_ckpt = {key: 'ckpt.'+key for key in runner.context.weight_shard}
+    tensors = {'ckpt.layers.1.proj.weight': 'b.safetensors', 'ckpt.embed_tokens.weight': 'd.safetensors',
+               'ckpt.layers.0.proj.weight': 'a.safetensors'}
+    def census(**source):
+        return dict(expert_projection=dict(producer=dict(source=dict(
+            files={'a.safetensors': 'a'*64, 'b.safetensors': 'b'*64, 'd.safetensors': 'd'*64},
+            tensors=tensors, auxiliary_sha256={}, config_sha256='c'*64) | source)))
+    read = selected_source_read_set(runner, ['layers.1.proj'], census=census())
+    assert read['layer_shards'] == ['b.safetensors'] and read['fixed_state_shards'] == ['d.safetensors']
+    with pytest.raises(RuntimeError, match='disagrees with the census producer roster.*embed_tokens'):
+        selected_source_read_set(runner, ['layers.1.proj'],
+            census=census(tensors=tensors | {'ckpt.embed_tokens.weight': 'a.safetensors'}))
+    with pytest.raises(RuntimeError, match='disagrees with the census producer roster.*layers.1'):
+        selected_source_read_set(runner, ['layers.1.proj'],
+            census=census(tensors={k: v for k, v in tensors.items() if 'layers.1' not in k}))
+    with pytest.raises(RuntimeError, match='not sealed.*d.safetensors'):
+        selected_source_read_set(runner, ['layers.1.proj'],
+            census=census(files={'a.safetensors': 'a'*64, 'b.safetensors': 'b'*64}))
+    with pytest.raises(RuntimeError, match='census-sealed producer source roster'):
+        selected_source_read_set(runner, ['layers.1.proj'], census={})


### PR DESCRIPTION
Closes #409. Code half of #388 (the at-scale profile on a real GLM selected row stays open there; it cannot run while the GLM canonical capture holds the frozen source).

## What changes

A selected-source row used to re-hash every file under the model root before touching an anchor, because `capture_identity` was designed for the canonical capture and #376 made it a per-row cost. Now the row byte-verifies only the shards it reads and inherits the rest.

- `prismaquant/cost_streaming.py`: `StreamedCausalLM.selected_source_shards(names)` returns the selected layers' shards, the fixed-state shards (every tensor outside the layers prefix: embed, norms, head, visual tower, all materialised at construction), and the tensor to shard map, from the runner's own weight map.
- `prismaquant/tessera_calibration_cache.py`: `capture_identity(..., verify_shards=None)` wraps a new `capture_identity_with_verification`. With `verify_shards` set, the named shards are hashed and every other shard's digest comes from the census-sealed roster `expert_projection.producer.source`. It refuses when the roster is missing, a named shard is not on disk or not sealed, or an on-disk shard is neither read nor sealed. Small files are always hashed. The identity itself is unchanged, so a row that verifies less must still reproduce the canonical identity.
- `prismaquant/tessera_campaign.py`: `selected_source_read_set` cross-checks the derived read set tensor by tensor against the sealed `tensors` map and refuses disagreement. `prepare_selected_source` picks the mode from the census: `roster-inherit` when a roster is sealed (and refuses when the canonical manifest is not pinned by `--calibration-cache-sha256`, since identity equality with the pinned manifest is the only attestation of inherited digests); `full-root` when the census seals no roster (dense-only models), hashing the whole root exactly as before. Mode and the verified, inherited and auxiliary file lists are stamped into `selected_source_preparation.source_verification`, not into the identity.
- `docs/ARCHITECTURE.md`: selected-source section updated and re-stamped, with the real-census bound.

## Bound on the real census (derived from `census.json`, not a measurement)

GLM-5.3-Flash-BF16: fixed state spans 2 of 120 shards (9.5 GB, shards 00001 and 00120). A typical selected row reads 5 shards, 25.6 GB of the 642.7 GB source, instead of hashing all of it.

## Tests

- `tests/test_selected_source_shard_identity.py` (new, 11): default path hashes the same file set as before; roster inheritance; empty selection hashes only small files; both stamp modes with full equality; five refusals (missing roster, shard not on disk, unsealed shard, unlisted on-disk shard, unpinned manifest).
- `tests/test_selected_source_glm_row.py` (new, 1): a re-sharded tiny `glm5_next` checkpoint; instruments `safe_open` and `sha256` and asserts every shard opened for tensor data is byte-verified, and that each shard's hash precedes its first data read after the row starts. Header-only opens at construction are logged, not asserted.
- `tests/test_tessera_calibration_cache.py`: the streamed arm of the CLI reuse test asserts the dense fixture takes `mode="full-root"` and hashes every shard. The synthetic census stays roster-less as on main.
- `tests/test_tessera_selected_source.py`: two appended unit tests.

Fixture hashed bytes per row: 835,408 bytes over 3 shards before; 597,856 bytes over 2 shards after (shard 00001 inherited).

## Receipts (PrismaBuild, priority -10, snapshot parent = the commit named)

RED at `57595485f9`: x86 dl380g10 `84f65359` shard_identity rc=1 (7 failed / 1 passed), `c01cca16` glm_row rc=1, `582c1883` selected_source rc=1 (2 failed / 10 passed / 1 skipped); sparklina `7e6ba6cc` rc=1, `912fcd61` rc=1.

GREEN at `bb7512cab1` (head), x86 dl380g10, 10 shards all rc=0 with CAS: `f54c5d43` selected_source 12 passed / 1 skipped, `9784582a` calibration_cache 34, `07324187` architecture_doc 13, `b8c400be` docs_staleness 6, `50a6bc37` shard_identity 11, `38511377` glm_row 1, `828092ac` glm_campaign_streaming 12 (end-to-end streamed selected row through `campaign.main`), `f21ebb48` joint_qualification_windows 9, `8fece63f` streaming_buffer_precision 7, `2bb9744b` tessera_materialization 25 / 1 skipped.

GREEN at `bb7512cab1`, sparklina, 8 shards rc=0 with CAS: `ca7539f7` 12 / 1 skipped, `7da6ab64` 34, `d9d8ab0e` 13, `bdde4bf3` 6, `2d3223f0` 11, `1398356c` 9, `da86a127` 7, `ae4da0e9` 25 / 1 skipped. Two shards skipped whole (pytest exit 5, rows `0651be63`, `38ac9635`): `test_selected_source_glm_row.py` and `test_glm_campaign_streaming.py` both import `tests/test_glm5_next_streamed_forward_parity.py`, whose `importorskip("transformers.models.glm5_next")` skips on the sparklina venv. The GLM-row evidence is x86-only.

Sealed snapshot trees of `f54c5d43` and `ca7539f7` differ from the head tree only by the `.pbrun-closure` file.

## Not in this PR

- The at-scale profile (#388 acceptance): before and after in-process profiles plus both Sparks' Netdata on one real GLM selected row.
- Sealing a source roster for dense-only censuses so they can inherit too; today only the packed-expert projection writes one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsJAfuLU26NWbYpSLrWFHJ
