### PR TITLE
fix: preserve observer sampling and concurrent progress serialization

### DIFF
--- a/docs/experiments/glm_observer_sample_recovery_20260909/README.md
+++ b/docs/experiments/glm_observer_sample_recovery_20260909/README.md
@@ -1,0 +1,21 @@
+# Continue observation after a failed Netdata sample
+
+The live selected expert action `73af05a17fa4` lost Netdata monitoring at
+01:39:43 UTC on September 9 after one response omitted its required power
+chart. The outer exception handler ended the thread, losing subsequent
+samples from both hosts while encoding continued. The original evidence is
+retained under the first-proof preparation row 0076; recovered server history
+is separately recorded and never substituted into that original stream.
+
+Catch individual sampling failures, retain bounded per-host failure counts and
+timestamps, and continue other hosts and later samples. Writer failures still
+end monitoring; any missing sample still fails the existing evidence gate.
+
+PB regression `aa80a577b9d0733dd3956481b3bbc482537adc896c037fba040f600cc708cea9`
+failed because only the first host was attempted. PB
+`ac140d7e0fb0e7a320b3fa52703884f3c970b59521adf68993343e7e50c0b273`
+passed the three observer/Netdata modules: 43 passed, 3 skipped, 7.35 seconds
+on DL380 CPU with four workers and native threads bounded to one. The skips
+are CUDA-only coverage. An earlier wrong-environment submission lacked
+compressed_tensors and did not collect; it is not a regression result.
+This changes observation recovery, not pricing, sampling values or admission.

--- a/docs/experiments/glm_observer_sample_recovery_20260909/README.md
+++ b/docs/experiments/glm_observer_sample_recovery_20260909/README.md
@@ -19,3 +19,23 @@ on DL380 CPU with four workers and native threads bounded to one. The skips
 are CUDA-only coverage. An earlier wrong-environment submission lacked
 compressed_tensors and did not collect; it is not a regression result.
 This changes observation recovery, not pricing, sampling values or admission.
+
+## Concurrent progress serialization (issue #460)
+
+A first monitor round added dictionary keys while the main thread could be
+serializing progress, raising `RuntimeError: dictionary changed size during
+iteration`. Initialize monitor counters and both host failure slots before
+starting threads; each failure record also has its complete key set before
+publication. Progress remains a non-atomic observation; the final snapshot
+follows thread shutdown and retains any errors.
+
+The deterministic regression pauses the actual JSON dictionary iterator before
+running the first monitor round, for both monitor kinds. PB
+`2093a627f4189ac9360beba0cef59b369783d8b9d3ea271ac13e99e478893b8f`
+failed both cases with the dictionary-size error. Final green PB
+`550b801d8faaea6d9895201fa0959007a9b3dc3bb3bda7f540a5019c6306f1cd`
+passed 45 tests with the same 3 CUDA-only skips in 7.40 seconds (DL380 CPU,
+four workers, one native thread each). The terminal record confirms exit 0
+and resource cleanup. The CAS result hash is
+`b966e20248cd4757ea42a8d4f8593f0e3944122d14993d0b1efa9d8b3feb5261`;
+the tested snapshot is `232e6c89ddef8faa177c604d60c19f4d01240458`.

--- a/experiments/glm_full_capture_profile.py
+++ b/experiments/glm_full_capture_profile.py
@@ -39,9 +39,11 @@ class CaptureObserver:
             cpu_affinity=sorted(os.sched_getaffinity(0)),
             kernel=os.uname().release,
             netdata=dict(hosts=['sparky', 'sparklina'], interval_seconds=5,
-                         byte_cap=3*1024**3),
+                         byte_cap=3*1024**3, bytes_written=0, samples=0,
+                         samples_scope='rounds attempted',
+                         sample_failures={'sparky': None, 'sparklina': None}),
             python_sampler=dict(scope='main_thread_only', interval_seconds=1,
-                                byte_cap=512*1024**2),
+                                byte_cap=512*1024**2, bytes_written=0, samples=0),
             profile_layers=sorted(self.profile_layers),
             forward_windows_zero_based=[[0, 1], [31, 32]])
         for name in ('srcversion', 'parameters/delegation_watermark'):
@@ -65,11 +67,11 @@ class CaptureObserver:
                                 # shutdown, but keep both hosts observable after
                                 # a transient HTTP/schema failure. Only successful
                                 # samples enter the measurement stream.
-                                failures = self.result[kind].setdefault('sample_failures', {})
+                                failures = self.result[kind]['sample_failures']
                                 now = time.time()
-                                if host not in failures:
+                                if failures[host] is None:
                                     failures[host] = dict(instrument=kind, host=host,
-                                        error=repr(error), first_failed_unix=now,
+                                        error=repr(error), last_error=repr(error), first_failed_unix=now,
                                         last_failed_unix=now, failed_samples=0)
                                     self.result['errors'].append(failures[host])
                                 failures[host].update(last_failed_unix=now,
@@ -86,7 +88,7 @@ class CaptureObserver:
                                     for x in frames],
                             process_io=Path('/proc/self/io').read_text()))
                     self.result[kind]['bytes_written'] = writer.bytes_written
-                    self.result[kind]['samples'] = self.result[kind].get('samples', 0)+1
+                    self.result[kind]['samples'] += 1
                     self.stopped.wait(self.result[kind]['interval_seconds'])
         except BaseException as error:
             self.result['errors'].append(dict(instrument=kind, error=repr(error)))

--- a/experiments/glm_full_capture_profile.py
+++ b/experiments/glm_full_capture_profile.py
@@ -58,7 +58,25 @@ class CaptureObserver:
                 while not self.stopped.is_set():
                     if kind == 'netdata':
                         for host in self.result[kind]['hosts']:
-                            writer.write(sample_netdata(host))
+                            try:
+                                sample = sample_netdata(host)
+                            except Exception as error:
+                                # Preserve the incomplete-evidence failure at
+                                # shutdown, but keep both hosts observable after
+                                # a transient HTTP/schema failure. Only successful
+                                # samples enter the measurement stream.
+                                failures = self.result[kind].setdefault('sample_failures', {})
+                                now = time.time()
+                                if host not in failures:
+                                    failures[host] = dict(instrument=kind, host=host,
+                                        error=repr(error), first_failed_unix=now,
+                                        last_failed_unix=now, failed_samples=0)
+                                    self.result['errors'].append(failures[host])
+                                failures[host].update(last_failed_unix=now,
+                                    last_error=repr(error),
+                                    failed_samples=failures[host]['failed_samples'] + 1)
+                                continue
+                            writer.write(sample)
                     else:
                         frame = sys._current_frames().get(self.main_thread)
                         frames = traceback.extract_stack(frame)

--- a/tests/test_glm_full_capture_profile.py
+++ b/tests/test_glm_full_capture_profile.py
@@ -54,3 +54,39 @@ def test_observer_preserves_forward_return_and_partial_failure(tmp_path):
     assert 'original forward failure' in result['campaign_error']
 
     assert json.loads((tmp_path/'partial/progress.json').read_text()) == result
+
+
+def test_netdata_failure_keeps_other_host_and_later_samples(tmp_path, monkeypatch):
+    from experiments import glm_full_capture_profile as module
+    observer = CaptureObserver(tmp_path/'sample-gap', profile_layers=())
+    calls = []
+    rounds = 0
+
+    def sample(host):
+        calls.append(host)
+        if len(calls) == 1:
+            raise RuntimeError('Netdata required GPU power chart missing')
+        return {'host': host, 'metrics': {'observed': True}}
+
+    def wait(_seconds):
+        nonlocal rounds
+        rounds += 1
+        if rounds == 2:
+            observer.stopped.set()
+        return observer.stopped.is_set()
+
+    monkeypatch.setattr(module, 'sample_netdata', sample)
+    monkeypatch.setattr(observer.stopped, 'wait', wait)
+    observer.monitor('netdata')
+    assert calls == ['sparky', 'sparklina', 'sparky', 'sparklina']
+    records = [json.loads(line) for line in (observer.out/'netdata.jsonl').read_text().splitlines()]
+    assert [row['host'] for row in records] == ['sparklina', 'sparky', 'sparklina']
+    assert observer.result['netdata']['samples'] == 2
+    # A lost sample remains an explicit incomplete-evidence failure, even when
+    # subsequent samples were retained. Collection recovery is not gap erasure.
+    with pytest.raises(RuntimeError, match='required profiler evidence'):
+        observer.__exit__(None, None, None)
+    result = json.loads((observer.out/'result.json').read_text())
+    assert result['status'] == 'failed'
+    assert result['errors'][0]['host'] == 'sparky'
+    assert 'GPU power chart missing' in result['errors'][0]['error']

--- a/tests/test_glm_full_capture_profile.py
+++ b/tests/test_glm_full_capture_profile.py
@@ -90,3 +90,33 @@ def test_netdata_failure_keeps_other_host_and_later_samples(tmp_path, monkeypatc
     assert result['status'] == 'failed'
     assert result['errors'][0]['host'] == 'sparky'
     assert 'GPU power chart missing' in result['errors'][0]['error']
+
+
+@pytest.mark.parametrize('kind,first_key', [('netdata', 'hosts'), ('python_sampler', 'scope')])
+def test_snapshot_survives_first_monitor_round_during_dict_iteration(tmp_path, monkeypatch, kind, first_key):
+    from experiments import glm_full_capture_profile as module
+    observer = CaptureObserver(tmp_path/kind, profile_layers=())
+    def sample(host):
+        if host == 'sparky':
+            raise RuntimeError('sample gap')
+        return {'host': host}
+    monkeypatch.setattr(module, 'sample_netdata', sample)
+    monkeypatch.setattr(observer.stopped, 'wait', lambda _: observer.stopped.set())
+    chunks = json.JSONEncoder(indent=2).iterencode(observer.result)
+    prefix = []
+    for chunk in chunks:
+        prefix.append(chunk)
+        if chunk == json.dumps(first_key):
+            break
+    else:
+        pytest.fail('snapshot never entered the monitor-owned dictionary')
+    # Force the real scheduling interleaving: JSON's dict iterator is alive
+    # while a first monitor round publishes counters and a first host failure.
+    observer.monitor(kind)
+    decoded = json.loads(''.join(prefix) + ''.join(chunks))
+    assert decoded[kind]['samples'] == 1
+    if kind == 'netdata':
+        assert decoded[kind]['sample_failures']['sparky']['failed_samples'] == 1
+        # Earlier fields can precede this monitor round in a progress snapshot.
+        # The final joined snapshot still carries the retained error.
+        assert observer.result['errors'][0]['host'] == 'sparky'


### PR DESCRIPTION
A transient missing GPU-power chart stopped the selected pricing observer’s Netdata thread, losing all later samples from both hosts while encoding continued. Continue after individual sampling failures and retain bounded per-host failure details; the final incomplete-evidence gate still fails and writer errors still stop monitoring.

A separate fix initializes monitor-owned dictionary keys before the threads start, preventing progress JSON serialization from failing when the first monitor round publishes its counters or first host failure. Progress remains non-atomic; final evidence is produced after shutdown.

Closes #458. Closes #460.

Validation through PrismaBuild: the original sampling regression fails on the old behavior; the deterministic concurrent-serialization regression fails for both monitor kinds on the old dictionary initialization. Final targeted run `550b801d8faa` passes 45 tests with 3 CUDA-only skips across the capture, selected-anchor and Netdata modules (DL380 CPU, four workers, one native thread each). Root verified the actual CAS payload, tested source, exit 0 and cleanup. Commands and full action hashes are recorded in `docs/experiments/glm_observer_sample_recovery_20260909/README.md`.
