### PR TITLE
Give back the activation-scale environment execute borrows

### DIFF
--- a/prismaquant/tessera_joint_aura.py
+++ b/prismaquant/tessera_joint_aura.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 from collections import defaultdict
+import functools
 from dataclasses import dataclass
 import hashlib
 import json
@@ -610,6 +611,41 @@ def _io_counters():
     return values
 
 
+ACTIVATION_SCALE_ENV = "PRISMAQUANT_PROD_ACT_SCALES"
+
+
+def _restores_activation_scale_env(function):
+    """Scope ``execute``'s activation-scale write to the call that makes it.
+
+    ``execute`` sets ``PRISMAQUANT_PROD_ACT_SCALES`` from the admitted plan so
+    the render path it drives reads the campaign's value.  As a process entry
+    point that is right; called in-process it leaves the value behind.  Every
+    admitted plan carries ``"0"`` (``_load_plan``), and that is the input
+    which turns the render scorer's activation clip OFF for everything that
+    runs afterwards (``production_weight_cache.py``, in
+    ``_local_forward_render_score``).  Nothing outside ``execute`` reads the
+    key, so restoring it on the way out leaves the campaign byte-identical
+    and leaves the process as it was found.
+    """
+    absent = object()
+
+    @functools.wraps(function)
+    def wrapper(*args, **kwargs):
+        import os
+
+        prior = os.environ.get(ACTIVATION_SCALE_ENV, absent)
+        try:
+            return function(*args, **kwargs)
+        finally:
+            if prior is absent:
+                os.environ.pop(ACTIVATION_SCALE_ENV, None)
+            else:
+                os.environ[ACTIVATION_SCALE_ENV] = prior
+
+    return wrapper
+
+
+@_restores_activation_scale_env
 def execute(command, config, *, plan_sha256, prepared=None, resume=False, source_transition=None):
     """Execute one admitted preparation or one dependent cost action."""
     if source_transition is not None:
@@ -636,7 +672,7 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False, source
     from .tessera_reader import load_declared_reader
 
     require_cuda_hot_path("tessera_joint_aura", "cuda")
-    os.environ["PRISMAQUANT_PROD_ACT_SCALES"] = config["execution"]["production_act_scales"]
+    os.environ[ACTIVATION_SCALE_ENV] = config["execution"]["production_act_scales"]
     torch.set_num_threads(1)
     torch.set_float32_matmul_precision("highest")
     torch.backends.cuda.matmul.allow_tf32 = False

--- a/tests/test_tessera_joint_aura.py
+++ b/tests/test_tessera_joint_aura.py
@@ -256,6 +256,54 @@ def test_plan_refuses_unqualified_probe_or_activation_policies(tmp_path, field, 
         _load_plan(path, sha(path))
 
 
+@pytest.mark.parametrize("prior", [None, "1"])
+def test_execute_scopes_the_activation_scale_env_to_the_call(tmp_path, monkeypatch, prior):
+    """The plan's activation-scale value is live inside execute and gone after.
+
+    execute sets PRISMAQUANT_PROD_ACT_SCALES so the render path it drives
+    reads the campaign's value, and every admitted plan carries "0".  Left
+    behind, that "0" is the input that turns the render scorer's activation
+    clip off for the rest of the process: with it set,
+    ``_local_forward_render_score`` skips the clamp and reports
+    ``activation_clipped`` False, which is what
+    ``tests/test_served_activation_contract.py::
+    test_stock_nvfp4_cache_score_is_unchanged`` then fails on.  Both halves
+    are asserted here; restoring without setting would be just as wrong.
+    """
+    import os
+    import torch
+    from types import SimpleNamespace
+    from prismaquant import tessera_joint_aura as bridge, calibration_data, cost_streaming, gpu_guard
+    key = bridge.ACTIVATION_SCALE_ENV
+    monkeypatch.delenv(key, raising=False)
+    if prior is not None:
+        monkeypatch.setenv(key, prior)
+
+    draw = dict(fit_ids_sha256="a" * 64, text_sha256="b" * 64, nsamples=512, seqlen=512, seed=0)
+    monkeypatch.setattr(gpu_guard, "require_cuda_hot_path", lambda *_args: None)
+    monkeypatch.setattr(bridge, "load_measured_anchor_input", lambda _inputs, **_kwargs: SimpleNamespace(
+        census={"model": "fixture", "attention_implementation": "eager"},
+        payload={"provenance": {"hessian": {"calibration_identity": draw}}}))
+    # Called after the write, so it is where the live value can be read.
+    during = {}
+    def _observe(*_args, **_kwargs):
+        during["value"] = os.environ.get(key)
+        return torch.zeros((1, 512), dtype=torch.int64), {"provenance": {**draw, "nsamples": 1}}
+    monkeypatch.setattr(calibration_data, "load_calibration_input", _observe)
+    monkeypatch.setattr(cost_streaming, "build_streamed_causal_lm", lambda *_a, **_k:
+        pytest.fail("subset draw reached model construction"))
+    config = {"model": "fixture", "inputs": {}, "output_root": str(tmp_path),
+        "calibration_input": {"path": "fixture", "sha256": "a" * 64},
+        "profile_tool": "cprofile",
+        "execution": {"production_act_scales": "0", "n_calib_samples": 1, "calib_seqlen": 512}}
+
+    with pytest.raises(ValueError, match="original full draw nsamples"):
+        bridge.execute("prepare", config, plan_sha256="b" * 64)
+
+    assert during["value"] == "0", "the plan's value must be live inside execute"
+    assert os.environ.get(key) == prior, "and must not outlive the call"
+
+
 @pytest.mark.parametrize("profile_tool", ["cprofile", "py-spy"])
 def test_original_full_draw_refuses_subset_before_model_load(tmp_path, monkeypatch, profile_tool):
     import torch


### PR DESCRIPTION
Closes #445.

## The defect

`tessera_joint_aura.execute` sets `PRISMAQUANT_PROD_ACT_SCALES` from the admitted plan so the render path it drives reads the campaign's value. As a process entry point that is right. The write was a bare assignment, so an in-process caller never got the variable back, and `_load_plan` requires every admitted plan to carry `"0"` — which is exactly the input that turns the render scorer's activation clip off:

```python
# production_weight_cache.py, _local_forward_render_score
if (activation_max_abs is not None and float(activation_max_abs) > 0
        and _env_flag("PRISMAQUANT_PROD_ACT_SCALES", True)):
    x_quant_input = x.clamp(-float(activation_max_abs), float(activation_max_abs))
    clipped = True
```

Four tests call `execute` in-process with `require_cuda_hot_path` patched out, so each disarmed the clip for everything that ran after it in the same xdist worker. The CPU full suite has been failing one test on that:

```
FAILED tests/test_served_activation_contract.py::test_stock_nvfp4_cache_score_is_unchanged - assert False is True
```

The failure shape is the confirmation. That test's first assertion, `record["score"] == dynamic`, still passes, because both calls take the same unclipped branch and agree. Only `activation_clipped` disagrees.

## The fix

Scope the write to the call. Inside `execute` nothing changes and the campaign is byte identical. Plenty of code outside `execute` reads the key -- `production_weight_cache` is exactly that code, which is why the leak bites -- but nothing needs this command's value to still be set after `execute` returns, so the process is left as it was found. A decorator rather than an inline `try/finally` because the alternative is re-indenting 180 lines for a two-line behaviour change.

The regression test sits at `execute`'s boundary, not at the render scorer, and asserts both halves — the plan's value is live during the call, read from inside a callback that runs after the write, and the prior value is back after the call raises. Restoring without setting would be just as wrong, so both are checked, with and without a pre-existing value.

## Receipts

All through PrismaBuild on `dl380g10`, one interpreter, `/home/rob/venvs/pq-cpu312/bin/python`, one shard, no xdist.

| receipt | tree | rc | files | result |
|---|---|---|---|---|
| `b712a5674dbb` | `e4ed1cd863` (main, before) | 1 | `test_tessera_joint_aura.py` then `test_served_activation_contract.py` | 1 failed, 58 passed |
| `75b09a0bc7b6` | `e4ed1cd863` (main, before) | 0 | `test_served_activation_contract.py` alone | 22 passed |
| `7374f991765e` | this branch | 0 | the same ordered pair that failed | 61 passed |

The first two are the cause: one interpreter, one box, one file of difference. The third is the same ordered pair going green here, with the two new cases included in the count.

## Scope

Not a defaults, stage-graph, format-menu, lane or ship-gate change, so `docs/ARCHITECTURE.md` is unaffected. `docs/design/runtime_flags.md` documents the flag's meaning, which is unchanged; only who gives it back is.

#419's CI failure was this, not its own changes. It should be refreshed on this base and re-run once this lands rather than declared broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsJAfuLU26NWbYpSLrWFHJ
