### PR TITLE
Say what the restored variable actually means

### DIFF
--- a/prismaquant/tessera_joint_aura.py
+++ b/prismaquant/tessera_joint_aura.py
@@ -623,9 +623,11 @@ def _restores_activation_scale_env(function):
     admitted plan carries ``"0"`` (``_load_plan``), and that is the input
     which turns the render scorer's activation clip OFF for everything that
     runs afterwards (``production_weight_cache.py``, in
-    ``_local_forward_render_score``).  Nothing outside ``execute`` reads the
-    key, so restoring it on the way out leaves the campaign byte-identical
-    and leaves the process as it was found.
+    ``_local_forward_render_score``).  Plenty of code outside ``execute``
+    reads the key -- the render scorer is exactly that code, which is why the
+    leak bites -- but nothing needs THIS command's value to still be set after
+    ``execute`` has returned.  So restoring it on the way out leaves the
+    campaign byte-identical and leaves the process as it was found.
     """
     absent = object()
 


### PR DESCRIPTION
Closes #451.

The decorator added in #446 claims nothing outside `execute` reads `PRISMAQUANT_PROD_ACT_SCALES`. That is not true, and #446 is the counterexample: `production_weight_cache._local_forward_render_score` reads it, which is the entire mechanism by which a leaked `"0"` disarmed the activation clip.

What the restore actually relies on is narrower and still sound: nothing needs this command's value to persist after `execute` returns. The docstring now says that.

Wording only. No behaviour change, so no test is owed; the existing boundary test still pins both halves of the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsJAfuLU26NWbYpSLrWFHJ