### PR TITLE
Bind explicit stock topology in offline gold instruments

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,17 @@
 As of: 2026-09-08 · `integrate/glm-packed-source-20260908`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-08, `fix/glm-gold-topology`) for explicit stock-vLLM
+topology in the offline gold KL/PPL tools (#434). Shared closed arguments
+forward TP degree, node count, rank-0 rendezvous, MP backends and an optional
+MoE backend to the existing LLM construction; omitted arguments retain TP1.
+The gold coordinator does not launch remote nodes. Multi-node runs require
+separately launched stock headless workers, explicit compatible MP settings,
+and per-node runtime evidence. Configured topology and the helper's source
+bytes join existing gold provenance. Full-vocab final-position KL remains
+distinct from HTTP top-K KL. This instrument change touches no frozen pricing
+package input, Tessera producer, serving qualification or performance claim.
+
 Re-stamped (2026-09-08, `integrate/glm-packed-source-20260908`) for the
 synchronized development/serving dependency pin to Tessera `07ad344c3275`
 (Tessera #431). The producer can bind an explicit packed research execution

--- a/experiments/measurements/glm-downstream-handoff-20260908/README.md
+++ b/experiments/measurements/glm-downstream-handoff-20260908/README.md
@@ -1,0 +1,308 @@
+# GLM downstream handoff — 2026-09-08
+
+This is the bounded handoff for six research artifacts: one Spark and two
+Sparks, each with accuracy, prefill and balanced selection intent. It binds
+existing interfaces and identifies missing inputs; it does not report six
+completed artifacts or production qualification. `handoff-draft.json` is an
+unsealed intake record with explicit nulls, not an accepted collection receipt.
+
+Source basis: PrismaQuant `21ae7d28b7d313654beda6b4e622d732d4276a34`, gold
+instrument fix `0661c3e7eb`, and frozen Tessera producer
+`07ad344c3275bb2fa7ce2432f93d89945d66f4c2`. No `prismaquant/` or Tessera source
+changes are part of this handoff. The original fit draw, producer identity,
+family menu, release pin and production ship gates remain owned by the root
+campaign. See the earlier [recipe intake](../glm-six-variant-recipes-20260908/README.md)
+for allocator and common-input details; this report updates its downstream
+dependencies, including the now bounded export-H reference handoff.
+
+## Dependency order and first full-engine gate
+
+```mermaid
+flowchart LR
+  A[Original COMPLETE capture] --> B[Measured wire union]
+  X[Source compatibility] --> C
+  B --> C[Prepared PWC and corrected original-graph joint costs]
+  C --> D[One allocation handoff]
+  D --> E[Candidate recipes under explicit byte budgets]
+  B --> F[First complete anchor plan and exact cached wires]
+  E --> G[Export selected research checkpoints]
+  F --> G
+  G --> H[Full engine load, generation, PPL, prefill and decode]
+  T[One authenticated fixed gold teacher] --> K[Paired fixed-draw KL]
+  G --> K
+  H --> S[Select and verify six outputs]
+  K --> S
+```
+
+The earliest full-engine attempt needs one complete whole-model anchor plan,
+all its accepted selected wires, a working calibrated packed export handoff,
+original BF16 passthrough tensors, full model
+configuration/tokenizer, and the explicit packed execution configuration.
+It does not require corrected-graph source compatibility and can start before
+joint costs, final six-way allocation or optional runtime-v2
+prediction. Raman owns anchor availability and selection; the first three
+isolated expert wires are insufficient. Verify all 45 text layers and all 42
+routed stacks, trained router/shared-expert behavior, and exact model inventory.
+
+The native TP1 checkpoint-config control receipt is
+`/mnt/shared/tessera-measurements/glm-packed-checkpoint-control-20260908/native-tp1-01/receipt.json`.
+It tested ordinary `TesseraConfig` registration, 288 experts, q256=512, chunk=8,
+1,853,603,840 owner bytes, 864 loads and one-token/empty execution. It used
+repeated wire fixtures; it is not trained-router, full-model, quality or TP2
+evidence. Its four-layer model config must never replace the full source config.
+
+## Common inputs and the six variants
+
+Reuse the original 36,423-unit/132-group census and the original 512×512 seed-0
+fit-token artifact. Root owns the COMPLETE manifest SHA and explicit derivative
+compatibility receipt. The common selected-candidate union must be measured,
+not interpolated. Run the existing `tessera_joint_aura prepare`, `run`, then
+`tessera_joint_allocation` commands in the earlier intake once. Pass the same
+resulting pickle as both allocator `--probe` and `--costs` for every variant.
+No second fitting capture, redraw or model probe is implied by this handoff.
+Wire anchors depend on COMPLETE capture; derivative compatibility gates the
+corrected joint path independently.
+
+| Variant key | Serving topology | Selection intent |
+|---|---|---|
+| `spark1_low_prefill_high_accuracy` | TP1, one node | Lowest held-out loss among byte-fit candidates passing a declared loose prefill limit |
+| `spark1_high_prefill_lower_accuracy` | TP1, one node | Highest measured prefill performance among candidates passing a declared quality ceiling |
+| `spark1_balanced` | TP1, one node | Explicit intermediate constraints or observed quality saturation |
+| `spark2_low_prefill_high_accuracy` | TP2, two nodes, one GPU per node | Same accuracy criterion, with independently observed device fit and runtime |
+| `spark2_high_prefill_lower_accuracy` | TP2, two nodes, one GPU per node | Same prefill criterion on the declared two-node workload |
+| `spark2_balanced` | TP2, two nodes, one GPU per node | Explicit intermediate constraints or observed quality saturation |
+
+The current `glm_packed_research_sm121` profile is emulation-only and TP1. Use
+its legal dense/routed family restrictions for common research candidates; do
+not claim it prices or qualifies TP2. Routed stacks allow the measured legal
+E4M3 K1 family or BF16, uniformly across members of each packed decision;
+dense/fused constraints remain enforced by the existing planner. Keep
+`PRISMAQUANT_TESSERA_MENU=readable` explicit and bind `--formats` to the measured
+union. Do not invent rungs, bpp grids, byte ceilings, SLOs or TP2 profile prices.
+
+For direct serving selection, use the allocator command in the earlier intake
+with explicit byte budgets and omit `--measured-runtime-*` and `--slo-*` options.
+`--target-disk-gb` is decimal GB; bpp excludes immutable BF16, while fit and
+recursive artifact bytes include it. Re-run the full allocator for each chosen
+budget and retain its final layer-config and metadata. Pareto or validator
+assignment payloads are not a substitute: they lack the selected wire/source
+metadata and the selector correctly refuses to borrow it from another recipe.
+
+## Plan and export handoff — calibrated packed intake blocked
+
+For each final allocator output, retain its SHA, carried expert population and
+projection, selected cost/wire identities, source/fit/producer bindings, and
+priced scales. The existing `_write_plan_assignment(assignment_path,
+expected_sha256=...)` in `prismaquant.tessera_export_lane` expands packed
+decision owners into a source-unit view and writes
+`<stem>.tessera-source-units.json`. This is only a metadata projection. Ordinary
+lane preflight calls it after release/scope qualification; that production
+preflight remains closed for these research cells. An explicitly authorized
+research preparation may reuse the helper without forging a build attestation.
+
+The existing Tessera command consumes that projected view:
+
+```text
+python experiments/plan_from_layer_config.py SOURCE_UNIT_LAYER_CONFIG \
+  ORIGINAL_MODEL PLAN_JSON --cover as-allocated --prismaquant PQ_CHECKOUT
+```
+
+Do not broadcast or allow fused disagreement. Check the plan sidecar for zero
+unplanned body tensors, exact population/coverage, no demotions, and retained
+immutable routers. A generated uniform-control proposal still needs measured
+wires; never assume the proposed rung exists in the accepted union.
+
+Use `cached_units_manifest(source, records, schema=CACHE_SCHEMA)` with the
+producer's own constant and accepted complete selected dense+expert records.
+Each record must retain `file`, `blob_sha256`, `blob_bytes` and `identity`; the
+source block and paths must bind the original checkpoint and existing wire
+directory. Validate exact plan coverage and blob bytes against receipts first.
+This existing metadata helper does not authenticate arbitrary records by itself.
+Retain the selected manifest SHA and every original receipt; never re-encode an
+unpriced missing unit to complete it. The existing campaign merger owns the
+complete accepted wire records and bounded H-reference descriptor.
+
+```text
+python experiments/export_tessera_serving.py ORIGINAL_MODEL VARIANT_CHECKPOINT \
+  --plan-json PLAN_JSON --cached-units SELECTED_CLOSED_MANIFEST \
+  --research-selected-moe-json PACKED_EXECUTION_JSON --allow-unserveable
+```
+
+This is the intended research export shape, currently **blocked for calibrated
+packed GLM wires** by the frozen producer gate described below; it is not a
+runnable accepted handoff. Export work would use PB admission.
+`--cached-units` covers dense and expert planned units with no encode fallback;
+the narrower `--cached-expert-units` would still permit dense re-encoding.
+The frozen exporter refuses any non-null `--hessian` when a packed stack is
+planned (`experiments/export_tessera_serving.py:1577`), including cached intake.
+Omitting it constructs expected cached-unit identity with `calibration: null`
+(`src/tessera/cached_unit.py:84–98`), which cannot match the accepted calibrated
+wire record. Both cached expert intake (`:2021`) and dense intake (`:2110`)
+reconstruct identity from that activation owner. **There is no valid current
+CLI argument combination for this calibrated full packed plan.** Do not strip
+calibration, change wires or invent an attestation to bypass the refusal.
+
+The required repaired handoff must pass `--hessian BOUNDED_H_REFERENCE_JSON`
+and the exact original encoder settings (`--ldlq-sigma`, `--ldlq-block` or its
+budget, refit objectives and reach-floor), then verify the cached identity.
+`--priced-inputs` and `--priced-inputs-sha256` are a paired optional exporter
+argument, but the calibrated allocation handoff should carry its real v2 priced
+block with capture seal and canonical reference binding. Its `require` method
+compares loaded H seal/binding and scales; it does not unblock the packed gate.
+Never fabricate a qualified preflight build. `--input-scales` is required for
+selected dense NVFP4 routes and must match the original priced scalar file;
+it is unnecessary for an all-E4M3/BF16 plan. A mixed menu cannot omit it merely
+because experts use E4M3. The final selected plan determines that exact subset.
+The root has been notified of this bounded producer intake defect; no frozen
+source expansion or replacement encoding was performed here.
+Keep verification enabled and export the whole model. PB owns any supported
+fanout and partitioning; this handoff creates no dispatcher.
+
+`PACKED_EXECUTION_JSON` is the existing versioned input:
+
+```json
+{"schema":"tessera.research_selected_moe.v1","decode_backend":"triton","expected_tensor_parallel_size":1,"max_experts_per_chunk":8}
+```
+
+For TP2, change only the explicit expected TP size to 2 in its own hashed input.
+Bind any different chunk bound to its actual resource evidence. Retain the
+checkpoint's full original config plus producer-generated quantization config,
+including `quant_method=tessera`. No serving enable flag or vLLM core patch is
+needed; `TESSERA_SERVE_MODE=resident` is the serving mode input.
+
+## Stock serving and gold instruments
+
+The inspected stock image is
+`vllm/vllm-openai@sha256:4e31c581716a5cb9ef31eddb0a425842b75cab07d5cd63fb9572e69ae8794c33`.
+Install/bind the exact frozen Tessera package through the existing known-good
+container recipe and record its bytes. Commands below run inside that environment
+with mounted immutable inputs and per-run outputs. vLLM work runs directly under
+Rob's exemption. Respect existing GPU work and isolate actual measurements.
+
+TP1 serving uses the ordinary CLI; every capitalized workload value is pending
+explicit binding and validation, not a suggested default:
+
+```text
+vllm serve CHECKPOINT --served-model-name VARIANT_KEY \
+  --tensor-parallel-size 1 --distributed-executor-backend mp \
+  --moe-backend triton --dtype bfloat16 --enforce-eager \
+  --gpu-memory-utilization MEMORY_FRACTION --max-model-len CONTEXT_LIMIT \
+  --max-num-batched-tokens BATCH_TOKEN_LIMIT --port HTTP_PORT \
+  --profiler-config PROFILER_JSON
+```
+
+For two nodes add `--tensor-parallel-size 2 --nnodes 2 --node-rank 0
+--master-addr RANK0_ADDRESS --master-port RENDEZVOUS_PORT
+--data-parallel-backend mp` (replace the TP1 flag). On the second box run the
+same stock `vllm serve` configuration with `--node-rank 1 --headless`, the same
+checkpoint bytes, rendezvous and workload/engine options. Preserve declared CPU
+affinity in both containers. This is declarative stock launch, not a new worker
+orchestration layer. Record both ranks' actual runtime/package/config identities.
+
+The PPL and full-KL tools now accept those same topology flags directly, with
+rank 0 as the only in-process coordinator. TP1 defaults are unchanged. Launch
+the stock rank-1 headless peer for a two-node gold run; use matching engine and
+workload options. The tools' `self_manifest` fingerprints local descendants;
+it does not attest a remote rank, whose receipt must be retained separately.
+
+```text
+python tools/measure_vllm_wikitext_ppl.py --model CHECKPOINT --output PPL_JSON \
+  --wikitext-inputs FIXED_PPL_INPUTS --seqlen SEQLEN --n-tokens TOKEN_COUNT \
+  --dtype bfloat16 --enforce-eager --moe-backend triton \
+  --gpu-memory-utilization MEMORY_FRACTION \
+  --max-num-batched-tokens BATCH_TOKEN_LIMIT --serve-image IMAGE_AT_DIGEST \
+  --tensor-parallel-size TP
+
+python tools/measure_vllm_full_kl.py --mode student --model CHECKPOINT \
+  --teacher-payload AUTHENTICATED_TEACHER --teacher-meta TEACHER_META \
+  --output KL_JSON --score-positions final --n-samples SAMPLE_COUNT \
+  --seqlen SEQLEN --max-logprobs VOCAB_SIZE --dtype bfloat16 --enforce-eager \
+  --moe-backend triton --gpu-memory-utilization MEMORY_FRACTION \
+  --max-num-batched-tokens BATCH_TOKEN_LIMIT --serve-image IMAGE_AT_DIGEST \
+  --tensor-parallel-size TP
+```
+
+For both TP2 gold commands append `--nnodes 2 --node-rank 0 --master-addr
+RANK0_ADDRESS --master-port RENDEZVOUS_PORT --distributed-executor-backend mp
+--data-parallel-backend mp`. Nonzero gold coordinator rank is refused before
+loading. These are validated CLI/kwargs contracts, not native TP2 measurements.
+
+For actual prefill/decode, the inspected stock `vllm bench serve` supports
+`--backend openai --base-url SERVER_ROOT --endpoint /v1/completions --model
+VARIANT_KEY`, declared dataset/input/output lengths, request rate/concurrency,
+`--seed`, `--num-prompts`, `--save-result --save-detailed --result-dir RUN_DIR
+--result-filename RESULT_JSON --percentile-metrics ttft,tpot,itl,e2el
+--metric-percentiles 50,95,99 --profile`. Bind the dataset schema and exact
+request-token payload before treating a benchmark command as executable; no
+request set is supplied here. Use the same hashed payload for paired candidates.
+The stock profiler JSON fields are `profiler: "torch"`,
+`torch_profiler_dir: "ABSOLUTE_RUN_DIR"`, `torch_profiler_record_shapes: true`,
+`torch_profiler_with_memory: true`, `torch_profiler_with_stack: true`.
+
+Measure full initialization/load/prepare/KV allocation and requests, each rank's
+peak and steady resident memory, and prefill/decode separately. Record actual
+request counts/errors, input/output tokens, concurrency, TTFT/ITL distributions,
+throughput and repeat uncertainty. Collect in-process traces and Netdata on both
+boxes for every before/after comparison; include power versus the approximately
+140 W GB10 envelope and useful work per joule. GPU utilization percentage is
+non-diagnostic. PB reservation arithmetic and operator timings do not establish
+full-engine fit or end-to-end p95. Runtime-v2 remains optional for prediction.
+
+## Teacher gap and final acceptance
+
+The BF16 source has 642,652,070,880 bytes and does not fit resident on one or two
+Sparks. TP2 plumbing does not solve the BF16 teacher. No GLM-bound teacher payload
+was found in the bounded local measurement/run inventory searched for this
+handoff; that is not a claim of global absence.
+
+`tools/build_streamed_full_kl_teacher.py` reuses the existing streamed model
+builder, but currently emits only all-position top-K=8192 for fixed 8×512,
+seed-42 training WikiText windows. It has neither explicit derivative/source
+authentication CLI inputs nor final-position full-vocabulary output. The shared
+`cost_streaming.build_streamed_causal_lm` already accepts source authentication
+and derivative inputs. The fixed seed-42 training draw is not yet proven disjoint from fitting; call
+its result fixed-draw gold KL until overlap is checked. A bounded teacher
+schema/CLI adaptation remains a named
+dependency, to be designed and reviewed before implementation. It would produce one
+authenticated fixed gold teacher reused by all six, not another fitting capture.
+Do not relabel the existing top-K output as exact full-vocabulary KL. PPL,
+generation and performance do not need that teacher and can run first.
+
+Each accepted variant needs exact input/output SHAs, recursive artifact byte
+count, quantizable-only bpp, full-model inventory, actual device-fit evidence,
+unforked-engine load and generation, paired held-out quality, measured workload
+performance, and its byte-matched uniform control. Root must bind budgets,
+quality ceilings and workload; the six intent names do not supply them.
+Use `artifact_collection.make_target_profile`, `make_collection_contract` and
+`make_stage_receipt` to seal real records only after inputs exist. Stage receipts
+carry contract reference, variant key (null for common work), stage/outcome,
+input/output/evidence references and producer reference. Include remote rank
+evidence explicitly. These APIs are offline record owners, not schedulers.
+
+Research execution and delivery do not admit the production Tessera lane.
+The current reviewed exact runtime pin has passed its pin check; routed/full-model
+device qualification and measured serving gates remain pending. No runtime-v2,
+release or qualification bypass is
+introduced by this instrument change.
+
+## Instrument validation
+
+Issue #434 covers the gold topology plumbing. The four public CLI/stub-engine
+regressions failed on the unchanged pre-fix tools in PB action
+`abce7b0beecaba6eadd222adbf48ef578de68751069460c600cae513c8687262` (exit 1,
+four failures). Its failed terminal/log and source bundle are verified; a failed
+action correctly has no successful CAS receipt. The fix passed 102 tests,
+zero skips, 112 Torch deprecation warnings, in 9.39 seconds on dl380g10 CPU
+with Python 3.12, Torch 2.10 and native threads bounded to one. PB action
+`48919781f545a692d5b4b8b97de047a3ccce472d20bee21b60609e18ef03bf13` exited 0;
+CAS receipt, actual result and source bundle match the tested code. The attached
+root audits contain exact hashes. Tests cover both public CLIs, actual LLM
+kwargs, unchanged omitted TP1 kwargs, invalid/remote-rank rejection, topology
+provenance and helper source closure. No native full-engine GPU run is claimed.
+
+Final PB action `b87ff6f43e4c43807ccc4d01126024579e904dbc24bc04a909d8920cbbdd4d16`
+compiled all touched tools/tests and passed 19 architecture/staleness tests,
+zero skips, 56 Torch deprecation warnings, in 6.73 seconds. It ran on dl380g10
+with 4 CPUs / 6 GiB and one native thread per worker. The canonical CAS receipt,
+result bytes and fetched source bundle were checked; see `compile-docs-audit.json`.
+Later changes are report/intake prose only. `git diff --check` passes.

--- a/experiments/measurements/glm-downstream-handoff-20260908/compile-docs-audit.json
+++ b/experiments/measurements/glm-downstream-handoff-20260908/compile-docs-audit.json
@@ -1,0 +1,41 @@
+{
+  "action": "b87ff6f43e4c43807ccc4d01126024579e904dbc24bc04a909d8920cbbdd4d16",
+  "returncode": 0,
+  "test_result": "compile succeeded; 19 passed, zero skips, 56 deprecation warnings in 6.73s",
+  "worker": "dl380g10",
+  "demand": {
+    "cpu": 4,
+    "mem_gb": 6
+  },
+  "receipt_sha256": "e29d6de3ba4cd1685841cebe111615b9fcd8596e3d7c0748be46d1c48b3a2a3b",
+  "payload": {
+    "bytes": 610,
+    "sha256": "29166bd0be4d58cc3a0d6b2cadb848b1b15b3ebb736047e6576d5ae71f4c3772"
+  },
+  "source_snapshot": {
+    "commit": "71cadc318c7819e3835c99e206fd490b94023dc9",
+    "input": {
+      "bytes": 27338218,
+      "id": "pbrun.checkout-snapshot",
+      "sha256": "177b39130b5d4a7bf1e3dbf77b972bac2e9c62d63620d49a381e051c85d5e560"
+    },
+    "parent": "0661c3e7eb9285753259abd933283ed01bd95617",
+    "refs": {},
+    "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+    "subdirectory": "."
+  },
+  "source_diff_snapshot_to_0661": [
+    ".pbrun-closure.f3b80966129e2120.json",
+    "experiments/measurements/glm-downstream-handoff-20260908/README.md",
+    "experiments/measurements/glm-downstream-handoff-20260908/handoff-draft.json",
+    "experiments/measurements/glm-downstream-handoff-20260908/root-gold-topology-negative-source-audit.json",
+    "experiments/measurements/glm-downstream-handoff-20260908/root-gold-topology-positive-cas-source-audit.json"
+  ],
+  "verified": [
+    "canonical receipt SHA",
+    "actual result SHA/size and successful terminal",
+    "source bundle SHA/size and fetched snapshot"
+  ],
+  "runtime_mode": "CPU Python3.12; no GPU",
+  "stdout": "bringing up nodes...\nbringing up nodes...\n\n...................                                                      [100%]\n=============================== warnings summary ===============================\ntests/test_docs_staleness.py: 42 warnings\ntests/test_architecture_doc.py: 14 warnings\n  /home/rob/venvs/pq-cpu312/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.\n    warnings.warn(\n\n-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html\n19 passed, 56 warnings in 6.73s\n"
+}

--- a/experiments/measurements/glm-downstream-handoff-20260908/handoff-draft.json
+++ b/experiments/measurements/glm-downstream-handoff-20260908/handoff-draft.json
@@ -1,0 +1,207 @@
+{
+  "document_kind": "unsealed_downstream_intake",
+  "status": "pending_bound_inputs_not_an_artifact_collection_contract",
+  "source_basis": {
+    "prismaquant": "21ae7d28b7d313654beda6b4e622d732d4276a34",
+    "gold_instrument_commit": "0661c3e7eb",
+    "tessera": "07ad344c3275bb2fa7ce2432f93d89945d66f4c2",
+    "runtime_image": "vllm/vllm-openai@sha256:4e31c581716a5cb9ef31eddb0a425842b75cab07d5cd63fb9572e69ae8794c33"
+  },
+  "shared_inputs": {
+    "source_census_sha256": "b63f7bf6c4320714b4ceb38fbd6996e032e0f0c9b82ac2a30a8337d846e358fd",
+    "fit_tokens_sha256": "9cd1fa129f249abd80d22efaeb8bc7e8b2d3b4252f173a8c6f2b2e496a4f8329",
+    "fit_draw": {
+      "samples": 512,
+      "seqlen": 512,
+      "seed": 0
+    },
+    "complete_capture_ref": null,
+    "source_compatibility_ref": null,
+    "measured_union_ref": null,
+    "joint_plan_ref": null,
+    "prepared_pwc_ref": null,
+    "joint_cost_ref": null,
+    "allocation_handoff_ref": null,
+    "bounded_hessian_refs": null,
+    "priced_scales_ref": null,
+    "teacher_payload_ref": null,
+    "teacher_meta_ref": null,
+    "heldout_tokens_ref": null,
+    "accounting_rule_ref": null
+  },
+  "input_owners": {
+    "capture_compatibility_and_shared_joint": "root campaign",
+    "first_complete_anchor_plan_and_wires": "Raman/root campaign",
+    "budgets_quality_limits_workload": "root/user inputs",
+    "teacher_schema_and_reuse": "pending reviewed bounded instrument plan",
+    "receipts": "existing artifact_collection record APIs"
+  },
+  "first_engine_gate_requires": [
+    "one_complete_whole_model_plan",
+    "all_selected_accepted_dense_and_expert_wires",
+    "original_bf16_passthrough",
+    "full_source_model_config_and_tokenizer",
+    "explicit_research_execution_json",
+    "runtime_and_package_identity_per_rank",
+    "declared_workload_and_resource_window",
+    "repaired_calibrated_packed_cached_export_intake"
+  ],
+  "first_engine_gate_does_not_wait_for": [
+    "joint_allocation_handoff",
+    "six_final_selections",
+    "runtime_v2_predictor",
+    "corrected_graph_source_compatibility"
+  ],
+  "variants": [
+    {
+      "variant_key": "spark1_low_prefill_high_accuracy",
+      "topology": {
+        "tensor_parallel_size": 1,
+        "nnodes": 1,
+        "gpus_per_node": 1,
+        "distributed_executor_backend": "mp",
+        "data_parallel_backend": "mp",
+        "moe_backend": "triton",
+        "serving_mode": "resident"
+      },
+      "artifact_byte_ceiling": null,
+      "usable_device_bytes_per_rank": null,
+      "quality_ceiling": null,
+      "prefill_limit": null,
+      "workload_ref": null,
+      "selected_layer_config_ref": null,
+      "selected_wire_manifest_ref": null,
+      "checkpoint_ref": null,
+      "full_engine_receipt_ref": null,
+      "quality_receipt_ref": null,
+      "performance_receipt_ref": null,
+      "uniform_control_ref": null
+    },
+    {
+      "variant_key": "spark1_high_prefill_lower_accuracy",
+      "topology": {
+        "tensor_parallel_size": 1,
+        "nnodes": 1,
+        "gpus_per_node": 1,
+        "distributed_executor_backend": "mp",
+        "data_parallel_backend": "mp",
+        "moe_backend": "triton",
+        "serving_mode": "resident"
+      },
+      "artifact_byte_ceiling": null,
+      "usable_device_bytes_per_rank": null,
+      "quality_ceiling": null,
+      "prefill_limit": null,
+      "workload_ref": null,
+      "selected_layer_config_ref": null,
+      "selected_wire_manifest_ref": null,
+      "checkpoint_ref": null,
+      "full_engine_receipt_ref": null,
+      "quality_receipt_ref": null,
+      "performance_receipt_ref": null,
+      "uniform_control_ref": null
+    },
+    {
+      "variant_key": "spark1_balanced",
+      "topology": {
+        "tensor_parallel_size": 1,
+        "nnodes": 1,
+        "gpus_per_node": 1,
+        "distributed_executor_backend": "mp",
+        "data_parallel_backend": "mp",
+        "moe_backend": "triton",
+        "serving_mode": "resident"
+      },
+      "artifact_byte_ceiling": null,
+      "usable_device_bytes_per_rank": null,
+      "quality_ceiling": null,
+      "prefill_limit": null,
+      "workload_ref": null,
+      "selected_layer_config_ref": null,
+      "selected_wire_manifest_ref": null,
+      "checkpoint_ref": null,
+      "full_engine_receipt_ref": null,
+      "quality_receipt_ref": null,
+      "performance_receipt_ref": null,
+      "uniform_control_ref": null
+    },
+    {
+      "variant_key": "spark2_low_prefill_high_accuracy",
+      "topology": {
+        "tensor_parallel_size": 2,
+        "nnodes": 2,
+        "gpus_per_node": 1,
+        "distributed_executor_backend": "mp",
+        "data_parallel_backend": "mp",
+        "moe_backend": "triton",
+        "serving_mode": "resident"
+      },
+      "artifact_byte_ceiling": null,
+      "usable_device_bytes_per_rank": null,
+      "quality_ceiling": null,
+      "prefill_limit": null,
+      "workload_ref": null,
+      "selected_layer_config_ref": null,
+      "selected_wire_manifest_ref": null,
+      "checkpoint_ref": null,
+      "full_engine_receipt_ref": null,
+      "quality_receipt_ref": null,
+      "performance_receipt_ref": null,
+      "uniform_control_ref": null
+    },
+    {
+      "variant_key": "spark2_high_prefill_lower_accuracy",
+      "topology": {
+        "tensor_parallel_size": 2,
+        "nnodes": 2,
+        "gpus_per_node": 1,
+        "distributed_executor_backend": "mp",
+        "data_parallel_backend": "mp",
+        "moe_backend": "triton",
+        "serving_mode": "resident"
+      },
+      "artifact_byte_ceiling": null,
+      "usable_device_bytes_per_rank": null,
+      "quality_ceiling": null,
+      "prefill_limit": null,
+      "workload_ref": null,
+      "selected_layer_config_ref": null,
+      "selected_wire_manifest_ref": null,
+      "checkpoint_ref": null,
+      "full_engine_receipt_ref": null,
+      "quality_receipt_ref": null,
+      "performance_receipt_ref": null,
+      "uniform_control_ref": null
+    },
+    {
+      "variant_key": "spark2_balanced",
+      "topology": {
+        "tensor_parallel_size": 2,
+        "nnodes": 2,
+        "gpus_per_node": 1,
+        "distributed_executor_backend": "mp",
+        "data_parallel_backend": "mp",
+        "moe_backend": "triton",
+        "serving_mode": "resident"
+      },
+      "artifact_byte_ceiling": null,
+      "usable_device_bytes_per_rank": null,
+      "quality_ceiling": null,
+      "prefill_limit": null,
+      "workload_ref": null,
+      "selected_layer_config_ref": null,
+      "selected_wire_manifest_ref": null,
+      "checkpoint_ref": null,
+      "full_engine_receipt_ref": null,
+      "quality_receipt_ref": null,
+      "performance_receipt_ref": null,
+      "uniform_control_ref": null
+    }
+  ],
+  "producer_intake_blocker": {
+    "source": "Tessera 07ad experiments/export_tessera_serving.py:1577",
+    "reason": "packed --hessian refused even with cached units; omission mismatches calibrated identity",
+    "disposition": "reported to root; no frozen source edits"
+  },
+  "teacher_draw_status": "fixed seed42 train WikiText; fitting overlap unverified"
+}

--- a/experiments/measurements/glm-downstream-handoff-20260908/root-gold-topology-negative-source-audit.json
+++ b/experiments/measurements/glm-downstream-handoff-20260908/root-gold-topology-negative-source-audit.json
@@ -1,0 +1,27 @@
+{
+  "action": "abce7b0beecaba6eadd222adbf48ef578de68751069460c600cae513c8687262",
+  "terminal_sha256": "04e1e494b87070424ea39392d49b22ef6c2e67fce6cb6bdf72a5885109898ba1",
+  "returncode": 1,
+  "expected_failure": "4 failing public CLI/stub engine regressions; old tools cannot express TP2 topology",
+  "stdout_sha256": "3be7472148d23811eaf747ea874a5e4691d72f3c41263d34eb269e5b45b9d841",
+  "source_snapshot": {
+    "commit": "305be379bb42edd749e96fa6e259b09a1b1e781a",
+    "input": {
+      "bytes": 27318703,
+      "id": "pbrun.checkout-snapshot",
+      "sha256": "cedc0eed7b09592fbc950e8a7b7e47ab9b06cbdea018fd518a1ea6871274813c"
+    },
+    "parent": "21ae7d28b7d313654beda6b4e622d732d4276a34",
+    "refs": {},
+    "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+    "subdirectory": "."
+  },
+  "source_diff_from_21ae7": [
+    ".pbrun-closure.dfec9cec9c0ae88f.json",
+    "tests/test_gold_engine_options.py"
+  ],
+  "regression_test_sha256": "e4c2bde1b70a3db3f15302f64371a0b447ee16911836ce3204ca4de9f0b20b5b",
+  "original_four_regressions_unchanged": true,
+  "additional_positive_test_lines": 69,
+  "successful_cas_receipt": false
+}

--- a/experiments/measurements/glm-downstream-handoff-20260908/root-gold-topology-positive-cas-source-audit.json
+++ b/experiments/measurements/glm-downstream-handoff-20260908/root-gold-topology-positive-cas-source-audit.json
@@ -1,0 +1,13 @@
+[
+  {
+    "action": "48919781f545a692d5b4b8b97de047a3ccce472d20bee21b60609e18ef03bf13",
+    "receipt": "c57b256c09206267c94b9037a17de72475a54367f0d147509733297a6593de0a",
+    "payload_sha256": "e13486e2d95b7b25fff2c7585281d04576c7d6e56a9503f3a27667bb226d803b",
+    "snapshot": "19500c982cb5cb62bb8364f92e528c30db7e729b",
+    "source_diff_from_commit": [
+      ".pbrun-closure.8d4d982668121c0a.json",
+      "docs/ARCHITECTURE.md"
+    ],
+    "stdout_tail": "bringing up nodes...\nbringing up nodes...\n\n........................................................................ [ 70%]\n..............................                                           [100%]\n=============================== warnings summary ===============================\n../../../../venvs/pq-cpu312/lib/python3.12/site-packages/torch/jit/_script.py:362: 112 warnings\n  /home/rob/venvs/pq-cpu312/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.\n    warnings.warn(\n\n-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html\n102 passed, 112 warnings in 9.39s\n"
+  }
+]

--- a/tests/test_gold_engine_options.py
+++ b/tests/test_gold_engine_options.py
@@ -1,0 +1,136 @@
+"""Gold runners must pass the declared stock topology to their actual LLM."""
+import importlib
+import sys
+import types
+
+import pytest
+
+
+RUNNERS = ("tools.measure_vllm_full_kl", "tools.measure_vllm_wikitext_ppl")
+
+
+def _args(**overrides):
+    fields = dict(model="artifact", dtype="bfloat16", gpu_memory_utilization=0.5,
+                  seqlen=512, max_logprobs=100, enforce_eager=True,
+                  quantization=None, max_num_batched_tokens=1024,
+                  tensor_parallel_size=2, nnodes=2, node_rank=0,
+                  master_addr="192.0.2.1", master_port=29501,
+                  distributed_executor_backend="mp", data_parallel_backend="mp",
+                  moe_backend="triton")
+    fields.update(overrides)
+    return types.SimpleNamespace(**fields)
+
+
+@pytest.mark.parametrize("runner", RUNNERS)
+def test_llm_receives_two_node_topology(monkeypatch, runner):
+    module = importlib.import_module(runner)
+    seen = {}
+    sentinel = object()
+    def llm(**kwargs):
+        seen.update(kwargs)
+        return sentinel
+    monkeypatch.setitem(sys.modules, "vllm", types.SimpleNamespace(LLM=llm))
+    monkeypatch.setattr(module, "refuse_if_spec_decode", lambda **kwargs: False)
+    args = _args()
+    result = (module._load_llm(args, max_model_len=513) if runner.endswith("full_kl")
+              else module._load_llm(args))
+    assert result is sentinel
+    assert {key: seen.get(key) for key in (
+        "tensor_parallel_size", "nnodes", "node_rank", "master_addr", "master_port",
+        "distributed_executor_backend", "data_parallel_backend", "moe_backend")} == {
+        "tensor_parallel_size": 2, "nnodes": 2, "node_rank": 0,
+        "master_addr": "192.0.2.1", "master_port": 29501,
+        "distributed_executor_backend": "mp", "data_parallel_backend": "mp",
+        "moe_backend": "triton"}
+    assert seen["enforce_eager"] is True
+    assert seen["max_num_batched_tokens"] == 1024
+
+
+@pytest.mark.parametrize("runner", RUNNERS)
+def test_public_cli_accepts_declared_two_node_topology(monkeypatch, runner):
+    module = importlib.import_module(runner)
+    class ReachedImageValidation(Exception):
+        pass
+    def image(args):
+        assert args.tensor_parallel_size == args.nnodes == 2
+        raise ReachedImageValidation
+    monkeypatch.setattr(module, "_resolve_serve_image", image)
+    argv = [runner, "--model", "artifact", "--output", "result.json",
+            "--tensor-parallel-size", "2", "--nnodes", "2", "--node-rank", "0",
+            "--master-addr", "192.0.2.1", "--master-port", "29501",
+            "--distributed-executor-backend", "mp", "--data-parallel-backend", "mp",
+            "--moe-backend", "triton"]
+    if runner.endswith("full_kl"):
+        argv += ["--mode", "teacher"]
+    monkeypatch.setattr(sys, "argv", argv)
+    with pytest.raises(ReachedImageValidation):
+        module.main()
+
+
+@pytest.mark.parametrize("runner", RUNNERS)
+def test_default_llm_options_preserve_single_node_behavior(monkeypatch, runner):
+    module = importlib.import_module(runner)
+    args = _args()
+    for field in ("tensor_parallel_size", "nnodes", "node_rank", "master_addr", "master_port",
+                  "distributed_executor_backend", "data_parallel_backend", "moe_backend"):
+        delattr(args, field)
+    seen = {}
+    monkeypatch.setitem(sys.modules, "vllm", types.SimpleNamespace(LLM=lambda **kw: seen.update(kw)))
+    monkeypatch.setattr(module, "refuse_if_spec_decode", lambda **kw: False)
+    if runner.endswith("full_kl"):
+        module._load_llm(args, max_model_len=513)
+    else:
+        module._load_llm(args)
+    assert seen == {"model": "artifact", "trust_remote_code": True, "dtype": "bfloat16",
+                    "tensor_parallel_size": 1, "gpu_memory_utilization": 0.5,
+                    "max_model_len": 513, "max_num_seqs": 1,
+                    "enforce_eager": True, "disable_log_stats": True,
+                    "max_num_batched_tokens": 1024,
+                    **({"max_logprobs": 100} if runner.endswith("full_kl") else {})}
+
+
+@pytest.mark.parametrize("fields", [
+    {"tensor_parallel_size": 0}, {"tensor_parallel_size": True},
+    {"tensor_parallel_size": 2.0}, {"nnodes": 0}, {"nnodes": 3},
+    {"node_rank": 1}, {"node_rank": False},
+    {"master_addr": ""}, {"master_addr": None},
+    {"master_port": 0}, {"master_port": 65536}, {"master_port": True},
+    {"master_port": None}, {"distributed_executor_backend": None},
+    {"data_parallel_backend": None}, {"distributed_executor_backend": "ray"},
+    {"moe_backend": "unknown"},
+])
+def test_incomplete_or_incompatible_topology_refuses_before_engine(fields):
+    from tools.gold_engine_options import gold_engine_kwargs
+    with pytest.raises(ValueError):
+        gold_engine_kwargs(_args(**fields))
+
+
+@pytest.mark.parametrize("runner", RUNNERS)
+def test_public_cli_refuses_worker_rank_before_model_access(monkeypatch, runner):
+    module = importlib.import_module(runner)
+    def forbidden(*args, **kwargs):
+        raise AssertionError("invalid topology reached model/image work")
+    monkeypatch.setattr(module, "_resolve_serve_image", forbidden)
+    argv = [runner, "--model", "artifact", "--output", "result.json", "--node-rank", "1"]
+    if runner.endswith("full_kl"):
+        argv += ["--mode", "teacher"]
+    monkeypatch.setattr(sys, "argv", argv)
+    with pytest.raises(SystemExit) as exc:
+        module.main()
+    assert exc.value.code == 2
+
+
+@pytest.mark.parametrize("runner", RUNNERS)
+def test_measurement_manifest_binds_topology_and_helper_source(monkeypatch, runner):
+    module = importlib.import_module(runner)
+    from tools.serve_fingerprint import _GOLD_PRODUCER_TOOL_FILES
+    tool = runner.split(".")[-1]
+    assert "tools/gold_engine_options.py" in _GOLD_PRODUCER_TOOL_FILES[tool]
+    monkeypatch.setattr(module, "gold_producer_identity", lambda name: {"git_commit": "a" * 40})
+    monkeypatch.setattr(module, "_resolve_serve_image", lambda args: "image@sha256:" + "b" * 64)
+    def manifest(**kwargs):
+        return {"serve_fingerprint": "c" * 64, **kwargs["extra"]}
+    monkeypatch.setattr(module, "self_manifest", manifest)
+    result = module._provenance(_args())
+    assert result["serve_manifest"]["gold_engine_configuration"]["tensor_parallel_size"] == 2
+    assert result["serve_manifest"]["gold_engine_configuration"]["nnodes"] == 2

--- a/tools/gold_engine_options.py
+++ b/tools/gold_engine_options.py
@@ -1,0 +1,63 @@
+"""Stock-vLLM topology arguments for the in-process gold coordinator.
+
+Remote nodes use the stock headless CLI. This module starts no processes.
+"""
+from __future__ import annotations
+
+import argparse
+
+
+def add_gold_engine_arguments(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_argument_group("stock gold-engine topology")
+    group.add_argument("--tensor-parallel-size", type=int, default=1)
+    group.add_argument("--nnodes", type=int, default=None)
+    group.add_argument("--node-rank", type=int, default=None,
+                       help="gold runs on rank 0; launch other nodes with stock vllm serve --headless")
+    group.add_argument("--master-addr", default=None)
+    group.add_argument("--master-port", type=int, default=None)
+    group.add_argument("--distributed-executor-backend", choices=("mp",), default=None)
+    group.add_argument("--data-parallel-backend", choices=("mp",), default=None)
+    group.add_argument("--moe-backend", choices=("auto", "triton"), default=None)
+
+
+def gold_engine_kwargs(args: argparse.Namespace) -> dict:
+    """Validate before loading; omission preserves the original TP1 kwargs."""
+    result = {"tensor_parallel_size": getattr(args, "tensor_parallel_size", 1)}
+    for name in ("nnodes", "node_rank", "master_addr", "master_port",
+                 "distributed_executor_backend", "data_parallel_backend", "moe_backend"):
+        value = getattr(args, name, None)
+        if value is not None:
+            result[name] = value
+    tp, nodes = result["tensor_parallel_size"], result.get("nnodes", 1)
+    for name, value in (("tensor_parallel_size", tp), ("nnodes", nodes)):
+        if type(value) is not int or value <= 0:
+            raise ValueError(f"{name} must be a positive integer")
+    if tp % nodes:
+        raise ValueError("nnodes must evenly divide tensor_parallel_size (DP/PP/PCP stay 1)")
+    rank = result.get("node_rank", 0)
+    if type(rank) is not int or rank != 0:
+        raise ValueError("gold runs only on node_rank 0; use stock headless workers for other nodes")
+    if "master_addr" in result and (
+            not isinstance(result["master_addr"], str) or not result["master_addr"].strip()):
+        raise ValueError("master_addr must be a nonempty host address")
+    if "master_port" in result and (
+            type(result["master_port"]) is not int or not 1 <= result["master_port"] <= 65535):
+        raise ValueError("master_port must be an integer in 1..65535")
+    for name in ("distributed_executor_backend", "data_parallel_backend"):
+        if name in result and result[name] != "mp":
+            raise ValueError(f"{name} must be mp when explicitly selected")
+    if "moe_backend" in result and result["moe_backend"] not in ("auto", "triton"):
+        raise ValueError("moe_backend must be auto or triton")
+    if nodes > 1:
+        required = ("master_addr", "master_port", "distributed_executor_backend", "data_parallel_backend")
+        missing = [name for name in required if name not in result]
+        if missing:
+            raise ValueError(f"multi-node gold requires explicit {', '.join(missing)}")
+    return result
+
+
+def validate_gold_engine_arguments(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    try:
+        gold_engine_kwargs(args)
+    except ValueError as exc:
+        parser.error(str(exc))

--- a/tools/measure_vllm_full_kl.py
+++ b/tools/measure_vllm_full_kl.py
@@ -22,6 +22,7 @@ from prismaquant_source_bootstrap import activate_prismaquant_source
 activate_prismaquant_source()
 
 try:  # package mode (`python -m tools.measure_vllm_full_kl`)
+    from .gold_engine_options import add_gold_engine_arguments, gold_engine_kwargs, validate_gold_engine_arguments
     from .full_kl_teacher_payload import (
         load_teacher_evidence,
         safe_load_torch_payload,
@@ -29,6 +30,7 @@ try:  # package mode (`python -m tools.measure_vllm_full_kl`)
     from .serve_fingerprint import gold_producer_identity, self_manifest
     from .spec_decode_guard import refuse_if_spec_decode
 except ImportError:  # script mode (`python /repo/tools/measure_vllm_full_kl.py`)
+    from gold_engine_options import add_gold_engine_arguments, gold_engine_kwargs, validate_gold_engine_arguments
     from full_kl_teacher_payload import (  # type: ignore
         load_teacher_evidence,
         safe_load_torch_payload,
@@ -100,6 +102,7 @@ def _provenance(args) -> dict:
         extra={
             "measurement_tool": "measure_vllm_full_kl",
             "producer_identity": producer,
+            "gold_engine_configuration": gold_engine_kwargs(args),
         },
         image=_resolve_serve_image(args),
     )
@@ -186,7 +189,7 @@ def _load_llm(args, *, max_model_len: int) -> "LLM":
         "model": args.model,
         "trust_remote_code": True,
         "dtype": args.dtype,
-        "tensor_parallel_size": 1,
+        **gold_engine_kwargs(args),
         "gpu_memory_utilization": args.gpu_memory_utilization,
         "max_model_len": max_model_len,
         "max_num_seqs": 1,
@@ -678,6 +681,7 @@ def _student(args) -> int:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
+    add_gold_engine_arguments(parser)
     parser.add_argument("--mode", choices=["teacher", "student"], required=True)
     parser.add_argument("--model", required=True)
     parser.add_argument("--output", required=True)
@@ -729,6 +733,7 @@ def main() -> int:
         help="RNG seed for the WikiText window draw (teacher mode only; "
         "students replay the windows stored in the teacher payload)")
     args = parser.parse_args()
+    validate_gold_engine_arguments(parser, args)
     # Resolve the image before anything loads a model: an unnamed image is a
     # reproducibility hole (R15), and discovering it only when the provenance
     # block is written would waste the whole measurement.

--- a/tools/measure_vllm_wikitext_ppl.py
+++ b/tools/measure_vllm_wikitext_ppl.py
@@ -21,10 +21,12 @@ from prismaquant_source_bootstrap import activate_prismaquant_source
 activate_prismaquant_source()
 
 try:  # package mode (`python -m tools.measure_vllm_wikitext_ppl`)
+    from .gold_engine_options import add_gold_engine_arguments, gold_engine_kwargs, validate_gold_engine_arguments
     from .dsv4_wikitext_inputs import load_dsv4_wikitext_inputs
     from .serve_fingerprint import gold_producer_identity, self_manifest
     from .spec_decode_guard import refuse_if_spec_decode
 except ImportError:  # script mode (`python /repo/tools/measure_vllm_wikitext_ppl.py`)
+    from gold_engine_options import add_gold_engine_arguments, gold_engine_kwargs, validate_gold_engine_arguments
     from dsv4_wikitext_inputs import load_dsv4_wikitext_inputs  # type: ignore
     from serve_fingerprint import (  # type: ignore
         gold_producer_identity,
@@ -111,6 +113,7 @@ def _provenance(args) -> dict:
         extra={
             "measurement_tool": "measure_vllm_wikitext_ppl",
             "producer_identity": producer,
+            "gold_engine_configuration": gold_engine_kwargs(args),
         },
         image=_resolve_serve_image(args),
     )
@@ -354,7 +357,7 @@ def _load_llm(args) -> "LLM":
         "model": args.model,
         "trust_remote_code": True,
         "dtype": args.dtype,
-        "tensor_parallel_size": 1,
+        **gold_engine_kwargs(args),
         "gpu_memory_utilization": args.gpu_memory_utilization,
         "max_model_len": int(args.seqlen) + 1,
         "max_num_seqs": 1,
@@ -411,6 +414,7 @@ def _logprob_value(entry, token_id: int) -> float:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    add_gold_engine_arguments(parser)
     parser.add_argument("--model", required=True)
     parser.add_argument("--output", required=True)
     parser.add_argument("--dataset-cache-dir", default="/hfcache/datasets")
@@ -448,6 +452,7 @@ def main() -> int:
         "PQ_SERVE_IMAGE): the serve fingerprint is not evidence without it.",
     )
     args = parser.parse_args()
+    validate_gold_engine_arguments(parser, args)
 
     # Resolve the image before the tokenizer or the model loads: an unnamed
     # image is a reproducibility hole (R15), and discovering it only when the

--- a/tools/serve_fingerprint.py
+++ b/tools/serve_fingerprint.py
@@ -96,10 +96,12 @@ _GOLD_PRODUCER_COMMON_FILES = (
 )
 _GOLD_PRODUCER_TOOL_FILES = {
     "measure_vllm_full_kl": (
+        "tools/gold_engine_options.py",
         "tools/full_kl_teacher_payload.py",
         "tools/measure_vllm_full_kl.py",
     ),
     "measure_vllm_wikitext_ppl": (
+        "tools/gold_engine_options.py",
         "tools/full_kl_teacher_payload.py",
         "tools/measure_vllm_wikitext_ppl.py",
     ),


### PR DESCRIPTION
The offline full-vocabulary KL and WikiText PPL instruments hard-coded TP1, so a declared two-Spark run could not configure the stock engine topology. Both tools now share validated TP/node/rendezvous/MP/MoE options, preserve omitted TP1 behavior, reject remote coordinator ranks before loading, and record the configured topology plus helper bytes in existing provenance. Remote workers remain separately launched stock headless vLLM processes and need their own runtime evidence.

The accompanying GLM handoff binds six research variant inputs, existing plan/export/gold interfaces and the earliest whole-model anchor gate. It records two unresolved dependencies explicitly: calibrated packed cached export currently refuses its required Hessian input, and the fixed gold teacher needs authenticated source/derivative support with fitting overlap checked. No frozen PrismaQuant pricing package, Tessera producer, menu, pin or serving qualification changes are included.

Validation: four public CLI/stub-engine regressions fail before the fix; PrismaBuild passes 102 instrument/provenance tests plus 19 architecture/staleness tests and compile checks, zero skips. Actual terminal/CAS/result/source audits are checked in under `experiments/measurements/glm-downstream-handoff-20260908/`. No native full-model or TP2 GPU measurement is claimed. Built on the validated #432 integration; the PR now targets main.

Closes https://github.com/RobTand/prismaquant/issues/434
