### PR TITLE
Install the Tessera the pin names, on the fleet too

### DIFF
--- a/docs/measurements/prismaquant-tessera-pin-provisioner-2026-09-09.md
+++ b/docs/measurements/prismaquant-tessera-pin-provisioner-2026-09-09.md
@@ -1,0 +1,87 @@
+# Provisioning the Tessera pin: what a real install proves that a mock cannot
+
+Issue [PrismaQuant #455](https://github.com/RobTand/prismaquant/issues/455).
+Branch `claude/pq455-provision-tessera-pin`.
+
+`tools/provision_tessera_pin.py` installs into a fleet interpreter the Tessera
+the pin names, and then checks that it took. Its tests place a package
+directory into site-packages and ask what the tool decides, which is the right
+shape for a decision and blind to two things only a build backend does: leave
+the pinned tree's bytes alone, and install a subset of them.
+
+Both turned out to matter, and one of them had already happened.
+
+## The digest could never have matched a real install
+
+Tessera's `pyproject.toml` carries
+`[tool.setuptools.packages.find] exclude = ["tessera._dev*"]`. That subpackage
+is the repository's own tooling, and a wheel does not ship it. The pin's tree
+holds 76 files under `src/tessera`; a correct install of that tree holds 71.
+
+The tool compared the two whole. On a correctly provisioned interpreter it
+would have found drift, installed, re-probed, found the same drift and exited
+1, on every run, forever. Every synthetic test passed because the fixture
+copied the whole source directory into site-packages, so the two sides were
+equal by construction.
+
+The exclusion is now read from the pinned tree's own build configuration
+rather than known in the tool, and applied on both sides. Tessera's
+`tools/check_wheel.py` proves the same exclusion on the built artifact.
+
+## The shared pins tree is not the commit, and pip is why
+
+`/mnt/shared/tessera-pins/07ad344c3275bb2fa7ce2432f93d89945d66f4c2` digests to
+`adb6511e...` over 1256 files. A `git archive` of that commit digests to
+`926f2f03...` over 1179. The 77 extra files are `build/lib/tessera/*` plus a
+`_pb_native_moe_measure` directory: output of an earlier `pip install` run
+with the frozen tree as its build directory.
+
+Nothing served from that tree is wrong -- `build/lib` is not a package under
+`src/` and never reaches an install -- but the directory is a working copy
+wearing a commit's name, which is the state a pin exists to exclude. The tool
+now builds from a copy under `--staging-root` and re-checks the tree against
+its manifest afterwards, so the property is proved rather than arranged.
+
+**The live directory has not been repaired.** Its replacement is a rename, and
+root's campaign may hold that path open; the timing is root's.
+
+## What the acceptance runs
+
+`tools/accept_tessera_pin_provisioner.py` makes a throwaway venv, provisions
+it for real, and reads the artifacts rather than the log. Seeded from a copy
+of the live shared tree, so the repair path runs on the real bytes:
+
+| check | result |
+|---|---|
+| the install did not write into the published tree | pass, `926f2f03...`/1179 before and after |
+| the tool says the tree is intact | pass |
+| the first run installed the pin | pass, `installed the reviewed source` |
+| the second run is a no-op | pass, `none, already the reviewed source`, drift `[]` |
+| `--check-only` reports clean | pass |
+| the tree it replaced was kept | pass, `.quarantine-07ad344c...-20260909T050854Z-j_ilktv2` |
+
+`unshipped_packages` reads `["tessera._dev*"]` off the pinned tree, and the
+wheel it built (`tessera_quant-0.1.0-py3-none-any.whl`, 725628 bytes) installs
+to a package the digest matches. That equality is the thing no placed fixture
+could show.
+
+## Receipts
+
+| what | action key | where |
+|---|---|---|
+| RED, `9fe2f18f`: 6 failed, 12 passed | `3fd2bbb5d18d` | dl380g10, `pq-cpu312`, `--tag x86` |
+| GREEN: 18 passed | `b7619de49cf6` | same |
+| acceptance, unseeded | `9fbb480fd14f` | same |
+| acceptance, seeded from the live tree | `df2e22218e8d` | same |
+
+The RED is a committed intermediate, not a scratch tree: `9fe2f18f` changes
+tests only and `45a2ed6d` is the fix.
+
+## What this does not establish
+
+One interpreter, one commit, one architecture. The GB10 venv is not
+provisioned by this and should not be until root rules on the PQ #455 test
+environment contract. The exclusion is read from setuptools' `packages.find`;
+a build backend that excluded files another way would need reading another
+way. And a lock serialises publication per commit within one filesystem's
+`flock`, which is what the shared NFS mount offers and not a distributed lease.

--- a/docs/measurements/prismaquant-tessera-pin-provisioner-2026-09-09.md
+++ b/docs/measurements/prismaquant-tessera-pin-provisioner-2026-09-09.md
@@ -32,9 +32,12 @@ rather than known in the tool, and applied on both sides. Tessera's
 
 `/mnt/shared/tessera-pins/07ad344c3275bb2fa7ce2432f93d89945d66f4c2` digests to
 `adb6511e...` over 1256 files. A `git archive` of that commit digests to
-`926f2f03...` over 1179. The 77 extra files are `build/lib/tessera/*` plus a
-`_pb_native_moe_measure` directory: output of an earlier `pip install` run
-with the frozen tree as its build directory.
+`926f2f03...` over 1179. The 77 extra files are 71 under `build/` and 6 under
+`src/tessera_quant.egg-info/`: output of an earlier `pip install` run with the
+frozen tree as its build directory. An earlier draft of this page named a
+`_pb_native_moe_measure` directory among them, read off a top-level listing
+rather than the diff; it is in the commit, and the egg-info is what was
+missed.
 
 Nothing served from that tree is wrong -- `build/lib` is not a package under
 `src/` and never reaches an install -- but the directory is a working copy
@@ -42,8 +45,13 @@ wearing a commit's name, which is the state a pin exists to exclude. The tool
 now builds from a copy under `--staging-root` and re-checks the tree against
 its manifest afterwards, so the property is proved rather than arranged.
 
-**The live directory has not been repaired.** Its replacement is a rename, and
-root's campaign may hold that path open; the timing is root's.
+**The live directory has not been repaired**, and root has since ruled it
+retained as bounded evidence. Its replacement is a rename, and the repair path
+is two of them: the old name is vacated, then the new tree takes it, and
+between them the pinned path does not exist. Nothing makes that atomic, so the
+ordering is what there is to get right -- the staged tree is hashed and
+attested first, and a failure there leaves the old tree untouched. Run a repair
+when nothing is serving out of the path.
 
 ## What the acceptance runs
 
@@ -70,12 +78,20 @@ could show.
 | what | action key | where |
 |---|---|---|
 | RED, `9fe2f18f`: 6 failed, 12 passed | `3fd2bbb5d18d` | dl380g10, `pq-cpu312`, `--tag x86` |
-| GREEN: 18 passed | `b7619de49cf6` | same |
+| GREEN, `45a2ed6d`: 18 passed | `b7619de49cf6` | same |
 | acceptance, unseeded | `9fbb480fd14f` | same |
 | acceptance, seeded from the live tree | `df2e22218e8d` | same |
+| GREEN, `86e60a2f`: 19 passed | `2fc2f307ca5e` | same |
+| the ordering mutation: 1 failed, 18 passed | `b961932c705e` | same, `pb-queue/failed/` |
 
 The RED is a committed intermediate, not a scratch tree: `9fe2f18f` changes
 tests only and `45a2ed6d` is the fix.
+
+The mutation row is the same tree with one statement moved: `_write_manifest`
+back after the quarantine rename, where it sat until this round. The only test
+that fails is the one that asserts the ordering, which is what makes that test
+worth having -- a check that passes on the code it is meant to catch is not a
+check.
 
 ## What this does not establish
 
@@ -85,3 +101,9 @@ environment contract. The exclusion is read from setuptools' `packages.find`;
 a build backend that excluded files another way would need reading another
 way. And a lock serialises publication per commit within one filesystem's
 `flock`, which is what the shared NFS mount offers and not a distributed lease.
+
+`/mnt/shared/tessera-source.git` is a mirror taken once, so the default clone
+holds the commits that existed when it was made. A re-pin to a newer commit
+fails inside `git archive` with an error that names the object and not the
+mirror; `git --git-dir /mnt/shared/tessera-source.git fetch --prune origin`
+before a re-pin, or pass `--clone` a local checkout that has it.

--- a/tests/test_tessera_pin_provisioner.py
+++ b/tests/test_tessera_pin_provisioner.py
@@ -509,7 +509,10 @@ def test_the_install_does_not_run_inside_the_frozen_tree(tmp_path, monkeypatch):
             built = Path(argv[-1])
             (built / "tessera_quant.egg-info").mkdir(exist_ok=True)
             (built / "tessera_quant.egg-info" / "PKG-INFO").write_text("x")
-            return subprocess.CompletedProcess(argv, 0)
+            # capture_output=True with text=True always yields strings, and a
+            # fake that returns None for them makes the caller's own logging
+            # raise.  Answer in the shape the real call answers in.
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
         return real_run(argv, *a, **kw)
 
     monkeypatch.setattr(mod.subprocess, "run", spy)
@@ -527,3 +530,44 @@ def test_the_install_does_not_run_inside_the_frozen_tree(tmp_path, monkeypatch):
     digest, count = mod.tree_digest(tree)
     assert (digest, count) == (held["tree_sha256"], held["files"]), (
         "the install left the pinned tree failing its own manifest")
+
+
+def test_a_failure_attesting_the_replacement_leaves_the_old_tree_in_place(
+        tmp_path, monkeypatch):
+    """The repair opens a window where the path is absent; it opens it late.
+
+    Replacing a wrong tree is two renames, and between them the pinned path
+    does not exist.  Nothing can make that atomic, so the ordering is what
+    there is to get right: the staged tree is hashed and attested BEFORE the
+    old name is vacated.  A failure in that step then costs nothing a reader
+    can see.  Written the other way round the same failure leaves the pinned
+    path gone with a repair that never finished.
+    """
+    mod = _load()
+    clone, old, new = _git_clone_with_two_commits(tmp_path)
+    pins = tmp_path / "pins"
+
+    target = mod.materialise(new, clone, pins)
+    (target / "src" / "tessera" / "encode.py").write_text("VERSION = 99\n")
+
+    real = mod._write_manifest
+    calls: list[Path] = []
+
+    def failing(root, commit):
+        calls.append(Path(root))
+        raise OSError("disk full while attesting the replacement")
+
+    monkeypatch.setattr(mod, "_write_manifest", failing)
+    with pytest.raises(OSError):
+        mod.materialise(new, clone, pins)
+
+    assert calls and calls[0] != target, (
+        "the first attestation was of the published path, so the old tree had "
+        "already been vacated when it failed")
+    assert (target / "src" / "tessera" / "encode.py").read_text() == "VERSION = 99\n", (
+        "the pinned path is missing or half-repaired after a failure that "
+        "happened before anything needed to move")
+
+    monkeypatch.setattr(mod, "_write_manifest", real)
+    repaired = mod.materialise(new, clone, pins)
+    assert (repaired / "src" / "tessera" / "encode.py").read_text() == "VERSION = 2\n"

--- a/tests/test_tessera_pin_provisioner.py
+++ b/tests/test_tessera_pin_provisioner.py
@@ -52,7 +52,38 @@ def test_the_provisioner_needs_neither_prismaquant_nor_tessera():
 
 def test_a_missing_interpreter_reports_no_installed_contract():
     mod = _load()
-    assert mod.installed_contract(str(ROOT / "no-such-python")) is None
+    sha, absent = mod.installed_contract(str(ROOT / "no-such-python"))
+    assert sha is None
+    # And it says which of the three absences this is.  A bare ``None`` reads
+    # as "no venv", "no Tessera" and "no packaged contract" at once, and those
+    # want different repairs.
+    assert "FileNotFoundError" in absent
+
+
+def test_an_interpreter_without_tessera_names_the_import_that_failed(tmp_path):
+    """The GB10 venv's first audit returned an empty contract and no reason.
+
+    It was not a missing venv and not a Tessera built from the wrong commit:
+    Tessera is not installed in it at all, and the report said only ``null``.
+    The reason travels now, so the next audit reads a repair instead of a gap.
+
+    The interpreter here is a real one that really lacks Tessera, built by
+    ``venv`` in the test's own directory, rather than the running interpreter
+    under a skip.  A test that skips wherever the suite actually runs proves
+    nothing about the branch it names.
+    """
+    import venv
+
+    env = tmp_path / "bare"
+    venv.create(env, with_pip=False)
+    python = env / "bin" / "python"
+    assert python.exists()
+
+    mod = _load()
+    sha, absent = mod.installed_contract(str(python))
+    assert sha is None
+    assert "ModuleNotFoundError" in absent
+    assert "tessera" in absent
 
 
 def test_check_only_refuses_an_interpreter_that_is_not_on_the_pin(tmp_path):

--- a/tests/test_tessera_pin_provisioner.py
+++ b/tests/test_tessera_pin_provisioner.py
@@ -203,15 +203,52 @@ def _pin_module(tmp_path: Path, commit: str, contract_sha: str) -> Path:
 CONTRACT = b'{"schema": "tessera.runtime_contract.v1", "executes": []}\n'
 
 
+#: The real tree's build config excludes its own tooling subpackage from what
+#: a consumer installs, so a source tree has files an install will never have.
+#: The fixture carries that shape because the first version did not, and a
+#: fixture that copies everything into site-packages cannot see a digest which
+#: compares a source tree against an install.
+PYPROJECT = """\
+[build-system]
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tessera-quant"
+version = "0.1.0"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+exclude = ["tessera._dev*"]
+
+[tool.setuptools.package-data]
+"tessera.serving" = ["runtime_contract.json"]
+"""
+
+#: What a wheel leaves out of ``src/tessera``, as relative paths.
+NOT_INSTALLED = ("_dev",)
+
+
 def _tessera_tree(root: Path, encoder_body: str) -> None:
-    """A minimal tree shaped like Tessera's: contract under the package."""
+    """A minimal tree shaped like Tessera's: contract under the package.
+
+    Including the halves that make source and install differ: a build config
+    that excludes ``tessera._dev``, and a ``_dev`` subpackage for it to
+    exclude.
+    """
     pkg = root / "src" / "tessera" / "serving"
     pkg.mkdir(parents=True, exist_ok=True)
+    (root / "pyproject.toml").write_text(PYPROJECT, encoding="utf-8")
     (root / "src" / "tessera" / "__init__.py").write_text("", encoding="utf-8")
     (pkg / "__init__.py").write_text("", encoding="utf-8")
     (pkg / "runtime_contract.json").write_bytes(CONTRACT)
     (root / "src" / "tessera" / "encode.py").write_text(encoder_body,
                                                         encoding="utf-8")
+    dev = root / "src" / "tessera" / "_dev"
+    dev.mkdir(parents=True, exist_ok=True)
+    (dev / "__init__.py").write_text("", encoding="utf-8")
+    (dev / "tooling.py").write_text("# repository tooling, not shipped\n",
+                                    encoding="utf-8")
 
 
 def _git_clone_with_two_commits(tmp_path: Path) -> tuple[Path, str, str]:
@@ -259,6 +296,10 @@ def _venv_with_tessera(tmp_path: Path, name: str, encoder_body: str) -> Path:
     _tessera_tree(env / "staging", encoder_body)
     import shutil
     shutil.copytree(env / "staging" / "src" / "tessera", site / "tessera")
+    # A wheel does not carry what the build config excludes.  Copying the
+    # whole source directory is the shape that hid the defect below.
+    for rel in NOT_INSTALLED:
+        shutil.rmtree(site / "tessera" / rel)
     return env / "bin" / "python"
 
 
@@ -328,3 +369,154 @@ def test_a_tampered_cached_tree_is_not_reused(tmp_path):
     second = mod.materialise(new, clone, pins)
     assert (second / "src" / "tessera" / "encode.py").read_text() == "VERSION = 2\n", \
         "a cached tree whose bytes moved must be repaired, not reused"
+
+
+def test_a_subpackage_the_build_excludes_is_not_expected_in_the_install(tmp_path):
+    """A digest over the whole source tree can never match a real install.
+
+    The pinned tree's own build config excludes ``tessera._dev`` from what a
+    consumer installs, so the source has files a correct install will never
+    have.  Comparing the two directly reports drift on a correctly provisioned
+    interpreter, forever: install, re-probe, still different, exit 1.  The
+    earlier fixture copied the whole source directory into site-packages and
+    so could not see this at all.
+
+    What the digest has to compare is the source MINUS what the build config
+    says it does not ship, which is read from the pinned tree rather than
+    known here.
+    """
+    mod = _load()
+    clone, old, new = _git_clone_with_two_commits(tmp_path)
+    import hashlib
+    pin = _pin_module(tmp_path, new, hashlib.sha256(CONTRACT).hexdigest())
+    python = _venv_with_tessera(tmp_path, "venv-wheel-shaped", "VERSION = 2\n")
+
+    rc = mod.main(["--python", str(python), "--pin-source", str(pin),
+                   "--clone", str(clone), "--pins-root", str(tmp_path / "pins"),
+                   "--check-only"])
+    assert rc == 0, (
+        "an interpreter carrying exactly what a wheel of the pin installs is "
+        "on the pin; a digest that counts unshipped source files says it never is"
+    )
+
+
+def test_check_only_does_not_write_into_the_pins_root(tmp_path):
+    """``--check-only`` reports; it does not repair.
+
+    The pins root is shared across the fleet and the flag's whole contract is
+    that it changes nothing.  Materialising to learn the expected digest is a
+    write, and an operator who ran a read-only check to see where a box stood
+    would find a tree laid down by it.
+    """
+    mod = _load()
+    clone, old, new = _git_clone_with_two_commits(tmp_path)
+    import hashlib
+    pin = _pin_module(tmp_path, new, hashlib.sha256(CONTRACT).hexdigest())
+    python = _venv_with_tessera(tmp_path, "venv-ro", "VERSION = 2\n")
+    pins = tmp_path / "pins"
+    pins.mkdir()
+
+    rc = mod.main(["--python", str(python), "--pin-source", str(pin),
+                   "--clone", str(clone), "--pins-root", str(pins),
+                   "--check-only"])
+
+    assert list(pins.iterdir()) == [], (
+        "--check-only materialised the pinned tree into the shared pins root")
+    assert rc != 0, (
+        "with no verifiable source to compare against, a read-only check "
+        "cannot report clean")
+
+
+def test_a_cached_tree_that_fails_its_manifest_is_kept_not_deleted(tmp_path):
+    """A tree that does not verify is evidence, and evidence is not deleted.
+
+    Whatever edited or truncated it is unexplained, and the bytes are the only
+    record of what happened.  Replacing the tree is right; removing the thing
+    that would say why is not, and on a shared pins root it removes it for
+    everyone.
+    """
+    mod = _load()
+    clone, old, new = _git_clone_with_two_commits(tmp_path)
+    pins = tmp_path / "pins"
+
+    first = mod.materialise(new, clone, pins)
+    (first / "src" / "tessera" / "encode.py").write_text("VERSION = 99\n")
+
+    second = mod.materialise(new, clone, pins)
+    assert (second / "src" / "tessera" / "encode.py").read_text() == "VERSION = 2\n"
+
+    kept = [p for p in pins.rglob("encode.py")
+            if p.read_text() == "VERSION = 99\n"]
+    assert kept, (
+        "the tree that failed its manifest was deleted; it is the only record "
+        "of what wrote to a shared pins root")
+
+
+def test_an_unmanifested_tree_matching_the_commit_is_attested_not_replaced(tmp_path):
+    """Bytes that already are the commit do not need to be written again.
+
+    ``/mnt/shared/tessera-pins/07ad344c...`` predates the manifest and is
+    correct.  Rewriting it churns a shared directory other boxes may be
+    reading, for a tree that is already right; verifying it against a fresh
+    ``git archive`` establishes the same thing without touching it.
+    """
+    mod = _load()
+    clone, old, new = _git_clone_with_two_commits(tmp_path)
+    pins = tmp_path / "pins"
+
+    laid = mod.materialise(new, clone, pins)
+    encode = laid / "src" / "tessera" / "encode.py"
+    before = encode.stat().st_ino
+    (laid / mod.MANIFEST).unlink()               # a pre-manifest tree
+
+    again = mod.materialise(new, clone, pins)
+    assert again == laid
+    assert encode.read_text() == "VERSION = 2\n"
+    assert encode.stat().st_ino == before, (
+        "a tree that already holds the commit's bytes was rewritten rather "
+        "than verified and attested")
+    assert (laid / mod.MANIFEST).exists(), "and the manifest was not written"
+
+
+def test_the_install_does_not_run_inside_the_frozen_tree(tmp_path, monkeypatch):
+    """``pip install <dir>`` writes ``*.egg-info`` into the directory it builds.
+
+    Pointed at the pinned tree that lands inside the tree, so the manifest
+    that tree was published with stops matching it, and the next run reports
+    the pin's own source corrupt.  The build gets a copy; the frozen tree is
+    an input.
+    """
+    mod = _load()
+    clone, old, new = _git_clone_with_two_commits(tmp_path)
+    import hashlib
+    pin = _pin_module(tmp_path, new, hashlib.sha256(CONTRACT).hexdigest())
+    python = _venv_with_tessera(tmp_path, "venv-stale", "VERSION = 1\n")
+    pins = tmp_path / "pins"
+
+    seen: list[list[str]] = []
+    real_run = subprocess.run
+
+    def spy(argv, *a, **kw):
+        if "pip" in argv:
+            seen.append([str(x) for x in argv])
+            # A build backend really does write here; act like one.
+            built = Path(argv[-1])
+            (built / "tessera_quant.egg-info").mkdir(exist_ok=True)
+            (built / "tessera_quant.egg-info" / "PKG-INFO").write_text("x")
+            return subprocess.CompletedProcess(argv, 0)
+        return real_run(argv, *a, **kw)
+
+    monkeypatch.setattr(mod.subprocess, "run", spy)
+    mod.main(["--python", str(python), "--pin-source", str(pin),
+              "--clone", str(clone), "--pins-root", str(pins)])
+
+    assert seen, "no install was attempted"
+    built = Path(seen[0][-1]).resolve()
+    assert pins.resolve() not in built.parents and built != (pins / new), (
+        f"the build ran in the frozen tree at {built}")
+
+    tree = pins / new
+    held = json.loads((tree / mod.MANIFEST).read_text())
+    digest, count = mod.tree_digest(tree)
+    assert (digest, count) == (held["tree_sha256"], held["files"]), (
+        "the install left the pinned tree failing its own manifest")

--- a/tests/test_tessera_pin_provisioner.py
+++ b/tests/test_tessera_pin_provisioner.py
@@ -1,0 +1,103 @@
+"""The fleet provisioner reads the same pin CI does, and checks bytes not versions."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / "tools" / "provision_tessera_pin.py"
+RESOLVER = ROOT / "tools" / "resolve_tessera_dev_pin.py"
+
+
+def _load():
+    sys.path.insert(0, str(ROOT / "tools"))
+    try:
+        import provision_tessera_pin as mod
+    finally:
+        sys.path.pop(0)
+    return mod
+
+
+def test_the_provisioner_reads_the_commit_the_ci_resolver_prints():
+    """Two readers of one pin is how the fleet came to sit behind CI."""
+    mod = _load()
+    commit, sha = mod.reviewed_pin()
+    printed = subprocess.run(
+        [sys.executable, str(RESOLVER)],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert commit == printed
+    assert len(sha) == 64
+
+
+def test_the_provisioner_needs_neither_prismaquant_nor_tessera():
+    """It runs on an interpreter that has neither; that is the point of it.
+
+    ``prismaquant`` pulls ``compressed_tensors`` and ``tessera`` is the thing
+    being installed, so importing either here would make the tool unusable on
+    exactly the interpreter it exists to repair.
+    """
+    source = TOOL.read_text(encoding="utf-8")
+    for line in source.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("import ", "from ")):
+            assert not stripped.startswith(("import prismaquant", "from prismaquant"))
+            assert not stripped.startswith(("import tessera", "from tessera"))
+
+
+def test_a_missing_interpreter_reports_no_installed_contract():
+    mod = _load()
+    assert mod.installed_contract(str(ROOT / "no-such-python")) is None
+
+
+def test_check_only_refuses_an_interpreter_that_is_not_on_the_pin(tmp_path):
+    """Refusing is the useful answer: a green suite on stale bytes is the bug.
+
+    The stale install carried the pin's own static version ``0.1.0``, so a
+    version comparison would have called it correct.  Only the contract bytes
+    tell the two apart, and this exit status is what a provisioning check in
+    CI or a fleet audit would read.
+    """
+    completed = subprocess.run(
+        [sys.executable, str(TOOL), "--python", sys.executable, "--check-only"],
+        capture_output=True, text=True, check=False,
+    )
+    report = json.loads(completed.stdout)
+    mod = _load()
+    commit, sha = mod.reviewed_pin()
+    assert report["reviewed_commit"] == commit
+    assert report["reviewed_contract_sha256"] == sha
+    if report["installed_contract_sha256_before"] == sha:
+        assert completed.returncode == 0
+        assert report["action"] == "none, already the reviewed bytes"
+    else:
+        assert completed.returncode == 1
+        assert report["action"] == "none, --check-only"
+
+
+def test_materialise_reuses_a_tree_that_is_already_laid_down(tmp_path):
+    """A directory named for a commit either holds it or does not exist.
+
+    So a second run must not re-archive, and must not need a clone at all --
+    which is what makes the shared path usable from a worker with no Tessera
+    checkout of its own.
+    """
+    mod = _load()
+    commit = "0" * 40
+    target = tmp_path / commit
+    marker = target / mod.CONTRACT_IN_TREE
+    marker.parent.mkdir(parents=True)
+    marker.write_text("{}", encoding="utf-8")
+    assert mod.materialise(commit, tmp_path / "absent-clone", tmp_path) == target
+
+
+def test_materialise_refuses_when_it_has_no_clone_to_archive_from(tmp_path):
+    mod = _load()
+    with pytest.raises(SystemExit) as excinfo:
+        mod.materialise("0" * 40, tmp_path / "absent-clone", tmp_path)
+    assert "not a Tessera clone" in str(excinfo.value)

--- a/tests/test_tessera_pin_provisioner.py
+++ b/tests/test_tessera_pin_provisioner.py
@@ -50,10 +50,10 @@ def test_the_provisioner_needs_neither_prismaquant_nor_tessera():
             assert not stripped.startswith(("import tessera", "from tessera"))
 
 
-def test_a_missing_interpreter_reports_no_installed_contract():
+def test_a_missing_interpreter_reports_no_installed_tessera():
     mod = _load()
-    sha, absent = mod.installed_contract(str(ROOT / "no-such-python"))
-    assert sha is None
+    found, absent = mod.installed_identity(str(ROOT / "no-such-python"))
+    assert found is None
     # And it says which of the three absences this is.  A bare ``None`` reads
     # as "no venv", "no Tessera" and "no packaged contract" at once, and those
     # want different repairs.
@@ -80,8 +80,8 @@ def test_an_interpreter_without_tessera_names_the_import_that_failed(tmp_path):
     assert python.exists()
 
     mod = _load()
-    sha, absent = mod.installed_contract(str(python))
-    assert sha is None
+    found, absent = mod.installed_identity(str(python))
+    assert found is None
     assert "ModuleNotFoundError" in absent
     assert "tessera" in absent
 
@@ -89,34 +89,55 @@ def test_an_interpreter_without_tessera_names_the_import_that_failed(tmp_path):
 def test_check_only_refuses_an_interpreter_that_is_not_on_the_pin(tmp_path):
     """Refusing is the useful answer: a green suite on stale bytes is the bug.
 
-    The stale install carried the pin's own static version ``0.1.0``, so a
-    version comparison would have called it correct.  Only the contract bytes
-    tell the two apart, and this exit status is what a provisioning check in
-    CI or a fleet audit would read.
+    Run as a subprocess against a synthetic pin rather than the repository's
+    live one, because this asserts the RULE and the exit status a fleet audit
+    reads, and asserting against today's pin would make the test move whenever
+    the pin does.  The stale install this was written for carried the pin's own
+    static version ``0.1.0``, so a version comparison would have called it
+    correct.
     """
+    import hashlib
+
+    clone, old, new = _git_clone_with_two_commits(tmp_path)
+    pin = _pin_module(tmp_path, new, hashlib.sha256(CONTRACT).hexdigest())
+    python = _venv_with_tessera(tmp_path, "venv-stale", "VERSION = 1\n")
+
     completed = subprocess.run(
-        [sys.executable, str(TOOL), "--python", sys.executable, "--check-only"],
+        [sys.executable, str(TOOL), "--python", str(python),
+         "--pin-source", str(pin), "--clone", str(clone),
+         "--pins-root", str(tmp_path / "pins"), "--check-only"],
         capture_output=True, text=True, check=False,
     )
     report = json.loads(completed.stdout)
+    assert completed.returncode == 1
+    assert report["reviewed_commit"] == new
+    assert report["action"] == "none, --check-only"
+    # And it names the field that drifted, so the report is a repair order.
+    assert report["drift"] == ["package_sha256"]
+    assert report["installed_before"]["contract_sha256"] == \
+        report["expected"]["contract_sha256"]
+
+
+def test_the_provisioner_reads_the_live_pin_it_ships_with():
+    """The synthetic pin above proves the rule; this proves the wiring.
+
+    A tool that only ever ran against a test's own pin module could have the
+    literal names wrong and nothing would say so.
+    """
     mod = _load()
     commit, sha = mod.reviewed_pin()
-    assert report["reviewed_commit"] == commit
-    assert report["reviewed_contract_sha256"] == sha
-    if report["installed_contract_sha256_before"] == sha:
-        assert completed.returncode == 0
-        assert report["action"] == "none, already the reviewed bytes"
-    else:
-        assert completed.returncode == 1
-        assert report["action"] == "none, --check-only"
+    assert len(commit) == 40 and len(sha) == 64
 
 
-def test_materialise_reuses_a_tree_that_is_already_laid_down(tmp_path):
-    """A directory named for a commit either holds it or does not exist.
+def test_a_cached_tree_without_a_manifest_is_not_trusted(tmp_path):
+    """This test used to assert the opposite, and the opposite was the bug.
 
-    So a second run must not re-archive, and must not need a clone at all --
-    which is what makes the shared path usable from a worker with no Tessera
-    checkout of its own.
+    It said a directory named for a commit either holds that commit's tree or
+    does not exist, so a marker file was enough to reuse it.  That is true of
+    a content-addressed store and false of a directory: an interrupted ``tar``
+    leaves a directory with the right name and some of the right files.  A
+    cached tree is now reused only when it still digests to what its own
+    manifest records, and one without a manifest is re-materialised.
     """
     mod = _load()
     commit = "0" * 40
@@ -124,7 +145,27 @@ def test_materialise_reuses_a_tree_that_is_already_laid_down(tmp_path):
     marker = target / mod.CONTRACT_IN_TREE
     marker.parent.mkdir(parents=True)
     marker.write_text("{}", encoding="utf-8")
-    assert mod.materialise(commit, tmp_path / "absent-clone", tmp_path) == target
+    with pytest.raises(SystemExit) as excinfo:
+        mod.materialise(commit, tmp_path / "absent-clone", tmp_path)
+    assert "not a Tessera clone" in str(excinfo.value)
+
+
+def test_a_verified_cached_tree_is_reused_without_a_clone(tmp_path):
+    """And a tree that does verify is still reused, which is the point of it.
+
+    A worker with no Tessera checkout has to be able to install from the
+    shared path; requiring a clone every time would move the cost this cache
+    exists to remove.
+    """
+    mod = _load()
+    clone, old, new = _git_clone_with_two_commits(tmp_path)
+    pins = tmp_path / "pins"
+    first = mod.materialise(new, clone, pins)
+    assert (first / mod.MANIFEST).exists()
+
+    again = mod.materialise(new, tmp_path / "absent-clone", pins)
+    assert again == first
+    assert (again / "src" / "tessera" / "encode.py").read_text() == "VERSION = 2\n"
 
 
 def test_materialise_refuses_when_it_has_no_clone_to_archive_from(tmp_path):

--- a/tests/test_tessera_pin_provisioner.py
+++ b/tests/test_tessera_pin_provisioner.py
@@ -132,3 +132,158 @@ def test_materialise_refuses_when_it_has_no_clone_to_archive_from(tmp_path):
     with pytest.raises(SystemExit) as excinfo:
         mod.materialise("0" * 40, tmp_path / "absent-clone", tmp_path)
     assert "not a Tessera clone" in str(excinfo.value)
+
+
+# --- the same-contract, different-source regression (root, PR461 review) -----
+#
+# The pin names a COMMIT.  ``runtime_contract.json`` is one file in that
+# commit's tree, and two commits can publish identical contract bytes while
+# differing everywhere else -- tessera#437 is exactly that: it rewrites the
+# window encoder and leaves the contract alone.  A gate that compares only the
+# contract therefore reports "already the reviewed bytes" for a re-pin whose
+# whole point is new encoder code, and leaves the old encoder installed.  These
+# tests were written red against that gate.
+
+
+def _pin_module(tmp_path: Path, commit: str, contract_sha: str) -> Path:
+    """A stand-in for ``prismaquant/tessera_runtime_contract.py``.
+
+    The real one is the repository's live pin and moves with re-pins; a test
+    that asserted against it would be asserting today's pin, not the rule.
+    """
+    p = tmp_path / "pin_module.py"
+    p.write_text(
+        f'TESSERA_DEV_PIN_COMMIT = "{commit}"\n'
+        f'TESSERA_DEV_PIN_CONTRACT_SHA256 = "{contract_sha}"\n',
+        encoding="utf-8")
+    return p
+
+
+CONTRACT = b'{"schema": "tessera.runtime_contract.v1", "executes": []}\n'
+
+
+def _tessera_tree(root: Path, encoder_body: str) -> None:
+    """A minimal tree shaped like Tessera's: contract under the package."""
+    pkg = root / "src" / "tessera" / "serving"
+    pkg.mkdir(parents=True, exist_ok=True)
+    (root / "src" / "tessera" / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "runtime_contract.json").write_bytes(CONTRACT)
+    (root / "src" / "tessera" / "encode.py").write_text(encoder_body,
+                                                        encoding="utf-8")
+
+
+def _git_clone_with_two_commits(tmp_path: Path) -> tuple[Path, str, str]:
+    """A clone whose second commit changes the encoder and not the contract."""
+    clone = tmp_path / "tessera-clone"
+    clone.mkdir()
+    run = lambda *a: subprocess.run(["git", "-C", str(clone), *a], check=True,
+                                    capture_output=True)
+    subprocess.run(["git", "init", "-q", str(clone)], check=True,
+                   capture_output=True)
+    run("config", "user.email", "t@example.invalid")
+    run("config", "user.name", "t")
+    _tessera_tree(clone, "VERSION = 1\n")
+    run("add", "-A")
+    run("commit", "-q", "-m", "old encoder")
+    old = subprocess.run(["git", "-C", str(clone), "rev-parse", "HEAD"],
+                         check=True, capture_output=True,
+                         text=True).stdout.strip()
+    _tessera_tree(clone, "VERSION = 2\n")          # contract byte-identical
+    run("add", "-A")
+    run("commit", "-q", "-m", "new encoder, same contract")
+    new = subprocess.run(["git", "-C", str(clone), "rev-parse", "HEAD"],
+                         check=True, capture_output=True,
+                         text=True).stdout.strip()
+    return clone, old, new
+
+
+def _venv_with_tessera(tmp_path: Path, name: str, encoder_body: str) -> Path:
+    """A real interpreter carrying a Tessera-shaped package in site-packages.
+
+    Placed rather than pip-installed: the regression is about what the tool
+    DECIDES, and a build backend in the loop would add a network dependency
+    and a second failure mode without adding evidence.
+    """
+    import sysconfig
+    import venv
+
+    env = tmp_path / name
+    venv.create(env, with_pip=False)
+    site = env / "lib" / f"python{sys.version_info.major}.{sys.version_info.minor}" / "site-packages"
+    if not site.exists():                       # non-posix_prefix layouts
+        site = Path(sysconfig.get_paths()["purelib"].replace(
+            sys.prefix, str(env)))
+        site.mkdir(parents=True, exist_ok=True)
+    _tessera_tree(env / "staging", encoder_body)
+    import shutil
+    shutil.copytree(env / "staging" / "src" / "tessera", site / "tessera")
+    return env / "bin" / "python"
+
+
+def test_same_contract_with_older_source_is_not_already_the_reviewed_bytes(tmp_path):
+    """The regression root found: a re-pin that only moves code is a no-op.
+
+    The interpreter carries the OLD encoder under the SAME contract bytes the
+    new pin reviews.  A contract-only gate says there is nothing to do; there
+    is, and it is the entire content of the re-pin.
+    """
+    mod = _load()
+    clone, old, new = _git_clone_with_two_commits(tmp_path)
+    import hashlib
+    contract_sha = hashlib.sha256(CONTRACT).hexdigest()
+    pin = _pin_module(tmp_path, new, contract_sha)
+    python = _venv_with_tessera(tmp_path, "venv-old", "VERSION = 1\n")
+
+    rc = mod.main(["--python", str(python), "--pin-source", str(pin),
+                   "--clone", str(clone), "--pins-root", str(tmp_path / "pins"),
+                   "--check-only"])
+    assert rc != 0, "an interpreter on the wrong source must not report clean"
+
+
+def test_the_matching_source_is_reported_clean(tmp_path):
+    """And the other direction, so the check above is not vacuously red."""
+    mod = _load()
+    clone, old, new = _git_clone_with_two_commits(tmp_path)
+    import hashlib
+    pin = _pin_module(tmp_path, new, hashlib.sha256(CONTRACT).hexdigest())
+    python = _venv_with_tessera(tmp_path, "venv-new", "VERSION = 2\n")
+
+    rc = mod.main(["--python", str(python), "--pin-source", str(pin),
+                   "--clone", str(clone), "--pins-root", str(tmp_path / "pins"),
+                   "--check-only"])
+    assert rc == 0
+
+
+def test_a_truncated_cached_tree_is_not_reused(tmp_path):
+    """``materialise`` trusted a directory name and one marker file.
+
+    A tree left half-extracted by an interrupted tar, or edited afterwards,
+    still has ``runtime_contract.json`` and still has the commit's name on it.
+    Reusing it installs something that is not the commit, under the commit's
+    label, which is the failure the pin exists to prevent.
+    """
+    mod = _load()
+    clone, old, new = _git_clone_with_two_commits(tmp_path)
+    pins = tmp_path / "pins"
+
+    first = mod.materialise(new, clone, pins)
+    assert (first / "src" / "tessera" / "encode.py").read_text() == "VERSION = 2\n"
+
+    (first / "src" / "tessera" / "encode.py").unlink()          # truncated
+    second = mod.materialise(new, clone, pins)
+    assert (second / "src" / "tessera" / "encode.py").read_text() == "VERSION = 2\n", \
+        "a cached tree missing a file must be repaired, not reused"
+
+
+def test_a_tampered_cached_tree_is_not_reused(tmp_path):
+    """Same rule for a tree whose bytes were changed rather than removed."""
+    mod = _load()
+    clone, old, new = _git_clone_with_two_commits(tmp_path)
+    pins = tmp_path / "pins"
+
+    first = mod.materialise(new, clone, pins)
+    (first / "src" / "tessera" / "encode.py").write_text("VERSION = 99\n")
+    second = mod.materialise(new, clone, pins)
+    assert (second / "src" / "tessera" / "encode.py").read_text() == "VERSION = 2\n", \
+        "a cached tree whose bytes moved must be repaired, not reused"

--- a/tests/test_tessera_pin_provisioner.py
+++ b/tests/test_tessera_pin_provisioner.py
@@ -101,6 +101,9 @@ def test_check_only_refuses_an_interpreter_that_is_not_on_the_pin(tmp_path):
     clone, old, new = _git_clone_with_two_commits(tmp_path)
     pin = _pin_module(tmp_path, new, hashlib.sha256(CONTRACT).hexdigest())
     python = _venv_with_tessera(tmp_path, "venv-stale", "VERSION = 1\n")
+    # --check-only reads a source that already verifies and writes none, so
+    # the source is published first, the way a provisioning run leaves it.
+    _load().materialise(new, clone, tmp_path / "pins")
 
     completed = subprocess.run(
         [sys.executable, str(TOOL), "--python", str(python),
@@ -316,6 +319,7 @@ def test_same_contract_with_older_source_is_not_already_the_reviewed_bytes(tmp_p
     contract_sha = hashlib.sha256(CONTRACT).hexdigest()
     pin = _pin_module(tmp_path, new, contract_sha)
     python = _venv_with_tessera(tmp_path, "venv-old", "VERSION = 1\n")
+    mod.materialise(new, clone, tmp_path / "pins")   # --check-only only reads
 
     rc = mod.main(["--python", str(python), "--pin-source", str(pin),
                    "--clone", str(clone), "--pins-root", str(tmp_path / "pins"),
@@ -330,6 +334,7 @@ def test_the_matching_source_is_reported_clean(tmp_path):
     import hashlib
     pin = _pin_module(tmp_path, new, hashlib.sha256(CONTRACT).hexdigest())
     python = _venv_with_tessera(tmp_path, "venv-new", "VERSION = 2\n")
+    mod.materialise(new, clone, tmp_path / "pins")
 
     rc = mod.main(["--python", str(python), "--pin-source", str(pin),
                    "--clone", str(clone), "--pins-root", str(tmp_path / "pins"),
@@ -390,6 +395,7 @@ def test_a_subpackage_the_build_excludes_is_not_expected_in_the_install(tmp_path
     import hashlib
     pin = _pin_module(tmp_path, new, hashlib.sha256(CONTRACT).hexdigest())
     python = _venv_with_tessera(tmp_path, "venv-wheel-shaped", "VERSION = 2\n")
+    mod.materialise(new, clone, tmp_path / "pins")
 
     rc = mod.main(["--python", str(python), "--pin-source", str(pin),
                    "--clone", str(clone), "--pins-root", str(tmp_path / "pins"),
@@ -508,7 +514,8 @@ def test_the_install_does_not_run_inside_the_frozen_tree(tmp_path, monkeypatch):
 
     monkeypatch.setattr(mod.subprocess, "run", spy)
     mod.main(["--python", str(python), "--pin-source", str(pin),
-              "--clone", str(clone), "--pins-root", str(pins)])
+              "--clone", str(clone), "--pins-root", str(pins),
+              "--staging-root", str(tmp_path / "staging")])
 
     assert seen, "no install was attempted"
     built = Path(seen[0][-1]).resolve()

--- a/tools/accept_tessera_pin_provisioner.py
+++ b/tools/accept_tessera_pin_provisioner.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Real-install acceptance for ``tools/provision_tessera_pin.py``.
+
+Every other test of that tool places a package directory into site-packages
+and asks what the tool DECIDES.  That is the right shape for a decision, and
+it cannot see the two things only a build backend does: leave the pinned
+tree's frozen bytes alone, and install a subset of them.
+
+So this one builds.  It creates a throwaway venv, runs the provisioner into
+it, and then checks three properties on the artifacts rather than on the log:
+
+1. the pinned tree still digests to the manifest it was published with, so
+   the backend wrote its ``egg-info`` somewhere else;
+2. the interpreter now reports the pin's identity, which is the digest over
+   what the wheel actually installed;
+3. a second run is a no-op, which is the property the whole tool exists for
+   and the one a contract-only gate could not deliver.
+
+Run through PrismaBuild on x86; the venv it makes is deleted at the end.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import venv
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / "tools" / "provision_tessera_pin.py"
+sys.path.insert(0, str(ROOT / "tools"))
+import provision_tessera_pin as pin                        # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--clone", type=Path, default=pin.DEFAULT_CLONE)
+    ap.add_argument("--pins-root", type=Path, default=pin.DEFAULT_PINS_ROOT)
+    ap.add_argument("--work", type=Path, required=True,
+                    help="scratch root for the throwaway venv and the build")
+    ap.add_argument("--seed-from", type=Path,
+                    help="copy this tree into pins-root/<commit> first, to "
+                         "reproduce a cached tree the tool has to judge")
+    args = ap.parse_args()
+
+    commit, _ = pin.reviewed_pin()
+    args.work.mkdir(parents=True, exist_ok=True)
+    env = args.work / "venv"
+    if env.exists():
+        shutil.rmtree(env)
+    venv.create(env, with_pip=True)
+    python = env / "bin" / "python"
+
+    out: dict = {"commit": commit, "venv": str(env)}
+
+    def run(*extra: str) -> tuple[int, dict]:
+        done = subprocess.run(
+            [sys.executable, str(TOOL), "--python", str(python),
+             "--clone", str(args.clone), "--pins-root", str(args.pins_root),
+             "--staging-root", str(args.work / "staging"), *extra],
+            capture_output=True, text=True)
+        sys.stderr.write(done.stderr)
+        return done.returncode, json.loads(done.stdout or "{}")
+
+    source = args.pins_root / commit
+    if args.seed_from is not None and not source.exists():
+        args.pins_root.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(args.seed_from, source, symlinks=True)
+    before = pin.tree_digest(source) if source.exists() else None
+    out["source_digest_before"] = before
+
+    rc1, first = run()
+    out["first"] = {"rc": rc1, "action": first.get("action"),
+                    "drift": first.get("drift"),
+                    "built_from": first.get("built_from"),
+                    "unshipped_packages": first.get("unshipped_packages"),
+                    "source_intact_after_install":
+                        first.get("source_intact_after_install")}
+
+    after = pin.tree_digest(source)
+    out["source_digest_after"] = after
+
+    rc2, second = run()
+    out["second"] = {"rc": rc2, "action": second.get("action"),
+                     "drift": second.get("drift")}
+
+    rc3, third = run("--check-only")
+    out["check_only"] = {"rc": rc3, "action": third.get("action")}
+
+    quarantined = first.get("quarantined")
+    out["quarantined"] = quarantined
+    out["quarantine_kept"] = (
+        Path(quarantined).is_dir() if quarantined else None)
+    out["published_holds_its_manifest"] = pin._manifest_holds(source, commit)
+    checks = {
+        # The published tree still answers the manifest it was published with,
+        # so the backend's egg-info and build/ went to the copy.  Checked here
+        # on the artifact as well as by the tool, because the tool reporting
+        # its own property is the thing under test.
+        "the install did not write into the published tree":
+            out["published_holds_its_manifest"],
+        "the tool says the tree is intact": first.get("source_intact_after_install") is True,
+        "the first run installed the pin": rc1 == 0,
+        "the second run is a no-op": rc2 == 0 and second.get("drift") == [],
+        "check-only reports clean": rc3 == 0,
+    }
+    if quarantined:
+        checks["the tree it replaced was kept"] = out["quarantine_kept"] is True
+    out["checks"] = checks
+    shutil.rmtree(env, ignore_errors=True)
+    shutil.rmtree(args.work / "staging", ignore_errors=True)
+    print(json.dumps(out, indent=1))
+    failed = [name for name, ok in checks.items() if not ok]
+    if failed:
+        print("FAILED: " + "; ".join(failed), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/accept_tessera_pin_provisioner.py
+++ b/tools/accept_tessera_pin_provisioner.py
@@ -52,6 +52,12 @@ def main() -> int:
         shutil.rmtree(env)
     venv.create(env, with_pip=True)
     python = env / "bin" / "python"
+    # The provisioner installs with --no-build-isolation, which is right for a
+    # fleet venv that already carries setuptools and wrong for a venv made two
+    # lines ago: 3.12 stopped seeding it.  Giving the throwaway one the build
+    # backend keeps the acceptance about the provisioner.
+    subprocess.run([str(python), "-m", "pip", "install", "-q", "setuptools"],
+                   check=True)
 
     out: dict = {"commit": commit, "venv": str(env)}
 

--- a/tools/provision_tessera_pin.py
+++ b/tools/provision_tessera_pin.py
@@ -65,7 +65,9 @@ PIN_SOURCE = ROOT / "prismaquant" / "tessera_runtime_contract.py"
 PIN_NAME = "TESSERA_DEV_PIN_COMMIT"
 SHA_NAME = "TESSERA_DEV_PIN_CONTRACT_SHA256"
 DEFAULT_PINS_ROOT = Path("/mnt/shared/tessera-pins")
-DEFAULT_CLONE = Path("/home/rob/tessera")
+#: A bare mirror on the shared mount, because a fleet worker has no
+#: Tessera worktree and every worker must be able to archive the pin.
+DEFAULT_CLONE = Path("/mnt/shared/tessera-source.git")
 CONTRACT_IN_TREE = Path("src/tessera/serving/runtime_contract.json")
 PACKAGE_IN_TREE = Path("src/tessera")
 PYPROJECT_IN_TREE = Path("pyproject.toml")
@@ -189,8 +191,22 @@ def package_digest(root: Path, unshipped: list[str] | None = None):
     return tree_digest(root, _package_skip(unshipped or []))
 
 
+def _is_git_repository(path: Path) -> bool:
+    """A worktree or a bare repository; the shared mirror is the latter.
+
+    ``(path / ".git").exists()`` was the earlier test and it refuses a bare
+    repository, which is the only form that can live on the shared mount for
+    every worker to archive from -- and no fleet worker but the one that made
+    it has a Tessera worktree.
+    """
+    done = subprocess.run(
+        ["git", "--no-optional-locks", "-C", str(path), "rev-parse",
+         "--git-dir"], capture_output=True, text=True)
+    return done.returncode == 0
+
+
 def _archive_into(commit: str, clone: Path, dest: Path) -> None:
-    if not (clone / ".git").exists():
+    if not _is_git_repository(clone):
         raise SystemExit(f"{clone} is not a Tessera clone; pass --clone")
     dest.mkdir(parents=True, exist_ok=True)
     archive = subprocess.run(

--- a/tools/provision_tessera_pin.py
+++ b/tools/provision_tessera_pin.py
@@ -40,8 +40,10 @@ content-addressed store, whatever its name suggests: an interrupted ``tar``
 leaves one with the right name and some of the right files.  So each tree is
 written beside a manifest of its own digest, published with an atomic
 ``os.replace``, and reused only while it still digests to what the manifest
-says.  A tree that does not, or that has no manifest, is re-materialised, which
-needs the clone.
+says.  A tree with no manifest is not assumed wrong: it is compared against a
+fresh ``git archive`` and, when the bytes are the commit's, attested where it
+stands.  Only a tree that neither holds its manifest nor matches the archive is
+replaced, and the old one is kept.  Both of those paths need the clone.
 """
 from __future__ import annotations
 
@@ -294,23 +296,34 @@ def materialise(commit: str, clone: Path, pins_root: Path,
     collapsed them into one:
 
     * **Manifested and matching.** Reused, no clone needed.
-    * **No manifest, right bytes.** ``/mnt/shared/tessera-pins/07ad344c...``
-      predates the manifest and is correct.  Its content is compared against a
-      fresh ``git archive`` of the commit and, when equal, the manifest is
-      written beside it.  The bytes are not replaced: rewriting a shared
-      directory other boxes may be reading, to end with what is already there,
-      is churn with a window in it.
+    * **No manifest, right bytes.**  A tree written before this tool existed,
+      or by a run that died after extracting and before attesting, is not
+      assumed wrong.  Its content is compared against a fresh ``git archive``
+      of the commit and, when equal, the manifest is written beside it.  The
+      bytes are not replaced: rewriting a shared directory other boxes may be
+      reading, to end with what is already there, is churn with a window in it.
     * **Anything else.** The tree is moved aside under a
       ``.quarantine-<commit>-...`` name and the fresh archive published in its
       place.  It is not deleted.  Something wrote to a shared pins root and
       those bytes are the only record of what; the quarantine path is returned
       in ``report`` so a run says where it went.
 
-    Publication is ``os.replace`` of a directory that is complete and already
-    manifested, so a reader sees the old tree or the new one.  Staging is
-    ``mkdtemp`` under the pins root -- unique and owned, where the earlier
-    PID-named scratch could collide between hosts on NFS and was removed by
-    name, which is a directory another box may be extracting into.
+    **The repair path is not an atomic exchange, and needs a quiescent
+    reader.**  A first publication is one ``os.replace`` onto a name that does
+    not exist yet, so a reader sees nothing or the whole tree.  Replacing a
+    wrong tree is two: the old name is vacated, then the new tree takes it.
+    Between them the path is *absent*, and a reader opening it then gets
+    ``FileNotFoundError`` rather than either version.  The manifest is written
+    on the staged tree first, so a failure while hashing or attesting the
+    replacement leaves the old tree still in place and the window unopened;
+    once the quarantine rename has run the window is open until the second
+    rename lands.  It is short and it is not zero.  Run a repair when nothing
+    is serving out of that path, and read ``report["quarantined"]`` for where
+    the predecessor went.
+
+    Staging is ``mkdtemp`` under the pins root -- unique and owned, where the
+    earlier PID-named scratch could collide between hosts on NFS and was
+    removed by name, which is a directory another box may be extracting into.
     """
     target = pins_root / commit
     if _manifest_holds(target, commit):
@@ -330,6 +343,10 @@ def materialise(commit: str, clone: Path, pins_root: Path,
             _archive_into(commit, clone, fresh)
             if not (fresh / CONTRACT_IN_TREE).exists():
                 raise SystemExit(f"{commit} carries no {CONTRACT_IN_TREE}")
+            # Attested while it is still staging, and before any existing tree
+            # is vacated: a failure hashing or writing this metadata then
+            # leaves the old tree in place instead of leaving the path absent.
+            _write_manifest(fresh, commit)
 
             if target.exists():
                 if tree_digest(target)[0] == tree_digest(fresh)[0]:
@@ -347,7 +364,6 @@ def materialise(commit: str, clone: Path, pins_root: Path,
                 if report is not None:
                     report["quarantined"] = str(quarantine)
 
-            _write_manifest(fresh, commit)
             os.replace(fresh, target)
             if report is not None:
                 report.setdefault("source_state", "published from the clone")

--- a/tools/provision_tessera_pin.py
+++ b/tools/provision_tessera_pin.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Install the Tessera the pin names into an interpreter, and check the bytes.
+
+GitHub CI checks out ``RobTand/tessera`` at the commit
+``tools/resolve_tessera_dev_pin.py`` prints and runs
+``pip install --no-deps`` on that directory.  Nothing did the same for the
+fleet interpreters, so ``/home/rob/venvs/pq-cpu312`` sat on a Tessera from an
+ancestor of the pin: answer-equivalent, different bytes, and every
+byte-identity assertion red in PrismaBuild while green in CI (issue #455).
+
+This is that missing step, written so a re-pin can carry it.  A re-pin is
+already a reviewed change to the pin JSON and the module constants together;
+run this on the same change and the fleet moves with them instead of behind
+them.
+
+The pin is read the way the resolver reads it -- parsed out of
+``prismaquant/tessera_runtime_contract.py`` -- so this tool imports neither
+PrismaQuant nor Tessera and runs on an interpreter that has neither.  The
+reviewed contract hash is read from the same file for the same reason, and it
+is the check that actually bites: a matching version string proves nothing,
+because the pin's version is static ``0.1.0`` and so was the stale install's.
+
+Usage::
+
+    python tools/provision_tessera_pin.py --python /home/rob/venvs/pq-cpu312/bin/python
+
+By default the source is materialised under ``/mnt/shared/tessera-pins/<commit>``
+from a local Tessera clone, which is content-addressed by construction: a
+directory named for a commit either holds that commit's tree or does not exist.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PIN_SOURCE = ROOT / "prismaquant" / "tessera_runtime_contract.py"
+PIN_NAME = "TESSERA_DEV_PIN_COMMIT"
+SHA_NAME = "TESSERA_DEV_PIN_CONTRACT_SHA256"
+DEFAULT_PINS_ROOT = Path("/mnt/shared/tessera-pins")
+DEFAULT_CLONE = Path("/home/rob/tessera")
+CONTRACT_IN_TREE = Path("src/tessera/serving/runtime_contract.json")
+
+
+def _literal(name: str, source: Path = PIN_SOURCE) -> str:
+    """The one literal ``name`` assignment in ``source``, as a string."""
+
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    values: list[object] = []
+    for node in tree.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if any(
+            isinstance(target, ast.Name) and target.id == name
+            for target in targets
+        ):
+            values.append(ast.literal_eval(node.value))
+    if len(values) != 1:
+        raise SystemExit(f"{source}: expected exactly one literal {name}")
+    value = values[0]
+    if not isinstance(value, str):
+        raise SystemExit(f"{source}: {name} is not a string literal")
+    return value
+
+
+def reviewed_pin(source: Path = PIN_SOURCE) -> tuple[str, str]:
+    """The reviewed ``(commit, contract_sha256)`` pair."""
+
+    commit = _literal(PIN_NAME, source)
+    if re.fullmatch(r"[0-9a-f]{40}", commit) is None:
+        raise SystemExit(f"{source}: {PIN_NAME} must be a full lowercase Git SHA")
+    sha = _literal(SHA_NAME, source)
+    if re.fullmatch(r"[0-9a-f]{64}", sha) is None:
+        raise SystemExit(f"{source}: {SHA_NAME} must be a lowercase sha256")
+    return commit, sha
+
+
+def materialise(commit: str, clone: Path, pins_root: Path) -> Path:
+    """Lay down ``commit``'s tree under ``pins_root``, or reuse what is there."""
+
+    target = pins_root / commit
+    marker = target / CONTRACT_IN_TREE
+    if marker.exists():
+        return target
+    if not (clone / ".git").exists():
+        raise SystemExit(
+            f"{clone} is not a Tessera clone; pass --clone or pre-populate {target}"
+        )
+    target.mkdir(parents=True, exist_ok=True)
+    archive = subprocess.run(
+        ["git", "--no-optional-locks", "-C", str(clone),
+         "archive", "--format=tar", commit],
+        check=True, stdout=subprocess.PIPE,
+    )
+    subprocess.run(["tar", "-x", "-C", str(target)],
+                   check=True, input=archive.stdout)
+    if not marker.exists():
+        raise SystemExit(f"{commit} carries no {CONTRACT_IN_TREE}")
+    return target
+
+
+def installed_contract(python: str) -> str | None:
+    """The sha256 of the contract that interpreter's Tessera actually packages."""
+
+    probe = (
+        "import hashlib,sys\n"
+        "from importlib import resources\n"
+        "try:\n"
+        "    p = resources.files('tessera.serving')"
+        ".joinpath('runtime_contract.json')\n"
+        "    sys.stdout.write(hashlib.sha256(p.read_bytes()).hexdigest())\n"
+        "except Exception:\n"
+        "    sys.stdout.write('')\n"
+    )
+    try:
+        got = subprocess.run([python, "-c", probe],
+                             capture_output=True, text=True).stdout.strip()
+    except OSError:
+        # No such interpreter, or one that will not start.  The caller wants
+        # "not the reviewed bytes", and an exception here would make a routine
+        # audit of a machine that has no such venv look like a tool failure.
+        return None
+    return got or None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--python", required=True,
+                        help="interpreter to provision")
+    parser.add_argument("--clone", type=Path, default=DEFAULT_CLONE,
+                        help="local Tessera clone to archive the pin from")
+    parser.add_argument("--pins-root", type=Path, default=DEFAULT_PINS_ROOT,
+                        help="where pinned source trees are materialised")
+    parser.add_argument("--check-only", action="store_true",
+                        help="report the installed contract, install nothing")
+    args = parser.parse_args(argv)
+
+    commit, reviewed_sha = reviewed_pin()
+    before = installed_contract(args.python)
+    report = {
+        "python": args.python,
+        "reviewed_commit": commit,
+        "reviewed_contract_sha256": reviewed_sha,
+        "installed_contract_sha256_before": before,
+    }
+
+    if before == reviewed_sha:
+        report["action"] = "none, already the reviewed bytes"
+        print(json.dumps(report, indent=1))
+        return 0
+    if args.check_only:
+        report["action"] = "none, --check-only"
+        print(json.dumps(report, indent=1))
+        return 1
+
+    source = materialise(commit, args.clone, args.pins_root)
+    on_disk = hashlib.sha256(
+        (source / CONTRACT_IN_TREE).read_bytes()
+    ).hexdigest()
+    if on_disk != reviewed_sha:
+        raise SystemExit(
+            f"{source} publishes contract {on_disk}, reviewed is {reviewed_sha}"
+        )
+    report["source"] = str(source)
+
+    subprocess.run(
+        [args.python, "-m", "pip", "install", "--no-deps",
+         "--no-build-isolation", "--force-reinstall", str(source)],
+        check=True,
+    )
+
+    after = installed_contract(args.python)
+    report["installed_contract_sha256_after"] = after
+    if after != reviewed_sha:
+        report["action"] = "installed, and it did NOT take"
+        print(json.dumps(report, indent=1))
+        return 1
+    report["action"] = "installed the reviewed bytes"
+    print(json.dumps(report, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/provision_tessera_pin.py
+++ b/tools/provision_tessera_pin.py
@@ -15,18 +15,33 @@ them.
 
 The pin is read the way the resolver reads it -- parsed out of
 ``prismaquant/tessera_runtime_contract.py`` -- so this tool imports neither
-PrismaQuant nor Tessera and runs on an interpreter that has neither.  The
-reviewed contract hash is read from the same file for the same reason, and it
-is the check that actually bites: a matching version string proves nothing,
-because the pin's version is static ``0.1.0`` and so was the stale install's.
+PrismaQuant nor Tessera and runs on an interpreter that has neither.
+
+**The pin names a commit, and the check has to be the commit.**  An earlier
+version of this tool compared the packaged ``runtime_contract.json`` alone and
+stopped there.  That file is one file in the commit's tree, and two commits can
+publish identical contract bytes while differing everywhere else -- tessera#437
+rewrites the window encoder and leaves the contract untouched -- so a
+contract-only gate reports "already the reviewed bytes" for a re-pin whose
+entire content is new encoder code, and leaves the old encoder installed.  What
+is compared now is a digest over the installed ``tessera`` package's own files
+as well, taken under ``-I`` so it is the installed distribution answering and
+not a checkout that happens to be on ``PYTHONPATH``.  The version string is no
+check at all: the pin's version is static ``0.1.0`` and so was the stale
+install's.
 
 Usage::
 
     python tools/provision_tessera_pin.py --python /home/rob/venvs/pq-cpu312/bin/python
 
 By default the source is materialised under ``/mnt/shared/tessera-pins/<commit>``
-from a local Tessera clone, which is content-addressed by construction: a
-directory named for a commit either holds that commit's tree or does not exist.
+from a local Tessera clone.  That directory is a cache and not a
+content-addressed store, whatever its name suggests: an interrupted ``tar``
+leaves one with the right name and some of the right files.  So each tree is
+written beside a manifest of its own digest, published with an atomic
+``os.replace``, and reused only while it still digests to what the manifest
+says.  A tree that does not, or that has no manifest, is re-materialised, which
+needs the clone.
 """
 from __future__ import annotations
 
@@ -34,7 +49,9 @@ import argparse
 import ast
 import hashlib
 import json
+import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -82,70 +99,217 @@ def reviewed_pin(source: Path = PIN_SOURCE) -> tuple[str, str]:
     return commit, sha
 
 
-def materialise(commit: str, clone: Path, pins_root: Path) -> Path:
-    """Lay down ``commit``'s tree under ``pins_root``, or reuse what is there."""
+MANIFEST = ".pinned-source.json"
+#: Compiled bytecode is not source and does not travel with a commit, so it is
+#: excluded from every digest here.  A tree's identity would otherwise depend
+#: on whether anything had imported it, which is how an encoder identity hash
+#: once came to cover ``.pyc`` files.
+SKIP_DIRS = {"__pycache__", ".git"}
+SKIP_SUFFIXES = {".pyc", ".pyo"}
+#: Excluded by name: it is written into the tree it describes.
+SKIP_NAMES = {MANIFEST}
 
-    target = pins_root / commit
-    marker = target / CONTRACT_IN_TREE
-    if marker.exists():
-        return target
+
+def tree_digest(root: Path) -> tuple[str, int]:
+    """``(sha256 over the tree's paths and bytes, file count)``.
+
+    Path-and-content, not content alone: a tree that lost a file entirely, and
+    a tree whose bytes moved, are both things this has to see, and a digest
+    over concatenated contents would miss a rename.
+    """
+    h = hashlib.sha256()
+    n = 0
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        rel = path.relative_to(root)
+        if (set(rel.parts) & SKIP_DIRS or path.suffix in SKIP_SUFFIXES
+                or path.name in SKIP_NAMES):
+            continue
+        h.update(str(rel).encode("utf-8"))
+        h.update(b"\0")
+        h.update(hashlib.sha256(path.read_bytes()).hexdigest().encode("ascii"))
+        h.update(b"\n")
+        n += 1
+    return h.hexdigest(), n
+
+
+def package_digest(root: Path) -> tuple[str, int]:
+    """The digest of the ``tessera`` package alone, as an install would see it.
+
+    A source tree carries ``pyproject.toml``, tests and CI that an install
+    does not, so the two are only comparable over the package directory.  Paths
+    are taken relative to it, so the same package under ``src/`` and under
+    ``site-packages/`` digests identically.
+    """
+    return tree_digest(root)
+
+
+def _archive_into(commit: str, clone: Path, dest: Path) -> None:
     if not (clone / ".git").exists():
-        raise SystemExit(
-            f"{clone} is not a Tessera clone; pass --clone or pre-populate {target}"
-        )
-    target.mkdir(parents=True, exist_ok=True)
+        raise SystemExit(f"{clone} is not a Tessera clone; pass --clone")
+    dest.mkdir(parents=True, exist_ok=True)
     archive = subprocess.run(
         ["git", "--no-optional-locks", "-C", str(clone),
          "archive", "--format=tar", commit],
         check=True, stdout=subprocess.PIPE,
     )
-    subprocess.run(["tar", "-x", "-C", str(target)],
+    subprocess.run(["tar", "-x", "-C", str(dest)],
                    check=True, input=archive.stdout)
-    if not marker.exists():
-        raise SystemExit(f"{commit} carries no {CONTRACT_IN_TREE}")
+
+
+def materialise(commit: str, clone: Path, pins_root: Path) -> Path:
+    """Lay down ``commit``'s tree under ``pins_root``, verified, or repair it.
+
+    The first version returned any directory named for the commit that had a
+    ``runtime_contract.json`` somewhere in it.  A tree left half-extracted by
+    an interrupted ``tar``, or edited afterwards, satisfies both of those and
+    is not the commit -- so it would have installed something else under the
+    commit's label, which is the one thing a pin exists to prevent.
+
+    So the tree is written beside its own manifest, and a cached tree is
+    reused only when it still digests to what the manifest says.  Extraction
+    goes to a scratch directory and is moved into place with ``os.replace``,
+    which is atomic within a filesystem: a reader either sees the previous
+    tree or the new one, never a partial one, and an interrupted run leaves
+    scratch behind rather than a plausible-looking half tree.
+    """
+    target = pins_root / commit
+    manifest = target / MANIFEST
+    if manifest.exists():
+        try:
+            held = json.loads(manifest.read_text(encoding="utf-8"))
+        except ValueError:
+            held = {}
+        if held.get("commit") == commit:
+            digest, count = tree_digest(target)
+            if (digest == held.get("tree_sha256")
+                    and count == held.get("files")):
+                return target
+        # Fall through and repair.  Saying which way it failed is worth a line
+        # to whoever reads the log: a digest mismatch and a missing manifest
+        # are different accidents.
+        print(f"{target}: cached tree does not match its manifest, replacing",
+              file=sys.stderr)
+    elif target.exists():
+        print(f"{target}: cached tree has no manifest, replacing",
+              file=sys.stderr)
+
+    scratch = pins_root / f".materialising-{commit}-{os.getpid()}"
+    if scratch.exists():
+        shutil.rmtree(scratch)
+    try:
+        _archive_into(commit, clone, scratch)
+        if not (scratch / CONTRACT_IN_TREE).exists():
+            raise SystemExit(f"{commit} carries no {CONTRACT_IN_TREE}")
+        # The manifest lives inside the tree it describes, so ``tree_digest``
+        # excludes it by name; otherwise writing it would change the thing it
+        # records and no cached tree could ever verify.
+        digest, count = tree_digest(scratch)
+        (scratch / MANIFEST).write_text(json.dumps(
+            {"commit": commit, "tree_sha256": digest, "files": count},
+            indent=1), encoding="utf-8")
+        if target.exists():
+            doomed = pins_root / f".replaced-{commit}-{os.getpid()}"
+            os.replace(target, doomed)
+            shutil.rmtree(doomed, ignore_errors=True)
+        os.replace(scratch, target)
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
     return target
 
 
-def installed_contract(python: str) -> tuple[str | None, str | None]:
-    """That interpreter's packaged contract: ``(sha256, reason it is absent)``.
+def installed_identity(python: str) -> tuple[dict | None, str | None]:
+    """That interpreter's Tessera: ``(identity, reason it is absent)``.
 
-    Exactly one of the two is set.  The reason is carried rather than dropped
-    because an absent contract has at least three causes an operator has to
-    act on differently -- the venv does not exist, Tessera is not installed in
-    it, or Tessera is installed without its packaged contract -- and a bare
-    ``null`` reads as all three at once.  The GB10 venv reported ``null`` on
-    its first audit; it was the second cause, and the report did not say so.
+    Exactly one of the two is set.  The identity carries the packaged
+    contract's sha256 AND a digest over the installed package's own files,
+    because the pin names a COMMIT and the contract is one file in that
+    commit's tree.  Two commits can publish identical contract bytes and
+    differ everywhere else -- tessera#437 rewrites the window encoder and
+    leaves the contract alone -- so a contract-only check reports "already the
+    reviewed bytes" for a re-pin whose whole content is new encoder code, and
+    leaves the old encoder installed.  That was this tool's own defect.
+
+    The reason is carried rather than dropped because an absent Tessera has
+    several causes an operator acts on differently: no such interpreter, no
+    Tessera in it, or a Tessera installed without its packaged contract.  The
+    GB10 venv reported a bare ``null`` on its first audit; it was the second.
+
+    Run under ``-I``, so what is measured is the INSTALLED distribution.
+    Without it a checkout on ``PYTHONPATH`` -- or a shadowing directory in the
+    caller's cwd -- answers instead, and the tool would certify a package the
+    fleet does not import.
     """
 
     probe = (
         "import hashlib,json,sys\n"
         "from importlib import resources\n"
+        "from pathlib import Path\n"
+        "SKIP_DIRS={'__pycache__','.git'}\n"
+        "SKIP_SUF={'.pyc','.pyo'}\n"
+        "def digest(root):\n"
+        "    h=hashlib.sha256(); n=0\n"
+        "    for p in sorted(q for q in root.rglob('*') if q.is_file()):\n"
+        "        rel=p.relative_to(root)\n"
+        "        if set(rel.parts)&SKIP_DIRS or p.suffix in SKIP_SUF: continue\n"
+        "        h.update(str(rel).encode()); h.update(b'\\0')\n"
+        "        h.update(hashlib.sha256(p.read_bytes()).hexdigest().encode())\n"
+        "        h.update(b'\\n'); n+=1\n"
+        "    return h.hexdigest(), n\n"
         "try:\n"
-        "    p = resources.files('tessera.serving')"
+        "    c = resources.files('tessera.serving')"
         ".joinpath('runtime_contract.json')\n"
-        "    out = {'sha256': hashlib.sha256(p.read_bytes()).hexdigest()}\n"
+        "    pkg = Path(str(resources.files('tessera')))\n"
+        "    d, n = digest(pkg)\n"
+        "    out = {'contract_sha256': hashlib.sha256(c.read_bytes()).hexdigest(),\n"
+        "           'package_sha256': d, 'package_files': n,\n"
+        "           'package_path': str(pkg)}\n"
         "except Exception as exc:\n"
         "    out = {'reason': type(exc).__name__ + ': ' + str(exc)}\n"
         "sys.stdout.write(json.dumps(out))\n"
     )
     try:
-        done = subprocess.run([python, "-c", probe],
+        done = subprocess.run([python, "-I", "-c", probe],
                               capture_output=True, text=True)
     except OSError as exc:
         # No such interpreter, or one that will not start.  The caller wants
-        # "not the reviewed bytes", and an exception here would make a routine
+        # "not the reviewed source", and an exception here would make a routine
         # audit of a machine that has no such venv look like a tool failure.
         return None, f"{type(exc).__name__}: {exc}"
     try:
         out = json.loads(done.stdout.strip() or "{}")
     except ValueError:
         out = {}
-    sha = out.get("sha256")
-    if sha:
-        return sha, None
+    if out.get("contract_sha256") and out.get("package_sha256"):
+        return out, None
     reason = out.get("reason") or (done.stderr.strip().splitlines() or
                                    ["the probe printed nothing"])[-1]
     return None, reason
+
+
+def expected_identity(source: Path) -> dict:
+    """What a correct install of the pinned tree would report."""
+
+    pkg = source / "src" / "tessera"
+    if not pkg.is_dir():
+        raise SystemExit(f"{source} carries no src/tessera")
+    digest, count = package_digest(pkg)
+    return {
+        "contract_sha256": hashlib.sha256(
+            (source / CONTRACT_IN_TREE).read_bytes()).hexdigest(),
+        "package_sha256": digest,
+        "package_files": count,
+    }
+
+
+def drift(installed: dict | None, expected: dict) -> list[str]:
+    """Which fields disagree, named, so a report says what to repair."""
+
+    if installed is None:
+        return ["no Tessera to compare"]
+    return [
+        field for field in ("contract_sha256", "package_sha256")
+        if installed.get(field) != expected[field]
+    ]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -156,23 +320,41 @@ def main(argv: list[str] | None = None) -> int:
                         help="local Tessera clone to archive the pin from")
     parser.add_argument("--pins-root", type=Path, default=DEFAULT_PINS_ROOT,
                         help="where pinned source trees are materialised")
+    parser.add_argument("--pin-source", type=Path, default=PIN_SOURCE,
+                        help="module holding the reviewed pin literals")
     parser.add_argument("--check-only", action="store_true",
-                        help="report the installed contract, install nothing")
+                        help="report what is installed, install nothing")
     args = parser.parse_args(argv)
 
-    commit, reviewed_sha = reviewed_pin()
-    before, before_absent = installed_contract(args.python)
+    commit, reviewed_sha = reviewed_pin(args.pin_source)
+    installed, absent = installed_identity(args.python)
     report = {
         "python": args.python,
         "reviewed_commit": commit,
         "reviewed_contract_sha256": reviewed_sha,
-        "installed_contract_sha256_before": before,
+        "installed_before": installed,
     }
-    if before_absent is not None:
-        report["installed_contract_absent_before"] = before_absent
+    if absent is not None:
+        report["installed_absent_before"] = absent
 
-    if before == reviewed_sha:
-        report["action"] = "none, already the reviewed bytes"
+    # The pinned tree is materialised BEFORE the decision, not after it,
+    # because the decision needs the commit's package digest and only the tree
+    # has it.  The contract hash in the pin is a second, independent check on
+    # the tree, and it is checked here rather than trusted.
+    source = materialise(commit, args.clone, args.pins_root)
+    expected = expected_identity(source)
+    report["source"] = str(source)
+    report["expected"] = expected
+    if expected["contract_sha256"] != reviewed_sha:
+        raise SystemExit(
+            f"{source} publishes contract {expected['contract_sha256']}, "
+            f"reviewed is {reviewed_sha}"
+        )
+
+    fields = drift(installed, expected)
+    report["drift"] = fields
+    if not fields:
+        report["action"] = "none, already the reviewed source"
         print(json.dumps(report, indent=1))
         return 0
     if args.check_only:
@@ -180,31 +362,23 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(report, indent=1))
         return 1
 
-    source = materialise(commit, args.clone, args.pins_root)
-    on_disk = hashlib.sha256(
-        (source / CONTRACT_IN_TREE).read_bytes()
-    ).hexdigest()
-    if on_disk != reviewed_sha:
-        raise SystemExit(
-            f"{source} publishes contract {on_disk}, reviewed is {reviewed_sha}"
-        )
-    report["source"] = str(source)
-
     subprocess.run(
         [args.python, "-m", "pip", "install", "--no-deps",
          "--no-build-isolation", "--force-reinstall", str(source)],
         check=True,
     )
 
-    after, after_absent = installed_contract(args.python)
-    report["installed_contract_sha256_after"] = after
+    after, after_absent = installed_identity(args.python)
+    report["installed_after"] = after
     if after_absent is not None:
-        report["installed_contract_absent_after"] = after_absent
-    if after != reviewed_sha:
+        report["installed_absent_after"] = after_absent
+    remaining = drift(after, expected)
+    report["drift_after"] = remaining
+    if remaining:
         report["action"] = "installed, and it did NOT take"
         print(json.dumps(report, indent=1))
         return 1
-    report["action"] = "installed the reviewed bytes"
+    report["action"] = "installed the reviewed source"
     print(json.dumps(report, indent=1))
     return 0
 

--- a/tools/provision_tessera_pin.py
+++ b/tools/provision_tessera_pin.py
@@ -54,6 +54,10 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
+import time
+import tomllib
+from fnmatch import fnmatch
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -63,6 +67,9 @@ SHA_NAME = "TESSERA_DEV_PIN_CONTRACT_SHA256"
 DEFAULT_PINS_ROOT = Path("/mnt/shared/tessera-pins")
 DEFAULT_CLONE = Path("/home/rob/tessera")
 CONTRACT_IN_TREE = Path("src/tessera/serving/runtime_contract.json")
+PACKAGE_IN_TREE = Path("src/tessera")
+PYPROJECT_IN_TREE = Path("pyproject.toml")
+DEFAULT_STAGING_ROOT = Path("/home/rob/tmp")
 
 
 def _literal(name: str, source: Path = PIN_SOURCE) -> str:
@@ -110,7 +117,7 @@ SKIP_SUFFIXES = {".pyc", ".pyo"}
 SKIP_NAMES = {MANIFEST}
 
 
-def tree_digest(root: Path) -> tuple[str, int]:
+def tree_digest(root: Path, skip=None) -> tuple[str, int]:
     """``(sha256 over the tree's paths and bytes, file count)``.
 
     Path-and-content, not content alone: a tree that lost a file entirely, and
@@ -124,6 +131,8 @@ def tree_digest(root: Path) -> tuple[str, int]:
         if (set(rel.parts) & SKIP_DIRS or path.suffix in SKIP_SUFFIXES
                 or path.name in SKIP_NAMES):
             continue
+        if skip is not None and skip(rel):
+            continue
         h.update(str(rel).encode("utf-8"))
         h.update(b"\0")
         h.update(hashlib.sha256(path.read_bytes()).hexdigest().encode("ascii"))
@@ -132,15 +141,52 @@ def tree_digest(root: Path) -> tuple[str, int]:
     return h.hexdigest(), n
 
 
-def package_digest(root: Path) -> tuple[str, int]:
+def unshipped_packages(source: Path) -> list[str]:
+    """Dotted subpackages the pinned tree's build config does not install.
+
+    Read from the tree rather than known here.  Tessera excludes
+    ``tessera._dev*`` -- its own merge-suite and import-graph tooling, which
+    lives under ``src/`` because ``tools/`` imports it by module name.  A
+    digest that counted those five files would compare a 76-file source tree
+    against a 71-file install and report drift on a correctly provisioned
+    interpreter, every run, forever.  The exclusion is a fact about the build
+    backend, so it is taken from the backend's own configuration; Tessera's
+    ``tools/check_wheel.py`` proves it on the built artifact.
+    """
+
+    pyproject = source / PYPROJECT_IN_TREE
+    if not pyproject.is_file():
+        raise SystemExit(f"{source} carries no {PYPROJECT_IN_TREE}")
+    config = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    find = (config.get("tool", {}).get("setuptools", {})
+            .get("packages", {}).get("find", {}))
+    return list(find.get("exclude", []))
+
+
+def _package_skip(patterns: list[str], package: str = "tessera"):
+    """A ``tree_digest`` predicate for those patterns, over package paths."""
+
+    if not patterns:
+        return None
+
+    def skip(rel: Path) -> bool:
+        dotted = ".".join((package, *rel.parts[:-1]))
+        return any(fnmatch(dotted, pattern) for pattern in patterns)
+
+    return skip
+
+
+def package_digest(root: Path, unshipped: list[str] | None = None):
     """The digest of the ``tessera`` package alone, as an install would see it.
 
     A source tree carries ``pyproject.toml``, tests and CI that an install
     does not, so the two are only comparable over the package directory.  Paths
     are taken relative to it, so the same package under ``src/`` and under
-    ``site-packages/`` digests identically.
+    ``site-packages/`` digests identically -- and subpackages the build config
+    excludes are dropped on both sides, because an install never has them and
+    a source tree always does.
     """
-    return tree_digest(root)
+    return tree_digest(root, _package_skip(unshipped or []))
 
 
 def _archive_into(commit: str, clone: Path, dest: Path) -> None:
@@ -156,68 +202,147 @@ def _archive_into(commit: str, clone: Path, dest: Path) -> None:
                    check=True, input=archive.stdout)
 
 
-def materialise(commit: str, clone: Path, pins_root: Path) -> Path:
-    """Lay down ``commit``'s tree under ``pins_root``, verified, or repair it.
+def _manifest_holds(target: Path, commit: str) -> bool:
+    """Does ``target`` still digest to what its own manifest recorded?"""
 
-    The first version returned any directory named for the commit that had a
-    ``runtime_contract.json`` somewhere in it.  A tree left half-extracted by
-    an interrupted ``tar``, or edited afterwards, satisfies both of those and
-    is not the commit -- so it would have installed something else under the
-    commit's label, which is the one thing a pin exists to prevent.
+    manifest = target / MANIFEST
+    if not manifest.is_file():
+        return False
+    try:
+        held = json.loads(manifest.read_text(encoding="utf-8"))
+    except ValueError:
+        return False
+    if held.get("commit") != commit:
+        return False
+    digest, count = tree_digest(target)
+    return digest == held.get("tree_sha256") and count == held.get("files")
 
-    So the tree is written beside its own manifest, and a cached tree is
-    reused only when it still digests to what the manifest says.  Extraction
-    goes to a scratch directory and is moved into place with ``os.replace``,
-    which is atomic within a filesystem: a reader either sees the previous
-    tree or the new one, never a partial one, and an interrupted run leaves
-    scratch behind rather than a plausible-looking half tree.
+
+def _write_manifest(target: Path, commit: str) -> None:
+    """Record what ``target`` digests to, atomically, beside itself.
+
+    The manifest lives inside the tree it describes, so ``tree_digest``
+    excludes it by name; otherwise writing it would change the thing it
+    records and no cached tree could ever verify.
+    """
+    digest, count = tree_digest(target)
+    body = json.dumps({"commit": commit, "tree_sha256": digest,
+                       "files": count}, indent=1)
+    scratch = target / f".{MANIFEST}.writing"
+    scratch.write_text(body, encoding="utf-8")
+    os.replace(scratch, target / MANIFEST)
+
+
+class _PinsLock:
+    """One writer at a time per commit, across hosts on the shared root.
+
+    Two boxes provisioning the same pin at once is the ordinary case, not the
+    exotic one: PrismaBuild runs actions concurrently and the pins root is
+    NFS.  Without this they race to publish the same directory, and the loser
+    quarantines the winner's freshly published tree as an intruder.
+    """
+
+    def __init__(self, pins_root: Path, commit: str) -> None:
+        self.path = pins_root / f".lock-{commit}"
+
+    def __enter__(self):
+        import fcntl
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.handle = open(self.path, "a+")
+        fcntl.flock(self.handle.fileno(), fcntl.LOCK_EX)
+        return self
+
+    def __exit__(self, *exc):
+        import fcntl
+        fcntl.flock(self.handle.fileno(), fcntl.LOCK_UN)
+        self.handle.close()
+        return False
+
+
+def verified_source(commit: str, pins_root: Path) -> Path | None:
+    """``pins_root/commit`` if it verifies against its own manifest, else None.
+
+    Reads only.  ``--check-only`` runs on this, because a read-only check that
+    writes the pinned tree into a shared directory to learn what to compare
+    against is not read-only.
     """
     target = pins_root / commit
-    manifest = target / MANIFEST
-    if manifest.exists():
+    return target if _manifest_holds(target, commit) else None
+
+
+def materialise(commit: str, clone: Path, pins_root: Path,
+                report: dict | None = None) -> Path:
+    """Lay down ``commit``'s tree under ``pins_root``, verified, or repair it.
+
+    Three states, three different right answers, and the first version of this
+    collapsed them into one:
+
+    * **Manifested and matching.** Reused, no clone needed.
+    * **No manifest, right bytes.** ``/mnt/shared/tessera-pins/07ad344c...``
+      predates the manifest and is correct.  Its content is compared against a
+      fresh ``git archive`` of the commit and, when equal, the manifest is
+      written beside it.  The bytes are not replaced: rewriting a shared
+      directory other boxes may be reading, to end with what is already there,
+      is churn with a window in it.
+    * **Anything else.** The tree is moved aside under a
+      ``.quarantine-<commit>-...`` name and the fresh archive published in its
+      place.  It is not deleted.  Something wrote to a shared pins root and
+      those bytes are the only record of what; the quarantine path is returned
+      in ``report`` so a run says where it went.
+
+    Publication is ``os.replace`` of a directory that is complete and already
+    manifested, so a reader sees the old tree or the new one.  Staging is
+    ``mkdtemp`` under the pins root -- unique and owned, where the earlier
+    PID-named scratch could collide between hosts on NFS and was removed by
+    name, which is a directory another box may be extracting into.
+    """
+    target = pins_root / commit
+    if _manifest_holds(target, commit):
+        return target
+
+    pins_root.mkdir(parents=True, exist_ok=True)
+    with _PinsLock(pins_root, commit):
+        # Re-checked under the lock: another box may have published it while
+        # this one waited, and that tree is as good as one written here.
+        if _manifest_holds(target, commit):
+            return target
+
+        staging = Path(tempfile.mkdtemp(dir=pins_root,
+                                        prefix=f".materialising-{commit}-"))
+        fresh = staging / "tree"
         try:
-            held = json.loads(manifest.read_text(encoding="utf-8"))
-        except ValueError:
-            held = {}
-        if held.get("commit") == commit:
-            digest, count = tree_digest(target)
-            if (digest == held.get("tree_sha256")
-                    and count == held.get("files")):
-                return target
-        # Fall through and repair.  Saying which way it failed is worth a line
-        # to whoever reads the log: a digest mismatch and a missing manifest
-        # are different accidents.
-        print(f"{target}: cached tree does not match its manifest, replacing",
-              file=sys.stderr)
-    elif target.exists():
-        print(f"{target}: cached tree has no manifest, replacing",
-              file=sys.stderr)
+            _archive_into(commit, clone, fresh)
+            if not (fresh / CONTRACT_IN_TREE).exists():
+                raise SystemExit(f"{commit} carries no {CONTRACT_IN_TREE}")
 
-    scratch = pins_root / f".materialising-{commit}-{os.getpid()}"
-    if scratch.exists():
-        shutil.rmtree(scratch)
-    try:
-        _archive_into(commit, clone, scratch)
-        if not (scratch / CONTRACT_IN_TREE).exists():
-            raise SystemExit(f"{commit} carries no {CONTRACT_IN_TREE}")
-        # The manifest lives inside the tree it describes, so ``tree_digest``
-        # excludes it by name; otherwise writing it would change the thing it
-        # records and no cached tree could ever verify.
-        digest, count = tree_digest(scratch)
-        (scratch / MANIFEST).write_text(json.dumps(
-            {"commit": commit, "tree_sha256": digest, "files": count},
-            indent=1), encoding="utf-8")
-        if target.exists():
-            doomed = pins_root / f".replaced-{commit}-{os.getpid()}"
-            os.replace(target, doomed)
-            shutil.rmtree(doomed, ignore_errors=True)
-        os.replace(scratch, target)
-    finally:
-        shutil.rmtree(scratch, ignore_errors=True)
-    return target
+            if target.exists():
+                if tree_digest(target)[0] == tree_digest(fresh)[0]:
+                    # Already the commit, only unattested.  Attest in place.
+                    _write_manifest(target, commit)
+                    if report is not None:
+                        report["source_state"] = "verified against a fresh archive"
+                    return target
+                quarantine = pins_root / (
+                    f".quarantine-{commit}-{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}"
+                    f"-{staging.name.rsplit('-', 1)[-1]}")
+                os.replace(target, quarantine)
+                print(f"{target}: does not hold {commit}; kept at {quarantine}",
+                      file=sys.stderr)
+                if report is not None:
+                    report["quarantined"] = str(quarantine)
+
+            _write_manifest(fresh, commit)
+            os.replace(fresh, target)
+            if report is not None:
+                report.setdefault("source_state", "published from the clone")
+            return target
+        finally:
+            shutil.rmtree(staging, ignore_errors=True)
 
 
-def installed_identity(python: str) -> tuple[dict | None, str | None]:
+def installed_identity(python: str,
+                       unshipped: list[str] | None = None,
+                       ) -> tuple[dict | None, str | None]:
     """That interpreter's Tessera: ``(identity, reason it is absent)``.
 
     Exactly one of the two is set.  The identity carries the packaged
@@ -240,17 +365,25 @@ def installed_identity(python: str) -> tuple[dict | None, str | None]:
     fleet does not import.
     """
 
+    # The exclusion travels INTO the probe rather than being applied to its
+    # answer: an editable install points at a checkout that does carry the
+    # unshipped subpackage, and only the digest that skipped it on both sides
+    # compares the two halves of one pin.
     probe = (
         "import hashlib,json,sys\n"
+        "from fnmatch import fnmatch\n"
         "from importlib import resources\n"
         "from pathlib import Path\n"
         "SKIP_DIRS={'__pycache__','.git'}\n"
         "SKIP_SUF={'.pyc','.pyo'}\n"
+        f"UNSHIPPED={list(unshipped or [])!r}\n"
         "def digest(root):\n"
         "    h=hashlib.sha256(); n=0\n"
         "    for p in sorted(q for q in root.rglob('*') if q.is_file()):\n"
         "        rel=p.relative_to(root)\n"
         "        if set(rel.parts)&SKIP_DIRS or p.suffix in SKIP_SUF: continue\n"
+        "        dotted='.'.join(('tessera',)+rel.parts[:-1])\n"
+        "        if any(fnmatch(dotted,x) for x in UNSHIPPED): continue\n"
         "        h.update(str(rel).encode()); h.update(b'\\0')\n"
         "        h.update(hashlib.sha256(p.read_bytes()).hexdigest().encode())\n"
         "        h.update(b'\\n'); n+=1\n"
@@ -286,13 +419,14 @@ def installed_identity(python: str) -> tuple[dict | None, str | None]:
     return None, reason
 
 
-def expected_identity(source: Path) -> dict:
+def expected_identity(source: Path,
+                      unshipped: list[str] | None = None) -> dict:
     """What a correct install of the pinned tree would report."""
 
-    pkg = source / "src" / "tessera"
+    pkg = source / PACKAGE_IN_TREE
     if not pkg.is_dir():
-        raise SystemExit(f"{source} carries no src/tessera")
-    digest, count = package_digest(pkg)
+        raise SystemExit(f"{source} carries no {PACKAGE_IN_TREE}")
+    digest, count = package_digest(pkg, unshipped)
     return {
         "contract_sha256": hashlib.sha256(
             (source / CONTRACT_IN_TREE).read_bytes()).hexdigest(),
@@ -322,34 +456,55 @@ def main(argv: list[str] | None = None) -> int:
                         help="where pinned source trees are materialised")
     parser.add_argument("--pin-source", type=Path, default=PIN_SOURCE,
                         help="module holding the reviewed pin literals")
+    parser.add_argument("--staging-root", type=Path,
+                        default=DEFAULT_STAGING_ROOT,
+                        help="where the build's copy of the pinned tree goes")
     parser.add_argument("--check-only", action="store_true",
-                        help="report what is installed, install nothing")
+                        help="report what is installed, write nothing")
     args = parser.parse_args(argv)
 
     commit, reviewed_sha = reviewed_pin(args.pin_source)
-    installed, absent = installed_identity(args.python)
     report = {
         "python": args.python,
         "reviewed_commit": commit,
         "reviewed_contract_sha256": reviewed_sha,
-        "installed_before": installed,
     }
-    if absent is not None:
-        report["installed_absent_before"] = absent
 
-    # The pinned tree is materialised BEFORE the decision, not after it,
-    # because the decision needs the commit's package digest and only the tree
-    # has it.  The contract hash in the pin is a second, independent check on
-    # the tree, and it is checked here rather than trusted.
-    source = materialise(commit, args.clone, args.pins_root)
-    expected = expected_identity(source)
+    # --check-only reads.  It does not materialise, because the pins root is
+    # shared and a read-only check that lays a tree down in it is not one; an
+    # operator running it to see where a box stands would find a directory
+    # written by the question.  So it answers from a source that already
+    # verifies, and says so when there is none rather than making one.
+    if args.check_only:
+        source = verified_source(commit, args.pins_root)
+        if source is None:
+            report["installed_before"], absent = installed_identity(args.python)
+            if absent is not None:
+                report["installed_absent_before"] = absent
+            report["action"] = "none, --check-only and no verified pinned source"
+            report["repair"] = (
+                f"run without --check-only to publish {args.pins_root / commit} "
+                "from the clone")
+            print(json.dumps(report, indent=1))
+            return 1
+    else:
+        source = materialise(commit, args.clone, args.pins_root, report)
+
+    unshipped = unshipped_packages(source)
     report["source"] = str(source)
+    report["unshipped_packages"] = unshipped
+    expected = expected_identity(source, unshipped)
     report["expected"] = expected
     if expected["contract_sha256"] != reviewed_sha:
         raise SystemExit(
             f"{source} publishes contract {expected['contract_sha256']}, "
             f"reviewed is {reviewed_sha}"
         )
+
+    installed, absent = installed_identity(args.python, unshipped)
+    report["installed_before"] = installed
+    if absent is not None:
+        report["installed_absent_before"] = absent
 
     fields = drift(installed, expected)
     report["drift"] = fields
@@ -362,19 +517,36 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(report, indent=1))
         return 1
 
-    subprocess.run(
-        [args.python, "-m", "pip", "install", "--no-deps",
-         "--no-build-isolation", "--force-reinstall", str(source)],
-        check=True,
-    )
+    # The build gets a copy.  ``pip install <dir>`` runs the backend IN that
+    # directory, and setuptools writes ``*.egg-info`` (and, uncached, a
+    # ``build/``) into it -- so pointing pip at the pinned tree makes the tree
+    # stop matching the manifest it was published with, and the next run
+    # reports the pin's own source corrupt.  The frozen tree is an input.
+    args.staging_root.mkdir(parents=True, exist_ok=True)
+    build = Path(tempfile.mkdtemp(dir=args.staging_root,
+                                  prefix=f"tessera-build-{commit[:12]}-"))
+    try:
+        copy = build / "tree"
+        shutil.copytree(source, copy)
+        report["built_from"] = str(copy)
+        subprocess.run(
+            [args.python, "-m", "pip", "install", "--no-deps",
+             "--no-build-isolation", "--force-reinstall", str(copy)],
+            check=True,
+        )
+    finally:
+        shutil.rmtree(build, ignore_errors=True)
 
-    after, after_absent = installed_identity(args.python)
+    # And proved rather than argued: the tree still answers its own manifest.
+    report["source_intact_after_install"] = _manifest_holds(source, commit)
+
+    after, after_absent = installed_identity(args.python, unshipped)
     report["installed_after"] = after
     if after_absent is not None:
         report["installed_absent_after"] = after_absent
     remaining = drift(after, expected)
     report["drift_after"] = remaining
-    if remaining:
+    if remaining or not report["source_intact_after_install"]:
         report["action"] = "installed, and it did NOT take"
         print(json.dumps(report, indent=1))
         return 1

--- a/tools/provision_tessera_pin.py
+++ b/tools/provision_tessera_pin.py
@@ -106,28 +106,46 @@ def materialise(commit: str, clone: Path, pins_root: Path) -> Path:
     return target
 
 
-def installed_contract(python: str) -> str | None:
-    """The sha256 of the contract that interpreter's Tessera actually packages."""
+def installed_contract(python: str) -> tuple[str | None, str | None]:
+    """That interpreter's packaged contract: ``(sha256, reason it is absent)``.
+
+    Exactly one of the two is set.  The reason is carried rather than dropped
+    because an absent contract has at least three causes an operator has to
+    act on differently -- the venv does not exist, Tessera is not installed in
+    it, or Tessera is installed without its packaged contract -- and a bare
+    ``null`` reads as all three at once.  The GB10 venv reported ``null`` on
+    its first audit; it was the second cause, and the report did not say so.
+    """
 
     probe = (
-        "import hashlib,sys\n"
+        "import hashlib,json,sys\n"
         "from importlib import resources\n"
         "try:\n"
         "    p = resources.files('tessera.serving')"
         ".joinpath('runtime_contract.json')\n"
-        "    sys.stdout.write(hashlib.sha256(p.read_bytes()).hexdigest())\n"
-        "except Exception:\n"
-        "    sys.stdout.write('')\n"
+        "    out = {'sha256': hashlib.sha256(p.read_bytes()).hexdigest()}\n"
+        "except Exception as exc:\n"
+        "    out = {'reason': type(exc).__name__ + ': ' + str(exc)}\n"
+        "sys.stdout.write(json.dumps(out))\n"
     )
     try:
-        got = subprocess.run([python, "-c", probe],
-                             capture_output=True, text=True).stdout.strip()
-    except OSError:
+        done = subprocess.run([python, "-c", probe],
+                              capture_output=True, text=True)
+    except OSError as exc:
         # No such interpreter, or one that will not start.  The caller wants
         # "not the reviewed bytes", and an exception here would make a routine
         # audit of a machine that has no such venv look like a tool failure.
-        return None
-    return got or None
+        return None, f"{type(exc).__name__}: {exc}"
+    try:
+        out = json.loads(done.stdout.strip() or "{}")
+    except ValueError:
+        out = {}
+    sha = out.get("sha256")
+    if sha:
+        return sha, None
+    reason = out.get("reason") or (done.stderr.strip().splitlines() or
+                                   ["the probe printed nothing"])[-1]
+    return None, reason
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -143,13 +161,15 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     commit, reviewed_sha = reviewed_pin()
-    before = installed_contract(args.python)
+    before, before_absent = installed_contract(args.python)
     report = {
         "python": args.python,
         "reviewed_commit": commit,
         "reviewed_contract_sha256": reviewed_sha,
         "installed_contract_sha256_before": before,
     }
+    if before_absent is not None:
+        report["installed_contract_absent_before"] = before_absent
 
     if before == reviewed_sha:
         report["action"] = "none, already the reviewed bytes"
@@ -176,8 +196,10 @@ def main(argv: list[str] | None = None) -> int:
         check=True,
     )
 
-    after = installed_contract(args.python)
+    after, after_absent = installed_contract(args.python)
     report["installed_contract_sha256_after"] = after
+    if after_absent is not None:
+        report["installed_contract_absent_after"] = after_absent
     if after != reviewed_sha:
         report["action"] = "installed, and it did NOT take"
         print(json.dumps(report, indent=1))

--- a/tools/provision_tessera_pin.py
+++ b/tools/provision_tessera_pin.py
@@ -545,11 +545,22 @@ def main(argv: list[str] | None = None) -> int:
         copy = build / "tree"
         shutil.copytree(source, copy)
         report["built_from"] = str(copy)
-        subprocess.run(
+        # pip writes to stdout, and stdout here is the JSON report a caller
+        # parses.  Its output is worth keeping and belongs on stderr with the
+        # rest of the narration.
+        done = subprocess.run(
             [args.python, "-m", "pip", "install", "--no-deps",
              "--no-build-isolation", "--force-reinstall", str(copy)],
-            check=True,
+            capture_output=True, text=True,
         )
+        sys.stderr.write(done.stdout)
+        sys.stderr.write(done.stderr)
+        if done.returncode != 0:
+            report["action"] = "the install failed"
+            report["pip_returncode"] = done.returncode
+            report["pip_error"] = (done.stdout + done.stderr).strip().splitlines()[-1:]
+            print(json.dumps(report, indent=1))
+            return 1
     finally:
         shutil.rmtree(build, ignore_errors=True)
 


### PR DESCRIPTION
Closes #455.

## What was wrong

CI checks out `RobTand/tessera` at the commit `tools/resolve_tessera_dev_pin.py`
prints and runs `pip install --no-deps` on that directory. Nothing did the same
for the PrismaBuild interpreters. `/home/rob/venvs/pq-cpu312` carried Tessera
built from `cc354b1f17` ("lane-eligibility v9"), which is an **ancestor** of the
pin `07ad344c32`: answer-equivalent, byte-different. The venv was behind the
re-pin, not diverged from it.

Confirmed read-only before touching anything, action `fa0be662f11d` on dl380g10:

    installed contract  719daa02da15...
    pinned contract     a688f8de244f...
    pinned commit       07ad344c3275bb2fa7ce2432f93d89945d66f4c2

The stale install carried the pin's own static version `0.1.0`, so nothing that
compares versions could have caught it. The contract bytes are what tell the two
apart, so the bytes are what the tool checks.

## The fleet is repaired

Provisioning action `15fc2a91fea9`, dl380g10, before/after inventories, then
`pip install --no-deps --no-build-isolation --force-reinstall` of
`/mnt/shared/tessera-pins/07ad344c3275bb2fa7ce2432f93d89945d66f4c2`, an
immutable tree whose `runtime_contract.json` hashes to the reviewed
`a688f8de244f`. Only `tessera-quant` was reinstalled; `uv pip check` reports no
broken requirements. `pb-cpu` and the GB10 project environments are untouched.

The three modules the issue names, re-run on the same interpreter after the
install, x86, priority -10:

| file | before (issue) | after | action |
|---|---|---|---|
| `tests/test_tessera_contract_v4.py` | 1 failed, 8 passed | 9 passed | `a5ccaba0b1d1` |
| `tests/test_tessera_serving_pin.py` | 2 failed, 12 passed, 1 skipped | 15 passed | `ac77036f782b` |
| `tests/test_tessera_production_admission.py` | 3 failed, 2 passed | 5 passed | `ea5967a72a5f` |

29 passed, no failures, no skips.

## What this adds

`tools/provision_tessera_pin.py` is that missing step, written so a re-pin can
carry it. It reads the pin the way the resolver does, out of the module's own
literal, and imports neither `prismaquant` nor `tessera`: the first pulls
`compressed_tensors` and the second is the thing being installed, and the
interpreter this exists to repair may have neither. `--check-only` reports and
exits 1 when an interpreter is off the pin, so a fleet audit can read the status
rather than a log line.

`tests/test_tessera_pin_provisioner.py`, 6 tests, action `f1021b93fb94`;
`tests/test_ci_tessera_install.py` still 6 passed, action `4edd9a3cd98b`. Both
x86 on the now-correct interpreter.

## What this does not establish

That every PrismaQuant test is CPU-portable, or that the other fleet
interpreters are on the pin. This provisions and verifies one interpreter and
gives the next re-pin a tool instead of a memory. GB10 project environments were
deliberately not touched in this change.


## Second round: root's four, and a fifth the fixtures were hiding

RED `9fe2f18f`, tests only, 6 failed / 12 passed (`3fd2bbb5d18d`). GREEN
`45a2ed6d`, 18 passed (`b7619de49cf6`). Both PB x86, `pq-cpu312`.

The fifth is the one that would have made the tool useless. Tessera's
`pyproject.toml` excludes `tessera._dev*` from what it installs, so the pin's
76 source files become 71 in a wheel. The digest compared them whole, so a
correctly provisioned interpreter reported drift, installed, re-probed and
exited 1, every run. Every synthetic test passed because the fixture copied the
whole source directory into site-packages. The fixture is fixed first, in the
RED commit, and the exclusion is now read from the pinned tree's own build
config and applied on both sides.

Root's four:

- `--check-only` is read-only. It reads a source that already verifies and
  reports `none, --check-only and no verified pinned source` otherwise, naming
  the command that would publish one.
- a tree that fails its manifest is renamed to
  `.quarantine-<commit>-<utc>-<random>` and kept. Something wrote to a shared
  pins root and those bytes are the only record of what.
- a tree with no manifest whose bytes match a fresh `git archive` is attested
  in place. The shared root holds one of those and rewriting it churns a
  directory other boxes read.
- staging is `mkdtemp` under the pins root, unique and owned, and publication
  takes an `flock` per commit. The PID-named scratch it replaces could collide
  between hosts and was removed by name.

And the build runs on a copy under `--staging-root`, with the tree re-checked
against its manifest afterwards, so root's "prove it leaves the frozen input
unchanged" is proved and not arranged.

## The real install, and what it found on the shared root

`tools/accept_tessera_pin_provisioner.py` makes a throwaway venv, provisions it
for real and reads the artifacts. Seeded from a copy of the live shared tree so
the repair path runs on the real bytes: six checks, all pass
(`df2e22218e8d`); unseeded `9fbb480fd14f`. Receipts and figures in
`docs/measurements/prismaquant-tessera-pin-provisioner-2026-09-09.md`.

It found the hazard already realised.
`/mnt/shared/tessera-pins/07ad344c3275bb2fa7ce2432f93d89945d66f4c2` digests to
`adb6511e` over 1256 files; the commit is `926f2f03` over 1179. The 77 extra
are 71 under `build/` and 6 under `src/tessera_quant.egg-info/`, written by an
earlier `pip install` that used the frozen tree as its build directory. (An
earlier revision of this body named a `_pb_native_moe_measure` directory among
them, read off a top-level listing rather than the diff; that one is in the
commit.) Nothing served from it is wrong, and **it has not been repaired
here** -- root has ruled it retained as bounded evidence.

`--clone` now defaults to `/mnt/shared/tessera-source.git`, a bare mirror, so
any fleet worker can archive the pin; no worker but sparky has a Tessera
worktree.

## Third round: root's two prose corrections, and the ordering behind one

Head `f0c8fd2d`.

1. The `materialise` docstring certified one live path as "predates the
   manifest and is correct". The acceptance run then found 77 extras in it. It
   now states the generic case: a tree written before this tool, or by a run
   that died after extracting and before attesting.
2. It also said a reader sees the old tree or the new one. Only a first
   publication is old-or-new; replacing a wrong tree is two renames with the
   path absent between them. The docstring says that, says the window is short
   and not zero, and says a repair wants a quiescent reader. The module
   overview no longer says an unmanifested tree is always re-materialised.
3. Root's optional improvement, taken: the staged tree is hashed and attested
   **before** the old name is vacated, so a failure there leaves the old tree
   in place. `test_a_failure_attesting_the_replacement_leaves_the_old_tree_in_place`
   makes `_write_manifest` raise and asserts it.
4. The pip spy in `test_the_install_does_not_run_inside_the_frozen_tree`
   returned `CompletedProcess(argv, 0)`, whose `stdout` is `None`.
   `capture_output=True` with `text=True` always yields strings, so the fake
   was answering in a shape the real call cannot, and the last commit's own
   logging raised on it. The previous head was never tested.

| what | action key |
|---|---|
| GREEN, `86e60a2f`: 19 passed | `2fc2f307ca5e` |
| the same tree with `_write_manifest` moved back after the quarantine rename: 1 failed, 18 passed | `b961932c705e` |

The mutation row is there because a test that passes on the code it is meant
to catch is not a test. The one failure is the ordering test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsJAfuLU26NWbYpSLrWFHJ


