### PR TITLE
Keep complete GLM Hessian handoff bounded through export

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,16 @@
 As of: 2026-09-08 · `integrate/glm-bounded-handoff-20260908`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-08, `integrate/glm-bounded-handoff-20260908`) for the
+synchronized development/serving dependency pin to Tessera `9d2314819f02`
+(#429), required by bounded canonical H references. The exact packaged
+contract SHA is `a688f8de244f936ec3a63a782e20af7985733e7a6fb0b4b981b5fe4c44112212`.
+Its only structural change from the prior pin is LFM construction output
+sizes; the allocator admission answer, serving-cell and native-extension
+tables are unchanged. Version `0.1.0` remains advisory with
+`version_is_release=false`. The explicit research TP2 controls do not promote
+a runtime cell. New priced wires bind the final producer source identity.
+
 Re-stamped (2026-09-08, `fix/bounded-export-handoff`) for the opt-in
 canonical Hessian reference handoff. Selected reuse may declare
 `--export-hessian-reference-policy` with explicit metadata/file/H byte caps.
@@ -19,7 +29,7 @@ Legacy `.pt` handoffs keep their eager behavior. Sampled selected-wire
 materialization explicitly refuses reference inputs until it has a bounded
 reference union; complete priced wires remain the supported reference scope.
 This adds no cache or scheduler, changes no row resident-prefetch estimator,
-serving pin, wire format or ship gate. It requires the reviewed producer reader
+wire format or ship gate. It requires the reviewed producer reader
 and a fresh producer source identity for new prices; old wire identities are
 not reused under the changed producer hash. CPU contract validation does not
 establish native throughput, GPU residency or full-model serving performance.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,27 @@
 As of: 2026-09-08 · `integrate/glm-source-derivative-20260908`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-08, `fix/bounded-export-handoff`) for the opt-in
+canonical Hessian reference handoff. Selected reuse may declare
+`--export-hessian-reference-policy` with explicit metadata/file/H byte caps.
+The existing row writer emits `hessian_capture.references.json`, binding the
+complete canonical capture and exact census, full-census counts, per-unit H
+commitments and the unchanged old row capture SHA. Dispatcher merge verifies
+row/provenance/selection bindings and unions only metadata; it does not load
+or copy the full H corpus. Allocation carries the separate canonical binding,
+and export emits `tessera.priced_export_inputs.v2` for the producer's bounded
+reference reader. Intake reports H payload verification as deferred; every
+actual H consumption, including cached-wire identity, checks original file
+bytes and the committed H through the producer's held-descriptor owner.
+Legacy `.pt` handoffs keep their eager behavior. Sampled selected-wire
+materialization explicitly refuses reference inputs until it has a bounded
+reference union; complete priced wires remain the supported reference scope.
+This adds no cache or scheduler, changes no row resident-prefetch estimator,
+serving pin, wire format or ship gate. It requires the reviewed producer reader
+and a fresh producer source identity for new prices; old wire identities are
+not reused under the changed producer hash. CPU contract validation does not
+establish native throughput, GPU residency or full-model serving performance.
+
 Re-stamped (2026-09-08, `codex/joint-operator-windows-profile`) for the opt-in
 GLM KDA derivative contract. The GLM profile declares a closed, source-pinned
 strictly upper-triangular premask of the fallback decay exponent; declaring it

--- a/experiments/hessian_reference_contract_check.py
+++ b/experiments/hessian_reference_contract_check.py
@@ -1,0 +1,45 @@
+"""PB CPU validation with an independently hash-bound producer source archive."""
+import argparse
+import compileall
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+import tarfile
+import tempfile
+
+
+def main():
+    parser=argparse.ArgumentParser()
+    parser.add_argument('--producer-archive',required=True)
+    parser.add_argument('--producer-sha256',required=True)
+    parser.add_argument('--producer-commit',required=True)
+    args,tests=parser.parse_known_args()
+    archive=Path(args.producer_archive)
+    actual=hashlib.sha256(archive.read_bytes()).hexdigest()
+    if actual != args.producer_sha256:
+        raise RuntimeError('producer archive SHA-256 changed')
+    with tempfile.TemporaryDirectory(prefix='bounded-hessian-producer-') as temporary:
+        with tarfile.open(archive) as source:
+            source.extractall(temporary,filter='data')
+        producer=Path(temporary)
+        sys.path.insert(0,str(Path.cwd()))
+        sys.path.insert(0,str(producer/'src'))
+        os.environ['TESSERA_REPO']=str(producer)
+        import tessera
+        if Path(tessera.__file__).resolve() != producer/'src/tessera/__init__.py':
+            raise RuntimeError('loaded producer differs from the verified source archive')
+        print(json.dumps(dict(producer_commit=args.producer_commit,
+            producer_archive_sha256=actual,producer_module=str(tessera.__file__)),sort_keys=True),flush=True)
+        files=['prismaquant/tessera_calibration_cache.py','prismaquant/tessera_campaign.py',
+            'prismaquant/tessera_export_lane.py','prismaquant/tessera_menu.py',
+            'prismaquant/tessera_materialization.py','tools/dispatch_tessera_campaign.py']
+        if not all(compileall.compile_file(path,quiet=1) for path in files):
+            raise RuntimeError('touched module compilation failed')
+        import pytest
+        return pytest.main(tests)
+
+
+if __name__=='__main__':
+    raise SystemExit(main())

--- a/experiments/measurements/bounded-hessian-handoff-20260908/4915c95804a917c5674af1f4db747511b323648247f51deef4e79a710b05b8f7.json
+++ b/experiments/measurements/bounded-hessian-handoff-20260908/4915c95804a917c5674af1f4db747511b323648247f51deef4e79a710b05b8f7.json
@@ -1,0 +1,88 @@
+{
+  "action_key": "4915c95804a917c5674af1f4db747511b323648247f51deef4e79a710b05b8f7",
+  "checks": {
+    "complete_terminal": true
+  },
+  "cleanup": {
+    "complete": true,
+    "released_ok": true,
+    "stop_reason": "failed"
+  },
+  "logs": [
+    {
+      "bytes": 887,
+      "path": "attempts/4915c95804a917c5674af1f4db747511b323648247f51deef4e79a710b05b8f7/9bfaf20a8f4679b072a7ce268aef3bb35afe415e2a8a7b8406a3d03091503373/00000001.stderr.9f85870df9bb1d174f9b2bb38848dcbaaec087b8586065bce1f4122c49f16e91.log",
+      "sha256": "9f85870df9bb1d174f9b2bb38848dcbaaec087b8586065bce1f4122c49f16e91",
+      "stream": "stderr",
+      "verified": true
+    },
+    {
+      "bytes": 1749,
+      "path": "attempts/4915c95804a917c5674af1f4db747511b323648247f51deef4e79a710b05b8f7/9bfaf20a8f4679b072a7ce268aef3bb35afe415e2a8a7b8406a3d03091503373/00000001.stdout.004741b19cd31500e72cff587943f40f884a41980d9aa7a55880d9ed8f7a2815.log",
+      "sha256": "004741b19cd31500e72cff587943f40f884a41980d9aa7a55880d9ed8f7a2815",
+      "stream": "stdout",
+      "verified": true
+    }
+  ],
+  "outcome": {
+    "action_returncode": 1,
+    "action_signal": null,
+    "attempts": 1,
+    "claimed_by": "dl380g10:2449040:7a325fef",
+    "claimed_host": "dl380g10",
+    "claimed_unix": 1788892732.483914,
+    "elapsed_s": 2.799426317214966,
+    "finished_host": "dl380g10",
+    "finished_unix": 1788892736.0852933,
+    "reason": null,
+    "receipt_published": null,
+    "returncode": 1,
+    "status": "failed"
+  },
+  "receipt": {
+    "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/49/4915c95804a917c5674af1f4db747511b323648247f51deef4e79a710b05b8f7.json",
+    "present": false
+  },
+  "resources": {
+    "memory_peak_bytes": 221151232,
+    "oom_kill": 0,
+    "oom_local": 0,
+    "processes_live": 0
+  },
+  "sealed": {
+    "cas_root": "/mnt/shared/prismabuild-fleet/cas",
+    "checkout_root": null,
+    "checkout_snapshot": {
+      "commit": "c0a163f4455c72cde7e6101d044766610d4e6ba6",
+      "input": {
+        "bytes": 8177763,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "8beef45ded25a089becea0ee136b29d76fb82364c8c7d7e450fe21743ae54b74"
+      },
+      "parent": "ad828f67823c8b927a932d8b788984a019ed6bd4",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "max_attempts": 1,
+    "needs_gpu": false,
+    "preempted_by": null,
+    "priority": -10,
+    "published_by": "sparky",
+    "published_unix": 1788892727.4317048,
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 3
+    },
+    "retry_safe": false,
+    "supersedes_withdrawal": null,
+    "tags": [
+      "x86"
+    ],
+    "worker_script": "/mnt/shared/prismabuild-fleet/runtime-generations/437ad81b1129-1788868060-209c40b934b6/tools/prismabuild_worker.py"
+  },
+  "state": "failed",
+  "test_summary": [
+    "1 failed, 21 deselected in 1.23s"
+  ]
+}

--- a/experiments/measurements/bounded-hessian-handoff-20260908/4915c95804a917c5674af1f4db747511b323648247f51deef4e79a710b05b8f7.stdout.log
+++ b/experiments/measurements/bounded-hessian-handoff-20260908/4915c95804a917c5674af1f4db747511b323648247f51deef4e79a710b05b8f7.stdout.log
@@ -1,0 +1,26 @@
+F                                                                        [100%]
+=================================== FAILURES ===================================
+_________ test_unsorted_reference_json_preserves_existing_capture_seal _________
+
+reference = (PosixPath('/home/rob/tmp/pytest-of-rob/pytest-3286/test_unsorted_reference_json_p0/hessian_capture.references.json'),...75227d'}, 'b': {'path': 'inputs/b.pt', 'sha256': '31e2fe19d0c2a9c575b0c2bc28908f1c3ab3ca149ea7d825c950807ff16aeeea'}}})
+
+    def test_unsorted_reference_json_preserves_existing_capture_seal(reference):
+        handoff,payload,H,*_=reference
+        payload['hessians']={name:payload['hessians'][name] for name in ('b','a')}
+        handoff.write_text(json.dumps(payload,sort_keys=False))
+        source=ActivationSource.from_capture(handoff)
+>       assert source.capture_sha256()==ActivationSource(H,payload['provenance']).capture_sha256()
+E       AssertionError: assert '44c1c7a8f999...3348a279f8148' == '3922a8cb3beb...82fe6dc52b38b'
+E
+E         - 3922a8cb3beb3567eaa469f3e8498bae33d90dae78c7b1e204f82fe6dc52b38b
+E         + 44c1c7a8f99911cb3bb6ad88a296ca9f186a133ca9bb07f9d293348a279f8148
+
+tests/test_hessian_reference_capture.py:206: AssertionError
+
+tessera surface: NO CUDA -- torch 2.11.0+cpu reports no CUDA device
+tessera surface: 0 test(s) skipped, 0 module(s) not collected
+tessera surface: this run did not exercise the CUDA-gated surface. Its pass count is not coverage of it.
+tessera surface: 0 test(s) allocated on the device
+=========================== short test summary info ============================
+FAILED tests/test_hessian_reference_capture.py::test_unsorted_reference_json_preserves_existing_capture_seal
+1 failed, 21 deselected in 1.23s

--- a/experiments/measurements/bounded-hessian-handoff-20260908/740c213d5bd5fd890cf2496d421363d8a8fd23cd696b5548663504066bfa40b2.json
+++ b/experiments/measurements/bounded-hessian-handoff-20260908/740c213d5bd5fd890cf2496d421363d8a8fd23cd696b5548663504066bfa40b2.json
@@ -1,0 +1,98 @@
+{
+  "action_key": "740c213d5bd5fd890cf2496d421363d8a8fd23cd696b5548663504066bfa40b2",
+  "checks": {
+    "actual_cas_payload_bytes_and_sha256": true,
+    "actual_source_bundle_bytes_and_sha256": true,
+    "canonical_receipt_sha256": true,
+    "complete_terminal": true,
+    "tested_source_differs_from_final_commit_only_in_pb_closure_metadata": true
+  },
+  "cleanup": {
+    "complete": true,
+    "released_ok": true,
+    "stop_reason": "executed"
+  },
+  "logs": [
+    {
+      "bytes": 0,
+      "path": "attempts/740c213d5bd5fd890cf2496d421363d8a8fd23cd696b5548663504066bfa40b2/9f764c6b031fa38a188945c73f02c3a98cea1f2da32f4b182ec2d21b7b3a3919/00000001.stderr.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.log",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stream": "stderr",
+      "verified": true
+    },
+    {
+      "bytes": 2867,
+      "path": "attempts/740c213d5bd5fd890cf2496d421363d8a8fd23cd696b5548663504066bfa40b2/9f764c6b031fa38a188945c73f02c3a98cea1f2da32f4b182ec2d21b7b3a3919/00000001.stdout.f55eacee5cb73f66165c0f4554f096979e6dbce1fe5f207967d2633781e64bcb.log",
+      "sha256": "f55eacee5cb73f66165c0f4554f096979e6dbce1fe5f207967d2633781e64bcb",
+      "stream": "stdout",
+      "verified": true
+    }
+  ],
+  "outcome": {
+    "action_returncode": null,
+    "action_signal": null,
+    "attempts": 1,
+    "claimed_by": "dl380g10:2758162:f2816c65",
+    "claimed_host": "dl380g10",
+    "claimed_unix": 1788892835.0223937,
+    "elapsed_s": 18.65619993209839,
+    "finished_host": "dl380g10",
+    "finished_unix": 1788892854.4298072,
+    "reason": null,
+    "receipt_published": null,
+    "returncode": 0,
+    "status": "executed"
+  },
+  "receipt": {
+    "action_manifest_sha256": "1d033989da65342cd1b9a8ef472b6bc0e44291185fc044c6ec327c68826e71bb",
+    "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/74/740c213d5bd5fd890cf2496d421363d8a8fd23cd696b5548663504066bfa40b2.json",
+    "present": true,
+    "receipt_sha256": "7bfd4e1a819716aa6cb8ccbe607f6de8eae3d3d7431978958cadeed23cc81e4d",
+    "result": {
+      "bytes": 387,
+      "sha256": "ffef0976e96241582103496fba6bed0adff5d5394398cf4099e2cba82116c74f"
+    }
+  },
+  "resources": {
+    "memory_peak_bytes": 378736640,
+    "oom_kill": 0,
+    "oom_local": 0,
+    "processes_live": 0
+  },
+  "sealed": {
+    "cas_root": "/mnt/shared/prismabuild-fleet/cas",
+    "checkout_root": null,
+    "checkout_snapshot": {
+      "commit": "b9dfcc753a2df6a0661e33ea4ce6711a43f6856e",
+      "input": {
+        "bytes": 8178297,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "27a4a03ef33ed01455768d2773d477a4c38750754c494190c0db760261db9c3b"
+      },
+      "parent": "615e1c0302693447a9cd713bb1f9dddc21fbd378",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "max_attempts": 1,
+    "needs_gpu": false,
+    "preempted_by": null,
+    "priority": -10,
+    "published_by": "sparky",
+    "published_unix": 1788892834.6020849,
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 3
+    },
+    "retry_safe": false,
+    "supersedes_withdrawal": null,
+    "tags": [
+      "x86"
+    ],
+    "worker_script": "/mnt/shared/prismabuild-fleet/runtime-generations/437ad81b1129-1788868060-209c40b934b6/tools/prismabuild_worker.py"
+  },
+  "state": "done",
+  "test_summary": [
+    "71 passed in 17.15s"
+  ]
+}

--- a/experiments/measurements/bounded-hessian-handoff-20260908/740c213d5bd5fd890cf2496d421363d8a8fd23cd696b5548663504066bfa40b2.stdout.log
+++ b/experiments/measurements/bounded-hessian-handoff-20260908/740c213d5bd5fd890cf2496d421363d8a8fd23cd696b5548663504066bfa40b2.stdout.log
@@ -1,0 +1,7 @@
+.......................................................................  [100%]
+
+tessera surface: NO CUDA -- torch 2.11.0+cpu reports no CUDA device
+tessera surface: 0 test(s) skipped, 0 module(s) not collected
+tessera surface: this run did not exercise the CUDA-gated surface. Its pass count is not coverage of it.
+tessera surface: 0 test(s) allocated on the device
+71 passed in 17.15s

--- a/experiments/measurements/bounded-hessian-handoff-20260908/8326b6e31f23e4e7ad563c47a902003a698cbcee83b4fea502a46c19ca6c1070.json
+++ b/experiments/measurements/bounded-hessian-handoff-20260908/8326b6e31f23e4e7ad563c47a902003a698cbcee83b4fea502a46c19ca6c1070.json
@@ -1,0 +1,88 @@
+{
+  "action_key": "8326b6e31f23e4e7ad563c47a902003a698cbcee83b4fea502a46c19ca6c1070",
+  "checks": {
+    "complete_terminal": true
+  },
+  "cleanup": {
+    "complete": true,
+    "released_ok": true,
+    "stop_reason": "failed"
+  },
+  "logs": [
+    {
+      "bytes": 887,
+      "path": "attempts/8326b6e31f23e4e7ad563c47a902003a698cbcee83b4fea502a46c19ca6c1070/9526775bdbd918a4063369a8637be782449d8365bf70554ff1605a9e4d76e4cd/00000001.stderr.9f85870df9bb1d174f9b2bb38848dcbaaec087b8586065bce1f4122c49f16e91.log",
+      "sha256": "9f85870df9bb1d174f9b2bb38848dcbaaec087b8586065bce1f4122c49f16e91",
+      "stream": "stderr",
+      "verified": true
+    },
+    {
+      "bytes": 3104,
+      "path": "attempts/8326b6e31f23e4e7ad563c47a902003a698cbcee83b4fea502a46c19ca6c1070/9526775bdbd918a4063369a8637be782449d8365bf70554ff1605a9e4d76e4cd/00000001.stdout.76d91d129c21bd2b61c5f6a557f0f332c3607e557b9a8da600df9724a1bc3262.log",
+      "sha256": "76d91d129c21bd2b61c5f6a557f0f332c3607e557b9a8da600df9724a1bc3262",
+      "stream": "stdout",
+      "verified": true
+    }
+  ],
+  "outcome": {
+    "action_returncode": 1,
+    "action_signal": null,
+    "attempts": 1,
+    "claimed_by": "dl380g10:2438999:c108b6ca",
+    "claimed_host": "dl380g10",
+    "claimed_unix": 1788890777.9172852,
+    "elapsed_s": 3.2967636585235596,
+    "finished_host": "dl380g10",
+    "finished_unix": 1788890782.0063157,
+    "reason": null,
+    "receipt_published": null,
+    "returncode": 1,
+    "status": "failed"
+  },
+  "receipt": {
+    "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/83/8326b6e31f23e4e7ad563c47a902003a698cbcee83b4fea502a46c19ca6c1070.json",
+    "present": false
+  },
+  "resources": {
+    "memory_peak_bytes": 465571840,
+    "oom_kill": 0,
+    "oom_local": 0,
+    "processes_live": 0
+  },
+  "sealed": {
+    "cas_root": "/mnt/shared/prismabuild-fleet/cas",
+    "checkout_root": null,
+    "checkout_snapshot": {
+      "commit": "9b26440b6bf62179350c0a54b33ddbe7c02dc815",
+      "input": {
+        "bytes": 8167662,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "625ada8b9abcd80b2b2890f95bae45535abfe5918cfbc9d7ec40479e2b6ea9ce"
+      },
+      "parent": "98aa317a06e55731c36c53f509adc04260668cc1",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "max_attempts": 1,
+    "needs_gpu": false,
+    "preempted_by": null,
+    "priority": -10,
+    "published_by": "sparky",
+    "published_unix": 1788890776.2322805,
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 3
+    },
+    "retry_safe": false,
+    "supersedes_withdrawal": null,
+    "tags": [
+      "x86"
+    ],
+    "worker_script": "/mnt/shared/prismabuild-fleet/runtime-generations/437ad81b1129-1788868060-209c40b934b6/tools/prismabuild_worker.py"
+  },
+  "state": "failed",
+  "test_summary": [
+    "1 failed in 1.70s"
+  ]
+}

--- a/experiments/measurements/bounded-hessian-handoff-20260908/8326b6e31f23e4e7ad563c47a902003a698cbcee83b4fea502a46c19ca6c1070.stdout.log
+++ b/experiments/measurements/bounded-hessian-handoff-20260908/8326b6e31f23e4e7ad563c47a902003a698cbcee83b4fea502a46c19ca6c1070.stdout.log
@@ -1,0 +1,45 @@
+F                                                                        [100%]
+=================================== FAILURES ===================================
+_ test_public_reader_binds_commitments_without_loading_h_then_verifies_access __
+
+reference = (PosixPath('/home/rob/tmp/pytest-of-rob/pytest-3239/test_public_reader_binds_commi0/hessian_capture.references.json'),...75227d'}, 'b': {'path': 'inputs/b.pt', 'sha256': '31e2fe19d0c2a9c575b0c2bc28908f1c3ab3ca149ea7d825c950807ff16aeeea'}}})
+monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x72c6fb8bc510>
+
+    def test_public_reader_binds_commitments_without_loading_h_then_verifies_access(reference, monkeypatch):
+        handoff,payload,H,_,_=reference
+        original=torch.load;loads=[]
+        def observed(path,*args,**kwargs):
+            assert not str(path).endswith('.json'), 'reference JSON must not take the eager torch.load route'
+            loads.append((str(path),dict(kwargs)))
+            return original(path,*args,**kwargs)
+        monkeypatch.setattr(torch,'load',observed)
+>       source=ActivationSource.from_capture(handoff)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/test_hessian_reference_capture.py:68:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+src/tessera/export.py:771: in from_capture
+    payload = _torch.load(str(path), map_location="cpu", weights_only=False)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+path = '/home/rob/tmp/pytest-of-rob/pytest-3239/test_public_reader_binds_commi0/hessian_capture.references.json'
+args = (), kwargs = {'map_location': 'cpu', 'weights_only': False}
+
+    def observed(path,*args,**kwargs):
+>       assert not str(path).endswith('.json'), 'reference JSON must not take the eager torch.load route'
+E       AssertionError: reference JSON must not take the eager torch.load route
+E       assert not True
+E        +  where True = <built-in method endswith of str object at 0x72c6f91e12c0>('.json')
+E        +    where <built-in method endswith of str object at 0x72c6f91e12c0> = '/home/rob/tmp/pytest-of-rob/pytest-3239/test_public_reader_binds_commi0/hessian_capture.references.json'.endswith
+E        +      where '/home/rob/tmp/pytest-of-rob/pytest-3239/test_public_reader_binds_commi0/hessian_capture.references.json' = str('/home/rob/tmp/pytest-of-rob/pytest-3239/test_public_reader_binds_commi0/hessian_capture.references.json')
+
+tests/test_hessian_reference_capture.py:64: AssertionError
+
+tessera surface: NO CUDA -- torch 2.11.0+cpu reports no CUDA device
+tessera surface: 0 test(s) skipped, 0 module(s) not collected
+tessera surface: this run did not exercise the CUDA-gated surface. Its pass count is not coverage of it.
+tessera surface: 0 test(s) allocated on the device
+=========================== short test summary info ============================
+FAILED tests/test_hessian_reference_capture.py::test_public_reader_binds_commitments_without_loading_h_then_verifies_access
+1 failed in 1.70s

--- a/experiments/measurements/bounded-hessian-handoff-20260908/README.md
+++ b/experiments/measurements/bounded-hessian-handoff-20260908/README.md
@@ -1,0 +1,97 @@
+# Bounded canonical Hessian handoff — CPU contract evidence
+
+2026-09-08. PrismaQuant source `11cdcc823325a56b14a53692a3db2565bc5d16ce`
+(base `00a7b5d35b82e7b78caeb5b461e16b2de7a5c5a9`) and Tessera source
+`615e1c0302693447a9cd713bb1f9dddc21fbd378` (base
+`98aa317a06e55731c36c53f509adc04260668cc1`, implementation `ad828f6782`,
+separate ordering correction `615e1c0302`). Author worktrees were isolated;
+no runtime release pin, format admission, row resource estimator or native
+experiment was changed by this work. Cross-repository integration and producer
+development-pin updates belong to the coordinator's later integration.
+
+The opt-in selected campaign argument `--export-hessian-reference-policy`
+accepts a closed `tessera.hessian_reference_load.v1` policy with positive byte
+caps `max_metadata_bytes`, `max_file_bytes`, `max_hessian_bytes`. Metadata has a
+128 MiB bootstrap ceiling and the declared metadata cap cannot exceed it;
+H cannot exceed the declared file cap. The row writer emits metadata references
+to the existing complete canonical capture, its exact census, full-census
+counts and selected-unit H commitments. The old `tessera.hessian_capture.v1`
+content seal remains exact, including unsorted reference JSON. Row merge binds
+each row seal/provenance/selection and unions only metadata. Allocation carries
+the canonical manifest/census binding separately; producer intake uses the
+closed `tessera.priced_export_inputs.v2` expectation.
+
+Metadata acceptance is not verification of unconsumed H. Every actual H lookup,
+including cached-wire input identity, hashes the bounded original canonical
+file and actual H through a held descriptor before returning a detached copy.
+The reader keeps JSON metadata and descriptors, never an H/X cache. One lookup
+can own one capped source mapping, one H copy and existing H-sized hash bytes;
+caller-owned H and encoder workspaces are additional. The tests assert no
+retained returned H and that source changes during mapping load are refused.
+Legacy `.pt` input remains eager. Sampled selected-wire materialization refuses
+references at request intake because its existing completion union is eager;
+complete priced wires are the supported reference scope. No fallback copies
+the complete H corpus.
+
+## Verified runs
+
+All execution used PrismaBuild, one CPU, native thread libraries bounded to
+one, one attempt, priority -10 and x86 tooling placement (`dl380g10`). Producer
+used `/home/rob/venvs/pb-cpu/bin/python` (Torch 2.11.0+cpu), 3 GiB reservation;
+PQ used `/home/rob/venvs/pq-cpu312/bin/python`, 4 GiB reservation. These are
+correctness runs, not timing comparisons or GPU qualification.
+
+| Action | Result | Meaning |
+|---|---|---|
+| `8326b6e31f23e4e7ad563c47a902003a698cbcee83b4fea502a46c19ca6c1070` | 1 expected failure, 1.70 s | Baseline public reader sends reference JSON through eager `torch.load`; new bounded behavior absent. |
+| `4915c95804a917c5674af1f4db747511b323648247f51deef4e79a710b05b8f7` | 1 expected failure, 21 deselected, 1.23 s | Review regression: unsorted valid reference metadata changed the old seal in initial implementation. |
+| `740c213d5bd5fd890cf2496d421363d8a8fd23cd696b5548663504066bfa40b2` | 71 passed, 0 skipped, 0 missing modules, 17.15 s | Final producer reader, priced intake, legacy capture role and cached producer tests. No CUDA allocation. |
+| `e77e2f2fe875f2fc16b030d4b642d684cb7b277ae036e32419e9165081b47a9f` | 200 passed, 2 skipped, 14 Torch deprecation warnings, 111.54 s | Final PQ compile, exact-producer handoff, canonical capture, priced export, materialization, dispatch/merge, allocator, bounded legacy writer and documentation checks. |
+
+PQ's two skips are explicit: the old producer without a capture-seal API is
+inapplicable to this producer, and the native writer measurement requires its
+separate explicit opt-in. No new reference test was skipped. The successful
+public selected-CLI test preserves its canonical manifest and source identity,
+reads only required source shards, forbids extra calibration forwards, and
+publishes references without an H `.pt` sidecar. It uses the existing small
+source-orchestration fixture and an empty research menu; it is not a native
+model pricing or serving run. Other tests cover row digest equivalence,
+metadata-only merge, exact selection and binding refusals, deferred payload
+reporting, policy applicability, mixed allocation binding and sampled intake
+refusal. Producer cases cover source/metadata replacement, byte corruption,
+limits, forged commitments, detached lifetime, `for_unit`, cached-wire intake,
+v1/v2 separation and legacy eager loading.
+
+Final PQ execution ran `experiments/hessian_reference_contract_check.py`. It
+hashes and extracts the producer archive inside the admitted process, checks
+the imported module path, compiles all six changed runtime/CLI modules, then
+runs the eleven named test files. Archive:
+`/mnt/shared/prismaquant-experiments/hessian-reference-handoff-20260908/tessera-615e1c0302693447a9cd713bb1f9dddc21fbd378.tar`,
+SHA-256 `c6a6e849f7826ab18053004d4d625b2f26d9131923fda32b20fc6ca6a458aba7`.
+
+The checked JSON receipts contain action resource requests, terminal outcomes,
+log locations and byte hashes, exact snapshot inputs, CAS receipt/result
+identities, cleanup and measured process memory. Actual logs and source-bundle
+bytes/hashes were checked; canonical receipt hashes were recomputed and actual
+CAS result bytes/hashes verified. Final producer/PQ source snapshots differ
+from the named final commits only in PB closure metadata. Producer peak scope
+memory was 378,736,640 bytes; PQ was 918,777,856 bytes. Both finished with no OOM,
+no live process and complete successful scope release. These peaks describe
+small CPU fixtures, not full-census native resource demand.
+
+The GLM canonical capture was not consumed or rewritten by these tests. No
+native H handoff, CUDA encode, full-model export, serving correctness,
+throughput, physical page eviction or GPU residency claim follows from them.
+The changed producer package receives a new encoder source hash; original
+capture reuse remains compatible through its original model/census identity,
+but old encoded-wire identities cannot be reused under the new producer hash.
+
+`invocations.json` records the exact final command arguments and resource
+declarations. `preparation-attempts.json` gives the separate failed fixture and
+tooling attempts and their disposition; they are not counted as coverage.
+The initial local-placement submission was withdrawn from the ready queue
+before any execution and replaced by the explicit x86 tooling class.
+
+Checked-in stdout excerpts omit the trailing worker receipt JSON and trim
+line-end spaces. The receipt JSONs retain hashes and locations of the exact
+original logs whose bytes were independently verified.

--- a/experiments/measurements/bounded-hessian-handoff-20260908/README.md
+++ b/experiments/measurements/bounded-hessian-handoff-20260908/README.md
@@ -95,3 +95,37 @@ before any execution and replaced by the explicit x86 tooling class.
 Checked-in stdout excerpts omit the trailing worker receipt JSON and trim
 line-end spaces. The receipt JSONs retain hashes and locations of the exact
 original logs whose bytes were independently verified.
+
+## Final integration and dependency pin
+
+The final root integration `1228c3523166` includes the merged six-variant
+intake (`main` merge `50b209fc702c`), the bounded H handoff, and synchronized
+development/serving pins to reviewed Tessera `9d2314819f02` (PR #429).
+The producer contract SHA is
+`a688f8de244f936ec3a63a782e20af7985733e7a6fb0b4b981b5fe4c44112212`.
+A structural comparison to the prior `ba582d4` contract found only LFM
+construction output sizes added. The allocator answer, serving-cell and
+native-extension tables are unchanged; version 0.1.0 remains advisory and
+no TP2 runtime cell is promoted. The exact reviewed producer includes the
+separately reproduced FIFO refusal fix. The new source seal must be used
+consistently by pricing and export; old wires are not relabeled.
+
+PB action `b1c1dd4dc4d3fb37c7ec2e6bab2060a4cc67b3c204d7a487c741331ec3b8b79d`
+passed 239 tests with 3 skips in 87.63 seconds, CPU only, on the x86 tooling
+worker with one CPU, 4 GiB and OMP/MKL/OpenBLAS threads of one. It exercised
+the eleven earlier handoff/merge/materialization/architecture modules plus
+serving-pin and contract-v4/v5 tests through the existing archive-bound
+`experiments/hessian_reference_contract_check.py`. The archive is
+`/mnt/shared/tessera-measurements/glm-tp2-plan-20260908/source-producer-9d2314819.tar`,
+SHA `30bf315c472062bf3aca1d47b76d21d3a92f157711baae68cf0f73a1739d875b`.
+The three skips concern a legacy producer-absence case, the explicit native
+writer measurement and an unsupplied immutable v5 publisher contract. No
+native handoff performance claim is made. Terminal return code, cleanup,
+canonical CAS receipt and actual payload/source bytes were independently
+verified; the tested source differs only by generated PB closure metadata.
+`root-final-handoff-pin-cas-source-audit.json` retains the exact stdout and
+source comparison. Full invocation/output is in the shared canonical-census
+root as `root-final-handoff-pin-tests.log`.
+
+The separate prose-only fix corrects an obsolete statement that the serving
+pin still contains PENDING sentinels. It changes no gate behavior.

--- a/experiments/measurements/bounded-hessian-handoff-20260908/e77e2f2fe875f2fc16b030d4b642d684cb7b277ae036e32419e9165081b47a9f.json
+++ b/experiments/measurements/bounded-hessian-handoff-20260908/e77e2f2fe875f2fc16b030d4b642d684cb7b277ae036e32419e9165081b47a9f.json
@@ -1,0 +1,100 @@
+{
+  "action_key": "e77e2f2fe875f2fc16b030d4b642d684cb7b277ae036e32419e9165081b47a9f",
+  "checks": {
+    "actual_cas_payload_bytes_and_sha256": true,
+    "actual_source_bundle_bytes_and_sha256": true,
+    "canonical_receipt_sha256": true,
+    "complete_terminal": true,
+    "tested_source_differs_from_final_commit_only_in_pb_closure_metadata": true
+  },
+  "cleanup": {
+    "complete": true,
+    "released_ok": true,
+    "stop_reason": "executed"
+  },
+  "logs": [
+    {
+      "bytes": 0,
+      "path": "attempts/e77e2f2fe875f2fc16b030d4b642d684cb7b277ae036e32419e9165081b47a9f/e016aad9bde61cb077bb87f9f3ceb92735e7fb8c24025d72c5052743eb8ae64b/00000001.stderr.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.log",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "stream": "stderr",
+      "verified": true
+    },
+    {
+      "bytes": 3782,
+      "path": "attempts/e77e2f2fe875f2fc16b030d4b642d684cb7b277ae036e32419e9165081b47a9f/e016aad9bde61cb077bb87f9f3ceb92735e7fb8c24025d72c5052743eb8ae64b/00000001.stdout.b952470473b0276c927a2b2d09a9f1eee105451aa814f5fc7fed24be0e66cc6e.log",
+      "sha256": "b952470473b0276c927a2b2d09a9f1eee105451aa814f5fc7fed24be0e66cc6e",
+      "stream": "stdout",
+      "verified": true
+    }
+  ],
+  "outcome": {
+    "action_returncode": null,
+    "action_signal": null,
+    "attempts": 1,
+    "claimed_by": "dl380g10:2755069:1191e2ba",
+    "claimed_host": "dl380g10",
+    "claimed_unix": 1788893230.3046086,
+    "elapsed_s": 114.36253523826599,
+    "finished_host": "dl380g10",
+    "finished_unix": 1788893346.7361784,
+    "reason": null,
+    "receipt_published": null,
+    "returncode": 0,
+    "status": "executed"
+  },
+  "receipt": {
+    "action_manifest_sha256": "591df71c02c32b106fd463b274f6e21927cf6116deb8bce5d776e056089dbdbb",
+    "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/e7/e77e2f2fe875f2fc16b030d4b642d684cb7b277ae036e32419e9165081b47a9f.json",
+    "present": true,
+    "receipt_sha256": "c7b2e4b518d019806708eedd4bb6090ec5ac2b97d6e31e66167d4686b180dc6c",
+    "result": {
+      "bytes": 1300,
+      "sha256": "ee295565e13c3a642b30bf90fc5b45c7a8b446a26a1bac2654b32618b03b3af5"
+    }
+  },
+  "resources": {
+    "memory_peak_bytes": 918777856,
+    "oom_kill": 0,
+    "oom_local": 0,
+    "processes_live": 0
+  },
+  "sealed": {
+    "cas_root": "/mnt/shared/prismabuild-fleet/cas",
+    "checkout_root": null,
+    "checkout_snapshot": {
+      "commit": "7ad9332808b430b003d575304b3ba28ce9fdc9c9",
+      "input": {
+        "bytes": 26991714,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "0b9e7dc09a280fd6c47c432d755fadb09cbf05b9ddbb0b5e218490705e280288"
+      },
+      "parent": "00a7b5d35b82e7b78caeb5b461e16b2de7a5c5a9",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "max_attempts": 1,
+    "needs_gpu": false,
+    "preempted_by": null,
+    "priority": -10,
+    "published_by": "sparky",
+    "published_unix": 1788893229.128694,
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 4
+    },
+    "retry_safe": false,
+    "supersedes_withdrawal": null,
+    "tags": [
+      "x86"
+    ],
+    "worker_script": "/mnt/shared/prismabuild-fleet/runtime-generations/437ad81b1129-1788868060-209c40b934b6/tools/prismabuild_worker.py"
+  },
+  "state": "done",
+  "test_summary": [
+    "SKIPPED [1] tests/test_tessera_priced_export_inputs.py:333: this tessera publishes the seal; see the test above",
+    "SKIPPED [1] tests/test_bounded_hessian_sidecar.py:50: explicit native writer measurement only",
+    "200 passed, 2 skipped, 14 warnings in 111.54s (0:01:51)"
+  ]
+}

--- a/experiments/measurements/bounded-hessian-handoff-20260908/e77e2f2fe875f2fc16b030d4b642d684cb7b277ae036e32419e9165081b47a9f.stdout.log
+++ b/experiments/measurements/bounded-hessian-handoff-20260908/e77e2f2fe875f2fc16b030d4b642d684cb7b277ae036e32419e9165081b47a9f.stdout.log
@@ -1,0 +1,14 @@
+{"producer_archive_sha256": "c6a6e849f7826ab18053004d4d625b2f26d9131923fda32b20fc6ca6a458aba7", "producer_commit": "615e1c0302693447a9cd713bb1f9dddc21fbd378", "producer_module": "/home/rob/tmp/bounded-hessian-producer-3e50zx0a/src/tessera/__init__.py"}
+......................................................................s. [ 35%]
+........................................................................ [ 71%]
+.....................................................s....               [100%]
+=============================== warnings summary ===============================
+../../../../venvs/pq-cpu312/lib/python3.12/site-packages/torch/jit/_script.py:362: 14 warnings
+  /home/rob/venvs/pq-cpu312/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
+    warnings.warn(
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ============================
+SKIPPED [1] tests/test_tessera_priced_export_inputs.py:333: this tessera publishes the seal; see the test above
+SKIPPED [1] tests/test_bounded_hessian_sidecar.py:50: explicit native writer measurement only
+200 passed, 2 skipped, 14 warnings in 111.54s (0:01:51)

--- a/experiments/measurements/bounded-hessian-handoff-20260908/invocations.json
+++ b/experiments/measurements/bounded-hessian-handoff-20260908/invocations.json
@@ -1,0 +1,59 @@
+{
+  "common_pbrun": {
+    "cpus": 1,
+    "environment": {
+      "MKL_NUM_THREADS": "1",
+      "OMP_NUM_THREADS": "1",
+      "OPENBLAS_NUM_THREADS": "1"
+    },
+    "max_attempts": 1,
+    "priority": -10,
+    "tag": "x86"
+  },
+  "prismaquant": {
+    "argv": [
+      "/home/rob/venvs/pq-cpu312/bin/python",
+      "experiments/hessian_reference_contract_check.py",
+      "--producer-archive",
+      "/mnt/shared/prismaquant-experiments/hessian-reference-handoff-20260908/tessera-615e1c0302693447a9cd713bb1f9dddc21fbd378.tar",
+      "--producer-sha256",
+      "c6a6e849f7826ab18053004d4d625b2f26d9131923fda32b20fc6ca6a458aba7",
+      "--producer-commit",
+      "615e1c0302693447a9cd713bb1f9dddc21fbd378",
+      "-q",
+      "-rs",
+      "tests/test_tessera_hessian_reference_handoff.py",
+      "tests/test_tessera_input_handoff.py",
+      "tests/test_tessera_calibration_cache.py",
+      "tests/test_tessera_priced_export_inputs.py",
+      "tests/test_tessera_materialization.py",
+      "tests/test_docs_staleness.py",
+      "tests/test_architecture_doc.py",
+      "tests/test_tessera_campaign_fanout.py",
+      "tests/test_tessera_campaign_merge_integrity.py",
+      "tests/test_allocator_tessera_priced_inputs.py",
+      "tests/test_bounded_hessian_sidecar.py"
+    ],
+    "checkout_commit": "11cdcc823325a56b14a53692a3db2565bc5d16ce",
+    "mem_gb": 4,
+    "timeout_s": 300
+  },
+  "producer": {
+    "argv": [
+      "/home/rob/venvs/pb-cpu/bin/python",
+      "-m",
+      "pytest",
+      "-q",
+      "tests/test_hessian_reference_capture.py",
+      "tests/test_priced_inputs_snapshot.py",
+      "tests/test_capture_role.py",
+      "tests/test_cached_producer.py"
+    ],
+    "checkout_commit": "615e1c0302693447a9cd713bb1f9dddc21fbd378",
+    "environment": {
+      "PYTHONPATH": "src"
+    },
+    "mem_gb": 3,
+    "timeout_s": 240
+  }
+}

--- a/experiments/measurements/bounded-hessian-handoff-20260908/preparation-attempts.json
+++ b/experiments/measurements/bounded-hessian-handoff-20260908/preparation-attempts.json
@@ -1,0 +1,516 @@
+[
+  {
+    "action_key": "bd35a84a6654fed064a7e19fbd749c2a7d4f134eb0e05cfe6a07b5a5332e583b",
+    "checks": {
+      "complete_terminal": true
+    },
+    "cleanup": {
+      "complete": null,
+      "released_ok": null,
+      "stop_reason": null
+    },
+    "lesson": "Withdrawn from ready before execution: inherited local placement; corrected to x86 tooling class.",
+    "logs": [],
+    "outcome": {
+      "action_returncode": null,
+      "action_signal": null,
+      "attempts": 0,
+      "claimed_by": null,
+      "claimed_host": null,
+      "claimed_unix": null,
+      "elapsed_s": null,
+      "finished_host": null,
+      "finished_unix": null,
+      "reason": "Submission inherited local placement; CPU dependency requires the x86 CPU tooling class.",
+      "receipt_published": null,
+      "returncode": null,
+      "status": "withdrawn"
+    },
+    "receipt": {
+      "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/bd/bd35a84a6654fed064a7e19fbd749c2a7d4f134eb0e05cfe6a07b5a5332e583b.json",
+      "present": false
+    },
+    "sealed": {
+      "cas_root": "/mnt/shared/prismabuild-fleet/cas",
+      "checkout_root": null,
+      "checkout_snapshot": {
+        "commit": "835b1652acf02521451c48e4dd5d8d81f42ec3da",
+        "input": {
+          "bytes": 8176339,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "cde4d6e1f9bf35d3a596f69de32743303117900a70fe792849493ae0a3510ee7"
+        },
+        "parent": "98aa317a06e55731c36c53f509adc04260668cc1",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      },
+      "max_attempts": 1,
+      "needs_gpu": false,
+      "preempted_by": null,
+      "priority": -10,
+      "published_by": "sparky",
+      "published_unix": 1788892217.358952,
+      "resources": {
+        "cpu": 1,
+        "mem_gb": 3
+      },
+      "retry_safe": false,
+      "supersedes_withdrawal": null,
+      "tags": [
+        "sparky"
+      ],
+      "worker_script": "/mnt/shared/prismabuild-fleet/runtime-generations/437ad81b1129-1788868060-209c40b934b6/tools/prismabuild_worker.py"
+    },
+    "state": "withdrawn"
+  },
+  {
+    "action_key": "60ba0aa0c0c41b901060bd914a148bfb32c25ba3dce8adad1308b762857f7e77",
+    "checks": {
+      "complete_terminal": true
+    },
+    "cleanup": {
+      "complete": true,
+      "released_ok": true,
+      "stop_reason": "failed"
+    },
+    "lesson": "Initial expanded tests used ValueError for producer GrammarError and mutated shared policy fixture. Fixed exception handling and copied policy per fixture.",
+    "logs": [
+      {
+        "bytes": 887,
+        "path": "attempts/60ba0aa0c0c41b901060bd914a148bfb32c25ba3dce8adad1308b762857f7e77/dcecfeebbdf5f59f81570ff242e85c908a81debda3a1bfbe500accc5b0460ea4/00000001.stderr.9f85870df9bb1d174f9b2bb38848dcbaaec087b8586065bce1f4122c49f16e91.log",
+        "sha256": "9f85870df9bb1d174f9b2bb38848dcbaaec087b8586065bce1f4122c49f16e91",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 65360,
+        "path": "attempts/60ba0aa0c0c41b901060bd914a148bfb32c25ba3dce8adad1308b762857f7e77/dcecfeebbdf5f59f81570ff242e85c908a81debda3a1bfbe500accc5b0460ea4/00000001.stdout.39a2ec183e702686d4292ef711682ab51df3db5652666b0fbd8aede5e2b379ba.log",
+        "sha256": "39a2ec183e702686d4292ef711682ab51df3db5652666b0fbd8aede5e2b379ba",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": 1,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:2286463:ac9cfbf7",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788892285.8578296,
+      "elapsed_s": 4.317409038543701,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788892290.913755,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 1,
+      "status": "failed"
+    },
+    "receipt": {
+      "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/60/60ba0aa0c0c41b901060bd914a148bfb32c25ba3dce8adad1308b762857f7e77.json",
+      "present": false
+    },
+    "resources": {
+      "memory_peak_bytes": 474537984,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "sealed": {
+      "cas_root": "/mnt/shared/prismabuild-fleet/cas",
+      "checkout_root": null,
+      "checkout_snapshot": {
+        "commit": "b382ddf2642f74f9dd53051aa46050cd0c047704",
+        "input": {
+          "bytes": 8176340,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "10f1e301c4e5a9304ba06242a6d5d9e4879b99729f9813063876628e9d126bf8"
+        },
+        "parent": "98aa317a06e55731c36c53f509adc04260668cc1",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      },
+      "max_attempts": 1,
+      "needs_gpu": false,
+      "preempted_by": null,
+      "priority": -10,
+      "published_by": "sparky",
+      "published_unix": 1788892285.02712,
+      "resources": {
+        "cpu": 1,
+        "mem_gb": 3
+      },
+      "retry_safe": false,
+      "supersedes_withdrawal": null,
+      "tags": [
+        "x86"
+      ],
+      "worker_script": "/mnt/shared/prismabuild-fleet/runtime-generations/437ad81b1129-1788868060-209c40b934b6/tools/prismabuild_worker.py"
+    },
+    "state": "failed",
+    "test_summary": [
+      "18 failed, 17 passed in 2.62s"
+    ]
+  },
+  {
+    "action_key": "c4988c71bfcca9a84c9a2be9ab52dbaa13af9a411c7e51505a0d7b65bb1275d4",
+    "checks": {
+      "complete_terminal": true
+    },
+    "cleanup": {
+      "complete": true,
+      "released_ok": true,
+      "stop_reason": "failed"
+    },
+    "lesson": "for_unit fixture omitted the required scale-plane setting; supplied the actual CHANNEL plane.",
+    "logs": [
+      {
+        "bytes": 887,
+        "path": "attempts/c4988c71bfcca9a84c9a2be9ab52dbaa13af9a411c7e51505a0d7b65bb1275d4/47db62a955969e1db5c11f70883f67ffa905fb632fb3022901b58e317ae5c798/00000001.stderr.9f85870df9bb1d174f9b2bb38848dcbaaec087b8586065bce1f4122c49f16e91.log",
+        "sha256": "9f85870df9bb1d174f9b2bb38848dcbaaec087b8586065bce1f4122c49f16e91",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 3416,
+        "path": "attempts/c4988c71bfcca9a84c9a2be9ab52dbaa13af9a411c7e51505a0d7b65bb1275d4/47db62a955969e1db5c11f70883f67ffa905fb632fb3022901b58e317ae5c798/00000001.stdout.ae5e9505e47ef863f110524ed3bbf8f0a2045efbe1b64542444ecdda04f26f0d.log",
+        "sha256": "ae5e9505e47ef863f110524ed3bbf8f0a2045efbe1b64542444ecdda04f26f0d",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": 1,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:2286455:2ef943cc",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788892450.5344458,
+      "elapsed_s": 3.123781442642212,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788892454.4712722,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 1,
+      "status": "failed"
+    },
+    "receipt": {
+      "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/c4/c4988c71bfcca9a84c9a2be9ab52dbaa13af9a411c7e51505a0d7b65bb1275d4.json",
+      "present": false
+    },
+    "resources": {
+      "memory_peak_bytes": 228626432,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "sealed": {
+      "cas_root": "/mnt/shared/prismabuild-fleet/cas",
+      "checkout_root": null,
+      "checkout_snapshot": {
+        "commit": "7bf5a61317f60021fb6494b8c17b2252c9946780",
+        "input": {
+          "bytes": 8176371,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "38ac40d7846d11a94d2960fa463047c90ac025248a76f107157c7c225519b4a7"
+        },
+        "parent": "98aa317a06e55731c36c53f509adc04260668cc1",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      },
+      "max_attempts": 1,
+      "needs_gpu": false,
+      "preempted_by": null,
+      "priority": -10,
+      "published_by": "sparky",
+      "published_unix": 1788892449.2485769,
+      "resources": {
+        "cpu": 1,
+        "mem_gb": 3
+      },
+      "retry_safe": false,
+      "supersedes_withdrawal": null,
+      "tags": [
+        "x86"
+      ],
+      "worker_script": "/mnt/shared/prismabuild-fleet/runtime-generations/437ad81b1129-1788868060-209c40b934b6/tools/prismabuild_worker.py"
+    },
+    "state": "failed",
+    "test_summary": [
+      "1 failed, 34 passed in 1.54s"
+    ]
+  },
+  {
+    "action_key": "7c054464a971b9bf16a7928e8b98c1d4edd2aba0c281738cf4cb1ea8af1df7eb",
+    "checks": {
+      "complete_terminal": true
+    },
+    "cleanup": {
+      "complete": true,
+      "released_ok": true,
+      "stop_reason": "failed"
+    },
+    "lesson": "Generic pb-cpu environment lacked compressed_tensors; five modules failed collection. Switched to existing pq-cpu312 environment.",
+    "logs": [
+      {
+        "bytes": 887,
+        "path": "attempts/7c054464a971b9bf16a7928e8b98c1d4edd2aba0c281738cf4cb1ea8af1df7eb/bb0d8374b1bd253137acfd40f56bb3c801415738b388ffeee06143f00bc824e9/00000001.stderr.7e7d5192bc2b33ff6b7994c3525c8ba66505d6b4255ae1282babc834bc14dcb4.log",
+        "sha256": "7e7d5192bc2b33ff6b7994c3525c8ba66505d6b4255ae1282babc834bc14dcb4",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 5066,
+        "path": "attempts/7c054464a971b9bf16a7928e8b98c1d4edd2aba0c281738cf4cb1ea8af1df7eb/bb0d8374b1bd253137acfd40f56bb3c801415738b388ffeee06143f00bc824e9/00000001.stdout.b5b77511f4338f4a33b5b203cad986827417f74d60fd4a7eda4d58582abdb9ff.log",
+        "sha256": "b5b77511f4338f4a33b5b203cad986827417f74d60fd4a7eda4d58582abdb9ff",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": 2,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:2449040:b1959924",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788892717.4186797,
+      "elapsed_s": 3.0129172801971436,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788892722.3598003,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 1,
+      "status": "failed"
+    },
+    "receipt": {
+      "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/7c/7c054464a971b9bf16a7928e8b98c1d4edd2aba0c281738cf4cb1ea8af1df7eb.json",
+      "present": false
+    },
+    "resources": {
+      "memory_peak_bytes": 209408000,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "sealed": {
+      "cas_root": "/mnt/shared/prismabuild-fleet/cas",
+      "checkout_root": null,
+      "checkout_snapshot": {
+        "commit": "7bc184ef1865ff8e4aae6da816339e22549bb8d7",
+        "input": {
+          "bytes": 26989925,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "e1e273ba7fea30bea028c8e5f8dd2a3bdcfa22f03398ffba162e8be44adcfb03"
+        },
+        "parent": "00a7b5d35b82e7b78caeb5b461e16b2de7a5c5a9",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      },
+      "max_attempts": 1,
+      "needs_gpu": false,
+      "preempted_by": null,
+      "priority": -10,
+      "published_by": "sparky",
+      "published_unix": 1788892716.6206882,
+      "resources": {
+        "cpu": 1,
+        "mem_gb": 4
+      },
+      "retry_safe": false,
+      "supersedes_withdrawal": null,
+      "tags": [
+        "x86"
+      ],
+      "worker_script": "/mnt/shared/prismabuild-fleet/runtime-generations/437ad81b1129-1788868060-209c40b934b6/tools/prismabuild_worker.py"
+    },
+    "state": "failed",
+    "test_summary": [
+      "_______ ERROR collecting tests/test_tessera_hessian_reference_handoff.py _______",
+      "_____________ ERROR collecting tests/test_tessera_input_handoff.py _____________",
+      "___________ ERROR collecting tests/test_tessera_calibration_cache.py ___________",
+      "_________ ERROR collecting tests/test_tessera_priced_export_inputs.py __________",
+      "____________ ERROR collecting tests/test_tessera_materialization.py ____________"
+    ]
+  },
+  {
+    "action_key": "a88e8a82760cb983a7e7b18c33427e89495bfd100685f5e254aced369290c7c3",
+    "checks": {
+      "complete_terminal": true
+    },
+    "cleanup": {
+      "complete": true,
+      "released_ok": true,
+      "stop_reason": "failed"
+    },
+    "lesson": "New direct dispatcher import omitted tools on sys.path; fixed test import setup.",
+    "logs": [
+      {
+        "bytes": 887,
+        "path": "attempts/a88e8a82760cb983a7e7b18c33427e89495bfd100685f5e254aced369290c7c3/c81dc9a3c9429303a273f4db2764a0ad68e0305df8941e7310f9460fc0a20dec/00000001.stderr.7e7d5192bc2b33ff6b7994c3525c8ba66505d6b4255ae1282babc834bc14dcb4.log",
+        "sha256": "7e7d5192bc2b33ff6b7994c3525c8ba66505d6b4255ae1282babc834bc14dcb4",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 1783,
+        "path": "attempts/a88e8a82760cb983a7e7b18c33427e89495bfd100685f5e254aced369290c7c3/c81dc9a3c9429303a273f4db2764a0ad68e0305df8941e7310f9460fc0a20dec/00000001.stdout.d3b7db1de137bb4feba8fb53595ff5a60be1379b36b8834491d425d6aec6ed5f.log",
+        "sha256": "d3b7db1de137bb4feba8fb53595ff5a60be1379b36b8834491d425d6aec6ed5f",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": 2,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:2976141:3bf6c0e8",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788892845.0847723,
+      "elapsed_s": 8.036994457244873,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788892854.9251213,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 1,
+      "status": "failed"
+    },
+    "receipt": {
+      "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/a8/a88e8a82760cb983a7e7b18c33427e89495bfd100685f5e254aced369290c7c3.json",
+      "present": false
+    },
+    "resources": {
+      "memory_peak_bytes": 389509120,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "sealed": {
+      "cas_root": "/mnt/shared/prismabuild-fleet/cas",
+      "checkout_root": null,
+      "checkout_snapshot": {
+        "commit": "5ff72fb15c3f2ec0938790b73f4df83711c00c3e",
+        "input": {
+          "bytes": 26989923,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "a8a53a9876d26ae798683c5754387167e9f15cdf57497cfad20a6d50e2378607"
+        },
+        "parent": "00a7b5d35b82e7b78caeb5b461e16b2de7a5c5a9",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      },
+      "max_attempts": 1,
+      "needs_gpu": false,
+      "preempted_by": null,
+      "priority": -10,
+      "published_by": "sparky",
+      "published_unix": 1788892842.097001,
+      "resources": {
+        "cpu": 1,
+        "mem_gb": 4
+      },
+      "retry_safe": false,
+      "supersedes_withdrawal": null,
+      "tags": [
+        "x86"
+      ],
+      "worker_script": "/mnt/shared/prismabuild-fleet/runtime-generations/437ad81b1129-1788868060-209c40b934b6/tools/prismabuild_worker.py"
+    },
+    "state": "failed",
+    "test_summary": [
+      "_______ ERROR collecting tests/test_tessera_hessian_reference_handoff.py _______"
+    ]
+  },
+  {
+    "action_key": "cb51b7f0fd5495e7e45aadde146f24fdede5316ee8233f46e76f68a5878c0ca3",
+    "checks": {
+      "complete_terminal": true
+    },
+    "cleanup": {
+      "complete": true,
+      "released_ok": true,
+      "stop_reason": "failed"
+    },
+    "lesson": "Uniformity fixture used unrecognized format names, so validator ignored them. Fixed to valid Tessera names; final suite covers the intended mixed-binding rejection.",
+    "logs": [
+      {
+        "bytes": 887,
+        "path": "attempts/cb51b7f0fd5495e7e45aadde146f24fdede5316ee8233f46e76f68a5878c0ca3/f0616abcc1a5f63ad9efb4720ccb0835c432a0f8a385057db6a6ef6b82aca613/00000001.stderr.9f85870df9bb1d174f9b2bb38848dcbaaec087b8586065bce1f4122c49f16e91.log",
+        "sha256": "9f85870df9bb1d174f9b2bb38848dcbaaec087b8586065bce1f4122c49f16e91",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 1978,
+        "path": "attempts/cb51b7f0fd5495e7e45aadde146f24fdede5316ee8233f46e76f68a5878c0ca3/f0616abcc1a5f63ad9efb4720ccb0835c432a0f8a385057db6a6ef6b82aca613/00000001.stdout.0632a815e486682e7424733b74ddf30975164c0f53ec08dd44c1f60132c65269.log",
+        "sha256": "0632a815e486682e7424733b74ddf30975164c0f53ec08dd44c1f60132c65269",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": 1,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:2758162:c49d1b0c",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788893035.4422054,
+      "elapsed_s": 77.2719988822937,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788893114.626147,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 1,
+      "status": "failed"
+    },
+    "receipt": {
+      "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/cb/cb51b7f0fd5495e7e45aadde146f24fdede5316ee8233f46e76f68a5878c0ca3.json",
+      "present": false
+    },
+    "resources": {
+      "memory_peak_bytes": 721260544,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "sealed": {
+      "cas_root": "/mnt/shared/prismabuild-fleet/cas",
+      "checkout_root": null,
+      "checkout_snapshot": {
+        "commit": "907b9504f0ee44099ae988af4f19f57b238fe2f0",
+        "input": {
+          "bytes": 26991508,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "158ad4928c836ccc9c80d30e4adb33bf5898232722e7e4c7d5c5ec25f6d2e796"
+        },
+        "parent": "00a7b5d35b82e7b78caeb5b461e16b2de7a5c5a9",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      },
+      "max_attempts": 1,
+      "needs_gpu": false,
+      "preempted_by": null,
+      "priority": -10,
+      "published_by": "sparky",
+      "published_unix": 1788893035.0741825,
+      "resources": {
+        "cpu": 1,
+        "mem_gb": 4
+      },
+      "retry_safe": false,
+      "supersedes_withdrawal": null,
+      "tags": [
+        "x86"
+      ],
+      "worker_script": "/mnt/shared/prismabuild-fleet/runtime-generations/437ad81b1129-1788868060-209c40b934b6/tools/prismabuild_worker.py"
+    },
+    "state": "failed",
+    "test_summary": [
+      "1 failed, 139 passed, 1 skipped, 14 warnings in 74.67s (0:01:14)"
+    ]
+  }
+]

--- a/experiments/measurements/bounded-hessian-handoff-20260908/root-final-handoff-pin-cas-source-audit.json
+++ b/experiments/measurements/bounded-hessian-handoff-20260908/root-final-handoff-pin-cas-source-audit.json
@@ -1,0 +1,12 @@
+[
+  {
+    "action": "b1c1dd4dc4d3fb37c7ec2e6bab2060a4cc67b3c204d7a487c741331ec3b8b79d",
+    "receipt": "e164661dbd18c49e9ccc0c50a550a466a1b19c55c42180d64785cbf9aadb8be7",
+    "payload_sha256": "80311a0354f381f6e6016570c5ad36311b1a711e10ac91486bf5a2c707794818",
+    "snapshot": "4c82a58d2582dd5eaa11fbd41efa589f86d66227",
+    "source_diff_from_commit": [
+      ".pbrun-closure.8b28b933399c099d.json"
+    ],
+    "stdout_tail": "{\"producer_archive_sha256\": \"30bf315c472062bf3aca1d47b76d21d3a92f157711baae68cf0f73a1739d875b\", \"producer_commit\": \"9d2314819f027e53ba169039a10cd27594d36670\", \"producer_module\": \"/home/rob/tmp/bounded-hessian-producer-5x55mq4t/src/tessera/__init__.py\"}\n......................................................................s. [ 29%]\n........................................................................ [ 59%]\n..........................................................s............. [ 89%]\n.........................s                                               [100%]\n=============================== warnings summary ===============================\n../../../../venvs/pq-cpu312/lib/python3.12/site-packages/torch/jit/_script.py:362: 14 warnings\n  /home/rob/venvs/pq-cpu312/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.\n    warnings.warn(\n\n-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html\n=========================== short test summary info ============================\nSKIPPED [1] tests/test_tessera_priced_export_inputs.py:333: this tessera publishes the seal; see the test above\nSKIPPED [1] tests/test_bounded_hessian_sidecar.py:50: explicit native writer measurement only\nSKIPPED [1] tests/test_tessera_contract_v5.py:114: explicit immutable v5 publisher contract was not supplied\n239 passed, 3 skipped, 14 warnings in 87.63s (0:01:27)\n"
+  }
+]

--- a/experiments/measurements/bounded-hessian-handoff-20260908/root-hessian-pq-positive-audit.json
+++ b/experiments/measurements/bounded-hessian-handoff-20260908/root-hessian-pq-positive-audit.json
@@ -1,0 +1,12 @@
+[
+  {
+    "action": "e77e2f2fe875f2fc16b030d4b642d684cb7b277ae036e32419e9165081b47a9f",
+    "receipt": "c7b2e4b518d019806708eedd4bb6090ec5ac2b97d6e31e66167d4686b180dc6c",
+    "payload_sha256": "ee295565e13c3a642b30bf90fc5b45c7a8b446a26a1bac2654b32618b03b3af5",
+    "snapshot": "7ad9332808b430b003d575304b3ba28ce9fdc9c9",
+    "source_diff_from_commit": [
+      ".pbrun-closure.25f2b76ab058e6ec.json"
+    ],
+    "stdout_tail": "{\"producer_archive_sha256\": \"c6a6e849f7826ab18053004d4d625b2f26d9131923fda32b20fc6ca6a458aba7\", \"producer_commit\": \"615e1c0302693447a9cd713bb1f9dddc21fbd378\", \"producer_module\": \"/home/rob/tmp/bounded-hessian-producer-3e50zx0a/src/tessera/__init__.py\"}\n......................................................................s. [ 35%]\n........................................................................ [ 71%]\n.....................................................s....               [100%]\n=============================== warnings summary ===============================\n../../../../venvs/pq-cpu312/lib/python3.12/site-packages/torch/jit/_script.py:362: 14 warnings\n  /home/rob/venvs/pq-cpu312/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.\n    warnings.warn(\n\n-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html\n=========================== short test summary info ============================\nSKIPPED [1] tests/test_tessera_priced_export_inputs.py:333: this tessera publishes the seal; see the test above\nSKIPPED [1] tests/test_bounded_hessian_sidecar.py:50: explicit native writer measurement only\n200 passed, 2 skipped, 14 warnings in 111.54s (0:01:51)\n"
+  }
+]

--- a/experiments/measurements/bounded-hessian-handoff-20260908/root-hessian-producer-positive-audit.json
+++ b/experiments/measurements/bounded-hessian-handoff-20260908/root-hessian-producer-positive-audit.json
@@ -1,0 +1,12 @@
+[
+  {
+    "action": "740c213d5bd5fd890cf2496d421363d8a8fd23cd696b5548663504066bfa40b2",
+    "receipt": "7bfd4e1a819716aa6cb8ccbe607f6de8eae3d3d7431978958cadeed23cc81e4d",
+    "payload_sha256": "ffef0976e96241582103496fba6bed0adff5d5394398cf4099e2cba82116c74f",
+    "snapshot": "b9dfcc753a2df6a0661e33ea4ce6711a43f6856e",
+    "source_diff_from_commit": [
+      ".pbrun-closure.27a97d15b0b7b34a.json"
+    ],
+    "stdout_tail": ".......................................................................  [100%]\n\ntessera surface: NO CUDA -- torch 2.11.0+cpu reports no CUDA device\ntessera surface: 0 test(s) skipped, 0 module(s) not collected\ntessera surface: this run did not exercise the CUDA-gated surface. Its pass count is not coverage of it.\ntessera surface: 0 test(s) allocated on the device\n71 passed in 17.15s\n"
+  }
+]

--- a/prismaquant/tessera_calibration_cache.py
+++ b/prismaquant/tessera_calibration_cache.py
@@ -714,12 +714,17 @@ class CaptureWriter:
 
 def require_capture_contract(path, expected_sha256=None):
     """Validate a complete canonical capture before downstream preparation."""
-    from prismaquant import validate_source_initialization_contract
     path = Path(path)
     raw = path.read_bytes()
     if expected_sha256 is not None and hashlib.sha256(raw).hexdigest() != expected_sha256:
         raise RuntimeError('priced calibration capture manifest changed')
     manifest = json.loads(raw)
+    return validate_capture_contract(manifest)
+
+
+def validate_capture_contract(manifest):
+    """Validate the canonical contract on an already owned metadata snapshot."""
+    from prismaquant import validate_source_initialization_contract
     identity = manifest.get('identity') or {}
     if manifest.get('schema') != SCHEMA or manifest.get('status') != 'complete':
         raise RuntimeError('not a complete canonical calibration capture v2')
@@ -736,6 +741,98 @@ def require_capture_contract(path, expected_sha256=None):
             set(manifest.get('entries',{})) != set(identity['units'])):
         raise RuntimeError('canonical capture runtime, source or completeness is invalid')
     return manifest
+
+
+def open_hessian_reference(path):
+    """Reuse the producer's bounded reader under the full canonical contract.
+
+    No new H storage or residency cache is created. The returned owner retains
+    only metadata; every mapping value access authenticates one existing input
+    file and its committed H. The caller must close this owner.
+    """
+    try:
+        from tessera.hessian_capture import ReferenceHessians
+    except ImportError as error:
+        raise RuntimeError('canonical Hessian references require the reviewed Tessera reference reader') from error
+    owner = ReferenceHessians(path)
+    try:
+        validate_capture_contract(owner.canonical_manifest())
+        return owner
+    except BaseException:
+        owner.close()
+        raise
+
+
+def write_hessian_reference(path, descriptor):
+    """Publish a metadata-only handoff after both owners accept its commitments."""
+    path = Path(path)
+    temporary = path.with_name(path.name+'.tmp')
+    try:
+        _json(temporary, descriptor)
+        with open_hessian_reference(temporary) as owner:
+            digest = owner.descriptor['capture_sha256']
+        os.replace(temporary, path)
+        return digest
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def canonical_hessian_reference_descriptor(*, hessians, counts, provenance,
+        canonical_capture, census_path, load_policy):
+    """Commit resident row H to the original capture without copying its bytes."""
+    try:
+        from tessera.cached_unit import tensor_identity
+        from tessera.hessian_capture import REFERENCE_SCHEMA, capture_sha256_from_units
+    except ImportError as error:
+        raise RuntimeError('canonical Hessian references require the reviewed Tessera reference reader') from error
+    if not isinstance(canonical_capture, dict) or set(canonical_capture) != {'path','sha256'}:
+        raise RuntimeError('Hessian reference needs a hash-bound canonical capture')
+    manifest = require_capture_contract(canonical_capture['path'], canonical_capture['sha256'])
+    census_path = Path(census_path).resolve()
+    census_digest = sha256(census_path)
+    if census_digest != manifest['identity']['census_sha256']:
+        raise RuntimeError('Hessian reference census differs from the complete capture')
+    identities = {name:tensor_identity(value) for name,value in hessians.items() if value is not None}
+    digest = capture_sha256_from_units(provenance, {n:v['sha256'] for n,v in identities.items()})
+    return dict(schema=REFERENCE_SCHEMA,
+        canonical_capture=dict(path=str(Path(canonical_capture['path']).resolve()),
+                               sha256=canonical_capture['sha256']),
+        census=dict(path=str(census_path),sha256=census_digest),
+        provenance=dict(provenance),counts=dict(counts),hessians=identities,
+        capture_sha256=digest,rows=[dict(units=sorted(identities),capture_sha256=digest)],
+        load_policy=dict(load_policy))
+
+
+def hessian_reference_binding(canonical_capture_sha256, census_sha256):
+    """The optional source binding carried unchanged from prices to export."""
+    from tessera.hessian_capture import BINDING_SCHEMA, normalize_reference_binding
+    return normalize_reference_binding(dict(schema=BINDING_SCHEMA,
+        canonical_capture_sha256=canonical_capture_sha256,census_sha256=census_sha256))
+
+
+def merge_hessian_reference_descriptors(descriptors):
+    """Union accepted metadata snapshots without reading or retaining any H."""
+    import copy
+    from tessera.hessian_capture import capture_sha256_from_units
+    result = None
+    for descriptor in descriptors:
+        if result is None:
+            result = copy.deepcopy(descriptor)
+            continue
+        for key in ('schema','canonical_capture','census','provenance','counts','load_policy'):
+            if result[key] != descriptor[key]:
+                raise RuntimeError(f'Hessian reference union differs at {key}')
+        overlap = result['hessians'].keys() & descriptor['hessians'].keys()
+        if overlap:
+            raise RuntimeError('Hessian reference units occur in multiple rows: '+', '.join(sorted(overlap)[:4]))
+        result['hessians'].update(copy.deepcopy(descriptor['hessians']))
+        result['rows'].extend(copy.deepcopy(descriptor['rows']))
+    if result is None:
+        raise RuntimeError('Hessian reference union needs at least one accepted row')
+    result['hessians'] = dict(sorted(result['hessians'].items()))
+    result['capture_sha256'] = capture_sha256_from_units(result['provenance'],
+        {n:v['sha256'] for n,v in result['hessians'].items()})
+    return result
 
 
 def authenticate_selected_capture_source(census_path, capture_path, *, expected_sha256,

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -1240,6 +1240,7 @@ def campaign_cost_payload(
         # the allocation binds to the payload and not only to the draw's
         # triple (RobTand/prismaquant#204); None on a weights-only campaign.
         "capture_sha256": _h.get("capture_sha256"),
+        **({'reference_binding':dict(_h['reference_binding'])} if _h.get('reference_binding') is not None else {}),
         "kwarg": tuple(_h.get("kwargs", ())) or _h.get("kwarg"),
     }
 
@@ -3392,7 +3393,8 @@ def _save_hessian_capture_with_page_release(payload, path, *, resource_check=Non
 
 def write_export_inputs(cache_dir: Path, *, hessians, hessian_rows,
                         hessian_identity, static_scales, static_scale_policy,
-                        release_file_pages=False, resource_check=None):
+                        release_file_pages=False, resource_check=None,
+                        hessian_reference=None):
     """Write the exporter's ``--hessian`` and ``--input-scales`` inputs.
 
     ``(hessian_capture_path | None, input_scales_path | None,
@@ -3400,7 +3402,7 @@ def write_export_inputs(cache_dir: Path, *, hessians, hessian_rows,
     campaign's table is priced under exactly these Hessians and these static
     activation scales, so the export leg must be handed them back or the
     artifact built is not the artifact priced (RobTand/prismaquant#193).
-    Both files are in the shapes Tessera's exporter consumes:
+    Legacy files use the shapes Tessera's exporter consumes:
 
     * ``hessian_capture.pt`` -- ``{"H": {unit: XᵀX}, "counts", "provenance"}``,
       what ``ActivationSource.from_capture`` loads; the H tensors are the
@@ -3420,6 +3422,10 @@ def write_export_inputs(cache_dir: Path, *, hessians, hessian_rows,
       scalar per unit, the exporter's stock-NVFP4 spelling, valued exactly as
       the W4A4 costs were scored.
 
+    Opt-in ``hessian_reference`` writes only a canonical reference JSON with
+    the same H content seal and explicit load bounds. The producer verifies
+    actual H bytes on consumption; metadata intake does not verify untouched H.
+
     ``hessians=None`` is the deliberate weights-only campaign: no capture is
     written, matching the ``supplied=false`` stamp the rows carry.
     """
@@ -3431,7 +3437,20 @@ def write_export_inputs(cache_dir: Path, *, hessians, hessian_rows,
 
     hessian_capture_path = None
     capture_sha256 = None
-    if hessians is not None:
+    if hessian_reference is not None:
+        from . import tessera_calibration_cache as capture_store
+        if hessians is None or set(hessian_reference) != {'canonical_capture', 'census_path', 'load_policy'}:
+            raise RuntimeError('Hessian reference requires resident H and its canonical capture/census/load policy')
+        descriptor = capture_store.canonical_hessian_reference_descriptor(
+            hessians=hessians, counts=hessian_rows,
+            provenance={**dict(hessian_identity), 'hessian_role':'fit'}, **hessian_reference)
+        hessian_capture_path = cache_dir/'hessian_capture.references.json'
+        capture_sha256 = capture_store.write_hessian_reference(hessian_capture_path, descriptor)
+        if resource_check is not None:
+            resource_check('after_selected_export_reference_write')
+        print(f'[campaign] wrote {hessian_capture_path} '
+              f'({len(descriptor["hessians"])} H commitments; no copied H payloads)', flush=True)
+    elif hessians is not None:
         hessian_capture_path = cache_dir / "hessian_capture.pt"
         capture_provenance = {**dict(hessian_identity), "hessian_role": "fit"}
         saved_hessians = {name: h for name, h in hessians.items()
@@ -3819,6 +3838,8 @@ def _main(argv, *, source_scope) -> int:
                     help="Opt-in shared capture; bounded also checks phase ownership and physical memory.")
     ap.add_argument("--capture-load-policy", type=json.loads, default=None,
                     help="Explicit verified activation load v1 JSON policy; requires bounded capture.")
+    ap.add_argument('--export-hessian-reference-policy', type=json.loads, default=None,
+                    help='Opt-in canonical H reference load-policy JSON; requires selected reuse of a complete capture.')
     ap.add_argument("--capture-calibration-out", default=None,
                     help="Capture full-census float32 prefix X and uncapped H once, then exit.")
     ap.add_argument("--calibration-cache", default=None,
@@ -3840,6 +3861,14 @@ def _main(argv, *, source_scope) -> int:
     selected_source = bool(args.streaming and args.units and args.calibration_cache
                            and args.calibration_cache_sha256
                            and not (args.census_out or args.capture_calibration_out))
+    if args.export_hessian_reference_policy is not None:
+        if not selected_source:
+            ap.error('--export-hessian-reference-policy requires selected reuse of a hash-bound complete capture')
+        try:
+            from tessera.hessian_capture import normalize_reference_load_policy
+            args.export_hessian_reference_policy = normalize_reference_load_policy(args.export_hessian_reference_policy)
+        except (ImportError, ValueError) as error:
+            ap.error(f'canonical H references need a compatible producer and valid load policy: {error}')
     if args.streaming and not selected_source and (
             not (args.census_out or args.capture_calibration_out) or args.units):
         ap.error("--streaming requires full-scope census/capture or --units with a hash-bound complete calibration cache")
@@ -4457,6 +4486,9 @@ def _main(argv, *, source_scope) -> int:
         hessian_identity=hessian_identity,
         static_scales=static_scales,
         static_scale_policy=static_scale_policy,
+        **(dict(hessian_reference=dict(canonical_capture=calibration_cache,
+                census_path=args.calibration_census,load_policy=args.export_hessian_reference_policy))
+           if args.export_hessian_reference_policy is not None else {}),
         **(dict(release_file_pages=True,
                 resource_check=None if selected_guard is None else selected_guard.check)
            if selected_source else {}),
@@ -4904,6 +4936,9 @@ def _main(argv, *, source_scope) -> int:
                 # for the export leg's --hessian input; None on --hessian off.
                 "capture_path": (None if hessian_capture_path is None
                                  else str(hessian_capture_path)),
+                **({'reference_binding':calibration_store.hessian_reference_binding(
+                    calibration_cache['sha256'],capture_identity['census_sha256'])}
+                   if args.export_hessian_reference_policy is not None else {}),
                 # The content digest of that payload (Tessera's own seal
                 # rule), stamped on every row so the allocation binds to
                 # the capture BY CONTENT, not by the draw's triple alone

--- a/prismaquant/tessera_export_lane.py
+++ b/prismaquant/tessera_export_lane.py
@@ -994,6 +994,10 @@ def hessian_capture_sha256(hessians: "Mapping[str, Any]",
     import torch
 
     _require_capture_context_roster()
+    if _is_hessian_reference(hessians):
+        from tessera.hessian_capture import capture_sha256_from_units
+        hessians.require_provenance(provenance)
+        return capture_sha256_from_units(provenance, hessians.committed_units())
     identity = {field: provenance.get(field)
                 for field in PRICED_HESSIAN_IDENTITY_FIELDS}
     identity.update({field: provenance.get(field)
@@ -1033,6 +1037,16 @@ def _tessera_capture_seal(hessians, provenance) -> "str | None":
         ) from exc
 
 
+def _is_hessian_reference(value):
+    if isinstance(value, dict):
+        return False
+    try:
+        from tessera.hessian_capture import ReferenceHessians
+    except ImportError:
+        return False
+    return isinstance(value, ReferenceHessians)
+
+
 def _bound_hessian_capture(hessian_path: Path) -> tuple:
     """``(hessians, provenance, capture_sha256)`` of the payload itself.
 
@@ -1049,6 +1063,14 @@ def _bound_hessian_capture(hessian_path: Path) -> tuple:
     """
     import torch
 
+    if str(hessian_path).endswith('.references.json'):
+        from .tessera_calibration_cache import open_hessian_reference
+        owner = open_hessian_reference(hessian_path)
+        try:
+            return owner, owner.provenance, hessian_capture_sha256(owner, owner.provenance)
+        except BaseException:
+            owner.close()
+            raise
     payload = torch.load(str(hessian_path), map_location="cpu",
                          weights_only=False)
     hessians = payload.get("H") if isinstance(payload, Mapping) else None
@@ -1215,42 +1237,57 @@ def require_priced_export_inputs(
                 "capture it writes) and re-allocate."
             )
         hessians, identity, digest = _bound_hessian_capture(hessian_path)
-        role = identity.get("hessian_role")
-        if role is not None and role != "fit":
-            raise TesseraExportLaneError(
-                f"--hessian {hessian_path} is a {role!r} capture and must "
-                "not shape bytes")
-        mismatched = {
-            field: (identity.get(field), value)
-            for field, value in expected.items()
-            if identity.get(field) != value
-        }
-        if mismatched:
-            raise TesseraExportLaneError(
-                f"--hessian {hessian_path} is not the capture that priced "
-                "this allocation: "
-                + "; ".join(
-                    f"{field}: capture={got!r} != allocation={want!r}"
-                    for field, (got, want) in sorted(mismatched.items()))
-                + ". An encode against a different Hessian ships bytes the "
-                  "allocation did not price; hand the campaign's own capture "
-                  "or re-allocate."
-            )
-        if digest != priced_digest:
-            raise TesseraExportLaneError(
-                f"--hessian {hessian_path} is not the capture that priced "
-                f"this allocation: capture_sha256 payload={digest} != "
-                f"allocation={priced_digest}. Its identity triple agrees, so "
-                "this is the same token draw over different Hessian content "
-                "or capture context (model, seqlen, source) -- a rewritten, "
-                "re-captured or corrupted payload. An encode against it ships "
-                "bytes the allocation did not price; hand the campaign's own "
-                "capture or re-allocate."
-            )
-        report["hessian"] = str(hessian_path)
-        report["hessian_capture_sha256"] = digest
-        report["hessian_capture_seal_crosscheck"] = _crosscheck_capture_seal(
-            hessian_path, hessians, identity, digest)
+        reference_binding = hessians.binding() if _is_hessian_reference(hessians) else None
+        if reference_binding != block.get('reference_binding'):
+            if _is_hessian_reference(hessians):
+                hessians.close()
+            raise TesseraExportLaneError('canonical Hessian reference binding differs from the allocation')
+        if reference_binding is not None:
+            if not set(selected) <= set(hessians):
+                hessians.close()
+                raise TesseraExportLaneError('canonical Hessian commitments do not cover every selected unit')
+            report.update(hessian_reference_binding=reference_binding,
+                          hessian_payload_verification='deferred_to_consumption', hessian_verified_units=[])
+        try:
+            role = identity.get("hessian_role")
+            if role is not None and role != "fit":
+                raise TesseraExportLaneError(
+                    f"--hessian {hessian_path} is a {role!r} capture and must "
+                    "not shape bytes")
+            mismatched = {
+                field: (identity.get(field), value)
+                for field, value in expected.items()
+                if identity.get(field) != value
+            }
+            if mismatched:
+                raise TesseraExportLaneError(
+                    f"--hessian {hessian_path} is not the capture that priced "
+                    "this allocation: "
+                    + "; ".join(
+                        f"{field}: capture={got!r} != allocation={want!r}"
+                        for field, (got, want) in sorted(mismatched.items()))
+                    + ". An encode against a different Hessian ships bytes the "
+                      "allocation did not price; hand the campaign's own capture "
+                      "or re-allocate."
+                )
+            if digest != priced_digest:
+                raise TesseraExportLaneError(
+                    f"--hessian {hessian_path} is not the capture that priced "
+                    f"this allocation: capture_sha256 payload={digest} != "
+                    f"allocation={priced_digest}. Its identity triple agrees, so "
+                    "this is the same token draw over different Hessian content "
+                    "or capture context (model, seqlen, source) -- a rewritten, "
+                    "re-captured or corrupted payload. An encode against it ships "
+                    "bytes the allocation did not price; hand the campaign's own "
+                    "capture or re-allocate."
+                )
+            report["hessian"] = str(hessian_path)
+            report["hessian_capture_sha256"] = digest
+            report["hessian_capture_seal_crosscheck"] = _crosscheck_capture_seal(
+                hessian_path, hessians, identity, digest)
+        finally:
+            if _is_hessian_reference(hessians):
+                hessians.close()
     elif hessian_path is not None:
         raise TesseraExportLaneError(
             "the allocation was priced weights-only (tessera_hessian."
@@ -1476,9 +1513,13 @@ def preflight(model_path: str | Path, *, target=None,
             "source_model": str(model_path), "layer_config": str(assignment_path),
             "layer_config_sha": assignment_sha,
             "priced_inputs": {
-                "schema": "tessera.priced_export_inputs.v1",
+                "schema": ('tessera.priced_export_inputs.v2'
+                           if priced_inputs.get('hessian_reference_binding') is not None
+                           else 'tessera.priced_export_inputs.v1'),
                 "hessian_capture_sha256": priced_inputs["hessian_capture_sha256"],
                 "input_global_scales": priced_inputs["input_global_scales"],
+                **({'hessian_reference_binding':priced_inputs['hessian_reference_binding']}
+                   if priced_inputs.get('hessian_reference_binding') is not None else {}),
             },
         }
         if scope is not None:

--- a/prismaquant/tessera_materialization.py
+++ b/prismaquant/tessera_materialization.py
@@ -62,6 +62,9 @@ def _request(path):
         raise RuntimeError('selected-wire cost input changed')
     with Path(request['cost_path']).open('rb') as handle:
         cost = pickle.load(handle)
+    if (cost.get('provenance', {}).get('hessian') or {}).get('reference_binding') is not None:
+        raise RuntimeError('canonical Hessian references require complete priced wires; '
+                           'sampled selected-wire materialization has no bounded reference union yet')
     assignment = canonicalize_assignment(request['layer_config'])
     if assignment != request['assignment']:
         raise RuntimeError('selected-wire assignment changed')

--- a/prismaquant/tessera_menu.py
+++ b/prismaquant/tessera_menu.py
@@ -1751,9 +1751,14 @@ def assert_uniform_hessian_identity(costs: "dict") -> dict:
                 legacy_rows += 1
             else:
                 schema = "modern"
+            reference = ident.get('reference_binding')
+            if reference is not None:
+                import json
+                from tessera.hessian_capture import normalize_reference_binding
+                reference = json.dumps(normalize_reference_binding(reference), sort_keys=True)
             key = (schema, modern, bool(ident.get("supplied")),
                    ident.get("text_sha"), ident.get("token_count"),
-                   ident.get("kwarg"), ident.get("capture_sha256"))
+                   ident.get("kwarg"), ident.get("capture_sha256"), reference)
             seen[key] = seen.get(key, 0) + 1
     if len(seen) > 1:
         raise ValueError(
@@ -1763,7 +1768,7 @@ def assert_uniform_hessian_identity(costs: "dict") -> dict:
                 f"supplied={k[2]} text_sha={str(k[3])[:12]} "
                 f"tokens={k[4]} kwarg={k[5]} "
                 f"capture_sha256={None if k[6] is None else str(k[6])[:12]} "
-                f"({n} rows)"
+                f"reference_binding={k[7]} ({n} rows)"
                 for k, n in sorted(seen.items(), key=lambda kv: -kv[1]))
             + ". Rows priced with and without a Hessian, on different "
               "calibration draws, or against different captures of one draw, "
@@ -1780,6 +1785,7 @@ def assert_uniform_hessian_identity(costs: "dict") -> dict:
         "kwarg": None if key is None else key[5],
         **triple,
         "capture_sha256": None if key is None else key[6],
+        **({'reference_binding':json.loads(key[7])} if key is not None and key[7] is not None else {}),
         "identity_schema": None if key is None else key[0],
         "stamped_rows": sum(seen.values()),
         "legacy_rows": int(legacy_rows),

--- a/prismaquant/tessera_runtime/tessera_serving_runtime_pin.json
+++ b/prismaquant/tessera_runtime/tessera_serving_runtime_pin.json
@@ -1,10 +1,10 @@
 {
   "schema": "prismaquant.tessera_serving_runtime_pin.v2",
   "repository": "https://github.com/RobTand/tessera.git",
-  "commit": "ba582d476a3b6db9057ebd1385dc52926f171451",
+  "commit": "9d2314819f027e53ba169039a10cd27594d36670",
   "version": "0.1.0",
   "version_is_release": false,
-  "contract_sha256": "719daa02da1564b56a141ca2702ae29d4fda553460978efbb6510ddcd1824927",
+  "contract_sha256": "a688f8de244f936ec3a63a782e20af7985733e7a6fb0b4b981b5fe4c44112212",
   "runtime_contract_schema": "tessera.runtime-contract.v1",
   "plugin_entry_point": "tessera = tessera.serving:register",
   "serving_residency_env": "TESSERA_SERVE_MODE",

--- a/prismaquant/tessera_runtime_contract.py
+++ b/prismaquant/tessera_runtime_contract.py
@@ -1065,8 +1065,8 @@ def contract_answer(contract: "TesseraContract") -> dict:
     ``platforms`` and ``regimes`` are read by the EXPORT lane's own reader
     (``tessera_export_lane.require_declared_structure`` through
     ``lane_eligibility.load_eligibility_table``), which is gated by the
-    RELEASE pin -- an exact commit and sha, fail-closed today on PENDING
-    sentinels.  Pulling them in here would make an export-lane edit re-stale
+    RELEASE pin -- an exact reviewed commit and contract SHA, refusing
+    unresolved sentinels or mismatched installed contract bytes.  Pulling them in here would make an export-lane edit re-stale
     the allocator's menu, which is issue #38's own failure mode wearing a
     different hat.  Each pin covers the values its own gates read.
 

--- a/prismaquant/tessera_runtime_contract.py
+++ b/prismaquant/tessera_runtime_contract.py
@@ -147,13 +147,15 @@ TESSERA_DEV_PIN_ENV = "PRISMAQUANT_TESSERA_DEV_PIN"
 
 #: The Tessera commit this pin's answer was reviewed against.  Declared and
 #: recorded; NOT compared to anything.  A moving ``master`` is not a review
-#: event -- :data:`TESSERA_DEV_PIN_ANSWER` is what refuses. Re-pinned to
-#: ba582d4 (Tessera #356) for the producer snapshot API; the answer remains
-#: byte-identical to the contract last re-read at
+#: event -- :data:`TESSERA_DEV_PIN_ANSWER` is what refuses. Re-pinned
+#: 2026-09-08 to 9d2314819 (Tessera #429) for bounded canonical Hessian
+#: references and their nonblocking file refusal. The allocator/serving-cell
+#: answer remains unchanged; the raw contract additionally records LFM
+#: construction output sizes. The admission answer was last changed at
 #: contract v22 / lane schema v9 (Tessera master 8ed1d9a, the merge of its
 #: #332, which answers its #327; v21 landed at b8b1cb38 in its #313 and the
 #: release e78959ed carried v20). The development and serving pins now both
-#: bind ba582d4: they name ONE object, and
+#: bind 9d2314819: they name ONE object, and
 #: letting them drift is how two of this repository's own spec files came to
 #: disagree about one runtime.  Between the v17 review and this one the
 #: answer moved in exactly four places and nowhere else -- no family, rung,
@@ -206,14 +208,14 @@ TESSERA_DEV_PIN_ENV = "PRISMAQUANT_TESSERA_DEV_PIN"
 #: Verified by fetching ``RobTand/tessera`` master into a scratch repository
 #: and hashing the blob at the tip -- never a working tree (the command is in
 #: ``tessera_runtime/README.md``).  No tag names the commit.
-TESSERA_DEV_PIN_COMMIT = "ba582d476a3b6db9057ebd1385dc52926f171451"
+TESSERA_DEV_PIN_COMMIT = "9d2314819f027e53ba169039a10cd27594d36670"
 
 #: sha256 of ``tessera/serving/runtime_contract.json`` at that commit -- the
 #: bytes a human read when the answer below was accepted.  Recorded, and
 #: compared into provenance against the bytes this run read, so prose-only
 #: drift is visible; it is not the refusal.
 TESSERA_DEV_PIN_CONTRACT_SHA256 = (
-    "719daa02da1564b56a141ca2702ae29d4fda553460978efbb6510ddcd1824927"
+    "a688f8de244f936ec3a63a782e20af7985733e7a6fb0b4b981b5fe4c44112212"
 )
 
 #: The ANSWER this pin was reviewed against -- every value the ADMISSION

--- a/prismaquant/tessera_serving_runtime_pin.py
+++ b/prismaquant/tessera_serving_runtime_pin.py
@@ -168,7 +168,7 @@ TESSERA_SERVING_RUNTIME_CONTRACT_SHA256_PENDING = "PENDING_TESSERA_CONTRACT_SHA2
 #: the same commit.  Re-check it against the COMMIT rather than a past HEAD,
 #: which nobody can re-run::
 #:
-#:     git -C "$TS" cat-file -p ba582d476a3b6db9057ebd1385dc52926f171451:src/tessera/serving/runtime_contract.json | sha256sum
+#:     git -C "$TS" cat-file -p 9d2314819f027e53ba169039a10cd27594d36670:src/tessera/serving/runtime_contract.json | sha256sum
 #:
 #: Re-pinned 2026-09-05 to ba582d4 (Tessera #356) for the priced-input
 #: exporter snapshot API required by PrismaQuant #231. The v22 contract bytes
@@ -177,12 +177,17 @@ TESSERA_SERVING_RUNTIME_CONTRACT_SHA256_PENDING = "PENDING_TESSERA_CONTRACT_SHA2
 #: No git tag names this commit, so ``version_is_release`` stays false in the
 #: JSON beside this module: ``0.1.0`` is what the checkout's ``pyproject``
 #: says, not a cut release.
+#: Re-pinned 2026-09-08 to 9d2314819 (Tessera #429) for the bounded
+#: canonical Hessian reader and FIFO refusal. The raw contract additionally
+#: carries LFM construction output sizes; the admission answer, native
+#: extensions and serving-cell table are unchanged. Native TP2 remains an
+#: explicit research construction with no runtime-cell promotion.
 TESSERA_SERVING_RUNTIME_PINNED_COMMIT = (
-    "ba582d476a3b6db9057ebd1385dc52926f171451"
+    "9d2314819f027e53ba169039a10cd27594d36670"
 )
 TESSERA_SERVING_RUNTIME_PINNED_VERSION = "0.1.0"
 TESSERA_SERVING_RUNTIME_PINNED_CONTRACT_SHA256 = (
-    "719daa02da1564b56a141ca2702ae29d4fda553460978efbb6510ddcd1824927"
+    "a688f8de244f936ec3a63a782e20af7985733e7a6fb0b4b981b5fe4c44112212"
 )
 
 #: The vLLM plugin entry-point name the released runtime registers.  It is the

--- a/tests/test_tessera_hessian_reference_handoff.py
+++ b/tests/test_tessera_hessian_reference_handoff.py
@@ -1,0 +1,159 @@
+"""Canonical H handoffs union commitments and authenticate only consumed H."""
+import copy
+import sys
+import json
+from pathlib import Path
+
+import pytest
+import torch
+
+from prismaquant import tessera_calibration_cache as cc
+from prismaquant import tessera_campaign as campaign
+from prismaquant import tessera_export_lane as export
+from test_tessera_calibration_cache import canonical_fields, identity
+from test_tessera_priced_export_inputs import TRIPLE, _assignment
+
+POLICY=dict(schema='tessera.hessian_reference_load.v1', max_metadata_bytes=1024**2,
+            max_file_bytes=1024**2,max_hessian_bytes=1024**2)
+sys.path.insert(0,str(Path(__file__).resolve().parents[1]/'tools'))
+from tools import dispatch_tessera_campaign as dispatch
+
+
+@pytest.fixture
+def handoff(tmp_path):
+    model=tmp_path/'source';model.mkdir()
+    (model/'config.json').write_text('{}');(model/'model.safetensors').write_bytes(b'fixture')
+    census=dict(model=str(model),counts={'a':5,'b':7},max_abs={'a':4.,'b':8.},
+        unit_shapes={'a':[3,2],'b':[3,2]},layer_stride=1,anchor_groups={'u:a':['a'],'u:b':['b']},**canonical_fields())
+    path=tmp_path/'census.json';path.write_text(json.dumps(census))
+    calibration=dict(TRIPLE,model=str(model),seqlen=8,source='fixture')
+    capture_id=identity(path,calibration=calibration,max_act_rows=2)
+    H={'a':torch.eye(2)*13,'b':torch.eye(2)*25};X={n:torch.ones(2,2) for n in H}
+    record=cc.publish_capture(tmp_path/'capture',census_path=path,identity=capture_id,acts=X,
+        hessians=H,counts=census['counts'],maxima=census['max_abs'])
+    return dict(H=H,census=census,census_path=path,calibration=calibration,record=record,tmp=tmp_path)
+
+
+def write_row(f,name):
+    root=f['tmp']/name;root.mkdir()
+    return campaign.write_export_inputs(root,hessians={name:f['H'][name]},
+        hessian_rows=f['census']['counts'],hessian_identity=f['calibration'],
+        static_scales={},static_scale_policy='fixture',hessian_reference=dict(
+            canonical_capture=f['record'],census_path=f['census_path'],load_policy=POLICY))
+
+
+def test_row_handoff_has_exact_old_seal_and_no_h_sidecar(handoff,monkeypatch):
+    f=handoff
+    monkeypatch.setattr(torch,'save',lambda *a,**kw:pytest.fail('H sidecar materialization'))
+    path,_,digest=write_row(f,'a')
+    assert path.name=='hessian_capture.references.json'
+    assert not list(path.parent.glob('*.pt*'))
+    assert digest==export.hessian_capture_sha256({'a':f['H']['a']},{**f['calibration'],'hessian_role':'fit'})
+    with cc.open_hessian_reference(path) as owner:
+        assert owner.receipt()['verified_units']==[]
+        torch.testing.assert_close(owner['a'],f['H']['a'],rtol=0,atol=0)
+
+
+def rows(f):
+    dirs={};payloads={}
+    for name in f['H']:
+        path,_,digest=write_row(f,name)
+        binding=cc.hessian_reference_binding(f['record']['sha256'],cc.sha256(f['census_path']))
+        dirs[name]=path.parent.parent/name
+        cache=path.parent/'cache';cache.mkdir();path.replace(cache/path.name)
+        hessian=dict(TRIPLE,supplied=True,capture_sha256=digest,reference_binding=binding)
+        payloads[name]=dict(costs={name:{'format':{'hessian_identity':hessian}}},provenance=dict(
+            calibration_cache=f['record'],hessian=hessian,
+            unit_selection={'groups':[{'members':[name]}]}))
+    return dirs,payloads
+
+
+def test_dispatch_union_never_reads_h_and_matches_legacy_full_seal(handoff,monkeypatch):
+    f=handoff;dirs,payloads=rows(f)
+    monkeypatch.setattr(torch,'load',lambda *a,**kw:pytest.fail('eager H load during metadata merge'))
+    path,_,digest=dispatch.merge_export_inputs(dirs,payloads,out_cache=f['tmp']/'merged',
+        identity=f['calibration'],policy='fixture',static_scales={},census=f['census'])
+    assert digest==export.hessian_capture_sha256(f['H'],{**f['calibration'],'hessian_role':'fit'})
+    with cc.open_hessian_reference(path) as owner:
+        assert set(owner)==set(f['H']) and len(owner.descriptor['rows'])==2
+        assert owner.receipt()['loaded_entries']==0
+
+
+@pytest.mark.parametrize('defect',['row_seal','row_binding','canonical','roster','mixed'])
+def test_dispatch_refuses_unbound_reference_rows(handoff,defect):
+    f=handoff;dirs,payloads=rows(f);p=payloads['a']
+    if defect=='row_seal':p['costs']['a']['format']['hessian_identity']['capture_sha256']='0'*64
+    elif defect=='row_binding':p['provenance']['hessian']['reference_binding']['census_sha256']='0'*64
+    elif defect=='canonical':p['provenance']['calibration_cache']={**f['record'],'sha256':'0'*64}
+    elif defect=='roster':p['provenance']['unit_selection']['groups'][0]['members']=['b']
+    else:p['provenance']['hessian'].pop('reference_binding')
+    with pytest.raises(dispatch.MergeRefused):
+        dispatch.merge_export_inputs(dirs,payloads,out_cache=f['tmp']/'merged',
+            identity=f['calibration'],policy='fixture',static_scales={},census=f['census'])
+    assert not (f['tmp']/'merged/hessian_capture.references.json').exists()
+
+
+def test_export_gate_binds_reference_without_claiming_unconsumed_payloads(handoff,monkeypatch):
+    f=handoff;path,_,digest=write_row(f,'a')
+    assignment=_assignment(f['tmp'],formats={'a':'TESSERA_E4M3_K1_R1024'},capture_sha256=digest)
+    payload=json.loads(assignment.read_text())
+    payload['__prismaquant__']['tessera_hessian']['reference_binding']=cc.hessian_reference_binding(f['record']['sha256'],cc.sha256(f['census_path']))
+    assignment.write_text(json.dumps(payload))
+    monkeypatch.setattr(torch,'load',lambda *a,**kw:pytest.fail('gate eagerly consumes H'))
+    result=export.require_priced_export_inputs(assignment,hessian_path=path)
+    assert result['hessian_payload_verification']=='deferred_to_consumption'
+    assert result['hessian_verified_units']==[]
+    payload['__prismaquant__']['tessera_hessian']['reference_binding']['census_sha256']='0'*64
+    assignment.write_text(json.dumps(payload))
+    with pytest.raises(export.TesseraExportLaneError,match='binding differs'):
+        export.require_priced_export_inputs(assignment,hessian_path=path)
+
+
+@pytest.mark.parametrize('mode',['inapplicable','invalid'])
+def test_cli_reference_policy_refuses_before_any_source_intake(tmp_path,capsys,mode):
+    args=['--model',str(tmp_path/'absent'),'--out',str(tmp_path/'cost.pkl'),
+          '--cache-dir',str(tmp_path/'cache'),'--export-hessian-reference-policy']
+    if mode=='invalid':
+        args += [json.dumps({**POLICY,'max_file_bytes':0}),'--streaming','--units','a',
+                 '--calibration-cache',str(tmp_path/'absent.json'),'--calibration-cache-sha256','a'*64]
+    else:args += [json.dumps(POLICY)]
+    with pytest.raises(SystemExit) as error:campaign.main(args)
+    assert error.value.code==2
+    assert ('requires selected reuse' if mode=='inapplicable' else 'invalid byte bounds') in capsys.readouterr().err
+    assert not (tmp_path/'cache').exists()
+
+
+def test_uniform_identity_carries_binding_and_refuses_mixed_modes():
+    from prismaquant.tessera_menu import assert_uniform_hessian_identity
+    binding=cc.hessian_reference_binding('a'*64,'b'*64)
+    base=dict(TRIPLE,supplied=True,capture_sha256='c'*64,reference_binding=binding)
+    costs={'a':{'TESSERA_E4M3_K1_R1024':{'hessian_identity':copy.deepcopy(base)},'TESSERA_E4M3_K1_R512':{'hessian_identity':copy.deepcopy(base)}}}
+    assert assert_uniform_hessian_identity(costs)['reference_binding']==binding
+    costs['a']['TESSERA_E4M3_K1_R512']['hessian_identity']['reference_binding']['census_sha256']='d'*64
+    with pytest.raises(ValueError,match='mixes Hessian identities'):assert_uniform_hessian_identity(costs)
+    costs['a']['TESSERA_E4M3_K1_R512']['hessian_identity'].pop('reference_binding')
+    with pytest.raises(ValueError,match='mixes Hessian identities'):assert_uniform_hessian_identity(costs)
+
+
+def test_sampled_materialization_refuses_reference_before_source_or_h_load(tmp_path,monkeypatch):
+    import hashlib,pickle
+    from prismaquant import tessera_materialization as materialization
+    cost=tmp_path/'cost.pkl';cost.write_bytes(pickle.dumps({'provenance':{'hessian':{'reference_binding':cc.hessian_reference_binding('a'*64,'b'*64)}}}))
+    request=tmp_path/'request.json';request.write_text(json.dumps(dict(schema=materialization.REQUEST_SCHEMA,
+        status='selection_only_nonexportable',cost_path=str(cost),cost_sha256=hashlib.sha256(cost.read_bytes()).hexdigest())))
+    monkeypatch.setattr(torch,'load',lambda *a,**kw:pytest.fail('H load before reference materialization refusal'))
+    with pytest.raises(RuntimeError,match='no bounded reference union yet'):materialization._request(request)
+
+
+def test_selected_public_cli_publishes_references_without_changing_capture(monkeypatch,tmp_path):
+    from test_selected_source_authentication import test_selected_campaign_hashes_only_consumed_shards_and_preserves_identity
+    original=campaign.main
+    def reference_main(argv):
+        return original([*argv,'--export-hessian-reference-policy',json.dumps(POLICY)])
+    monkeypatch.setattr(campaign,'main',reference_main)
+    test_selected_campaign_hashes_only_consumed_shards_and_preserves_identity(monkeypatch,tmp_path)
+    path=tmp_path/'cache/hessian_capture.references.json'
+    assert path.is_file() and not (path.parent/'hessian_capture.pt').exists()
+    with cc.open_hessian_reference(path) as owner:
+        assert owner.receipt()['loaded_entries']==0
+        assert owner.binding()['canonical_capture_sha256']==cc.sha256(tmp_path/'capture/capture_manifest.json')

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -94,7 +94,7 @@ SHARED_PROVENANCE = (
 #: own units, and reconciling it is what the merge is for.
 SHARED_HESSIAN = (
     "supplied", "text_sha", "token_count", "text_sha256", "fit_ids_sha256",
-    "fit_tokens", "kwarg",
+    "fit_tokens", "kwarg", "reference_binding",
 )
 
 
@@ -861,6 +861,52 @@ def merge_payloads(row_payloads: dict, *, census: dict, capture_sha256: str) -> 
     return payload
 
 
+def _merge_export_hessian_references(row_dirs, payloads, *, out_cache, identity,
+                                     policy, static_scales, census):
+    from prismaquant import tessera_calibration_cache as store
+    from prismaquant.tessera_campaign import write_export_inputs
+
+    def accepted_rows():
+        for row_id in sorted(row_dirs):
+            path = Path(row_dirs[row_id])/'cache'/'hessian_capture.references.json'
+            payload = payloads[row_id]
+            with store.open_hessian_reference(path) as owner:
+                owner.require_census(census)
+                owner.require_provenance({**identity,'hessian_role':'fit'})
+                descriptor = owner.descriptor
+                provenance = payload['provenance']
+                if provenance.get('calibration_cache') != descriptor['canonical_capture']:
+                    raise MergeRefused(f'{row_id}: reference does not bind the row canonical capture')
+                if provenance['hessian'].get('reference_binding') != owner.binding():
+                    raise MergeRefused(f'{row_id}: reference binding differs from the row provenance')
+                identities = _hessian_identities(payload)
+                if (not identities or any(row.get('capture_sha256') != descriptor['capture_sha256'] or
+                        row.get('reference_binding') != owner.binding() for row in identities)):
+                    raise MergeRefused(f'{row_id}: reference commitments do not bind the exact priced row seals')
+                groups = (provenance.get('unit_selection') or {}).get('groups')
+                if not isinstance(groups, list) or not groups:
+                    raise MergeRefused(f'{row_id}: reference row has no selected unit roster')
+                expected = {name for group in groups for name in group.get('sampled', group['members'])}
+                if set(owner) != expected:
+                    raise MergeRefused(f'{row_id}: reference H roster differs from the exact selected members')
+                if owner.receipt()['loaded_entries'] != 0:
+                    raise MergeRefused('Hessian reference merge unexpectedly consumed tensor bytes')
+            yield descriptor
+
+    try:
+        descriptor = store.merge_hessian_reference_descriptors(accepted_rows())
+        out_cache.mkdir(parents=True, exist_ok=True)
+        path = out_cache/'hessian_capture.references.json'
+        digest = store.write_hessian_reference(path, descriptor)
+        _, scales, _ = write_export_inputs(out_cache, hessians=None, hessian_rows=census['counts'],
+            hessian_identity=identity, static_scales=static_scales, static_scale_policy=policy)
+    except (ValueError, RuntimeError, OSError) as error:
+        if isinstance(error, MergeRefused):
+            raise
+        raise MergeRefused(f'canonical Hessian reference merge refused: {error}') from error
+    return path, scales, digest
+
+
 def merge_export_inputs(row_dirs: dict, payloads: dict, *, out_cache: Path,
                         identity: dict, policy: str, static_scales: dict,
                         census: dict):
@@ -877,6 +923,13 @@ def merge_export_inputs(row_dirs: dict, payloads: dict, *, out_cache: Path,
     digested triple; no unit may be captured twice with different bytes; and
     the union's ``counts`` must be the census's, over the census's roster.
     """
+    reference_modes = [(payloads[row].get('provenance',{}).get('hessian') or {}).get('reference_binding')
+                       for row in sorted(row_dirs)]
+    if any(value is not None for value in reference_modes):
+        if any(value is None for value in reference_modes):
+            raise MergeRefused('cannot merge legacy and canonical-reference Hessian handoffs')
+        return _merge_export_hessian_references(row_dirs, payloads, out_cache=out_cache,
+            identity=identity, policy=policy, static_scales=static_scales, census=census)
     import torch
 
     from prismaquant.tessera_campaign import write_export_inputs


### PR DESCRIPTION
Merging the complete GLM candidate roster previously accumulated every calibration Hessian into one eager `.pt` object. The new opt-in handoff joins canonical metadata references and row seals instead; the reviewed Tessera reader verifies one bounded original H file/tensor when consumed. Pricing, row merge, allocation and exporter inputs preserve the same complete-capture/census binding. Unsupported sampled materialization refuses references at intake. Legacy eager inputs remain supported.

Synchronizes the development and serving dependency pins to reviewed Tessera `9d2314819f02` (RobTand/tessera#429), which supplies the public reader and nonblocking regular-file refusal. The exact raw contract changes only LFM construction output sizes; the allocator admission answer, serving-cell and native-extension tables are unchanged. Version 0.1.0 remains advisory, and no TP2 runtime cell or production eligibility is promoted. New pricing/export must use a consistent producer source seal.

Validation through PrismaBuild: initial handoff suite 200 passed / 2 skipped; final integrated handoff, merge, allocation, materialization, pin and architecture checks **239 passed / 3 skipped**, CPU only. Six touched implementation modules compiled. Root independently verified terminal exit/cleanup, canonical CAS receipts, actual payloads and source bundles; the final test source matches `1228c3523166` apart from generated closure metadata. Skips cover the legacy producer-absence case, explicit native writer measurement and absent immutable v5 publisher contract. Native handoff performance and full GLM quality/fit remain unmeasured. Full CI is pending.

Commands, exact producer archive hash, receipts and source audits: `experiments/measurements/bounded-hessian-handoff-20260908/README.md`. Includes a separate prose-only correction of the obsolete PENDING-pin description.

Closes #425. Depends on RobTand/tessera#429. Refs #388.
