### PR TITLE
Wire verified capture loading into selected streaming reuse

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,28 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `fix/glm-model-bound-wikitext-inputs`. Stamps
+As of: 2026-09-08 · `fix/glm-selected-verified-capture`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-08, `fix/glm-selected-verified-capture`) for opt-in
+`--capture-load-policy` on selected streaming reuse of a SHA-bound complete
+calibration capture. The existing verified activation loader authenticates
+one private serialized buffer against each original manifest entry, validates
+its archive/storage/FP32 tensors, and releases the buffer before CUDA transfer.
+The dispatcher and runtime share the selected-resource plan's additional
+capture-prefetch phase: resident selected weights/X/H, one decoded storage S,
+private file buffer F, full-file source-page exposure F, explicit scratch M,
+and existing headroom. All original phases and physical refusal gates remain.
+Digest-named `capture-load-execution-<sha256>.json` sidecars record the actual
+load chain, byte counts, original manifest binding, resources and memory guard;
+selected-source provenance binds the sidecar's path/SHA. A later refused or
+interrupted resume cannot replace an earlier sidecar. The explicit CLI policy
+remains in checkpoint settings and changed implementation source remains a
+resume boundary; this does not authorize silent reuse of old priced anchors.
+The canonical capture identity and payload bytes remain unchanged; the option
+does not run calibration forward or reprobe source projections. The option is
+still unset by default. Gates: `tests/test_selected_verified_capture.py`,
+existing verified-load, selected-source, admission and campaign resume tests.
+CPU contracts alone do not establish native I/O, speed or served quality.
 
 Re-stamped (2026-09-08, `fix/glm-model-bound-wikitext-inputs`) for the
 explicit offline `prismaquant.model_wikitext_inputs/2` input contract.
@@ -26,6 +47,7 @@ and per-node runtime evidence. Configured topology and the helper's source
 bytes join existing gold provenance. Full-vocab final-position KL remains
 distinct from HTTP top-K KL. This instrument change touches no frozen pricing
 package input, Tessera producer, serving qualification or performance claim.
+
 
 Re-stamped (2026-09-08, `integrate/glm-packed-source-20260908`) for the
 synchronized development/serving dependency pin to Tessera `07ad344c3275`
@@ -259,8 +281,9 @@ remain covered by the physical guard's runtime margin.
 The raw buffer expires before CPU results can transfer to CUDA. File changes,
 unknown owners, overbudget storage and unsupported copying reads refuse.
 
-`--capture-load-policy` accepts that JSON only with streamed
-`shared-inputs-bounded-v1` capture. Materialization and final sealing price
+`--capture-load-policy` accepts that JSON with streamed
+`shared-inputs-bounded-v1` capture or selected streaming reuse of a hash-bound
+complete capture. Materialization and final sealing price
 private serialized buffer, full-file source-page exposure and scratch separately; forward/source-validation phases
 retain their existing terms. The unchanged physical cap must admit the maximum
 phase. Joint preparation accepts the same top-level `capture_load_policy` only

--- a/experiments/measurements/selected-verified-capture-20260908/README.md
+++ b/experiments/measurements/selected-verified-capture-20260908/README.md
@@ -150,3 +150,31 @@ both-host Netdata, exact resident/selected bytes, and native tensor parity.
 Compare the prefetch phase, not whole campaign duration, and retain original
 calibration/runtime/resource conditions. Until that completes, reduced physical
 I/O, speed and work-per-joule for this selected route remain unmeasured.
+
+
+## Review branch and source boundaries
+
+The dedicated `fix/glm-selected-verified-capture-review` delivery branch is
+stacked on observer PR #442 at `2cf67c1a6641e9bc44c7972739a6ce02d95dd645`.
+It carries only the reader, focused tests, evidence and audit-reference fix.
+The original tested branch remains retained; its CPU receipts continue to name
+that original source. The focused 17-test receipt compares to immutable
+`5f12978a8bfd625b217774a81e76e662273666fd`, replacing the ambiguous `HEAD` label.
+
+Read-only source comparison in `delivery-source-audit.json` verifies byte
+identity for autoscale, both existing capture loaders, the new focused test
+file and the existing observer. Campaign and dispatcher differ from the tested
+tree by the separate unmerged family-restriction implementation, which this PR
+does not carry. The cherry-pick resolved only architecture stamp history and
+preserved current-main model-bound WikiText and gold-topology documentation.
+Existing CPU results are not represented as a rerun on this delivery tree.
+
+The underlying verified-loader and selected-source APIs are already on main.
+The #442 stack supplies the established batch observer used for the before
+measurement; native follow-up also needs the bounded window in #444 and the
+coordinator's separately reviewed restricted-family pricing source, frozen
+producer and unchanged canonical capture. Those campaign integration inputs
+are not changes made by this reader PR. A new integrated pricing checkout must
+pass normal source/policy resume boundaries and retain its own exact evidence.
+No native after-change run, default switch, artifact qualification or speed
+claim is part of this draft delivery.

--- a/experiments/measurements/selected-verified-capture-20260908/README.md
+++ b/experiments/measurements/selected-verified-capture-20260908/README.md
@@ -1,0 +1,152 @@
+# Selected capture loading diagnosis and opt-in wiring — 2026-09-08
+
+Selected anchor reuse read its 49.53 GB canonical X/H selection twice before
+encoding. The existing verified activation loader was unreachable from that
+CLI path. Commit `ae781f4ea5` exposes it through the existing explicit
+`--capture-load-policy`, with complete resource accounting and separate bound
+execution evidence. Commit `5f12978a8b` adds direct policy/source resume-boundary
+tests. The option remains unset by default. Native after-change measurement is
+pending the coordinator's GPU window; this report claims no speedup.
+
+## Attributable before measurement
+
+Original expert action
+`ab1c32b1a4c8fabc1bc27161cd5e8690b106503cd868e3640e1339a487d11e38`
+ran the frozen `8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5` checkout on Sparky,
+original producer image content
+`eb8592abd71390231b49aba119e36f02ad91ea867b06df1c67af3833004d07bd`,
+Torch 2.13.0+cu130, CUDA 13.0. Selected row 0076 is layer-4 routed experts,
+864 entries: 576 files of 75,499,429 bytes and 288 of 20,973,477 bytes.
+Total selected file size is 49,528,032,480 bytes. The original complete capture
+manifest remains SHA256
+`f4bcbf408d3aa81b04c1fabd1d2d7457176a95dcccdd5ed368800de5c37e277c`.
+The unchanged calibration is 512 samples × 512 tokens, seed 0, full-census H,
+with a maximum 512-row FP32 scoring prefix.
+
+`before-read-audit.json` binds fixed snapshots of the actual main-thread
+sampler and both-host Netdata. There are 607 prefetch samples from Unix
+1788909253.506646 through 1788909859.848720 (606.342 seconds). The enclosing
+samples span 1788909252.506191–1788909861.158911 and account for
+99,056,222,208 physical read bytes. Twice the selected files is
+99,056,064,960 bytes: the difference is 157,248 bytes. The narrower sampled
+window reads 98,716,471,296 physical bytes and 101,440,741,694 `rchar` bytes.
+Its physical rate is 162.81 MB/s and selected payload/time is 81.68 MB/s
+(decimal MB). These are sampled process/window figures, not per-file syscall
+traces; `rchar` includes metadata/other reads and cannot be labeled payload.
+
+In those 607 samples, 499 end at `tessera_calibration_cache.py:40` (file read),
+25 at line 49 (digest update), 38 at Torch `load_tensor`, and 28 at finite
+validation. Only three stacks include `CaptureMemoryGuard.check`; the evidence
+does not identify guard overhead as the dominant cost. Whole-process counters
+also include selected source-weight preparation: its separate 51-sample
+window has 35,947,208,704 physical read bytes. Attributing the process's entire
+~160 GB counter to the 49.53 GB capture selection would be wrong.
+
+Both-host Netdata contributes 121 samples during prefetch. Sparky's power is
+12.98 W mean (12–13 W), CPU idle 92.42%, and iowait 5.07%; Sparklina's power is
+19.55 W mean (4–43 W), CPU idle 84.37%, and iowait 9.16%. This supports a
+waiting GPU during selected prefetch. GPU utilization is not used as saturation
+evidence. The metrics retain their host/window scope and are not attributed
+exclusively to this action.
+
+## Cause and bounded change
+
+At frozen source `8d8a293f`, campaign lines 3962–3965 reject
+`--capture-load-policy` outside new bounded capture generation; selected reuse
+at lines 4292–4298 does not forward it. This was missing call-path wiring,
+not an invocation flag that the coordinator forgot.
+
+The legacy path at `tessera_calibration_cache.py:906–913` hashes each selected
+artifact while advising consumed pages away, then `torch.load` reads the file
+again. Its page release at lines 934–935 is another boundary, not another
+payload verification read. The existing `_verified_capture_entry` at line 485
+uses `load_verified_activation_cache_entry` in `perturbed_x_cache.py:579`:
+one held regular nonsymlink object, original expected payload SHA256, actual
+before/after file signature checks, explicit F/S/M bounds, one hashed private
+buffer, bounded archive and tensor validation, and buffer expiry before CUDA
+transfer. No stat signature substitutes for the checksum.
+
+The change allows that policy only for existing bounded capture generation or
+selected streaming reuse with units and a SHA-bound complete capture. The
+existing complete-manifest, census, selected-source descriptor and runtime
+authentication still run. No new capture, source projection probe, cache,
+scheduler, format, default, or numerical method is introduced.
+
+The dispatcher and runtime use the same new `capture_prefetch` resource phase:
+selected resident weights/X/H, one decoded storage S, private serialized F,
+full-file source-page F, scratch M and existing headroom. Existing source,
+export and encoding phase terms are retained. The physical guard still checks
+actual read/decode/transfer boundaries. A digest-named execution sidecar records
+actual loader byte counts and load digest chain, original capture binding,
+resource plan and guard; selected-source provenance carries its path/SHA.
+Immutable receipt names prevent an interrupted or refused later resume from
+replacing evidence referenced by an older cost output.
+
+The original capture identity and file bytes do not change. The CLI policy
+remains in checkpoint settings, and changed package source SHA remains a resume
+boundary. Existing explicit seed intake has its ordinary per-row gates; this
+change does not select that path or authorize inheriting old priced anchors.
+The coordinator must review the source transition before a new pricing freeze.
+
+## Post-prefetch observation and disposition
+
+The initial anchor profiler rejected its 9,222,546,186-byte CUDA trace against
+the 536,870,912-byte cap. It recorded `observation_failed` and no accepted CUDA
+trace. The observer preserved the completed anchor return so the campaign could
+journal it. Profiler failure is not a native qualification pass.
+
+A fixed post-observer slice contains 299 samples over 298.383 seconds: 266 end
+at Tessera `window_viterbi.py:771`, `sse += float(final.sum())`, which waits for
+preceding GPU work; 11 end at graph replay and two at `tensor_identity`.
+Sparky's 59 Netdata samples show 58.08 W mean / 61 W maximum, CPU idle 92.11%
+and iowait 0.44%; Sparklina has 4.12 W mean and CPU idle 97.63%. This identifies
+the observed host wait, not the responsible GPU instruction/kernel bottleneck
+or saturation. The coordinator owns the replacement bounded CUDA profiler.
+
+The coordinator withdrew this exact action after the observation failure.
+At the final read-only audit, its owned PID 2467709 was gone; 88 unit envelopes
+contained 88 anchors, with each serialized payload digest checked. There is no
+completed `cost.pkl`. Journals, existing wires, profiler evidence and canonical
+capture remain at their original paths. Wires were not independently requalified
+by this disposition audit. The records are retained partial evidence and may
+only pass the normal explicit resume/seed/source-transition gates; this agent
+did not stop or restart the action. `withdrawn-expert-disposition.json` binds
+the retained journal and profile files.
+
+## Validation and remaining native gate
+
+Regression-first PB `fd3ae6aab1bc06c59b19b1699dac43e56618c5585e7658d9598998371a9ff08d`
+ran the new tests against unchanged implementation: three expected failures
+(CLI refusal, missing admission policy, missing dispatcher forwarding), four
+refusal cases passed. The positive implementation has 235 completed unique
+CPU tests and one existing CUDA-only encoder-memo test skipped. This includes
+15 new selected-loader cases, two existing pre-acceptance resume refusals,
+verified loader/capture/source authentication, admission, fanout and architecture
+tests. Compile checks passed for all touched Python modules. CPU workers ran
+through PB on dl380g10, one native thread each, with independent files fanned
+out (up to nine actions). No new GPU work ran for this change.
+
+The broader `test_tessera_campaign_resume.py` was not completed: its 4 GiB action
+`7814eecd02a9fb7aef948103fe8aeb1537b9ec066b5a5073cb02657bc091e9e0` OOMed after two
+progress dots. A 12 GiB attempt
+`f2e22ec4352190831f0f27a618a4669601bb771092e68fbb43da84d5fad7de75` reached 13 dots,
+then the 300-second deadline (4,685,869,056-byte peak, no OOM). Neither has a
+completed pytest summary or counts toward the passing total. This file performs
+real CPU encodes; the focused journal policy/source tests cover the changed
+reuse boundary without claiming those unfinished wire/encoding cases passed.
+
+`cpu-action-audits.json` verifies actual terminal cleanup, logs, canonical CAS
+receipt and producer attestation digests, CAS payload bytes, and actual source
+bundles. Successful snapshots differ from the tested code/test commits only by
+PB's generated closure. Expected failures, OOM and timeout are retained with
+actual status and missing CAS where applicable. All successful actions exited
+zero with complete cleanup and no OOM/live processes; the compile CAS payload
+is correctly empty.
+
+The coordinator's next same-row expert qualification can supply the after
+measurement with the explicit policy, original capture and corrected observer.
+It must retain loader execution receipt, main-thread/process-I/O profile,
+both-host Netdata, exact resident/selected bytes, and native tensor parity.
+Compare the prefetch phase, not whole campaign duration, and retain original
+calibration/runtime/resource conditions. Until that completes, reduced physical
+I/O, speed and work-per-joule for this selected route remain unmeasured.

--- a/experiments/measurements/selected-verified-capture-20260908/before-read-audit.json
+++ b/experiments/measurements/selected-verified-capture-20260908/before-read-audit.json
@@ -1,0 +1,349 @@
+{
+  "enclosing_after_unix": 1788909861.158911,
+  "enclosing_before_unix": 1788909252.506191,
+  "enclosing_window_delta_io": {
+    "cancelled_write_bytes": 0,
+    "rchar": 101821777606,
+    "read_bytes": 99056222208,
+    "syscr": 81349,
+    "syscw": 854,
+    "wchar": 3338998,
+    "write_bytes": 3502080
+  },
+  "file_size_counts": {
+    "20973477": 288,
+    "75499429": 576
+  },
+  "first_prefetch_unix": 1788909253.5066457,
+  "guard_stack_samples": 3,
+  "host_metrics": {
+    "sparklina": {
+      "metrics": {
+        "nvidia_smi.gpu_gpu-b1eceeea-fec7-371e-2cf3-cd10f2e7b705_power_draw/power_draw": {
+          "max": 43.0,
+          "mean": 19.553719008264462,
+          "min": 4.0,
+          "n": 121
+        },
+        "prismabuild.mount_latency/claim": {
+          "max": 95323.0,
+          "mean": 10935.495867768595,
+          "min": 3311.0,
+          "n": 121
+        },
+        "prismabuild.mount_latency/listdir": {
+          "max": 454.0,
+          "mean": 146.6694214876033,
+          "min": 42.0,
+          "n": 121
+        },
+        "prismabuild.mount_latency/open": {
+          "max": 2800.0,
+          "mean": 530.1157024793389,
+          "min": 114.0,
+          "n": 121
+        },
+        "prismabuild.mount_latency/stat": {
+          "max": 20.0,
+          "mean": 3.5702479338842976,
+          "min": 2.0,
+          "n": 121
+        },
+        "prismabuild.mount_latency/worst": {
+          "max": 706786.0,
+          "mean": 37238.20661157025,
+          "min": 3812.0,
+          "n": 121
+        },
+        "prismabuild.mount_rpc_time/queue": {
+          "max": 53398.0,
+          "mean": 1723.611570247934,
+          "min": 0.0,
+          "n": 121
+        },
+        "prismabuild.mount_rpc_time/rtt": {
+          "max": 72619.0,
+          "mean": 10741.710743801654,
+          "min": 444.0,
+          "n": 121
+        },
+        "system.cpu/guest": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0,
+          "n": 121
+        },
+        "system.cpu/guest_nice": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0,
+          "n": 121
+        },
+        "system.cpu/idle": {
+          "max": 98.8471178,
+          "mean": 84.3748651446281,
+          "min": 66.29667,
+          "n": 121
+        },
+        "system.cpu/iowait": {
+          "max": 20.5823293,
+          "mean": 9.156401803305785,
+          "min": 0.3007519,
+          "n": 121
+        },
+        "system.cpu/irq": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0,
+          "n": 121
+        },
+        "system.cpu/nice": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0,
+          "n": 121
+        },
+        "system.cpu/softirq": {
+          "max": 0.1009082,
+          "mean": 0.009144778512396694,
+          "min": 0.0,
+          "n": 121
+        },
+        "system.cpu/steal": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0,
+          "n": 121
+        },
+        "system.cpu/system": {
+          "max": 8.1488934,
+          "mean": 1.990285941322314,
+          "min": 0.4509018,
+          "n": 121
+        },
+        "system.cpu/user": {
+          "max": 23.7160121,
+          "mean": 4.469302327272727,
+          "min": 0.3507014,
+          "n": 121
+        }
+      },
+      "samples": 121
+    },
+    "sparky": {
+      "metrics": {
+        "nvidia_smi.gpu_gpu-e76c7efc-c157-b1f4-1348-83e4eb5092f4_power_draw/power_draw": {
+          "max": 13.0,
+          "mean": 12.983471074380166,
+          "min": 12.0,
+          "n": 121
+        },
+        "prismabuild.mount_latency/claim": {
+          "max": 95160.0,
+          "mean": 10116.388429752065,
+          "min": 3034.0,
+          "n": 121
+        },
+        "prismabuild.mount_latency/listdir": {
+          "max": 283.0,
+          "mean": 107.7107438016529,
+          "min": 46.0,
+          "n": 121
+        },
+        "prismabuild.mount_latency/open": {
+          "max": 2425.0,
+          "mean": 684.8760330578513,
+          "min": 104.0,
+          "n": 121
+        },
+        "prismabuild.mount_latency/stat": {
+          "max": 9.0,
+          "mean": 2.8264462809917354,
+          "min": 2.0,
+          "n": 121
+        },
+        "prismabuild.mount_latency/worst": {
+          "max": 712757.0,
+          "mean": 35645.47107438016,
+          "min": 3173.0,
+          "n": 121
+        },
+        "prismabuild.mount_rpc_time/queue": {
+          "max": 171.0,
+          "mean": 55.247933884297524,
+          "min": 0.0,
+          "n": 121
+        },
+        "prismabuild.mount_rpc_time/rtt": {
+          "max": 28680.0,
+          "mean": 6913.214876033057,
+          "min": 377.0,
+          "n": 121
+        },
+        "system.cpu/guest": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0,
+          "n": 121
+        },
+        "system.cpu/guest_nice": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0,
+          "n": 121
+        },
+        "system.cpu/idle": {
+          "max": 94.1796287,
+          "mean": 92.4242279677686,
+          "min": 83.0111902,
+          "n": 121
+        },
+        "system.cpu/iowait": {
+          "max": 10.286001,
+          "mean": 5.066723959504132,
+          "min": 3.512293,
+          "n": 121
+        },
+        "system.cpu/irq": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0,
+          "n": 121
+        },
+        "system.cpu/nice": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0,
+          "n": 121
+        },
+        "system.cpu/softirq": {
+          "max": 0.0508906,
+          "mean": 0.007472192561983471,
+          "min": 0.0,
+          "n": 121
+        },
+        "system.cpu/steal": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0,
+          "n": 121
+        },
+        "system.cpu/system": {
+          "max": 5.0428643,
+          "mean": 1.0635082776859504,
+          "min": 0.4014049,
+          "n": 121
+        },
+        "system.cpu/user": {
+          "max": 7.8840285,
+          "mean": 1.4380675925619835,
+          "min": 0.2506266,
+          "n": 121
+        }
+      },
+      "samples": 121
+    }
+  },
+  "last_prefetch_unix": 1788909859.8487196,
+  "manifest_sha256": "f4bcbf408d3aa81b04c1fabd1d2d7457176a95dcccdd5ed368800de5c37e277c",
+  "physical_bytes_per_second": 162806566.69299453,
+  "physical_to_selected_bytes": 1.9931434049164556,
+  "prefetch_samples": 607,
+  "rchar_to_selected_bytes": 2.04814802071863,
+  "sample_window_delta_io": {
+    "cancelled_write_bytes": 0,
+    "rchar": 101440741694,
+    "read_bytes": 98716471296,
+    "syscr": 75816,
+    "syscw": 848,
+    "wchar": 3336850,
+    "write_bytes": 3497984
+  },
+  "sample_window_seconds": 606.3420739173889,
+  "sampler_samples": 904,
+  "schema": "prismaquant.selected_capture_prefetch_read_audit.v1",
+  "selected_entries": 864,
+  "selected_file_bytes": 49528032480,
+  "selected_payload_bytes_per_second": 81683318.06502339,
+  "snapshots": [
+    {
+      "bytes": 997729,
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/selected-verified-capture-01/before-python_sampler.jsonl",
+      "sha256": "b7ec484b00d8ab92bf2ed5a5a4c2855fdf24017797a111cd12ebb6d4d3eee73d"
+    },
+    {
+      "bytes": 4169030,
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/selected-verified-capture-01/before-netdata.jsonl",
+      "sha256": "3ba5db1ca3c10903572927851d25a0f16f9c55d052b80fc27cad66d42f32852f"
+    }
+  ],
+  "source_action": "ab1c32b1a4c8fabc1bc27161cd5e8690b106503cd868e3640e1339a487d11e38",
+  "top_frame_counts": [
+    {
+      "file": "/workspace/prismaquant/tessera_calibration_cache.py",
+      "function": "sha256",
+      "line": 40,
+      "samples": 499
+    },
+    {
+      "file": "/usr/local/lib/python3.12/dist-packages/torch/serialization.py",
+      "function": "load_tensor",
+      "line": 2128,
+      "samples": 38
+    },
+    {
+      "file": "/workspace/prismaquant/tessera_calibration_cache.py",
+      "function": "_validate_tensors",
+      "line": 416,
+      "samples": 28
+    },
+    {
+      "file": "/workspace/prismaquant/tessera_calibration_cache.py",
+      "function": "sha256",
+      "line": 49,
+      "samples": 25
+    },
+    {
+      "file": "/workspace/prismaquant/perturbed_x_cache.py",
+      "function": "release_activation_cache_file_pages",
+      "line": 441,
+      "samples": 6
+    },
+    {
+      "file": "/workspace/prismaquant/tessera_calibration_cache.py",
+      "function": "prefetch_capture",
+      "line": 924,
+      "samples": 3
+    },
+    {
+      "file": "/usr/lib/python3.12/pathlib.py",
+      "function": "open",
+      "line": 1015,
+      "samples": 3
+    },
+    {
+      "file": "/usr/local/lib/python3.12/dist-packages/torch/serialization.py",
+      "function": "_is_zipfile",
+      "line": 439,
+      "samples": 2
+    },
+    {
+      "file": "/usr/local/lib/python3.12/dist-packages/psutil/_common.py",
+      "function": "open_binary",
+      "line": 682,
+      "samples": 1
+    },
+    {
+      "file": "/workspace/prismaquant/tessera_calibration_cache.py",
+      "function": "sha256",
+      "line": 30,
+      "samples": 1
+    },
+    {
+      "file": "/workspace/prismaquant/perturbed_x_cache.py",
+      "function": "_advise_activation_descriptor",
+      "line": 427,
+      "samples": 1
+    }
+  ]
+}

--- a/experiments/measurements/selected-verified-capture-20260908/cpu-action-audits.json
+++ b/experiments/measurements/selected-verified-capture-20260908/cpu-action-audits.json
@@ -1,0 +1,1113 @@
+[
+  {
+    "action_key": "15a1aace22678abcbc6d31c400bce4f8b1b5003ff0a61f26f8f42912a6b6f4df",
+    "cleanup": {
+      "complete": true,
+      "released_ok": true
+    },
+    "logs": [
+      {
+        "bytes": 0,
+        "path": "attempts/15a1aace22678abcbc6d31c400bce4f8b1b5003ff0a61f26f8f42912a6b6f4df/3229fbc91501a7cb39a4bc6d7d72d296fac3cefe5e197683954afe34ba071c38/00000001.stderr.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.log",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 3746,
+        "path": "attempts/15a1aace22678abcbc6d31c400bce4f8b1b5003ff0a61f26f8f42912a6b6f4df/3229fbc91501a7cb39a4bc6d7d72d296fac3cefe5e197683954afe34ba071c38/00000001.stdout.3874e61497f2a7ae49cbb304f8864ebfb4cc3fd472ffde078e8bf4666ac1a48f.log",
+        "sha256": "3874e61497f2a7ae49cbb304f8864ebfb4cc3fd472ffde078e8bf4666ac1a48f",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": null,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:3632169:1c89e8d3",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788910613.1613479,
+      "elapsed_s": 8.551233291625977,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788910623.9017913,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 0,
+      "status": "executed"
+    },
+    "receipt": {
+      "attestation_sha256": "a67141db39abeea4cbf1ff3f22fa1c743be5b34113b72896f33f1012387c7d8c",
+      "canonical_body_sha256": "b5b4cab4b9821ca7db95765c8d54c260394c1e18a7acd1b315db1a03bd3ae3e9",
+      "file_sha256": "e19d6da86ede7830b55f595251b773e26f595803b7d233a47ad507e850fa9ab3",
+      "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/15/15a1aace22678abcbc6d31c400bce4f8b1b5003ff0a61f26f8f42912a6b6f4df.json",
+      "result": {
+        "bytes": 1264,
+        "sha256": "1d1b9757f2627261de386d1d7c2a1db425d82f9d1d26fb590499fce89eab775d"
+      },
+      "verified": true
+    },
+    "resources": {
+      "memory_peak_bytes": 458412032,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "source": {
+      "actual_bundle_sha256_verified": true,
+      "all_tree_differences": [
+        ".pbrun-closure.db27c628e5de670f.json"
+      ],
+      "reference": "ae781f4ea5",
+      "snapshot": {
+        "commit": "ebdf673a67123612b37040ae5a24e0057298e43a",
+        "input": {
+          "bytes": 27402389,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "6fb62f0df615a22ea48f8a62ac64ec65aac4107eb6e1582ea3cd8d37026893aa"
+        },
+        "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      }
+    },
+    "state": "done",
+    "summary": [
+      "70 passed, 16 warnings in 6.22s"
+    ],
+    "terminal": {
+      "path": "/mnt/shared/prismabuild-fleet/pb-queue/done/15a1aace22678abcbc6d31c400bce4f8b1b5003ff0a61f26f8f42912a6b6f4df.json",
+      "sha256": "0caf4c78d0f98c1998a1da6a07036953166d7de8f1d03b5fcb418eb4ebf22bc5"
+    }
+  },
+  {
+    "action_key": "2b409e7b4e1733e1fd0a292dc55fc137de72edacce83bb3a65621ab5356cd367",
+    "cleanup": {
+      "complete": true,
+      "released_ok": true
+    },
+    "logs": [
+      {
+        "bytes": 0,
+        "path": "attempts/2b409e7b4e1733e1fd0a292dc55fc137de72edacce83bb3a65621ab5356cd367/98a3732ef42458e300a64fdc6d67707196c1799006624f50e3a58bf508c87f1f/00000001.stderr.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.log",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 3006,
+        "path": "attempts/2b409e7b4e1733e1fd0a292dc55fc137de72edacce83bb3a65621ab5356cd367/98a3732ef42458e300a64fdc6d67707196c1799006624f50e3a58bf508c87f1f/00000001.stdout.07c4b36a018aa814e728cc02cfcce0bfc40c8b3cfbc38670e60c1de8aa03a035.log",
+        "sha256": "07c4b36a018aa814e728cc02cfcce0bfc40c8b3cfbc38670e60c1de8aa03a035",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": null,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:3734443:8ea86ec6",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788910614.6237059,
+      "elapsed_s": 7.837682485580444,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788910624.5108788,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 0,
+      "status": "executed"
+    },
+    "receipt": {
+      "attestation_sha256": "6732292b2b4cb73da009f3ae8819e36cab31fce5d9d371ad6b44d997f3209745",
+      "canonical_body_sha256": "07b9058a22860562bd2f24c6ea77f1ac2d871d857340a33d87ebaa3bfdf0281c",
+      "file_sha256": "f054a0675d94e0be96c8053b2011dc48e150f2f72fc499cd354cbe73e66b93a3",
+      "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/2b/2b409e7b4e1733e1fd0a292dc55fc137de72edacce83bb3a65621ab5356cd367.json",
+      "result": {
+        "bytes": 525,
+        "sha256": "9a69e52bc0df6fa98b4646e9f92031794ea03b5b0153c54c5c87b18afd6805c6"
+      },
+      "verified": true
+    },
+    "resources": {
+      "memory_peak_bytes": 367316992,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "source": {
+      "actual_bundle_sha256_verified": true,
+      "all_tree_differences": [
+        ".pbrun-closure.3da2d4d176e9c1f2.json"
+      ],
+      "reference": "ae781f4ea5",
+      "snapshot": {
+        "commit": "9607dae9b3881710a2ac1e842c2a526200a504bc",
+        "input": {
+          "bytes": 27402390,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "45f2de707b8cc3d454e1f56cbb93d70e771b1c43d98f0ae28bad4e30e819ec5a"
+        },
+        "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      }
+    },
+    "state": "done",
+    "summary": [
+      "13 passed, 14 warnings in 5.42s"
+    ],
+    "terminal": {
+      "path": "/mnt/shared/prismabuild-fleet/pb-queue/done/2b409e7b4e1733e1fd0a292dc55fc137de72edacce83bb3a65621ab5356cd367.json",
+      "sha256": "d71437b8db90780e0678f87761b4d43c6cc61e0359746b13c3cf146b73834c82"
+    }
+  },
+  {
+    "action_key": "385f62dcdd109c5a17f163203f52d303fe9a6ba843e1e8a57718afe4864950d8",
+    "cleanup": {
+      "complete": true,
+      "released_ok": true
+    },
+    "logs": [
+      {
+        "bytes": 0,
+        "path": "attempts/385f62dcdd109c5a17f163203f52d303fe9a6ba843e1e8a57718afe4864950d8/9dcd7d60e2fe634e798e8e26991fe8cd12171f50cd79cd7864196a96e3156637/00000001.stderr.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.log",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 3057,
+        "path": "attempts/385f62dcdd109c5a17f163203f52d303fe9a6ba843e1e8a57718afe4864950d8/9dcd7d60e2fe634e798e8e26991fe8cd12171f50cd79cd7864196a96e3156637/00000001.stdout.b9aec2fd0453a326342f751f10c708418153d200299e92e74bae8f1c4da54c63.log",
+        "sha256": "b9aec2fd0453a326342f751f10c708418153d200299e92e74bae8f1c4da54c63",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": null,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:3631268:42caec8e",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788910614.4085648,
+      "elapsed_s": 10.075134992599487,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788910626.5997992,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 0,
+      "status": "executed"
+    },
+    "receipt": {
+      "attestation_sha256": "1efd464d0720895623ce6bb40db5d7e76851e09742f61ff437199086e20e635f",
+      "canonical_body_sha256": "923df538da4545c5d00d36d29e5d3fc40179008457e74c9974f6c8409dd53089",
+      "file_sha256": "4e8572460a26c0c56a15fb2b8f32bc0f6a38430bb4d78d8ff6dd90ec64cfb249",
+      "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/38/385f62dcdd109c5a17f163203f52d303fe9a6ba843e1e8a57718afe4864950d8.json",
+      "result": {
+        "bytes": 576,
+        "sha256": "c3f40fe368786078b977dd4d00d429e9d0d29ae46eaa45148fc46894f461017c"
+      },
+      "verified": true
+    },
+    "resources": {
+      "memory_peak_bytes": 457781248,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "source": {
+      "actual_bundle_sha256_verified": true,
+      "all_tree_differences": [
+        ".pbrun-closure.a65275fedc4c280d.json"
+      ],
+      "reference": "ae781f4ea5",
+      "snapshot": {
+        "commit": "925b89db84033a9aae86162700a7c4cea2d18f8b",
+        "input": {
+          "bytes": 27402391,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "8af5bae25162026444e5a1ecd4d5caff0975d3127065ff36029aad15b5462fff"
+        },
+        "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      }
+    },
+    "state": "done",
+    "summary": [
+      "34 passed, 14 warnings in 7.59s"
+    ],
+    "terminal": {
+      "path": "/mnt/shared/prismabuild-fleet/pb-queue/done/385f62dcdd109c5a17f163203f52d303fe9a6ba843e1e8a57718afe4864950d8.json",
+      "sha256": "cb3a56b75bb73a8cf168f1f4553561f40ea686e3d6f5d0dd82c6586381b2303d"
+    }
+  },
+  {
+    "action_key": "3ccc91c9f149b897cb857a6adee68f5eeab1af86d82bf9b6f31ba51960f8f34b",
+    "cleanup": {
+      "complete": true,
+      "released_ok": true
+    },
+    "logs": [
+      {
+        "bytes": 0,
+        "path": "attempts/3ccc91c9f149b897cb857a6adee68f5eeab1af86d82bf9b6f31ba51960f8f34b/0b2a597a090fcb0b5eece14441819dcde5601e5fa01f6be84b3a3f6b67d9df68/00000001.stderr.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.log",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 3003,
+        "path": "attempts/3ccc91c9f149b897cb857a6adee68f5eeab1af86d82bf9b6f31ba51960f8f34b/0b2a597a090fcb0b5eece14441819dcde5601e5fa01f6be84b3a3f6b67d9df68/00000001.stdout.0699fe92c3ced425746936fd1ec0fba010a08c75ddb48fc9f107c57435af4078.log",
+        "sha256": "0699fe92c3ced425746936fd1ec0fba010a08c75ddb48fc9f107c57435af4078",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": null,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:3631270:80fb8e16",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788910610.1496596,
+      "elapsed_s": 7.375136852264404,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788910619.3199167,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 0,
+      "status": "executed"
+    },
+    "receipt": {
+      "attestation_sha256": "32b35435018e16f79f474a0137491c5aff6c10d9c7cc2ffce0ab093a8873969b",
+      "canonical_body_sha256": "1d266037edc1c228c57072cb11bff38efc2e3cd2c548312ca3def8a2f4951b0e",
+      "file_sha256": "ec015ff257fff1dc63a1445c43993977ea22cfcf8da12e6922b3b8f3275c98b8",
+      "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/3c/3ccc91c9f149b897cb857a6adee68f5eeab1af86d82bf9b6f31ba51960f8f34b.json",
+      "result": {
+        "bytes": 522,
+        "sha256": "90296c4ea4a26dc06c7c322102cf95bd269abb0df9dfe37fedf180da4ea8f08d"
+      },
+      "verified": true
+    },
+    "resources": {
+      "memory_peak_bytes": 363069440,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "source": {
+      "actual_bundle_sha256_verified": true,
+      "all_tree_differences": [
+        ".pbrun-closure.edb6f5194ceefdc3.json"
+      ],
+      "reference": "ae781f4ea5",
+      "snapshot": {
+        "commit": "825947c8fa6cb34fefb78eb64b39b5fa004ad9bf",
+        "input": {
+          "bytes": 27402389,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "e9c5cb35b9cfbc9b87182131e626605b9c4011c6c4e1d8dd86c9068898811ff4"
+        },
+        "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      }
+    },
+    "state": "done",
+    "summary": [
+      "6 passed, 14 warnings in 5.06s"
+    ],
+    "terminal": {
+      "path": "/mnt/shared/prismabuild-fleet/pb-queue/done/3ccc91c9f149b897cb857a6adee68f5eeab1af86d82bf9b6f31ba51960f8f34b.json",
+      "sha256": "d29413a172a3972ea04eff0c58c3c512c819a9afef3e0f9701df81f4be491385"
+    }
+  },
+  {
+    "action_key": "54f278d5a7badbea1bc41152bef1e4bfabe6250246ec901d1ca30bf8721435f5",
+    "cleanup": {
+      "complete": true,
+      "released_ok": true
+    },
+    "logs": [
+      {
+        "bytes": 0,
+        "path": "attempts/54f278d5a7badbea1bc41152bef1e4bfabe6250246ec901d1ca30bf8721435f5/bb22f35415191adbf1d77ab7f156bf37da18b26ae1e4370a9b31e8a14adf1f48/00000001.stderr.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.log",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 3057,
+        "path": "attempts/54f278d5a7badbea1bc41152bef1e4bfabe6250246ec901d1ca30bf8721435f5/bb22f35415191adbf1d77ab7f156bf37da18b26ae1e4370a9b31e8a14adf1f48/00000001.stdout.d888b994160a5798d3d19d35b6691d0294ffe76a23945655e14d49d2aee7438a.log",
+        "sha256": "d888b994160a5798d3d19d35b6691d0294ffe76a23945655e14d49d2aee7438a",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": null,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:3727052:4f113aa2",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788910615.0381625,
+      "elapsed_s": 8.334429740905762,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788910625.4286501,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 0,
+      "status": "executed"
+    },
+    "receipt": {
+      "attestation_sha256": "a26f233556197ab396958238e74917b040a4f0b430d0df6abb010095b66cfb47",
+      "canonical_body_sha256": "ed714ba9937ac9e1c2a96caa6f02a248e72c5cbd14a7c939269bb8a0613e50c8",
+      "file_sha256": "30796eb4d4bd896078caaf7bd575b74f3464cb04a47489b14997216c4d63bcb8",
+      "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/54/54f278d5a7badbea1bc41152bef1e4bfabe6250246ec901d1ca30bf8721435f5.json",
+      "result": {
+        "bytes": 576,
+        "sha256": "fc56ba534a7a68d5534116e4f83858201c02eb81296a3f6c4dbbd51db44c9624"
+      },
+      "verified": true
+    },
+    "resources": {
+      "memory_peak_bytes": 400662528,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "source": {
+      "actual_bundle_sha256_verified": true,
+      "all_tree_differences": [
+        ".pbrun-closure.21cd80009a193fc9.json"
+      ],
+      "reference": "ae781f4ea5",
+      "snapshot": {
+        "commit": "1e82609a5310a74b4e8064ce4719edd99e922b7c",
+        "input": {
+          "bytes": 27402389,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "f8b78e465b8358a113c208b3f8e9e99a4e7bba831ee475a359bbfb6f7dce2f00"
+        },
+        "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      }
+    },
+    "state": "done",
+    "summary": [
+      "20 passed, 14 warnings in 6.21s"
+    ],
+    "terminal": {
+      "path": "/mnt/shared/prismabuild-fleet/pb-queue/done/54f278d5a7badbea1bc41152bef1e4bfabe6250246ec901d1ca30bf8721435f5.json",
+      "sha256": "784f9c94d9be38cdb456b28cb7fbfb3f029efa7d91c8afed2e39ae68c2e4cece"
+    }
+  },
+  {
+    "action_key": "7814eecd02a9fb7aef948103fe8aeb1537b9ec066b5a5073cb02657bc091e9e0",
+    "cleanup": {
+      "complete": true,
+      "released_ok": true
+    },
+    "logs": [
+      {
+        "bytes": 82,
+        "path": "attempts/7814eecd02a9fb7aef948103fe8aeb1537b9ec066b5a5073cb02657bc091e9e0/1facc118577ceb49599b73fc7f855bdf00a7b55ace840d431787bf3447cd8b57/00000001.stderr.41e2fd97fa54a6a2763b65193a6fb0956389a8ab055f273613a03b7eeb48446a.log",
+        "sha256": "41e2fd97fa54a6a2763b65193a6fb0956389a8ab055f273613a03b7eeb48446a",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 2,
+        "path": "attempts/7814eecd02a9fb7aef948103fe8aeb1537b9ec066b5a5073cb02657bc091e9e0/1facc118577ceb49599b73fc7f855bdf00a7b55ace840d431787bf3447cd8b57/00000001.stdout.5ec1f7e700f37c3d0b2981d04855fc34b94aaa15457b05ca571817442d228f81.log",
+        "sha256": "5ec1f7e700f37c3d0b2981d04855fc34b94aaa15457b05ca571817442d228f81",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": null,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:3631266:0a2c11ad",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788910613.281552,
+      "elapsed_s": 14.003170490264893,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788910634.5622032,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 137,
+      "status": "failed"
+    },
+    "receipt": {
+      "present": false
+    },
+    "resources": {
+      "memory_peak_bytes": 4294967296,
+      "oom_kill": 5,
+      "oom_local": 1,
+      "processes_live": 0
+    },
+    "source": {
+      "actual_bundle_sha256_verified": true,
+      "all_tree_differences": [
+        ".pbrun-closure.2b08810cd1696a68.json"
+      ],
+      "reference": "ae781f4ea5",
+      "snapshot": {
+        "commit": "ef162c16e6f53e0cdb2a3aa3c2edc4472c01fdd4",
+        "input": {
+          "bytes": 27402391,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "aba12763976beb2a276bca5362bc7824f814c60908268dab457ddca4a56dd89f"
+        },
+        "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      }
+    },
+    "state": "failed",
+    "summary": [],
+    "terminal": {
+      "path": "/mnt/shared/prismabuild-fleet/pb-queue/failed/7814eecd02a9fb7aef948103fe8aeb1537b9ec066b5a5073cb02657bc091e9e0.json",
+      "sha256": "2d18146c524ab2b2fcd82eee8ec944b0984fa26f9a252148d79969fde776f11a"
+    }
+  },
+  {
+    "action_key": "84295ea5ec267b5014c1a9c7d25f1faf0b10f015239f94f7d36fa74454e2d038",
+    "cleanup": {
+      "complete": true,
+      "released_ok": true
+    },
+    "logs": [
+      {
+        "bytes": 0,
+        "path": "attempts/84295ea5ec267b5014c1a9c7d25f1faf0b10f015239f94f7d36fa74454e2d038/a6bee7860154614c3ad516f8db1e90d7da96550052dadb555fdda349165069b8/00000001.stderr.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.log",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 3024,
+        "path": "attempts/84295ea5ec267b5014c1a9c7d25f1faf0b10f015239f94f7d36fa74454e2d038/a6bee7860154614c3ad516f8db1e90d7da96550052dadb555fdda349165069b8/00000001.stdout.8e8b3e5ddf4382b42625b9e8e792b71179ce370958672ec3d2ce37a5d33dffad.log",
+        "sha256": "8e8b3e5ddf4382b42625b9e8e792b71179ce370958672ec3d2ce37a5d33dffad",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": null,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:3631269:60cf811f",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788910613.0616598,
+      "elapsed_s": 8.460450410842896,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788910623.5038452,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 0,
+      "status": "executed"
+    },
+    "receipt": {
+      "attestation_sha256": "20badab51e214be83b9c95acf3d9e163065ef29fb5b3cf538e31ea6b839ba99b",
+      "canonical_body_sha256": "c7d26bfd067828f613d396c8480a41d9fb55b9f9d5fdf082f395218c09ca953c",
+      "file_sha256": "c7a5d4c3856ba62968a1ca9802cb00d937691edaeb3b40f4ccca0c9a807a2a54",
+      "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/84/84295ea5ec267b5014c1a9c7d25f1faf0b10f015239f94f7d36fa74454e2d038.json",
+      "result": {
+        "bytes": 543,
+        "sha256": "1d97449f064716b30647df8c9ea60daac11d7a4df0a29ffc1dd63dd00a9d5064"
+      },
+      "verified": true
+    },
+    "resources": {
+      "memory_peak_bytes": 393019392,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "source": {
+      "actual_bundle_sha256_verified": true,
+      "all_tree_differences": [
+        ".pbrun-closure.79d5741dd6701148.json"
+      ],
+      "reference": "ae781f4ea5",
+      "snapshot": {
+        "commit": "4e139abcecc76cab521eaa31e19e573678d43b85",
+        "input": {
+          "bytes": 27402390,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "4d8d8eb18112f020e7d4d4758609aa11cfd46aa8683f0073c513bf208332ff1c"
+        },
+        "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      }
+    },
+    "state": "done",
+    "summary": [
+      "10 passed, 1 skipped, 14 warnings in 6.00s"
+    ],
+    "terminal": {
+      "path": "/mnt/shared/prismabuild-fleet/pb-queue/done/84295ea5ec267b5014c1a9c7d25f1faf0b10f015239f94f7d36fa74454e2d038.json",
+      "sha256": "7bc39f64d709a4a31d2e595be8d02ab84e32ec9abd5b432e0042e192fa05f9c1"
+    }
+  },
+  {
+    "action_key": "b6752697968a0818ad9a8dd8fa9270020f212a4880e0709fb97727d624e135d0",
+    "cleanup": {
+      "complete": true,
+      "released_ok": true
+    },
+    "logs": [
+      {
+        "bytes": 0,
+        "path": "attempts/b6752697968a0818ad9a8dd8fa9270020f212a4880e0709fb97727d624e135d0/5bb388753633ec0454062ca235c58c824d371ff5e1bedf3e9136bb57eacc90fe/00000001.stderr.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.log",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 3014,
+        "path": "attempts/b6752697968a0818ad9a8dd8fa9270020f212a4880e0709fb97727d624e135d0/5bb388753633ec0454062ca235c58c824d371ff5e1bedf3e9136bb57eacc90fe/00000001.stdout.14cbaa90dbe7b65be26cff66087810d2daa28f1c5840ad0ff4d5755d08c64c10.log",
+        "sha256": "14cbaa90dbe7b65be26cff66087810d2daa28f1c5840ad0ff4d5755d08c64c10",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": null,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:3631269:2c3b46ee",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788910683.8515544,
+      "elapsed_s": 12.86786150932312,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788910698.560505,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 0,
+      "status": "executed"
+    },
+    "receipt": {
+      "attestation_sha256": "bb9f87c64ce6767add1a7815599ca20efec46da863a4a6ac61d6e7b08635ad33",
+      "canonical_body_sha256": "c1bf547fb0a8e9f3eddc9d7926fee0ef63af96786fc0c051267fc939429430e9",
+      "file_sha256": "67e359641af381dfa83a6fea247f80e74518739c6cbeeb923a480b721db0d536",
+      "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/b6/b6752697968a0818ad9a8dd8fa9270020f212a4880e0709fb97727d624e135d0.json",
+      "result": {
+        "bytes": 533,
+        "sha256": "1061cddc014a0cf716ac871e6913d4643f75b16fe5e8d6b3027eaa82a48e4022"
+      },
+      "verified": true
+    },
+    "resources": {
+      "memory_peak_bytes": 688422912,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "source": {
+      "actual_bundle_sha256_verified": true,
+      "all_tree_differences": [
+        ".pbrun-closure.3da0af3086f1c7c4.json"
+      ],
+      "reference": "ae781f4ea5",
+      "snapshot": {
+        "commit": "d622f2845ecae1f1950c894046d7bc2c9a7eacf4",
+        "input": {
+          "bytes": 27402389,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "a1cb1fb4268f4e2d5f3956526996d24448307ab483b64bdbf538ad2744d5944c"
+        },
+        "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      }
+    },
+    "state": "done",
+    "summary": [
+      "39 passed, 14 warnings in 10.57s"
+    ],
+    "terminal": {
+      "path": "/mnt/shared/prismabuild-fleet/pb-queue/done/b6752697968a0818ad9a8dd8fa9270020f212a4880e0709fb97727d624e135d0.json",
+      "sha256": "f1b2ec33aba87cbede1324e4b8fbd24b6c6fffffa68f4f08781999983b715ad1"
+    }
+  },
+  {
+    "action_key": "c7ef81e34ff69b1986d839cb05a47a262efd6bc2b82b243003a33b8c0760d9f7",
+    "cleanup": {
+      "complete": true,
+      "released_ok": true
+    },
+    "logs": [
+      {
+        "bytes": 0,
+        "path": "attempts/c7ef81e34ff69b1986d839cb05a47a262efd6bc2b82b243003a33b8c0760d9f7/207d732d5ae0557bece59f62136fecba8fe69da8a12933d1534c9a50889d4467/00000001.stderr.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.log",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 3057,
+        "path": "attempts/c7ef81e34ff69b1986d839cb05a47a262efd6bc2b82b243003a33b8c0760d9f7/207d732d5ae0557bece59f62136fecba8fe69da8a12933d1534c9a50889d4467/00000001.stdout.6f5ab47662da46f01d21c014b750b5c6e289b4b1262d65cac19ed0f97df9b42a.log",
+        "sha256": "6f5ab47662da46f01d21c014b750b5c6e289b4b1262d65cac19ed0f97df9b42a",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": null,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:3725954:b96f5e9c",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788910613.1421516,
+      "elapsed_s": 8.412572145462036,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788910623.6843967,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 0,
+      "status": "executed"
+    },
+    "receipt": {
+      "attestation_sha256": "dee897f5d376afb9be002b750c3884bab23d8bc7aec03f1d0ae175455abbe3ee",
+      "canonical_body_sha256": "9f7c603ac4de04b14ddd788d6139bab06199f5f99e18df0c51bcb82feb2e061b",
+      "file_sha256": "b37140168f332921b89c545679cf66cfbbe46e55380f1122b0e04620e333a54b",
+      "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/c7/c7ef81e34ff69b1986d839cb05a47a262efd6bc2b82b243003a33b8c0760d9f7.json",
+      "result": {
+        "bytes": 576,
+        "sha256": "3f0aec2e517e665c149706cc45bcbaf210653f67f63e2faf442ab135351df95f"
+      },
+      "verified": true
+    },
+    "resources": {
+      "memory_peak_bytes": 396775424,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "source": {
+      "actual_bundle_sha256_verified": true,
+      "all_tree_differences": [
+        ".pbrun-closure.4ca8ad85e1eaa8f0.json"
+      ],
+      "reference": "ae781f4ea5",
+      "snapshot": {
+        "commit": "932ec9ed24ec33c08044777d9ad666480352fdc2",
+        "input": {
+          "bytes": 27402390,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "765be08bd316021c6099e8ad37dd37c51646491504ec54d5d6344e8c0ec2416d"
+        },
+        "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      }
+    },
+    "state": "done",
+    "summary": [
+      "13 passed, 14 warnings in 6.10s"
+    ],
+    "terminal": {
+      "path": "/mnt/shared/prismabuild-fleet/pb-queue/done/c7ef81e34ff69b1986d839cb05a47a262efd6bc2b82b243003a33b8c0760d9f7.json",
+      "sha256": "f5de34ed9c8d2455de9b9ff3a46e3f0b8b5dffb51aa3bb1bc819bafc621463dc"
+    }
+  },
+  {
+    "action_key": "f2967423efd578862f3e5d634dca329318b69605249eef806534a9afd7ab3d6a",
+    "cleanup": {
+      "complete": true,
+      "released_ok": true
+    },
+    "logs": [
+      {
+        "bytes": 0,
+        "path": "attempts/f2967423efd578862f3e5d634dca329318b69605249eef806534a9afd7ab3d6a/7f33dea611b28e98dcc0fa558f77806d63e04230e5ef7a1aceea76b5bf75d3d1/00000001.stderr.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.log",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 2479,
+        "path": "attempts/f2967423efd578862f3e5d634dca329318b69605249eef806534a9afd7ab3d6a/7f33dea611b28e98dcc0fa558f77806d63e04230e5ef7a1aceea76b5bf75d3d1/00000001.stdout.6a884ac758de1fd3421e2b2449343ce40913f3e9ebc9fbade23d5712a10d3d9b.log",
+        "sha256": "6a884ac758de1fd3421e2b2449343ce40913f3e9ebc9fbade23d5712a10d3d9b",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": null,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:3631270:2db18e06",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788910689.7410593,
+      "elapsed_s": 0.7951252460479736,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788910692.3694818,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 0,
+      "status": "executed"
+    },
+    "receipt": {
+      "attestation_sha256": "25c06106e6083ac058231a440a5b407cd5b8a4df37900eb28a4fc8743be82f81",
+      "canonical_body_sha256": "02df3f7233ee0311fa3ff9b0e43839170aaeeb7b8d929ab5c1a2fe75221e091f",
+      "file_sha256": "bc5cd0647338f53bb65bfb7edc35360f1fb3ac33a4ca59e70578c289b36134a2",
+      "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/f2/f2967423efd578862f3e5d634dca329318b69605249eef806534a9afd7ab3d6a.json",
+      "result": {
+        "bytes": 0,
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      },
+      "verified": true
+    },
+    "resources": {
+      "memory_peak_bytes": 47661056,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "source": {
+      "actual_bundle_sha256_verified": true,
+      "all_tree_differences": [
+        ".pbrun-closure.04d51ce97d7b3215.json"
+      ],
+      "reference": "ae781f4ea5",
+      "snapshot": {
+        "commit": "eeb07ad90ff519a2b9d575b5d73c1192357072ff",
+        "input": {
+          "bytes": 27402389,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "7fb5c6d3601510d3a650c3593def843a904a6c64f201fa95078fd2cf6da1abca"
+        },
+        "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      }
+    },
+    "state": "done",
+    "summary": [],
+    "terminal": {
+      "path": "/mnt/shared/prismabuild-fleet/pb-queue/done/f2967423efd578862f3e5d634dca329318b69605249eef806534a9afd7ab3d6a.json",
+      "sha256": "9917dab6e9df9d8929e635ea5dbec1a1b85e78df24581da7815f6ca2874489bc"
+    }
+  },
+  {
+    "action_key": "f2e22ec4352190831f0f27a618a4669601bb771092e68fbb43da84d5fad7de75",
+    "cleanup": {
+      "complete": true,
+      "released_ok": true
+    },
+    "logs": [
+      {
+        "bytes": 0,
+        "path": "attempts/f2e22ec4352190831f0f27a618a4669601bb771092e68fbb43da84d5fad7de75/377054f1d2c83391f28877e79db1fcab09565a6a0650966177d252a9ef7c18ca/00000001.stderr.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.log",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 13,
+        "path": "attempts/f2e22ec4352190831f0f27a618a4669601bb771092e68fbb43da84d5fad7de75/377054f1d2c83391f28877e79db1fcab09565a6a0650966177d252a9ef7c18ca/00000001.stdout.1daed90b5518b44bf5d8add9b231fef90f7083e36bf6f679f988b5b00403e308.log",
+        "sha256": "1daed90b5518b44bf5d8add9b231fef90f7083e36bf6f679f988b5b00403e308",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": null,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:3682595:1358da40",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788910664.7250772,
+      "elapsed_s": 300.06713938713074,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788910966.6314564,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": null,
+      "status": "timeout"
+    },
+    "receipt": {
+      "present": false
+    },
+    "resources": {
+      "memory_peak_bytes": 4685869056,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "source": {
+      "actual_bundle_sha256_verified": true,
+      "all_tree_differences": [
+        ".pbrun-closure.7dd6507701a5b0c6.json"
+      ],
+      "reference": "ae781f4ea5",
+      "snapshot": {
+        "commit": "8a30d4c6a9c3bbf8bdd7a1eafd8f69c50dc8078e",
+        "input": {
+          "bytes": 27402391,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "fe9cdbd1eccf7c42a80419434f87429c3e024e3ccdba0876c18ab5be22e28e41"
+        },
+        "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      }
+    },
+    "state": "failed",
+    "summary": [],
+    "terminal": {
+      "path": "/mnt/shared/prismabuild-fleet/pb-queue/failed/f2e22ec4352190831f0f27a618a4669601bb771092e68fbb43da84d5fad7de75.json",
+      "sha256": "bf7622c34d6773cb2eae0a52528f1f4a665413e7f01b9193ac8c00ad884ba79e"
+    }
+  },
+  {
+    "action_key": "f3a5d1eb99f3ac845e747c4097953df70e775aed70e2d645681dd8a49edf8914",
+    "cleanup": {
+      "complete": true,
+      "released_ok": true
+    },
+    "logs": [
+      {
+        "bytes": 0,
+        "path": "attempts/f3a5d1eb99f3ac845e747c4097953df70e775aed70e2d645681dd8a49edf8914/aee4c8e12226aeeba727c2f1f4c8ac0a8bb667bb7a8c7b06fa46144e92e0946a/00000001.stderr.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.log",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 3379,
+        "path": "attempts/f3a5d1eb99f3ac845e747c4097953df70e775aed70e2d645681dd8a49edf8914/aee4c8e12226aeeba727c2f1f4c8ac0a8bb667bb7a8c7b06fa46144e92e0946a/00000001.stdout.16a899c6c69ce8a093cee76ad7bbecba673b93cdc42683710ce28d54b4b1d74d.log",
+        "sha256": "16a899c6c69ce8a093cee76ad7bbecba673b93cdc42683710ce28d54b4b1d74d",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": null,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:3682595:607c3a96",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788910613.0289705,
+      "elapsed_s": 9.236634016036987,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788910624.405677,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 0,
+      "status": "executed"
+    },
+    "receipt": {
+      "attestation_sha256": "f72673b6d6e702726161e2898253b089d1c7d40506eead13d9bafe7c8e2a5b3d",
+      "canonical_body_sha256": "39767aa30a3d6629b908a4728864758ed0320842eff849ecb3fed7738f3ff258",
+      "file_sha256": "effb838038ed0c60b16cceaa06e81846988a4e43fc538d99100ba8f9ec246928",
+      "path": "/mnt/shared/prismabuild-fleet/cas/actions/v3/f3/f3a5d1eb99f3ac845e747c4097953df70e775aed70e2d645681dd8a49edf8914.json",
+      "result": {
+        "bytes": 898,
+        "sha256": "b9ba7c2c1aaabd11a5ccf3e7e51935769734b94dd82d0a0ab957800f2938c66c"
+      },
+      "verified": true
+    },
+    "resources": {
+      "memory_peak_bytes": 412151808,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "source": {
+      "actual_bundle_sha256_verified": true,
+      "all_tree_differences": [
+        ".pbrun-closure.49f84149eec9b07a.json"
+      ],
+      "reference": "ae781f4ea5",
+      "snapshot": {
+        "commit": "5257c795496050e8278cd0b26b4983103996262f",
+        "input": {
+          "bytes": 27402392,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "809761050b438f08cd63b1d62446eae23008dda52224ec7164b9e35cbecba531"
+        },
+        "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      }
+    },
+    "state": "done",
+    "summary": [
+      "26 passed, 15 warnings in 6.77s"
+    ],
+    "terminal": {
+      "path": "/mnt/shared/prismabuild-fleet/pb-queue/done/f3a5d1eb99f3ac845e747c4097953df70e775aed70e2d645681dd8a49edf8914.json",
+      "sha256": "6a81c8e9b55c50864663e6284e4dff88997e0e66df72074e1503af390e5bd6f5"
+    }
+  },
+  {
+    "action_key": "fac8659196710650facd4df2bf9cfd559c2dcd5fb79a4827bd96ebe8caff2c1b",
+    "cleanup": {
+      "complete": true,
+      "released_ok": true
+    },
+    "logs": [
+      {
+        "bytes": 0,
+        "path": "attempts/fac8659196710650facd4df2bf9cfd559c2dcd5fb79a4827bd96ebe8caff2c1b/84c9fea275ac234e58e21b01044a0a864795efc1bb4cbc70360684dd4493f156/00000001.stderr.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.log",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 3057,
+        "path": "attempts/fac8659196710650facd4df2bf9cfd559c2dcd5fb79a4827bd96ebe8caff2c1b/84c9fea275ac234e58e21b01044a0a864795efc1bb4cbc70360684dd4493f156/00000001.stdout.17816a8d0d2c447f6fa7fe288a160da8a224064278f2dc3ce3dee10cbbc78036.log",
+        "sha256": "17816a8d0d2c447f6fa7fe288a160da8a224064278f2dc3ce3dee10cbbc78036",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": null,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:3725954:9f5b1588",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788910985.4218812,
+      "elapsed_s": 7.363023281097412,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788910994.6517692,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 0,
+      "status": "executed"
+    },
+    "receipt": {
+      "present": false
+    },
+    "resources": {
+      "memory_peak_bytes": 400191488,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "source": {
+      "actual_bundle_sha256_verified": true,
+      "all_tree_differences": [
+        ".pbrun-closure.c357129a261247e0.json"
+      ],
+      "reference": "HEAD",
+      "snapshot": {
+        "commit": "eaed9631ed95ab50d147f46304af07eed1754d58",
+        "input": {
+          "bytes": 27403548,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "06739e7f50bea0779d0c4567b7c7be47e64de2abe14e2054872dae47e8ea4a24"
+        },
+        "parent": "ae781f4ea51822f8a67fe81cef6e767585742948",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      }
+    },
+    "state": "done",
+    "summary": [
+      "17 passed, 14 warnings in 5.40s"
+    ],
+    "terminal": {
+      "path": "/mnt/shared/prismabuild-fleet/pb-queue/done/fac8659196710650facd4df2bf9cfd559c2dcd5fb79a4827bd96ebe8caff2c1b.json",
+      "sha256": "b675ef80761325ef52db2a19af54d5d0ca97765a8eff095318fc6eff87224516"
+    }
+  },
+  {
+    "action_key": "fd3ae6aab1bc06c59b19b1699dac43e56618c5585e7658d9598998371a9ff08d",
+    "cleanup": {
+      "complete": true,
+      "released_ok": true
+    },
+    "logs": [
+      {
+        "bytes": 887,
+        "path": "attempts/fd3ae6aab1bc06c59b19b1699dac43e56618c5585e7658d9598998371a9ff08d/a2d52f04687c17f5c700a1568d7b6a711124b4a9c86f44802f8ea49bebbeec0d/00000001.stderr.84bbc63f750f413cb0fb5f8ddd41eb196820496d3141f31bc073d1590e41bbd3.log",
+        "sha256": "84bbc63f750f413cb0fb5f8ddd41eb196820496d3141f31bc073d1590e41bbd3",
+        "stream": "stderr",
+        "verified": true
+      },
+      {
+        "bytes": 8305,
+        "path": "attempts/fd3ae6aab1bc06c59b19b1699dac43e56618c5585e7658d9598998371a9ff08d/a2d52f04687c17f5c700a1568d7b6a711124b4a9c86f44802f8ea49bebbeec0d/00000001.stdout.1edac6ffafce6dded3da46c250bc48e8215021f6cbcffa56d28d44ad00c99bbe.log",
+        "sha256": "1edac6ffafce6dded3da46c250bc48e8215021f6cbcffa56d28d44ad00c99bbe",
+        "stream": "stdout",
+        "verified": true
+      }
+    ],
+    "outcome": {
+      "action_returncode": 1,
+      "action_signal": null,
+      "attempts": 1,
+      "claimed_by": "dl380g10:3631270:8b72cda9",
+      "claimed_host": "dl380g10",
+      "claimed_unix": 1788910289.4391887,
+      "elapsed_s": 7.5008156299591064,
+      "finished_host": "dl380g10",
+      "finished_unix": 1788910298.7207756,
+      "reason": null,
+      "receipt_published": null,
+      "returncode": 1,
+      "status": "failed"
+    },
+    "receipt": {
+      "present": false
+    },
+    "resources": {
+      "memory_peak_bytes": 405704704,
+      "oom_kill": 0,
+      "oom_local": 0,
+      "processes_live": 0
+    },
+    "source": {
+      "actual_bundle_sha256_verified": true,
+      "all_tree_differences": [
+        ".pbrun-closure.9be37291efc79bdd.json",
+        "tests/test_selected_verified_capture.py"
+      ],
+      "reference": "8d8a293ffb",
+      "snapshot": {
+        "commit": "3ee6c90ba82f411f46626fa781f0d28f3a2a9e15",
+        "input": {
+          "bytes": 27392074,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "50876382b3a1ae5da4105d57827c62c1f9c7b831dbc134b4e57e1a876c899cec"
+        },
+        "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      }
+    },
+    "state": "failed",
+    "summary": [
+      "3 failed, 4 passed, 14 warnings in 5.47s"
+    ],
+    "terminal": {
+      "path": "/mnt/shared/prismabuild-fleet/pb-queue/failed/fd3ae6aab1bc06c59b19b1699dac43e56618c5585e7658d9598998371a9ff08d.json",
+      "sha256": "b3537bc26d3a2910d57dffedce0a30ecdfb023a430db41cf42a9b27b4693b8ba"
+    }
+  }
+]

--- a/experiments/measurements/selected-verified-capture-20260908/cpu-action-audits.json
+++ b/experiments/measurements/selected-verified-capture-20260908/cpu-action-audits.json
@@ -1012,7 +1012,7 @@
       "all_tree_differences": [
         ".pbrun-closure.c357129a261247e0.json"
       ],
-      "reference": "HEAD",
+      "reference": "5f12978a8bfd625b217774a81e76e662273666fd",
       "snapshot": {
         "commit": "eaed9631ed95ab50d147f46304af07eed1754d58",
         "input": {

--- a/experiments/measurements/selected-verified-capture-20260908/cpu-followup-campaign.json
+++ b/experiments/measurements/selected-verified-capture-20260908/cpu-followup-campaign.json
@@ -1,0 +1,52 @@
+[
+  {
+    "cwd": "/home/rob/tmp/pq-glm-selected-verified-capture",
+    "tags": [
+      "x86"
+    ],
+    "demand": {
+      "cpu": 1,
+      "mem_gb": 4
+    },
+    "priority": -10,
+    "timeout_s": 240,
+    "env": {
+      "OMP_NUM_THREADS": "1",
+      "MKL_NUM_THREADS": "1",
+      "OPENBLAS_NUM_THREADS": "1"
+    },
+    "argv": [
+      "/home/rob/venvs/pq-cpu312/bin/python",
+      "-m",
+      "pytest",
+      "-q",
+      "tests/test_tessera_campaign_fanout.py"
+    ]
+  },
+  {
+    "cwd": "/home/rob/tmp/pq-glm-selected-verified-capture",
+    "tags": [
+      "x86"
+    ],
+    "demand": {
+      "cpu": 1,
+      "mem_gb": 4
+    },
+    "priority": -10,
+    "timeout_s": 240,
+    "env": {
+      "OMP_NUM_THREADS": "1",
+      "MKL_NUM_THREADS": "1",
+      "OPENBLAS_NUM_THREADS": "1"
+    },
+    "argv": [
+      "/home/rob/venvs/pq-cpu312/bin/python",
+      "-m",
+      "py_compile",
+      "prismaquant/tessera_campaign.py",
+      "prismaquant/autoscale.py",
+      "tools/dispatch_tessera_campaign.py",
+      "tests/test_selected_verified_capture.py"
+    ]
+  }
+]

--- a/experiments/measurements/selected-verified-capture-20260908/cpu-invocations.json
+++ b/experiments/measurements/selected-verified-capture-20260908/cpu-invocations.json
@@ -1,0 +1,561 @@
+[
+  {
+    "action_key": "15a1aace22678abcbc6d31c400bce4f8b1b5003ff0a61f26f8f42912a6b6f4df",
+    "command": [
+      "env",
+      "TMPDIR=/home/rob/tmp",
+      "OMP_NUM_THREADS=1",
+      "MKL_NUM_THREADS=1",
+      "OPENBLAS_NUM_THREADS=1",
+      "TORCH_NUM_THREADS=1",
+      "PYTHONPATH=src:experiments",
+      "/home/rob/venvs/pq-cpu312/bin/python",
+      "-m",
+      "pytest",
+      "-q",
+      "--no-header",
+      "-p",
+      "no:cacheprovider",
+      "tests/test_verified_capture_load.py"
+    ],
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 4
+    },
+    "result_summary": [
+      "70 passed, 16 warnings in 6.22s"
+    ],
+    "source_snapshot": {
+      "commit": "ebdf673a67123612b37040ae5a24e0057298e43a",
+      "input": {
+        "bytes": 27402389,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "6fb62f0df615a22ea48f8a62ac64ec65aac4107eb6e1582ea3cd8d37026893aa"
+      },
+      "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "status": "done",
+    "tags": [
+      "x86"
+    ]
+  },
+  {
+    "action_key": "2b409e7b4e1733e1fd0a292dc55fc137de72edacce83bb3a65621ab5356cd367",
+    "command": [
+      "env",
+      "TMPDIR=/home/rob/tmp",
+      "OMP_NUM_THREADS=1",
+      "MKL_NUM_THREADS=1",
+      "OPENBLAS_NUM_THREADS=1",
+      "TORCH_NUM_THREADS=1",
+      "PYTHONPATH=src:experiments",
+      "/home/rob/venvs/pq-cpu312/bin/python",
+      "-m",
+      "pytest",
+      "-q",
+      "--no-header",
+      "-p",
+      "no:cacheprovider",
+      "tests/test_architecture_doc.py"
+    ],
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 4
+    },
+    "result_summary": [
+      "13 passed, 14 warnings in 5.42s"
+    ],
+    "source_snapshot": {
+      "commit": "9607dae9b3881710a2ac1e842c2a526200a504bc",
+      "input": {
+        "bytes": 27402390,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "45f2de707b8cc3d454e1f56cbb93d70e771b1c43d98f0ae28bad4e30e819ec5a"
+      },
+      "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "status": "done",
+    "tags": [
+      "x86"
+    ]
+  },
+  {
+    "action_key": "385f62dcdd109c5a17f163203f52d303fe9a6ba843e1e8a57718afe4864950d8",
+    "command": [
+      "env",
+      "TMPDIR=/home/rob/tmp",
+      "OMP_NUM_THREADS=1",
+      "MKL_NUM_THREADS=1",
+      "OPENBLAS_NUM_THREADS=1",
+      "TORCH_NUM_THREADS=1",
+      "PYTHONPATH=src:experiments",
+      "/home/rob/venvs/pq-cpu312/bin/python",
+      "-m",
+      "pytest",
+      "-q",
+      "--no-header",
+      "-p",
+      "no:cacheprovider",
+      "tests/test_tessera_calibration_cache.py"
+    ],
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 4
+    },
+    "result_summary": [
+      "34 passed, 14 warnings in 7.59s"
+    ],
+    "source_snapshot": {
+      "commit": "925b89db84033a9aae86162700a7c4cea2d18f8b",
+      "input": {
+        "bytes": 27402391,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "8af5bae25162026444e5a1ecd4d5caff0975d3127065ff36029aad15b5462fff"
+      },
+      "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "status": "done",
+    "tags": [
+      "x86"
+    ]
+  },
+  {
+    "action_key": "3ccc91c9f149b897cb857a6adee68f5eeab1af86d82bf9b6f31ba51960f8f34b",
+    "command": [
+      "env",
+      "TMPDIR=/home/rob/tmp",
+      "OMP_NUM_THREADS=1",
+      "MKL_NUM_THREADS=1",
+      "OPENBLAS_NUM_THREADS=1",
+      "TORCH_NUM_THREADS=1",
+      "PYTHONPATH=src:experiments",
+      "/home/rob/venvs/pq-cpu312/bin/python",
+      "-m",
+      "pytest",
+      "-q",
+      "--no-header",
+      "-p",
+      "no:cacheprovider",
+      "tests/test_docs_staleness.py"
+    ],
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 4
+    },
+    "result_summary": [
+      "6 passed, 14 warnings in 5.06s"
+    ],
+    "source_snapshot": {
+      "commit": "825947c8fa6cb34fefb78eb64b39b5fa004ad9bf",
+      "input": {
+        "bytes": 27402389,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "e9c5cb35b9cfbc9b87182131e626605b9c4011c6c4e1d8dd86c9068898811ff4"
+      },
+      "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "status": "done",
+    "tags": [
+      "x86"
+    ]
+  },
+  {
+    "action_key": "54f278d5a7badbea1bc41152bef1e4bfabe6250246ec901d1ca30bf8721435f5",
+    "command": [
+      "env",
+      "TMPDIR=/home/rob/tmp",
+      "OMP_NUM_THREADS=1",
+      "MKL_NUM_THREADS=1",
+      "OPENBLAS_NUM_THREADS=1",
+      "TORCH_NUM_THREADS=1",
+      "PYTHONPATH=src:experiments",
+      "/home/rob/venvs/pq-cpu312/bin/python",
+      "-m",
+      "pytest",
+      "-q",
+      "--no-header",
+      "-p",
+      "no:cacheprovider",
+      "tests/test_streamed_capture_admission.py"
+    ],
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 4
+    },
+    "result_summary": [
+      "20 passed, 14 warnings in 6.21s"
+    ],
+    "source_snapshot": {
+      "commit": "1e82609a5310a74b4e8064ce4719edd99e922b7c",
+      "input": {
+        "bytes": 27402389,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "f8b78e465b8358a113c208b3f8e9e99a4e7bba831ee475a359bbfb6f7dce2f00"
+      },
+      "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "status": "done",
+    "tags": [
+      "x86"
+    ]
+  },
+  {
+    "action_key": "7814eecd02a9fb7aef948103fe8aeb1537b9ec066b5a5073cb02657bc091e9e0",
+    "command": [
+      "env",
+      "TMPDIR=/home/rob/tmp",
+      "OMP_NUM_THREADS=1",
+      "MKL_NUM_THREADS=1",
+      "OPENBLAS_NUM_THREADS=1",
+      "TORCH_NUM_THREADS=1",
+      "PYTHONPATH=src:experiments",
+      "/home/rob/venvs/pq-cpu312/bin/python",
+      "-m",
+      "pytest",
+      "-q",
+      "--no-header",
+      "-p",
+      "no:cacheprovider",
+      "tests/test_tessera_campaign_resume.py"
+    ],
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 4
+    },
+    "result_summary": [],
+    "source_snapshot": {
+      "commit": "ef162c16e6f53e0cdb2a3aa3c2edc4472c01fdd4",
+      "input": {
+        "bytes": 27402391,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "aba12763976beb2a276bca5362bc7824f814c60908268dab457ddca4a56dd89f"
+      },
+      "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "status": "failed",
+    "tags": [
+      "x86"
+    ]
+  },
+  {
+    "action_key": "84295ea5ec267b5014c1a9c7d25f1faf0b10f015239f94f7d36fa74454e2d038",
+    "command": [
+      "env",
+      "TMPDIR=/home/rob/tmp",
+      "OMP_NUM_THREADS=1",
+      "MKL_NUM_THREADS=1",
+      "OPENBLAS_NUM_THREADS=1",
+      "TORCH_NUM_THREADS=1",
+      "PYTHONPATH=src:experiments",
+      "/home/rob/venvs/pq-cpu312/bin/python",
+      "-m",
+      "pytest",
+      "-q",
+      "--no-header",
+      "-p",
+      "no:cacheprovider",
+      "tests/test_tessera_selected_source.py"
+    ],
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 4
+    },
+    "result_summary": [
+      "10 passed, 1 skipped, 14 warnings in 6.00s"
+    ],
+    "source_snapshot": {
+      "commit": "4e139abcecc76cab521eaa31e19e573678d43b85",
+      "input": {
+        "bytes": 27402390,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "4d8d8eb18112f020e7d4d4758609aa11cfd46aa8683f0073c513bf208332ff1c"
+      },
+      "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "status": "done",
+    "tags": [
+      "x86"
+    ]
+  },
+  {
+    "action_key": "b6752697968a0818ad9a8dd8fa9270020f212a4880e0709fb97727d624e135d0",
+    "command": [
+      "/home/rob/venvs/pq-cpu312/bin/python",
+      "-m",
+      "pytest",
+      "-q",
+      "tests/test_tessera_campaign_fanout.py"
+    ],
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 4
+    },
+    "result_summary": [
+      "39 passed, 14 warnings in 10.57s"
+    ],
+    "source_snapshot": {
+      "commit": "d622f2845ecae1f1950c894046d7bc2c9a7eacf4",
+      "input": {
+        "bytes": 27402389,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "a1cb1fb4268f4e2d5f3956526996d24448307ab483b64bdbf538ad2744d5944c"
+      },
+      "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "status": "done",
+    "tags": [
+      "x86"
+    ]
+  },
+  {
+    "action_key": "c7ef81e34ff69b1986d839cb05a47a262efd6bc2b82b243003a33b8c0760d9f7",
+    "command": [
+      "env",
+      "TMPDIR=/home/rob/tmp",
+      "OMP_NUM_THREADS=1",
+      "MKL_NUM_THREADS=1",
+      "OPENBLAS_NUM_THREADS=1",
+      "TORCH_NUM_THREADS=1",
+      "PYTHONPATH=src:experiments",
+      "/home/rob/venvs/pq-cpu312/bin/python",
+      "-m",
+      "pytest",
+      "-q",
+      "--no-header",
+      "-p",
+      "no:cacheprovider",
+      "tests/test_selected_verified_capture.py"
+    ],
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 4
+    },
+    "result_summary": [
+      "13 passed, 14 warnings in 6.10s"
+    ],
+    "source_snapshot": {
+      "commit": "932ec9ed24ec33c08044777d9ad666480352fdc2",
+      "input": {
+        "bytes": 27402390,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "765be08bd316021c6099e8ad37dd37c51646491504ec54d5d6344e8c0ec2416d"
+      },
+      "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "status": "done",
+    "tags": [
+      "x86"
+    ]
+  },
+  {
+    "action_key": "f2967423efd578862f3e5d634dca329318b69605249eef806534a9afd7ab3d6a",
+    "command": [
+      "/home/rob/venvs/pq-cpu312/bin/python",
+      "-m",
+      "py_compile",
+      "prismaquant/tessera_campaign.py",
+      "prismaquant/autoscale.py",
+      "tools/dispatch_tessera_campaign.py",
+      "tests/test_selected_verified_capture.py"
+    ],
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 4
+    },
+    "result_summary": [],
+    "source_snapshot": {
+      "commit": "eeb07ad90ff519a2b9d575b5d73c1192357072ff",
+      "input": {
+        "bytes": 27402389,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "7fb5c6d3601510d3a650c3593def843a904a6c64f201fa95078fd2cf6da1abca"
+      },
+      "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "status": "done",
+    "tags": [
+      "x86"
+    ]
+  },
+  {
+    "action_key": "f2e22ec4352190831f0f27a618a4669601bb771092e68fbb43da84d5fad7de75",
+    "command": [
+      "env",
+      "TMPDIR=/home/rob/tmp",
+      "OMP_NUM_THREADS=1",
+      "MKL_NUM_THREADS=1",
+      "OPENBLAS_NUM_THREADS=1",
+      "TORCH_NUM_THREADS=1",
+      "PYTHONPATH=src:experiments",
+      "/home/rob/venvs/pq-cpu312/bin/python",
+      "-m",
+      "pytest",
+      "-q",
+      "--no-header",
+      "-p",
+      "no:cacheprovider",
+      "tests/test_tessera_campaign_resume.py"
+    ],
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 12
+    },
+    "result_summary": [],
+    "source_snapshot": {
+      "commit": "8a30d4c6a9c3bbf8bdd7a1eafd8f69c50dc8078e",
+      "input": {
+        "bytes": 27402391,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "fe9cdbd1eccf7c42a80419434f87429c3e024e3ccdba0876c18ab5be22e28e41"
+      },
+      "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "status": "failed",
+    "tags": [
+      "x86"
+    ]
+  },
+  {
+    "action_key": "f3a5d1eb99f3ac845e747c4097953df70e775aed70e2d645681dd8a49edf8914",
+    "command": [
+      "env",
+      "TMPDIR=/home/rob/tmp",
+      "OMP_NUM_THREADS=1",
+      "MKL_NUM_THREADS=1",
+      "OPENBLAS_NUM_THREADS=1",
+      "TORCH_NUM_THREADS=1",
+      "PYTHONPATH=src:experiments",
+      "/home/rob/venvs/pq-cpu312/bin/python",
+      "-m",
+      "pytest",
+      "-q",
+      "--no-header",
+      "-p",
+      "no:cacheprovider",
+      "tests/test_selected_source_authentication.py"
+    ],
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 4
+    },
+    "result_summary": [
+      "26 passed, 15 warnings in 6.77s"
+    ],
+    "source_snapshot": {
+      "commit": "5257c795496050e8278cd0b26b4983103996262f",
+      "input": {
+        "bytes": 27402392,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "809761050b438f08cd63b1d62446eae23008dda52224ec7164b9e35cbecba531"
+      },
+      "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "status": "done",
+    "tags": [
+      "x86"
+    ]
+  },
+  {
+    "action_key": "fac8659196710650facd4df2bf9cfd559c2dcd5fb79a4827bd96ebe8caff2c1b",
+    "command": [
+      "/home/rob/venvs/pq-cpu312/bin/python",
+      "-m",
+      "pytest",
+      "-q",
+      "tests/test_selected_verified_capture.py",
+      "tests/test_tessera_campaign_resume.py::test_main_refuses_unbound_checkpoint_before_accepting_anchors"
+    ],
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 4
+    },
+    "result_summary": [
+      "17 passed, 14 warnings in 5.40s"
+    ],
+    "source_snapshot": {
+      "commit": "eaed9631ed95ab50d147f46304af07eed1754d58",
+      "input": {
+        "bytes": 27403548,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "06739e7f50bea0779d0c4567b7c7be47e64de2abe14e2054872dae47e8ea4a24"
+      },
+      "parent": "ae781f4ea51822f8a67fe81cef6e767585742948",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "status": "done",
+    "tags": [
+      "x86"
+    ]
+  },
+  {
+    "action_key": "fd3ae6aab1bc06c59b19b1699dac43e56618c5585e7658d9598998371a9ff08d",
+    "command": [
+      "/home/rob/venvs/pq-cpu312/bin/python",
+      "-m",
+      "pytest",
+      "-q",
+      "tests/test_selected_verified_capture.py"
+    ],
+    "resources": {
+      "cpu": 1,
+      "mem_gb": 4
+    },
+    "result_summary": [
+      "3 failed, 4 passed, 14 warnings in 5.47s"
+    ],
+    "source_snapshot": {
+      "commit": "3ee6c90ba82f411f46626fa781f0d28f3a2a9e15",
+      "input": {
+        "bytes": 27392074,
+        "id": "pbrun.checkout-snapshot",
+        "sha256": "50876382b3a1ae5da4105d57827c62c1f9c7b831dbc134b4e57e1a876c899cec"
+      },
+      "parent": "8d8a293ffbcadf6a40ec91fde03d8f690eafd2e5",
+      "refs": {},
+      "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+      "subdirectory": "."
+    },
+    "status": "failed",
+    "tags": [
+      "x86"
+    ]
+  }
+]

--- a/experiments/measurements/selected-verified-capture-20260908/cpu-positive-01.json
+++ b/experiments/measurements/selected-verified-capture-20260908/cpu-positive-01.json
@@ -1,0 +1,83 @@
+[
+  {
+    "files": [
+      "tests/test_selected_verified_capture.py"
+    ],
+    "ran": true,
+    "returncode": 0,
+    "shard": 0,
+    "summary": "13 passed, 14 warnings in 6.10s"
+  },
+  {
+    "files": [
+      "tests/test_verified_capture_load.py"
+    ],
+    "ran": true,
+    "returncode": 0,
+    "shard": 1,
+    "summary": "70 passed, 16 warnings in 6.22s"
+  },
+  {
+    "files": [
+      "tests/test_tessera_calibration_cache.py"
+    ],
+    "ran": true,
+    "returncode": 0,
+    "shard": 2,
+    "summary": "34 passed, 14 warnings in 7.59s"
+  },
+  {
+    "files": [
+      "tests/test_tessera_selected_source.py"
+    ],
+    "ran": true,
+    "returncode": 0,
+    "shard": 3,
+    "summary": "10 passed, 1 skipped, 14 warnings in 6.00s"
+  },
+  {
+    "files": [
+      "tests/test_selected_source_authentication.py"
+    ],
+    "ran": true,
+    "returncode": 0,
+    "shard": 4,
+    "summary": "26 passed, 15 warnings in 6.77s"
+  },
+  {
+    "files": [
+      "tests/test_streamed_capture_admission.py"
+    ],
+    "ran": true,
+    "returncode": 0,
+    "shard": 5,
+    "summary": "20 passed, 14 warnings in 6.21s"
+  },
+  {
+    "files": [
+      "tests/test_tessera_campaign_resume.py"
+    ],
+    "ran": false,
+    "returncode": 137,
+    "shard": 6,
+    "summary": "NO PYTEST SUMMARY -- 1 file(s) did not run (the shard ended rc=137, before or outside pytest)"
+  },
+  {
+    "files": [
+      "tests/test_architecture_doc.py"
+    ],
+    "ran": true,
+    "returncode": 0,
+    "shard": 7,
+    "summary": "13 passed, 14 warnings in 5.42s"
+  },
+  {
+    "files": [
+      "tests/test_docs_staleness.py"
+    ],
+    "ran": true,
+    "returncode": 0,
+    "shard": 8,
+    "summary": "6 passed, 14 warnings in 5.06s"
+  }
+]

--- a/experiments/measurements/selected-verified-capture-20260908/cpu-resume-02.json
+++ b/experiments/measurements/selected-verified-capture-20260908/cpu-resume-02.json
@@ -1,0 +1,11 @@
+[
+  {
+    "files": [
+      "tests/test_tessera_campaign_resume.py"
+    ],
+    "ran": false,
+    "returncode": 1,
+    "shard": 0,
+    "summary": "NO PYTEST SUMMARY -- 1 file(s) did not run (the shard ended rc=1, before or outside pytest)"
+  }
+]

--- a/experiments/measurements/selected-verified-capture-20260908/delivery-source-audit.json
+++ b/experiments/measurements/selected-verified-capture-20260908/delivery-source-audit.json
@@ -1,0 +1,35 @@
+{
+  "schema": "prismaquant.selected_reader_delivery_source_audit.v1",
+  "tested_tree": "dc59bcf099",
+  "delivery_tree": "27dc5bd8fc32f0f25bb9c08ba402a5eece25044e",
+  "base": "2cf67c1a6641e9bc44c7972739a6ce02d95dd645",
+  "byte_identical": [
+    {
+      "path": "prismaquant/autoscale.py",
+      "sha256": "ffd2dd1380b77514e9e2ed236486858c52c9c3ccf3e1988d74ce38df2c1efaea",
+      "byte_identical": true
+    },
+    {
+      "path": "prismaquant/tessera_calibration_cache.py",
+      "sha256": "39b30efb634e3605886b52dfaac6a74f8953f2237583e029b197983bded80156",
+      "byte_identical": true
+    },
+    {
+      "path": "prismaquant/perturbed_x_cache.py",
+      "sha256": "ecd243410a8cb578ed7a8d80f7544fdef8a05b92278d7663c239746b397ed65c",
+      "byte_identical": true
+    },
+    {
+      "path": "tests/test_selected_verified_capture.py",
+      "sha256": "cf7630e0cf58c86cdf423be29e3622082376b300d871d1eb8d35b5596f5a901f",
+      "byte_identical": true
+    },
+    {
+      "path": "experiments/glm_full_capture_profile.py",
+      "sha256": "56c1d2dde5c5ed1135983c20d60ea4343adee926f374d91ca74f380668f56ca6",
+      "byte_identical": true
+    }
+  ],
+  "other_production_differences": "tessera_campaign.py and dispatch_tessera_campaign.py omit the separate unmerged family-restriction implementation present in the tested branch; remaining inherited changes are current-main gold tooling and related documentation/tests.",
+  "validation_limit": "Read-only source comparison; not a test result on the delivery tree. Native after-change measurement remains pending."
+}

--- a/experiments/measurements/selected-verified-capture-20260908/post-prefetch-audit.json
+++ b/experiments/measurements/selected-verified-capture-20260908/post-prefetch-audit.json
@@ -1,0 +1,825 @@
+{
+  "after_observer_finish_unix": 1788910133.728102,
+  "first": 1788910133.9296627,
+  "host_metrics": {
+    "sparklina": {
+      "metrics": {
+        "nvidia_smi.gpu_gpu-b1eceeea-fec7-371e-2cf3-cd10f2e7b705_power_draw/power_draw": {
+          "max": 11.0,
+          "mean": 4.11864406779661,
+          "min": 4.0
+        },
+        "system.cpu/guest": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0
+        },
+        "system.cpu/guest_nice": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0
+        },
+        "system.cpu/idle": {
+          "max": 98.8966901,
+          "mean": 97.62713840338984,
+          "min": 86.4892014
+        },
+        "system.cpu/iowait": {
+          "max": 2.361809,
+          "mean": 0.8831489779661017,
+          "min": 0.2003005
+        },
+        "system.cpu/irq": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0
+        },
+        "system.cpu/nice": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0
+        },
+        "system.cpu/softirq": {
+          "max": 0.0501756,
+          "mean": 0.0025478966101694913,
+          "min": 0.0
+        },
+        "system.cpu/steal": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0
+        },
+        "system.cpu/system": {
+          "max": 4.0703518,
+          "mean": 0.6835467610169491,
+          "min": 0.3503504
+        },
+        "system.cpu/user": {
+          "max": 11.1501758,
+          "mean": 0.8036179644067797,
+          "min": 0.2506266
+        }
+      },
+      "samples": 59
+    },
+    "sparky": {
+      "metrics": {
+        "nvidia_smi.gpu_gpu-e76c7efc-c157-b1f4-1348-83e4eb5092f4_power_draw/power_draw": {
+          "max": 61.0,
+          "mean": 58.08474576271186,
+          "min": 14.0
+        },
+        "system.cpu/guest": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0
+        },
+        "system.cpu/guest_nice": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0
+        },
+        "system.cpu/idle": {
+          "max": 96.686747,
+          "mean": 92.11163986949153,
+          "min": 75.5276382
+        },
+        "system.cpu/iowait": {
+          "max": 0.6529382,
+          "mean": 0.43538151186440677,
+          "min": 0.0501505
+        },
+        "system.cpu/irq": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0
+        },
+        "system.cpu/nice": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0
+        },
+        "system.cpu/softirq": {
+          "max": 0.0503018,
+          "mean": 0.004255167796610169,
+          "min": 0.0
+        },
+        "system.cpu/steal": {
+          "max": 0.0,
+          "mean": 0.0,
+          "min": 0.0
+        },
+        "system.cpu/system": {
+          "max": 5.2261307,
+          "mean": 1.2352677288135594,
+          "min": 0.3007519
+        },
+        "system.cpu/user": {
+          "max": 19.1457286,
+          "mean": 6.213455711864407,
+          "min": 2.0090407
+        }
+      },
+      "samples": 59
+    }
+  },
+  "journal_anchors": 72,
+  "journal_bindings": [
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/a9b02c5f428e667c8bbbb86b9cba68c035740a191d830813b0a53a39783c5004.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.14.down_proj",
+      "sha256": "e78ac40107107fd9191e8086b7404da63843aed3d8b9ad55590c81ca25e287ca",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/33128491a04e71be0b1afe07cae9023da672466973039e729225aa3777c1fe80.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.111.down_proj",
+      "sha256": "7bfe008c9d0864e2561dc1c34c9e8dda3aeec3f7ace81263381864e212d51d41",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/408ac461a32e7943501466708d9e3c892e8aca17c2c1d35db4c903013174ca6f.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.116.down_proj",
+      "sha256": "6ccc2c717442742544353b792e460b0d2cef84b71d358be6c792ebfa7890fc20",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/0b30cb39310c285679ac7c732e38e62043fee74deb151dedce097c84025dc8a9.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.140.down_proj",
+      "sha256": "72019e81f4a770b9455e57701a7eec4a92f187abdf620c08c43cd7e8bc6a7a61",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/027efe0d6a146d8b98f3313e41ec69023dc384016a45ad4c1eefa21daa25d80a.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.104.down_proj",
+      "sha256": "4d75aaf84c52bd0a549d614d4e0fae2c70c104aa174d9d9d8432f55c6b921484",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/c625628a41e664483f93ba479b58b8df12ea716a13c898c199d7ab734310cd82.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.141.down_proj",
+      "sha256": "6d64f30616bc83bb92243d4763e2b8bf6c8e649a172f2f9101393556ad626e0e",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/9e1f2ea1b263124f07cd00eb48ff42530e54132d1035b54d8b248ad636721a54.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.146.down_proj",
+      "sha256": "664a8c357cdaaa5dd3edb02e9c29ed18cb00503e8406b0f4968d05f5caefe018",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/de03fa83ef2494afb702d7e2dbbb94a5a3f10a878711a591d1cc05c4efa7db05.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.118.down_proj",
+      "sha256": "b0d25dbaeb068665366ac2422278d761976c88dedbb7b0e9f8e12de559894277",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/395af4a2909551d39125a618128d8ad5b3388e791d783c5d9220a2267ea55bb8.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.137.down_proj",
+      "sha256": "689f9939aa5e40f9d3302fd87fac5900fcc265b9f1b518103e6f2e567dc8b7d5",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/37458737c17b80863b159d8af19dd6a7006da1ea1034bec1ee94f724a5ae10d9.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.162.down_proj",
+      "sha256": "45a6f230c1a22070f180a2e413a5618afc505e51e309187304f49d7a0d857398",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/f85a249de67958e0de432e95c745d4c5040b5e4087adb999d8a3f138403ae27d.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.10.down_proj",
+      "sha256": "ae9abb0dfb59ee4068339c0323e3f66e0a39aa6aebabeae055fd0f582b353430",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/97d47cb0cc756aaea97b453df384e8df686b4942fa3e5ad884281835cbae7fed.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.119.down_proj",
+      "sha256": "45199429e367086bb40e78718b2430280a5ef2d55169d07ee7f167c3555b18c5",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/09bf9451fa1c8238833a14cd415740926df4b38ebe5e14c4845c4b722576e1b4.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.112.down_proj",
+      "sha256": "453ce3353756d3efe657b63c88d61fc05a99392e8e24a5ee31a01fd693e69bcd",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/1a9eeecd2e8ae7bdd742915b191d650f444f5a40e32da90cc9754b323b81109c.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.115.down_proj",
+      "sha256": "bbbb73bd63de33b0b8654c0631206a4de46e298df05767a4a848bb3468e985e8",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/79c811fc1623474bb26028510966669215f1dc5d0624220b5466f6e74aa2b60a.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.135.down_proj",
+      "sha256": "977ebc2a1e13d19e099e664b74100d1d515c979fb7689ce250ca038f11e8320e",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/710f97a9b7cb5d6c944d7b70bdc1083ecf360e5d98b0079f4fb6d5c97b05e41c.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.110.down_proj",
+      "sha256": "9efe60cdecc5d6bee4a9f474ccced9c657997983a19cbccc885f7c1239eea3f1",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/d1e0b7edf573e1a5128d607ffb1c3ca17e178cf4f3ec49876d5eb347b204c89f.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.154.down_proj",
+      "sha256": "960da25c59d99a1f2c733d9a078aac4ffccf7209b4dd40f81e9f63f5f691de6a",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/6b4672a279ac99c6954083d1fa89cd40b00ef52c7aab26ef147e2eec4da986b3.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.153.down_proj",
+      "sha256": "5a029b0d31ac18e76cd10a52c9a2e29da31e949cc7bffe6c47fd4a1fb9ac820a",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/fbb54d6c8b34fdf276e0b97bcf936269c78587d5e5be3adea6f00b2fcff46336.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.1.down_proj",
+      "sha256": "47745a639bcaed8ba52fb513391e2490797f784d3d92f172f0b743d6aa35bd75",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/b5fc0f8271c81f0977f57d58f79bef054e51574d3766ed2a2487608c13a96155.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.152.down_proj",
+      "sha256": "22fbab72c01fd308b721fbf54edc4e713eb2272ffe03fed3921742cea1bd2525",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/d763ffce639bda72c4079fc6828568c907c6bf06104873eab3f4ece58b24795f.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.143.down_proj",
+      "sha256": "927f1b159e9ce6b58049abff09580d73d2f07fb2933c9178f24eaf0195a8c406",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/db2657b256a3c5b1234cdb58cc21b82926214e8d39d12bb5264463a3a6293b72.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.158.down_proj",
+      "sha256": "5562e73a57740b9c2a0b719520fe55d2f8a2cd938dd03c46e651d5e4e91b9231",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/29366b01bffc076de726ee2df3c3586d260cfea3ec58907378d4fd014382f557.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.125.down_proj",
+      "sha256": "bca5c44dddd05abaa8ab5eab90ce170e3acc9b4dd0157ef5a0ec9d84cdff13f2",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/83a2c727c26eeaf38a1bfe2d37eb0cef2805b3b7731d1ba6a73352981925519a.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.160.down_proj",
+      "sha256": "c0e35b781aa101a99cda45b1bab2bcc9e4b894847408793c60ecfcccc3f5594c",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/92c222202315607c6318537bfecf6048da2c10d2cf8bacc1997505fe22a6b265.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.129.down_proj",
+      "sha256": "da32a542611c1a46badb7e9dec17bac9b12cb26ac857df4b27f4222ae00a3e56",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/d114213800a159727477ea335b9b912eb03e06df31944508b85490f3796e0f28.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.145.down_proj",
+      "sha256": "b96dcd506a7afa8025cb0d01d3e21849284f54511665ef96f5fb5bd8abc37db1",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/b8b8280fcd18303693f69e2c17b83243d014f57a6a35e9e6f134abcce26097ed.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.124.down_proj",
+      "sha256": "c640e65b7067a39d073f50047393a8f7522a158d3d179b5e5f562a649b2cadb7",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/d5f72f62dcd78f9c0b317ca6ff7b14281c310332a4390422c1382b779127fa32.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.136.down_proj",
+      "sha256": "aa234ca92aa07eb2c6dd3d2e2f5d135b9c0edcafa8140eaade973dcb98bf0997",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/0dc825c059f4c548751b3a0087f1975293fcd52f7ec6871c566703cbbaf67493.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.109.down_proj",
+      "sha256": "79a8edd9e3a22f96e7c36706311638cd65506b2f6293a170d6c62dac30901de9",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/e34cf8df32522d699271627ebd3853b5cf452ac03c887ce85a5a595ccbcad0a0.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.147.down_proj",
+      "sha256": "02d407a3cffdd83524df7dba47b85e39ea4b9566da7d097bc2336e321615ceb4",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/42de301f96ebdeddea8741bc932cb775c029a00e7125b181bda67e54790a8a50.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.150.down_proj",
+      "sha256": "0bcd36b0cb8d3c3358ad8f22ebbc3a1015494e6ae6e3f565dfe3cf05908ac2d7",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/3319ecfb5e14506d9420732b8156a7d7e768dbf7cbf4258a94e6929d7c2df028.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.100.down_proj",
+      "sha256": "d255345d54a3bf3357ea878ab72f3ebe628f02dcf7c3cbb6e3c567d811d83fe0",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/decd00df4c4f139d010f38fed3518f876c9401215d69091abf1d2fd18da6e3e4.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.106.down_proj",
+      "sha256": "90db240bd881d5c8b901fc089d54b7140e2c58ea575b1c318133d7b82d6f7e57",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/08b53712455fa368d8c028816542d2d8c9aa264ab7f608d2e54dc1401b2ab3fb.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.139.down_proj",
+      "sha256": "e7f789bd96ba0d2d476d0a42811d7aa45dcc0e6ed338544aa7846bd8082ee37e",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/9d8db29d48da34ab0b6117dec6f045a313158665d366baae2ec7e7cdd9625ace.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.0.down_proj",
+      "sha256": "b8f1ae803b8599e4cc2d3bd1e749a6f44fc5ef0f6c6576843eb7a7f4dbd0a8b7",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/f8b5fa3549b9021112a5dca677c7edfd7bbef36b42dc4feb281e5420dbb4aa20.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.159.down_proj",
+      "sha256": "a47462039fb608c3077774fa2a1970d5386dc21c6dac747ce5477889883316e7",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/a7cb1c647bae11cf64297160067959922a7f83c894e65eca2b1eb49a0c94e820.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.101.down_proj",
+      "sha256": "64ed3884a31ef7c20799d973cb76b2f8c4305f60848d7db7c290d9367ba803f3",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/f35ec914a8d972ee6985826ccc9e88fab72877ba5a8fc5147ecede7194cb72b6.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.113.down_proj",
+      "sha256": "02b4fba1f84c90c575d8173858d7331dafe3d98b299af01bc778ae678d205dac",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/fbba4724e68de4fa3a12dfe663c7109ff9df0b1dbac1c0ad1e877bc1ae0fd658.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.134.down_proj",
+      "sha256": "4f9a39abc5ec760915978a82326c686e9f737d5c74fc75b25575f3763be74d0f",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/7319b03cb644190ebe12dd3019d7b553d4b4eaf48379f93d72bdbc4baed83190.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.148.down_proj",
+      "sha256": "87f8c461576ef26fb1372864db36624ca09414bd10a021218fe21823924a21e1",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/32052ec8c2c991e5cb15efde7fbc221a3e45bd95b40a0bcaf8123847dbd07bb0.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.102.down_proj",
+      "sha256": "d2168db2b52ee7d03733b2d86d2c43b5f65584c497bb82ff2c8c133f58fbe23d",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/7b04d137b2bd07ac4d07ecc4e5b2acec7d0e70ddd39fd786a2214c79b65a086c.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.128.down_proj",
+      "sha256": "cb11d984e1bd7e0774a73d35771fac38891e13ba99eb0ecb2cc2bd6b9a87f1fb",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/990922d3ceddd9c6b360882acd306d2c3f637048a684b5a84a4ed9fad4a06013.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.127.down_proj",
+      "sha256": "029f3f4a61506fdca33f8c5f234b156c9cf56635043cebb444b5becab69a8a91",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/49aecf7e1c7945255338f22dce6496deab7a660fceb9ff53d0bebf48dd14441e.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.151.down_proj",
+      "sha256": "0b162877f0712b94a51bc40edf77b42abc10189ffabff2b68ef07b87e58d5566",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/257951a102e302d69011216c1a1dd1f059dcd7699aed2345e9e3449f68813aa3.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.155.down_proj",
+      "sha256": "3a48eb40a86ab0998c1302a9cfaab44d3b4d665b5d42ef1451dc7610c2541ab3",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/f983ab59bd4af5a7b359344e4b115d0b9a75f119fcecfc931b684225bcd460d3.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.13.down_proj",
+      "sha256": "06b9c5405420568f708a284a763a922ddc5dfc2fc9d42a2926bd0ff7b6a2d027",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/b67101051ba529c303a9fd9568dfdbb6884bbe61006b23f10d6122385c8d0850.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.142.down_proj",
+      "sha256": "850c8e4b865c6e7ab3b3e170b51d3aa3c12040e77d028ca88647b994f1a4ecca",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/0130fe34188c659af2b49f1445dfce740236c78caa6cb90c0cf9724b6439d521.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.11.down_proj",
+      "sha256": "d7e12dc77e9321a2c744f710dd4cc59f448bf9680931bb083c31b0981b181c37",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/bd43c604025c05ba38d76efebd9eca7f5c6f408125c9f567e92dbca64de3ecfd.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.120.down_proj",
+      "sha256": "e015957277e8c798db2b66da74f0b9a9834ffec9dd7fe539d6c9d0fbfd7818d9",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/836732d0f8e691780fed671e7b9f9ea6294315ade9f2817e7544bc667c05b30d.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.103.down_proj",
+      "sha256": "f343da70b2a79b9cb7e49e249816fa3cbead002af202089dc0da88a6ee59c3d8",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/a05d0fcda8fb8763f0f5de703fe34e135305a5ac4726f6e1aba38272f023cc50.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.156.down_proj",
+      "sha256": "3b9a5f07e7c02843187094a6d55d41ea0783cb684a8913eeba8922115e63a624",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/fffab544ab93563e6710b003139a2aaae5f3f04a0b2773362868d9711f31b30a.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.161.down_proj",
+      "sha256": "cb6ed89975d75640e639e3989962ac265c2d214bd5ed5f09889ff7952a94db69",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/5e185def0cc8e68a98cef8d98594495c103130a8cf2cc752b8645857e83650da.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.123.down_proj",
+      "sha256": "7a83615a3ae2817d995b95d1dff70f45cf95b48c7090b45e8a910005af9178fc",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/20f0cbf381f7872c726b1b50e0bbe542078aa878589c297f82122c921c8d82d6.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.122.down_proj",
+      "sha256": "633d894ec0fedffe417ac7c188c0df8c8a2de31e0abf046b5d68043c97a1b1c1",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/d11a0da0a1840b3fd357c1b6df119ad99b14db26617e64c75102637c08037c9f.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.15.down_proj",
+      "sha256": "2ba3fb262d836b2fffe328f2bff84f480269977d3aadcfe30a728a9d91cf4b53",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/ef09c644a74d282c3a04b7571378eb7069501d0837e395de4ee5e00fa4bb2beb.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.108.down_proj",
+      "sha256": "3b5f2bd4d5f019eb697186531515197e746990857e77fb3eecbc96013bdf1d6b",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/1f55bb9b4076f345cc9780dae9ce4ce16a4155ae3f9e58bdd89f479cee4b1900.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.149.down_proj",
+      "sha256": "db80aef68701054c18b21eb5875f0443237f5f4f79469a9bd13dfe8b37010e0e",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/8bebbc6ebe630e8e9c73ce9073855c37951e446f0590feb986c8e77847bd7ce3.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.126.down_proj",
+      "sha256": "4a696387da2138fd721cf3f3e22dfe4bda81125f05885d666b9b56547873ee67",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/6e4e0869496c481ae77b2fa05f80ebb3d456f58444599a242c4e44461eb50bba.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.133.down_proj",
+      "sha256": "f20f2b51500843b1a3058906d7075b9e709cb269c499dcee4939173c5a7632cb",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/ca26aeac390a0d7b5d2e8033699033832932e407025d3a79ca814f6552fb0a85.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.132.down_proj",
+      "sha256": "ea850b792b99867228441136de60af73d244ab1ce765c59cb1a1276d5d71f010",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/e878439fd95fdd32308a213a7e2b01aded8b48145b446580b916df48af7fc00c.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.130.down_proj",
+      "sha256": "5702497c5e68eabac552171a41f8cebbf5383411df5940244123a31b5f4d1b65",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/425d321a242a2a2c7826c7e1066189a87ef26a8400301e4d032320e8e1f751d1.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.105.down_proj",
+      "sha256": "9c22afdec0046d2a7cdc1ec5b960d6db37c6fadf3852e80ceea218df9cd3bc75",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/e35523f57925810e2f3f78af8319da92fa02714dc7fe5505dd57398f149bcc29.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.121.down_proj",
+      "sha256": "b0c4bf663f333253ce5c576c13165b1e5b73e36339843a72b6771623d848cc0f",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/15547947d6c3661da1613c55394b562f7e97988b60ad47530ba7fe65d882c547.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.107.down_proj",
+      "sha256": "e668c4002f00195f01021b8fe441a67db669e65c5304af4e31b64a319e54a189",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/d367822d7bf4f2dcd664fa7a45d25935acdd90ebbdc13fb457e28c0e009b01cc.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.157.down_proj",
+      "sha256": "ce8c60fa219e065d2ea571d0876094465ec48f5d45a2c161bf5ecbad893a1dda",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/9df6b4e76c4bc4af8e51ebaad35446595ff52feb2b3f3885c36f3d612baf21c0.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.12.down_proj",
+      "sha256": "eb453e22b872f10201f74c5a4ec40ea3fb91338bc56180c1c9930481ba419e37",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/d12f3f692d549c8869c6b1e455798507b6d7f3dcaf7b5698f5ba089875968e0b.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.131.down_proj",
+      "sha256": "20ef0c9e3af3eba3b03dc4e2915d41284cd59b0b1e9eefdef8ec78bbd247122b",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/6ac5c00f96cb749654add44be87580b3ee773f1402897520b7ece65aeaa3c7ad.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.138.down_proj",
+      "sha256": "39f8c35e2457ed1b26d898dd17f210d07464048db9a42bc8a797a657ae6d14fc",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/26dad29f44434c187c75c253a6e5ea8b747adee4c4c26da4faf44e4b6e9ea1a1.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.144.down_proj",
+      "sha256": "1b9a6c0b9f0bce85c031de993680f5447cd7e6ec3644ef53abfd757a13569d3b",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/8d7a482ad8364cd816bdb68139af3af3ba20710c4f19ab2bcc71e4dd22a76c62.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.117.down_proj",
+      "sha256": "32eeab01e006665b1ec97edbf80c79b7d08c47e82900bb99000ca59c7edf2687",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/51032bd1b02e42e35c1dd37068d6d20db01964f52629ec2fbf98f0697a108ea3.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.114.down_proj",
+      "sha256": "515af18ad4865a7504d09c58a8052936312014184013c560480085112be9ab68",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/d5fad333775a8417ba942f2d0502292e19177795373241eb6b00cd7abc27c12d.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.16.down_proj",
+      "sha256": "6ab9d38d3dd16707e2b054d5424e0bbcc315f55269ea862ed54b7c1749a6b23c",
+      "wire_records": 1
+    }
+  ],
+  "journal_files": 72,
+  "journal_observed_unix": 1788910463.7228405,
+  "journal_unit_records": 72,
+  "last": 1788910432.3122528,
+  "observer": {
+    "batch_size": 8,
+    "call_index": 0,
+    "cuda_events": 0,
+    "error": "RuntimeError('anchor trace exceeded its exported byte cap or was empty')",
+    "finished_unix": 1788910133.728102,
+    "format_name": "TESSERA_E4M3_K1_R832",
+    "qname": null,
+    "qnames": [
+      "model.language_model.layers.4.mlp.experts.0.down_proj",
+      "model.language_model.layers.4.mlp.experts.1.down_proj",
+      "model.language_model.layers.4.mlp.experts.10.down_proj",
+      "model.language_model.layers.4.mlp.experts.100.down_proj",
+      "model.language_model.layers.4.mlp.experts.101.down_proj",
+      "model.language_model.layers.4.mlp.experts.102.down_proj",
+      "model.language_model.layers.4.mlp.experts.103.down_proj",
+      "model.language_model.layers.4.mlp.experts.104.down_proj"
+    ],
+    "rejected_trace_bytes": 9222546186,
+    "started_unix": 1788909983.9614086,
+    "status": "observation_failed"
+  },
+  "samples": 299,
+  "scope": "Live sampled stack and host window after rejected first profiler export. No accepted CUDA trace or instruction attribution.",
+  "snapshot_unix": 1788910433.0079606,
+  "snapshots": [
+    {
+      "bytes": 1652115,
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/selected-verified-capture-01/post-prefetch-python_sampler.jsonl",
+      "sha256": "38f1951cb075bf2fdc4eacd88b34d7dbefe8617e9692b21fa15fda151e498306"
+    },
+    {
+      "bytes": 5479024,
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/selected-verified-capture-01/post-prefetch-netdata.jsonl",
+      "sha256": "25536b544e8e66ff56ff3da0f3a7db966d48c5aad93e2f704f3cfe80af4047c6"
+    },
+    {
+      "bytes": 4445,
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/selected-verified-capture-01/post-prefetch-progress.json",
+      "sha256": "16f3efa170f34aac7c22248ce95da51944fa079023dc993af561889500124da7"
+    }
+  ],
+  "top": [
+    {
+      "file": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/full-anchor-preparation-03/producer-source-07ad344c3/src/tessera/window_viterbi.py",
+      "function": "viterbi_window_fused",
+      "line": 771,
+      "samples": 266
+    },
+    {
+      "file": "/usr/local/lib/python3.12/dist-packages/torch/cuda/graphs.py",
+      "function": "replay",
+      "line": 186,
+      "samples": 11
+    },
+    {
+      "file": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/full-anchor-preparation-03/producer-source-07ad344c3/src/tessera/wire.py",
+      "function": "_to_bits",
+      "line": 84,
+      "samples": 4
+    },
+    {
+      "file": "/usr/local/lib/python3.12/dist-packages/torch/serialization.py",
+      "function": "__exit__",
+      "line": 834,
+      "samples": 4
+    },
+    {
+      "file": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/full-anchor-preparation-03/producer-source-07ad344c3/src/tessera/cached_unit.py",
+      "function": "tensor_identity",
+      "line": 45,
+      "samples": 2
+    },
+    {
+      "file": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/full-anchor-preparation-03/producer-source-07ad344c3/src/tessera/encode.py",
+      "function": "columns_of",
+      "line": 2782,
+      "samples": 2
+    },
+    {
+      "file": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/full-anchor-preparation-03/producer-source-07ad344c3/src/tessera/compensate.py",
+      "function": "block_ldl",
+      "line": 115,
+      "samples": 1
+    },
+    {
+      "file": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/full-anchor-preparation-03/producer-source-07ad344c3/src/tessera/encode.py",
+      "function": "trellis_pass",
+      "line": 2824,
+      "samples": 1
+    },
+    {
+      "file": "/usr/lib/python3.12/pathlib.py",
+      "function": "write_bytes",
+      "line": 1038,
+      "samples": 1
+    },
+    {
+      "file": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/full-anchor-preparation-03/producer-source-07ad344c3/src/tessera/layout.py",
+      "function": "build_terminal",
+      "line": 679,
+      "samples": 1
+    },
+    {
+      "file": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/full-anchor-preparation-03/producer-source-07ad344c3/src/tessera/wire.py",
+      "function": "pack_levels",
+      "line": 263,
+      "samples": 1
+    },
+    {
+      "file": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/full-anchor-preparation-03/producer-source-07ad344c3/src/tessera/window_viterbi.py",
+      "function": "viterbi_window_fused",
+      "line": 774,
+      "samples": 1
+    }
+  ]
+}

--- a/experiments/measurements/selected-verified-capture-20260908/withdrawn-expert-disposition.json
+++ b/experiments/measurements/selected-verified-capture-20260908/withdrawn-expert-disposition.json
@@ -1,0 +1,732 @@
+{
+  "action": "ab1c32b1a4c8fabc1bc27161cd5e8690b106503cd868e3640e1339a487d11e38",
+  "cost_pickle_exists": false,
+  "disposition": "Root withdrew failed profiler qualification. Journals/wires and original capture retained; not a completed row/qualified profile. Any future source or policy transition requires normal resume/seed verification and root review; no restart by this agent.",
+  "journal_bindings": [
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/a9b02c5f428e667c8bbbb86b9cba68c035740a191d830813b0a53a39783c5004.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.14.down_proj",
+      "sha256": "e78ac40107107fd9191e8086b7404da63843aed3d8b9ad55590c81ca25e287ca",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/46a2df9da30065f4eaf44635ba43425508fbaa1418aec29033bd9a0ea57cae1b.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.175.down_proj",
+      "sha256": "8d9ce2d91f2b3f21b66d26fbbd6b818e7f512abe88d5aa4b189118e3c5d7cc2e",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/33128491a04e71be0b1afe07cae9023da672466973039e729225aa3777c1fe80.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.111.down_proj",
+      "sha256": "7bfe008c9d0864e2561dc1c34c9e8dda3aeec3f7ace81263381864e212d51d41",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/5c669f7b66e5e82f91e6d995f55908f1d930757a484357f379036e37dfab1419.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.164.down_proj",
+      "sha256": "b8249dfff7612bf48b4642f8e455c218cef58f80a856789192c7f9d4226aab8c",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/408ac461a32e7943501466708d9e3c892e8aca17c2c1d35db4c903013174ca6f.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.116.down_proj",
+      "sha256": "6ccc2c717442742544353b792e460b0d2cef84b71d358be6c792ebfa7890fc20",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/6e756782e126f9a174cd46a221202fc3b0e3f4e937e14706af2a04ebe28d0795.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.172.down_proj",
+      "sha256": "efa1276f49927b8c21036435ced95bd5107f18408ca69075f203f4079e1d6c3e",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/0b30cb39310c285679ac7c732e38e62043fee74deb151dedce097c84025dc8a9.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.140.down_proj",
+      "sha256": "72019e81f4a770b9455e57701a7eec4a92f187abdf620c08c43cd7e8bc6a7a61",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/027efe0d6a146d8b98f3313e41ec69023dc384016a45ad4c1eefa21daa25d80a.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.104.down_proj",
+      "sha256": "4d75aaf84c52bd0a549d614d4e0fae2c70c104aa174d9d9d8432f55c6b921484",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/c625628a41e664483f93ba479b58b8df12ea716a13c898c199d7ab734310cd82.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.141.down_proj",
+      "sha256": "6d64f30616bc83bb92243d4763e2b8bf6c8e649a172f2f9101393556ad626e0e",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/9e1f2ea1b263124f07cd00eb48ff42530e54132d1035b54d8b248ad636721a54.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.146.down_proj",
+      "sha256": "664a8c357cdaaa5dd3edb02e9c29ed18cb00503e8406b0f4968d05f5caefe018",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/de03fa83ef2494afb702d7e2dbbb94a5a3f10a878711a591d1cc05c4efa7db05.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.118.down_proj",
+      "sha256": "b0d25dbaeb068665366ac2422278d761976c88dedbb7b0e9f8e12de559894277",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/395af4a2909551d39125a618128d8ad5b3388e791d783c5d9220a2267ea55bb8.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.137.down_proj",
+      "sha256": "689f9939aa5e40f9d3302fd87fac5900fcc265b9f1b518103e6f2e567dc8b7d5",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/37458737c17b80863b159d8af19dd6a7006da1ea1034bec1ee94f724a5ae10d9.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.162.down_proj",
+      "sha256": "45a6f230c1a22070f180a2e413a5618afc505e51e309187304f49d7a0d857398",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/f85a249de67958e0de432e95c745d4c5040b5e4087adb999d8a3f138403ae27d.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.10.down_proj",
+      "sha256": "ae9abb0dfb59ee4068339c0323e3f66e0a39aa6aebabeae055fd0f582b353430",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/a6276486feb01f58c21bf6fc1c878223b5cf66039581788dc4e97d41ee777297.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.168.down_proj",
+      "sha256": "09ff7d41e22dbf38a9635fd73445e83b5e1d56e134476b35a152e3cabb120421",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/97d47cb0cc756aaea97b453df384e8df686b4942fa3e5ad884281835cbae7fed.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.119.down_proj",
+      "sha256": "45199429e367086bb40e78718b2430280a5ef2d55169d07ee7f167c3555b18c5",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/09bf9451fa1c8238833a14cd415740926df4b38ebe5e14c4845c4b722576e1b4.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.112.down_proj",
+      "sha256": "453ce3353756d3efe657b63c88d61fc05a99392e8e24a5ee31a01fd693e69bcd",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/ca7816eb06381fb4e054dec59cfbb6b50de349066eec043c8525aaa6d0c53de0.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.166.down_proj",
+      "sha256": "051bbef703293ee419ddaeab5b6114318eb8f0d6b276af055c40ec546df7b496",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/1a9eeecd2e8ae7bdd742915b191d650f444f5a40e32da90cc9754b323b81109c.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.115.down_proj",
+      "sha256": "bbbb73bd63de33b0b8654c0631206a4de46e298df05767a4a848bb3468e985e8",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/79c811fc1623474bb26028510966669215f1dc5d0624220b5466f6e74aa2b60a.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.135.down_proj",
+      "sha256": "977ebc2a1e13d19e099e664b74100d1d515c979fb7689ce250ca038f11e8320e",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/710f97a9b7cb5d6c944d7b70bdc1083ecf360e5d98b0079f4fb6d5c97b05e41c.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.110.down_proj",
+      "sha256": "9efe60cdecc5d6bee4a9f474ccced9c657997983a19cbccc885f7c1239eea3f1",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/720a597c6d391b7276dbfadf1095a9196df0c2e53feba947725725df353e1835.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.170.down_proj",
+      "sha256": "d643d5e5fa1b183a5e968d06339826b97ead12611f435979bfb795370b78faa5",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/d1e0b7edf573e1a5128d607ffb1c3ca17e178cf4f3ec49876d5eb347b204c89f.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.154.down_proj",
+      "sha256": "960da25c59d99a1f2c733d9a078aac4ffccf7209b4dd40f81e9f63f5f691de6a",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/6b4672a279ac99c6954083d1fa89cd40b00ef52c7aab26ef147e2eec4da986b3.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.153.down_proj",
+      "sha256": "5a029b0d31ac18e76cd10a52c9a2e29da31e949cc7bffe6c47fd4a1fb9ac820a",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/fbb54d6c8b34fdf276e0b97bcf936269c78587d5e5be3adea6f00b2fcff46336.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.1.down_proj",
+      "sha256": "47745a639bcaed8ba52fb513391e2490797f784d3d92f172f0b743d6aa35bd75",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/b5fc0f8271c81f0977f57d58f79bef054e51574d3766ed2a2487608c13a96155.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.152.down_proj",
+      "sha256": "22fbab72c01fd308b721fbf54edc4e713eb2272ffe03fed3921742cea1bd2525",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/d763ffce639bda72c4079fc6828568c907c6bf06104873eab3f4ece58b24795f.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.143.down_proj",
+      "sha256": "927f1b159e9ce6b58049abff09580d73d2f07fb2933c9178f24eaf0195a8c406",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/db2657b256a3c5b1234cdb58cc21b82926214e8d39d12bb5264463a3a6293b72.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.158.down_proj",
+      "sha256": "5562e73a57740b9c2a0b719520fe55d2f8a2cd938dd03c46e651d5e4e91b9231",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/29366b01bffc076de726ee2df3c3586d260cfea3ec58907378d4fd014382f557.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.125.down_proj",
+      "sha256": "bca5c44dddd05abaa8ab5eab90ce170e3acc9b4dd0157ef5a0ec9d84cdff13f2",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/ac759a56161a93a251a85cc7998997bc2eacce6998e71efaf506c1f4d37464c1.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.165.down_proj",
+      "sha256": "52cc94923b71a1f6c4c5478fb5ac19f7d8a51cec50da21fd03d0eddfe3e8b3c3",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/83a2c727c26eeaf38a1bfe2d37eb0cef2805b3b7731d1ba6a73352981925519a.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.160.down_proj",
+      "sha256": "c0e35b781aa101a99cda45b1bab2bcc9e4b894847408793c60ecfcccc3f5594c",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/92c222202315607c6318537bfecf6048da2c10d2cf8bacc1997505fe22a6b265.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.129.down_proj",
+      "sha256": "da32a542611c1a46badb7e9dec17bac9b12cb26ac857df4b27f4222ae00a3e56",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/d114213800a159727477ea335b9b912eb03e06df31944508b85490f3796e0f28.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.145.down_proj",
+      "sha256": "b96dcd506a7afa8025cb0d01d3e21849284f54511665ef96f5fb5bd8abc37db1",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/b8b8280fcd18303693f69e2c17b83243d014f57a6a35e9e6f134abcce26097ed.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.124.down_proj",
+      "sha256": "c640e65b7067a39d073f50047393a8f7522a158d3d179b5e5f562a649b2cadb7",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/6eb0ed0ed8e939b5e721cd381496b9d53a8787cf9d0b0f066d78a2d7f58c8fab.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.169.down_proj",
+      "sha256": "874e80319bff6c91853cbd2ca3b737381094d4f8899e8123cc61306ab5dc8014",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/d5f72f62dcd78f9c0b317ca6ff7b14281c310332a4390422c1382b779127fa32.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.136.down_proj",
+      "sha256": "aa234ca92aa07eb2c6dd3d2e2f5d135b9c0edcafa8140eaade973dcb98bf0997",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/0dc825c059f4c548751b3a0087f1975293fcd52f7ec6871c566703cbbaf67493.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.109.down_proj",
+      "sha256": "79a8edd9e3a22f96e7c36706311638cd65506b2f6293a170d6c62dac30901de9",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/e34cf8df32522d699271627ebd3853b5cf452ac03c887ce85a5a595ccbcad0a0.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.147.down_proj",
+      "sha256": "02d407a3cffdd83524df7dba47b85e39ea4b9566da7d097bc2336e321615ceb4",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/42de301f96ebdeddea8741bc932cb775c029a00e7125b181bda67e54790a8a50.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.150.down_proj",
+      "sha256": "0bcd36b0cb8d3c3358ad8f22ebbc3a1015494e6ae6e3f565dfe3cf05908ac2d7",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/3319ecfb5e14506d9420732b8156a7d7e768dbf7cbf4258a94e6929d7c2df028.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.100.down_proj",
+      "sha256": "d255345d54a3bf3357ea878ab72f3ebe628f02dcf7c3cbb6e3c567d811d83fe0",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/decd00df4c4f139d010f38fed3518f876c9401215d69091abf1d2fd18da6e3e4.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.106.down_proj",
+      "sha256": "90db240bd881d5c8b901fc089d54b7140e2c58ea575b1c318133d7b82d6f7e57",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/08b53712455fa368d8c028816542d2d8c9aa264ab7f608d2e54dc1401b2ab3fb.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.139.down_proj",
+      "sha256": "e7f789bd96ba0d2d476d0a42811d7aa45dcc0e6ed338544aa7846bd8082ee37e",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/9d8db29d48da34ab0b6117dec6f045a313158665d366baae2ec7e7cdd9625ace.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.0.down_proj",
+      "sha256": "b8f1ae803b8599e4cc2d3bd1e749a6f44fc5ef0f6c6576843eb7a7f4dbd0a8b7",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/f8b5fa3549b9021112a5dca677c7edfd7bbef36b42dc4feb281e5420dbb4aa20.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.159.down_proj",
+      "sha256": "a47462039fb608c3077774fa2a1970d5386dc21c6dac747ce5477889883316e7",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/12ec842d79d034ea646ccb1d451731de1bd7f795f50ebc9867b0b9b48c2b69a0.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.173.down_proj",
+      "sha256": "d1c95bf5ec623f1964fac9ff5d2761ab0d7e44e704d4fb9a26fda9779cad0d1f",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/a7cb1c647bae11cf64297160067959922a7f83c894e65eca2b1eb49a0c94e820.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.101.down_proj",
+      "sha256": "64ed3884a31ef7c20799d973cb76b2f8c4305f60848d7db7c290d9367ba803f3",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/f35ec914a8d972ee6985826ccc9e88fab72877ba5a8fc5147ecede7194cb72b6.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.113.down_proj",
+      "sha256": "02b4fba1f84c90c575d8173858d7331dafe3d98b299af01bc778ae678d205dac",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/fbba4724e68de4fa3a12dfe663c7109ff9df0b1dbac1c0ad1e877bc1ae0fd658.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.134.down_proj",
+      "sha256": "4f9a39abc5ec760915978a82326c686e9f737d5c74fc75b25575f3763be74d0f",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/7319b03cb644190ebe12dd3019d7b553d4b4eaf48379f93d72bdbc4baed83190.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.148.down_proj",
+      "sha256": "87f8c461576ef26fb1372864db36624ca09414bd10a021218fe21823924a21e1",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/32052ec8c2c991e5cb15efde7fbc221a3e45bd95b40a0bcaf8123847dbd07bb0.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.102.down_proj",
+      "sha256": "d2168db2b52ee7d03733b2d86d2c43b5f65584c497bb82ff2c8c133f58fbe23d",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/7b04d137b2bd07ac4d07ecc4e5b2acec7d0e70ddd39fd786a2214c79b65a086c.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.128.down_proj",
+      "sha256": "cb11d984e1bd7e0774a73d35771fac38891e13ba99eb0ecb2cc2bd6b9a87f1fb",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/990922d3ceddd9c6b360882acd306d2c3f637048a684b5a84a4ed9fad4a06013.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.127.down_proj",
+      "sha256": "029f3f4a61506fdca33f8c5f234b156c9cf56635043cebb444b5becab69a8a91",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/49aecf7e1c7945255338f22dce6496deab7a660fceb9ff53d0bebf48dd14441e.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.151.down_proj",
+      "sha256": "0b162877f0712b94a51bc40edf77b42abc10189ffabff2b68ef07b87e58d5566",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/257951a102e302d69011216c1a1dd1f059dcd7699aed2345e9e3449f68813aa3.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.155.down_proj",
+      "sha256": "3a48eb40a86ab0998c1302a9cfaab44d3b4d665b5d42ef1451dc7610c2541ab3",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/d5600780195dc94a96e000e40c047c0e2884e3ac65b7a54e395a42424b04765e.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.176.down_proj",
+      "sha256": "2e85041695af931f1467608c3021cd56adb691918366342f66aca6b744b4d1eb",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/f983ab59bd4af5a7b359344e4b115d0b9a75f119fcecfc931b684225bcd460d3.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.13.down_proj",
+      "sha256": "06b9c5405420568f708a284a763a922ddc5dfc2fc9d42a2926bd0ff7b6a2d027",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/b67101051ba529c303a9fd9568dfdbb6884bbe61006b23f10d6122385c8d0850.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.142.down_proj",
+      "sha256": "850c8e4b865c6e7ab3b3e170b51d3aa3c12040e77d028ca88647b994f1a4ecca",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/0130fe34188c659af2b49f1445dfce740236c78caa6cb90c0cf9724b6439d521.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.11.down_proj",
+      "sha256": "d7e12dc77e9321a2c744f710dd4cc59f448bf9680931bb083c31b0981b181c37",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/0dcf9975a1a4fe5bc2747c7a0b35d914fafe7a53225c23afceda5dc7e15b9560.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.174.down_proj",
+      "sha256": "7d37f37ce9d2b5de78c2c65cf18078b3d8eb11932d4b5101fb124a2caac17a3a",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/5199bd99e023cf48a01f47743e35de740087e89a5fad77e7425e4db94f337fbe.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.177.down_proj",
+      "sha256": "d0af9ba740b9d821e00f0b44e3114363a9ed5430762d9b1a9d0473ee0bddccca",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/bd43c604025c05ba38d76efebd9eca7f5c6f408125c9f567e92dbca64de3ecfd.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.120.down_proj",
+      "sha256": "e015957277e8c798db2b66da74f0b9a9834ffec9dd7fe539d6c9d0fbfd7818d9",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/836732d0f8e691780fed671e7b9f9ea6294315ade9f2817e7544bc667c05b30d.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.103.down_proj",
+      "sha256": "f343da70b2a79b9cb7e49e249816fa3cbead002af202089dc0da88a6ee59c3d8",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/a05d0fcda8fb8763f0f5de703fe34e135305a5ac4726f6e1aba38272f023cc50.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.156.down_proj",
+      "sha256": "3b9a5f07e7c02843187094a6d55d41ea0783cb684a8913eeba8922115e63a624",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/fffab544ab93563e6710b003139a2aaae5f3f04a0b2773362868d9711f31b30a.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.161.down_proj",
+      "sha256": "cb6ed89975d75640e639e3989962ac265c2d214bd5ed5f09889ff7952a94db69",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/5e185def0cc8e68a98cef8d98594495c103130a8cf2cc752b8645857e83650da.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.123.down_proj",
+      "sha256": "7a83615a3ae2817d995b95d1dff70f45cf95b48c7090b45e8a910005af9178fc",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/20f0cbf381f7872c726b1b50e0bbe542078aa878589c297f82122c921c8d82d6.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.122.down_proj",
+      "sha256": "633d894ec0fedffe417ac7c188c0df8c8a2de31e0abf046b5d68043c97a1b1c1",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/d11a0da0a1840b3fd357c1b6df119ad99b14db26617e64c75102637c08037c9f.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.15.down_proj",
+      "sha256": "2ba3fb262d836b2fffe328f2bff84f480269977d3aadcfe30a728a9d91cf4b53",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/ef09c644a74d282c3a04b7571378eb7069501d0837e395de4ee5e00fa4bb2beb.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.108.down_proj",
+      "sha256": "3b5f2bd4d5f019eb697186531515197e746990857e77fb3eecbc96013bdf1d6b",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/1f55bb9b4076f345cc9780dae9ce4ce16a4155ae3f9e58bdd89f479cee4b1900.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.149.down_proj",
+      "sha256": "db80aef68701054c18b21eb5875f0443237f5f4f79469a9bd13dfe8b37010e0e",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/9087ae9b96ef562cf537806b9c2b8a92013d44ee902ca75698a74f4e4379ab33.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.171.down_proj",
+      "sha256": "c1eb8fe150a39717699546ffb4d1640f2d21aa420878e4fa2bb436c83fd7bc7e",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/8bebbc6ebe630e8e9c73ce9073855c37951e446f0590feb986c8e77847bd7ce3.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.126.down_proj",
+      "sha256": "4a696387da2138fd721cf3f3e22dfe4bda81125f05885d666b9b56547873ee67",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/5d09bf3996b81e7b3597a6fb3ef8985ced4e6990f70ebc1404efdbb6bca3ac50.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.17.down_proj",
+      "sha256": "84f6c54134a1c28692533736dc19a248b1a523f2b1da1c1179c5caad40651d96",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/6e4e0869496c481ae77b2fa05f80ebb3d456f58444599a242c4e44461eb50bba.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.133.down_proj",
+      "sha256": "f20f2b51500843b1a3058906d7075b9e709cb269c499dcee4939173c5a7632cb",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/ca26aeac390a0d7b5d2e8033699033832932e407025d3a79ca814f6552fb0a85.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.132.down_proj",
+      "sha256": "ea850b792b99867228441136de60af73d244ab1ce765c59cb1a1276d5d71f010",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/e878439fd95fdd32308a213a7e2b01aded8b48145b446580b916df48af7fc00c.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.130.down_proj",
+      "sha256": "5702497c5e68eabac552171a41f8cebbf5383411df5940244123a31b5f4d1b65",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/425d321a242a2a2c7826c7e1066189a87ef26a8400301e4d032320e8e1f751d1.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.105.down_proj",
+      "sha256": "9c22afdec0046d2a7cdc1ec5b960d6db37c6fadf3852e80ceea218df9cd3bc75",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/e35523f57925810e2f3f78af8319da92fa02714dc7fe5505dd57398f149bcc29.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.121.down_proj",
+      "sha256": "b0c4bf663f333253ce5c576c13165b1e5b73e36339843a72b6771623d848cc0f",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/15547947d6c3661da1613c55394b562f7e97988b60ad47530ba7fe65d882c547.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.107.down_proj",
+      "sha256": "e668c4002f00195f01021b8fe441a67db669e65c5304af4e31b64a319e54a189",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/1327f0aee09c037358ff24b478fe2ad95b9aa8f96d5db790eebaa5815b270b41.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.163.down_proj",
+      "sha256": "3d16478b3c27d2db5a698168e7a4588187c63086e435b3e982e72c17aa664dbe",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/d367822d7bf4f2dcd664fa7a45d25935acdd90ebbdc13fb457e28c0e009b01cc.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.157.down_proj",
+      "sha256": "ce8c60fa219e065d2ea571d0876094465ec48f5d45a2c161bf5ecbad893a1dda",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/f481eeac4435226d98d685bc3d4180bcd805cd3d31e7c91dc45cfc3134efd056.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.167.down_proj",
+      "sha256": "cf0e2796fe52e3dd814512a2a19950b00c79336e6f2e4984b51a36d514553f42",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/9df6b4e76c4bc4af8e51ebaad35446595ff52feb2b3f3885c36f3d612baf21c0.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.12.down_proj",
+      "sha256": "eb453e22b872f10201f74c5a4ec40ea3fb91338bc56180c1c9930481ba419e37",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/d12f3f692d549c8869c6b1e455798507b6d7f3dcaf7b5698f5ba089875968e0b.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.131.down_proj",
+      "sha256": "20ef0c9e3af3eba3b03dc4e2915d41284cd59b0b1e9eefdef8ec78bbd247122b",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/6ac5c00f96cb749654add44be87580b3ee773f1402897520b7ece65aeaa3c7ad.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.138.down_proj",
+      "sha256": "39f8c35e2457ed1b26d898dd17f210d07464048db9a42bc8a797a657ae6d14fc",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/26dad29f44434c187c75c253a6e5ea8b747adee4c4c26da4faf44e4b6e9ea1a1.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.144.down_proj",
+      "sha256": "1b9a6c0b9f0bce85c031de993680f5447cd7e6ec3644ef53abfd757a13569d3b",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/8d7a482ad8364cd816bdb68139af3af3ba20710c4f19ab2bcc71e4dd22a76c62.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.117.down_proj",
+      "sha256": "32eeab01e006665b1ec97edbf80c79b7d08c47e82900bb99000ca59c7edf2687",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/51032bd1b02e42e35c1dd37068d6d20db01964f52629ec2fbf98f0697a108ea3.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.114.down_proj",
+      "sha256": "515af18ad4865a7504d09c58a8052936312014184013c560480085112be9ab68",
+      "wire_records": 1
+    },
+    {
+      "anchors": 1,
+      "identity_sha256": "f683d4344cb9af379ad15846d3ac5a368fa537aada25cf5786775fcd84cb68f3",
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/cost.anchors.json.parts/units/d5fad333775a8417ba942f2d0502292e19177795373241eb6b00cd7abc27c12d.pkl",
+      "qname": "model.language_model.layers.4.mlp.experts.16.down_proj",
+      "sha256": "6ab9d38d3dd16707e2b054d5424e0bbcc315f55269ea862ed54b7c1749a6b23c",
+      "wire_records": 1
+    }
+  ],
+  "observed_unix": 1788910775.359658,
+  "owned_pid_exists": false,
+  "profile_bindings": [
+    {
+      "bytes": 4445,
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/profile/attempt-2478f0168d48443e93ff4f0d84025c9f/progress.json",
+      "sha256": "16f3efa170f34aac7c22248ce95da51944fa079023dc993af561889500124da7"
+    },
+    {
+      "bytes": 1880640,
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/profile/attempt-2478f0168d48443e93ff4f0d84025c9f/python_sampler.jsonl",
+      "sha256": "f50fefd58248af86fe8ae62c1defb45e5cc349e2fbc71403f63b42ea5a36078e"
+    },
+    {
+      "bytes": 5939667,
+      "path": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-01/workspace/rows/row-0076/profile/attempt-2478f0168d48443e93ff4f0d84025c9f/netdata.jsonl",
+      "sha256": "a493585f3cf0d79e71bf6201eda5f0b59fe632161613846b795883a495e96971"
+    }
+  ],
+  "retained_anchors": 88,
+  "retained_unit_records": 88
+}

--- a/prismaquant/autoscale.py
+++ b/prismaquant/autoscale.py
@@ -310,7 +310,7 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
 
 def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
                               cache_slots, prefetch_workers, headroom_gb,
-                              anchor_batch_size=1):
+                              anchor_batch_size=1, capture_load_policy=None):
     """Bound selected-source preparation separately from resident encoding.
 
     This extends the source loader's header/dtype accounting. No source
@@ -318,6 +318,8 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
     encoder memo retains at most one compatible batch's factors.
     """
     import math
+    from .perturbed_x_cache import normalize_verified_activation_load
+    capture_load_policy = normalize_verified_activation_load(capture_load_policy)
     if not unit_shapes or type(anchor_batch_size) is not int or anchor_batch_size < 1:
         raise ValueError('selected anchors require nonempty units and a positive batch size')
     source = streamed_calibration_resources(model_path, unit_shapes=unit_shapes,
@@ -357,7 +359,20 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
         serialization_scratch_bytes=2*widest_h)
     phases = dict(source_preparation=preparation, export_inputs=export_inputs,
                   resident_anchors=encoding)
+    if capture_load_policy is not None:
+        # The existing loader retains one private serialized buffer and may
+        # leave its entire source file in the kernel despite page advice.
+        # Decode can coexist with already resident selected X/H, but source
+        # staging and encoder factors belong to different completed phases.
+        phases['capture_prefetch'] = dict(common,
+            selected_hessian_bytes=source['full_hessian_bytes'],
+            selected_prefix_bytes=source['full_prefix_bytes'],
+            capture_decode_storage_bytes=widest_h+widest_x,
+            capture_serialized_buffer_bytes=capture_load_policy['max_buffer_bytes'],
+            capture_source_page_cache_bytes=capture_load_policy['max_buffer_bytes'],
+            capture_load_scratch_bytes=capture_load_policy['max_scratch_bytes'])
     return dict(schema='prismaquant.selected_anchor_resources.v2', phases=phases,
+        **({'capture_load_policy': capture_load_policy} if capture_load_policy is not None else {}),
         memory_bytes=max(sum(phase.values()) for phase in phases.values()),
         selected_source_weight_bytes=weights, selected_layers=layers,
         source_header_sha256=source['source_header_sha256'],

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -3709,6 +3709,34 @@ def _run_streamed_calibration(args, runner, profile, *, mode, population,
     return 0
 
 
+def _prefetch_selected_capture(args, *, expected_identity, census, names, device,
+                               resources, guard=None):
+    """Use the existing resident prefetch and publish its separate load receipt."""
+    import hashlib
+    from . import tessera_calibration_cache as store
+    from .cost_stage_checkpoint import atomic_write_bytes
+    from .perturbed_x_cache import normalize_verified_activation_load
+    policy = normalize_verified_activation_load(args.capture_load_policy)
+    execution = {} if policy is not None else None
+    values, capture = store.prefetch_capture(args.calibration_cache,
+        expected_identity=expected_identity, census=census, names=names, device=device,
+        expected_sha256=args.calibration_cache_sha256,
+        resource_check=None if guard is None else guard.check, release_file_pages=True,
+        **(dict(verified_load_policy=policy, load_execution=execution) if policy is not None else {}))
+    if execution is None:
+        return values, capture, None
+    record = dict(schema='prismaquant.capture_load_run.v1', capture=capture,
+        prefetch=execution, resources=resources,
+        memory_guard=None if guard is None else guard.snapshot())
+    raw = (json.dumps(record, indent=2, sort_keys=True, allow_nan=False)+'\n').encode()
+    digest = hashlib.sha256(raw).hexdigest()
+    # A later refused/interrupted resume must not replace execution evidence
+    # already referenced by a surviving priced output.
+    output = Path(args.cache_dir)/f'capture-load-execution-{digest}.json'
+    atomic_write_bytes(output, raw)
+    return values, capture, dict(path=str(output.resolve()), sha256=digest)
+
+
 def main(argv: "Sequence[str] | None" = None) -> int:
     from contextlib import ExitStack
     with ExitStack() as source_scope:
@@ -3837,7 +3865,7 @@ def _main(argv, *, source_scope) -> int:
                     choices=("legacy", "shared-inputs-release-v1", "shared-inputs-bounded-v1"),
                     help="Opt-in shared capture; bounded also checks phase ownership and physical memory.")
     ap.add_argument("--capture-load-policy", type=json.loads, default=None,
-                    help="Explicit verified activation load v1 JSON policy; requires bounded capture.")
+                    help="Explicit verified activation load v1 JSON policy; requires bounded capture or hash-bound selected streaming reuse.")
     ap.add_argument('--export-hessian-reference-policy', type=json.loads, default=None,
                     help='Opt-in canonical H reference load-policy JSON; requires selected reuse of a complete capture.')
     ap.add_argument("--capture-calibration-out", default=None,
@@ -3852,15 +3880,15 @@ def _main(argv, *, source_scope) -> int:
         args.capture_load_policy = normalize_verified_activation_load(args.capture_load_policy)
     except ValueError as exc:
         ap.error(str(exc))
-    if args.capture_load_policy is not None and not (
-            args.streaming and args.capture_calibration_out and
-            args.streaming_capture_policy == 'shared-inputs-bounded-v1'):
-        ap.error('--capture-load-policy requires streamed shared-inputs-bounded-v1 capture')
     if args.streaming_capture_policy != "legacy" and not (args.streaming and args.capture_calibration_out):
         ap.error("--streaming-capture-policy requires --streaming and --capture-calibration-out")
     selected_source = bool(args.streaming and args.units and args.calibration_cache
                            and args.calibration_cache_sha256
                            and not (args.census_out or args.capture_calibration_out))
+    if args.capture_load_policy is not None and not (selected_source or (
+            args.streaming and args.capture_calibration_out and
+            args.streaming_capture_policy == 'shared-inputs-bounded-v1')):
+        ap.error('--capture-load-policy requires streamed shared-inputs-bounded-v1 capture or hash-bound selected streaming reuse')
     if args.export_hessian_reference_policy is not None:
         if not selected_source:
             ap.error('--export-hessian-reference-policy requires selected reuse of a hash-bound complete capture')
@@ -4121,7 +4149,9 @@ def _main(argv, *, source_scope) -> int:
             cache_slots=args.streaming_cache_slots,
             prefetch_workers=args.streaming_prefetch_workers,
             headroom_gb=args.streaming_cache_headroom_gb,
-            anchor_batch_size=args.anchor_batch_size)
+            anchor_batch_size=args.anchor_batch_size,
+            **(dict(capture_load_policy=args.capture_load_policy)
+               if args.capture_load_policy is not None else {}))
         if device == 'cuda':
             if selected_resources['memory_bytes'] > selected_guard.cap_bytes:
                 raise RuntimeError('selected anchor cgroup budget is smaller than its checked phase plan')
@@ -4176,12 +4206,17 @@ def _main(argv, *, source_scope) -> int:
             print(f"[campaign] complete calibration capture reused: {record}", flush=True)
             return 0
     if args.calibration_cache:
-        values, calibration_cache = calibration_store.prefetch_capture(
-            args.calibration_cache, expected_identity=capture_identity,
-            census=census, names=targets, device=device,
-            expected_sha256=args.calibration_cache_sha256,
-            **(dict(resource_check=None if selected_guard is None else selected_guard.check,
-                    release_file_pages=True) if selected_source else {}))
+        if selected_source:
+            values, calibration_cache, load_receipt = _prefetch_selected_capture(args,
+                expected_identity=capture_identity, census=census, names=targets,
+                device=device, resources=selected_resources, guard=selected_guard)
+            if load_receipt is not None:
+                selected_source_preparation['capture_load_execution'] = load_receipt
+        else:
+            values, calibration_cache = calibration_store.prefetch_capture(
+                args.calibration_cache, expected_identity=capture_identity,
+                census=census, names=targets, device=device,
+                expected_sha256=args.calibration_cache_sha256)
         acts, hessians, hessian_rows, act_max_abs = values
         if selected_guard is not None:
             selected_guard.check('after_selected_capture_prefetch')

--- a/tests/test_selected_verified_capture.py
+++ b/tests/test_selected_verified_capture.py
@@ -154,3 +154,28 @@ def test_selected_legacy_reuse_keeps_its_path_and_has_no_load_receipt(capture, t
         census=census, names=['a'], device='cpu', resources={})
     assert torch.equal(values[0]['a'], acts['a']) and same_capture == record and execution is None
     assert not list((tmp_path/'selected-cache').glob('capture-load-execution-*.json'))
+
+
+@pytest.mark.parametrize('change', ['load_policy', 'source'])
+def test_selected_load_policy_and_source_keep_existing_resume_boundaries(tmp_path, monkeypatch, change):
+    from prismaquant import tessera_campaign as campaign, production_weight_cache as pwc
+    from prismaquant.cost_stage_checkpoint import prepare_journal
+    source = {'value': 'a'*64}
+    monkeypatch.setattr(pwc, '_production_cache_source_sha256', lambda: source['value'])
+    args = SimpleNamespace(capture_load_policy=policy(), cache_dir='/first-cache')
+    def identity():
+        return campaign._campaign_checkpoint_identity(weights={'a': torch.ones(2, 2)},
+            acts={'a': torch.ones(2, 2)}, hessians={'a': torch.eye(2)}, menus={'a': []},
+            args=args, calibration_identity={'fit_ids_sha256': 'original-draw'},
+            serving_scope=None, static_scales={}, static_scale_policy='fixture')
+    before = identity()
+    journal = tmp_path/'journal'
+    prepare_journal(journal, stage='Tessera campaign', resume=True, identity=before, qnames=['a'])
+    if change == 'load_policy':
+        args.capture_load_policy = policy(buffer=2*1024**2)
+    else:
+        source['value'] = 'b'*64
+    after = identity()
+    assert before['calibration'] == after['calibration'] and before['units'] == after['units']
+    with pytest.raises(RuntimeError, match='checkpoint identity mismatch'):
+        prepare_journal(journal, stage='Tessera campaign', resume=True, identity=after, qnames=['a'])

--- a/tests/test_selected_verified_capture.py
+++ b/tests/test_selected_verified_capture.py
@@ -1,0 +1,156 @@
+"""Selected reuse keeps canonical identity while authenticating one buffer."""
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from test_tessera_calibration_cache import capture
+from test_verified_capture_load import policy
+
+
+def test_selected_cli_accepts_explicit_load_policy_before_authentication(monkeypatch, tmp_path):
+    from test_tessera_campaign_resume import _main_fixture
+    from prismaquant import tessera_calibration_cache as cc
+    from prismaquant.autoscale import BOUNDED_CAPTURE_ENV
+    campaign, _, argv, _, _ = _main_fixture(monkeypatch, tmp_path)
+    argv[argv.index('--hessian')+1] = 'require'
+    for key, value in BOUNDED_CAPTURE_ENV.items():
+        monkeypatch.setenv(key, value)
+    def reached(*args, **kwargs):
+        raise RuntimeError('actual complete-capture authentication reached')
+    monkeypatch.setattr(cc, 'authenticate_selected_capture_source', reached)
+    with pytest.raises(RuntimeError, match='complete-capture authentication reached'):
+        campaign.main([*argv, '--streaming', '--units', '/units',
+            '--calibration-census', '/census', '--calibration-cache', '/capture',
+            '--calibration-cache-sha256', 'a'*64, '--attention-implementation', 'eager',
+            '--capture-load-policy', json.dumps(policy())])
+
+
+@pytest.mark.parametrize('extra', [[], ['--streaming'], ['--units', '/units'],
+    ['--streaming', '--units', '/units', '--calibration-cache', '/capture']])
+def test_selected_policy_requires_hash_bound_selected_streaming_scope(tmp_path, extra):
+    from prismaquant.tessera_campaign import main
+    with pytest.raises(SystemExit) as error:
+        main(['--model', '/missing', '--out', str(tmp_path/'out'),
+            '--cache-dir', str(tmp_path/'cache'), '--capture-load-policy',
+            json.dumps(policy()), *extra])
+    assert error.value.code == 2
+    assert not (tmp_path/'cache').exists()
+
+
+def test_selected_admission_prices_private_buffer_source_pages_and_scratch(monkeypatch):
+    from prismaquant import autoscale
+    source = dict(live_layer_prefix='layers.',
+        terms=dict(nonbody_source_bytes=100, declared_headroom_bytes=200),
+        body_layer_bytes={'0': 1000}, body_loader_transient_bytes={'0': 100},
+        body_source_file_bytes={'0': 900}, unit_source_weight_bytes={'layers.0.proj': 24},
+        full_hessian_bytes=64, full_prefix_bytes=32, source_header_sha256='a'*64)
+    monkeypatch.setattr(autoscale, 'streamed_calibration_resources', lambda *a, **k: source)
+    kwargs = dict(unit_shapes={'layers.0.proj': [3, 4]}, counts={'layers.0.proj': 9},
+        max_act_rows=2, cache_slots=2, prefetch_workers=1, headroom_gb=0)
+    legacy = autoscale.selected_anchor_resources('/source', **kwargs)
+    verified = autoscale.selected_anchor_resources('/source', **kwargs, capture_load_policy=policy())
+    assert {name: verified['phases'][name] for name in legacy['phases']} == legacy['phases']
+    phase = verified['phases']['capture_prefetch']
+    assert phase['capture_serialized_buffer_bytes'] == policy()['max_buffer_bytes']
+    assert phase['capture_source_page_cache_bytes'] == policy()['max_buffer_bytes']
+    assert phase['capture_load_scratch_bytes'] == policy()['max_scratch_bytes']
+    assert phase['capture_decode_storage_bytes'] == 96
+    assert phase['selected_hessian_bytes'] == 64 and phase['selected_prefix_bytes'] == 32
+    assert verified['capture_load_policy'] == policy()
+    assert verified['memory_bytes'] == max(sum(p.values()) for p in verified['phases'].values())
+
+
+def test_dispatch_seals_same_selected_load_demand(monkeypatch):
+    from tools import dispatch_tessera_campaign as dispatch
+    from prismaquant import autoscale
+    seen = {}
+    def selected(model, **kwargs):
+        seen.update(kwargs)
+        return {'memory_bytes': 100}
+    monkeypatch.setattr(autoscale, 'selected_anchor_resources', selected)
+    dispatch._streamed_resource_plan(dict(model='/source', campaign_argv=[
+        '--streaming', '--capture-load-policy', json.dumps(policy())]),
+        dict(unit_shapes={'a': [3, 4]}, counts={'a': 9}), ['a'], selected_source=True)
+    assert seen['capture_load_policy'] == policy()
+
+
+def _selected_args(tmp_path, record, load_policy):
+    return SimpleNamespace(calibration_cache=record['path'],
+        calibration_cache_sha256=record['sha256'], capture_load_policy=load_policy,
+        cache_dir=str(tmp_path/'selected-cache'))
+
+
+def test_selected_prefetch_preserves_original_capture_and_records_actual_load(capture, tmp_path, monkeypatch):
+    import hashlib
+    from prismaquant import tessera_campaign as campaign, tessera_calibration_cache as cc
+    root, _, census, identity, acts, hs, record = capture
+    original_manifest = Path(record['path']).read_bytes()
+    original_files = {p: p.read_bytes() for p in (root/'inputs').glob('*.pt')}
+    reads = []
+    original = cc._verified_capture_entry
+    def tracked(path, name, **kwargs):
+        reads.append((name, kwargs['expected_sha256']))
+        return original(path, name, **kwargs)
+    monkeypatch.setattr(cc, '_verified_capture_entry', tracked)
+    args = _selected_args(tmp_path, record, policy())
+    resources = {'capture_load_policy': policy(), 'memory_bytes': 8*1024**2}
+    values, returned_capture, execution = campaign._prefetch_selected_capture(args,
+        expected_identity=identity, census=census, names=['a'], device='cpu', resources=resources)
+    assert returned_capture == record
+    assert torch.equal(values[0]['a'], acts['a']) and torch.equal(values[1]['a'], hs['a'])
+    assert values[2] == {'a': census['counts']['a']} and values[3] == {'a': census['max_abs']['a']}
+    raw = Path(execution['path']).read_bytes()
+    assert hashlib.sha256(raw).hexdigest() == execution['sha256']
+    assert execution['sha256'] in Path(execution['path']).name
+    run = json.loads(raw)
+    assert run['capture'] == record and run['resources'] == resources
+    assert run['prefetch']['policy'] == policy() and run['prefetch']['loaded_entries'] == 1
+    assert run['prefetch']['source_read_bytes'] == (root/'inputs/a.pt').stat().st_size
+    assert run['prefetch']['live_buffer_bytes'] == 0
+    assert reads == [('a', json.loads(original_manifest)['entries']['a']['sha256'])]
+    assert Path(record['path']).read_bytes() == original_manifest
+    assert all(p.read_bytes() == original for p, original in original_files.items())
+    # A different load policy gets a different execution receipt, preserving
+    # the old binding and exactly the same canonical capture/tensor identity.
+    args.capture_load_policy = policy(buffer=2*1024**2)
+    _, same_capture, other = campaign._prefetch_selected_capture(args,
+        expected_identity=identity, census=census, names=['a'], device='cpu', resources=resources)
+    assert same_capture == record and other != execution
+    assert Path(execution['path']).read_bytes() == raw
+
+
+@pytest.mark.parametrize('failure', ['capture_sha', 'artifact_sha', 'oversize', 'guard'])
+def test_selected_prefetch_refuses_without_publishing_load_authority(capture, tmp_path, failure):
+    from prismaquant import tessera_campaign as campaign
+    root, _, census, identity, _, _, record = capture
+    args = _selected_args(tmp_path, record, policy())
+    guard = None
+    if failure == 'capture_sha':
+        args.calibration_cache_sha256 = '0'*64
+    elif failure == 'artifact_sha':
+        p = root/'inputs/a.pt'
+        p.write_bytes(p.read_bytes()+b'changed')
+    elif failure == 'oversize':
+        args.capture_load_policy = policy(buffer=1)
+    else:
+        def refuse(*args, **kwargs):
+            raise RuntimeError('physical guard refusal')
+        guard = SimpleNamespace(check=refuse)
+    with pytest.raises(RuntimeError):
+        campaign._prefetch_selected_capture(args, expected_identity=identity, census=census,
+            names=['a'], device='cpu', resources={}, guard=guard)
+    assert not list(Path(args.cache_dir).glob('capture-load-execution-*.json'))
+
+
+def test_selected_legacy_reuse_keeps_its_path_and_has_no_load_receipt(capture, tmp_path, monkeypatch):
+    from prismaquant import tessera_campaign as campaign, tessera_calibration_cache as cc
+    _, _, census, identity, acts, _, record = capture
+    monkeypatch.setattr(cc, '_verified_capture_entry', lambda *a, **k: pytest.fail('legacy used verified loader'))
+    values, same_capture, execution = campaign._prefetch_selected_capture(
+        _selected_args(tmp_path, record, None), expected_identity=identity,
+        census=census, names=['a'], device='cpu', resources={})
+    assert torch.equal(values[0]['a'], acts['a']) and same_capture == record and execution is None
+    assert not list((tmp_path/'selected-cache').glob('capture-load-execution-*.json'))

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -187,7 +187,9 @@ def _streamed_resource_plan(spec, census, members, *, selected_source=False):
                         argument('--streaming-cache-headroom-gb', 24., float)))
     if selected_source:
         return selected_anchor_resources(spec['model'], **options,
-            anchor_batch_size=argument('--anchor-batch-size', 1))
+            anchor_batch_size=argument('--anchor-batch-size', 1),
+            **(dict(capture_load_policy=argument('--capture-load-policy', None, json.loads))
+               if '--capture-load-policy' in argv else {}))
     return streamed_calibration_resources(spec['model'], **options,
         nsamples=argument('--nsamples', 8), seqlen=argument('--seqlen', 512),
         capture_policy=argument('--streaming-capture-policy', 'legacy', str))


### PR DESCRIPTION
Selected streaming reuse rejected the existing verified-loader policy and read its 49.53 GB canonical capture selection twice before encoding. Allow the explicit policy on SHA-bound selected reuse, forward it through the existing prefetch, reserve the private buffer/source-page/decode/scratch phase in the shared runtime/admission plan, and bind an immutable loader execution receipt to selected-source provenance. The original capture bytes, unset default and checkpoint source/policy boundaries remain intact.

Regression-first PrismaBuild: 3 expected failures and 4 passes before the fix; 235 completed unique CPU passes and one existing CUDA-only skip afterward, plus compile checks. A 4 GiB broader resume action OOMed; its 12 GiB retry timed out after 13 progress dots. Neither counts as passed. Actual source bundles, terminal status, CAS/attestation/payload evidence and both-host baseline telemetry are committed in `experiments/measurements/selected-verified-capture-20260908/`. The focused receipt now names immutable test commit `5f12978a8bfd625b217774a81e76e662273666fd`.

This draft is stacked on #442 at `2cf67c1a6641e9bc44c7972739a6ce02d95dd645`. It cherry-picks only the reader/tests/evidence from the retained 8d8a-based tested branch. Existing loaders, resource implementation and focused tests are byte-identical to tested source; the separate unmerged family-restriction work is omitted, and the sole conflict resolved architecture history. The committed delivery source audit distinguishes this read-only comparison from a test rerun on this exact delivery tree.

Native follow-up requires #444's bounded observer and the coordinator's separately reviewed restricted-family pricing source, frozen producer and unchanged canonical capture. It must record actual load bytes, original capture binding, tensor parity, main-thread/process-I/O profile and both-host Netdata under comparable residency/resources. Native after-change I/O, speed and work-per-joule remain unmeasured; this draft claims no speedup or serving qualification. New integrated pricing must obey normal source/policy resume boundaries.

Fixes #447.
