### PR TITLE
Pin reviewed best-form Tessera producer for GLM pricing

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,25 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `integration/glm-first-artifact-pricing-delivery`. Stamps
+As of: 2026-09-09 · `integration/glm-reviewed-best-form-producer`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-09, `integration/glm-reviewed-best-form-producer`) for the
+synchronized development/serving dependency pin to Tessera `b1eb1dccc9df`
+(#437/#438). Its best-form window recurrence and tile controls remain opt-in;
+the package also includes the reviewed calibrated cached-export and rank-local
+TP2 intake fixes (#434/#436). The packaged runtime contract is byte-identical
+to `07ad344c3275`, and the admission answer, format menu, serving cells and
+encoder defaults remain unchanged. Native GLM row-0076 measurements preserve
+all 32 selected experts' wire bytes and scores at both R832 and R1088 with
+this producer; they do not establish full-model KL, a serving release or a
+blanket batch-width policy. Wider batches improved work/J at R832 and worsened
+it at R1088. The original complete calibration capture remains reusable under
+its own identity; old priced anchors retain their old source seal and are not
+relabeled or automatically adopted under the new producer. New pricing binds
+the new source identity. Provision fleet dependencies with
+`tools/provision_tessera_pin.py` through PrismaBuild; the provisioner compares
+the shipped package files as well as the contract and builds outside the frozen
+source tree. Detailed measurements and gates accompany the pin integration.
 
 Re-stamped (2026-09-08, `fix/glm-selected-verified-capture`) for opt-in
 `--capture-load-policy` on selected streaming reuse of a SHA-bound complete

--- a/docs/experiments/tessera_best_form_pin_20260909/README.md
+++ b/docs/experiments/tessera_best_form_pin_20260909/README.md
@@ -1,0 +1,51 @@
+# Reviewed Tessera producer pin, 2026-09-09
+
+The development and serving source pins now name
+`b1eb1dccc9df6773ab94e1c98f316f45bb18ab4c`. This includes upstream
+Tessera #434/#436/#437/#438: cached packed export, rank-local TP2 intake,
+opt-in best-form trellis and explicit opt-in tile controls. The packaged
+contract remains SHA256
+`a688f8de244f936ec3a63a782e20af7985733e7a6fb0b4b981b5fe4c44112212`.
+No producer default, format menu, admission answer or serving qualification
+changes. The source package identity in the GPU experiments is
+`bcad2ef2a7fdec2aab51b30d59f1f5e10b4933637ca4ffc74ee05e20816c1822`.
+
+Actual GLM row-0076 runs retain exact wire bytes and pricing scores for the
+first 32 experts at R832 and R1088, with the original capture reused and
+864 selected entries resident. No source forwards occurred. B32 vs B8 improved
+throughput/work per joule by 1.24504x/1.24089x at R832, and
+1.12470x/0.880061x at R1088. A separate first-16-expert R1088 comparison
+favoured B16 vs B8 by 1.15141x/1.02186x. Comparisons are within each run's
+host and environment; they do not establish a blanket batch policy or
+full-model quality. Sustained 90–100 W remains unmet. Full performance
+records, raw profiles, both-host telemetry, actual-file parity and CAS/source
+audits are retained in [the experiment branch at 82a312bb1b](https://github.com/RobTand/prismaquant/blob/82a312bb1b/docs/experiments/glm_best_form_screen_20260909/README.md).
+The shared evidence root is
+`/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-02/`.
+
+Pin integration tests: **249 CPU tests passed; zero skipped or uncollected**,
+ten modules, eight independent PB shards with two workers each and one native
+thread per worker. Torch 2.10.0+cpu, Python 3.12, dl380g10; no device coverage
+is claimed from these tests. The interpreter is
+`/home/rob/venvs/pq-cpu312-glm-best-form-b1eb1dccc/bin/python`, separately
+provisioned from the frozen reviewed producer without changing the fleet base
+venv. Provisioning action
+`8a21bbc82233d7228ae45cd1d891eb8c4f386d748b113f22d402f7c51ffa10ec`
+built outside the immutable source and passed a second check-only verification.
+The retained provisioner script fails if the scoped environment already exists.
+
+`cpu-receipts.json` gives all eight action keys, payload/receipt hashes,
+executed snapshots, module assignments and summaries. Root checked actual
+terminal exits, cleanup, receipt/payload hashes and snapshot sources against
+`2a30407878`. Differences were the PB closure and then-untracked provisioning
+script; tested production source matches. The 28 warnings per shard are
+Torch JIT deprecation warnings. Run with the published `pbtest.py`,
+`--checkout` this branch, `--python` the scoped interpreter, `--tag x86`,
+`--shards 8 --workers-per-shard 2 --threads-per-shard 1 --mem-gb 4`,
+`--timeout-s 600 --wait-s 1200 --priority -10`, and the ten modules listed in
+the receipt file.
+
+Original capture identity is retained. Priced anchors from the old producer
+keep their old source seal; this pin change does not relabel or automatically
+adopt them. New pricing binds the new producer. Full pricing remains paused
+for publication-overlap implementation and measurement at this checkpoint.

--- a/docs/experiments/tessera_best_form_pin_20260909/cpu-receipts.json
+++ b/docs/experiments/tessera_best_form_pin_20260909/cpu-receipts.json
@@ -1,0 +1,124 @@
+{
+  "mode": "CPU",
+  "device_allocations": 0,
+  "passed": 249,
+  "skipped": 0,
+  "uncollected": 0,
+  "source_commit": "2a30407878",
+  "shards": [
+    {
+      "action": "7e95453a38201c2b9ce8fabc9dad0c3c280c2763c6e8145ad8c9880a873d8b44",
+      "receipt": "e0941c10ecff87c0f91c360d5ad7a4b14889d9fa4b014215f7a3d6b14f5fe309",
+      "payload_sha256": "f7e9d582d4e57d312ef4b9ea566ac5687d12bbc6538e33f4539f092d185a4438",
+      "snapshot": "62c708d05437d0104da2f7270b6536eadf190242",
+      "source_diff_from_commit": [
+        ".pbrun-closure.34ebc39060f8133b.json",
+        "docs/experiments/tessera_best_form_pin_20260909/provision_cpu.py"
+      ],
+      "files": [
+        "tests/test_tessera_serving_pin.py",
+        "tests/test_architecture_doc.py"
+      ],
+      "summary": "28 passed, 28 warnings in 7.99s"
+    },
+    {
+      "action": "f9243f1be355aa2735f73552d5765d5b0fe12965cf0c8a46388b7c7e4a0b71f5",
+      "receipt": "c2ed37f7ac89ab91479207b90c9ad276b6ad0260d0befbb3ae0d3c87f9c44583",
+      "payload_sha256": "e4b91e5a1e2658debcbfef3378ca4b25736e6eaddc2c3900611a824880c74f3b",
+      "snapshot": "d7e875ab052d599aaeefcebd594fc3e2c6660e42",
+      "source_diff_from_commit": [
+        ".pbrun-closure.7c97cbc9b0dca3ee.json",
+        "docs/experiments/tessera_best_form_pin_20260909/provision_cpu.py"
+      ],
+      "files": [
+        "tests/test_tessera_contract_v4.py",
+        "tests/test_docs_staleness.py"
+      ],
+      "summary": "15 passed, 28 warnings in 7.76s"
+    },
+    {
+      "action": "b0e99d0debe8185aec5112016fd21729935d172c219793dddf7cee590b49242d",
+      "receipt": "a0bc96500dcece09a8537a1a0812164bf44abb1f15ac81444b76eb861dc4ba22",
+      "payload_sha256": "47d1584523543ed4eb0c0146a7775d6ac5319c836a92cc4a4b6edfa44fb3f548",
+      "snapshot": "ec9a894bc2afc4cb6081839a36c6c87dbe0ef0c4",
+      "source_diff_from_commit": [
+        ".pbrun-closure.dec412ddfa248f73.json",
+        "docs/experiments/tessera_best_form_pin_20260909/provision_cpu.py"
+      ],
+      "files": [
+        "tests/test_tessera_lane_v6.py"
+      ],
+      "summary": "19 passed, 28 warnings in 8.16s"
+    },
+    {
+      "action": "32d78988b9956239120bc7d97651b0aa2973689f691c04aac54a81dc9f75e232",
+      "receipt": "683102deb0aff049f1e16bac815a34a314a0fc7a1b87142dbfe26c26b72de0bb",
+      "payload_sha256": "ec953cfbf3e44fa74174215a5ebd84da7cc68f674fe309c5d1da0deacd403502",
+      "snapshot": "99116304d3f43d0cb01f4a0cae1aa02e6b392bd0",
+      "source_diff_from_commit": [
+        ".pbrun-closure.0853aa5e2ea4dbf5.json",
+        "docs/experiments/tessera_best_form_pin_20260909/provision_cpu.py"
+      ],
+      "files": [
+        "tests/test_tessera_lane_v9.py"
+      ],
+      "summary": "59 passed, 28 warnings in 8.51s"
+    },
+    {
+      "action": "5fe87860ae0485383c7751eec917de836011a84e7fc1b31b7939872deae09d7d",
+      "receipt": "635a25246f13e219e5fb8ad6c2535026dfab788cef1407d00a053bc85ab32c30",
+      "payload_sha256": "91cdc22d77d4045a75266ba226db9b0e324e3e003ef4f6aa56383882fdfda194",
+      "snapshot": "5a50a8b50f6987f44bbe4af9365be88e11203504",
+      "source_diff_from_commit": [
+        ".pbrun-closure.5d4eac2828ffbd51.json",
+        "docs/experiments/tessera_best_form_pin_20260909/provision_cpu.py"
+      ],
+      "files": [
+        "tests/test_tessera_lane_admission.py"
+      ],
+      "summary": "22 passed, 28 warnings in 8.24s"
+    },
+    {
+      "action": "f94c6ba430f0278cbe9b06b1805829be77fc0f8bb7e46a879a1bf3fac4b71b4f",
+      "receipt": "d4b046473105681321035d1925de918f99abe79ffcd5be327bf577faf4a1838d",
+      "payload_sha256": "e3b8ee9ab4e46a34c1187edb6a3db83a6ac02e6d7ced888d8a810b0c0525d4f7",
+      "snapshot": "98eec0aa887ec9436659e1bf1caba4f18feba755",
+      "source_diff_from_commit": [
+        ".pbrun-closure.6746fa30db290e36.json",
+        "docs/experiments/tessera_best_form_pin_20260909/provision_cpu.py"
+      ],
+      "files": [
+        "tests/test_tessera_export_lane.py"
+      ],
+      "summary": "21 passed, 28 warnings in 8.03s"
+    },
+    {
+      "action": "d97e081d3552f05caf61a7977a553904d783fc276211e03425d8b527ee83d313",
+      "receipt": "83b47bcf9936b9794a36c409d7424a40cf5c6d8945c1bd6549e0bfcf8b3d590b",
+      "payload_sha256": "46e2f94dd584981a50667492eaabc6045d4d27f22c47e9993e658113d77c106e",
+      "snapshot": "f672aacea4fcf109a4a69689d958a32dca6e96ba",
+      "source_diff_from_commit": [
+        ".pbrun-closure.a99a1de0058a1234.json",
+        "docs/experiments/tessera_best_form_pin_20260909/provision_cpu.py"
+      ],
+      "files": [
+        "tests/test_tessera_formats.py"
+      ],
+      "summary": "66 passed, 28 warnings in 75.20s (0:01:15)"
+    },
+    {
+      "action": "a36014597d2cd64099ec27693ada8c2c585582bfd68e7ee1aebc5eeb8e035e82",
+      "receipt": "090926d1079f10242fb323dc4d6f6d7f317290b637c166648a3f0468c5bd82d0",
+      "payload_sha256": "6203017bcac7aca1a32b6d65958f3b9035ef05c59901992e651f296824fd343e",
+      "snapshot": "e02df4717aa904ca4dfb8d311c69938f393dbf8b",
+      "source_diff_from_commit": [
+        ".pbrun-closure.a6206598c90a07e5.json",
+        "docs/experiments/tessera_best_form_pin_20260909/provision_cpu.py"
+      ],
+      "files": [
+        "tests/test_tessera_pin_provisioner.py"
+      ],
+      "summary": "19 passed, 28 warnings in 8.44s"
+    }
+  ]
+}

--- a/docs/experiments/tessera_best_form_pin_20260909/provision_cpu.py
+++ b/docs/experiments/tessera_best_form_pin_20260909/provision_cpu.py
@@ -1,0 +1,25 @@
+"""Provision a scoped CPU test interpreter without mutating the fleet base venv."""
+from pathlib import Path
+import json
+import subprocess
+import sys
+import venv
+
+base=Path('/home/rob/venvs/pq-cpu312')
+target=Path('/home/rob/venvs/pq-cpu312-glm-best-form-b1eb1dccc')
+source=Path('/mnt/shared/tessera-measurements/glm-canonical-census-20260908/producer-source-best-tile-reviewed-01')
+assert sys.prefix==str(base),sys.prefix
+if target.exists():
+    raise RuntimeError(f'scoped environment already exists; inspect before reusing: {target}')
+venv.EnvBuilder(with_pip=False).create(target)
+site=next((target/'lib').glob('python*/site-packages'))
+base_site=base/'lib'/site.parent.name/'site-packages'
+assert base_site.is_dir()
+(site/'fleet-base-dependencies.pth').write_text(str(base_site)+'\n')
+python=str(target/'bin/python')
+command=[sys.executable,'tools/provision_tessera_pin.py','--python',python,'--clone',str(source)]
+subprocess.run(command,check=True)
+subprocess.run([*command,'--check-only'],check=True)
+probe=subprocess.check_output([python,'-I','-c','import json,tessera,torch; print(json.dumps(dict(tessera=tessera.__file__,torch=torch.__version__)))'],text=True)
+identity=json.loads(probe);assert identity['tessera'].startswith(str(site)+'/')
+print(json.dumps(dict(status='SCOPED_ENV_READY',python=python,base_dependencies=str(base_site),identity=identity)))

--- a/prismaquant/tessera_runtime/README.md
+++ b/prismaquant/tessera_runtime/README.md
@@ -197,13 +197,15 @@ p.write_text(s)
 EDIT_CONSTS
 ```
 
-Verify — ONE shell segment, and the empty `CUDA_VISIBLE_DEVICES` prefix is
-required by this repository's pool hook:
+Use a fleet interpreter provisioned at the reviewed pin, then route CPU
+verification through PrismaBuild:
 
 ```bash
-cd /home/rob/prismaquant && CUDA_VISIBLE_DEVICES="" PYTHONPATH=. \
-  TRITON_CACHE_DIR=/home/rob/tmp/triton-cache nice -n 10 \
-  /home/rob/dq-runs/venvs/prismaquant-cu130/bin/python -m pytest -q -p no:cacheprovider \
+python3 /mnt/shared/prismabuild-fleet/repo/tools/pbrun.py \
+  --cwd /home/rob/prismaquant --tag x86 --cpus 4 --demand mem_gb=8 \
+  --priority -10 --env OMP_NUM_THREADS=1 --env MKL_NUM_THREADS=1 \
+  --env OPENBLAS_NUM_THREADS=1 -- \
+  /home/rob/venvs/pq-cpu312/bin/python -m pytest -q -n 4 \
   tests/test_tessera_serving_pin.py tests/test_tessera_lane_v6.py \
   tests/test_tessera_lane_admission.py tests/test_tessera_export_lane.py
 ```

--- a/prismaquant/tessera_runtime/tessera_serving_runtime_pin.json
+++ b/prismaquant/tessera_runtime/tessera_serving_runtime_pin.json
@@ -1,7 +1,7 @@
 {
   "schema": "prismaquant.tessera_serving_runtime_pin.v2",
   "repository": "https://github.com/RobTand/tessera.git",
-  "commit": "07ad344c3275bb2fa7ce2432f93d89945d66f4c2",
+  "commit": "b1eb1dccc9df6773ab94e1c98f316f45bb18ab4c",
   "version": "0.1.0",
   "version_is_release": false,
   "contract_sha256": "a688f8de244f936ec3a63a782e20af7985733e7a6fb0b4b981b5fe4c44112212",

--- a/prismaquant/tessera_runtime_contract.py
+++ b/prismaquant/tessera_runtime_contract.py
@@ -148,6 +148,12 @@ TESSERA_DEV_PIN_ENV = "PRISMAQUANT_TESSERA_DEV_PIN"
 #: The Tessera commit this pin's answer was reviewed against.  Declared and
 #: recorded; NOT compared to anything.  A moving ``master`` is not a review
 #: event -- :data:`TESSERA_DEV_PIN_ANSWER` is what refuses. Re-pinned
+#: 2026-09-09 to b1eb1dccc (Tessera #437/#438) for the opt-in best-form
+#: window encoder and explicit tile controls. Actual GLM endpoint runs retain
+#: exact wire bytes and scores; no encoder default or serving cell changes.
+#: The pin also includes the reviewed cached-export and rank-local TP2 intake
+#: fixes (#434/#436), whose bounded controls do not qualify a full GLM serve.
+#: Previously re-pinned
 #: 2026-09-08 to 07ad344c3 (Tessera #431) for explicit packed checkpoint
 #: execution and strict typed export carriers, retaining the exact contract
 #: bytes and admission answer. Previously re-pinned
@@ -158,7 +164,7 @@ TESSERA_DEV_PIN_ENV = "PRISMAQUANT_TESSERA_DEV_PIN"
 #: contract v22 / lane schema v9 (Tessera master 8ed1d9a, the merge of its
 #: #332, which answers its #327; v21 landed at b8b1cb38 in its #313 and the
 #: release e78959ed carried v20). The development and serving pins now both
-#: bind 07ad344c3: they name ONE object, and
+#: bind b1eb1dccc: they name ONE object, and
 #: letting them drift is how two of this repository's own spec files came to
 #: disagree about one runtime.  Between the v17 review and this one the
 #: answer moved in exactly four places and nowhere else -- no family, rung,
@@ -211,7 +217,7 @@ TESSERA_DEV_PIN_ENV = "PRISMAQUANT_TESSERA_DEV_PIN"
 #: Verified by fetching ``RobTand/tessera`` master into a scratch repository
 #: and hashing the blob at the tip -- never a working tree (the command is in
 #: ``tessera_runtime/README.md``).  No tag names the commit.
-TESSERA_DEV_PIN_COMMIT = "07ad344c3275bb2fa7ce2432f93d89945d66f4c2"
+TESSERA_DEV_PIN_COMMIT = "b1eb1dccc9df6773ab94e1c98f316f45bb18ab4c"
 
 #: sha256 of ``tessera/serving/runtime_contract.json`` at that commit -- the
 #: bytes a human read when the answer below was accepted.  Recorded, and

--- a/prismaquant/tessera_serving_runtime_pin.py
+++ b/prismaquant/tessera_serving_runtime_pin.py
@@ -168,7 +168,7 @@ TESSERA_SERVING_RUNTIME_CONTRACT_SHA256_PENDING = "PENDING_TESSERA_CONTRACT_SHA2
 #: the same commit.  Re-check it against the COMMIT rather than a past HEAD,
 #: which nobody can re-run::
 #:
-#:     git -C "$TS" cat-file -p 07ad344c3275bb2fa7ce2432f93d89945d66f4c2:src/tessera/serving/runtime_contract.json | sha256sum
+#:     git -C "$TS" cat-file -p b1eb1dccc9df6773ab94e1c98f316f45bb18ab4c:src/tessera/serving/runtime_contract.json | sha256sum
 #:
 #: Re-pinned 2026-09-05 to ba582d4 (Tessera #356) for the priced-input
 #: exporter snapshot API required by PrismaQuant #231. The v22 contract bytes
@@ -186,8 +186,12 @@ TESSERA_SERVING_RUNTIME_CONTRACT_SHA256_PENDING = "PENDING_TESSERA_CONTRACT_SHA2
 #: packed checkpoint execution declaration and strict typed export carriers.
 #: Contract bytes and admission answers remain unchanged. This is a producer
 #: API/source dependency, with no full-model or TP2 qualification claim.
+#: Re-pinned 2026-09-09 to b1eb1dccc for the opt-in best-form encoder and
+#: tile controls (#437/#438), including reviewed cached-export and rank-local
+#: intake fixes (#434/#436). Actual GLM pricing preserves measured bytes and
+#: scores; the unchanged contract and answer grant no new serving qualification.
 TESSERA_SERVING_RUNTIME_PINNED_COMMIT = (
-    "07ad344c3275bb2fa7ce2432f93d89945d66f4c2"
+    "b1eb1dccc9df6773ab94e1c98f316f45bb18ab4c"
 )
 TESSERA_SERVING_RUNTIME_PINNED_VERSION = "0.1.0"
 TESSERA_SERVING_RUNTIME_PINNED_CONTRACT_SHA256 = (

--- a/tests/test_tessera_pin_provisioner.py
+++ b/tests/test_tessera_pin_provisioner.py
@@ -461,10 +461,9 @@ def test_a_cached_tree_that_fails_its_manifest_is_kept_not_deleted(tmp_path):
 def test_an_unmanifested_tree_matching_the_commit_is_attested_not_replaced(tmp_path):
     """Bytes that already are the commit do not need to be written again.
 
-    ``/mnt/shared/tessera-pins/07ad344c...`` predates the manifest and is
-    correct.  Rewriting it churns a shared directory other boxes may be
-    reading, for a tree that is already right; verifying it against a fresh
-    ``git archive`` establishes the same thing without touching it.
+    A tree written before manifests existed may already match its commit.
+    Rewriting those verified bytes churns a shared directory other boxes may
+    be reading; compare against a fresh ``git archive`` and attest in place.
     """
     mod = _load()
     clone, old, new = _git_clone_with_two_commits(tmp_path)


### PR DESCRIPTION
Pin both Tessera source dependencies to reviewed b1eb1dccc, bringing in the opt-in best-form encoder/tile controls and reviewed cached-export/TP2-intake fixes. Contract bytes, serving admission and producer defaults stay the same. New pricing binds the new producer; the original capture is reusable and old priced anchors keep their original source identities.

Validation: 249 CPU tests passed across 8 PrismaBuild shards (10 modules, no skips or missing collection), with actual CAS receipts and source snapshots checked. Native GB10 GLM comparisons preserve all 32 selected experts' wire bytes and scores at both R832/R1088; before/after profiles and both-host telemetry are retained. B32 improves energy per expert at R832 but worsens it at R1088; no blanket batch policy or full-model/serving qualification is claimed. The sustained 90–100 W target remains open. See docs/experiments/tessera_best_form_pin_20260909/README.md and cpu-receipts.json for provenance, environment, results and limitations.

Related to #283. Separate prose correction updates the recorded pin's verification example to use the actual pinned source and PrismaBuild.

Closes #463.

Full required CI on aef98009cb passed: 7,320 tests, 204 skips, 3 expected failures, 192 subtests; actual log and pinned producer checked. CPU-only skips do not establish GPU coverage. Run 34316465643; log SHA256 73e24a94cf1c115e2723ba70e21abda4d13a34d0088bab9cb484f02c3dc24ee9.
