### PR TITLE
Authenticate consumed source shards through complete-capture descriptor leases

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,30 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `integrate/capture-followups-20260908`. Stamps
+As of: 2026-09-08 · `fix/selected-source-authentication`. Stamps
 follow, newest first, each recording its own branch and date.
+
+
+Re-stamped (2026-09-08, `fix/selected-source-authentication`) for selected
+source authentication from a hash-bound complete canonical capture (#388).
+The full source roster, calibration identity and capture identity stay byte
+identical. Before model construction, the campaign validates that complete
+manifest against the census and freshly hashes its metadata and producer
+auxiliaries. Existing streaming readers authenticate each consumed shard once
+per selected invocation through a held read-only descriptor, including early
+nonbody state, FP8 scales and projected expert reads. Header-only inspection of
+an unconsumed shard does not hash its payload. The descriptor owner is shared
+by existing reader/prefetch threads and remains alive through their completion;
+source mutation or pathname replacement fails closed. Files must remain stable
+through these read leases; stat fences reject changes and never authorize a
+cached digest. The preparation receipt reports consumed-file authentication
+separately from the unchanged canonical identity. There is no persistent hash
+cache, new source residency mechanism, or relaxed partial-capture acceptance.
+CPU regression and tamper/thread/descriptor tests qualify this ownership
+contract; native selected-row I/O, memory and timing still require a matched
+before/after run with the original complete GLM manifest and both profiler and
+host telemetry. No full-GLM speed or fit gain is claimed by this change.
+Gate: `tests/test_selected_source_authentication.py` and existing selected,
+streaming reader, capture and campaign tests.
 
 Re-stamped (2026-09-08, `integrate/capture-followups-20260908`) for Hessian
 writer refusal and completed-file page release (#395, #396). A tensor-bearing

--- a/docs/measurements/selected-source-authentication-2026-09-08.md
+++ b/docs/measurements/selected-source-authentication-2026-09-08.md
@@ -59,3 +59,23 @@ checkpoint hash, GPU run, menu, serving gate, or calibration draw changed.
 Native selected-row I/O, memory and timing qualification waits for the original
 complete manifest and a matched before/after run with in-process profiling and
 both hosts' telemetry. No full-model speed or fit result is claimed here.
+
+## Root integration qualification
+
+Integration with the verified capture loader at `3a94d7520b67` passed **355
+CPU tests across 23 files, with one CUDA-only encoder-memo skip and two passing
+subtests**. The root audit verified all 23 successful terminal records, result
+receipts and source CAS snapshots; each source tree differs from that integration
+commit only by its PB closure manifest. The invocation and consolidated coverage
+are recorded beside the earlier evidence in
+`root-integrated-cpu-invocation-01.json`,
+`root-integrated-cpu-consolidated.json`, and
+`root-integrated-positive-cas-audit.json`.
+
+One initial shard reserved one CPU while its qualification-window fixture
+explicitly requested two cache workers. The affinity guard correctly rejected
+that fixture. Only that file was retried with two CPUs and passed nine tests
+in action `568bfcd59e2238c4cd06e8220af80a5edec31efc1716cd3de4bb6db85926d771`.
+The original failure and reservation diagnosis are retained in
+`root-integrated-cpu-affinity-negative.json`; no runtime change was needed.
+Native GLM measurements required by #388 remain outstanding.

--- a/docs/measurements/selected-source-authentication-2026-09-08.md
+++ b/docs/measurements/selected-source-authentication-2026-09-08.md
@@ -1,0 +1,61 @@
+# Selected-source authentication CPU qualification — 2026-09-08
+
+Issue #388: selected anchor preparation previously rehashed every source shard
+through `capture_identity`, including payload that the selected row never read.
+The complete-capture identity is unchanged. A selected invocation now binds the
+complete manifest and census before model construction, authenticates metadata,
+and gives the existing source readers one shared owner of source descriptors.
+The first tensor read hashes that held shard; subsequent readers reuse that
+invocation's authenticated descriptor. There is no persistent digest cache.
+
+The complete tiny-capture campaign regression retains actual nonbody and layer
+readers, replacing only model construction with the existing orchestration
+fixture. Before the fix it hashed **2,130,208 payload bytes**; the corrected path
+hashes exactly the **32,960 bytes** in the consumed head and selected shards.
+Both paths assert selected tensor equality and preservation of their original
+complete canonical identity and manifest bytes. This is a byte-count regression,
+not a throughput measurement or an actual GLM selected-row A/B.
+
+The final focused PrismaBuild action
+`1c95e20c822cfd6ee904f3da3450146de8fbeb7c8005782f9e8a5c479491638f`
+passed **89 tests, with one CUDA-only encoder-memo skip**. It covers original
+identity preservation, unused payload deferral, metadata and selected payload
+tampering with restored mtime, census/manifest/source-roster refusal, shared
+threaded reads, reader draining on error, projected source tensors, paired
+scales, descriptor replacement, FIFO refusal, HF-style symlinks, context failure
+cleanup, metadata leases, and escaped slice refusal. The FIFO regression was
+first reproduced in a two-second bounded child in action `ff1a912a9be1…`, then
+fixed with a nonblocking open followed by regular-file validation. The final
+source and test files were compared byte for byte with the passing CAS snapshot.
+
+Broader validation covered 15 files: **232 passed, one CUDA-only skip** before
+the four final FIFO/context/symlink cases were added and rerun in the focused
+suite above. Two initial mixed shards reached their declared 4 GiB ceiling;
+their five files were resubmitted through PB fanout at 8 GiB per shard and all
+passed. Completed green shards were retained. The wider run includes the actual
+tiny GLM source/campaign tests and existing FP8/MXFP4, streaming, projection,
+resume and architecture tests. A separate PB compile action `8d10a8ec6cb5…`
+passed for all six changed runtime modules and both changed test modules.
+
+All runs were CPU-only on the eligible x86 fleet using Python 3.12 and the
+scoped `pq-cpu312` environment (Torch 2.10.0+cpu, Transformers 5.16.1). Native
+threads were bounded to one; test actions used priority -10 and explicit CPU
+and memory admission. Deprecation warnings include Torch JIT and the bounded
+FIFO test's POSIX fork. The earlier prototype's obsolete orchestration test,
+the two expected red regressions, and both memory-limit failures are retained.
+
+The audit index is
+`/mnt/shared/tessera-measurements/glm-canonical-census-20260908/selected-source-authentication-01/pb-audit.json`.
+It checks all 17 terminal records, cleanup, source CAS hashes and successful
+result CAS/receipt hashes: 12 successful actions and five retained failed
+attempts. `source-audit.json`, `cpu-suite.json`, `cpu-suite-memory-retry.json`
+and the action logs are in the same directory.
+
+Ordinary source files must remain stable for their descriptor leases. Stat
+fences reject mutation or pathname replacement; they do not authenticate bytes
+or make a concurrently mutable filesystem immutable. The public selected path
+still requires the complete canonical manifest. No original GLM capture, full
+checkpoint hash, GPU run, menu, serving gate, or calibration draw changed.
+Native selected-row I/O, memory and timing qualification waits for the original
+complete manifest and a matched before/after run with in-process profiling and
+both hosts' telemetry. No full-model speed or fit result is claimed here.

--- a/docs/measurements/selected-source-authentication-2026-09-08.md
+++ b/docs/measurements/selected-source-authentication-2026-09-08.md
@@ -79,3 +79,16 @@ in action `568bfcd59e2238c4cd06e8220af80a5edec31efc1716cd3de4bb6db85926d771`.
 The original failure and reservation diagnosis are retained in
 `root-integrated-cpu-affinity-negative.json`; no runtime change was needed.
 Native GLM measurements required by #388 remain outstanding.
+
+The first full CI run (`34251207739`) found nine failures in the older
+prefetch-scheduling fixture: it bypasses `StreamingContext.__init__` and omitted
+the new optional authentication field. PB action `4e244dd5b4b0…` independently
+reproduced all nine failures. Initializing that fixture field to `None` restores
+the ordinary unauthenticated scheduling tests without changing runtime code.
+PB action `2057d00854c6e2c24b962054f7bd5595ff4d6b0f5a9ac2f54cc97c7280d5e361`
+then passed all **32 tests** in the scheduling and streamed-admission files,
+with five admitted CPUs for the main thread and four fixture readers, one native
+thread per reader, and 4 GiB. The original CI result (6,870 passed, nine failed,
+201 skipped, three xfailed, 192 passing subtests) is retained as a failed run.
+The root evidence is `root-prefetch-fixture-negative.json` and
+`root-prefetch-fixture-positive-cas-audit.json` beside the earlier receipts.

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -855,6 +855,7 @@ def build_streamed_causal_lm(
     prefetch_lookahead: int = 2,
     require_prefetched_residency: bool = False,
     attn_implementation: str | None = None,
+    source_authentication=None,
 ) -> StreamedCausalLM:
     """Build the repository's existing streaming context and wrap it."""
     from prismaquant.streaming_model import _build_streaming_context
@@ -870,6 +871,7 @@ def build_streamed_causal_lm(
         prefetch_min_available_gb=prefetch_min_available_gb,
         log_prefix="[cost-streaming]",
         attn_implementation=attn_implementation,
+        **({'source_authentication': source_authentication} if source_authentication is not None else {}),
     )
     effective_lookahead = max(0, int(prefetch_lookahead))
     if context.max_cache_slots is not None:

--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -86,6 +86,20 @@ except ModuleNotFoundError:
 from safetensors import safe_open
 
 
+def _source_safe_open(path, *, source_authentication=None, **kwargs):
+    """Use the existing reader, optionally through its complete-capture owner."""
+    if source_authentication is None:
+        return safe_open(path, **kwargs)
+    return source_authentication.safe_open(safe_open, path, **kwargs)
+
+
+def _source_json(path, source_authentication=None):
+    if source_authentication is not None:
+        return source_authentication.read_json(path)
+    with open(path) as handle:
+        return json.load(handle)
+
+
 # ---------------------------------------------------------------------------
 # v21 #5: opt-in direct-to-CUDA safetensors load. Default path opens the
 # safetensors file with framework="pt" (CPU mmap) and explicitly moves
@@ -126,7 +140,7 @@ def _safe_open_kwargs(device: torch.device) -> dict:
 
 
 def _build_weight_map(model_path: str, *,
-                      multimodal: bool = False
+                      multimodal: bool = False, source_authentication=None,
                       ) -> tuple[dict[str, str], dict[str, str]]:
     """Return ({model_key: shard_path}, {model_key: checkpoint_key}).
 
@@ -157,13 +171,12 @@ def _build_weight_map(model_path: str, *,
 
     index_file = os.path.join(model_path, "model.safetensors.index.json")
     if os.path.exists(index_file):
-        with open(index_file) as f:
-            raw = json.load(f)["weight_map"]
+        raw = _source_json(index_file, source_authentication)["weight_map"]
     else:
         single = os.path.join(model_path, "model.safetensors")
         if not os.path.exists(single):
             raise FileNotFoundError(f"no safetensors under {model_path}")
-        with safe_open(single, framework="pt") as f:
+        with _source_safe_open(single, framework="pt", source_authentication=source_authentication) as f:
             raw = {k: single for k in f.keys()}
     model_to_shard: dict[str, str] = {}
     model_to_ckpt: dict[str, str] = {}
@@ -267,7 +280,7 @@ def _fp8_dequant_block(
 
 
 def _build_fp8_scale_inv_map(model_path: str, *,
-                             multimodal: bool = False
+                             multimodal: bool = False, source_authentication=None,
                              ) -> "Fp8ScaleInvMap":
     """Return `{model_weight_key: (scale_shard_path, scale_ckpt_key)}`
     for every native-FP8 weight tensor (fp8_e4m3fn + paired
@@ -308,13 +321,12 @@ def _build_fp8_scale_inv_map(model_path: str, *,
 
     index_file = os.path.join(model_path, "model.safetensors.index.json")
     if os.path.exists(index_file):
-        with open(index_file) as f:
-            raw = json.load(f)["weight_map"]
+        raw = _source_json(index_file, source_authentication)["weight_map"]
     else:
         single = os.path.join(model_path, "model.safetensors")
         if not os.path.exists(single):
             return Fp8ScaleInvMap()
-        with safe_open(single, framework="pt") as f:
+        with _source_safe_open(single, framework="pt", source_authentication=source_authentication) as f:
             raw = {k: single for k in f.keys()}
 
     out: dict[str, tuple[str, str]] = {}
@@ -603,6 +615,7 @@ def _apply_fp8_dequant_inplace(
     out: dict[str, torch.Tensor],
     fp8_scale_inv_map: dict[str, tuple[str, str]],
     device: torch.device,
+    *, source_authentication=None,
 ) -> int:
     """For each tensor in `out` whose key matches a `fp8_scale_inv_map`
     entry, read the scale_inv, apply the checkpoint-declared block
@@ -639,7 +652,7 @@ def _apply_fp8_dequant_inplace(
     # Step 1: Read all scales from source safetensors once per shard.
     loaded_scales: dict[str, torch.Tensor] = {}  # name -> fp32 scale (cpu)
     for shard, reads in scale_reads.items():
-        with safe_open(shard, framework="pt") as f:
+        with _source_safe_open(shard, framework="pt", source_authentication=source_authentication) as f:
             for model_name, scale_key in reads:
                 loaded_scales[model_name] = f.get_tensor(scale_key)
 
@@ -824,6 +837,7 @@ def _materialize(model: nn.Module, prefixes: list[str],
                  model_to_ckpt: dict[str, str],
                  device: torch.device, dtype: torch.dtype,
                  fp8_scale_inv_map: dict[str, tuple[str, str]] | None = None,
+                 *, source_authentication=None,
                  ) -> int:
     """Load all tensors whose model-side name starts with any prefix in
     `prefixes` onto `device`, with parameters as `dtype` and buffers in their declared dtype. Uses the checkpoint-side key to
@@ -845,11 +859,11 @@ def _materialize(model: nn.Module, prefixes: list[str],
     open_kwargs = _safe_open_kwargs(device)
     for shard, pairs in by_shard.items():
         try:
-            f_ctx = safe_open(shard, **open_kwargs)
+            f_ctx = _source_safe_open(shard, source_authentication=source_authentication, **open_kwargs)
         except (TypeError, RuntimeError):
             # Older safetensors / unsupported device combos: drop the
             # device kwarg and fall back to the host-stage path.
-            f_ctx = safe_open(shard, framework="pt")
+            f_ctx = _source_safe_open(shard, framework="pt", source_authentication=source_authentication)
         with f_ctx as f:
             for model_name, ckpt_name in pairs:
                 t = f.get_tensor(ckpt_name)
@@ -860,7 +874,8 @@ def _materialize(model: nn.Module, prefixes: list[str],
                     t = t.to(buffer_dtypes.get(model_name, dtype))
                 out[model_name] = t
     if fp8_scale_inv_map:
-        _apply_fp8_dequant_inplace(out, fp8_scale_inv_map, device)
+        _apply_fp8_dequant_inplace(out, fp8_scale_inv_map, device,
+            **({'source_authentication': source_authentication} if source_authentication is not None else {}))
     loaded = 0
     for model_name, t in out.items():
         install_dtype = t.dtype if t.is_floating_point() else None
@@ -1429,6 +1444,7 @@ def _read_layer_to_device(prefix: str,
                           pack_experts=None,
                           merge_concat=None,
                           buffer_dtypes: dict[str, torch.dtype] | None = None,
+                          source_authentication=None,
                           ) -> dict[str, torch.Tensor]:
     """Read all tensors under `prefix` from safetensors and place them
     on `device`. Returns {model_name: device_tensor}.
@@ -1461,17 +1477,18 @@ def _read_layer_to_device(prefix: str,
     direct = "device" in open_kwargs
     release_pages = (os.environ.get('PRISMAQUANT_RELEASE_SOURCE_PAGES') == '1'
                      and device.type == 'cuda')
-    source_stats = {shard: os.stat(shard) for shard in by_shard} if release_pages else {}
+    source_stats = {shard: (os.stat(shard) if source_authentication is None else
+        source_authentication.file_stat(shard)) for shard in by_shard} if release_pages else {}
     def _read_chunk(shard: str,
                     pairs: list[tuple[str, str]]) -> dict[str, torch.Tensor]:
         local: dict[str, torch.Tensor] = {}
         if not pairs:
             return local
         try:
-            f_ctx = safe_open(shard, **open_kwargs)
+            f_ctx = _source_safe_open(shard, source_authentication=source_authentication, **open_kwargs)
             used_direct = direct
         except (TypeError, RuntimeError):
-            f_ctx = safe_open(shard, framework="pt")
+            f_ctx = _source_safe_open(shard, framework="pt", source_authentication=source_authentication)
             used_direct = False
         # This existing read chunk owns its mmap-backed/converted staging
         # through one stream event, rather than retaining it for the layer.
@@ -1512,7 +1529,8 @@ def _read_layer_to_device(prefix: str,
             # Reached only on a successful chunk: its map is closed, copies
             # completed and CPU views released. Other readers may still run.
             _advise_consumed_safetensors_pages(
-                shard, [key for _, key in pairs], source_stats[shard])
+                shard if source_authentication is None else source_authentication.descriptor_path(shard),
+                [key for _, key in pairs], source_stats[shard])
         return local
 
     total_tensors = sum(len(pairs) for pairs in by_shard.values())
@@ -1525,9 +1543,10 @@ def _read_layer_to_device(prefix: str,
                 jobs.append((shard, chunk))
         futures = [pool.submit(_read_chunk, shard, chunk)
                    for shard, chunk in jobs]
-        if release_pages:
+        if release_pages or source_authentication is not None:
             # Drain every launched reader before propagating an error;
             # each chunk fences its own copies, including on read failure.
+            # An authenticated owner must outlive every reader on CPU too.
             wait_futures(futures)
         # `.result()` re-raises any worker exception: a partially gathered
         # layer must never be installed as if it were complete.
@@ -1548,7 +1567,8 @@ def _read_layer_to_device(prefix: str,
             "refusing to install a partial layer"
         )
     if fp8_scale_inv_map:
-        _apply_fp8_dequant_inplace(out, fp8_scale_inv_map, device)
+        _apply_fp8_dequant_inplace(out, fp8_scale_inv_map, device,
+            **({'source_authentication': source_authentication} if source_authentication is not None else {}))
     if pack_experts is not None:
         # Generic per-expert -> packed-3D bridge for checkpoints that ship
         # MoE experts unfused while the live module is packed. No-op (None)

--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -1319,13 +1319,9 @@ def fill_packed_experts_from_source(
 # --------------------------------------------------------------------------
 # Intra-layer parallel gather.
 #
-# One streamed layer of a large MoE checkpoint is thousands of small
-# tensors (GLM-5.3-Flash: 1759 tensors / ~7 GB of FP8 source per body
-# layer, spread over two shards). Reading them one at a time is a single
-# mmap page-in stream plus a single H2D copy stream — measured at
-# ~1.3 GB/s on the GB10 NVMe while the device sat at 5% utilisation,
-# against a ~5 GB/s parallel-read floor for the same disk. That is disk
-# pressure on a hot path, i.e. a bug under design principle 7.
+# A large MoE layer can contain thousands of small source tensors. The
+# bounded gather overlaps source reads and copy submission across reader
+# chunks while the existing layer prefetch path owns residency.
 #
 # The gather below is the ONLY change to the read: the same tensors, the
 # same dtype cast, the same contiguity fix, the same post-gather FP8

--- a/prismaquant/streaming_model.py
+++ b/prismaquant/streaming_model.py
@@ -68,6 +68,7 @@ from .layer_streaming import (
     _build_concat_merger,
     _model_tensor_dtypes,
     _source_tensor_dtypes,
+    _source_json,
     _build_expert_packer,
     _build_install_resolver,
     _build_weight_map,
@@ -198,7 +199,7 @@ class _StreamingInitializationAudit:
         })
 
 
-def _bypass_hf_fp8_module_rewrite(model_path: str) -> bool:
+def _bypass_hf_fp8_module_rewrite(model_path: str, *, source_authentication=None) -> bool:
     """True when HF's FP8 pre-load module rewrite must be skipped here.
 
     Two independent conditions, and they belong in different places:
@@ -216,9 +217,10 @@ def _bypass_hf_fp8_module_rewrite(model_path: str) -> bool:
     reads the source fp8 bytes and applies `.weight_scale_inv` inline.
     """
     try:
-        with open(os.path.join(model_path, "config.json")) as f:
-            cfg = json.load(f)
+        cfg = _source_json(os.path.join(model_path, "config.json"), source_authentication)
     except Exception:
+        if source_authentication is not None:
+            raise
         return False
     qc = cfg.get("quantization_config") or {}
     if qc.get("quant_method") != "fp8" or "weight_block_size" not in qc:
@@ -411,6 +413,7 @@ def _estimate_layer_cache_bytes(
     target_dtype: torch.dtype,
     fp4_experts: bool = False,
     tensor_dtypes: dict[str, torch.dtype] | None = None,
+    source_authentication=None,
 ) -> tuple[int, list[int]]:
     """Estimate dequanted cache bytes per decoder layer without loading data.
 
@@ -437,7 +440,9 @@ def _estimate_layer_cache_bytes(
     sizes = [0 for _ in range(num_layers)]
     try:
         for shard, pairs in by_shard.items():
-            with safe_open(shard, framework="pt") as f:
+            context = (safe_open(shard, framework="pt") if source_authentication is None else
+                       source_authentication.safe_open(safe_open, shard, framework="pt"))
+            with context as f:
                 for idx, ckpt_name, fp4_packed, load_dtype in pairs:
                     sl = f.get_slice(ckpt_name)
                     n = 1
@@ -447,6 +452,8 @@ def _estimate_layer_cache_bytes(
                         sl.get_dtype(), load_dtype,
                         fp4_packed=fp4_packed)
     except Exception:
+        if source_authentication is not None:
+            raise
         return 0, sizes
     nonzero = [s for s in sizes if s > 0]
     return (max(nonzero) if nonzero else 0), sizes
@@ -542,7 +549,7 @@ class StreamingContext:
                  prefetch_workers: int = 3,
                  prefetch_min_available_bytes: int = 0,
                  expert_packer=None,
-                 concat_merger=None):
+                 concat_merger=None, source_authentication=None):
         self.model = model
         self.base_model = base_model
         self.layers = layers
@@ -589,6 +596,7 @@ class StreamingContext:
         # `concat_merges`). None for every other checkpoint/model (zero
         # behavior change). Built once in `_build_streaming_context`.
         self.concat_merger = concat_merger
+        self.source_authentication = source_authentication
         self._inflight: dict[int, Any] = {}
         self._inflight_lock = threading.Lock()
         # Sequential-walk tracking for the automatic prefetch top-up.
@@ -649,7 +657,9 @@ class StreamingContext:
             self.device, fp8_scale_inv_map=self.fp8_scale_inv_map,
             pack_experts=self.expert_packer,
             merge_concat=self.concat_merger,
-            buffer_dtypes=self.buffer_dtypes)
+            buffer_dtypes=self.buffer_dtypes,
+            **({'source_authentication': self.source_authentication}
+               if self.source_authentication is not None else {}))
         # The cache may still decline to RETAIN the layer under its dynamic
         # budget (or evict it as `pinned_until_read` before the consumer
         # arrives). That is a retention decision, not a delivery decision:
@@ -848,7 +858,9 @@ class StreamingContext:
             self.device, fp8_scale_inv_map=self.fp8_scale_inv_map,
             pack_experts=self.expert_packer,
             merge_concat=self.concat_merger,
-            buffer_dtypes=self.buffer_dtypes)
+            buffer_dtypes=self.buffer_dtypes,
+            **({'source_authentication': self.source_authentication}
+               if self.source_authentication is not None else {}))
         self.layer_cache.put(L, tensors)
         return tensors, "cold"
 
@@ -1375,6 +1387,7 @@ def _build_streaming_context(model_path: str, *,
                              multimodal: bool = False,
                              visual_requires_grad: bool = False,
                              attn_implementation: str | None = None,
+                             source_authentication=None,
                              ) -> StreamingContext:
     """One-time setup: AutoConfig + empty skeleton, then manually
     materialize only the always-resident head pieces. Decoder layers
@@ -1410,6 +1423,11 @@ def _build_streaming_context(model_path: str, *,
     import psutil
     from transformers import AutoConfig, AutoModelForCausalLM
 
+    authenticated = ({} if source_authentication is None else
+                     {'source_authentication': source_authentication})
+    if source_authentication is not None:
+        source_authentication.require_unchanged()
+
     from .sensitivity_probe import stage_multimodal, stage_text_only
 
     if not multimodal:
@@ -1430,7 +1448,7 @@ def _build_streaming_context(model_path: str, *,
     if multimodal:
         staged = stage_multimodal(model_path)
     else:
-        bypass_hf_fp8_rewrite = _bypass_hf_fp8_module_rewrite(model_path)
+        bypass_hf_fp8_rewrite = _bypass_hf_fp8_module_rewrite(model_path, **authenticated)
         staged = stage_text_only(model_path)
         if bypass_hf_fp8_rewrite:
             print(f"{log_prefix} manual meta streaming load avoids HF fp8 "
@@ -1476,7 +1494,7 @@ def _build_streaming_context(model_path: str, *,
         p.requires_grad_(False)
     base_model, layers = _get_layer_list(model)
 
-    weight_shard, weight_ckpt = _build_weight_map(model_path, multimodal=multimodal)
+    weight_shard, weight_ckpt = _build_weight_map(model_path, multimodal=multimodal, **authenticated)
     # Native-FP8 source dequant map. Populated only for checkpoints that
     # ship `.weight_scale_inv` siblings (MiniMax-M2/M2.7, DeepSeek-V3).
     # Empty dict for plain BF16 checkpoints — `_read_layer_to_device`
@@ -1486,7 +1504,7 @@ def _build_streaming_context(model_path: str, *,
     # leaving every downstream pass operating on raw codes (range ±448)
     # instead of true weights (range ±0.2).
     fp8_scale_inv_map = _build_fp8_scale_inv_map(
-        model_path, multimodal=multimodal)
+        model_path, multimodal=multimodal, **authenticated)
     if fp8_scale_inv_map:
         print(f"{log_prefix} fp8 scale_inv map: {len(fp8_scale_inv_map)} "
               f"weights will be dequanted inline at layer-load",
@@ -1501,6 +1519,7 @@ def _build_streaming_context(model_path: str, *,
         device,
         dtype,
         fp8_scale_inv_map=fp8_scale_inv_map,
+        **authenticated,
     )
     # Weight tying: a `tie_word_embeddings` checkpoint ships no
     # `lm_head.weight`, so `_materialize` above has nothing to install and
@@ -1567,7 +1586,7 @@ def _build_streaming_context(model_path: str, *,
                 visual_prefix + ".",
                 weight_shard, weight_ckpt, dtype, device,
                 fp8_scale_inv_map=fp8_scale_inv_map,
-                buffer_dtypes=_model_tensor_dtypes(model, dtype))
+                buffer_dtypes=_model_tensor_dtypes(model, dtype), **authenticated)
             print(f"{log_prefix} materializing visual tower: "
                   f"{len(tensors)}/{len(vis_keys)} tensors -> {device}", flush=True)
             if _module_has_meta_tensors(visual_module):
@@ -1659,6 +1678,7 @@ def _build_streaming_context(model_path: str, *,
         target_dtype=dtype,
         fp4_experts=declared_fp4_expert_dtype(model_path),
         tensor_dtypes=_source_tensor_dtypes(model, dtype, concat_merger),
+        **authenticated,
     )
     worker_count, worker_src = _auto_prefetch_workers(
         cache_bytes, estimated_layer_bytes, requested=prefetch_workers)
@@ -1686,6 +1706,9 @@ def _build_streaming_context(model_path: str, *,
     prefetch_pool = ThreadPoolExecutor(
         max_workers=worker_count, thread_name_prefix="prefetch")
 
+    if source_authentication is not None:
+        source_authentication.require_unchanged()
+
     return StreamingContext(
         model=model, base_model=base_model, layers=layers,
         layers_prefix=layers_prefix, num_layers=num_layers,
@@ -1702,4 +1725,5 @@ def _build_streaming_context(model_path: str, *,
         prefetch_min_available_bytes=min_available_bytes,
         expert_packer=_build_expert_packer(model, weight_ckpt),
         concat_merger=concat_merger,
+        **authenticated,
     )

--- a/prismaquant/tessera_calibration_cache.py
+++ b/prismaquant/tessera_calibration_cache.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import os
 from pathlib import Path
+import stat
+import threading
 
 from .cost_stage_checkpoint import atomic_write_bytes, prepare_journal, write_unit
 
@@ -18,11 +21,14 @@ STAGE = 'tessera_calibration_capture'
 SOURCE = 'tessera_campaign_prefix_f32_v1'
 
 
-def sha256(path, *, resource_check=None, release_read_pages=False):
-    with Path(path).open('rb') as handle:
-        if resource_check is not None or release_read_pages:
-            import os
-            import stat
+def sha256(path, *, resource_check=None, release_read_pages=False, file_descriptor=None):
+    # A descriptor alias opens the already owned object, never its possibly
+    # replaced source pathname. The ordinary full-capture path is unchanged.
+    if file_descriptor is not None and (type(file_descriptor) is not int or file_descriptor < 0):
+        raise ValueError('source hash descriptor must be an open file descriptor')
+    read_path = Path(path) if file_descriptor is None else Path(f'/proc/self/fd/{file_descriptor}')
+    with read_path.open('rb') as handle:
+        if resource_check is not None or release_read_pages or file_descriptor is not None:
             original = os.fstat(handle.fileno())
             if release_read_pages and not stat.S_ISREG(original.st_mode):
                 raise RuntimeError('source hash page release requires a regular file')
@@ -61,12 +67,20 @@ def _json(path, value):
 
 def capture_identity(census_path, *, calibration, max_act_rows,
                      model_load_contract, attention_implementation,
-                     resource_check=None, release_read_pages=False):
-    """Hash source bytes on every invocation; mtimes never authorize reuse."""
+                     resource_check=None, release_read_pages=False,
+                     source_authentication=None):
+    """Preserve full identity; selected readers authenticate consumed objects.
+
+    Canonical capture hashes every source file. A hash-bound complete capture
+    can supply its original roster only through the descriptor owner below;
+    no pathname/mtime digest cache authorizes a selected source read.
+    """
     import importlib.metadata
     import torch
     census_path = Path(census_path)
-    census = json.loads(census_path.read_text())
+    census_raw = census_path.read_bytes()
+    census = json.loads(census_raw)
+    census_digest = hashlib.sha256(census_raw).hexdigest()
     if type(max_act_rows) is not int or max_act_rows < 1:
         raise ValueError('capture scoring prefix must have positive max_act_rows')
     from prismaquant import validate_source_initialization_contract
@@ -85,7 +99,6 @@ def capture_identity(census_path, *, calibration, max_act_rows,
         raise RuntimeError('calibration capture needs a complete local source checkpoint')
     def source_digest(path):
         return sha256(path, resource_check=resource_check, release_read_pages=release_read_pages)
-    source = {p.name:source_digest(p) for p in files if p.is_file()}
     # The census already seals the producer's complete source/auxiliary
     # roster (including non-JSON tokenizer assets such as chat_template.jinja).
     # Check those bytes too, without inventing another producer identity.
@@ -94,18 +107,295 @@ def capture_identity(census_path, *, calibration, max_act_rows,
     expected = {**declared.get('files',{}),**declared.get('auxiliary_sha256',{})}
     if declared.get('config_sha256'):
         expected['config.json'] = declared['config_sha256']
-    for name,digest in expected.items():
-        actual = source[name] if name in source else source_digest(root/name)
-        if actual != digest:
-            raise RuntimeError(f'calibration source differs from census producer: {name}')
+    if source_authentication is None:
+        source = {p.name:source_digest(p) for p in files if p.is_file()}
+        for name,digest in expected.items():
+            actual = source[name] if name in source else source_digest(root/name)
+            if actual != digest:
+                raise RuntimeError(f'calibration source differs from census producer: {name}')
+    else:
+        if not isinstance(source_authentication, CaptureSourceAuthentication):
+            raise TypeError('selected source needs the complete-capture descriptor owner')
+        source = source_authentication.source_files(root, census_digest,
+            {p.name for p in files if p.is_file()}, expected)
     if not any(name.endswith('.safetensors') for name in source):
         raise RuntimeError('calibration capture source has no safetensors weights')
     return dict(schema=SCHEMA, model_load_contract=contract,
                 attention_implementation=attention_implementation,
-                census_sha256=sha256(census_path),capture_runtime=runtime,
+                census_sha256=census_digest,capture_runtime=runtime,
                 source_files=source, calibration=dict(calibration),
                 max_act_rows=int(max_act_rows), storage_source=SOURCE,
                 units={name:list(shape) for name,shape in sorted(census['unit_shapes'].items())})
+
+
+def _source_stat(value):
+    return (value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns, value.st_ctime_ns)
+
+
+class CaptureSourceAuthentication:
+    """One complete capture's source descriptors, not a weight/digest cache.
+
+    Header inspection may open an unconsumed shard without hashing its payload.
+    Tensor reads authenticate the same held object first, once in this owner's
+    lifetime. Stat fences reject mutation/replacement; only SHA256 authenticates
+    content. Ordinary source files must remain stable through their read leases.
+    Construct through ``authenticate_selected_capture_source``.
+    """
+
+    def __init__(self, root, identity, producer_source, *, manifest_sha256,
+                 resource_check=None, release_read_pages=False):
+        self.root = Path(os.path.abspath(root))
+        self._identity_json = json.dumps(identity, sort_keys=True, allow_nan=False)
+        self._source_files = dict(identity['source_files'])
+        self._expected = dict(self._source_files)
+        declared = {**producer_source.get('files', {}),
+                    **producer_source.get('auxiliary_sha256', {})}
+        if producer_source.get('config_sha256'):
+            declared['config.json'] = producer_source['config_sha256']
+        for name, digest in declared.items():
+            if name in self._expected and self._expected[name] != digest:
+                raise RuntimeError(f'capture source roster differs from census producer: {name}')
+            self._expected[name] = digest
+        for name, digest in self._expected.items():
+            if (not isinstance(name, str) or not name or Path(name).name != name or
+                    name in ('.', '..') or not isinstance(digest, str) or
+                    len(digest) != 64 or any(c not in '0123456789abcdef' for c in digest)):
+                raise RuntimeError('capture source roster has an invalid path or SHA256')
+        self.manifest_sha256 = manifest_sha256
+        self.resource_check = resource_check
+        self.release_read_pages = release_read_pages
+        self._files = {}
+        self._lock = threading.RLock()
+        self._readers = 0
+        self._closed = False
+
+    def __enter__(self):
+        self._require_open()
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
+
+    def _require_open(self):
+        if self._closed:
+            raise RuntimeError('capture source descriptor owner is closed')
+
+    def _name(self, path):
+        value = Path(os.path.abspath(path))
+        if value.parent != self.root or value.name not in self._expected:
+            raise RuntimeError(f'consumed source is absent from the sealed roster: {path}')
+        return value.name
+
+    def _file(self, path):
+        name = self._name(path)
+        with self._lock:
+            self._require_open()
+            if name not in self._files:
+                # A replaced FIFO must be refused by fstat, never block in
+                # open waiting for a writer. Regular files and HF symlinks
+                # retain the same read semantics with O_NONBLOCK.
+                fd = os.open(self.root/name, os.O_RDONLY | os.O_CLOEXEC | os.O_NONBLOCK)
+                try:
+                    before = os.fstat(fd)
+                    if not stat.S_ISREG(before.st_mode):
+                        raise RuntimeError('authenticated source must be a regular file')
+                    state = dict(fd=fd, before=before, sha256=None, payload_reads=0,
+                                 lock=threading.Lock())
+                    self._check_file(name, state)
+                    self._files[name] = state
+                except BaseException:
+                    os.close(fd)
+                    raise
+            return name, self._files[name]
+
+    def _check_file(self, name, state):
+        try:
+            current = (os.fstat(state['fd']), os.stat(self.root/name))
+            if any(_source_stat(value) != _source_stat(state['before']) for value in current):
+                raise RuntimeError(f'authenticated source changed during consumption: {name}')
+        except OSError as exc:
+            raise RuntimeError(f'authenticated source changed during consumption: {name}') from exc
+
+    def require_unchanged(self):
+        with self._lock:
+            self._require_open()
+            for name, state in self._files.items():
+                self._check_file(name, state)
+
+    def _authenticate(self, name, state):
+        with state['lock']:
+            self._check_file(name, state)
+            if state['sha256'] is None:
+                digest = sha256(self.root/name, file_descriptor=state['fd'],
+                    resource_check=self.resource_check,
+                    release_read_pages=self.release_read_pages)
+                self._check_file(name, state)
+                if digest != self._expected[name]:
+                    raise RuntimeError(f'calibration source content differs from sealed capture: {name}')
+                state['sha256'] = digest
+
+    def source_files(self, root, census_digest, names, producer_digests):
+        canonical = json.loads(self._identity_json)
+        if (Path(os.path.abspath(root)) != self.root or
+                census_digest != canonical['census_sha256'] or names != set(self._source_files) or
+                any(self._expected.get(name) != digest for name, digest in producer_digests.items())):
+            raise RuntimeError('selected source census or complete source roster changed')
+        # Metadata includes producer auxiliaries outside capture's historical
+        # glob. Keep that glob/identity unchanged, while still authenticating it.
+        for name in sorted(self._expected):
+            if not name.endswith('.safetensors'):
+                _, state = self._file(self.root/name)
+                self._authenticate(name, state)
+        self.require_unchanged()
+        return dict(self._source_files)
+
+    def read_json(self, path):
+        with self._lock:
+            name, state = self._file(path)
+            if name.endswith('.safetensors'):
+                raise RuntimeError('source JSON reader cannot read a payload shard')
+            self._readers += 1
+        try:
+            self._authenticate(name, state)
+            with open(f"/proc/self/fd/{state['fd']}", 'rb') as handle:
+                result = json.load(handle)
+            self._check_file(name, state)
+            return result
+        finally:
+            with self._lock:
+                self._readers -= 1
+
+    def safe_open(self, factory, path, *args, **kwargs):
+        return _CaptureSourceSafeOpen(self, factory, path, args, kwargs)
+
+    def file_stat(self, path):
+        name, state = self._file(path)
+        self._check_file(name, state)
+        return state['before']
+
+    def descriptor_path(self, path):
+        name, state = self._file(path)
+        self._check_file(name, state)
+        if state['sha256'] is None:
+            raise RuntimeError('source payload descriptor has not been authenticated')
+        return f"/proc/self/fd/{state['fd']}"
+
+    def receipt(self):
+        self.require_unchanged()
+        verified = [{"name": name, "sha256": state['sha256'],
+            "bytes_hashed": state['before'].st_size, "payload_reads": state['payload_reads']}
+            for name, state in sorted(self._files.items()) if state['sha256'] is not None]
+        return dict(schema='prismaquant.selected_source_authentication.v1',
+            capture_manifest_sha256=self.manifest_sha256,
+            census_sha256=json.loads(self._identity_json)['census_sha256'],
+            authentication='fresh SHA256 through held read-only source descriptors',
+            verified_files=verified,
+            payload_bytes_hashed=sum(row['bytes_hashed'] for row in verified
+                                     if row['name'].endswith('.safetensors')),
+            metadata_only_shards=sorted(name for name, state in self._files.items()
+                if name.endswith('.safetensors') and state['sha256'] is None))
+
+    def close(self):
+        with self._lock:
+            if self._closed:
+                return
+            if self._readers:
+                raise RuntimeError('cannot close capture source with active readers')
+            try:
+                self.require_unchanged()
+            finally:
+                self._closed = True
+                for state in self._files.values():
+                    os.close(state['fd'])
+
+
+class _CaptureSourceSafeOpen:
+    def __init__(self, owner, factory, path, args, kwargs):
+        self.owner, self.name = owner, owner._name(path)
+        self.entered = self.closed = self.authenticated = False
+        with owner._lock:
+            _, self.state = owner._file(path)
+            owner._check_file(self.name, self.state)
+            owner._readers += 1
+        self.context = None
+        try:
+            self.context = factory(f"/proc/self/fd/{self.state['fd']}", *args, **kwargs)
+            owner._check_file(self.name, self.state)
+        except BaseException as exc:
+            try:
+                if self.context is not None:
+                    self.context.__exit__(type(exc), exc, exc.__traceback__)
+            finally:
+                with owner._lock:
+                    owner._readers -= 1
+            raise
+
+    def __enter__(self):
+        try:
+            self.handle = self.context.__enter__()
+            self.owner._check_file(self.name, self.state)
+            self.entered = True
+            return self
+        except BaseException:
+            self.__exit__(None, None, None)
+            raise
+
+    def __exit__(self, *args):
+        if self.closed:
+            return
+        try:
+            self.context.__exit__(*args)
+            self.owner._check_file(self.name, self.state)
+        finally:
+            self.closed = True
+            with self.owner._lock:
+                self.owner._readers -= 1
+
+    def _require_entered(self):
+        if not self.entered or self.closed:
+            raise RuntimeError('authenticated source reader is outside its read lease')
+
+    def _payload(self):
+        self._require_entered()
+        self.owner._check_file(self.name, self.state)
+        if not self.authenticated:
+            self.owner._authenticate(self.name, self.state)
+            self.authenticated = True
+        with self.state['lock']:
+            self.state['payload_reads'] += 1
+
+    def keys(self):
+        self._require_entered()
+        return self.handle.keys()
+
+    def metadata(self):
+        self._require_entered()
+        return self.handle.metadata()
+
+    def get_tensor(self, name):
+        self._payload()
+        return self.handle.get_tensor(name)
+
+    def get_slice(self, name):
+        self._require_entered()
+        return _CaptureSourceSlice(self, self.handle.get_slice(name))
+
+
+class _CaptureSourceSlice:
+    def __init__(self, reader, value):
+        self.reader, self.value = reader, value
+
+    def get_shape(self):
+        self.reader._require_entered()
+        return self.value.get_shape()
+
+    def get_dtype(self):
+        self.reader._require_entered()
+        return self.value.get_dtype()
+
+    def __getitem__(self, index):
+        self.reader._payload()
+        return self.value[index]
 
 
 def _validate_tensors(name, payload, census, max_rows):
@@ -290,9 +580,10 @@ def require_capture_contract(path, expected_sha256=None):
     """Validate a complete canonical capture before downstream preparation."""
     from prismaquant import validate_source_initialization_contract
     path = Path(path)
-    if expected_sha256 is not None and sha256(path) != expected_sha256:
+    raw = path.read_bytes()
+    if expected_sha256 is not None and hashlib.sha256(raw).hexdigest() != expected_sha256:
         raise RuntimeError('priced calibration capture manifest changed')
-    manifest = json.loads(path.read_text())
+    manifest = json.loads(raw)
     identity = manifest.get('identity') or {}
     if manifest.get('schema') != SCHEMA or manifest.get('status') != 'complete':
         raise RuntimeError('not a complete canonical calibration capture v2')
@@ -309,6 +600,41 @@ def require_capture_contract(path, expected_sha256=None):
             set(manifest.get('entries',{})) != set(identity['units'])):
         raise RuntimeError('canonical capture runtime, source or completeness is invalid')
     return manifest
+
+
+def authenticate_selected_capture_source(census_path, capture_path, *, expected_sha256,
+        model, max_act_rows, attention_implementation, calibration_parameters=None,
+        resource_check=None, release_read_pages=False):
+    """Bind the public complete-capture contract before selected source loading.
+
+    The original identity stays equivalent. Payload validation is deferred only
+    to the authenticated reader's first tensor consumption; small metadata and
+    all identity fields are checked before model construction.
+    """
+    if (not isinstance(expected_sha256, str) or len(expected_sha256) != 64 or
+            any(c not in '0123456789abcdef' for c in expected_sha256)):
+        raise RuntimeError('selected source requires a hash-bound complete capture')
+    manifest = require_capture_contract(capture_path, expected_sha256=expected_sha256)
+    canonical = manifest['identity']
+    census = json.loads(Path(census_path).read_text())
+    if (census.get('model') != str(model) or
+            canonical['model_load_contract']['schema'] != 'prismaquant.streaming_initialization.v1' or
+            any(census.get(key) != value for key, value in (calibration_parameters or {}).items())):
+        raise RuntimeError('selected source model, draw or streaming witness differs from census')
+    producer = ((census.get('expert_projection') or {}).get('producer') or {}).get('source') or {}
+    owner = CaptureSourceAuthentication(model, canonical, producer,
+        manifest_sha256=expected_sha256, resource_check=resource_check,
+        release_read_pages=release_read_pages)
+    try:
+        actual = capture_identity(census_path, calibration=canonical['calibration'],
+            max_act_rows=max_act_rows, model_load_contract=census.get('model_load_contract'),
+            attention_implementation=attention_implementation, source_authentication=owner)
+        if actual != canonical:
+            raise RuntimeError('selected source capture identity differs from the canonical census')
+        return owner
+    except BaseException:
+        owner.close()
+        raise
 
 
 def prefetch_capture(path, *, expected_identity, census, names, device,

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -2971,7 +2971,7 @@ def _require_campaign_population(model, profile, layer_stride: int) -> ExpertPop
 def _project_expert_population(population: ExpertPopulation, *, weights, menus,
                                model_path, cache_dir: Path, measured=None,
                                projection=None, resource_check=None,
-                               release_source_pages=False) -> tuple[dict, dict]:
+                               release_source_pages=False, source_authentication=None) -> tuple[dict, dict]:
     """Ask the producer to project every in-scope stack; bind it; check the bytes.
 
     Each request covers the whole campaign (the producer hashes the checkpoint
@@ -3027,7 +3027,8 @@ def _project_expert_population(population: ExpertPopulation, *, weights, menus,
             bound, weights=weights, model_path=model_path,
             source=carried["producer"]["source"],
             measured=measured, resource_check=resource_check,
-            release_source_pages=release_source_pages)
+            release_source_pages=release_source_pages,
+            **({'source_authentication': source_authentication} if source_authentication is not None else {}))
 
     ladders: dict[str, list[tuple[str, int]]] = {}
     for stack, units in sorted(population.declared.items()):
@@ -3105,12 +3106,13 @@ def _project_expert_population(population: ExpertPopulation, *, weights, menus,
     return carried, _checked_projected_units(
         bound, weights=weights, model_path=model_path,
         source=answer["source"], measured=measured,
-        resource_check=resource_check, release_source_pages=release_source_pages)
+        resource_check=resource_check, release_source_pages=release_source_pages,
+        **({'source_authentication': source_authentication} if source_authentication is not None else {}))
 
 
 def _checked_projected_units(bound, *, weights, model_path, source,
                              measured=None, resource_check=None,
-                             release_source_pages=False) -> dict[str, dict]:
+                             release_source_pages=False, source_authentication=None) -> dict[str, dict]:
     """The producer's unit records for the units this run prices, bytes checked.
 
     Each unit's source tensor is read from the shard the producer hashed and
@@ -3135,8 +3137,10 @@ def _checked_projected_units(bound, *, weights, model_path, source,
             try:
                 if release_source_pages:
                     path = Path(model_path)/source['tensors'][unit['source_tensor']]
-                    source_stats.setdefault(str(path), path.stat())
-                weight = source_unit_weight(model_path, source, unit)
+                    source_stats.setdefault(str(path), path.stat() if source_authentication is None
+                                            else source_authentication.file_stat(path))
+                weight = source_unit_weight(model_path, source, unit,
+                    **({'source_authentication': source_authentication} if source_authentication is not None else {}))
             except ExpertProjectionError as exc:
                 raise RuntimeError(
                     f"Tessera campaign cannot read the producer's source tensor for "
@@ -3166,7 +3170,8 @@ def _checked_projected_units(bound, *, weights, model_path, source,
     if release_source_pages:
         from .layer_streaming import _advise_consumed_safetensors_pages
         for path, keys in consumed.items():
-            _advise_consumed_safetensors_pages(path, keys, source_stats[path])
+            _advise_consumed_safetensors_pages(path if source_authentication is None
+                else source_authentication.descriptor_path(path), keys, source_stats[path])
     return projected
 
 
@@ -3675,6 +3680,12 @@ def _run_streamed_calibration(args, runner, profile, *, mode, population,
 
 
 def main(argv: "Sequence[str] | None" = None) -> int:
+    from contextlib import ExitStack
+    with ExitStack() as source_scope:
+        return _main(argv, source_scope=source_scope)
+
+
+def _main(argv, *, source_scope) -> int:
     import torch
 
     from . import format_registry as fr
@@ -3856,9 +3867,28 @@ def main(argv: "Sequence[str] | None" = None) -> int:
         Path(args.out).with_suffix(".anchors.json")
     )
 
+    source_authentication = None
+    selected_guard = None
+    if selected_source:
+        from . import tessera_calibration_cache as calibration_store
+        if device == 'cuda':
+            from .memory_management import CaptureMemoryGuard
+            selected_guard = CaptureMemoryGuard(device)
+        source_authentication = source_scope.enter_context(
+            calibration_store.authenticate_selected_capture_source(
+                args.calibration_census, args.calibration_cache,
+                expected_sha256=args.calibration_cache_sha256, model=args.model,
+                max_act_rows=args.max_act_rows, attention_implementation=args.attention_implementation,
+                calibration_parameters=dict(nsamples=args.nsamples, seqlen=args.seqlen, seed=args.seed),
+                resource_check=None if selected_guard is None else selected_guard.check,
+                release_read_pages=True))
+
     from .model_profiles import detect_profile
     profile = detect_profile(args.model)
     runner = None
+    if source_authentication is not None:
+        # Drain any failed preparation before the descriptor owner closes.
+        source_scope.callback(lambda: runner.shutdown() if runner is not None else None)
     if args.streaming:
         from .cost_streaming import build_streamed_causal_lm
         runner = build_streamed_causal_lm(args.model, device=torch.device(device), dtype=torch.bfloat16,
@@ -3868,7 +3898,8 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             cache_headroom_gb=args.streaming_cache_headroom_gb,
             prefetch_min_available_gb=args.streaming_cache_headroom_gb,
             prefetch_lookahead=args.streaming_cache_slots-1, require_prefetched_residency=True,
-            attn_implementation=args.attention_implementation)
+            attn_implementation=args.attention_implementation,
+            **({'source_authentication': source_authentication} if source_authentication is not None else {}))
         model = runner.model
     else:
         from transformers import AutoModelForCausalLM
@@ -4006,7 +4037,6 @@ def main(argv: "Sequence[str] | None" = None) -> int:
     capture_identity = None
     selected_source_preparation = None
     selected_weights = None
-    selected_guard = None
     if census is not None:
         # Validate the whole scope before a selected unit's artifact is read.
         if (set(census["counts"]) != set(census_targets) or
@@ -4042,8 +4072,6 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             headroom_gb=args.streaming_cache_headroom_gb,
             anchor_batch_size=args.anchor_batch_size)
         if device == 'cuda':
-            from .memory_management import CaptureMemoryGuard
-            selected_guard = CaptureMemoryGuard(device)
             if selected_resources['memory_bytes'] > selected_guard.cap_bytes:
                 raise RuntimeError('selected anchor cgroup budget is smaller than its checked phase plan')
             selected_guard.check('before_selected_capture_identity')
@@ -4060,6 +4088,7 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             args.calibration_census, calibration=bound_calibration,
             max_act_rows=args.max_act_rows, model_load_contract=model_load_contract,
             attention_implementation=attention_implementation,
+            **({'source_authentication': source_authentication} if source_authentication is not None else {}),
             **(dict(resource_check=None if selected_guard is None else selected_guard.check,
                     release_read_pages=True) if selected_source else {}))
     if selected_source:
@@ -4226,9 +4255,14 @@ def main(argv: "Sequence[str] | None" = None) -> int:
             measured=set(expert_targets),
             projection=(None if census is None else census.get("expert_projection")),
             **(dict(resource_check=None if selected_guard is None else selected_guard.check,
-                    release_source_pages=True) if selected_source else {}))
+                    release_source_pages=True, source_authentication=source_authentication)
+               if selected_source else {}))
         print(f"[campaign] producer projected {len(expert_projection['stacks'])} stacks; "
               f"{len(projected_units)} expert units priced here", flush=True)
+
+    if source_authentication is not None:
+        selected_source_preparation['source_authentication'] = source_authentication.receipt()
+        source_authentication.close()
 
     if census_only:
         payload = calibration_census(

--- a/prismaquant/tessera_expert_projection.py
+++ b/prismaquant/tessera_expert_projection.py
@@ -362,7 +362,8 @@ def carried_units(carried: Any) -> tuple[dict, dict[str, dict], dict[str, str]]:
 # ---------------------------------------------------------------------------
 # The source bytes the producer will read
 # ---------------------------------------------------------------------------
-def source_unit_weight(model_path: str | Path, source: Mapping[str, Any], unit: Mapping[str, Any]):
+def source_unit_weight(model_path: str | Path, source: Mapping[str, Any], unit: Mapping[str, Any],
+                       *, source_authentication=None):
     """Read the unit's whole source tensor from the shard the producer hashed.
 
     The exporter re-reads exactly this tensor (``packed_expert_weight`` on an
@@ -377,7 +378,9 @@ def source_unit_weight(model_path: str | Path, source: Mapping[str, Any], unit: 
     except KeyError:
         raise ExpertProjectionError(f"{tensor}: not in the producer's hashed tensor roster")
     path = Path(model_path) / file
-    with safe_open(str(path), framework="pt", device="cpu") as handle:
+    context = (safe_open(str(path), framework="pt", device="cpu") if source_authentication is None else
+               source_authentication.safe_open(safe_open, path, framework="pt", device="cpu"))
+    with context as handle:
         if tensor not in handle.keys():
             raise ExpertProjectionError(f"{tensor}: absent from {path}")
         weight = handle.get_tensor(tensor)

--- a/tests/test_selected_source_authentication.py
+++ b/tests/test_selected_source_authentication.py
@@ -1,0 +1,544 @@
+"""Selected capture reuse authenticates consumed source objects, once per row."""
+import hashlib
+import importlib.metadata
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+def test_selected_campaign_hashes_only_consumed_shards_and_preserves_identity(
+    monkeypatch, tmp_path,
+):
+    """The public selected path must not hash an untouched payload shard."""
+    import prismaquant
+    from safetensors.torch import save_file
+    from prismaquant import autoscale, cost_streaming, layer_streaming
+    from prismaquant import tessera_calibration_cache as cc
+    from test_tessera_campaign_resume import _main_fixture, UNIT
+
+    monkeypatch.setattr(torch.cuda, 'is_available', lambda: False)
+    campaign, _, argv, model, inputs = _main_fixture(monkeypatch, tmp_path)
+    model.config = SimpleNamespace(_attn_implementation='eager')
+    model.lm_head = torch.nn.Linear(256, 32, bias=False, dtype=torch.bfloat16)
+    selected = model.model.layers[0].proj.weight.detach().clone()
+    source = tmp_path/'source'
+    source.mkdir()
+    (source/'config.json').write_text('{}')
+    tensors = {
+        'head.safetensors': {'lm_head.weight': model.lm_head.weight.detach().clone()},
+        'selected.safetensors': {UNIT+'.weight': selected},
+        'unused.safetensors': {'unused.weight': torch.zeros(1024, 1024, dtype=torch.bfloat16)},
+    }
+    weight_map = {}
+    for name, values in tensors.items():
+        save_file(values, str(source/name))
+        weight_map.update(dict.fromkeys(values, name))
+    (source/'model.safetensors.index.json').write_text(json.dumps({'weight_map': weight_map}))
+    version = importlib.metadata.version('transformers')
+    contract = dict(schema='prismaquant.streaming_initialization.v1',
+        scope='streamed_text_source_forward', status='completed',
+        transformers_version=version, model_class='SyntheticSource',
+        dtype='torch.bfloat16', layers_prefix='model.layers.', num_layers=1,
+        persistent_tensors=2, derived_buffers=0,
+        state_sha256='a'*64, source_map_sha256='b'*64)
+    calibration = campaign.th.calibration_identity(inputs['text'], inputs['tokens'], fit_tokens=4,
+        source='wikitext-2-raw-v1/train', split_role='calibration', model=str(source),
+        seed=0, nsamples=32, seqlen=512, fit_tokens_min=4)
+    census = campaign.calibration_census({UNIT:4}, {UNIT:3.},
+        args=SimpleNamespace(model=str(source), nsamples=32, seqlen=512, seed=0, layer_stride=1),
+        groups={'u:'+UNIT:[UNIT]}, dense_targets=[UNIT], expert_targets=[],
+        shapes={UNIT:[32,256]}, identity=calibration, model_load_contract=contract,
+        attention_implementation='eager', capture_runtime=dict(torch=torch.__version__,
+            cuda=torch.version.cuda, transformers=version))
+    census_path = tmp_path/'census.json'
+    census_path.write_text(json.dumps(census))
+    canonical = cc.capture_identity(census_path, calibration=calibration, max_act_rows=4,
+        model_load_contract=contract, attention_implementation='eager')
+    complete = cc.publish_capture(tmp_path/'capture', census_path=census_path,
+        identity=canonical, acts={UNIT:inputs['rows']}, hessians={UNIT:inputs['hessian']},
+        counts=census['counts'], maxima=census['max_abs'])
+    manifest_before = Path(complete['path']).read_bytes()
+    copied, hashed, identities = [], [], []
+    original_hash, original_identity = cc.sha256, cc.capture_identity
+
+    def counting_hash(path, **kwargs):
+        if Path(path).suffix == '.safetensors':
+            hashed.append((Path(path).name, Path(path).stat().st_size))
+        return original_hash(path, **kwargs)
+
+    def record_identity(*args, **kwargs):
+        result = original_identity(*args, **kwargs)
+        identities.append(result)
+        return result
+
+    def build(*_args, **kwargs):
+        # Keep the public campaign orchestration, and the actual shard reader.
+        # Only model construction is the existing small orchestration fixture.
+        authentication = kwargs.get('source_authentication')
+        owned = {} if authentication is None else {'source_authentication': authentication}
+        shards, keys = layer_streaming._build_weight_map(str(source), **owned)
+        layer_streaming._materialize(model, ['lm_head.'], shards, keys,
+            torch.device('cpu'), torch.bfloat16, **owned)
+
+        def snapshot(names, **_kwargs):
+            assert names == [UNIT]
+            values = layer_streaming._read_layer_to_device('model.layers.0.', shards, keys,
+                torch.bfloat16, torch.device('cpu'), **owned)
+            value = values[UNIT+'.weight'].clone()
+            copied.append(value)
+            return {UNIT:value}, dict(schema='prismaquant.selected_source_weights.v1',
+                source_forward_count=0)
+
+        return SimpleNamespace(model=model, snapshot_selected_weights=snapshot, shutdown=lambda: None)
+
+    monkeypatch.setattr(cc, 'sha256', counting_hash)
+    monkeypatch.setattr(cc, 'capture_identity', record_identity)
+    monkeypatch.setattr(cost_streaming, 'build_streamed_causal_lm', build)
+    monkeypatch.setattr(autoscale, 'selected_anchor_resources', lambda *a, **k: dict(
+        memory_bytes=1024**3, selected_source_weight_bytes=selected.numel()*2,
+        phases={'resident_anchors': {'factorization_scratch_bytes': 4*256**2*4}}))
+    monkeypatch.setattr(campaign, '_collect_activations', lambda *a, **k: pytest.fail('repeated forward'))
+    selection = tmp_path/'selection.json'
+    selection.write_text(json.dumps(dict(schema=campaign.UNITS_SCHEMA,
+        groups=[dict(key='u:'+UNIT, members=[UNIT])])) )
+    argv[argv.index('--model')+1] = str(source)
+    argv[argv.index('--hessian')+1] = 'require'
+    assert campaign.main([*argv, '--attention-implementation', 'eager', '--streaming',
+        '--streaming-cache-headroom-gb', '0', '--units', str(selection),
+        '--calibration-census', str(census_path), '--calibration-cache', complete['path'],
+        '--calibration-cache-sha256', complete['sha256'], '--nsamples', '32',
+        '--seqlen', '512', '--layer-stride', '1', '--max-act-rows', '4']) == campaign.EXIT_EMPTY_MENU
+    assert copied and torch.equal(copied[0], selected)
+    assert identities and all(value == canonical for value in identities)
+    assert hashlib.sha256(Path(complete['path']).read_bytes()).hexdigest() == complete['sha256']
+    assert Path(complete['path']).read_bytes() == manifest_before
+    expected = sorted((name, (source/name).stat().st_size)
+        for name in ('head.safetensors', 'selected.safetensors'))
+    print({'hashed_shards': hashed, 'hashed_payload_bytes': sum(size for _,size in hashed),
+           'required_payload_bytes': sum(size for _,size in expected)})
+    assert sorted(hashed) == expected
+
+
+@pytest.fixture
+def complete_source(tmp_path):
+    from safetensors.torch import save_file
+    from prismaquant import tessera_calibration_cache as cc
+    root = tmp_path/'model'
+    root.mkdir()
+    (root/'config.json').write_text('{}')
+    (root/'chat_template.jinja').write_text('immutable auxiliary')
+    tensors = {'head.safetensors': {'lm_head.weight': torch.ones(2, 2)},
+        'selected.safetensors': {'model.layers.0.a.weight': torch.arange(4.).reshape(2, 2),
+                                 'model.layers.0.b.weight': torch.ones(2, 2)*3},
+        'unused.safetensors': {'model.layers.1.a.weight': torch.ones(2, 2)*9}}
+    mapping = {}
+    for name, values in tensors.items():
+        save_file(values, str(root/name))
+        mapping.update(dict.fromkeys(values, name))
+    (root/'model.safetensors.index.json').write_text(json.dumps({'weight_map': mapping}))
+    version = importlib.metadata.version('transformers')
+    contract = dict(schema='prismaquant.streaming_initialization.v1',
+        scope='streamed_text_source_forward', status='completed', transformers_version=version,
+        model_class='SyntheticSource', dtype='torch.bfloat16', layers_prefix='model.layers.',
+        num_layers=2, persistent_tensors=4, derived_buffers=0,
+        state_sha256='a'*64, source_map_sha256='b'*64)
+    source = dict(files={name: cc.sha256(root/name) for name in tensors}, tensors=mapping,
+        config_sha256=cc.sha256(root/'config.json'),
+        auxiliary_sha256={'chat_template.jinja': cc.sha256(root/'chat_template.jinja')})
+    census = dict(model=str(root), model_load_contract=contract,
+        capture_runtime=dict(torch=torch.__version__, cuda=torch.version.cuda, transformers=version),
+        attention_implementation='eager', nsamples=2, seqlen=2, seed=0, layer_stride=1,
+        counts={'a':2}, max_abs={'a':3.}, unit_shapes={'a':[2,2]},
+        anchor_groups={'u:a':['a']}, expert_projection={'producer': {'source':source}})
+    census_path = tmp_path/'census.json'
+    census_path.write_text(json.dumps(census))
+    canonical = cc.capture_identity(census_path, calibration={'fit_ids_sha256':'draw'},
+        max_act_rows=2, model_load_contract=contract, attention_implementation='eager')
+    capture = cc.publish_capture(tmp_path/'capture', census_path=census_path, identity=canonical,
+        acts={'a':torch.ones(2,2)}, hessians={'a':torch.eye(2)},
+        counts=census['counts'], maxima=census['max_abs'])
+    kwargs = dict(census_path=census_path, capture_path=capture['path'],
+        expected_sha256=capture['sha256'], model=str(root), max_act_rows=2,
+        attention_implementation='eager', calibration_parameters=dict(nsamples=2,seqlen=2,seed=0))
+    return SimpleNamespace(root=root, census=census, canonical=canonical, kwargs=kwargs,
+                           tensors=tensors, capture=capture)
+
+
+def _mutate_preserving_mtime(path):
+    import os
+    before = path.stat()
+    with path.open('r+b') as handle:
+        handle.seek(-1, 2)
+        old = handle.read(1)
+        handle.seek(-1, 2)
+        handle.write(bytes([old[0] ^ 1]))
+    os.utime(path, ns=(before.st_atime_ns, before.st_mtime_ns))
+
+
+@pytest.mark.parametrize('name', ['config.json', 'model.safetensors.index.json', 'chat_template.jinja'])
+def test_metadata_tampering_refused_before_source_construction(complete_source, name):
+    from prismaquant import tessera_calibration_cache as cc
+    _mutate_preserving_mtime(complete_source.root/name)
+    with pytest.raises(RuntimeError, match='content differs'):
+        cc.authenticate_selected_capture_source(**complete_source.kwargs)
+
+
+@pytest.mark.parametrize('change', ['missing_hash', 'wrong_hash', 'partial', 'missing_entry',
+                                    'identity_units', 'census_draw', 'census_roster'])
+def test_complete_capture_and_census_binding_fail_closed(complete_source, change):
+    from prismaquant import tessera_calibration_cache as cc
+    f = complete_source
+    kwargs = dict(f.kwargs)
+    if change == 'missing_hash':
+        kwargs['expected_sha256'] = None
+    elif change == 'wrong_hash':
+        kwargs['expected_sha256'] = '0'*64
+    elif change.startswith('census_'):
+        census = dict(f.census)
+        if change == 'census_draw':
+            census['seed'] = 1
+        else:
+            census['unit_shapes'] = {'unknown':[2,2]}
+        kwargs['census_path'].write_text(json.dumps(census))
+    else:
+        path = Path(kwargs['capture_path'])
+        manifest = json.loads(path.read_text())
+        if change == 'partial':
+            manifest['status'] = 'capturing'
+        elif change == 'missing_entry':
+            manifest['entries'].clear()
+        else:
+            manifest['identity']['units']['a'] = [4,2]
+        path.write_text(json.dumps(manifest))
+        kwargs['expected_sha256'] = cc.sha256(path)
+    with pytest.raises(RuntimeError):
+        cc.authenticate_selected_capture_source(**kwargs)
+
+
+def test_new_source_roster_entry_is_not_accepted(complete_source):
+    from prismaquant import tessera_calibration_cache as cc
+    (complete_source.root/'new.json').write_text('{}')
+    with pytest.raises(RuntimeError, match='roster changed'):
+        cc.authenticate_selected_capture_source(**complete_source.kwargs)
+
+
+def test_unconsumed_payload_is_not_hashed_but_later_consumption_is_refused(complete_source, monkeypatch):
+    from safetensors import safe_open
+    from prismaquant import tessera_calibration_cache as cc
+    f = complete_source
+    _mutate_preserving_mtime(f.root/'unused.safetensors')
+    with cc.authenticate_selected_capture_source(**f.kwargs) as owner:
+        hashed = []
+        original = cc.sha256
+        def count(path, **kwargs):
+            hashed.append(Path(path).name)
+            assert kwargs['file_descriptor'] >= 0
+            return original(path, **kwargs)
+        monkeypatch.setattr(cc, 'sha256', count)
+        with owner.safe_open(safe_open, f.root/'unused.safetensors', framework='pt') as handle:
+            assert handle.get_slice('model.layers.1.a.weight').get_shape() == [2,2]
+        assert not hashed
+        with owner.safe_open(safe_open, f.root/'selected.safetensors', framework='pt') as handle:
+            assert torch.equal(handle.get_tensor('model.layers.0.a.weight'), f.tensors['selected.safetensors']['model.layers.0.a.weight'])
+        with pytest.raises(RuntimeError, match='content differs'):
+            with owner.safe_open(safe_open, f.root/'unused.safetensors', framework='pt') as handle:
+                handle.get_slice('model.layers.1.a.weight')[:]
+        assert hashed == ['selected.safetensors', 'unused.safetensors']
+        assert owner.receipt()['payload_bytes_hashed'] == (f.root/'selected.safetensors').stat().st_size
+
+
+def test_threaded_shared_shard_hashes_once_and_preserves_read_bytes(complete_source, monkeypatch):
+    import os
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+    from safetensors import safe_open
+    from prismaquant import tessera_calibration_cache as cc
+    f = complete_source
+    with cc.authenticate_selected_capture_source(**f.kwargs) as owner:
+        original, hashed = cc.sha256, []
+        def count(path, **kwargs):
+            fd = kwargs['file_descriptor']
+            assert os.fstat(fd).st_ino == Path(path).stat().st_ino
+            hashed.append((Path(path).name, fd))
+            return original(path, **kwargs)
+        monkeypatch.setattr(cc, 'sha256', count)
+        barrier = threading.Barrier(8)
+        def read(_index):
+            with owner.safe_open(safe_open, f.root/'selected.safetensors', framework='pt') as handle:
+                barrier.wait(timeout=10)
+                a = handle.get_slice('model.layers.0.a.weight')[:].clone()
+                b = handle.get_tensor('model.layers.0.b.weight').clone()
+                return a, b
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            values = list(pool.map(read, range(8)))
+        for a, b in values:
+            assert torch.equal(a, f.tensors['selected.safetensors']['model.layers.0.a.weight'])
+            assert torch.equal(b, f.tensors['selected.safetensors']['model.layers.0.b.weight'])
+        assert len(hashed) == 1
+        row = next(row for row in owner.receipt()['verified_files'] if row['name'].endswith('.safetensors'))
+        assert row['payload_reads'] == 16
+        fd = hashed[0][1]
+    with pytest.raises(OSError):
+        os.fstat(fd)
+
+
+def test_owned_descriptor_refuses_path_replacement_before_factory_returns(complete_source):
+    import os
+    from safetensors import safe_open
+    from prismaquant import tessera_calibration_cache as cc
+    f = complete_source
+    owner = cc.authenticate_selected_capture_source(**f.kwargs)
+    path = f.root/'selected.safetensors'
+    held, released = [], []
+    class Tracked:
+        def __init__(self, context):
+            self.context = context
+        def __exit__(self, *args):
+            released.append(True)
+            return self.context.__exit__(*args)
+    def replace(alias, **kwargs):
+        held.append(int(alias.rsplit('/', 1)[1]))
+        assert Path(alias).stat().st_ino == path.stat().st_ino
+        replacement = f.root/'replacement.tmp'
+        replacement.write_bytes(path.read_bytes())
+        os.replace(replacement, path)
+        return Tracked(safe_open(alias, **kwargs))
+    with pytest.raises(RuntimeError, match='changed during consumption'):
+        owner.safe_open(replace, path, framework='pt')
+    assert released == [True]
+    assert owner._readers == 0
+    with pytest.raises(RuntimeError, match='changed during consumption'):
+        owner.close()
+    with pytest.raises(OSError):
+        os.fstat(held[0])
+
+
+def test_mutation_after_hash_is_rejected_and_descriptors_close(complete_source, monkeypatch):
+    import os
+    from safetensors import safe_open
+    from prismaquant import tessera_calibration_cache as cc
+    f = complete_source
+    owner = cc.authenticate_selected_capture_source(**f.kwargs)
+    original, descriptors = cc.sha256, []
+    def mutate(path, **kwargs):
+        descriptors.append(kwargs['file_descriptor'])
+        result = original(path, **kwargs)
+        _mutate_preserving_mtime(Path(path))
+        return result
+    monkeypatch.setattr(cc, 'sha256', mutate)
+    with pytest.raises(RuntimeError, match='changed during consumption'):
+        with owner.safe_open(safe_open, f.root/'selected.safetensors', framework='pt') as handle:
+            handle.get_tensor('model.layers.0.a.weight')
+    with pytest.raises(RuntimeError, match='changed during consumption'):
+        owner.close()
+    assert descriptors
+    for fd in descriptors:
+        with pytest.raises(OSError):
+            os.fstat(fd)
+
+
+def test_read_lease_prevents_close_and_slice_escape(complete_source):
+    from safetensors import safe_open
+    from prismaquant import tessera_calibration_cache as cc
+    f = complete_source
+    owner = cc.authenticate_selected_capture_source(**f.kwargs)
+    with owner.safe_open(safe_open, f.root/'selected.safetensors', framework='pt') as handle:
+        view = handle.get_slice('model.layers.0.a.weight')
+        with pytest.raises(RuntimeError, match='active readers'):
+            owner.close()
+        assert torch.equal(view[:], f.tensors['selected.safetensors']['model.layers.0.a.weight'])
+    with pytest.raises(RuntimeError, match='outside its read lease'):
+        view[:]
+    owner.close()
+    owner.close()
+    with pytest.raises(RuntimeError, match='closed'):
+        owner.read_json(f.root/'config.json')
+
+
+def test_unknown_source_path_refused_before_open(complete_source):
+    from safetensors import safe_open
+    from prismaquant import tessera_calibration_cache as cc
+    f = complete_source
+    with cc.authenticate_selected_capture_source(**f.kwargs) as owner:
+        with pytest.raises(RuntimeError, match='absent from the sealed roster'):
+            owner.safe_open(safe_open, f.root/'../other.safetensors', framework='pt')
+
+
+def test_layer_reader_drains_other_owned_chunks_before_error(complete_source, monkeypatch):
+    import threading
+    import time
+    from safetensors import safe_open
+    from prismaquant import layer_streaming as ls, tessera_calibration_cache as cc
+    f = complete_source
+    started, finished = threading.Event(), threading.Event()
+    class Reader:
+        def __init__(self, alias, **kwargs):
+            self.context = safe_open(alias, **kwargs)
+        def __enter__(self):
+            self.handle = self.context.__enter__()
+            return self
+        def __exit__(self, *args):
+            return self.context.__exit__(*args)
+        def get_tensor(self, name):
+            if name.endswith('a.weight'):
+                assert started.wait(timeout=5)
+                raise RuntimeError('intentional first chunk failure')
+            started.set()
+            time.sleep(0.05)
+            result = self.handle.get_tensor(name)
+            finished.set()
+            return result
+    monkeypatch.setattr(ls, 'safe_open', Reader)
+    monkeypatch.setattr(ls, 'layer_read_threads', lambda: 2)
+    monkeypatch.setattr(ls, '_LAYER_READ_MIN_TENSORS', 1)
+    with cc.authenticate_selected_capture_source(**f.kwargs) as owner:
+        shards, keys = ls._build_weight_map(str(f.root), source_authentication=owner)
+        with pytest.raises(RuntimeError, match='intentional first chunk failure'):
+            ls._read_layer_to_device('model.layers.0.', shards, keys, torch.float32,
+                torch.device('cpu'), source_authentication=owner)
+        assert finished.is_set()
+        assert owner._readers == 0
+
+
+def test_projected_tensor_and_scale_readers_share_source_authentication(complete_source, monkeypatch):
+    from prismaquant import layer_streaming as ls, tessera_calibration_cache as cc
+    from prismaquant.tessera_expert_projection import source_unit_weight
+    f = complete_source
+    with cc.authenticate_selected_capture_source(**f.kwargs) as owner:
+        original, hashed = cc.sha256, []
+        def count(path, **kwargs):
+            hashed.append(Path(path).name)
+            return original(path, **kwargs)
+        monkeypatch.setattr(cc, 'sha256', count)
+        key = 'model.layers.0.a.weight'
+        source = f.census['expert_projection']['producer']['source']
+        unit = dict(source_tensor=key, rows=2, cols=2)
+        for _ in range(2):
+            weight = source_unit_weight(f.root, source, unit, source_authentication=owner)
+            assert torch.equal(weight, f.tensors['selected.safetensors'][key])
+        out = {'quantized': torch.ones(4,4)}
+        scales = ls.Fp8ScaleInvMap({'quantized':(str(f.root/'unused.safetensors'),
+            'model.layers.1.a.weight')}, block=(2,2))
+        assert ls._apply_fp8_dequant_inplace(out, scales, torch.device('cpu'),
+            source_authentication=owner) == 1
+        assert torch.equal(out['quantized'], torch.ones(4,4)*9)
+        assert hashed == ['selected.safetensors', 'unused.safetensors']
+
+
+def test_metadata_read_lease_prevents_concurrent_close(complete_source, monkeypatch):
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+    from prismaquant import tessera_calibration_cache as cc
+    f = complete_source
+    with cc.authenticate_selected_capture_source(**f.kwargs) as owner:
+        entered, resume = threading.Event(), threading.Event()
+        original = cc.json.load
+        def blocked(handle):
+            entered.set()
+            assert resume.wait(timeout=5)
+            return original(handle)
+        monkeypatch.setattr(cc.json, 'load', blocked)
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(owner.read_json, f.root/'config.json')
+            assert entered.wait(timeout=5)
+            try:
+                with pytest.raises(RuntimeError, match='active readers'):
+                    owner.close()
+            finally:
+                resume.set()
+            assert future.result(timeout=5) == {}
+
+
+def test_manifest_hash_and_parse_use_the_same_bytes(complete_source, monkeypatch):
+    from prismaquant import tessera_calibration_cache as cc
+    f = complete_source
+    path = Path(f.capture['path'])
+    original = Path.read_bytes
+    def swap_after_read(value):
+        raw = original(value)
+        if value == path:
+            value.write_text('{"status":"untrusted replacement"}')
+        return raw
+    monkeypatch.setattr(Path, 'read_bytes', swap_after_read)
+    manifest = cc.require_capture_contract(path, expected_sha256=f.capture['sha256'])
+    assert manifest['identity'] == f.canonical
+    assert manifest['status'] == 'complete'
+
+
+def test_fifo_source_replacement_refuses_without_blocking(complete_source):
+    import multiprocessing
+    import os
+    from prismaquant import tessera_calibration_cache as cc
+    f = complete_source
+    path = f.root/'selected.safetensors'
+    path.unlink()
+    os.mkfifo(path)
+    # A forked, owned probe makes a blocking-open regression bounded too.
+    context = multiprocessing.get_context('fork')
+    outcomes = context.Queue()
+    def open_source():
+        owner = cc.CaptureSourceAuthentication(f.root, f.canonical,
+            f.census['expert_projection']['producer']['source'], manifest_sha256=f.capture['sha256'])
+        try:
+            owner.file_stat(path)
+        except RuntimeError as exc:
+            outcomes.put(str(exc))
+        finally:
+            owner.close()
+    process = context.Process(target=open_source)
+    process.start()
+    process.join(timeout=2)
+    hung = process.is_alive()
+    if hung:
+        process.terminate()
+        process.join(timeout=5)
+    try:
+        assert not hung, 'source open blocked on a FIFO before regular-file validation'
+        assert process.exitcode == 0
+        assert 'regular file' in outcomes.get(timeout=2)
+    finally:
+        outcomes.close()
+        outcomes.join_thread()
+
+
+@pytest.mark.parametrize('failure', ['enter', 'exit'])
+def test_underlying_context_failure_releases_read_lease(complete_source, failure):
+    from prismaquant import tessera_calibration_cache as cc
+    f = complete_source
+    calls = []
+    class Failing:
+        def __init__(self, *_args, **_kwargs):
+            pass
+        def __enter__(self):
+            calls.append('enter')
+            if failure == 'enter':
+                raise RuntimeError('context enter failure')
+            return self
+        def __exit__(self, *_args):
+            calls.append('exit')
+            if failure == 'exit':
+                raise RuntimeError('context exit failure')
+    with cc.authenticate_selected_capture_source(**f.kwargs) as owner:
+        with pytest.raises(RuntimeError, match=f'context {failure} failure'):
+            with owner.safe_open(Failing, f.root/'selected.safetensors', framework='pt'):
+                pass
+        assert calls == ['enter', 'exit']
+        assert owner._readers == 0
+
+
+def test_legitimate_hf_style_source_symlink_preserves_authentication(complete_source, tmp_path):
+    from safetensors import safe_open
+    from prismaquant import tessera_calibration_cache as cc
+    f = complete_source
+    path = f.root/'selected.safetensors'
+    blob = tmp_path/'hub-blob'
+    path.rename(blob)
+    path.symlink_to(blob)
+    with cc.authenticate_selected_capture_source(**f.kwargs) as owner:
+        with owner.safe_open(safe_open, path, framework='pt') as handle:
+            value = handle.get_tensor('model.layers.0.a.weight')
+            assert torch.equal(value, f.tensors['selected.safetensors']['model.layers.0.a.weight'])
+        assert owner.receipt()['payload_bytes_hashed'] == blob.stat().st_size

--- a/tests/test_streamed_prefetch_scheduling.py
+++ b/tests/test_streamed_prefetch_scheduling.py
@@ -63,6 +63,7 @@ def _make_ctx(
     ctx.fp8_scale_inv_map = {}
     ctx.expert_packer = None
     ctx.concat_merger = None
+    ctx.source_authentication = None
     ctx.estimated_layer_bytes = LAYER_BYTES
     ctx.prefetch_workers = workers
     ctx.prefetch_min_available_bytes = pressure_floor

--- a/tests/test_tessera_selected_source.py
+++ b/tests/test_tessera_selected_source.py
@@ -231,7 +231,7 @@ def test_native_bounded_encoder_memo_keeps_wire_and_price_bytes(tmp_path, monkey
         path.write_text(json.dumps(dict(measurements=measurements, wire_and_price_parity=True), indent=2)+'\n')
 
 
-def test_selected_capture_cli_reaches_existing_streamed_source(monkeypatch, tmp_path):
+def test_selected_capture_cli_refuses_missing_capture_before_streamed_source(monkeypatch, tmp_path):
     from test_tessera_campaign_resume import _main_fixture
     from prismaquant import cost_streaming
     from prismaquant.autoscale import BOUNDED_CAPTURE_ENV
@@ -242,15 +242,11 @@ def test_selected_capture_cli_reaches_existing_streamed_source(monkeypatch, tmp_
     for name, value in BOUNDED_CAPTURE_ENV.items():
         monkeypatch.setenv(name, value)
 
-    class SelectedSourceReached(Exception):
-        pass
-
     def build(*args, **kwargs):
-        assert kwargs['require_prefetched_residency'] is True
-        raise SelectedSourceReached
+        pytest.fail('source construction preceded complete-capture authentication')
 
     monkeypatch.setattr(cost_streaming, 'build_streamed_causal_lm', build)
-    with pytest.raises(SelectedSourceReached):
+    with pytest.raises(FileNotFoundError, match='capture_manifest.json'):
         campaign.main([*argv, '--streaming', '--units', str(tmp_path/'units.json'),
             '--calibration-census', str(tmp_path/'census.json'),
             '--calibration-cache', str(tmp_path/'capture_manifest.json'),


### PR DESCRIPTION
Selected capture consumers previously hashed every checkpoint payload through `capture_identity` before reading their selected rows. This change binds the complete manifest and census before model construction, then authenticates each consumed shard once through a held descriptor shared by the existing source readers. The original complete capture identity remains intact; unused shard payloads are deferred, and metadata, mutation, replacement, escaped reads, and incomplete captures fail closed.

Descriptor leases cover asynchronous readers, construction failures, runner shutdown, and projected source tensors. The tiny complete-capture regression reduces hashed payload from 2,130,208 to 32,960 bytes while preserving selected tensor values and manifest bytes. This is a CPU byte-count result; the original GLM capture and native before/after measurements remain pending, the remaining native measurement is tracked in #388.

Validation: PrismaBuild integration suite **355 passed, 1 CUDA-only encoder-memo skip, 2 passing subtests**, covering 23 files. Root review verified all successful terminal records, receipts, result hashes, and source snapshots. One fixture requiring two cache workers was initially under-reserved at one CPU; only that file was resubmitted at two CPUs and passed. The final documentation checks also passed 19 tests. Full CI then exposed a prefetch fixture that bypassed the context initializer and lacked the new optional field; PB reproduced all nine failures. The one-line fixture correction passed all 32 scheduling/admission tests; runtime code is unchanged. The final full CI passed 6,879 tests and 192 subtests, with 201 skips and three expected failures (run 34253411730). Earlier FIFO and unused-payload regressions were demonstrated before their fixes. Evidence and limitations are in [the measurement record](https://github.com/RobTand/prismaquant/blob/0f7515f730c1fc7831f1c36a7734cf438b2b66d8/docs/measurements/selected-source-authentication-2026-09-08.md).

Separate incidental prose correction: removed an unsupported GPU-utilization saturation claim from the source-reader docstring.

Closes #409. Refs #388.
