### PR TITLE
Let the next batch encode while the last one is written

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,28 +5,41 @@ follow, newest first, each recording its own branch and date.
 
 Re-stamped (2026-09-09, `claude/bounded-publication-overlap`) for the campaign's
 opt-in **bounded publication overlap** (§4.10). `--publication-overlap-bytes N`
-(default `0`, which is the historical synchronous path byte for byte) stages up
-to N bytes of already-encoded artifacts and writes them on one bounded writer
-thread, so the next anchor batch encodes while the previous batch's render and
-wire files are written. The device-to-host copy of each render stays on the
-thread that owns the device work; the writer then calls the same
+(default `0`, which is the historical synchronous path byte for byte) runs one
+bounded writer thread so the next anchor batch encodes while the previous
+batch's artifacts are persisted. Three links move onto that thread, in queue
+order: the render and wire files, the wire receipt that is read back off them,
+and the `write_unit` journal write that cites the receipt. The
+device-to-host copy of each render stays on the thread that owns the device
+work, and the writer then calls the same
 `production_weight_cache._store_rendered_weight_entry` and the same
 tmp-plus-`os.replace` wire write the synchronous path calls, so there is no
 second cache and no change to what a published file is. An anchor is added to
-`measured` and marked for the journal only after its own files exist, so the
-checkpoint invariant that every journalled anchor row carries a wire receipt
-read back off a published file is unchanged; a round, a deadline stop and the
-end of the loop are drain barriers. Each job is charged
-`tensor.nbytes + len(blob)` and a submit blocks over budget, so staging is
-bounded; the memory guard's `after_selected_anchor_batch` bracket therefore
-includes staged bytes, and the publisher's budget, peak charge and blocked
-seconds are stamped on cost provenance under `publication_overlap` so a reader
-can attribute them. A writer failure is closed: everything queued behind it is
-dropped unwritten and the campaign's batch handler re-raises rather than
-continuing. The option is excluded from checkpoint input identity, because it
-chooses which thread performs two writes whose arguments it does not touch.
-Gate: `tests/test_tessera_publication.py`. Its barrier tests establish ordering
-only; no speed, work-per-joule or I/O claim is made here.
+`measured` and marked for the journal only after its own receipt exists, so
+the checkpoint invariant that every journalled anchor row carries a wire
+receipt read back off a published file is unchanged. A round, a deadline stop
+and the end of the loop are drain barriers; the publisher's lifetime is a
+`try`/`finally`, and unwinding commits the rows whose receipts really
+completed before dropping what is still staged, so a batch that succeeded
+before a later one failed keeps its journal row.
+
+The byte budget is a bound rather than a statistic: the producer reserves
+before it allocates, an artifact larger than the whole budget is refused
+instead of admitted as a special case, and `autoscale.
+selected_anchor_resources` charges the budget as `publication_staging_bytes`
+in the `resident_anchors` phase, propagated from both the campaign CLI and
+`tools/dispatch_tessera_campaign.py`. The memory guard's
+`after_selected_anchor_batch` bracket therefore includes staged bytes, and the
+publisher's budget, peak charge and blocked seconds are stamped on cost
+provenance under `publication_overlap` so a reader can attribute them. A
+writer failure is closed: everything queued behind it is dropped unwritten and
+the campaign's batch handler re-raises rather than continuing. The option is
+excluded from checkpoint input identity, because it chooses which thread
+performs writes whose arguments it does not touch. Gates:
+`tests/test_tessera_publication.py`,
+`tests/test_tessera_campaign_publication_cli.py`. The barrier tests establish
+ordering and bounds only; the device-to-host copy remains synchronous, and no
+speed, work-per-joule or I/O claim is made here.
 
 Re-stamped (2026-09-08, `fix/glm-selected-verified-capture`) for opt-in
 `--capture-load-policy` on selected streaming reuse of a SHA-bound complete

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,32 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-08 · `integration/glm-first-artifact-pricing-delivery`. Stamps
+As of: 2026-09-09 · `claude/bounded-publication-overlap`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-09, `claude/bounded-publication-overlap`) for the campaign's
+opt-in **bounded publication overlap** (§4.10). `--publication-overlap-bytes N`
+(default `0`, which is the historical synchronous path byte for byte) stages up
+to N bytes of already-encoded artifacts and writes them on one bounded writer
+thread, so the next anchor batch encodes while the previous batch's render and
+wire files are written. The device-to-host copy of each render stays on the
+thread that owns the device work; the writer then calls the same
+`production_weight_cache._store_rendered_weight_entry` and the same
+tmp-plus-`os.replace` wire write the synchronous path calls, so there is no
+second cache and no change to what a published file is. An anchor is added to
+`measured` and marked for the journal only after its own files exist, so the
+checkpoint invariant that every journalled anchor row carries a wire receipt
+read back off a published file is unchanged; a round, a deadline stop and the
+end of the loop are drain barriers. Each job is charged
+`tensor.nbytes + len(blob)` and a submit blocks over budget, so staging is
+bounded; the memory guard's `after_selected_anchor_batch` bracket therefore
+includes staged bytes, and the publisher's budget, peak charge and blocked
+seconds are stamped on cost provenance under `publication_overlap` so a reader
+can attribute them. A writer failure is closed: everything queued behind it is
+dropped unwritten and the campaign's batch handler re-raises rather than
+continuing. The option is excluded from checkpoint input identity, because it
+chooses which thread performs two writes whose arguments it does not touch.
+Gate: `tests/test_tessera_publication.py`. Its barrier tests establish ordering
+only; no speed, work-per-joule or I/O claim is made here.
 
 Re-stamped (2026-09-08, `fix/glm-selected-verified-capture`) for opt-in
 `--capture-load-policy` on selected streaming reuse of a SHA-bound complete
@@ -1419,7 +1444,9 @@ and calls Tessera's `encode_linears` with each unit's own ActivationSource
 mapping. Each result uses the scalar path's served activation scale, wire
 decoder, production scorer and cache writer. Per-unit wire identity and
 journal envelopes remain unchanged; each completed batch is journalled before
-the next starts. Batch width is excluded from input identity, so a resume can
+the next starts (under `--publication-overlap-bytes` a batch is journalled when
+its own files land, which may be during the next batch's encode; see the
+2026-09-09 stamp). Batch width is excluded from input identity, so a resume can
 change execution width without repricing completed rows. Measured rows record
 batch width and identify equally apportioned batch encoding time; that is
 accounting, not independently measured per-unit latency. Default width remains

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,9 +19,13 @@ second cache and no change to what a published file is. An anchor is added to
 the checkpoint invariant that every journalled anchor row carries a wire
 receipt read back off a published file is unchanged. A round, a deadline stop
 and the end of the loop are drain barriers; the publisher's lifetime is a
-`try`/`finally`, and unwinding commits the rows whose receipts really
-completed before dropping what is still staged, so a batch that succeeded
-before a later one failed keeps its journal row.
+`try`/`finally` it is started inside, and unwinding commits the rows whose
+receipts really completed before dropping what is still staged, so a batch
+that succeeded before a later one failed keeps its journal row. That commit
+is unconditional: rows a batch's `apply_completed` had already put into the
+pending checkpoint are unwritten until a flush, and the batch cadence need
+not have reached one, so flushing only when the unwind itself journalled
+something would lose exactly the batch it exists to keep.
 
 The byte budget is a bound rather than a statistic: the producer reserves
 before it allocates, an artifact larger than the whole budget is refused

--- a/prismaquant/autoscale.py
+++ b/prismaquant/autoscale.py
@@ -310,7 +310,8 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
 
 def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
                               cache_slots, prefetch_workers, headroom_gb,
-                              anchor_batch_size=1, capture_load_policy=None):
+                              anchor_batch_size=1, capture_load_policy=None,
+                              publication_overlap_bytes=0):
     """Bound selected-source preparation separately from resident encoding.
 
     This extends the source loader's header/dtype accounting. No source
@@ -435,7 +436,19 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
         # whether that release is complete is the loader's contract, not a
         # term derivable from a shape.
         entry_validation_bytes=2*widest_capture_entry,
-        source_validation_bytes=sum(source['body_source_file_bytes'][k] for k in layers)+widest_weight)
+        source_validation_bytes=sum(source['body_source_file_bytes'][k] for k in layers)+widest_weight,
+        # tessera_publication.BoundedPublisher's own bound, charged as itself.
+        # Staged artifacts are host bytes waiting to be written: the CPU BF16
+        # render (_canonical_rendered_weight_tensor) and the wire blob, live
+        # from the reserve that admits them to the os.replace that publishes
+        # them. This is the whole term rather than a term plus a producer-side
+        # copy because the reservation is taken BEFORE the copy is made and an
+        # artifact larger than the budget is refused, so no thread ever holds
+        # staged bytes outside it. Charging at submit time, or admitting one
+        # oversized job, would both have made this number smaller than what
+        # the run can actually hold. A run that does not ask for staging
+        # charges nothing.
+        publication_staging_bytes=int(publication_overlap_bytes))
     export_inputs = dict(common, selected_hessian_bytes=source['full_hessian_bytes'],
         selected_prefix_bytes=source['full_prefix_bytes'],
         # tessera_campaign._save_hessian_capture_with_page_release pauses the

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -425,7 +425,7 @@ def _activation_kwargs_memo(source, weights, device, *, max_entries=None,
 def _measure_anchor(
     *, qname: str, weight, activations, format_name: str, cache, wire_dir: Path,
     activation_kwargs_for=None, hessian_required: bool = True,
-    static_input_scale: "float | None" = None,
+    static_input_scale: "float | None" = None, publisher=None,
 ):
     """Render one rung, price it as served, and store the wire beside it.
 
@@ -465,7 +465,8 @@ def _measure_anchor(
         hessian_required=prepared["hessian_required"])
     return _finish_anchor(qname=qname, weight=weight, activations=activations,
         format_name=format_name, cache=cache, wire_dir=wire_dir,
-        prepared=prepared, render=render, blob=blob, elapsed=time.time() - started)
+        prepared=prepared, render=render, blob=blob, elapsed=time.time() - started,
+        publisher=publisher)
 
 
 def _prepare_anchor(*, qname, format_name, activation_kwargs_for,
@@ -543,11 +544,22 @@ def _prepare_anchor(*, qname, format_name, activation_kwargs_for,
 
 
 def _finish_anchor(*, qname, weight, activations, format_name, cache, wire_dir,
-                   prepared, render, blob, elapsed, encoding_batch_size=1):
-    """Score decoded bytes and publish the existing cache/wire entries."""
+                   prepared, render, blob, elapsed, encoding_batch_size=1,
+                   publisher=None):
+    """Score decoded bytes and publish the existing cache/wire entries.
+
+    ``publisher``, when given, is a
+    :class:`~prismaquant.tessera_publication.BoundedPublisher` that performs
+    the two writes on its own thread instead of here.  The bytes handed to it
+    are the same bytes and the writes are the same calls; what moves is only
+    which thread runs them, and the caller then owes the completion an
+    ordering rule -- the anchor is not journalled until its files exist.  With
+    no publisher this function is what it has always been, line for line.
+    """
     import torch
     from .production_weight_cache import (
-        _local_forward_render_score, _store_rendered_weight_entry)
+        _canonical_rendered_weight_tensor, _local_forward_render_score,
+        _store_rendered_weight_entry)
 
     spec, family, rung = (prepared[key] for key in ("spec", "family", "rung"))
     activation_qdq, input_scale = (prepared[key] for key in (
@@ -566,31 +578,50 @@ def _finish_anchor(*, qname, weight, activations, format_name, cache, wire_dir,
         raise RuntimeError(f"unexpected render-score metric {metric!r}")
     hessian_applied = bool(prepared["activation_kwargs"])
 
-    _store_rendered_weight_entry(
-        weights=cache.weights,
-        qname=qname,
-        fmt=format_name,
-        tensor=render,
-        cache_dir_path=Path(cache.cache_dir) if cache.cache_dir else None,
-        weight_dtype=torch.bfloat16,
-    )
+    # The device-to-host copy stays on the thread that owns the device work,
+    # whichever way the bytes are written.  ``_store_rendered_weight_entry``
+    # canonicalises again below and that second call is an identity on a CPU
+    # tensor already in the target dtype and contiguous, so the synchronous
+    # path stores the same object it always stored.  Staging it here is what
+    # gives the writer thread bytes nobody else owns.
+    staged = _canonical_rendered_weight_tensor(render, weight_dtype=torch.bfloat16)
     # The wire, beside the render.  A ``.tessera`` shard per (qname, rung),
     # named the way the cache names its weight shards, so the export leg can
     # find the exact bytes this row was priced on instead of re-encoding.
     wire_path = _wire_path(wire_dir, qname, format_name)
-    tmp = wire_path.with_suffix(".tessera.tmp")
-    tmp.write_bytes(blob)
-    os.replace(tmp, wire_path)
-    if getattr(cache, 'metadata', {}).get('release_completed_anchor_file_pages'):
-        # The existing PWC entry is already disk-backed. Completed anchor
-        # files must not accumulate an unbounded page-cache owner across rungs.
-        # The release helper checks the entry's identity, fsyncs and advises
-        # it from its own descriptor. No verification consumes a second hash
-        # of these completed files here.
-        from .perturbed_x_cache import release_activation_cache_file_pages
-        rendered_path = Path(cache.cache_dir)/cache.weights[(qname, format_name)]
-        for path in (rendered_path, wire_path):
-            release_activation_cache_file_pages(path, expected_stat=path.stat())
+
+    def _publish():
+        _store_rendered_weight_entry(
+            weights=cache.weights,
+            qname=qname,
+            fmt=format_name,
+            tensor=staged,
+            cache_dir_path=Path(cache.cache_dir) if cache.cache_dir else None,
+            weight_dtype=torch.bfloat16,
+        )
+        tmp = wire_path.with_suffix(".tessera.tmp")
+        tmp.write_bytes(blob)
+        os.replace(tmp, wire_path)
+        if getattr(cache, 'metadata', {}).get('release_completed_anchor_file_pages'):
+            # The existing PWC entry is already disk-backed. Completed anchor
+            # files must not accumulate an unbounded page-cache owner across
+            # rungs. The release helper checks the entry's identity, fsyncs
+            # and advises it from its own descriptor. No verification consumes
+            # a second hash of these completed files here.
+            from .perturbed_x_cache import release_activation_cache_file_pages
+            rendered_path = Path(cache.cache_dir)/cache.weights[(qname, format_name)]
+            for path in (rendered_path, wire_path):
+                release_activation_cache_file_pages(path, expected_stat=path.stat())
+
+    if publisher is None:
+        _publish()
+    else:
+        from .tessera_publication import PublicationJob
+        publisher.submit(PublicationJob(
+            key=(qname, format_name),
+            charged_bytes=(staged.numel() * staged.element_size()) + len(blob),
+            publish=_publish,
+        ))
 
     bits = spec.bits_for_shape(tuple(weight.shape))
     return CampaignAnchor(
@@ -617,7 +648,8 @@ def _finish_anchor(*, qname, weight, activations, format_name, cache, wire_dir,
 
 def _measure_anchor_batch(*, qnames, weights, activations, format_name,
                           cache, wire_dir, activation_kwargs_for=None,
-                          hessian_required=True, static_input_scales=None):
+                          hessian_required=True, static_input_scales=None,
+                          publisher=None):
     """One producer batch, with the scalar path's per-unit gates and storage."""
     from .tessera_render import encode_tessera_units
 
@@ -640,7 +672,8 @@ def _measure_anchor_batch(*, qnames, weights, activations, format_name,
     elapsed = (time.time() - started) / len(qnames)
     return [_finish_anchor(qname=name, weight=weight, activations=acts,
         format_name=format_name, cache=cache, wire_dir=wire_dir, prepared=entry,
-        render=render, blob=blob, elapsed=elapsed, encoding_batch_size=len(qnames))
+        render=render, blob=blob, elapsed=elapsed,
+        encoding_batch_size=len(qnames), publisher=publisher)
         for name, weight, acts, entry, (render, blob) in zip(
             qnames, weights, activations, prepared, encoded)]
 
@@ -1523,8 +1556,14 @@ def _campaign_checkpoint_identity(*, weights, acts, hessians, menus, args,
         if (not isinstance(structure_by_unit, Mapping) or set(structure_by_unit) != set(menus)
                 or any(s not in ("dense", "routed_moe") for s in structure_by_unit.values())):
             raise ValueError("family restriction identity requires every priced unit's structure")
-    # Locations, batch width and a wall-clock interruption limit are not
-    # encoding/scoring inputs. All other explicit campaign settings remain bound by default.
+    # Locations, batch width, publication staging and a wall-clock
+    # interruption limit are not encoding/scoring inputs.  All other explicit
+    # campaign settings remain bound by default.
+    #
+    # ``publication_overlap_bytes`` chooses which thread performs two writes
+    # whose arguments it does not touch.  Binding it would make a run that
+    # staged its artifacts unable to resume a journal written without staging,
+    # which is a refusal about scheduling wearing an identity's clothes.
     #
     # ``units``, ``calibration_census`` and ``census_out`` are locations too,
     # and each one's load-bearing content is already bound by value somewhere
@@ -1542,7 +1581,8 @@ def _campaign_checkpoint_identity(*, weights, acts, hessians, menus, args,
     for name in ("out", "cache_dir", "checkpoint", "deadline_seconds",
                  "units", "calibration_census", "census_out",
                  "capture_calibration_out", "calibration_cache", "calibration_cache_sha256",
-                 "seed_checkpoint", "seed_wire_dir", "anchor_batch_size"):
+                 "seed_checkpoint", "seed_wire_dir", "anchor_batch_size",
+                 "publication_overlap_bytes"):
         settings.pop(name, None)
     return {
         **({"family_restriction": {"policy": restriction,
@@ -3852,6 +3892,7 @@ def _main(argv, *, source_scope) -> int:
     from .production_weight_cache import ProductionWeightCache
     from .tessera_menu import MENU_MODES, PARALLEL_NONE, menu_mode
     from .tessera_rate_surface import leave_one_anchor_out
+    from .tessera_publication import PublicationError
     from .tessera_render import (
         HessianContractError, tessera_encoder_hessian_status,
     )
@@ -3885,6 +3926,13 @@ def _main(argv, *, source_scope) -> int:
                     help="maximum compatible expert anchors in one producer "
                          "batch within this action (1 = scalar). Does not "
                          "change the anchor schedule or PB placement.")
+    ap.add_argument("--publication-overlap-bytes", type=int, default=0,
+                    help="stage up to N bytes of already-encoded render/wire "
+                         "artifacts on one writer thread so the next batch "
+                         "encodes while they are written (0 = publish "
+                         "synchronously on the encode thread, the default and "
+                         "byte-for-byte the historical path). An anchor is "
+                         "still journalled only after its own files exist.")
     ap.add_argument("--max-rounds", type=int, default=0,
                     help="hard stop on adaptive rounds (0 = governed by "
                          "--anchor-budget instead). Rounds are not the "
@@ -4022,6 +4070,8 @@ def _main(argv, *, source_scope) -> int:
             ap.error("capture/reuse requires positive --max-act-rows")
     if args.anchor_batch_size < 1:
         ap.error("--anchor-batch-size must be positive")
+    if args.publication_overlap_bytes < 0:
+        ap.error("--publication-overlap-bytes cannot be negative")
     if args.anchor_batch_size > 1:
         from .tessera_render import require_tessera_batch_encoder
         require_tessera_batch_encoder()
@@ -4716,6 +4766,56 @@ def _main(argv, *, source_scope) -> int:
                        identity_sha256=identity_sha256, state=state)
         dirty_checkpoint_units.clear()
 
+    # Anchors whose bytes are staged but not yet written, keyed the way the
+    # publisher keys its jobs.  An anchor lives here instead of in ``measured``
+    # for exactly as long as its files do not exist, which is what keeps
+    # ``flush_checkpoint``'s existing invariant true without changing it: every
+    # anchor row it journals has a wire receipt beside it, and every one of
+    # those receipts was read back off a file that had already landed.
+    awaiting_publication: dict = {}
+    publisher = None
+    if int(args.publication_overlap_bytes) > 0:
+        from .tessera_publication import BoundedPublisher
+        publisher = BoundedPublisher(
+            budget_bytes=int(args.publication_overlap_bytes))
+        print(f"[campaign] publication overlap: staging up to "
+              f"{int(args.publication_overlap_bytes)} bytes on one writer "
+              "thread", flush=True)
+
+    def journal_anchor(anchor, identity) -> None:
+        """Make this anchor's wire receipt and mark its unit for the journal.
+
+        The receipt is read back off the published file, which is what makes
+        it a statement about bytes that exist rather than about bytes that
+        were intended.  Both paths run this same code; they differ only in
+        when it is safe to run it.
+        """
+        name = anchor.qname
+        wire_records[name][anchor.format_name] = _checkpoint_wire_record(
+            anchor, wire_dir, identity)
+        measured.setdefault(name, {}).setdefault(
+            anchor.family, []).append(anchor)
+        dirty_checkpoint_units.add(name)
+
+    def apply_publications(keys) -> None:
+        """Turn published files into journallable rows, in publication order."""
+        for key in keys:
+            journal_anchor(*awaiting_publication.pop(key))
+
+    def record_anchor(anchor, identity) -> None:
+        """Journal this anchor now, or when the writer says its bytes exist."""
+        if publisher is None:
+            journal_anchor(anchor, identity)
+            return
+        key = (anchor.qname, anchor.format_name)
+        if key in awaiting_publication:
+            # Two anchors for one (unit, rung) would have one publication key
+            # and one of them would be journalled under the other's receipt.
+            # The anchor schedule does not produce this; if it ever does, it
+            # is a scheduling defect and not something to average over.
+            raise RuntimeError(f"{anchor.qname} {anchor.format_name} is already staged")
+        awaiting_publication[key] = (anchor, identity)
+
     # Adopted rows are journalled BEFORE the anchor loop, because the loop can
     # end without reaching its own flush: a group whose gate is already closed
     # has nothing pending in round one and breaks out.  A seeded run is exactly
@@ -4908,9 +5008,19 @@ def _main(argv, *, source_scope) -> int:
         if selected_source and selected_source_preparation is not None:
             selected_source_preparation['anchor_batch_growth_bytes'] = anchor_batch_growth
         for batch in batches:
+            # Rows whose files landed while the last batch encoded. Applied at
+            # the top of the batch rather than the bottom, so the receipt read
+            # back off each published file runs one batch behind the write
+            # instead of immediately after it.
+            if publisher is not None:
+                apply_publications(publisher.completed())
             if out_of_time():
                 stopped_early = True
                 print("[campaign] deadline reached; stopping", flush=True)
+                # A deadline is a termination, so the staged bytes are written
+                # and journalled before the loop is left; they were paid for.
+                if publisher is not None:
+                    apply_publications(publisher.drain())
                 break
             names = [item[0] for item in batch]
             family, rung = batch[0][1:]
@@ -4944,7 +5054,12 @@ def _main(argv, *, source_scope) -> int:
                         weights=[weights[name].to(device) for name in names],
                         activations=[acts[name].to(device) for name in names],
                         static_input_scales=static_scales, **common)
-            except (HessianContractError, ActivationScaleContractError):
+            except (HessianContractError, ActivationScaleContractError,
+                    PublicationError):
+                # A staged artifact that did not reach its disk is not one
+                # batch's bad luck: the writer has stopped and everything
+                # behind it was dropped unwritten. Printing and continuing
+                # here would advance the loop past files that do not exist.
                 raise
             except Exception as exc:
                 if selected_guard is not None and selected_guard.failure is not None:
@@ -4953,18 +5068,20 @@ def _main(argv, *, source_scope) -> int:
                       f"{exc}", flush=True)
                 continue
             if selected_guard is not None:
+                # With publication staging on, this upper bracket includes the
+                # staged CPU bytes of any batch the writer has not finished.
+                # That is real resident memory the plan is charging for, so it
+                # belongs in the growth figure rather than being filtered out
+                # of it; the publisher's own budget and peak are stamped
+                # separately on the receipt so a reader can attribute it.
                 selected_guard.check('after_selected_anchor_batch')
                 anchor_batch_growth.append(selected_guard.last[
                     'conservative_cgroup_plus_cuda_reserved_bytes'] - batch_floor)
             for anchor in anchors:
-                name = anchor.qname
-                identity = _checkpoint_anchor_identity(
+                record_anchor(anchor, _checkpoint_anchor_identity(
                     anchor, weights=weights, menus=menus,
                     calibration_source=calibration_source, static_scales=static_scales,
-                    projected_units=projected_units)
-                wire_records[name][fmt] = _checkpoint_wire_record(anchor, wire_dir, identity)
-                measured.setdefault(name, {}).setdefault(family, []).append(anchor)
-                dirty_checkpoint_units.add(name)
+                    projected_units=projected_units))
             completed += len(anchors)
             # Commit every joined quantum before advancing. The scalar mode
             # keeps its existing ten-anchor flush cadence.
@@ -4973,6 +5090,10 @@ def _main(argv, *, source_scope) -> int:
                 print(f"[campaign] r{round_index} {completed}/{len(pending)} "
                       f"batch={len(anchors)} {fmt} "
                       f"encode_seconds={sum(a.seconds for a in anchors):.3f}", flush=True)
+        # The round is a consumer barrier: the next round reads ``measured``
+        # to decide what is still pending, so nothing may still be in flight.
+        if publisher is not None:
+            apply_publications(publisher.drain())
         flush_checkpoint()
         if stopped_early:
             break
@@ -4981,6 +5102,20 @@ def _main(argv, *, source_scope) -> int:
                 f"campaign adaptive round {round_index} made no progress: "
                 "all pending anchors failed; successful anchors are journaled. "
                 "Refusing to repeat unchanged work; retry after resolving the failure.")
+
+    publication_stats = None
+    if publisher is not None:
+        # Every round already drained, and a round that broke out staged
+        # nothing; this is the last barrier, and it is where a writer failure
+        # that nothing else looked at is raised.
+        apply_publications(publisher.drain())
+        if awaiting_publication:
+            raise RuntimeError(
+                "publication drained with anchors still staged: "
+                + ", ".join(f"{q} {f}" for q, f in sorted(awaiting_publication)))
+        publication_stats = publisher.stats()
+        publisher.close()
+        flush_checkpoint()
 
     loo: dict[str, dict[str, dict]] = {}
     for name, by_family in measured.items():
@@ -4993,6 +5128,14 @@ def _main(argv, *, source_scope) -> int:
     provenance = {
         "provenance": {
             "menu_mode": mode,
+            # How the artifacts were written, and what that cost. Absent means
+            # the default: every render and wire published on the encode
+            # thread before the next batch started. Present means one bounded
+            # writer thread ran them alongside the following encode, and the
+            # row says the budget, the peak charge and how long the encode
+            # thread spent blocked on it -- which is the number that says
+            # whether the bound was the limit or the disk was.
+            "publication_overlap": publication_stats,
             # Units the mode admitted no rung for. Empty on a healthy run;
             # never absent, so a reader never has to guess whether the run
             # was asked the question.

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -81,6 +81,7 @@ from .nvfp4_activation_contract import (
     ActivationScaleContractError as _OwnedActivationScaleContractError,
 )
 from .tessera_expert_projection import EXPERT_WIRES_KEY, POPULATION_KEY, PROJECTION_KEY
+from .tessera_publication import PublicationJob
 
 __all__ = [
     "CENSUS_SCHEMA",
@@ -578,13 +579,28 @@ def _finish_anchor(*, qname, weight, activations, format_name, cache, wire_dir,
         raise RuntimeError(f"unexpected render-score metric {metric!r}")
     hessian_applied = bool(prepared["activation_kwargs"])
 
-    # The device-to-host copy stays on the thread that owns the device work,
-    # whichever way the bytes are written.  ``_store_rendered_weight_entry``
-    # canonicalises again below and that second call is an identity on a CPU
-    # tensor already in the target dtype and contiguous, so the synchronous
-    # path stores the same object it always stored.  Staging it here is what
-    # gives the writer thread bytes nobody else owns.
-    staged = _canonical_rendered_weight_tensor(render, weight_dtype=torch.bfloat16)
+    # Room first, then the bytes.  The copy below is a new host allocation the
+    # writer will own, so the budget has to admit it BEFORE it exists: charging
+    # it after the fact would leave this thread holding one artifact more than
+    # the bound allows, every time the writer is behind.  The size is known
+    # without making it -- one BF16 element per render element, plus the blob
+    # the encoder already returned.
+    if publisher is not None:
+        publisher.reserve(render.numel() * 2 + len(blob))
+    try:
+        # The device-to-host copy stays on the thread that owns the device
+        # work, whichever way the bytes are written.
+        # ``_store_rendered_weight_entry`` canonicalises again below and that
+        # second call is an identity on a CPU tensor already in the target
+        # dtype and contiguous, so the synchronous path stores the same object
+        # it always stored.  Staging it here is what gives the writer thread
+        # bytes nobody else owns.
+        staged = _canonical_rendered_weight_tensor(
+            render, weight_dtype=torch.bfloat16)
+    except BaseException:
+        if publisher is not None:
+            publisher.release(render.numel() * 2 + len(blob))
+        raise
     # The wire, beside the render.  A ``.tessera`` shard per (qname, rung),
     # named the way the cache names its weight shards, so the export leg can
     # find the exact bytes this row was priced on instead of re-encoding.
@@ -616,9 +632,10 @@ def _finish_anchor(*, qname, weight, activations, format_name, cache, wire_dir,
     if publisher is None:
         _publish()
     else:
-        from .tessera_publication import PublicationJob
+        # The reservation above was taken for exactly these bytes; the
+        # element count is the render's and the dtype is BF16 either way.
         publisher.submit(PublicationJob(
-            key=(qname, format_name),
+            key=(FILES_JOB, qname, format_name),
             charged_bytes=(staged.numel() * staged.element_size()) + len(blob),
             publish=_publish,
         ))
@@ -1843,36 +1860,57 @@ def _checkpoint_wire_record(anchor, wire_dir, identity, *, existing=None):
             f"{anchor.format_name}: {exc}") from exc
 
 
+# Job namespaces on the one publication queue. They exist so a completion
+# says which link of the chain finished: the files, the receipt read back off
+# them, or the journal write that cites the receipt.
+FILES_JOB = "files"
+RECEIPT_JOB = "receipt"
+CHECKPOINT_JOB = "checkpoint"
+
+
 class _AnchorPublicationLedger:
     """Decides when a measured anchor is allowed to become a journal row.
 
-    The campaign's rule is that an anchor row and its wire receipt are written
-    together, and that the receipt is read back off a file that exists.  With
-    the publication of that file moved to another thread, "exists" stops being
-    something the encode thread knows by having just done it, so this object
-    holds the anchor until the writer says so.
+    The campaign's rule is a chain: the render and wire files are written,
+    then the wire receipt is made by reading the published file back, then the
+    anchor row and that receipt go into the checkpoint together.  Each link
+    must not precede the one before it.  Doing all three on the encode thread
+    made that ordering free; doing any of them elsewhere makes it something
+    this object has to hold.
 
-    ``journal_anchor(anchor, identity)`` is the caller's own three lines: make
-    the receipt, add the row, mark the unit dirty.  It is called exactly once
-    per anchor either way; what changes is when.
+    It holds it with one queue.  The publisher runs one writer thread in
+    submission order, so a receipt job submitted after a file job runs after
+    it, and a checkpoint job submitted after both runs after both.  Nothing
+    here reorders; it only decides what to put on the queue and when to
+    believe a completion.
 
-    Without a publisher this is a pass-through, which is what makes the
-    default path the historical path rather than a re-implementation of it.
+    ``make_record(anchor, identity)`` is the caller's receipt call, and
+    ``journal_anchor(anchor, record)`` is the caller's three lines that put a
+    row and its receipt into the pending checkpoint.  With no publisher both
+    run inline exactly where they always ran, which is what makes the default
+    path the historical path rather than a re-implementation of it.
     """
 
-    def __init__(self, *, publisher, journal_anchor):
+    def __init__(self, *, publisher, make_record, journal_anchor):
         self._publisher = publisher
+        self._make_record = make_record
         self._journal = journal_anchor
         self._staged: dict = {}
+        self._records: dict = {}
+        self._checkpoint_seq = 0
 
     @property
     def staged(self) -> dict:
         return self._staged
 
+    @property
+    def active(self) -> bool:
+        return self._publisher is not None
+
     def record(self, anchor, identity) -> None:
         """Journal now, or when this anchor's own bytes have been written."""
         if self._publisher is None:
-            self._journal(anchor, identity)
+            self._journal(anchor, self._make_record(anchor, identity))
             return
         key = (anchor.qname, anchor.format_name)
         if key in self._staged:
@@ -1882,13 +1920,66 @@ class _AnchorPublicationLedger:
             # scheduling defect, not something to average over.
             raise RuntimeError(
                 f"{anchor.qname} {anchor.format_name} is already staged")
-        self._staged[key] = (anchor, identity)
+        self._staged[key] = anchor
+
+        def make():
+            # Runs on the writer, behind this unit's own file job, so the
+            # read-back inside the receipt call reads a file that exists and
+            # the encode thread never waits for it.
+            self._records[key] = self._make_record(anchor, identity)
+
+        self._publisher.submit(PublicationJob(
+            key=(RECEIPT_JOB, *key), charged_bytes=0, publish=make))
+
+    def submit_checkpoint(self, write) -> None:
+        """Order one journal write behind every receipt it depends on."""
+        if self._publisher is None:
+            write()
+            return
+        key = (CHECKPOINT_JOB, self._checkpoint_seq)
+        self._checkpoint_seq += 1
+        self._publisher.submit(PublicationJob(
+            key=key, charged_bytes=0, publish=write))
 
     def apply_completed(self) -> int:
         """Journal whatever the writer has finished since the last call."""
         if self._publisher is None:
             return 0
         return self._apply(self._publisher.completed())
+
+    def close(self) -> int:
+        """Journal every receipt that really completed, then stop staging.
+
+        Called on the way out of the pricing loop, including on the way out of
+        an exception, and always after the publisher's own thread has stopped.
+        What is left then is a list of completions the writer finished before
+        it stopped: those are files that exist and receipts that were read
+        back off them, and a batch that succeeded before a later one failed
+        must not lose its journal row because the loop is unwinding.  That
+        loss would be a regression against the synchronous path, which
+        checkpointed each batch before starting the next.
+
+        Everything still staged is dropped.  No receipt, no row: those units
+        are re-priced by the next run over the same paths.  Nothing is
+        refused here, because this runs while an exception is already on its
+        way out and the original failure is the one worth reporting.  After
+        this the ledger writes inline again, so a caller may flush.
+        """
+        if self._publisher is None:
+            return 0
+        completed = self._publisher.completed()
+        self._publisher = None
+        applied = 0
+        for tag, *rest in completed:
+            key = tuple(rest)
+            if tag != RECEIPT_JOB or key not in self._records \
+                    or key not in self._staged:
+                continue
+            self._journal(self._staged.pop(key), self._records.pop(key))
+            applied += 1
+        self._staged.clear()
+        self._records.clear()
+        return applied
 
     def drain(self) -> int:
         """Wait for every staged anchor, journal it, and refuse a remainder."""
@@ -1902,9 +1993,21 @@ class _AnchorPublicationLedger:
         return applied
 
     def _apply(self, keys) -> int:
-        for key in keys:
-            self._journal(*self._staged.pop(key))
-        return len(keys)
+        applied = 0
+        for tag, *rest in keys:
+            if tag in (FILES_JOB, CHECKPOINT_JOB):
+                # Both exist to be ordered, not to be reported: the files a
+                # receipt reads and the journal write a receipt precedes.
+                continue
+            if tag != RECEIPT_JOB:
+                raise RuntimeError(f"publication reported an unknown job {tag!r}")
+            key = tuple(rest)
+            if key not in self._records or key not in self._staged:
+                raise RuntimeError(
+                    f"publication reported a receipt nothing staged: {key!r}")
+            self._journal(self._staged.pop(key), self._records.pop(key))
+            applied += 1
+        return applied
 
 
 def _adopt_seed_checkpoint(manifest_path, wire_dir_arg, *, targets, wire_dir,
@@ -4377,6 +4480,7 @@ def _main(argv, *, source_scope) -> int:
             prefetch_workers=args.streaming_prefetch_workers,
             headroom_gb=args.streaming_cache_headroom_gb,
             anchor_batch_size=args.anchor_batch_size,
+            publication_overlap_bytes=args.publication_overlap_bytes,
             **(dict(capture_load_policy=args.capture_load_policy)
                if args.capture_load_policy is not None else {}))
         if device == 'cuda':
@@ -4819,22 +4923,11 @@ def _main(argv, *, source_scope) -> int:
               flush=True)
         return EXIT_EMPTY_MENU
 
-    def flush_checkpoint() -> None:
-        for name in sorted(dirty_checkpoint_units):
-            rows = [vars(anchor) for anchors in measured.get(name, {}).values()
-                    for anchor in anchors]
-            state = {"anchors": rows, "wire_records": wire_records[name]}
-            if unservable.get(name):
-                state["unservable"] = unservable[name]
-            write_unit(journal, stage="Tessera campaign", qname=name,
-                       identity_sha256=identity_sha256, state=state)
-        dirty_checkpoint_units.clear()
-
     # An anchor waits in the ledger, rather than in ``measured``, for exactly
-    # as long as its files do not exist.  That is what keeps
-    # ``flush_checkpoint``'s existing invariant true without changing it: every
-    # anchor row it journals has a wire receipt beside it, and every one of
-    # those receipts was read back off a file that had already landed.
+    # as long as its files do not exist.  That is what keeps the checkpoint
+    # invariant true without changing it: every anchor row journalled here has
+    # a wire receipt beside it, and every one of those receipts was read back
+    # off a file that had already landed.
     publisher = None
     if int(args.publication_overlap_bytes) > 0:
         from .tessera_publication import BoundedPublisher
@@ -4844,23 +4937,45 @@ def _main(argv, *, source_scope) -> int:
               f"{int(args.publication_overlap_bytes)} bytes on one writer "
               "thread", flush=True)
 
-    def journal_anchor(anchor, identity) -> None:
-        """Make this anchor's wire receipt and mark its unit for the journal.
-
-        The receipt is read back off the published file, which is what makes
-        it a statement about bytes that exist rather than about bytes that
-        were intended.  Both paths run this same code; they differ only in
-        when it is safe to run it.
-        """
+    def journal_anchor(anchor, record) -> None:
+        """Put one anchor row and its wire receipt into the pending state."""
         name = anchor.qname
-        wire_records[name][anchor.format_name] = _checkpoint_wire_record(
-            anchor, wire_dir, identity)
+        wire_records[name][anchor.format_name] = record
         measured.setdefault(name, {}).setdefault(
             anchor.family, []).append(anchor)
         dirty_checkpoint_units.add(name)
 
     ledger = _AnchorPublicationLedger(
-        publisher=publisher, journal_anchor=journal_anchor)
+        publisher=publisher,
+        make_record=lambda anchor, identity: _checkpoint_wire_record(
+            anchor, wire_dir, identity),
+        journal_anchor=journal_anchor)
+
+    def flush_checkpoint() -> None:
+        # The rows are snapshotted here, on the thread that owns them, and
+        # only the write itself is ordered behind the receipts it cites.
+        # ``vars`` returns the anchor's live ``__dict__``, so it is copied
+        # rather than handed over.
+        states = []
+        for name in sorted(dirty_checkpoint_units):
+            rows = [dict(vars(anchor))
+                    for anchors in measured.get(name, {}).values()
+                    for anchor in anchors]
+            state = {"anchors": rows,
+                     "wire_records": dict(wire_records[name])}
+            if unservable.get(name):
+                state["unservable"] = dict(unservable[name])
+            states.append((name, state))
+        dirty_checkpoint_units.clear()
+        if not states:
+            return
+
+        def write():
+            for name, state in states:
+                write_unit(journal, stage="Tessera campaign", qname=name,
+                           identity_sha256=identity_sha256, state=state)
+
+        ledger.submit_checkpoint(write)
 
     # Adopted rows are journalled BEFORE the anchor loop, because the loop can
     # end without reaching its own flush: a group whose gate is already closed
@@ -4954,207 +5069,238 @@ def _main(argv, *, source_scope) -> int:
               "anchors per window family at the band ends"
               + (f", a third for {len(audit_units)} audit unit(s)"
                  if audit_units else ""), flush=True)
-    round_index = 0
-    while True:
-        round_index += 1
-        if int(args.max_rounds) > 0 and round_index > int(args.max_rounds):
-            print(f"[campaign] --max-rounds {args.max_rounds} reached",
-                  flush=True)
-            break
-        pending: list[tuple[str, str, int]] = []
-        for key, members in sorted(anchor_groups.items()):
-            for family, allowed in group_rates[key].items():
-                # The grid is what EVERY member actually measured: one
-                # member's failed encode must not let the group think it has
-                # an anchor there.
-                member_rates = {
-                    m: {a.body_rate_q256 for a in measured.get(m, {}).get(family, [])}
-                    for m in members}
-                grid = sorted(set.intersection(*member_rates.values())) if members else []
-                if round_index == 1:
-                    want = round_one_rates(allowed, band=rate_band,
-                                           anchors=args.anchors, snap=_snap)
-                    extra = (None if not audit_units else
-                             audit_extra_rate(allowed, want, snap=_snap))
-                    for m in members:
-                        rates = set(want)
-                        if extra is not None and m in audit_units:
-                            rates.add(extra)
-                        have = member_rates[m]
-                        pending.extend((m, family, rate)
-                                       for rate in sorted(rates - have))
-                    continue
-                if len(grid) >= budget:
-                    surface_stop.setdefault((key, family), "anchor_budget")
-                    continue
-                worst = 0.0
-                worst_loo: dict = {}
-                ready = True
-                interpolable = 0
-                for m in members:
-                    anchors = measured.get(m, {}).get(family, [])
-                    if len(anchors) < 3:
-                        ready = False
-                        break
-                    member_loo = _loo_for(anchors, leave_one_anchor_out)
-                    if _loo_refused(member_loo):
-                        # A refused surface has no leave-one-out error, and a
-                        # missing error is not a zero one.  Reading it as 0.0
-                        # would say "this surface interpolates perfectly" about
-                        # the one surface that does not interpolate at all --
-                        # and would close the gate on it.  It contributes
-                        # nothing to ``worst`` instead, so the group keeps
-                        # spending anchors for whichever members can still use
-                        # them, and the refusal is reported as itself.
-                        continue
-                    interpolable += 1
-                    value = float(
-                        member_loo.get("max_abs_log2_error", 0.0) or 0.0)
-                    if value > worst:
-                        worst, worst_loo = value, member_loo
-                if not ready:
-                    # LOO cannot judge two endpoints. Bootstrap an interior
-                    # anchor through next_anchor_rate's widest-gap fallback;
-                    # missing LOO is neither a closed gate nor a refusal.
-                    worst_loo = {}
-                elif not interpolable:
-                    surface_stop.setdefault((key, family), "non_interpolable")
-                    continue
-                elif worst <= args.loo_gate:
-                    surface_stop.setdefault((key, family), "gate_closed")
-                    continue
-                nxt = next_anchor_rate(grid, worst_loo)
-                nxt = _snap(nxt, allowed) if nxt is not None else None
-                if nxt is None or nxt in grid:
-                    surface_stop.setdefault((key, family), "no_room")
-                    continue
-                # A failed sibling does not invalidate an already measured
-                # member/rung or authorize overwriting its original cost.
-                pending.extend((m, family, nxt) for m in members
-                               if nxt not in member_rates[m])
-        if not pending:
-            if round_index == 1 and measured:
-                # A resumed/seeded endpoint set still needs its adaptive gate
-                # checked; an empty bootstrap is not a completed surface.
-                continue
-            print(f"[campaign] round {round_index}: nothing pending", flush=True)
-            break
-        print(f"[campaign] round {round_index}: {len(pending)} anchors",
-              flush=True)
-        batches = _anchor_batches(
-            [item for item in pending if acts.get(item[0]) is not None],
-            weights=weights, expert_members=expert_members,
-            batch_size=args.anchor_batch_size)
-        completed = 0
-        # One entry per encode step, in order, each the growth across that
-        # step's own bracket. The list is stamped on the selected receipt now
-        # and filled as the loop runs, so a reader gets the steady-state cost
-        # separately from the first batch's one-time runtime charge.
-        anchor_batch_growth = []
-        if selected_source and selected_source_preparation is not None:
-            selected_source_preparation['anchor_batch_growth_bytes'] = anchor_batch_growth
-        for batch in batches:
-            # Rows whose files landed while the last batch encoded. Applied at
-            # the top of the batch rather than the bottom, so the receipt read
-            # back off each published file runs one batch behind the write
-            # instead of immediately after it.
-            ledger.apply_completed()
-            if out_of_time():
-                stopped_early = True
-                print("[campaign] deadline reached; stopping", flush=True)
-                # A deadline is a termination, so the staged bytes are written
-                # and journalled before the loop is left; they were paid for.
-                ledger.drain()
+    # The publisher owns a thread; every exit from the pricing loop,
+    # including one that raises, has to go past its close. Close drains
+    # what is queued, so files already computed still land, and it cannot
+    # raise, so it cannot mask the exception that brought us here.
+    try:
+        round_index = 0
+        while True:
+            round_index += 1
+            if int(args.max_rounds) > 0 and round_index > int(args.max_rounds):
+                print(f"[campaign] --max-rounds {args.max_rounds} reached",
+                      flush=True)
                 break
-            names = [item[0] for item in batch]
-            family, rung = batch[0][1:]
-            fmt = f"{family}_R{rung}"
-            batch_floor = None
-            if selected_guard is not None:
-                # The lower bracket of the encode step. Without it the step's
-                # growth can only be read against whichever checkpoint
-                # happened to precede it, which is a different phase's charge,
-                # and the pair is taken PER OCCURRENCE because the first batch
-                # carries the runtime's one-time first-use cost while later
-                # batches are the steady state the plan actually charges for
-                # (RobTand/prismaquant#390).
-                selected_guard.check('before_selected_anchor_batch')
-                batch_floor = selected_guard.last[
-                    'conservative_cgroup_plus_cuda_reserved_bytes']
-            try:
-                common = dict(format_name=fmt, cache=cache, wire_dir=wire_dir,
-                    activation_kwargs_for=(
-                        _activation_kwargs_for if want_h else None),
-                    hessian_required=want_h)
-                if len(batch) == 1:
-                    name = names[0]
-                    anchors = [_measure_anchor(
-                        qname=name, weight=weights[name].to(device),
-                        activations=acts[name].to(device),
-                        static_input_scale=static_scales.get(name), **common)]
-                else:
-                    anchors = _measure_anchor_batch(
-                        qnames=names,
-                        weights=[weights[name].to(device) for name in names],
-                        activations=[acts[name].to(device) for name in names],
-                        static_input_scales=static_scales, **common)
-            except (HessianContractError, ActivationScaleContractError,
-                    PublicationError):
-                # A staged artifact that did not reach its disk is not one
-                # batch's bad luck: the writer has stopped and everything
-                # behind it was dropped unwritten. Printing and continuing
-                # here would advance the loop past files that do not exist.
-                raise
-            except Exception as exc:
-                if selected_guard is not None and selected_guard.failure is not None:
-                    raise  # A physical memory refusal must stop the action.
-                print(f"[campaign] {names} {fmt}: FAILED {type(exc).__name__}: "
-                      f"{exc}", flush=True)
-                continue
-            if selected_guard is not None:
-                # With publication staging on, this upper bracket includes the
-                # staged CPU bytes of any batch the writer has not finished.
-                # That is real resident memory the plan is charging for, so it
-                # belongs in the growth figure rather than being filtered out
-                # of it; the publisher's own budget and peak are stamped
-                # separately on the receipt so a reader can attribute it.
-                selected_guard.check('after_selected_anchor_batch')
-                anchor_batch_growth.append(selected_guard.last[
-                    'conservative_cgroup_plus_cuda_reserved_bytes'] - batch_floor)
-            for anchor in anchors:
-                ledger.record(anchor, _checkpoint_anchor_identity(
-                    anchor, weights=weights, menus=menus,
-                    calibration_source=calibration_source, static_scales=static_scales,
-                    projected_units=projected_units))
-            completed += len(anchors)
-            # Commit every joined quantum before advancing. The scalar mode
-            # keeps its existing ten-anchor flush cadence.
-            if args.anchor_batch_size > 1 or (completed - 1) % 10 == 0:
-                flush_checkpoint()
-                print(f"[campaign] r{round_index} {completed}/{len(pending)} "
-                      f"batch={len(anchors)} {fmt} "
-                      f"encode_seconds={sum(a.seconds for a in anchors):.3f}", flush=True)
-        # The round is a consumer barrier: the next round reads ``measured``
-        # to decide what is still pending, so nothing may still be in flight.
-        ledger.drain()
-        flush_checkpoint()
-        if stopped_early:
-            break
-        if round_index > 1 and completed == 0:
-            raise RuntimeError(
-                f"campaign adaptive round {round_index} made no progress: "
-                "all pending anchors failed; successful anchors are journaled. "
-                "Refusing to repeat unchanged work; retry after resolving the failure.")
+            pending: list[tuple[str, str, int]] = []
+            for key, members in sorted(anchor_groups.items()):
+                for family, allowed in group_rates[key].items():
+                    # The grid is what EVERY member actually measured: one
+                    # member's failed encode must not let the group think it has
+                    # an anchor there.
+                    member_rates = {
+                        m: {a.body_rate_q256 for a in measured.get(m, {}).get(family, [])}
+                        for m in members}
+                    grid = sorted(set.intersection(*member_rates.values())) if members else []
+                    if round_index == 1:
+                        want = round_one_rates(allowed, band=rate_band,
+                                               anchors=args.anchors, snap=_snap)
+                        extra = (None if not audit_units else
+                                 audit_extra_rate(allowed, want, snap=_snap))
+                        for m in members:
+                            rates = set(want)
+                            if extra is not None and m in audit_units:
+                                rates.add(extra)
+                            have = member_rates[m]
+                            pending.extend((m, family, rate)
+                                           for rate in sorted(rates - have))
+                        continue
+                    if len(grid) >= budget:
+                        surface_stop.setdefault((key, family), "anchor_budget")
+                        continue
+                    worst = 0.0
+                    worst_loo: dict = {}
+                    ready = True
+                    interpolable = 0
+                    for m in members:
+                        anchors = measured.get(m, {}).get(family, [])
+                        if len(anchors) < 3:
+                            ready = False
+                            break
+                        member_loo = _loo_for(anchors, leave_one_anchor_out)
+                        if _loo_refused(member_loo):
+                            # A refused surface has no leave-one-out error, and a
+                            # missing error is not a zero one.  Reading it as 0.0
+                            # would say "this surface interpolates perfectly" about
+                            # the one surface that does not interpolate at all --
+                            # and would close the gate on it.  It contributes
+                            # nothing to ``worst`` instead, so the group keeps
+                            # spending anchors for whichever members can still use
+                            # them, and the refusal is reported as itself.
+                            continue
+                        interpolable += 1
+                        value = float(
+                            member_loo.get("max_abs_log2_error", 0.0) or 0.0)
+                        if value > worst:
+                            worst, worst_loo = value, member_loo
+                    if not ready:
+                        # LOO cannot judge two endpoints. Bootstrap an interior
+                        # anchor through next_anchor_rate's widest-gap fallback;
+                        # missing LOO is neither a closed gate nor a refusal.
+                        worst_loo = {}
+                    elif not interpolable:
+                        surface_stop.setdefault((key, family), "non_interpolable")
+                        continue
+                    elif worst <= args.loo_gate:
+                        surface_stop.setdefault((key, family), "gate_closed")
+                        continue
+                    nxt = next_anchor_rate(grid, worst_loo)
+                    nxt = _snap(nxt, allowed) if nxt is not None else None
+                    if nxt is None or nxt in grid:
+                        surface_stop.setdefault((key, family), "no_room")
+                        continue
+                    # A failed sibling does not invalidate an already measured
+                    # member/rung or authorize overwriting its original cost.
+                    pending.extend((m, family, nxt) for m in members
+                                   if nxt not in member_rates[m])
+            if not pending:
+                if round_index == 1 and measured:
+                    # A resumed/seeded endpoint set still needs its adaptive gate
+                    # checked; an empty bootstrap is not a completed surface.
+                    continue
+                print(f"[campaign] round {round_index}: nothing pending", flush=True)
+                break
+            print(f"[campaign] round {round_index}: {len(pending)} anchors",
+                  flush=True)
+            batches = _anchor_batches(
+                [item for item in pending if acts.get(item[0]) is not None],
+                weights=weights, expert_members=expert_members,
+                batch_size=args.anchor_batch_size)
+            completed = 0
+            # One entry per encode step, in order, each the growth across that
+            # step's own bracket. The list is stamped on the selected receipt now
+            # and filled as the loop runs, so a reader gets the steady-state cost
+            # separately from the first batch's one-time runtime charge.
+            anchor_batch_growth = []
+            if selected_source and selected_source_preparation is not None:
+                selected_source_preparation['anchor_batch_growth_bytes'] = anchor_batch_growth
+            for batch in batches:
+                # Rows whose files landed while the last batch encoded. Applied at
+                # the top of the batch rather than the bottom, so the receipt read
+                # back off each published file runs one batch behind the write
+                # instead of immediately after it.
+                ledger.apply_completed()
+                if out_of_time():
+                    stopped_early = True
+                    print("[campaign] deadline reached; stopping", flush=True)
+                    # A deadline is a termination, so the staged bytes are written
+                    # and journalled before the loop is left; they were paid for.
+                    ledger.drain()
+                    break
+                names = [item[0] for item in batch]
+                family, rung = batch[0][1:]
+                fmt = f"{family}_R{rung}"
+                batch_floor = None
+                if selected_guard is not None:
+                    # The lower bracket of the encode step. Without it the step's
+                    # growth can only be read against whichever checkpoint
+                    # happened to precede it, which is a different phase's charge,
+                    # and the pair is taken PER OCCURRENCE because the first batch
+                    # carries the runtime's one-time first-use cost while later
+                    # batches are the steady state the plan actually charges for
+                    # (RobTand/prismaquant#390).
+                    selected_guard.check('before_selected_anchor_batch')
+                    batch_floor = selected_guard.last[
+                        'conservative_cgroup_plus_cuda_reserved_bytes']
+                try:
+                    common = dict(format_name=fmt, cache=cache, wire_dir=wire_dir,
+                        activation_kwargs_for=(
+                            _activation_kwargs_for if want_h else None),
+                        hessian_required=want_h, publisher=publisher)
+                    if len(batch) == 1:
+                        name = names[0]
+                        anchors = [_measure_anchor(
+                            qname=name, weight=weights[name].to(device),
+                            activations=acts[name].to(device),
+                            static_input_scale=static_scales.get(name), **common)]
+                    else:
+                        anchors = _measure_anchor_batch(
+                            qnames=names,
+                            weights=[weights[name].to(device) for name in names],
+                            activations=[acts[name].to(device) for name in names],
+                            static_input_scales=static_scales, **common)
+                except (HessianContractError, ActivationScaleContractError,
+                        PublicationError):
+                    # A staged artifact that did not reach its disk is not one
+                    # batch's bad luck: the writer has stopped and everything
+                    # behind it was dropped unwritten. Printing and continuing
+                    # here would advance the loop past files that do not exist.
+                    raise
+                except Exception as exc:
+                    if selected_guard is not None and selected_guard.failure is not None:
+                        raise  # A physical memory refusal must stop the action.
+                    # A batch that raises part way through has already handed
+                    # the writer files for its early units. Nothing records
+                    # those units, so no receipt job follows and nothing is
+                    # staged; their file completions are ignored, the bytes
+                    # land, and the next round re-prices them over the same
+                    # paths. That is what the synchronous path already does
+                    # when a partial batch writes files and journals none of
+                    # them, so the failure semantics do not change here.
+                    print(f"[campaign] {names} {fmt}: FAILED {type(exc).__name__}: "
+                          f"{exc}", flush=True)
+                    continue
+                if selected_guard is not None:
+                    # With publication staging on, this upper bracket includes the
+                    # staged CPU bytes of any batch the writer has not finished.
+                    # That is real resident memory the plan is charging for, so it
+                    # belongs in the growth figure rather than being filtered out
+                    # of it; the publisher's own budget and peak are stamped
+                    # separately on the receipt so a reader can attribute it.
+                    selected_guard.check('after_selected_anchor_batch')
+                    anchor_batch_growth.append(selected_guard.last[
+                        'conservative_cgroup_plus_cuda_reserved_bytes'] - batch_floor)
+                for anchor in anchors:
+                    ledger.record(anchor, _checkpoint_anchor_identity(
+                        anchor, weights=weights, menus=menus,
+                        calibration_source=calibration_source, static_scales=static_scales,
+                        projected_units=projected_units))
+                completed += len(anchors)
+                # Commit every joined quantum before advancing. The scalar mode
+                # keeps its existing ten-anchor flush cadence.
+                if args.anchor_batch_size > 1 or (completed - 1) % 10 == 0:
+                    flush_checkpoint()
+                    print(f"[campaign] r{round_index} {completed}/{len(pending)} "
+                          f"batch={len(anchors)} {fmt} "
+                          f"encode_seconds={sum(a.seconds for a in anchors):.3f}", flush=True)
+            # The round is a consumer barrier: the next round reads ``measured``
+            # to decide what is still pending, so nothing may still be in flight.
+            ledger.drain()
+            flush_checkpoint()
+            if stopped_early:
+                break
+            if round_index > 1 and completed == 0:
+                raise RuntimeError(
+                    f"campaign adaptive round {round_index} made no progress: "
+                    "all pending anchors failed; successful anchors are journaled. "
+                    "Refusing to repeat unchanged work; retry after resolving the failure.")
 
-    publication_stats = None
-    if publisher is not None:
-        # Every round already drained, and a round that broke out staged
-        # nothing; this is the last barrier, and it is where a writer failure
-        # that nothing else looked at is raised.
-        ledger.drain()
-        publication_stats = publisher.stats()
-        publisher.close()
-        flush_checkpoint()
+        publication_stats = None
+        if publisher is not None:
+            # The last barrier, and where a writer failure nothing else looked at
+            # is raised. Drain the receipts, journal whatever they made dirty,
+            # then wait for that journal write too: the checkpoint is the last
+            # thing published and it cites everything before it.
+            ledger.drain()
+            flush_checkpoint()
+            ledger.drain()
+            publication_stats = publisher.stats()
+
+    finally:
+        if publisher is not None:
+            # The thread first, so nothing is still writing, and then the rows
+            # for whatever it finished. On the way out of an exception this is
+            # the batch that succeeded before the one that failed; on the
+            # normal path everything is already journalled and both calls are
+            # no-ops. Any second failure here is reported and dropped: it must
+            # not replace the exception that brought us here.
+            publisher.close()
+            try:
+                if ledger.close():
+                    flush_checkpoint()
+            except Exception as cleanup_error:  # noqa: BLE001
+                print("[campaign] could not journal the completed anchors "
+                      f"while unwinding: {type(cleanup_error).__name__}: "
+                      f"{cleanup_error}", file=sys.stderr, flush=True)
 
     loo: dict[str, dict[str, dict]] = {}
     for name, by_family in measured.items():

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -5326,8 +5326,8 @@ def _main(argv, *, source_scope) -> int:
                 # only when ``close`` itself journalled something loses them.
                 # ``flush_checkpoint`` returns on an empty set, so the normal
                 # path still costs nothing.
-                if ledger.close():
-                    flush_checkpoint()
+                ledger.close()
+                flush_checkpoint()
             except Exception as cleanup_error:  # noqa: BLE001
                 print("[campaign] could not journal the completed anchors "
                       f"while unwinding: {type(cleanup_error).__name__}: "

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -1843,6 +1843,70 @@ def _checkpoint_wire_record(anchor, wire_dir, identity, *, existing=None):
             f"{anchor.format_name}: {exc}") from exc
 
 
+class _AnchorPublicationLedger:
+    """Decides when a measured anchor is allowed to become a journal row.
+
+    The campaign's rule is that an anchor row and its wire receipt are written
+    together, and that the receipt is read back off a file that exists.  With
+    the publication of that file moved to another thread, "exists" stops being
+    something the encode thread knows by having just done it, so this object
+    holds the anchor until the writer says so.
+
+    ``journal_anchor(anchor, identity)`` is the caller's own three lines: make
+    the receipt, add the row, mark the unit dirty.  It is called exactly once
+    per anchor either way; what changes is when.
+
+    Without a publisher this is a pass-through, which is what makes the
+    default path the historical path rather than a re-implementation of it.
+    """
+
+    def __init__(self, *, publisher, journal_anchor):
+        self._publisher = publisher
+        self._journal = journal_anchor
+        self._staged: dict = {}
+
+    @property
+    def staged(self) -> dict:
+        return self._staged
+
+    def record(self, anchor, identity) -> None:
+        """Journal now, or when this anchor's own bytes have been written."""
+        if self._publisher is None:
+            self._journal(anchor, identity)
+            return
+        key = (anchor.qname, anchor.format_name)
+        if key in self._staged:
+            # Two anchors for one (unit, rung) share a publication key, and
+            # one of them would be journalled under the other's receipt. The
+            # anchor schedule does not produce this; if it ever does it is a
+            # scheduling defect, not something to average over.
+            raise RuntimeError(
+                f"{anchor.qname} {anchor.format_name} is already staged")
+        self._staged[key] = (anchor, identity)
+
+    def apply_completed(self) -> int:
+        """Journal whatever the writer has finished since the last call."""
+        if self._publisher is None:
+            return 0
+        return self._apply(self._publisher.completed())
+
+    def drain(self) -> int:
+        """Wait for every staged anchor, journal it, and refuse a remainder."""
+        if self._publisher is None:
+            return 0
+        applied = self._apply(self._publisher.drain())
+        if self._staged:
+            raise RuntimeError(
+                "publication drained with anchors still staged: "
+                + ", ".join(f"{q} {f}" for q, f in sorted(self._staged)))
+        return applied
+
+    def _apply(self, keys) -> int:
+        for key in keys:
+            self._journal(*self._staged.pop(key))
+        return len(keys)
+
+
 def _adopt_seed_checkpoint(manifest_path, wire_dir_arg, *, targets, wire_dir,
                            adopt, admits, identity_sha256, validate_state=None) -> dict:
     """Offer another campaign's stored anchors to this run's row gates.
@@ -4766,13 +4830,11 @@ def _main(argv, *, source_scope) -> int:
                        identity_sha256=identity_sha256, state=state)
         dirty_checkpoint_units.clear()
 
-    # Anchors whose bytes are staged but not yet written, keyed the way the
-    # publisher keys its jobs.  An anchor lives here instead of in ``measured``
-    # for exactly as long as its files do not exist, which is what keeps
+    # An anchor waits in the ledger, rather than in ``measured``, for exactly
+    # as long as its files do not exist.  That is what keeps
     # ``flush_checkpoint``'s existing invariant true without changing it: every
     # anchor row it journals has a wire receipt beside it, and every one of
     # those receipts was read back off a file that had already landed.
-    awaiting_publication: dict = {}
     publisher = None
     if int(args.publication_overlap_bytes) > 0:
         from .tessera_publication import BoundedPublisher
@@ -4797,24 +4859,8 @@ def _main(argv, *, source_scope) -> int:
             anchor.family, []).append(anchor)
         dirty_checkpoint_units.add(name)
 
-    def apply_publications(keys) -> None:
-        """Turn published files into journallable rows, in publication order."""
-        for key in keys:
-            journal_anchor(*awaiting_publication.pop(key))
-
-    def record_anchor(anchor, identity) -> None:
-        """Journal this anchor now, or when the writer says its bytes exist."""
-        if publisher is None:
-            journal_anchor(anchor, identity)
-            return
-        key = (anchor.qname, anchor.format_name)
-        if key in awaiting_publication:
-            # Two anchors for one (unit, rung) would have one publication key
-            # and one of them would be journalled under the other's receipt.
-            # The anchor schedule does not produce this; if it ever does, it
-            # is a scheduling defect and not something to average over.
-            raise RuntimeError(f"{anchor.qname} {anchor.format_name} is already staged")
-        awaiting_publication[key] = (anchor, identity)
+    ledger = _AnchorPublicationLedger(
+        publisher=publisher, journal_anchor=journal_anchor)
 
     # Adopted rows are journalled BEFORE the anchor loop, because the loop can
     # end without reaching its own flush: a group whose gate is already closed
@@ -5012,15 +5058,13 @@ def _main(argv, *, source_scope) -> int:
             # the top of the batch rather than the bottom, so the receipt read
             # back off each published file runs one batch behind the write
             # instead of immediately after it.
-            if publisher is not None:
-                apply_publications(publisher.completed())
+            ledger.apply_completed()
             if out_of_time():
                 stopped_early = True
                 print("[campaign] deadline reached; stopping", flush=True)
                 # A deadline is a termination, so the staged bytes are written
                 # and journalled before the loop is left; they were paid for.
-                if publisher is not None:
-                    apply_publications(publisher.drain())
+                ledger.drain()
                 break
             names = [item[0] for item in batch]
             family, rung = batch[0][1:]
@@ -5078,7 +5122,7 @@ def _main(argv, *, source_scope) -> int:
                 anchor_batch_growth.append(selected_guard.last[
                     'conservative_cgroup_plus_cuda_reserved_bytes'] - batch_floor)
             for anchor in anchors:
-                record_anchor(anchor, _checkpoint_anchor_identity(
+                ledger.record(anchor, _checkpoint_anchor_identity(
                     anchor, weights=weights, menus=menus,
                     calibration_source=calibration_source, static_scales=static_scales,
                     projected_units=projected_units))
@@ -5092,8 +5136,7 @@ def _main(argv, *, source_scope) -> int:
                       f"encode_seconds={sum(a.seconds for a in anchors):.3f}", flush=True)
         # The round is a consumer barrier: the next round reads ``measured``
         # to decide what is still pending, so nothing may still be in flight.
-        if publisher is not None:
-            apply_publications(publisher.drain())
+        ledger.drain()
         flush_checkpoint()
         if stopped_early:
             break
@@ -5108,11 +5151,7 @@ def _main(argv, *, source_scope) -> int:
         # Every round already drained, and a round that broke out staged
         # nothing; this is the last barrier, and it is where a writer failure
         # that nothing else looked at is raised.
-        apply_publications(publisher.drain())
-        if awaiting_publication:
-            raise RuntimeError(
-                "publication drained with anchors still staged: "
-                + ", ".join(f"{q} {f}" for q, f in sorted(awaiting_publication)))
+        ledger.drain()
         publication_stats = publisher.stats()
         publisher.close()
         flush_checkpoint()

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -1907,6 +1907,21 @@ class _AnchorPublicationLedger:
     def active(self) -> bool:
         return self._publisher is not None
 
+    def open(self, publisher) -> None:
+        """Start deferring, from a pass-through that has nothing outstanding.
+
+        The ledger is constructed without a publisher so the rows a seed
+        adopted are journalled inline, on the historical path, before any
+        thread exists.  Attaching one afterwards is only legal while nothing
+        is staged, because a staged anchor belongs to a queue and there was
+        no queue to put it on.
+        """
+        if self._staged or self._records:
+            raise RuntimeError(
+                "the publication ledger cannot start deferring with "
+                f"{len(self._staged)} anchor(s) already staged")
+        self._publisher = publisher
+
     def record(self, anchor, identity) -> None:
         """Journal now, or when this anchor's own bytes have been written."""
         if self._publisher is None:
@@ -4928,14 +4943,13 @@ def _main(argv, *, source_scope) -> int:
     # invariant true without changing it: every anchor row journalled here has
     # a wire receipt beside it, and every one of those receipts was read back
     # off a file that had already landed.
+    # The writer itself is started INSIDE the try below, not here.  A thread
+    # that exists before the region whose ``finally`` closes it is a thread
+    # nothing joins if the setup between the two raises, and the seeded run's
+    # adopted rows are flushed in that gap.  So the ledger is built as a
+    # pass-through, the adopted flush runs inline exactly as it always did,
+    # and the publisher is attached as the first act of the guarded region.
     publisher = None
-    if int(args.publication_overlap_bytes) > 0:
-        from .tessera_publication import BoundedPublisher
-        publisher = BoundedPublisher(
-            budget_bytes=int(args.publication_overlap_bytes))
-        print(f"[campaign] publication overlap: staging up to "
-              f"{int(args.publication_overlap_bytes)} bytes on one writer "
-              "thread", flush=True)
 
     def journal_anchor(anchor, record) -> None:
         """Put one anchor row and its wire receipt into the pending state."""
@@ -4946,7 +4960,7 @@ def _main(argv, *, source_scope) -> int:
         dirty_checkpoint_units.add(name)
 
     ledger = _AnchorPublicationLedger(
-        publisher=publisher,
+        publisher=None,
         make_record=lambda anchor, identity: _checkpoint_wire_record(
             anchor, wire_dir, identity),
         journal_anchor=journal_anchor)
@@ -5074,6 +5088,15 @@ def _main(argv, *, source_scope) -> int:
     # what is queued, so files already computed still land, and it cannot
     # raise, so it cannot mask the exception that brought us here.
     try:
+        if int(args.publication_overlap_bytes) > 0:
+            from .tessera_publication import BoundedPublisher
+            publisher = BoundedPublisher(
+                budget_bytes=int(args.publication_overlap_bytes))
+            ledger.open(publisher)
+            print(f"[campaign] publication overlap: staging up to "
+                  f"{int(args.publication_overlap_bytes)} bytes on one writer "
+                  "thread", flush=True)
+
         round_index = 0
         while True:
             round_index += 1
@@ -5295,6 +5318,14 @@ def _main(argv, *, source_scope) -> int:
             # not replace the exception that brought us here.
             publisher.close()
             try:
+                # Unconditional, and that is the point: ``close`` journals
+                # only what the writer finished after the last
+                # ``apply_completed``, but rows journalled BY that call are
+                # in ``dirty_checkpoint_units`` and unwritten until a flush,
+                # and the batch cadence may not have reached one. Flushing
+                # only when ``close`` itself journalled something loses them.
+                # ``flush_checkpoint`` returns on an empty set, so the normal
+                # path still costs nothing.
                 if ledger.close():
                     flush_checkpoint()
             except Exception as cleanup_error:  # noqa: BLE001

--- a/prismaquant/tessera_publication.py
+++ b/prismaquant/tessera_publication.py
@@ -186,8 +186,8 @@ class BoundedPublisher:
 
         This does not raise on a writer failure.  The keys it returns are files
         that exist, and a caller that journals them is recording work that was
-        really done; the failure is raised by the next :meth:`submit` or
-        :meth:`drain`, and callers that must notice it without either can read
+        really done; the failure is raised by the next :meth:`reserve`,
+        :meth:`submit` or :meth:`drain`, and callers that must notice it without either can read
         :attr:`failure`.
         """
         with self._cond:

--- a/prismaquant/tessera_publication.py
+++ b/prismaquant/tessera_publication.py
@@ -1,0 +1,253 @@
+"""Bounded, ordered publication of artifacts the campaign has already made.
+
+The Tessera campaign encodes a batch of units on the GPU, scores each one, and
+then writes two files per unit: the rendered weight shard through
+:func:`prismaquant.production_weight_cache._store_rendered_weight_entry`, and
+the ``.tessera`` wire blob beside it.  Both writes happen on the thread that
+just finished the encode, so the next batch's encode does not start until the
+previous batch's bytes are on disk.  On the R1088 endpoint a sixteen-unit arm
+spends about 1.13 to 1.16 s inside sixteen ``torch.save`` calls and about
+0.40 s inside sixteen ``Path.write_bytes`` calls, against roughly 54 us of
+fsync: that is serialisation and copying, not device latency, and none of it
+needs the GPU.
+
+This module hands those two writes to one bounded writer thread so they can run
+while the next batch encodes.  What it deliberately does **not** do:
+
+* **It is not a second cache.**  A job calls the same
+  ``_store_rendered_weight_entry`` and the same tmp-plus-``os.replace`` wire
+  write the synchronous path calls, with the same arguments.  There is one
+  cache mechanism and this is not another one.
+* **It does not change what durable means.**  ``_store_rendered_weight_entry``
+  is invoked exactly as the campaign invokes it today, so a published file is
+  one that has been through ``os.replace``, and an fsync happens only where
+  ``release_completed_anchor_file_pages`` is configured.  Publication here
+  means *the same thing it means now*, on another thread.
+* **It does not decide when a receipt is written.**  The publisher only reports
+  which jobs are finished.  The caller is what turns a finished job into a
+  journal row, and that is the ordering rule the campaign has to keep: an
+  anchor may not reach the checkpoint before its own bytes have.
+
+Ownership and bounds:
+
+* The caller stages the CPU bytes -- the device-to-host copy stays on the
+  thread that owns the device work -- and then transfers them.  A submitted job
+  owns its tensor and its blob until it is published, and nothing else may
+  write to them.
+* Every job is charged ``tensor.nbytes + len(blob)`` and :meth:`submit` blocks
+  once the outstanding charge would exceed the budget, so staging cannot grow
+  without limit while the writer falls behind.  A single artifact larger than
+  the whole budget still publishes: it waits for an empty queue rather than
+  waiting for room that can never appear.
+* One writer thread and a FIFO queue, so jobs run in submission order and
+  completions are reported in that order.  Recovery stays deterministic.
+
+Failure is closed.  When a job raises, the writer keeps the exception, discards
+everything queued behind it *without writing any of it*, and every later
+:meth:`submit` and :meth:`drain` raises :class:`PublicationError` from the
+original.  Jobs that finished before the failure are real files, so
+:meth:`completed` still reports them and the caller may journal them; that is
+what makes the resume after a failed action skip work it has actually done
+rather than redo it or, worse, trust a row whose bytes never landed.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Callable, Hashable
+
+SCHEMA = "prismaquant.tessera_publication.v1"
+
+__all__ = [
+    "SCHEMA",
+    "PublicationError",
+    "PublicationJob",
+    "BoundedPublisher",
+]
+
+
+class PublicationError(RuntimeError):
+    """A staged artifact did not reach the disk it was promised to."""
+
+
+@dataclass(frozen=True)
+class PublicationJob:
+    """One unit's files, staged and ready to be written.
+
+    ``key`` names the job to the caller; the campaign uses
+    ``(qname, format_name)``.  ``charged_bytes`` is what the staged bytes cost
+    while they wait.  ``publish`` performs the writes and must be safe to run
+    on a thread other than the one that built it.
+    """
+
+    key: Hashable
+    charged_bytes: int
+    publish: Callable[[], None]
+
+    def __post_init__(self) -> None:
+        if int(self.charged_bytes) < 0:
+            raise ValueError("a publication job cannot be charged negative bytes")
+        if not callable(self.publish):
+            raise TypeError("a publication job needs a callable to publish with")
+
+
+class BoundedPublisher:
+    """One writer thread, a byte budget, and order-preserving completions."""
+
+    def __init__(self, *, budget_bytes: int, name: str = "tessera-publication"):
+        budget = int(budget_bytes)
+        if budget <= 0:
+            raise ValueError(
+                "a publisher needs a positive byte budget; the synchronous "
+                "path is no publisher at all, not a publisher of size zero")
+        self._budget = budget
+        self._cond = threading.Condition()
+        self._queued: deque[PublicationJob] = deque()
+        self._done: deque[Hashable] = deque()
+        self._charged = 0
+        self._outstanding = 0
+        self._failure: BaseException | None = None
+        self._closing = False
+        self._published = 0
+        self._peak_charged_bytes = 0
+        self._submit_blocked_seconds = 0.0
+        self._publish_seconds = 0.0
+        # Daemon so an unhandled exception on the main thread cannot leave the
+        # interpreter waiting on a writer nobody is going to drain.  The
+        # ordered shutdown is :meth:`close`, which callers run from a finally.
+        self._thread = threading.Thread(target=self._run, name=name, daemon=True)
+        self._thread.start()
+
+    # -- caller side --------------------------------------------------------
+
+    def submit(self, job: PublicationJob) -> None:
+        """Hand over one unit's staged bytes, blocking while over budget."""
+        charge = int(job.charged_bytes)
+        with self._cond:
+            self._raise_failure()
+            if self._closing:
+                raise PublicationError("publisher is closed; nothing more can be staged")
+            waited = time.monotonic()
+            # ``self._charged`` in the guard is what admits an artifact bigger
+            # than the entire budget: it waits for an empty queue, and then
+            # goes, instead of waiting for room that cannot appear.
+            while self._charged and self._charged + charge > self._budget:
+                self._cond.wait()
+                self._raise_failure()
+            self._submit_blocked_seconds += time.monotonic() - waited
+            self._queued.append(job)
+            self._charged += charge
+            self._outstanding += 1
+            if self._charged > self._peak_charged_bytes:
+                self._peak_charged_bytes = self._charged
+            self._cond.notify_all()
+
+    def completed(self) -> list:
+        """Take the keys published since the last call, in publication order.
+
+        This does not raise on a writer failure.  The keys it returns are files
+        that exist, and a caller that journals them is recording work that was
+        really done; the failure is raised by the next :meth:`submit` or
+        :meth:`drain`, and callers that must notice it without either can read
+        :attr:`failure`.
+        """
+        with self._cond:
+            out = list(self._done)
+            self._done.clear()
+            return out
+
+    def drain(self) -> list:
+        """Wait for every submitted job, then take the completed keys."""
+        with self._cond:
+            while self._outstanding and self._failure is None:
+                self._cond.wait()
+            # Raise before taking the keys, so a caller that hits the failure
+            # can still collect what did land on its way out.
+            self._raise_failure()
+            out = list(self._done)
+            self._done.clear()
+            return out
+
+    def close(self) -> None:
+        """Stop the writer.  Does not wait for the queue; drain first."""
+        with self._cond:
+            self._closing = True
+            self._cond.notify_all()
+        self._thread.join()
+
+    def __enter__(self) -> "BoundedPublisher":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    @property
+    def failure(self) -> BaseException | None:
+        with self._cond:
+            return self._failure
+
+    @property
+    def outstanding(self) -> int:
+        with self._cond:
+            return self._outstanding
+
+    def stats(self) -> dict:
+        """What the run charged and how long the encode thread waited."""
+        with self._cond:
+            return {
+                "schema": SCHEMA,
+                "budget_bytes": int(self._budget),
+                "published": int(self._published),
+                "peak_charged_bytes": int(self._peak_charged_bytes),
+                "submit_blocked_seconds": float(self._submit_blocked_seconds),
+                "publish_seconds": float(self._publish_seconds),
+                "failed": self._failure is not None,
+            }
+
+    # -- writer side --------------------------------------------------------
+
+    def _raise_failure(self) -> None:
+        if self._failure is not None:
+            raise PublicationError(
+                "a staged artifact was not published; nothing queued behind "
+                "the failure was written") from self._failure
+
+    def _run(self) -> None:
+        while True:
+            with self._cond:
+                while not self._queued and not self._closing:
+                    self._cond.wait()
+                if not self._queued:
+                    return
+                job = self._queued.popleft()
+            started = time.monotonic()
+            try:
+                job.publish()
+            except BaseException as exc:  # noqa: BLE001 - recorded and re-raised
+                with self._cond:
+                    if self._failure is None:
+                        self._failure = exc
+                    # Fail closed. Whatever was staged behind this job is
+                    # dropped unwritten, and its charge with it, so a caller
+                    # blocked on the budget wakes into the failure instead of
+                    # waiting on a writer that has stopped.
+                    self._queued.clear()
+                    self._charged = 0
+                    self._outstanding = 0
+                    self._cond.notify_all()
+                return
+            elapsed = time.monotonic() - started
+            with self._cond:
+                self._done.append(job.key)
+                self._charged -= int(job.charged_bytes)
+                self._outstanding -= 1
+                self._published += 1
+                self._publish_seconds += elapsed
+                self._cond.notify_all()
+            # Release the staged tensor and blob now rather than at the next
+            # iteration's pop: the budget says how much may be resident, and a
+            # job held one loop longer than its charge is a job outside it.
+            del job

--- a/prismaquant/tessera_publication.py
+++ b/prismaquant/tessera_publication.py
@@ -34,11 +34,15 @@ Ownership and bounds:
   thread that owns the device work -- and then transfers them.  A submitted job
   owns its tensor and its blob until it is published, and nothing else may
   write to them.
-* Every job is charged ``tensor.nbytes + len(blob)`` and :meth:`submit` blocks
-  once the outstanding charge would exceed the budget, so staging cannot grow
-  without limit while the writer falls behind.  A single artifact larger than
-  the whole budget still publishes: it waits for an empty queue rather than
-  waiting for room that can never appear.
+* **The budget is reserved before the bytes are made, not after.**  The caller
+  calls :meth:`reserve` with the size it is about to stage, and that call is
+  what blocks; only then does it allocate.  Charging at submit time would have
+  left the producer holding one more artifact than the budget allows, because
+  the copy it is about to hand over already exists by then.  An artifact
+  larger than the whole budget is refused rather than admitted as a special
+  case: admitting it would mean the declared bound is not the bound, and the
+  answer to a render that does not fit is a bigger budget, chosen by whoever
+  is accounting for the memory.
 * One writer thread and a FIFO queue, so jobs run in submission order and
   completions are reported in that order.  Recovery stays deterministic.
 
@@ -108,6 +112,7 @@ class BoundedPublisher:
         self._queued: deque[PublicationJob] = deque()
         self._done: deque[Hashable] = deque()
         self._charged = 0
+        self._reserved = 0
         self._outstanding = 0
         self._failure: BaseException | None = None
         self._closing = False
@@ -123,26 +128,57 @@ class BoundedPublisher:
 
     # -- caller side --------------------------------------------------------
 
-    def submit(self, job: PublicationJob) -> None:
-        """Hand over one unit's staged bytes, blocking while over budget."""
-        charge = int(job.charged_bytes)
+    def reserve(self, nbytes: int) -> None:
+        """Take room for bytes that do not exist yet, blocking until it fits.
+
+        The caller must follow a successful reserve with exactly one
+        :meth:`submit` of that size, or with :meth:`release`.
+        """
+        charge = int(nbytes)
+        if charge < 0:
+            raise ValueError("cannot reserve negative bytes")
+        if charge > self._budget:
+            raise PublicationError(
+                f"one artifact of {charge} bytes does not fit a publication "
+                f"budget of {self._budget}; raise --publication-overlap-bytes "
+                "or publish synchronously. Admitting it would mean the "
+                "declared bound is not the bound.")
         with self._cond:
             self._raise_failure()
             if self._closing:
                 raise PublicationError("publisher is closed; nothing more can be staged")
             waited = time.monotonic()
-            # ``self._charged`` in the guard is what admits an artifact bigger
-            # than the entire budget: it waits for an empty queue, and then
-            # goes, instead of waiting for room that cannot appear.
-            while self._charged and self._charged + charge > self._budget:
+            while self._charged + charge > self._budget:
                 self._cond.wait()
                 self._raise_failure()
             self._submit_blocked_seconds += time.monotonic() - waited
-            self._queued.append(job)
             self._charged += charge
-            self._outstanding += 1
+            self._reserved += charge
             if self._charged > self._peak_charged_bytes:
                 self._peak_charged_bytes = self._charged
+
+    def release(self, nbytes: int) -> None:
+        """Give back a reservation whose bytes were never staged."""
+        charge = int(nbytes)
+        with self._cond:
+            self._charged -= charge
+            self._reserved -= charge
+            self._cond.notify_all()
+
+    def submit(self, job: PublicationJob) -> None:
+        """Hand over one unit's staged bytes against an existing reservation."""
+        charge = int(job.charged_bytes)
+        with self._cond:
+            self._raise_failure()
+            if self._closing:
+                raise PublicationError("publisher is closed; nothing more can be staged")
+            if charge > self._reserved:
+                raise PublicationError(
+                    f"{charge} bytes were submitted against {self._reserved} "
+                    "reserved; every charged job reserves before it stages")
+            self._reserved -= charge
+            self._queued.append(job)
+            self._outstanding += 1
             self._cond.notify_all()
 
     def completed(self) -> list:
@@ -172,7 +208,15 @@ class BoundedPublisher:
             return out
 
     def close(self) -> None:
-        """Stop the writer.  Does not wait for the queue; drain first."""
+        """Publish what is queued, then stop the writer.
+
+        The writer keeps taking jobs until the queue is empty, so a close on
+        the way out of a failed run still lands the bytes that were already
+        computed.  It reports nothing and raises nothing: use :meth:`drain`
+        when the completions matter, and :meth:`close` when what matters is
+        that the thread is gone and nothing was abandoned half written.  After
+        a writer failure nothing is queued, so this returns at once.
+        """
         with self._cond:
             self._closing = True
             self._cond.notify_all()
@@ -236,6 +280,7 @@ class BoundedPublisher:
                     # waiting on a writer that has stopped.
                     self._queued.clear()
                     self._charged = 0
+                    self._reserved = 0
                     self._outstanding = 0
                     self._cond.notify_all()
                 return

--- a/tests/test_tessera_campaign_publication_cli.py
+++ b/tests/test_tessera_campaign_publication_cli.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import pickle
 import sys
+import time
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
@@ -181,6 +182,7 @@ def test_the_checkpoint_carries_every_unit_with_its_wire_receipt(
 
 def test_a_publication_failure_stops_the_action_instead_of_being_absorbed(
         monkeypatch, tmp_path):
+    from prismaquant.cost_stage_checkpoint import unit_path
     from prismaquant.tessera_publication import PublicationError
 
     campaign, _render = _fixture(monkeypatch, tmp_path)
@@ -196,27 +198,62 @@ def test_a_publication_failure_stops_the_action_instead_of_being_absorbed(
     monkeypatch.setattr(torch, "save", failing)
     with pytest.raises(PublicationError):
         campaign.main([*_argv(tmp_path), "--publication-overlap-bytes", str(1 << 20)])
-    # No cost table, and no journal row for a unit whose render never landed.
+    # No cost table, and no journal row for the unit whose render never
+    # landed. The failing save is the second one, and the second save is
+    # unit one's, because the writer publishes in submission order and
+    # submission order is the anchor order: so unit one has a row and unit
+    # two must not.
     assert not (tmp_path / "cost.pkl").exists()
-    checkpoint = tmp_path / "campaign.anchors.json"
-    if checkpoint.exists():
-        text = checkpoint.read_text()
-        assert saved[1].split("__")[0] not in text or "anchors" not in text
+    root = tmp_path / "campaign.anchors.json.parts"
+    assert not unit_path(root, UNITS[1]).exists(), (
+        "a unit whose bytes failed to land was journalled anyway")
+    assert unit_path(root, UNITS[0]).exists(), (
+        "the unit that did land lost its row when the action unwound")
 
 
+@pytest.mark.parametrize("apply_timing", ["eager", "deferred"])
 def test_a_fatal_encode_error_still_journals_the_batch_that_succeeded(
-        monkeypatch, tmp_path):
+        monkeypatch, tmp_path, apply_timing):
     """The regression the synchronous per-batch checkpoint did not have.
 
     With a writer behind, unit one's row is not journalled at the moment its
     encode returns; it is journalled when its bytes land.  If unit two then
     fails fatally, unwinding must still commit unit one.  Losing it would mean
     the resume re-encodes work the run really finished.
+
+    Which of the two unwind paths runs depends on a RACE the test must not
+    inherit: whether the writer had finished unit one by the time the next
+    batch called ``apply_completed``.
+
+    * ``deferred`` -- it had not, so the anchor is still staged and
+      ``ledger.close`` is what journals it.
+    * ``eager`` -- it had, so the row is already in the pending checkpoint
+      and ``close`` finds nothing; only an unconditional flush writes it.
+
+    On an unloaded box the second is the likely one, which is why the flush
+    in the ``finally`` may not be made conditional on ``close`` having
+    journalled something.  Both are forced here rather than sampled.
     """
     from prismaquant.cost_stage_checkpoint import unit_path
     from prismaquant.tessera_render import HessianContractError
 
     campaign, _render = _fixture(monkeypatch, tmp_path)
+    ledger_cls = campaign._AnchorPublicationLedger
+    original_apply = ledger_cls.apply_completed
+    if apply_timing == "eager":
+        def apply_completed(self):
+            # Wait the writer out, so every finished receipt is applied and
+            # sitting unflushed in the pending checkpoint when the encode
+            # below raises.
+            if self._publisher is not None:
+                while self._publisher.outstanding:
+                    time.sleep(0.005)
+            return original_apply(self)
+    else:
+        def apply_completed(self):
+            # Never applied, so everything is still staged at close.
+            return 0
+    monkeypatch.setattr(ledger_cls, "apply_completed", apply_completed)
     real_encode = campaign._encode_and_render
     calls = []
 

--- a/tests/test_tessera_campaign_publication_cli.py
+++ b/tests/test_tessera_campaign_publication_cli.py
@@ -1,0 +1,244 @@
+"""``--publication-overlap-bytes`` through the real CLI, not through its parts.
+
+The standalone publisher and ledger tests establish ordering on fakes. They
+cannot establish that the campaign passes a publisher to anything, and the
+first version of this branch did not: the flag built a writer, the ledger
+staged nothing, and every measurement still ran synchronously. So these drive
+``tessera_campaign.main`` end to end, on both the scalar and the batched anchor
+path, and compare the artifacts against the same run with the flag unset.
+
+Nothing here is a speed test. The claim is that the same bytes and the same
+prices come out, that the receipt and journal order holds, and that a writer
+failure stops the action instead of being absorbed by it.
+"""
+from __future__ import annotations
+
+import pickle
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+UNITS = ("model.layers.0.proj", "model.layers.1.proj")
+FAMILY = "TESSERA_E4M3_K1"
+FMT = f"{FAMILY}_R1024"
+
+
+def _fixture(monkeypatch, tmp_path):
+    """Two priceable units, one round, no GPU and no real calibration."""
+    from prismaquant import model_profiles, tessera_campaign, tessera_render
+    from prismaquant.model_profiles import DefaultProfile
+
+    model = torch.nn.Module()
+    model.model = torch.nn.Module()
+    model.model.layers = torch.nn.ModuleList(
+        [torch.nn.Module(), torch.nn.Module()])
+    generator = torch.Generator().manual_seed(186)
+    for index in range(2):
+        linear = torch.nn.Linear(256, 32, bias=False, dtype=torch.bfloat16)
+        with torch.no_grad():
+            linear.weight.copy_(torch.randn(32, 256, generator=generator))
+        model.model.layers[index].proj = linear
+    rows = torch.randn(4, 256, generator=torch.Generator().manual_seed(183))
+
+    transformers = ModuleType("transformers")
+    transformers.AutoModelForCausalLM = SimpleNamespace(
+        from_pretrained=lambda *_args, **_kwargs: model)
+    monkeypatch.setitem(sys.modules, "transformers", transformers)
+    monkeypatch.delenv("PRISMAQUANT_NVFP4_INPUT_GSCALE_FP8_RANGE", raising=False)
+    monkeypatch.setattr(model_profiles, "detect_profile", lambda _path: DefaultProfile())
+    monkeypatch.setattr(tessera_render, "tessera_encoder_hessian_status", lambda: {
+        "accepted": True, "reason": "CPU test fixture", "kwargs": [], "recipe": {},
+    })
+    monkeypatch.setattr(tessera_campaign, "_calibration_tokens",
+                        lambda *_args: ([torch.ones(1, 256, dtype=torch.long)], "one draw"))
+    monkeypatch.setattr(tessera_campaign, "_collect_activations", lambda *_args, **kwargs: (
+        {name: rows for name in UNITS}, {}, {name: 0 for name in UNITS},
+        {name: 3.0 for name in UNITS}))
+    monkeypatch.setattr(tessera_campaign, "expand_menus_for_targets",
+                        lambda _weights, targets, **_kwargs: {
+                            name: [SimpleNamespace(
+                                format_name=FMT, family=FAMILY,
+                                body_rate_q256=1024, bpp=4.0)] for name in targets})
+    return tessera_campaign, tessera_render
+
+
+def _argv(tmp_path):
+    return ["--model", "synthetic-current-model",
+            "--out", str(tmp_path / "cost.pkl"),
+            "--cache-dir", str(tmp_path / "cache"),
+            "--checkpoint", str(tmp_path / "campaign.anchors.json"),
+            "--hessian", "off", "--menu-mode", "research", "--max-rounds", "1"]
+
+
+def _artifacts(tmp_path):
+    """Every file the campaign published, by name, with its bytes."""
+    root = tmp_path / "cache"
+    return {path.name: path.read_bytes()
+            for path in sorted(root.rglob("*"))
+            if path.is_file() and path.suffix in {".pt", ".tessera"}}
+
+
+def _payload(tmp_path):
+    with (tmp_path / "cost.pkl").open("rb") as handle:
+        return pickle.load(handle)
+
+
+def _batched(monkeypatch, campaign, render, seen):
+    """Force the batched adapter over two dense units.
+
+    Which units may share a batch is `_anchor_batches`' decision and
+    `tests/test_tessera_campaign_batch.py` owns it. This test is about what
+    the batched path does with a publisher, so the grouping is supplied.
+    """
+    monkeypatch.setattr(render, "require_tessera_batch_encoder", lambda: None)
+    monkeypatch.setattr(campaign, "_anchor_batches",
+                        lambda pending, **_kwargs: [list(pending)])
+
+    def encode(weights, format_name, *, recipe, activation_kwargs, hessian_required):
+        seen.append(len(weights))
+        return [campaign._encode_and_render(
+            weight, format_name, recipe=recipe, activation_kwargs=kwargs,
+            hessian_required=hessian_required)
+            for weight, kwargs in zip(weights, activation_kwargs)]
+
+    monkeypatch.setattr(render, "encode_tessera_units", encode)
+
+
+@pytest.mark.parametrize("batch_size", [1, 2])
+def test_overlap_publishes_the_same_bytes_and_prices_as_the_default_path(
+        monkeypatch, tmp_path, batch_size):
+    from prismaquant.tessera_publication import SCHEMA
+
+    seen: list[int] = []
+    plain = tmp_path / "plain"
+    campaign, render = _fixture(monkeypatch, plain)
+    extra = []
+    if batch_size > 1:
+        _batched(monkeypatch, campaign, render, seen)
+        extra = ["--anchor-batch-size", "2"]
+    assert campaign.main([*_argv(plain), *extra]) == 0
+    assert _payload(plain)["provenance"]["publication_overlap"] is None, (
+        "the default path must not report a publisher it did not build")
+
+    staged = tmp_path / "staged"
+    campaign, render = _fixture(monkeypatch, staged)
+    if batch_size > 1:
+        _batched(monkeypatch, campaign, render, seen)
+    assert campaign.main([
+        *_argv(staged), *extra, "--publication-overlap-bytes", str(1 << 20)]) == 0
+
+    if batch_size > 1:
+        assert seen and max(seen) == 2, (
+            f"the batched adapter never saw a real batch: {seen}")
+    stats = _payload(staged)["provenance"]["publication_overlap"]
+    assert stats["schema"] == SCHEMA
+    assert stats["budget_bytes"] == 1 << 20
+    assert stats["failed"] is False
+    # Two file jobs, two receipts, and at least one journal write.
+    assert stats["published"] >= 5, stats
+    assert stats["peak_charged_bytes"] > 0, (
+        "nothing was ever staged, so nothing was ever overlapped")
+
+    assert _artifacts(plain) == _artifacts(staged), (
+        "the staged path published different bytes")
+    for unit in UNITS:
+        for path in (plain, staged):
+            assert _payload(path)["costs"][unit][FMT]["output_mse_measured"]
+        # Everything but the clock. ``encode_seconds`` is what the encode took
+        # on the box, and the first arm in a process pays the runtime's
+        # one-time first-use cost; it is not a price and this is not a
+        # measurement of one.
+        rows = [{k: v for k, v in _payload(path)["costs"][unit][FMT].items()
+                 if k != "encode_seconds"} for path in (plain, staged)]
+        assert rows[0] == rows[1]
+
+
+def test_the_checkpoint_carries_every_unit_with_its_wire_receipt(
+        monkeypatch, tmp_path):
+    campaign, _render = _fixture(monkeypatch, tmp_path)
+    assert campaign.main([
+        *_argv(tmp_path), "--publication-overlap-bytes", str(1 << 20)]) == 0
+    from prismaquant.cost_stage_checkpoint import unit_path
+
+    root = tmp_path / "campaign.anchors.json.parts"
+    for unit in UNITS:
+        envelope = pickle.loads(unit_path(root, unit).read_bytes())
+        state = pickle.loads(envelope["payload"])
+        assert state["wire_records"], f"{unit} was journalled with no receipt"
+        assert {row["format_name"] for row in state["anchors"]} == set(
+            state["wire_records"]), (
+            f"{unit} has an anchor row whose bytes nothing witnessed")
+        for record in state["wire_records"].values():
+            wire = tmp_path / "cache" / "wire" / record["file"]
+            assert wire.exists(), (
+                f"{unit} carries a receipt for a file that does not exist")
+            assert wire.stat().st_size == record["blob_bytes"]
+
+
+def test_a_publication_failure_stops_the_action_instead_of_being_absorbed(
+        monkeypatch, tmp_path):
+    from prismaquant.tessera_publication import PublicationError
+
+    campaign, _render = _fixture(monkeypatch, tmp_path)
+    real_save = torch.save
+    saved: list[str] = []
+
+    def failing(obj, path, *args, **kwargs):
+        saved.append(Path(path).name)
+        if len(saved) == 2:
+            raise OSError("no space left on device")
+        return real_save(obj, path, *args, **kwargs)
+
+    monkeypatch.setattr(torch, "save", failing)
+    with pytest.raises(PublicationError):
+        campaign.main([*_argv(tmp_path), "--publication-overlap-bytes", str(1 << 20)])
+    # No cost table, and no journal row for a unit whose render never landed.
+    assert not (tmp_path / "cost.pkl").exists()
+    checkpoint = tmp_path / "campaign.anchors.json"
+    if checkpoint.exists():
+        text = checkpoint.read_text()
+        assert saved[1].split("__")[0] not in text or "anchors" not in text
+
+
+def test_a_fatal_encode_error_still_journals_the_batch_that_succeeded(
+        monkeypatch, tmp_path):
+    """The regression the synchronous per-batch checkpoint did not have.
+
+    With a writer behind, unit one's row is not journalled at the moment its
+    encode returns; it is journalled when its bytes land.  If unit two then
+    fails fatally, unwinding must still commit unit one.  Losing it would mean
+    the resume re-encodes work the run really finished.
+    """
+    from prismaquant.cost_stage_checkpoint import unit_path
+    from prismaquant.tessera_render import HessianContractError
+
+    campaign, _render = _fixture(monkeypatch, tmp_path)
+    real_encode = campaign._encode_and_render
+    calls = []
+
+    def encode(weight, format_name, **kwargs):
+        calls.append(format_name)
+        if len(calls) == 2:
+            raise HessianContractError("no Hessian for this Linear")
+        return real_encode(weight, format_name, **kwargs)
+
+    monkeypatch.setattr(campaign, "_encode_and_render", encode)
+    with pytest.raises(HessianContractError, match="no Hessian"):
+        campaign.main([*_argv(tmp_path), "--publication-overlap-bytes", str(1 << 20)])
+
+    root = tmp_path / "campaign.anchors.json.parts"
+    survived = [unit for unit in UNITS if unit_path(root, unit).exists()]
+    assert survived, (
+        "the batch that succeeded before the fatal one lost its journal row")
+    for unit in survived:
+        envelope = pickle.loads(unit_path(root, unit).read_bytes())
+        state = pickle.loads(envelope["payload"])
+        assert state["anchors"] and state["wire_records"]
+        for record in state["wire_records"].values():
+            wire = tmp_path / "cache" / "wire" / record["file"]
+            assert wire.stat().st_size == record["blob_bytes"], (
+                "a row was committed against bytes that are not there")

--- a/tests/test_tessera_publication.py
+++ b/tests/test_tessera_publication.py
@@ -366,3 +366,135 @@ def test_the_temporary_file_is_not_left_behind_by_a_completed_publication(
         "model__layers__0__q__NVFP4.tessera"]
     assert not [p.name for p in cache_dir.glob("*.tmp")]
     assert os.listdir(cache_dir)
+
+
+# ---------------------------------------------------------------------------
+# The rule that a receipt never precedes the file it describes
+# ---------------------------------------------------------------------------
+
+class _Anchor:
+    def __init__(self, qname, format_name="NVFP4"):
+        self.qname = qname
+        self.format_name = format_name
+
+
+def _ledger(publisher, journalled):
+    from prismaquant.tessera_campaign import _AnchorPublicationLedger
+
+    return _AnchorPublicationLedger(
+        publisher=publisher,
+        journal_anchor=lambda anchor, identity: journalled.append(
+            (anchor.qname, identity)))
+
+
+def test_without_a_publisher_the_ledger_journals_where_it_always_did():
+    journalled = []
+    ledger = _ledger(None, journalled)
+    ledger.record(_Anchor("a.b"), "id-a")
+    assert journalled == [("a.b", "id-a")], (
+        "the default path must journal at the same point it always has")
+    assert ledger.apply_completed() == 0
+    assert ledger.drain() == 0
+    assert ledger.staged == {}
+
+
+def test_a_staged_anchor_is_not_journalled_while_its_writer_is_blocked():
+    journalled = []
+    barrier = threading.Event()
+    pub = _publisher()
+    ledger = _ledger(pub, journalled)
+    try:
+        pub.submit(PublicationJob(
+            key=("a.b", "NVFP4"), charged_bytes=1,
+            publish=lambda: barrier.wait(WAIT)))
+        ledger.record(_Anchor("a.b"), "id-a")
+        assert ledger.apply_completed() == 0
+        assert journalled == [], (
+            "an anchor row reached the journal before its own bytes reached "
+            "the disk; a resume would then read a receipt for a file that "
+            "does not exist")
+        barrier.set()
+        assert ledger.drain() == 1
+        assert journalled == [("a.b", "id-a")]
+        assert ledger.staged == {}
+    finally:
+        barrier.set()
+        pub.close()
+
+
+def test_the_ledger_journals_in_publication_order():
+    journalled = []
+    release = threading.Event()
+    pub = _publisher()
+    ledger = _ledger(pub, journalled)
+    try:
+        for name in ("a.b", "c.d", "e.f"):
+            pub.submit(PublicationJob(
+                key=(name, "NVFP4"), charged_bytes=1,
+                publish=lambda: release.wait(WAIT)))
+            ledger.record(_Anchor(name), f"id-{name}")
+        release.set()
+        assert ledger.drain() == 3
+    finally:
+        release.set()
+        pub.close()
+    assert journalled == [("a.b", "id-a.b"), ("c.d", "id-c.d"), ("e.f", "id-e.f")]
+
+
+def test_a_failed_publication_leaves_its_anchor_unjournalled():
+    journalled = []
+    release = threading.Event()
+    pub = _publisher()
+    ledger = _ledger(pub, journalled)
+    try:
+        pub.submit(PublicationJob(key=("good", "NVFP4"), charged_bytes=1,
+                                  publish=lambda: None))
+        ledger.record(_Anchor("good"), "id-good")
+
+        def boom():
+            assert release.wait(WAIT)
+            raise OSError("no space left on device")
+
+        pub.submit(PublicationJob(key=("bad", "NVFP4"), charged_bytes=1,
+                                  publish=boom))
+        ledger.record(_Anchor("bad"), "id-bad")
+        release.set()
+        with pytest.raises(PublicationError):
+            ledger.drain()
+        assert ("bad", "id-bad") not in journalled, (
+            "an anchor whose files never landed was journalled anyway")
+        # The unit that did land is still recoverable: applying the completed
+        # keys journals it, so a resume skips work that was really done.
+        assert ledger.apply_completed() == 1
+        assert journalled == [("good", "id-good")]
+        assert ("bad", "NVFP4") in ledger.staged
+    finally:
+        release.set()
+        pub.close()
+
+
+def test_a_drain_that_leaves_an_anchor_staged_refuses():
+    journalled = []
+    pub = _publisher()
+    ledger = _ledger(pub, journalled)
+    try:
+        # An anchor recorded with no job behind it is an ambiguous partial
+        # state: the drain has nothing to wait for and no completion to apply.
+        ledger.record(_Anchor("orphan"), "id-orphan")
+        with pytest.raises(RuntimeError, match="still staged"):
+            ledger.drain()
+        assert journalled == []
+    finally:
+        pub.close()
+
+
+def test_one_publication_key_cannot_hold_two_anchors():
+    journalled = []
+    pub = _publisher()
+    ledger = _ledger(pub, journalled)
+    try:
+        ledger.record(_Anchor("a.b"), "first")
+        with pytest.raises(RuntimeError, match="already staged"):
+            ledger.record(_Anchor("a.b"), "second")
+    finally:
+        pub.close()

--- a/tests/test_tessera_publication.py
+++ b/tests/test_tessera_publication.py
@@ -396,10 +396,24 @@ def test_a_failed_publication_surfaces_at_the_next_submit(tmp_path, monkeypatch)
 def test_the_budget_bounds_the_encode_thread_with_the_writer_blocked(
         tmp_path, monkeypatch):
     """One artifact in flight, and the next one not yet made."""
+    from prismaquant import production_weight_cache as pwc
+
     barrier = threading.Event()
     # 8x8 BF16 render plus a ten byte blob: room for exactly one.
     pub = BoundedPublisher(budget_bytes=8 * 8 * 2 + 10)
     returned = threading.Event()
+    # Only the producer's copies. The writer canonicalises again inside
+    # _store_rendered_weight_entry, and that call is an identity on a tensor
+    # this test is not asking about.
+    copies = []
+    real_canonical = pwc._canonical_rendered_weight_tensor
+
+    def counted(tensor, **kwargs):
+        if not threading.current_thread().name.startswith("tessera-publication"):
+            copies.append(1)
+        return real_canonical(tensor, **kwargs)
+
+    monkeypatch.setattr(pwc, "_canonical_rendered_weight_tensor", counted)
     try:
         _finish(tmp_path / "one", monkeypatch, publisher=pub, barrier=barrier,
                 qname="a.b")
@@ -414,6 +428,10 @@ def test_the_budget_bounds_the_encode_thread_with_the_writer_blocked(
         assert not returned.wait(0.5), (
             "a second artifact was staged while the first still occupied the "
             "whole budget; the bound is not a bound")
+        assert copies == [1], (
+            "the second render was copied to host while the budget was full: "
+            "reserving after the copy leaves the producer holding one "
+            "artifact more than the bound admits")
         assert pub.stats()["peak_charged_bytes"] == 8 * 8 * 2 + 10
         barrier.set()
         assert returned.wait(WAIT)

--- a/tests/test_tessera_publication.py
+++ b/tests/test_tessera_publication.py
@@ -629,3 +629,59 @@ def test_one_publication_key_cannot_hold_two_anchors():
             ledger.record(_Anchor("a.b"), "second")
     finally:
         pub.close()
+
+
+def test_the_dispatcher_carries_the_staging_bound_into_the_plan(monkeypatch):
+    """A row's declared demand has to include what its campaign will stage.
+
+    The flag reaches ``selected_anchor_resources`` twice over: the campaign
+    passes its own, and the dispatcher reads it back off the row's argv when
+    it sizes the worker that will admit the row.  Only the second is testable
+    without running a campaign, and it is the one a planning change breaks
+    silently, because a worker sized without the term still runs -- it just
+    runs a campaign holding bytes nobody reserved.
+    """
+    from prismaquant import autoscale
+    from tools import dispatch_tessera_campaign as dispatch
+
+    seen: dict = {}
+
+    def selected(model, **kwargs):
+        seen.update(kwargs)
+        return {"memory_bytes": 100}
+
+    monkeypatch.setattr(autoscale, "selected_anchor_resources", selected)
+    dispatch._streamed_resource_plan(
+        dict(model="/source", campaign_argv=[
+            "--streaming", "--publication-overlap-bytes", "8388608"]),
+        dict(unit_shapes={"a": [3, 4]}, counts={"a": 9}), ["a"],
+        selected_source=True)
+    assert seen["publication_overlap_bytes"] == 8388608
+
+    seen.clear()
+    dispatch._streamed_resource_plan(
+        dict(model="/source", campaign_argv=["--streaming"]),
+        dict(unit_shapes={"a": [3, 4]}, counts={"a": 9}), ["a"],
+        selected_source=True)
+    assert seen["publication_overlap_bytes"] == 0
+
+
+def test_the_plan_charges_the_staging_bound_where_the_anchors_live():
+    """And the number lands in the phase the staged bytes are resident in."""
+    from prismaquant import autoscale
+
+    kwargs = dict(unit_shapes={"layers.0.proj": [3, 4]},
+                  counts={"layers.0.proj": 9},
+                  max_act_rows=2, cache_slots=2, prefetch_workers=1,
+                  headroom_gb=0)
+    off = autoscale.selected_anchor_resources("/source", **kwargs)
+    on = autoscale.selected_anchor_resources(
+        "/source", **kwargs, publication_overlap_bytes=8388608)
+    assert off["phases"]["resident_anchors"].get(
+        "publication_staging_bytes", 0) == 0
+    assert on["phases"]["resident_anchors"]["publication_staging_bytes"] == 8388608
+    # Nothing else moved: the term is additive, not a re-sizing.
+    assert {k: v for k, v in on["phases"]["resident_anchors"].items()
+            if k != "publication_staging_bytes"} == {
+        k: v for k, v in off["phases"]["resident_anchors"].items()
+        if k != "publication_staging_bytes"}

--- a/tests/test_tessera_publication.py
+++ b/tests/test_tessera_publication.py
@@ -666,10 +666,23 @@ def test_the_dispatcher_carries_the_staging_bound_into_the_plan(monkeypatch):
     assert seen["publication_overlap_bytes"] == 0
 
 
-def test_the_plan_charges_the_staging_bound_where_the_anchors_live():
+def test_the_plan_charges_the_staging_bound_where_the_anchors_live(monkeypatch):
     """And the number lands in the phase the staged bytes are resident in."""
     from prismaquant import autoscale
 
+    # The source census is the part that needs a real checkpoint on disk;
+    # the term under test is added after it, so it is stood in for here.
+    monkeypatch.setattr(autoscale, "streamed_calibration_resources",
+                        lambda *_args, **_kwargs: dict(
+                            live_layer_prefix="layers.",
+                            terms=dict(nonbody_source_bytes=100,
+                                       declared_headroom_bytes=200),
+                            body_layer_bytes={"0": 1000},
+                            body_loader_transient_bytes={"0": 100},
+                            body_source_file_bytes={"0": 900},
+                            unit_source_weight_bytes={"layers.0.proj": 24},
+                            full_hessian_bytes=64, full_prefix_bytes=32,
+                            source_header_sha256="a" * 64))
     kwargs = dict(unit_shapes={"layers.0.proj": [3, 4]},
                   counts={"layers.0.proj": 9},
                   max_act_rows=2, cache_slots=2, prefetch_workers=1,

--- a/tests/test_tessera_publication.py
+++ b/tests/test_tessera_publication.py
@@ -1,0 +1,368 @@
+"""The campaign may publish an anchor's files on another thread, in order.
+
+Every timing assertion here is an ORDERING assertion held open by a barrier
+the test controls.  A barrier proves that one thing can begin before another
+has finished; it does not measure how much wall clock that is worth on a real
+endpoint, and nothing in this file should be read as a speed result.  The
+whole-cycle profiles and the both-host power series are collected separately,
+on the boxes, against the real arms.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from prismaquant.tessera_publication import (
+    BoundedPublisher, PublicationError, PublicationJob,
+)
+
+
+# A barrier a test holds and a writer waits on.  ``timeout`` everywhere, so a
+# defect in the code under test fails the test instead of hanging the shard.
+WAIT = 20.0
+
+
+def _publisher(**kwargs):
+    kwargs.setdefault("budget_bytes", 1 << 20)
+    return BoundedPublisher(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# The publisher on its own
+# ---------------------------------------------------------------------------
+
+def test_jobs_publish_in_submission_order():
+    order = []
+    pub = _publisher()
+    try:
+        for index in range(8):
+            pub.submit(PublicationJob(
+                key=index, charged_bytes=1,
+                publish=lambda index=index: order.append(index)))
+        assert pub.drain() == list(range(8))
+    finally:
+        pub.close()
+    assert order == list(range(8)), (
+        "one writer thread and a FIFO queue is what makes recovery "
+        f"deterministic; got {order}")
+
+
+def test_the_budget_blocks_a_submit_until_the_writer_catches_up():
+    release = threading.Event()
+    started = threading.Event()
+
+    def slow():
+        started.set()
+        assert release.wait(WAIT), "writer never released"
+
+    pub = BoundedPublisher(budget_bytes=100)
+    try:
+        pub.submit(PublicationJob(key="a", charged_bytes=60, publish=slow))
+        assert started.wait(WAIT)
+        blocked = threading.Event()
+
+        def second():
+            pub.submit(PublicationJob(key="b", charged_bytes=60,
+                                      publish=lambda: None))
+            blocked.set()
+
+        worker = threading.Thread(target=second)
+        worker.start()
+        # 60 + 60 > 100, and the first job is still resident, so the second
+        # submit has to wait rather than stage past the bound.
+        assert not blocked.wait(0.5), (
+            "an over-budget submit returned; staging is not bounded")
+        release.set()
+        assert blocked.wait(WAIT), "submit never unblocked after the writer drained"
+        worker.join(WAIT)
+        assert pub.drain() == ["a", "b"]
+        assert pub.stats()["peak_charged_bytes"] <= 100
+        assert pub.stats()["submit_blocked_seconds"] > 0.0
+    finally:
+        release.set()
+        pub.close()
+
+
+def test_an_artifact_larger_than_the_whole_budget_still_publishes():
+    pub = BoundedPublisher(budget_bytes=8)
+    try:
+        pub.submit(PublicationJob(key="huge", charged_bytes=4096,
+                                  publish=lambda: None))
+        assert pub.drain() == ["huge"], (
+            "an artifact bigger than the budget must wait for an empty queue, "
+            "not for room that cannot appear")
+    finally:
+        pub.close()
+
+
+def test_a_writer_failure_drops_what_was_queued_behind_it_unwritten():
+    written = []
+    release = threading.Event()
+
+    def first():
+        assert release.wait(WAIT)
+        raise OSError("no space left on device")
+
+    pub = _publisher()
+    try:
+        pub.submit(PublicationJob(key="a", charged_bytes=1, publish=first))
+        pub.submit(PublicationJob(
+            key="b", charged_bytes=1, publish=lambda: written.append("b")))
+        pub.submit(PublicationJob(
+            key="c", charged_bytes=1, publish=lambda: written.append("c")))
+        release.set()
+        with pytest.raises(PublicationError) as caught:
+            pub.drain()
+        assert isinstance(caught.value.__cause__, OSError)
+        assert written == [], (
+            "work queued behind a failed write must not be written: "
+            f"{written} landed after the failure")
+    finally:
+        release.set()
+        pub.close()
+
+
+def test_what_landed_before_a_failure_is_still_reported_for_recovery():
+    release = threading.Event()
+    pub = _publisher()
+    try:
+        pub.submit(PublicationJob(key="done", charged_bytes=1,
+                                  publish=lambda: None))
+
+        def boom():
+            assert release.wait(WAIT)
+            raise OSError("no space left on device")
+
+        pub.submit(PublicationJob(key="bad", charged_bytes=1, publish=boom))
+        release.set()
+        with pytest.raises(PublicationError):
+            pub.drain()
+        # The first job's files exist. A resume that is told about them skips
+        # work it really did; a resume that is not repeats it.
+        assert pub.completed() == ["done"]
+        assert isinstance(pub.failure, OSError)
+    finally:
+        release.set()
+        pub.close()
+
+
+def test_a_failure_reaches_a_submit_that_is_blocked_on_the_budget():
+    release = threading.Event()
+
+    def boom():
+        assert release.wait(WAIT)
+        raise OSError("no space left on device")
+
+    pub = BoundedPublisher(budget_bytes=100)
+    try:
+        pub.submit(PublicationJob(key="bad", charged_bytes=60, publish=boom))
+        raised = []
+
+        def second():
+            try:
+                pub.submit(PublicationJob(key="next", charged_bytes=60,
+                                          publish=lambda: None))
+            except BaseException as exc:  # noqa: BLE001
+                raised.append(exc)
+
+        worker = threading.Thread(target=second)
+        worker.start()
+        time.sleep(0.2)
+        release.set()
+        worker.join(WAIT)
+        assert not worker.is_alive(), (
+            "a caller blocked on the budget must wake into the failure, not "
+            "wait on a writer that has stopped")
+        assert raised and isinstance(raised[0], PublicationError)
+    finally:
+        release.set()
+        pub.close()
+
+
+def test_a_zero_budget_is_refused_rather_than_silently_synchronous():
+    with pytest.raises(ValueError):
+        BoundedPublisher(budget_bytes=0)
+
+
+# ---------------------------------------------------------------------------
+# The campaign's two writes, with and without a publisher
+# ---------------------------------------------------------------------------
+
+class _Spec:
+    act_dtype_name = "a16"
+
+    def bits_for_shape(self, shape):
+        return 4 * shape[0] * shape[1]
+
+    def memory_bytes_for_shape(self, shape):
+        return shape[0] * shape[1] // 2
+
+
+class _Family:
+    name = "TQ"
+
+
+class _Cache:
+    def __init__(self, cache_dir):
+        self.cache_dir = str(cache_dir)
+        self.weights = {}
+        self.metadata = {}
+
+
+def _prepared():
+    return dict(spec=_Spec(), family=_Family(), rung=1088,
+                activation_qdq=None, input_scale=None, activation_kwargs=None)
+
+
+def _finish(tmp_path, monkeypatch, *, publisher, qname="model.layers.0.q",
+            barrier=None, blob=b"wire-bytes"):
+    """Run ``_finish_anchor`` over fakes, optionally behind a save barrier."""
+    import torch
+
+    from prismaquant import production_weight_cache as pwc
+    from prismaquant import tessera_campaign as tc
+
+    monkeypatch.setattr(
+        pwc, "_local_forward_render_score",
+        lambda **kwargs: (0.25, "output_mse", False, 0))
+    if barrier is not None:
+        real_save = torch.save
+
+        def held(obj, path, *args, **kwargs):
+            assert barrier.wait(WAIT), "save barrier never released"
+            return real_save(obj, path, *args, **kwargs)
+
+        monkeypatch.setattr(torch, "save", held)
+
+    cache_dir = tmp_path / "cache"
+    wire_dir = tmp_path / "wire"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    wire_dir.mkdir(parents=True, exist_ok=True)
+    weight = torch.zeros((8, 8), dtype=torch.bfloat16)
+    return tc._finish_anchor(
+        qname=qname, weight=weight, activations=torch.zeros((4, 8)),
+        # Uppercase because the cache canonicalises its key and the wire path
+        # does not; a mixed-case name would name two different things.
+        format_name="NVFP4", cache=_Cache(cache_dir), wire_dir=wire_dir,
+        prepared=_prepared(), render=torch.zeros((8, 8)), blob=blob,
+        elapsed=1.0, publisher=publisher), cache_dir, wire_dir
+
+
+def test_a_blocked_writer_blocks_the_encode_thread_when_publication_is_synchronous(
+        tmp_path, monkeypatch):
+    """The baseline this branch exists to change, stated as a test."""
+    barrier = threading.Event()
+    returned = threading.Event()
+
+    def run():
+        _finish(tmp_path, monkeypatch, publisher=None, barrier=barrier)
+        returned.set()
+
+    worker = threading.Thread(target=run)
+    worker.start()
+    try:
+        assert not returned.wait(0.5), (
+            "the synchronous path returned while its writer was blocked")
+        barrier.set()
+        assert returned.wait(WAIT)
+    finally:
+        barrier.set()
+        worker.join(WAIT)
+
+
+def test_a_publisher_lets_the_next_unit_start_while_the_writer_is_blocked(
+        tmp_path, monkeypatch):
+    barrier = threading.Event()
+    pub = _publisher()
+    try:
+        anchor, cache_dir, wire_dir = _finish(
+            tmp_path, monkeypatch, publisher=pub, barrier=barrier,
+            qname="model.layers.0.q")
+        # The encode thread is back with a scored anchor while the writer is
+        # still inside torch.save. That is the whole point of the change.
+        assert anchor.qname == "model.layers.0.q"
+        assert pub.outstanding == 1
+        assert not (wire_dir / "model__layers__0__q__NVFP4.tessera").exists(), (
+            "the wire landed before the render it is sequenced behind")
+        assert pub.completed() == [], (
+            "a job reported complete while its writer was still blocked")
+        barrier.set()
+        assert pub.drain() == [("model.layers.0.q", "NVFP4")]
+    finally:
+        barrier.set()
+        pub.close()
+    # The drain leaves ordinary files, in the ordinary places, with the
+    # ordinary names: nothing here is a new store.
+    assert (wire_dir / "model__layers__0__q__NVFP4.tessera").read_bytes() == b"wire-bytes"
+    assert len(list(cache_dir.glob("*"))) == 1
+    assert not list(cache_dir.glob("*.tmp"))
+
+
+def test_the_published_render_is_the_tensor_the_synchronous_path_stores(
+        tmp_path, monkeypatch):
+    sync_anchor, sync_cache, sync_wire = _finish(
+        tmp_path / "sync", monkeypatch, publisher=None)
+    pub = _publisher()
+    try:
+        async_anchor, async_cache, async_wire = _finish(
+            tmp_path / "async", monkeypatch, publisher=pub)
+        pub.drain()
+    finally:
+        pub.close()
+    sync_file = next(iter(sync_cache.glob("*")))
+    async_file = next(iter(async_cache.glob("*")))
+    assert sync_file.name == async_file.name
+    assert sync_file.read_bytes() == async_file.read_bytes(), (
+        "the staged tensor is not the tensor the synchronous path stores")
+    assert next(iter(sync_wire.glob("*"))).read_bytes() == (
+        next(iter(async_wire.glob("*"))).read_bytes())
+    for field in ("dloss", "wire_bytes", "bits_per_param", "memory_bytes",
+                  "activation_contract", "hessian_applied"):
+        assert getattr(sync_anchor, field) == getattr(async_anchor, field), field
+
+
+def test_a_failed_publication_surfaces_at_the_next_submit(tmp_path, monkeypatch):
+    import torch
+
+    pub = _publisher()
+    try:
+        real_save = torch.save
+        calls = []
+
+        def failing(obj, path, *args, **kwargs):
+            calls.append(Path(path).name)
+            if len(calls) == 2:
+                raise OSError("no space left on device")
+            return real_save(obj, path, *args, **kwargs)
+
+        monkeypatch.setattr(torch, "save", failing)
+        _finish(tmp_path / "one", monkeypatch, publisher=pub, qname="a.b")
+        pub.drain()
+        _finish(tmp_path / "two", monkeypatch, publisher=pub, qname="c.d")
+        with pytest.raises(PublicationError):
+            pub.drain()
+        # Fail closed: the second unit's wire must not exist, because its
+        # render never landed and the two are one publication.
+        assert not list((tmp_path / "two" / "wire").glob("*.tessera")), (
+            "the wire was published after its render failed")
+    finally:
+        pub.close()
+
+
+def test_the_temporary_file_is_not_left_behind_by_a_completed_publication(
+        tmp_path, monkeypatch):
+    pub = _publisher()
+    try:
+        _, cache_dir, wire_dir = _finish(tmp_path, monkeypatch, publisher=pub)
+        pub.drain()
+    finally:
+        pub.close()
+    assert [p.name for p in wire_dir.glob("*")] == [
+        "model__layers__0__q__NVFP4.tessera"]
+    assert not [p.name for p in cache_dir.glob("*.tmp")]
+    assert os.listdir(cache_dir)

--- a/tests/test_tessera_publication.py
+++ b/tests/test_tessera_publication.py
@@ -32,6 +32,12 @@ def _publisher(**kwargs):
     return BoundedPublisher(**kwargs)
 
 
+def _stage(publisher, job):
+    """Reserve then submit, the way a producer must."""
+    publisher.reserve(job.charged_bytes)
+    publisher.submit(job)
+
+
 # ---------------------------------------------------------------------------
 # The publisher on its own
 # ---------------------------------------------------------------------------
@@ -41,7 +47,7 @@ def test_jobs_publish_in_submission_order():
     pub = _publisher()
     try:
         for index in range(8):
-            pub.submit(PublicationJob(
+            _stage(pub, PublicationJob(
                 key=index, charged_bytes=1,
                 publish=lambda index=index: order.append(index)))
         assert pub.drain() == list(range(8))
@@ -62,13 +68,13 @@ def test_the_budget_blocks_a_submit_until_the_writer_catches_up():
 
     pub = BoundedPublisher(budget_bytes=100)
     try:
-        pub.submit(PublicationJob(key="a", charged_bytes=60, publish=slow))
+        _stage(pub, PublicationJob(key="a", charged_bytes=60, publish=slow))
         assert started.wait(WAIT)
         blocked = threading.Event()
 
         def second():
-            pub.submit(PublicationJob(key="b", charged_bytes=60,
-                                      publish=lambda: None))
+            _stage(pub, PublicationJob(key="b", charged_bytes=60,
+                                       publish=lambda: None))
             blocked.set()
 
         worker = threading.Thread(target=second)
@@ -76,7 +82,7 @@ def test_the_budget_blocks_a_submit_until_the_writer_catches_up():
         # 60 + 60 > 100, and the first job is still resident, so the second
         # submit has to wait rather than stage past the bound.
         assert not blocked.wait(0.5), (
-            "an over-budget submit returned; staging is not bounded")
+            "an over-budget reservation returned; staging is not bounded")
         release.set()
         assert blocked.wait(WAIT), "submit never unblocked after the writer drained"
         worker.join(WAIT)
@@ -88,14 +94,47 @@ def test_the_budget_blocks_a_submit_until_the_writer_catches_up():
         pub.close()
 
 
-def test_an_artifact_larger_than_the_whole_budget_still_publishes():
+def test_an_artifact_larger_than_the_whole_budget_is_refused(monkeypatch):
+    """The declared bound is the bound, or it is not a bound."""
+    published = []
     pub = BoundedPublisher(budget_bytes=8)
     try:
-        pub.submit(PublicationJob(key="huge", charged_bytes=4096,
+        with pytest.raises(PublicationError, match="does not fit"):
+            pub.reserve(4096)
+        # And nothing was staged behind the refusal.
+        _stage(pub, PublicationJob(key="small", charged_bytes=8,
+                                   publish=lambda: published.append("small")))
+        assert pub.drain() == ["small"]
+        assert published == ["small"]
+        assert pub.stats()["peak_charged_bytes"] == 8
+    finally:
+        pub.close()
+
+
+def test_a_reservation_is_needed_before_charged_bytes_are_submitted():
+    pub = BoundedPublisher(budget_bytes=64)
+    try:
+        with pytest.raises(PublicationError, match="reserve"):
+            pub.submit(PublicationJob(key="unreserved", charged_bytes=16,
+                                      publish=lambda: None))
+        # A zero-charge job carries no bytes and needs no room: the receipt
+        # and journal jobs are ordering, not staging.
+        pub.submit(PublicationJob(key="free", charged_bytes=0,
                                   publish=lambda: None))
-        assert pub.drain() == ["huge"], (
-            "an artifact bigger than the budget must wait for an empty queue, "
-            "not for room that cannot appear")
+        assert pub.drain() == ["free"]
+    finally:
+        pub.close()
+
+
+def test_a_released_reservation_gives_its_room_back():
+    pub = BoundedPublisher(budget_bytes=64)
+    try:
+        pub.reserve(64)
+        pub.release(64)
+        # If the release had not landed this would block until the timeout.
+        _stage(pub, PublicationJob(key="after", charged_bytes=64,
+                                   publish=lambda: None))
+        assert pub.drain() == ["after"]
     finally:
         pub.close()
 
@@ -110,10 +149,10 @@ def test_a_writer_failure_drops_what_was_queued_behind_it_unwritten():
 
     pub = _publisher()
     try:
-        pub.submit(PublicationJob(key="a", charged_bytes=1, publish=first))
-        pub.submit(PublicationJob(
+        _stage(pub, PublicationJob(key="a", charged_bytes=1, publish=first))
+        _stage(pub, PublicationJob(
             key="b", charged_bytes=1, publish=lambda: written.append("b")))
-        pub.submit(PublicationJob(
+        _stage(pub, PublicationJob(
             key="c", charged_bytes=1, publish=lambda: written.append("c")))
         release.set()
         with pytest.raises(PublicationError) as caught:
@@ -131,14 +170,14 @@ def test_what_landed_before_a_failure_is_still_reported_for_recovery():
     release = threading.Event()
     pub = _publisher()
     try:
-        pub.submit(PublicationJob(key="done", charged_bytes=1,
-                                  publish=lambda: None))
+        _stage(pub, PublicationJob(key="done", charged_bytes=1,
+                                   publish=lambda: None))
 
         def boom():
             assert release.wait(WAIT)
             raise OSError("no space left on device")
 
-        pub.submit(PublicationJob(key="bad", charged_bytes=1, publish=boom))
+        _stage(pub, PublicationJob(key="bad", charged_bytes=1, publish=boom))
         release.set()
         with pytest.raises(PublicationError):
             pub.drain()
@@ -160,13 +199,13 @@ def test_a_failure_reaches_a_submit_that_is_blocked_on_the_budget():
 
     pub = BoundedPublisher(budget_bytes=100)
     try:
-        pub.submit(PublicationJob(key="bad", charged_bytes=60, publish=boom))
+        _stage(pub, PublicationJob(key="bad", charged_bytes=60, publish=boom))
         raised = []
 
         def second():
             try:
-                pub.submit(PublicationJob(key="next", charged_bytes=60,
-                                          publish=lambda: None))
+                _stage(pub, PublicationJob(key="next", charged_bytes=60,
+                                           publish=lambda: None))
             except BaseException as exc:  # noqa: BLE001
                 raised.append(exc)
 
@@ -292,7 +331,7 @@ def test_a_publisher_lets_the_next_unit_start_while_the_writer_is_blocked(
         assert pub.completed() == [], (
             "a job reported complete while its writer was still blocked")
         barrier.set()
-        assert pub.drain() == [("model.layers.0.q", "NVFP4")]
+        assert pub.drain() == [("files", "model.layers.0.q", "NVFP4")]
     finally:
         barrier.set()
         pub.close()
@@ -354,6 +393,50 @@ def test_a_failed_publication_surfaces_at_the_next_submit(tmp_path, monkeypatch)
         pub.close()
 
 
+def test_the_budget_bounds_the_encode_thread_with_the_writer_blocked(
+        tmp_path, monkeypatch):
+    """One artifact in flight, and the next one not yet made."""
+    barrier = threading.Event()
+    # 8x8 BF16 render plus a ten byte blob: room for exactly one.
+    pub = BoundedPublisher(budget_bytes=8 * 8 * 2 + 10)
+    returned = threading.Event()
+    try:
+        _finish(tmp_path / "one", monkeypatch, publisher=pub, barrier=barrier,
+                qname="a.b")
+
+        def second():
+            _finish(tmp_path / "two", monkeypatch, publisher=pub,
+                    barrier=barrier, qname="c.d")
+            returned.set()
+
+        worker = threading.Thread(target=second)
+        worker.start()
+        assert not returned.wait(0.5), (
+            "a second artifact was staged while the first still occupied the "
+            "whole budget; the bound is not a bound")
+        assert pub.stats()["peak_charged_bytes"] == 8 * 8 * 2 + 10
+        barrier.set()
+        assert returned.wait(WAIT)
+        worker.join(WAIT)
+        pub.drain()
+    finally:
+        barrier.set()
+        pub.close()
+
+
+def test_a_render_larger_than_the_budget_is_refused_before_it_is_copied(
+        tmp_path, monkeypatch):
+    pub = BoundedPublisher(budget_bytes=16)
+    try:
+        with pytest.raises(PublicationError, match="does not fit"):
+            _finish(tmp_path, monkeypatch, publisher=pub, qname="a.b")
+        assert not list((tmp_path / "cache").glob("*.pt")), (
+            "a refused artifact still reached the cache")
+        assert pub.stats()["peak_charged_bytes"] == 0
+    finally:
+        pub.close()
+
+
 def test_the_temporary_file_is_not_left_behind_by_a_completed_publication(
         tmp_path, monkeypatch):
     pub = _publisher()
@@ -383,19 +466,36 @@ def _ledger(publisher, journalled):
 
     return _AnchorPublicationLedger(
         publisher=publisher,
-        journal_anchor=lambda anchor, identity: journalled.append(
-            (anchor.qname, identity)))
+        make_record=lambda anchor, identity: f"record:{identity}",
+        journal_anchor=lambda anchor, record: journalled.append(
+            (anchor.qname, record)))
+
+
+def _files_job(publisher, name, publish):
+    """Stand in for the render/wire job ``_finish_anchor`` submits."""
+    from prismaquant.tessera_campaign import FILES_JOB
+
+    _stage(publisher, PublicationJob(
+        key=(FILES_JOB, name, "NVFP4"), charged_bytes=1, publish=publish))
 
 
 def test_without_a_publisher_the_ledger_journals_where_it_always_did():
     journalled = []
     ledger = _ledger(None, journalled)
+    assert ledger.active is False
     ledger.record(_Anchor("a.b"), "id-a")
-    assert journalled == [("a.b", "id-a")], (
+    assert journalled == [("a.b", "record:id-a")], (
         "the default path must journal at the same point it always has")
     assert ledger.apply_completed() == 0
     assert ledger.drain() == 0
     assert ledger.staged == {}
+
+
+def test_without_a_publisher_a_checkpoint_is_written_where_it_always_was():
+    written = []
+    ledger = _ledger(None, [])
+    ledger.submit_checkpoint(lambda: written.append("now"))
+    assert written == ["now"]
 
 
 def test_a_staged_anchor_is_not_journalled_while_its_writer_is_blocked():
@@ -404,9 +504,7 @@ def test_a_staged_anchor_is_not_journalled_while_its_writer_is_blocked():
     pub = _publisher()
     ledger = _ledger(pub, journalled)
     try:
-        pub.submit(PublicationJob(
-            key=("a.b", "NVFP4"), charged_bytes=1,
-            publish=lambda: barrier.wait(WAIT)))
+        _files_job(pub, "a.b", lambda: barrier.wait(WAIT))
         ledger.record(_Anchor("a.b"), "id-a")
         assert ledger.apply_completed() == 0
         assert journalled == [], (
@@ -415,11 +513,32 @@ def test_a_staged_anchor_is_not_journalled_while_its_writer_is_blocked():
             "does not exist")
         barrier.set()
         assert ledger.drain() == 1
-        assert journalled == [("a.b", "id-a")]
+        assert journalled == [("a.b", "record:id-a")]
         assert ledger.staged == {}
     finally:
         barrier.set()
         pub.close()
+
+
+def test_a_checkpoint_write_is_ordered_behind_the_receipts_it_cites():
+    order = []
+    barrier = threading.Event()
+    pub = _publisher()
+    ledger = _ledger(pub, order)
+    try:
+        _files_job(pub, "a.b", lambda: (barrier.wait(WAIT),
+                                        order.append("files")))
+        ledger.record(_Anchor("a.b"), "id-a")
+        ledger.submit_checkpoint(lambda: order.append("checkpoint"))
+        barrier.set()
+        ledger.drain()
+    finally:
+        barrier.set()
+        pub.close()
+    # The receipt is made on the writer, between the two, and the row it
+    # produced is applied by the caller; what matters here is that the journal
+    # write did not run before the bytes it cites were written.
+    assert order.index("files") < order.index("checkpoint")
 
 
 def test_the_ledger_journals_in_publication_order():
@@ -429,16 +548,15 @@ def test_the_ledger_journals_in_publication_order():
     ledger = _ledger(pub, journalled)
     try:
         for name in ("a.b", "c.d", "e.f"):
-            pub.submit(PublicationJob(
-                key=(name, "NVFP4"), charged_bytes=1,
-                publish=lambda: release.wait(WAIT)))
+            _files_job(pub, name, lambda: release.wait(WAIT))
             ledger.record(_Anchor(name), f"id-{name}")
         release.set()
         assert ledger.drain() == 3
     finally:
         release.set()
         pub.close()
-    assert journalled == [("a.b", "id-a.b"), ("c.d", "id-c.d"), ("e.f", "id-e.f")]
+    assert journalled == [("a.b", "record:id-a.b"), ("c.d", "record:id-c.d"),
+                          ("e.f", "record:id-e.f")]
 
 
 def test_a_failed_publication_leaves_its_anchor_unjournalled():
@@ -447,43 +565,37 @@ def test_a_failed_publication_leaves_its_anchor_unjournalled():
     pub = _publisher()
     ledger = _ledger(pub, journalled)
     try:
-        pub.submit(PublicationJob(key=("good", "NVFP4"), charged_bytes=1,
-                                  publish=lambda: None))
+        _files_job(pub, "good", lambda: release.wait(WAIT))
         ledger.record(_Anchor("good"), "id-good")
 
         def boom():
-            assert release.wait(WAIT)
             raise OSError("no space left on device")
 
-        pub.submit(PublicationJob(key=("bad", "NVFP4"), charged_bytes=1,
-                                  publish=boom))
+        _files_job(pub, "bad", boom)
         ledger.record(_Anchor("bad"), "id-bad")
         release.set()
         with pytest.raises(PublicationError):
             ledger.drain()
-        assert ("bad", "id-bad") not in journalled, (
+        assert ("bad", "record:id-bad") not in journalled, (
             "an anchor whose files never landed was journalled anyway")
         # The unit that did land is still recoverable: applying the completed
         # keys journals it, so a resume skips work that was really done.
         assert ledger.apply_completed() == 1
-        assert journalled == [("good", "id-good")]
+        assert journalled == [("good", "record:id-good")]
         assert ("bad", "NVFP4") in ledger.staged
     finally:
         release.set()
         pub.close()
 
 
-def test_a_drain_that_leaves_an_anchor_staged_refuses():
-    journalled = []
+def test_a_completion_nothing_staged_is_refused_rather_than_ignored():
     pub = _publisher()
-    ledger = _ledger(pub, journalled)
+    ledger = _ledger(pub, [])
     try:
-        # An anchor recorded with no job behind it is an ambiguous partial
-        # state: the drain has nothing to wait for and no completion to apply.
-        ledger.record(_Anchor("orphan"), "id-orphan")
-        with pytest.raises(RuntimeError, match="still staged"):
+        pub.submit(PublicationJob(key=("something-else", 1), charged_bytes=0,
+                                  publish=lambda: None))  # ordering job, no bytes
+        with pytest.raises(RuntimeError, match="unknown job"):
             ledger.drain()
-        assert journalled == []
     finally:
         pub.close()
 
@@ -493,6 +605,7 @@ def test_one_publication_key_cannot_hold_two_anchors():
     pub = _publisher()
     ledger = _ledger(pub, journalled)
     try:
+        _files_job(pub, "a.b", lambda: None)
         ledger.record(_Anchor("a.b"), "first")
         with pytest.raises(RuntimeError, match="already staged"):
             ledger.record(_Anchor("a.b"), "second")

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -201,6 +201,11 @@ def _streamed_resource_plan(spec, census, members, *, selected_source=False):
     if selected_source:
         return selected_anchor_resources(spec['model'], **options,
             anchor_batch_size=argument('--anchor-batch-size', 1),
+            # The row's own campaign will hold this many host bytes of staged
+            # artifacts, so the box that admits the row has to be told. A
+            # dispatcher that planned without it would size a worker for a
+            # campaign it is not about to run.
+            publication_overlap_bytes=argument('--publication-overlap-bytes', 0),
             **(dict(capture_load_policy=argument('--capture-load-policy', None, json.loads))
                if '--capture-load-policy' in argv else {}))
     return streamed_calibration_resources(spec['model'], **options,


### PR DESCRIPTION
Closes #464.

The campaign pauses after encoding each batch to publish files, read wire receipts and write its checkpoint. This adds a bounded FIFO writer so the next batch can encode while publication completes. A row becomes measured only after its receipt exists; checkpoint writes follow the receipts they cite. Reservations happen before staging, oversized jobs fail closed, and unwinding preserves completed rows and propagates writer failures. Existing cache and atomic file publication remain the implementation.

`--publication-overlap-bytes` is opt-in and defaults to zero. Its memory budget is included in campaign admission and forwarded by the dispatcher. The architecture document describes the contract.

Validation at head `83d265aa560f54e8430e7d8da4c0ea783fccb1b7`:

- Full CPU CI: 7,352 passed, 204 skipped, three xfailed and 192 subtests. Root checked the actual job log and head binding; this is not CUDA coverage.
- Focused PB checks cover ordering, budget, failure/unwind, checkpoint/resume and the actual CLI. Root inspected executed source bundles and failing regression mutations; details remain in the branch's earlier review record and root evidence.
- Native GB10 / torch 2.13+cu130 / immutable b1 producer: the fully resident 864-unit GLM row with 32 encoded units, R832/B8, completed two warm profiles plus an unprofiled ABBA comparison. All 192 wires and scores matched. Synchronous versus overlap: 237.0481 versus 231.4060 seconds total, **1.02438x throughput**. Work/J improved only 1.00520x, an inconclusive energy difference. Before/after CPU/CUDA traces and both-host Netdata accompany the measurement.
- The R1088 comparison completed four arms with exact wires/scores, then refused the next memory phase guard. Its single unprofiled pair showed 1.02469x throughput; it is partial evidence, not a completed ABBA comparison. No OOM; cleanup completed.

Native R832 PB action `55a9fbd847d34329793c1eb04e3b8a95b392a55ea298d28c1554d4d426b64056`, independent audit `3c2158f07380a41b59bf23136abd2c9ca129904aa970b048a828b9dc19c8fedd`. Root verified terminal exits, cleanup, actual outputs, receipt hashes and source snapshots. Full results and negative evidence are retained at [the experiment record](https://github.com/RobTand/prismaquant/blob/349481522a/docs/experiments/glm_publication_cycle_20260909/README.md), with shared artifact paths and complete keys.

These bounded measurements establish neither full-model throughput nor served quality. The observed gain is modest, so the synchronous default remains. The measurement harness is retained separately from this production change.
