### PR TITLE
Reuse published Hessian commitments for resident campaign sealing

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,25 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-09 · `claude/bounded-publication-overlap`. Stamps
+As of: 2026-09-09 · `fix/glm-resident-hessian-commitments`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-09, `fix/glm-resident-hessian-commitments`) for resident
+Hessian commitment reuse in the selected campaign's existing opt-in
+`--export-hessian-reference-policy` path. Resume and seed validation still
+precede publication of export inputs. After those gates accept, the campaign
+binds its resident H tensors to the producer's authenticated reference owner
+over the just-published commitments. The encoder and checkpoint identity paths
+share that owner's resident mapping; capture sealing uses its committed
+digests instead of hashing the full population again. Each encoder consumption
+still checks actual H content against its commitment. No H payload is loaded
+through the reference reader on this path, and the campaign's existing source
+scope closes the held metadata on successful returns and exceptions. The
+original capture seal and per-unit encoding input identities are preserved;
+the conservative producer source seal continues to track dependency changes.
+The plain mapping path remains for campaigns without reference export inputs.
+Tests in `tests/test_tessera_hessian_reference_handoff.py` cover the public CLI
+regression, identity parity, provenance refusal and metadata-owner cleanup.
+Native performance measurements are recorded separately from this contract.
 
 Re-stamped (2026-09-09, `claude/bounded-publication-overlap`) for the campaign's
 opt-in **bounded publication overlap** (§4.10). `--publication-overlap-bytes N`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,9 +1,9 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-09 · `fix/glm-resident-hessian-commitments`. Stamps
+As of: 2026-09-09 · `fix/glm-resident-hessian-source`. Stamps
 follow, newest first, each recording its own branch and date.
 
-Re-stamped (2026-09-09, `fix/glm-resident-hessian-commitments`) for resident
+Re-stamped (2026-09-09, `fix/glm-resident-hessian-source`) for resident
 Hessian commitment reuse in the selected campaign's existing opt-in
 `--export-hessian-reference-policy` path. Resume and seed validation still
 precede publication of export inputs. After those gates accept, the campaign
@@ -21,7 +21,7 @@ Tests in `tests/test_tessera_hessian_reference_handoff.py` cover the public CLI
 regression, identity parity, provenance refusal and metadata-owner cleanup.
 Native performance measurements are recorded separately from this contract.
 This integration pins the producer and serving dependency to the same Tessera
-development commit `7f8aef0dd1ba` from PR #441. Its packaged runtime contract
+development commit `387eda36fd41`, the merge of PR #441. Its packaged runtime contract
 is unchanged, so admission, formats and serving cells retain their previous
 answers. Producer source identity changes; existing priced rows are not
 relabeled under this source. Native qualification uses fresh output paths.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,6 +20,11 @@ The plain mapping path remains for campaigns without reference export inputs.
 Tests in `tests/test_tessera_hessian_reference_handoff.py` cover the public CLI
 regression, identity parity, provenance refusal and metadata-owner cleanup.
 Native performance measurements are recorded separately from this contract.
+This integration pins the producer and serving dependency to the same Tessera
+development commit `7f8aef0dd1ba` from PR #441. Its packaged runtime contract
+is unchanged, so admission, formats and serving cells retain their previous
+answers. Producer source identity changes; existing priced rows are not
+relabeled under this source. Native qualification uses fresh output paths.
 
 Re-stamped (2026-09-09, `claude/bounded-publication-overlap`) for the campaign's
 opt-in **bounded publication overlap** (§4.10). `--publication-overlap-bytes N`

--- a/docs/experiments/glm_resident_hessian_20260909/README.md
+++ b/docs/experiments/glm_resident_hessian_20260909/README.md
@@ -1,0 +1,86 @@
+# Resident Hessian commitment reuse, 2026-09-09
+
+On the canonical GLM-5.3-Flash row of 864 resident Hessians (43,486,543,872
+bytes), ordinary campaign publication already computes per-unit commitments.
+The next capture seal redundantly hashed that population. Tessera PR441 binds
+the existing resident tensors to its authenticated metadata owner, and
+PrismaQuant issue466 uses that public API after export inputs are accepted.
+Per-unit consumption still checks the tensor's digest. This removes no
+per-unit validation and creates no additional cache.
+
+## Native comparison
+
+PB `216d26085bed9aea062e8747d6f4b289506001fbbbd570b6817d5dfb92de651a`
+ran on Sparky, GB10, torch 2.13.0+cu130, with the qualified container and frozen
+producer `7f8aef0dd1ba4ef6a6ff5cf00ee9c2bc06c73e5d`. Producer source digest is
+`959a1a43b26865e5e04dfacbabd627634ade4537979568af9c00c76d9604f9ea`;
+packaged runtime contract remains
+`a688f8de244f936ec3a63a782e20af7985733e7a6fb0b4b981b5fe4c44112212`.
+The native PQ snapshot matches `1addeb62f7` apart from PB's closure.
+
+One ordinary selected-row campaign loads the original resident data, publishes
+references, then compares six fresh sources: profile plain/resident and timed
+plain/resident/resident/plain. Construction and capture sealing are timed
+together. All six seals are identical. Plain sources hash all 864 tensors;
+bound sources hash zero and read zero payload files.
+
+| Construction plus capture seal | Plain mapping | Resident references |
+|---|---:|---:|
+| Profiled pair | 39.67255 s | 0.46484 s |
+| Unprofiled repeat 1 | 39.34823 s | 0.67525 s |
+| Unprofiled repeat 2 | 39.02842 s | 0.72452 s |
+| Unprofiled mean | 39.18833 s | 0.69989 s |
+
+The measured saving is **38.49 seconds of startup sealing**. Both profile
+arms consume the same actual CUDA Hessian, retain its consumption hash and
+produce exactly matching LDL/metric values. Following the comparison, the
+ordinary R832/B8 campaign prefix produces 16 actual wires and scores exactly
+matching the frozen b1 baseline. Its first `_prepare_anchor` takes 0.01538 s.
+This is bounded native qualification, not a complete pricing row, full-model
+throughput or served-quality measurement.
+
+Both CPU/CUDA traces are complete. The plain trace has 870 GPU memcpy events,
+the resident trace nine; each includes one actual unit's consumption. The
+observer records 82 Netdata samples per host, and recovered power has 841/842
+samples on Sparky/Sparklina. Subsecond resident sealing is too short for a
+precise energy comparison from 2 Hz samples, so no work/J ratio is claimed.
+
+Native exit 0, cleanup, actual stdout, CAS payload/receipt hashes and executed
+source were checked independently. CPU artifact audit
+`078e56c52471742be144b6dddd932b870e24048529b1fb9e1c7d66ce40b15234`
+checks both trace files, annotation categories, actual wire hashes and
+checkpoint scores, reference identity, memory guard and telemetry coverage.
+Its first attempt `78cafd794245` incorrectly counted CPU and GPU annotations
+as one category and failed; the audit was corrected without rerunning native
+work. No product change was needed.
+
+Evidence root:
+`/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-02/performance-resident-h-seal-ab-01/`.
+Root verification records under `/mnt/shared/tessera-measurements/`:
+`glm-resident-hessian-native-cas-source-20260909.json` and
+`glm-resident-hessian-native-audit-cas-source-20260909.json`.
+The exact native invocation is the evidence root with `-invocation.json`
+appended. Harness and audit are retained in the separate measurement branch,
+not imported by production.
+
+## CPU and regression evidence
+
+Before the integration fix, the new actual-CLI regression failed specifically
+at the redundant `tensor_identity` call, PB
+`eeedf6f826a8d8960199d40e673b46db23bd9bd86acdda1b150bb4805e944cb2`.
+The corrected integration has 136 passes and two CUDA skips across nine
+focused files: handoff, priced export, resume, bound unit identity, batch path,
+campaign pins, serving pins, architecture and staleness. This total combines
+the unaffected shards with corrected affected shards; repeated passes are
+not counted twice. Early integration mistakes (binding before publication
+and an unsynchronized pin constant) failed seven tests and were fixed before
+the native run. Native device behavior is evidenced above, not by CPU skips.
+
+Tessera final API head `43ea9248ae` has 62 focused CPU passes and one CUDA skip,
+plus pure CI with 1,594 passes and 98 skips and successful wheel/sdist checks.
+Root verified all six focused CAS source snapshots against the exact head.
+Records: `glm-resident-hessian-{root-regression-before,fixed-integration-cas-source,unaffected-cas-source,producer-final-cas-source,producer-ci-audit}-20260909.json`
+under the shared measurement directory. Source tests cover unchanged capture
+and unit identities, mutation/roster/provenance refusals and successful/error
+owner cleanup. The producer digest changes conservatively; old priced rows
+are not relabeled under the updated producer.

--- a/docs/experiments/glm_resident_hessian_20260909/README.md
+++ b/docs/experiments/glm_resident_hessian_20260909/README.md
@@ -84,3 +84,13 @@ under the shared measurement directory. Source tests cover unchanged capture
 and unit identities, mutation/roster/provenance refusals and successful/error
 owner cleanup. The producer digest changes conservatively; old priced rows
 are not relabeled under the updated producer.
+
+## Integrated dependency
+
+Tessera PR441 merged as `387eda36fd410d6b2a4fb86b22285eab2a5e072c`.
+Its runtime source is identical to the measured frozen `7f8aef0dd1` tree.
+The final branch update adds a closed-owner lookup assertion and incorporates
+previously merged measurement prose. Its four focused PB shards pass 51 tests
+with one CUDA skip; pure CI at `f49365c7649b` passes 1,594 tests with 98 skips
+and wheel/sdist checks. Root verified actual source snapshots and final CI
+output. The PrismaQuant development and serving pins both name the merge.

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -4656,15 +4656,18 @@ def _main(argv, *, source_scope) -> int:
     if want_h:
         calibration_source = th.activation_source(hessians, hessian_identity)
 
-    _activation_kwargs_for = _activation_kwargs_memo(calibration_source, weights, device,
-        # The capacity the plan CHARGED, not the batch width it was derived
-        # from, so the memo policy has one owner (RobTand/prismaquant#389 can
-        # move it without the charge and the construction drifting apart).
-        max_entries=(selected_resources['encoder_memo_capacity']
-                     if selected_source else None),
-        resource_check=None if selected_guard is None else selected_guard.check,
-        factor_scratch_bytes=(selected_resources['phases']['resident_anchors']['factorization_scratch_bytes']
-                              if selected_source else 0))
+    def activation_kwargs_for(source):
+        return _activation_kwargs_memo(source, weights, device,
+            # The capacity the plan CHARGED, not the batch width it was derived
+            # from, so the memo policy has one owner (RobTand/prismaquant#389 can
+            # move it without the charge and the construction drifting apart).
+            max_entries=(selected_resources['encoder_memo_capacity']
+                         if selected_source else None),
+            resource_check=None if selected_guard is None else selected_guard.check,
+            factor_scratch_bytes=(selected_resources['phases']['resident_anchors']['factorization_scratch_bytes']
+                                  if selected_source else 0))
+
+    _activation_kwargs_for = activation_kwargs_for(calibration_source)
 
     cache = ProductionWeightCache(
         weights={}, levers={"tessera_campaign": True},
@@ -4679,6 +4682,16 @@ def _main(argv, *, source_scope) -> int:
         family_restriction=args.family_restriction,
         structure_by_unit=structure_by_unit,
     )
+    if args.export_hessian_reference_policy is not None:
+        # Resume was checked before any export input changed. Now reuse the
+        # commitments just computed from these same resident tensors, so the
+        # first anchor does not hash the full population again. Both encoder
+        # kwargs and checkpoint receipts must see the producer's resident
+        # mapping; its per-unit content checks remain at consumption.
+        calibration_source = th.activation_source(hessians, hessian_identity,
+            reference_path=hessian_capture_path, source_scope=source_scope)
+        _activation_kwargs_for = activation_kwargs_for(calibration_source)
+
     # PrismaQuant #291 (filed here first as #288). A narrowing menu mode --
     # ``attested`` without a dev pin, ``readable`` against a contract that
     # publishes no reader for these shapes -- used to resolve to nothing and

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -4682,16 +4682,6 @@ def _main(argv, *, source_scope) -> int:
         family_restriction=args.family_restriction,
         structure_by_unit=structure_by_unit,
     )
-    if args.export_hessian_reference_policy is not None:
-        # Resume was checked before any export input changed. Now reuse the
-        # commitments just computed from these same resident tensors, so the
-        # first anchor does not hash the full population again. Both encoder
-        # kwargs and checkpoint receipts must see the producer's resident
-        # mapping; its per-unit content checks remain at consumption.
-        calibration_source = th.activation_source(hessians, hessian_identity,
-            reference_path=hessian_capture_path, source_scope=source_scope)
-        _activation_kwargs_for = activation_kwargs_for(calibration_source)
-
     # PrismaQuant #291 (filed here first as #288). A narrowing menu mode --
     # ``attested`` without a dev pin, ``readable`` against a contract that
     # publishes no reader for these shapes -- used to resolve to nothing and
@@ -4924,6 +4914,16 @@ def _main(argv, *, source_scope) -> int:
                 resource_check=None if selected_guard is None else selected_guard.check)
            if selected_source else {}),
     )
+
+    if args.export_hessian_reference_policy is not None:
+        # Resume was checked before any export input changed. Now reuse the
+        # commitments just computed from these same resident tensors, so the
+        # first anchor does not hash the full population again. Both encoder
+        # kwargs and checkpoint receipts must see the producer's resident
+        # mapping; its per-unit content checks remain at consumption.
+        calibration_source = th.activation_source(hessians, hessian_identity,
+            reference_path=hessian_capture_path, source_scope=source_scope)
+        _activation_kwargs_for = activation_kwargs_for(calibration_source)
 
     # PrismaQuant #291 (filed here first as #288). A narrowing menu mode --
     # ``attested`` without a dev pin, ``readable`` against a contract that

--- a/prismaquant/tessera_hessian.py
+++ b/prismaquant/tessera_hessian.py
@@ -174,7 +174,7 @@ def encoder_recipe() -> dict:
 
 
 def activation_source(hessians: Mapping[str, Any], identity: Mapping[str, Any],
-                      **overrides: Any):
+                      *, reference_path=None, source_scope=None, **overrides: Any):
     """Build Tessera's ``ActivationSource``.  **The one construction.**
 
     ``hessians`` is keyed by qname (``model.layers.0.mlp.up_proj``), which is
@@ -186,9 +186,23 @@ def activation_source(hessians: Mapping[str, Any], identity: Mapping[str, Any],
     ``overrides`` reach the dataclass unchanged, so an ablation can move the
     sigma or the refit objective and the exported config records what it moved
     (``ActivationSource.config_block``).
+
+    An accepted campaign may supply its just-published ``reference_path`` to
+    reuse the producer's authenticated H commitments. The producer binds the
+    same resident tensors and still checks each consumed H against its seal;
+    it neither reloads payloads nor hashes the whole population a second time.
+    ``source_scope`` must own the metadata reader until every consumer ends.
     """
     from tessera.export import ActivationSource
 
+    if reference_path is not None:
+        if source_scope is None:
+            raise ValueError("a resident Hessian reference requires an owning source scope")
+        source = ActivationSource.from_capture(reference_path, resident_hessians=hessians,
+                                               **overrides)
+        source_scope.callback(source.hessians.close)
+        source.hessians.require_provenance({**dict(identity), "hessian_role": "fit"})
+        return source
     return ActivationSource(
         hessians=dict(hessians), provenance=dict(identity), **overrides)
 

--- a/prismaquant/tessera_runtime/tessera_serving_runtime_pin.json
+++ b/prismaquant/tessera_runtime/tessera_serving_runtime_pin.json
@@ -1,7 +1,7 @@
 {
   "schema": "prismaquant.tessera_serving_runtime_pin.v2",
   "repository": "https://github.com/RobTand/tessera.git",
-  "commit": "7f8aef0dd1ba4ef6a6ff5cf00ee9c2bc06c73e5d",
+  "commit": "387eda36fd410d6b2a4fb86b22285eab2a5e072c",
   "version": "0.1.0",
   "version_is_release": false,
   "contract_sha256": "a688f8de244f936ec3a63a782e20af7985733e7a6fb0b4b981b5fe4c44112212",

--- a/prismaquant/tessera_runtime/tessera_serving_runtime_pin.json
+++ b/prismaquant/tessera_runtime/tessera_serving_runtime_pin.json
@@ -1,7 +1,7 @@
 {
   "schema": "prismaquant.tessera_serving_runtime_pin.v2",
   "repository": "https://github.com/RobTand/tessera.git",
-  "commit": "b1eb1dccc9df6773ab94e1c98f316f45bb18ab4c",
+  "commit": "7f8aef0dd1ba4ef6a6ff5cf00ee9c2bc06c73e5d",
   "version": "0.1.0",
   "version_is_release": false,
   "contract_sha256": "a688f8de244f936ec3a63a782e20af7985733e7a6fb0b4b981b5fe4c44112212",

--- a/prismaquant/tessera_runtime_contract.py
+++ b/prismaquant/tessera_runtime_contract.py
@@ -163,8 +163,8 @@ TESSERA_DEV_PIN_ENV = "PRISMAQUANT_TESSERA_DEV_PIN"
 #: construction output sizes. The admission answer was last changed at
 #: contract v22 / lane schema v9 (Tessera master 8ed1d9a, the merge of its
 #: #332, which answers its #327; v21 landed at b8b1cb38 in its #313 and the
-#: release e78959ed carried v20). The development and serving pins now both
-#: bind b1eb1dccc: they name ONE object, and
+#: release e78959ed carried v20). At that review both pins were aligned on
+#: b1eb1dccc: they name ONE object, and
 #: letting them drift is how two of this repository's own spec files came to
 #: disagree about one runtime.  Between the v17 review and this one the
 #: answer moved in exactly four places and nowhere else -- no family, rung,
@@ -218,7 +218,7 @@ TESSERA_DEV_PIN_ENV = "PRISMAQUANT_TESSERA_DEV_PIN"
 #: PR #441. Its contract blob is identical to the previous master pin; the
 #: producer source identity changes and existing priced bytes keep their seal.
 #: No release tag names this development commit.
-TESSERA_DEV_PIN_COMMIT = "7f8aef0dd1ba4ef6a6ff5cf00ee9c2bc06c73e5d"
+TESSERA_DEV_PIN_COMMIT = "387eda36fd410d6b2a4fb86b22285eab2a5e072c"
 
 #: sha256 of ``tessera/serving/runtime_contract.json`` at that commit -- the
 #: bytes a human read when the answer below was accepted.  Recorded, and

--- a/prismaquant/tessera_runtime_contract.py
+++ b/prismaquant/tessera_runtime_contract.py
@@ -214,10 +214,11 @@ TESSERA_DEV_PIN_ENV = "PRISMAQUANT_TESSERA_DEV_PIN"
 #: derive.  The admission itself is unchanged: ``cell_evidence_admits`` is
 #: still status-only and still ``{repetitive}``.
 #:
-#: Verified by fetching ``RobTand/tessera`` master into a scratch repository
-#: and hashing the blob at the tip -- never a working tree (the command is in
-#: ``tessera_runtime/README.md``).  No tag names the commit.
-TESSERA_DEV_PIN_COMMIT = "b1eb1dccc9df6773ab94e1c98f316f45bb18ab4c"
+#: The resident-H integration uses the reviewed runtime tree from Tessera
+#: PR #441. Its contract blob is identical to the previous master pin; the
+#: producer source identity changes and existing priced bytes keep their seal.
+#: No release tag names this development commit.
+TESSERA_DEV_PIN_COMMIT = "7f8aef0dd1ba4ef6a6ff5cf00ee9c2bc06c73e5d"
 
 #: sha256 of ``tessera/serving/runtime_contract.json`` at that commit -- the
 #: bytes a human read when the answer below was accepted.  Recorded, and

--- a/prismaquant/tessera_serving_runtime_pin.py
+++ b/prismaquant/tessera_serving_runtime_pin.py
@@ -168,7 +168,7 @@ TESSERA_SERVING_RUNTIME_CONTRACT_SHA256_PENDING = "PENDING_TESSERA_CONTRACT_SHA2
 #: the same commit.  Re-check it against the COMMIT rather than a past HEAD,
 #: which nobody can re-run::
 #:
-#:     git -C "$TS" cat-file -p 7f8aef0dd1ba4ef6a6ff5cf00ee9c2bc06c73e5d:src/tessera/serving/runtime_contract.json | sha256sum
+#:     git -C "$TS" cat-file -p 387eda36fd410d6b2a4fb86b22285eab2a5e072c:src/tessera/serving/runtime_contract.json | sha256sum
 #:
 #: Re-pinned 2026-09-05 to ba582d4 (Tessera #356) for the priced-input
 #: exporter snapshot API required by PrismaQuant #231. The v22 contract bytes
@@ -191,7 +191,7 @@ TESSERA_SERVING_RUNTIME_CONTRACT_SHA256_PENDING = "PENDING_TESSERA_CONTRACT_SHA2
 #: intake fixes (#434/#436). Actual GLM pricing preserves measured bytes and
 #: scores; the unchanged contract and answer grant no new serving qualification.
 TESSERA_SERVING_RUNTIME_PINNED_COMMIT = (
-    "7f8aef0dd1ba4ef6a6ff5cf00ee9c2bc06c73e5d"
+    "387eda36fd410d6b2a4fb86b22285eab2a5e072c"
 )
 TESSERA_SERVING_RUNTIME_PINNED_VERSION = "0.1.0"
 TESSERA_SERVING_RUNTIME_PINNED_CONTRACT_SHA256 = (

--- a/prismaquant/tessera_serving_runtime_pin.py
+++ b/prismaquant/tessera_serving_runtime_pin.py
@@ -168,7 +168,7 @@ TESSERA_SERVING_RUNTIME_CONTRACT_SHA256_PENDING = "PENDING_TESSERA_CONTRACT_SHA2
 #: the same commit.  Re-check it against the COMMIT rather than a past HEAD,
 #: which nobody can re-run::
 #:
-#:     git -C "$TS" cat-file -p b1eb1dccc9df6773ab94e1c98f316f45bb18ab4c:src/tessera/serving/runtime_contract.json | sha256sum
+#:     git -C "$TS" cat-file -p 7f8aef0dd1ba4ef6a6ff5cf00ee9c2bc06c73e5d:src/tessera/serving/runtime_contract.json | sha256sum
 #:
 #: Re-pinned 2026-09-05 to ba582d4 (Tessera #356) for the priced-input
 #: exporter snapshot API required by PrismaQuant #231. The v22 contract bytes
@@ -191,7 +191,7 @@ TESSERA_SERVING_RUNTIME_CONTRACT_SHA256_PENDING = "PENDING_TESSERA_CONTRACT_SHA2
 #: intake fixes (#434/#436). Actual GLM pricing preserves measured bytes and
 #: scores; the unchanged contract and answer grant no new serving qualification.
 TESSERA_SERVING_RUNTIME_PINNED_COMMIT = (
-    "b1eb1dccc9df6773ab94e1c98f316f45bb18ab4c"
+    "7f8aef0dd1ba4ef6a6ff5cf00ee9c2bc06c73e5d"
 )
 TESSERA_SERVING_RUNTIME_PINNED_VERSION = "0.1.0"
 TESSERA_SERVING_RUNTIME_PINNED_CONTRACT_SHA256 = (

--- a/tests/test_tessera_hessian_reference_handoff.py
+++ b/tests/test_tessera_hessian_reference_handoff.py
@@ -159,7 +159,8 @@ def test_selected_public_cli_publishes_references_without_changing_capture(monke
         assert owner.binding()['canonical_capture_sha256']==cc.sha256(tmp_path/'capture/capture_manifest.json')
 
 
-def test_selected_cli_reuses_published_hessian_commitments(monkeypatch, tmp_path):
+@pytest.mark.parametrize('abort', [False, True])
+def test_selected_cli_reuses_published_hessian_commitments(monkeypatch, tmp_path, abort):
     """The source about to price must seal without another population scan."""
     from tessera import cached_unit
     sources = []
@@ -187,12 +188,64 @@ def test_selected_cli_reuses_published_hessian_commitments(monkeypatch, tmp_path
                 patch.setattr(cached_unit, 'tensor_identity', lambda *_a, **_k:
                     pytest.fail('resident capture was rehashed after its commitments were published'))
                 checked.append(sources[-1].capture_sha256())
+            if abort:
+                raise RuntimeError('injected post-binding failure')
         return original_label()
 
     monkeypatch.setattr(campaign, '_activation_kwargs_memo', memo)
     monkeypatch.setattr(campaign, 'write_export_inputs', write)
     monkeypatch.setattr(campaign, 'contract_source_label', label)
-    test_selected_public_cli_publishes_references_without_changing_capture(monkeypatch, tmp_path)
+    if abort:
+        with pytest.raises(RuntimeError, match='injected post-binding failure'):
+            test_selected_public_cli_publishes_references_without_changing_capture(monkeypatch, tmp_path)
+    else:
+        test_selected_public_cli_publishes_references_without_changing_capture(monkeypatch, tmp_path)
     assert checked
     descriptor = json.loads((tmp_path/'cache/hessian_capture.references.json').read_text())
     assert checked == [descriptor['capture_sha256']]
+    assert sources[-1].hessians.receipt()['closed']
+
+
+def test_resident_reference_preserves_seal_and_encoding_input_identity(handoff, monkeypatch):
+    from contextlib import ExitStack
+    from tessera.cached_unit import encoding_input_identity
+    from tessera.alphabet import E4M3_GRID
+    from prismaquant import tessera_hessian as th
+
+    f = handoff
+    path, _, digest = write_row(f, 'a')
+    hessians = {'a': f['H']['a']}
+    plain = th.activation_source(hessians, f['calibration'])
+    weight = torch.arange(6, dtype=torch.bfloat16).reshape(3, 2)
+    expected = encoding_input_identity(weight, 'a', E4M3_GRID, 1024, activation=plain)
+    with ExitStack() as scope:
+        source = th.activation_source(hessians, f['calibration'], reference_path=path,
+                                      source_scope=scope)
+        monkeypatch.setattr(torch, 'load', lambda *_a, **_k: pytest.fail('resident H payload reload'))
+        assert source.hessians['a'] is hessians['a']
+        assert source.capture_sha256() == plain.capture_sha256() == digest
+        actual = encoding_input_identity(weight, 'a', E4M3_GRID, 1024, activation=source)
+        assert actual == expected
+        assert source.hessians.receipt()['loaded_entries'] == 0
+    assert source.hessians.receipt()['closed']
+
+
+def test_resident_reference_refuses_a_different_caller_identity(handoff):
+    from contextlib import ExitStack
+    from tessera.errors import GrammarError
+    from prismaquant import tessera_hessian as th
+
+    f = handoff
+    path, _, _ = write_row(f, 'a')
+    with ExitStack() as scope:
+        with pytest.raises(GrammarError, match='provenance'):
+            th.activation_source({'a': f['H']['a']}, {**f['calibration'], 'seqlen': 99},
+                                 reference_path=path, source_scope=scope)
+
+
+def test_resident_reference_requires_explicit_lifetime_owner(handoff):
+    from prismaquant import tessera_hessian as th
+
+    f = handoff
+    with pytest.raises(ValueError, match='owning source scope'):
+        th.activation_source(f['H'], f['calibration'], reference_path=f['tmp']/'absent')

--- a/tests/test_tessera_hessian_reference_handoff.py
+++ b/tests/test_tessera_hessian_reference_handoff.py
@@ -157,3 +157,42 @@ def test_selected_public_cli_publishes_references_without_changing_capture(monke
     with cc.open_hessian_reference(path) as owner:
         assert owner.receipt()['loaded_entries']==0
         assert owner.binding()['canonical_capture_sha256']==cc.sha256(tmp_path/'capture/capture_manifest.json')
+
+
+def test_selected_cli_reuses_published_hessian_commitments(monkeypatch, tmp_path):
+    """The source about to price must seal without another population scan."""
+    from tessera import cached_unit
+    sources = []
+    original_memo = campaign._activation_kwargs_memo
+    original_write = campaign.write_export_inputs
+    original_label = campaign.contract_source_label
+    published = False
+    checked = []
+
+    def memo(source, *args, **kwargs):
+        sources.append(source)
+        return original_memo(source, *args, **kwargs)
+
+    def write(*args, **kwargs):
+        nonlocal published
+        result = original_write(*args, **kwargs)
+        published = True
+        return result
+
+    def label():
+        # The public fixture reaches the empty-menu gate after export inputs
+        # are committed. Exercise the same source the anchor loop would use.
+        if published:
+            with monkeypatch.context() as patch:
+                patch.setattr(cached_unit, 'tensor_identity', lambda *_a, **_k:
+                    pytest.fail('resident capture was rehashed after its commitments were published'))
+                checked.append(sources[-1].capture_sha256())
+        return original_label()
+
+    monkeypatch.setattr(campaign, '_activation_kwargs_memo', memo)
+    monkeypatch.setattr(campaign, 'write_export_inputs', write)
+    monkeypatch.setattr(campaign, 'contract_source_label', label)
+    test_selected_public_cli_publishes_references_without_changing_capture(monkeypatch, tmp_path)
+    assert checked
+    descriptor = json.loads((tmp_path/'cache/hessian_capture.references.json').read_text())
+    assert checked == [descriptor['capture_sha256']]


### PR DESCRIPTION
Closes #466.

After publishing Hessian references, the selected-source campaign constructed its capture seal by hashing the whole resident population again. It now binds Tessera's authenticated metadata commitments to the same resident tensors under the existing source scope, then rebuilds the encoder memo against that source. Resume validation remains before publication; each consumed unit still validates its actual tensor digest. Both development and serving pins advance to merged Tessera PR441 (`387eda36fd41`), with identical packaged runtime contract and serving-cell answers.

Native GB10 qualification over 864 actual GLM Hessians (43.49 GB): mean construction/seal time fell **39.19 s → 0.70 s** across unprofiled ABBA repeats. All six capture seals match, the bound source performs zero population hashes and zero payload reloads, actual CUDA LDL/metric values match exactly, and 16 ordinary campaign wires and scores match the frozen baseline. Before/after CPU/CUDA traces and both-host Netdata accompany the measurement. The subsecond candidate intervals do not support a precise 2 Hz energy comparison. This does not establish full-model throughput or served quality.

The actual-CLI regression failed at the redundant hash before the fix. Corrected focused integration has 136 passes and two CUDA skips; final pin integration at `9c896374d9` additionally passed 52 tests with no skips across four PB shards. Root verified actual PB logs, receipt and payload hashes, cleanup and executed source. Native PB `216d26085bed9aea062e8747d6f4b289506001fbbbd570b6817d5dfb92de651a`; independent artifact audit `078e56c52471742be144b6dddd932b870e24048529b1fb9e1c7d66ce40b15234`.

The architecture contract and [dated measurement record](https://github.com/RobTand/prismaquant/blob/9c896374d92f0100c484c866b5fc806742837857/docs/experiments/glm_resident_hessian_20260909/README.md) include scope, environments, negative evidence and artifact paths. The measurement harness is retained on a separate branch. Old priced rows retain their original source identity; this change does not relabel them.
