### PR TITLE
Reserve the declared process baseline outside the phase deltas

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,17 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-09 · `fix/glm-resident-hessian-source`. Stamps
+As of: 2026-09-09 · `claude/dispatch-process-baseline`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-09, `claude/dispatch-process-baseline`) for the campaign
+dispatcher's explicit process-baseline reservation. A recipe may declare
+`process_baseline_bytes` on its spec; `_row_memory_gb` charges it once on the
+demand, in both the streaming and resident-source branches, and never inside
+`memory_bytes`. `baseline_policy` gains
+`explicit-spec-reservation-measured-in-row` for a plan that carries one, and
+the plan records the integer beside `row_memory_gb`. The default is `0` and is
+byte-identical to the previous behaviour. The runtime's measured fail-closed
+guard is unchanged.
 
 Re-stamped (2026-09-09, `fix/glm-resident-hessian-source`) for resident
 Hessian commitment reuse in the selected campaign's existing opt-in
@@ -154,8 +164,27 @@ The guard now records its first reading as a measured baseline and reports
 that baseline beside its plan, and selected admission compares the plan with
 the cap less the baseline instead of with the raw cap. The guard's own refusal
 arithmetic is unchanged: its readings are already absolute. No pre-run baseline
-is invented for the dispatcher; `baseline_policy` records that declared
-headroom remains its only pre-run term.
+is derived for the dispatcher, which never enters the box a row lands on, but a
+recipe may **declare** one: `process_baseline_bytes` on the campaign spec, a
+non-negative integer of bytes defaulting to `0`. `load_spec` refuses anything
+else, `bool` included, before a row is derived. `_row_memory_gb` adds it to the
+demand in **both** branches, streaming and resident-source, since a process
+floor exists either way; it is never summed into `memory_bytes`, because the
+demand becomes a cap of exactly that many GiB while the row compares its plan
+with the cap less its measured floor, so a reservation folded into the plan
+would inflate both sides and net to zero. That is why `headroom_gb`, a term
+inside `memory_bytes`, could not close this gap. `baseline_policy` records
+which pre-run term a plan has:
+`declared-headroom-pre-run-measured-in-row` when nothing is declared, and
+`explicit-spec-reservation-measured-in-row` beside the integer when one is, so
+an absent reservation cannot read as coverage. The row's own first
+`CaptureMemoryGuard.check` remains the only measured floor of the three.
+Rounding was not a reservation: `ceil` leaves at most one GiB of slack and the
+floor measured on this fleet is 1,062,359,040 bytes, 0.9894 GiB, so before this
+key a row admitted according to where its `memory_bytes` landed modulo one GiB
+and both rows of the 132-row plan lost that, at 827,603,112 and 266,244,264
+bytes of slack. The declared value is the recipe's bound, not a claim about any
+universal maximum.
 A third quantity is measured and reported rather than charged. On the
 streaming fixture the first encode step grew 165.6 MB and the second grew
 2.7 MB against a 10.3 MB `resident_anchors` plan, and the row's peak sat

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,9 +9,10 @@ dispatcher's explicit process-baseline reservation. A recipe may declare
 demand, in both the streaming and resident-source branches, and never inside
 `memory_bytes`. `baseline_policy` gains
 `explicit-spec-reservation-measured-in-row` for a plan that carries one, and
-the plan records the integer beside `row_memory_gb`. The default is `0` and is
-byte-identical to the previous behaviour. The runtime's measured fail-closed
-guard is unchanged.
+the plan records the integer beside `row_memory_gb`. The default is `0`, which preserves
+every row's resource demand exactly; the plan file itself is not byte-identical,
+since it now carries `process_baseline_bytes: 0`. The runtime's measured
+fail-closed guard is unchanged.
 
 Re-stamped (2026-09-09, `fix/glm-resident-hessian-source`) for resident
 Hessian commitment reuse in the selected campaign's existing opt-in
@@ -181,9 +182,9 @@ an absent reservation cannot read as coverage. The row's own first
 `CaptureMemoryGuard.check` remains the only measured floor of the three.
 Rounding was not a reservation: `ceil` leaves at most one GiB of slack and the
 floor measured on this fleet is 1,062,359,040 bytes, 0.9894 GiB, so before this
-key a row admitted according to where its `memory_bytes` landed modulo one GiB
-and both rows of the 132-row plan lost that, at 827,603,112 and 266,244,264
-bytes of slack. The declared value is the recipe's bound, not a claim about any
+key a row admitted according to where its `memory_bytes` landed modulo one GiB,
+and both inspected example rows lost that, at 827,603,112 and 266,244,264 bytes
+of slack. The declared value is the recipe's bound, not a claim about any
 universal maximum.
 A third quantity is measured and reported rather than charged. On the
 streaming fixture the first encode step grew 165.6 MB and the second grew

--- a/prismaquant/autoscale.py
+++ b/prismaquant/autoscale.py
@@ -72,10 +72,45 @@ def require_bounded_capture_environment(environ):
             raise RuntimeError(f'bounded CUDA capture requires {name}={expected} before process startup')
 
 
+# A reservation is charged OUTSIDE the phase deltas, so it is never summed into
+# ``memory_bytes`` and never becomes a phase term.  Folded in, it would grow the
+# plan and the cap by the same amount and net to zero at the admission
+# predicate, which is exactly what declared headroom already does.
+BASELINE_POLICY_DECLARED_HEADROOM = 'declared-headroom-pre-run-measured-in-row'
+BASELINE_POLICY_EXPLICIT_RESERVATION = 'explicit-spec-reservation-measured-in-row'
+
+
+def validate_process_baseline_bytes(value, *, where='process_baseline_bytes'):
+    """A count of bytes, or not a reservation at all.
+
+    ``bool`` is rejected explicitly: it satisfies ``isinstance(v, int)`` and
+    would silently reserve one byte, which is worse than reserving nothing
+    because the plan would then say a reservation exists.
+    """
+    if type(value) is not int or value < 0:
+        raise RuntimeError(
+            f'{where} must be a non-negative int of bytes, not {value!r}')
+    return value
+
+
+def _baseline_fields(process_baseline_bytes):
+    """What a plan records about its pre-run term, and only what is true.
+
+    Zero is the legacy default and emits nothing at all, so a reader can tell a
+    declared reservation from the absence of one.  A plan that reserved nothing
+    must not be able to report coverage it does not have.
+    """
+    if not process_baseline_bytes:
+        return {}
+    return dict(process_baseline_bytes=process_baseline_bytes,
+                baseline_policy=BASELINE_POLICY_EXPLICIT_RESERVATION)
+
+
 def streamed_calibration_resources(model_path, *, unit_shapes, counts,
                                    nsamples, seqlen, max_act_rows, cache_slots,
                                    prefetch_workers, headroom_gb,
-                                   capture_policy='legacy', capture_load_policy=None):
+                                   capture_policy='legacy', capture_load_policy=None,
+                                   process_baseline_bytes=0):
     """Bound canonical capture using the shared loader's actual source layout.
 
     Headers and profile mappings determine source residency. Capture owns one
@@ -301,6 +336,7 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
     result.update(schema='prismaquant.streamed_calibration_resources.v2',
         capture_policy=capture_policy, input_groups=groups, phases=phases,
         memory_bytes=max(sum(phase.values()) for phase in phases.values()),
+        **_baseline_fields(validate_process_baseline_bytes(process_baseline_bytes)),
         transient_status='checked shared input groups; settled prefetch window and completed source release before materialization')
     # v1's additive terms are retained only in its own schema. v2 carries
     # mutually exclusive phase maps, with the maximum defining admission.
@@ -311,7 +347,7 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
 def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
                               cache_slots, prefetch_workers, headroom_gb,
                               anchor_batch_size=1, capture_load_policy=None,
-                              publication_overlap_bytes=0):
+                              publication_overlap_bytes=0, process_baseline_bytes=0):
     """Bound selected-source preparation separately from resident encoding.
 
     This extends the source loader's header/dtype accounting. No source
@@ -329,16 +365,22 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
     shape or dtype, and the producer's own encoder working set inside
     ``tessera.export.encode_linear``.
 
-    **What this plan cannot state, and says so instead.** A delta plan is over
-    a process floor -- interpreter, torch, the CUDA runtime, the pages the
-    process has touched -- and that floor is a property of the box and the
-    run, not of the roster. Nothing here can measure it: the planner runs in
-    the dispatcher's process, not the row's. So the pre-run term stays exactly
-    what it was, the caller's ``headroom_gb``, and ``baseline_policy`` says
-    so; the row measures its own floor at its first
-    ``CaptureMemoryGuard.check`` and stamps it beside this plan. Inventing a
-    torch-plus-CUDA constant here would have been a third quantity, unmeasured
-    on the box it was spent on.
+    **What this plan cannot measure, and says which term it has instead.** A
+    delta plan is over a process floor -- interpreter, torch, the CUDA runtime,
+    the pages the process has touched -- and that floor is a property of the
+    box and the run, not of the roster. Nothing here can measure it: the
+    planner runs in the dispatcher's process, not the row's, and inventing a
+    torch-plus-CUDA constant would be a third quantity, unmeasured on the box
+    it was spent on. So this plan never derives one. A caller may
+    **declare** one, as ``process_baseline_bytes``, and then it is that
+    caller's number and ``baseline_policy`` names it as declared rather than
+    measured. Declared or not, the reservation is recorded beside
+    ``memory_bytes`` and is never summed into it: it is charged outside the
+    phase deltas by whoever converts this plan into a reservation, because
+    folding it in would grow the plan and the cap together and net to zero at
+    the row's admission predicate. The row still measures its own floor at its
+    first ``CaptureMemoryGuard.check`` and stamps it beside this plan, which
+    remains the only measured number of the three.
 
     **A second charge this plan does not own.** A row's first CUDA
     factorisation and its first ``encode_linear`` load libraries and build
@@ -497,10 +539,14 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
         export_input_writer_policy='verified-tensor-record-prefix',
         encoder_memo_policy='compatible-anchor-batch-width',
         encoder_memo_capacity=memo_capacity,
-        # The only pre-run term is the caller's declared headroom. The row
+        # The pre-run term, named rather than derived. Without a declared
+        # reservation the only one is the caller's headroom, and the row
         # measures its own process floor and stamps it beside this plan; see
-        # the docstring for why nothing here invents one.
-        baseline_policy='declared-headroom-pre-run-measured-in-row',
+        # the docstring for why nothing here invents one. A declared
+        # reservation replaces this value and is emitted beside it, so an
+        # absent reservation cannot read as coverage.
+        **{'baseline_policy': BASELINE_POLICY_DECLARED_HEADROOM,
+           **_baseline_fields(validate_process_baseline_bytes(process_baseline_bytes))},
         source_forward_count=0)
 
 

--- a/prismaquant/autoscale.py
+++ b/prismaquant/autoscale.py
@@ -100,6 +100,7 @@ def _baseline_fields(process_baseline_bytes):
     declared reservation from the absence of one.  A plan that reserved nothing
     must not be able to report coverage it does not have.
     """
+    validate_process_baseline_bytes(process_baseline_bytes)
     if not process_baseline_bytes:
         return {}
     return dict(process_baseline_bytes=process_baseline_bytes,
@@ -121,6 +122,10 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
     from the final prefetch window. The
     declared headroom is additional forward/allocator/runtime workspace.
     """
+    # Ahead of every return in this function, including the legacy one
+    # below: a caller that declares a malformed reservation must be
+    # refused before it is handed a plan that silently ignored it.
+    validate_process_baseline_bytes(process_baseline_bytes)
     import math
     from .artifact_completeness import read_artifact_header
     from .model_profiles import detect_profile
@@ -262,6 +267,10 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
     # metadata/journals have an explicit per-unit serialization allowance.
     disk = total_h+total_x+widest_unit+len(unit_shapes)*16384
     result = dict(schema='prismaquant.streamed_calibration_resources.v1',
+        # On the v1 result, so the legacy early return below carries it too:
+        # a caller that declares a reservation and gets a plan back with no
+        # record of it has been told the opposite of the truth.
+        **_baseline_fields(process_baseline_bytes),
         source_header_sha256=hashlib.sha256(json.dumps(header, sort_keys=True,
             separators=(',', ':')).encode()).hexdigest(),
         terms=terms, memory_bytes=sum(terms.values()), disk_bytes=disk,
@@ -336,7 +345,6 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
     result.update(schema='prismaquant.streamed_calibration_resources.v2',
         capture_policy=capture_policy, input_groups=groups, phases=phases,
         memory_bytes=max(sum(phase.values()) for phase in phases.values()),
-        **_baseline_fields(validate_process_baseline_bytes(process_baseline_bytes)),
         transient_status='checked shared input groups; settled prefetch window and completed source release before materialization')
     # v1's additive terms are retained only in its own schema. v2 carries
     # mutually exclusive phase maps, with the maximum defining admission.
@@ -400,6 +408,7 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
     native row records the number rather than covering it, and asserts the
     steady-state step against the plan (RobTand/prismaquant#390).
     """
+    validate_process_baseline_bytes(process_baseline_bytes)
     import math
     from .perturbed_x_cache import normalize_verified_activation_load
     capture_load_policy = normalize_verified_activation_load(capture_load_policy)
@@ -546,7 +555,7 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
         # reservation replaces this value and is emitted beside it, so an
         # absent reservation cannot read as coverage.
         **{'baseline_policy': BASELINE_POLICY_DECLARED_HEADROOM,
-           **_baseline_fields(validate_process_baseline_bytes(process_baseline_bytes))},
+           **_baseline_fields(process_baseline_bytes)},
         source_forward_count=0)
 
 

--- a/tests/test_streamed_capture_admission.py
+++ b/tests/test_streamed_capture_admission.py
@@ -245,3 +245,44 @@ def test_verified_load_buffer_is_priced_only_in_load_phases(glm_checkpoint):
     assert after['memory_bytes'] == max(sum(p.values()) for p in after['phases'].values())
     with pytest.raises(ValueError, match='bounded capture'):
         streamed_calibration_resources(source, **kwargs, capture_load_policy=policy)
+
+
+@pytest.mark.parametrize('capture_policy', ['legacy', 'shared-inputs-bounded-v1'])
+def test_every_capture_policy_records_the_reservation_it_was_given(
+        glm_checkpoint, capture_policy):
+    """The legacy plan returns early, and returned without the reservation.
+
+    ``streamed_calibration_resources`` builds a v1 result and returns it
+    immediately unless the policy is ``shared-inputs-bounded-v1``.  A
+    reservation attached only to the v2 update therefore reached one policy
+    and silently vanished on the other, and a malformed one was accepted
+    there.  Both policies are exercised because the early return is the whole
+    defect: a plan that drops a declared reservation has told its caller the
+    opposite of the truth, and the caller is what sizes the row.
+
+    ``memory_bytes`` is asserted equal across the pair on each policy: the
+    reservation is recorded, never summed into the deltas.
+    """
+    from prismaquant.autoscale import streamed_calibration_resources
+    from prismaquant.model_profiles.glm5_next import Glm5NextProfile
+    from prismaquant.routed_experts import profile_declared_packed_expert_projections
+    model, source = glm_checkpoint
+    members = profile_declared_packed_expert_projections(model, Glm5NextProfile())
+    shapes = {member.qname: list(member.weight.shape) for member in members}
+    common = dict(unit_shapes=shapes, counts={name: 2 for name in shapes},
+                  nsamples=1, seqlen=2, max_act_rows=7, cache_slots=2,
+                  prefetch_workers=1, headroom_gb=1, capture_policy=capture_policy)
+
+    plain = streamed_calibration_resources(source, **common)
+    reserved = streamed_calibration_resources(source, process_baseline_bytes=2147483648,
+                                              **common)
+    assert 'process_baseline_bytes' not in plain
+    assert 'baseline_policy' not in plain
+    assert reserved['process_baseline_bytes'] == 2147483648
+    assert reserved['baseline_policy'] == 'explicit-spec-reservation-measured-in-row'
+    assert reserved['memory_bytes'] == plain['memory_bytes']
+
+    for malformed in (-1, 1.5, '2147483648', True, None):
+        with pytest.raises(RuntimeError, match='process_baseline_bytes'):
+            streamed_calibration_resources(source, process_baseline_bytes=malformed,
+                                           **common)

--- a/tests/test_tessera_selected_source.py
+++ b/tests/test_tessera_selected_source.py
@@ -342,31 +342,58 @@ def test_selected_capture_cli_refuses_missing_capture_before_streamed_source(mon
 # 0.9894 GiB.
 GLM_MEASURED_PROCESS_FLOOR_BYTES = 1_062_359_040
 
-# A plan whose rounding slack is 900,000,000 bytes, below that floor.  The two
-# real rows of the 132-row plan sit at 827,603,112 and 266,244,264 bytes of
-# slack, so both are on this side of the line; this fixture stands for them at
-# a size a test can hold.
-_ROUNDING_LOSER_PLAN_BYTES = 2321225472
+# A plan whose rounding slack is 900,000,000 bytes, below that floor.  Both
+# inspected example rows sit at 827,603,112 and 266,244,264 bytes of slack, so
+# both are on this side of the line.  The magnitude is chosen so the guard's
+# own 2 GiB physical margin is not what refuses: the point of the fixture is
+# the slack, and it has to be the only thing that is tight.
+_ROUNDING_LOSER_PLAN_BYTES = 20 * 1024 ** 3 + 173_741_824
 
 
-def _row_is_admitted(mem_gb: int, memory_bytes: int, floor_bytes: int) -> bool:
+def _row_is_admitted(tmp_path, mem_gb, memory_bytes, floor_bytes, monkeypatch):
     """The two ends a row's demand actually has to meet, joined.
 
-    PrismaBuild turns a row's ``mem_gb`` into a cgroup cap of exactly that many
-    GiB -- ``prismabuild/pool.py:2850`` constructs the scope with
-    ``memory * 1024 ** 3`` -- and the row then refuses unless its phase plan
-    fits under that cap *less* the floor it measures in its own process
-    (``prismaquant/tessera_campaign.py:4515``).  Neither end is under test
-    here; this reproduces the one-line predicate so a dispatcher-side demand
-    can be checked against the thing that will actually judge it.
+    The cap is built the way PrismaBuild builds it -- ``pool.py:2850``
+    constructs the resource scope with ``memory * 1024 ** 3``, so ``mem_gb``
+    is exactly that many GiB -- and the floor is read by a **real**
+    ``CaptureMemoryGuard`` from a real cgroup tree, not asserted.  Only the
+    two readings the guard cannot take on a CPU test box are supplied: the
+    cgroup's own ``memory.current`` and the CUDA reservation, whose sum is the
+    floor.  The predicate below is then the row's, at
+    ``prismaquant/tessera_campaign.py:4515``.
+
+    Reading the floor through the guard rather than substituting a constant is
+    what makes this a regression on the mechanism: a change to how the guard
+    measures its baseline, or to which of the two readings it sums, moves this
+    test.  A hardcoded number would not have noticed.
     """
-    return memory_bytes <= mem_gb * 1024 ** 3 - floor_bytes
+    from prismaquant import memory_management as memory
+    root = tmp_path/'cgroup'
+    child = root/'job'
+    child.mkdir(parents=True, exist_ok=True)
+    (root/'memory.max').write_text(str(mem_gb * 1024 ** 3))
+    (root/'memory.current').write_text(str(floor_bytes))
+    (child/'memory.max').write_text('max')
+    membership = tmp_path/'membership'
+    membership.write_text('0::/job\n')
+    monkeypatch.setattr(memory.torch.cuda, 'memory_reserved', lambda _device: 0)
+    # The guard's own two refusals -- its 2 GiB physical margin and its host
+    # floor -- are deliberately kept slack here.  They are real and they bind
+    # the row at runtime, but they are not the arithmetic under test, and a
+    # fixture that tripped them would fail for a reason that has nothing to do
+    # with whether the demand reserved the baseline.
+    monkeypatch.setattr(memory, '_host_memory_info', lambda: (64 * 1024 ** 3, 128 * 1024 ** 3))
+    guard = memory.CaptureMemoryGuard('cuda', cgroup_root=root, membership=membership)
+    guard.check('before_selected_capture_identity')
+    assert guard.baseline_bytes() == floor_bytes, 'the guard did not read the floor under test'
+    assert guard.cap_bytes == mem_gb * 1024 ** 3, 'the cap is not the demand PrismaBuild would set'
+    return not (memory_bytes > guard.cap_bytes - guard.baseline_bytes())
 
 
 @pytest.mark.parametrize('reservation,demand_gb,admitted', [
-    (None, 3, False),
-    (800_000_000, 3, False),
-    (2147483648, 5, True),
+    (None, 21, False),
+    (800_000_000, 21, False),
+    (2147483648, 23, True),
 ])
 def test_row_demand_reserves_the_process_floor_it_will_be_admitted_against(
         monkeypatch, tmp_path, reservation, demand_gb, admitted):
@@ -382,7 +409,8 @@ def test_row_demand_reserves_the_process_floor_it_will_be_admitted_against(
     GiB of slack, and the measured floor is 0.9894 GiB -- *less* than the most
     ``ceil`` can ever leave.  A row therefore admitted or refused according to
     where its ``memory_bytes`` happened to land modulo one GiB, which is an
-    accident no one owns and no receipt records.  Both real rows lose it.
+    accident no one owns and no receipt records.  Both inspected example rows
+    lose it.
 
     The middle arm is the one worth reading twice.  A declared 800,000,000
     bytes is *smaller than the slack it replaces*, so it does not even move the
@@ -423,8 +451,9 @@ def test_row_demand_reserves_the_process_floor_it_will_be_admitted_against(
                           '--calibration-cache', '/capture']) == 0
     row = json.loads((tmp_path/'manifest.json').read_text())[0]
     assert row['demand']['mem_gb'] == demand_gb
-    assert _row_is_admitted(row['demand']['mem_gb'], _ROUNDING_LOSER_PLAN_BYTES,
-                            GLM_MEASURED_PROCESS_FLOOR_BYTES) is admitted
+    assert _row_is_admitted(tmp_path, row['demand']['mem_gb'],
+                            _ROUNDING_LOSER_PLAN_BYTES,
+                            GLM_MEASURED_PROCESS_FLOOR_BYTES, monkeypatch) is admitted
 
 
 @pytest.mark.parametrize('value', [-1, 1.5, '2147483648', True, None])
@@ -472,3 +501,41 @@ def test_an_absent_reservation_still_reports_the_pre_run_term_it_actually_has(mo
     assert reserved['baseline_policy'] == 'explicit-spec-reservation-measured-in-row'
     assert reserved['memory_bytes'] == plain['memory_bytes']
     assert reserved['phases'] == plain['phases']
+
+
+def test_the_resident_source_branch_charges_the_same_reservation(monkeypatch, tmp_path):
+    """A process floor exists whether or not the row streams.
+
+    The resident-source branch of ``_row_memory_gb`` is a different expression
+    with its own ``ceil`` and its own ``headroom_gb`` addend, so a key wired
+    into the streaming branch alone would mean one thing on one path and
+    nothing on the other, under one name.
+    """
+    import math
+    from tools import dispatch_tessera_campaign as dispatch
+    gib = 1024 ** 3
+    monkeypatch.setattr(dispatch, '_model_bytes', lambda model: 10 * gib)
+    census = dict(unit_shapes={'layers.0.proj': [4, 8]})
+    spec = dict(model='/source', campaign_argv=[], headroom_gb=3, max_act_rows=2)
+    hessian, rows = 8 ** 2 * 4, 8 * 2 * 4
+    body = 10 * gib + hessian + rows
+
+    plain = dispatch._row_memory_gb(spec, ['layers.0.proj'], census)
+    assert plain == math.ceil(body / gib) + 3
+
+    reserved = dispatch._row_memory_gb(
+        {**spec, 'process_baseline_bytes': 2147483648}, ['layers.0.proj'], census)
+    # Charged inside the same ceil as the body, so the demand covers
+    # body + reservation rather than rounding each of them up separately.
+    assert reserved == math.ceil((body + 2147483648) / gib) + 3
+    assert reserved - plain == 2
+
+    # Headroom is untouched by the reservation: they are separate terms and
+    # only one of them is inside ``memory_bytes``.
+    assert dispatch._row_memory_gb(
+        {**spec, 'headroom_gb': 9, 'process_baseline_bytes': 2147483648},
+        ['layers.0.proj'], census) == reserved + 6
+
+    with pytest.raises(RuntimeError, match='process_baseline_bytes'):
+        dispatch._row_memory_gb({**spec, 'process_baseline_bytes': '2147483648'},
+                                ['layers.0.proj'], census)

--- a/tests/test_tessera_selected_source.py
+++ b/tests/test_tessera_selected_source.py
@@ -335,3 +335,140 @@ def test_selected_capture_cli_refuses_missing_capture_before_streamed_source(mon
             '--calibration-cache', str(tmp_path/'capture_manifest.json'),
             '--calibration-cache-sha256', 'a'*64,
             '--attention-implementation', 'eager'])
+
+
+# The floor a GLM row measured for itself on this fleet, from the receipt that
+# established that native evidence exists at all: 1,062,359,040 bytes, which is
+# 0.9894 GiB.
+GLM_MEASURED_PROCESS_FLOOR_BYTES = 1_062_359_040
+
+# A plan whose rounding slack is 900,000,000 bytes, below that floor.  The two
+# real rows of the 132-row plan sit at 827,603,112 and 266,244,264 bytes of
+# slack, so both are on this side of the line; this fixture stands for them at
+# a size a test can hold.
+_ROUNDING_LOSER_PLAN_BYTES = 2321225472
+
+
+def _row_is_admitted(mem_gb: int, memory_bytes: int, floor_bytes: int) -> bool:
+    """The two ends a row's demand actually has to meet, joined.
+
+    PrismaBuild turns a row's ``mem_gb`` into a cgroup cap of exactly that many
+    GiB -- ``prismabuild/pool.py:2850`` constructs the scope with
+    ``memory * 1024 ** 3`` -- and the row then refuses unless its phase plan
+    fits under that cap *less* the floor it measures in its own process
+    (``prismaquant/tessera_campaign.py:4515``).  Neither end is under test
+    here; this reproduces the one-line predicate so a dispatcher-side demand
+    can be checked against the thing that will actually judge it.
+    """
+    return memory_bytes <= mem_gb * 1024 ** 3 - floor_bytes
+
+
+@pytest.mark.parametrize('reservation,demand_gb,admitted', [
+    (None, 3, False),
+    (800_000_000, 3, False),
+    (2147483648, 5, True),
+])
+def test_row_demand_reserves_the_process_floor_it_will_be_admitted_against(
+        monkeypatch, tmp_path, reservation, demand_gb, admitted):
+    """A row's demand has to cover the floor the row is judged against.
+
+    The plan states **deltas** over whatever the process already holds; the cap
+    is **absolute**; and the row subtracts its measured floor from the cap
+    before comparing.  So the floor is taken off one side and charged on
+    neither, and until now nothing joined the dispatcher that states the demand
+    to the predicate that spends it.
+
+    What stood in for a reservation was rounding.  ``ceil`` leaves at most one
+    GiB of slack, and the measured floor is 0.9894 GiB -- *less* than the most
+    ``ceil`` can ever leave.  A row therefore admitted or refused according to
+    where its ``memory_bytes`` happened to land modulo one GiB, which is an
+    accident no one owns and no receipt records.  Both real rows lose it.
+
+    The middle arm is the one worth reading twice.  A declared 800,000,000
+    bytes is *smaller than the slack it replaces*, so it does not even move the
+    demand: the row still asks for 3 GiB and still refuses.  A reservation that
+    fits inside the rounding it was supposed to make unnecessary buys nothing,
+    and must not be able to report that it did.
+    """
+    import json
+    from tools import dispatch_tessera_campaign as dispatch
+
+    gib = 1024 ** 3
+    slack = (-_ROUNDING_LOSER_PLAN_BYTES) % gib
+    assert 0 < slack < GLM_MEASURED_PROCESS_FLOOR_BYTES, (
+        'the fixture only says anything if its rounding slack is below the '
+        'floor; a plan that wins the lottery would pass without a reservation')
+
+    census = dict(model='/source', anchor_groups={'u:layers.0.proj': ['layers.0.proj']},
+        layer_stride=1, unit_shapes={'layers.0.proj': [3, 4]}, counts={'layers.0.proj': 9})
+    (tmp_path/'census.json').write_text(json.dumps(census))
+    spec = dict(model='/source', campaign_argv=['--streaming'], cwd=str(tmp_path),
+                python='python3', env={}, cpus=1)
+    if reservation is not None:
+        spec['process_baseline_bytes'] = reservation
+    (tmp_path/'spec.json').write_text(json.dumps(spec))
+    monkeypatch.setattr(dispatch, '_calibration_cache_binding',
+                        lambda *a: dict(path='/capture', sha256='a'*64))
+    # A constant plan across every arm: the reservation must move the demand
+    # without moving the deltas.  Fold it into ``memory_bytes`` instead and the
+    # predicate compares an inflated plan against an inflated cap and nets to
+    # zero, which is exactly what declared headroom already does.
+    monkeypatch.setattr(dispatch, '_streamed_resource_plan',
+        lambda spec, census, members, *, selected_source: dict(
+            memory_bytes=_ROUNDING_LOSER_PLAN_BYTES, selected_layers=['0'],
+            baseline_policy='declared-headroom-pre-run-measured-in-row'))
+
+    assert dispatch.main(['plan', '--spec', str(tmp_path/'spec.json'),
+                          '--workspace', str(tmp_path),
+                          '--calibration-cache', '/capture']) == 0
+    row = json.loads((tmp_path/'manifest.json').read_text())[0]
+    assert row['demand']['mem_gb'] == demand_gb
+    assert _row_is_admitted(row['demand']['mem_gb'], _ROUNDING_LOSER_PLAN_BYTES,
+                            GLM_MEASURED_PROCESS_FLOOR_BYTES) is admitted
+
+
+@pytest.mark.parametrize('value', [-1, 1.5, '2147483648', True, None])
+def test_a_malformed_process_baseline_reservation_refuses_before_any_row(
+        tmp_path, value):
+    """A reservation is a count of bytes or it is not a reservation.
+
+    ``True`` is in this list on purpose: it passes ``isinstance(v, int)`` and
+    would silently reserve one byte.
+    """
+    import json
+    from tools import dispatch_tessera_campaign as dispatch
+    spec = dict(model='/source', campaign_argv=['--streaming'], cwd=str(tmp_path),
+                python='python3', env={}, cpus=1, process_baseline_bytes=value)
+    (tmp_path/'spec.json').write_text(json.dumps(spec))
+    with pytest.raises(RuntimeError, match='process_baseline_bytes'):
+        dispatch.load_spec(tmp_path/'spec.json')
+
+
+def test_an_absent_reservation_still_reports_the_pre_run_term_it_actually_has(monkeypatch):
+    """Zero cannot read as coverage.
+
+    A reader of a plan has to be able to tell a declared reservation from the
+    absence of one, or the policy field stops being evidence.  With nothing
+    declared the plan says exactly what it said before, and carries no
+    reservation key at all; with a reservation declared it names it and says
+    so.  ``memory_bytes`` is identical either way, because the reservation is
+    never a phase delta.
+    """
+    from prismaquant import autoscale
+    monkeypatch.setattr(autoscale, 'streamed_calibration_resources', lambda *a, **k: dict(
+        live_layer_prefix='layers.', terms=dict(nonbody_source_bytes=100, declared_headroom_bytes=200),
+        body_layer_bytes={'0': 1000}, body_loader_transient_bytes={'0': 100},
+        body_source_file_bytes={'0': 900}, unit_source_weight_bytes={'layers.0.proj': 24},
+        full_hessian_bytes=128, full_prefix_bytes=64, source_header_sha256='a'*64))
+    options = dict(unit_shapes={'layers.0.proj': [3, 4]}, counts={'layers.0.proj': 9},
+                   max_act_rows=2, cache_slots=2, prefetch_workers=1,
+                   headroom_gb=0, anchor_batch_size=3)
+    plain = autoscale.selected_anchor_resources('/source', **options)
+    reserved = autoscale.selected_anchor_resources('/source', process_baseline_bytes=2147483648,
+                                                   **options)
+    assert 'process_baseline_bytes' not in plain
+    assert plain['baseline_policy'] == 'declared-headroom-pre-run-measured-in-row'
+    assert reserved['process_baseline_bytes'] == 2147483648
+    assert reserved['baseline_policy'] == 'explicit-spec-reservation-measured-in-row'
+    assert reserved['memory_bytes'] == plain['memory_bytes']
+    assert reserved['phases'] == plain['phases']

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -199,7 +199,8 @@ def _row_memory_gb(spec: dict, members: list[str], census: dict, *, selected_sou
     Rounding is not a reservation. ``ceil`` leaves at most one GiB of slack,
     and the floor measured on this fleet is 1,062,359,040 bytes -- 0.9894 GiB,
     less than the most ``ceil`` can leave -- so before this key a row admitted
-    according to where its ``memory_bytes`` landed modulo one GiB. The row
+    according to where its ``memory_bytes`` landed modulo one GiB, which both
+    inspected example rows lost. The row
     still measures its own floor at its first ``CaptureMemoryGuard.check`` and
     stamps it on its receipt (RobTand/prismaquant#390); that reading, not this
     declaration, remains the measured number.

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -136,7 +136,23 @@ def load_spec(path: Path) -> dict:
             "takes its deadline from the fleet, not from inside the round loop")
     if "container" in spec:
         validate_container(spec)
+    _process_baseline_bytes(spec, where=str(path))
     return spec
+
+
+def _process_baseline_bytes(spec: dict, *, where="spec") -> int:
+    """The per-row process floor this recipe reserves, in bytes.
+
+    Zero, the legacy default, reserves nothing and is what every spec written
+    before this key meant.  The value is the recipe's, not this tool's: no
+    universal torch-plus-CUDA constant is invented here, because a floor is a
+    property of the box and the runtime a row lands on and this planner never
+    enters either.
+    """
+    from prismaquant.autoscale import validate_process_baseline_bytes
+    return validate_process_baseline_bytes(
+        spec.get("process_baseline_bytes", 0),
+        where=f"{where}: process_baseline_bytes")
 
 
 def _model_bytes(model: str) -> int:
@@ -159,29 +175,47 @@ def _row_memory_gb(spec: dict, members: list[str], census: dict, *, selected_sou
 
     plus the spec's declared headroom for the forward pass and the encoder.
 
-    **No process baseline is charged here, deliberately.** A phase plan states
-    deltas, and the floor those deltas sit on -- interpreter, torch, the CUDA
-    runtime, the pages the row's process has touched -- is a property of the
-    box the row lands on, which this planner never enters. The two honest
-    options were a baseline recorded from a prior receipt with its host and
-    runtime scope, and leaving the spec's declared headroom as the only
-    pre-run term. This takes the second: no receipt at this head carries a
-    scoped baseline, and a torch-plus-CUDA constant invented here would be a
-    third quantity, unmeasured on the box it was spent on. The selected plan
-    records that choice in ``baseline_policy``, and the row measures its own
-    floor at its first ``CaptureMemoryGuard.check`` and stamps it on its
-    receipt (RobTand/prismaquant#390).
+    **The spec's process baseline is charged here, once, outside the deltas.**
+    A phase plan states deltas, and the floor those deltas sit on --
+    interpreter, torch, the CUDA runtime, the pages the row's process has
+    touched -- is a property of the box the row lands on, which this planner
+    never enters. So it is still never derived here; it is *declared*, as the
+    spec's ``process_baseline_bytes``, defaulting to zero. Its own scope
+    travels with it: it is the recipe's number, not a universal maximum.
+
+    It is added to the demand and never to ``memory_bytes``, because the
+    demand becomes a cgroup cap of exactly that many GiB
+    (``prismabuild/pool.py:2850``) while the row refuses unless its plan fits
+    under that cap *less* the floor it measures for itself
+    (``prismaquant/tessera_campaign.py:4515``). Fold the reservation into the
+    plan instead and the predicate compares an inflated delta against an
+    inflated cap and nets to zero -- which is exactly why the spec's declared
+    headroom, a term inside ``memory_bytes``, could never close this gap.
+
+    Both branches charge it. A process floor exists whether or not a row
+    streams, so leaving the resident-source branch out would make the key mean
+    one thing on one path and nothing on the other.
+
+    Rounding is not a reservation. ``ceil`` leaves at most one GiB of slack,
+    and the floor measured on this fleet is 1,062,359,040 bytes -- 0.9894 GiB,
+    less than the most ``ceil`` can leave -- so before this key a row admitted
+    according to where its ``memory_bytes`` landed modulo one GiB. The row
+    still measures its own floor at its first ``CaptureMemoryGuard.check`` and
+    stamps it on its receipt (RobTand/prismaquant#390); that reading, not this
+    declaration, remains the measured number.
     """
     gib = 1024 ** 3
+    baseline = _process_baseline_bytes(spec)
     if "--streaming" in spec['campaign_argv']:
         resource = _streamed_resource_plan(spec, census, members, selected_source=selected_source)
-        return int(math.ceil(resource['memory_bytes']/gib))
+        return int(math.ceil((resource['memory_bytes'] + baseline)/gib))
     shapes = census.get("unit_shapes") or {}
     hessian = sum(int(shapes.get(name, [0, 0])[1]) ** 2 * 4 for name in members)
     rows = sum(int(shapes.get(name, [0, 0])[1]) * int(spec.get("max_act_rows", 512)) * 4
                for name in members)
     total = _model_bytes(spec["model"]) + hessian + rows
-    return int(math.ceil(total / gib)) + int(spec.get("headroom_gb", 24))
+    return (int(math.ceil((total + baseline) / gib))
+            + int(spec.get("headroom_gb", 24)))
 
 
 def _streamed_resource_plan(spec, census, members, *, selected_source=False):
@@ -197,7 +231,11 @@ def _streamed_resource_plan(spec, census, members, *, selected_source=False):
         cache_slots=argument('--streaming-cache-slots', 2),
         prefetch_workers=argument('--streaming-prefetch-workers', 1),
         headroom_gb=max(float(spec.get('headroom_gb', 24)),
-                        argument('--streaming-cache-headroom-gb', 24., float)))
+                        argument('--streaming-cache-headroom-gb', 24., float)),
+        # Recorded beside ``memory_bytes``, never summed into it: the plan
+        # stays pure phase deltas and the reservation is charged once, in
+        # ``_row_memory_gb``, on the demand.
+        process_baseline_bytes=_process_baseline_bytes(spec))
     if selected_source:
         return selected_anchor_resources(spec['model'], **options,
             anchor_batch_size=argument('--anchor-batch-size', 1),
@@ -639,6 +677,12 @@ def cmd_plan(args) -> int:
         "groups_per_row": int(args.groups_per_row),
         "rows_per_box": per_box,
         "row_memory_gb": row_memory_gb,
+        # The reservation those demands carry, stated once for the whole plan
+        # because it is a per-row constant. Zero means none was declared, and
+        # every row's phase plan records the same thing in its own
+        # ``baseline_policy``, so a reader cannot mistake an absent
+        # reservation for a covered one.
+        "process_baseline_bytes": _process_baseline_bytes(spec),
         # The rows the manifest does not hold, at the demand they were derived
         # at. A reader of the plan sees the whole layout; a reader of the
         # manifest sees only what was submitted.


### PR DESCRIPTION
Closes RobTand/prismaquant#469.

## The problem

A row's memory demand and the predicate that spends it were never joined. `_row_memory_gb` states the demand; PrismaBuild turns it into a cgroup cap of exactly that many GiB (`prismabuild/pool.py:2850`); the row then refuses unless its phase plan fits under that cap **less** the process floor it measures for itself (`prismaquant/tessera_campaign.py:4515`). The plan states deltas, the cap is absolute, and the floor was subtracted from one side and charged on neither.

`ceil` leaves at most one GiB of slack. The floor measured on this fleet is 1,062,359,040 bytes, 0.9894 GiB, which is *less* than the most `ceil` can leave. So admission turned on where a row's `memory_bytes` happened to land modulo one GiB. Both rows of the planned restart lost:

| row | `memory_bytes` | `ceil` slack | before | after (2 GiB declared) |
|---|---:|---:|---|---|
| expert row0076 | 106,546,579,288 | 827,603,112 | refuse | admit |
| dense0002 | 58,789,556,056 | 266,244,264 | refuse | admit |

`headroom_gb` could not close this at any size: it is a term *inside* `memory_bytes`, so it grows the plan and the cap equally and nets to zero at the predicate.

## Spec semantics

`process_baseline_bytes` is an optional non-negative int on the campaign spec, defaulting to zero.

**Charged** once, in `_row_memory_gb`, on the demand, on both the streaming and resident-source branches. A process floor exists whether or not a row streams, so a key that applied on one path would mean two things under one name. It is never summed into `memory_bytes`, which stays pure phase deltas.

**Recorded** in two places that behave differently, deliberately:

- The top-level dispatch plan emits `process_baseline_bytes` **always, including zero** (`tools/dispatch_tessera_campaign.py:686`). It is a per-row constant, stated once for the plan.
- A resource subplan emits `process_baseline_bytes` and `baseline_policy='explicit-spec-reservation-measured-in-row'` **only when nonzero** (`autoscale._baseline_fields`). At zero, `streamed_calibration_resources` emits neither key and `selected_anchor_resources` keeps `baseline_policy='declared-headroom-pre-run-measured-in-row'`. Demand and the default subplan output are unchanged when nothing is declared, so an absent reservation cannot read as a covered one.

`load_spec` refuses `-1`, `1.5`, `"2147483648"`, `None` and `True` before any row is derived. `True` explicitly: it satisfies `isinstance(v, int)` and would silently reserve one byte.

`tessera_campaign.py:4515` is unchanged. Its readings are already absolute, and subtracting the baseline there would count the floor twice. The declared value is the recipe's configured bound; the row's own first `CaptureMemoryGuard.check` remains the only measured floor.

## Validation

Red at `c636eb3af`, the first commit here, through PrismaBuild: action `981f8faf09acb11b05addf1eff9295454e633e77db25feaac829bc8651aa2f59`, rc 1, 7 failed 14 passed 1 skipped, `checkout_snapshot.parent` `c636eb3afc54687b3acf2bd4fc1147d1b071bb5a`. The failing set is the intended one; the `None` and `800_000_000` admission arms pass red, because refusal was the status quo.

Green at `6bbfcbd23` on `dl380g10`, tags `['x86']`, 3/3 shards:

| file | action | snapshot | result |
|---|---|---|---|
| `test_tessera_selected_source.py` | `3a30eb5123607416c9d6f998f1f5ffc75ce8f23e4a9aaa08be8222e1b7d40960` | `7ae7fd816a556cc8ecdffb35631497a7bfd9429d82a9fbe69093e49348ed9d05` | 22 passed 1 skipped |
| `test_streamed_capture_admission.py` | `436dcad85e78e7fa32b8cfcab52bb63122d923cb2aa95bd8f3ffdb340f5d53e4` | `1ff786996fa89234dcd8a8ed33c6ab1373531807f7cf6b126aa667b1893ec60e` | 22 passed |
| `test_glm_campaign_streaming.py` | `da2cff513cda898ea64f2219e37d08e512b1344eff1388808bd5b074ee742c4f` | `fd321029a5d1a236417029af4f9f3f225b6e44943d850145bbc55e70e7c0a55d` | 12 passed |

The last file carries a pre-existing `baseline_policy == 'declared-headroom-pre-run-measured-in-row'` assertion and passes unmodified: the backwards-compatibility check.

The admission arms build a real `CaptureMemoryGuard` over a real cgroup tree, supply only the two readings a CPU box cannot take, and assert the guard read the floor and the cap under test before applying the row comparison. A declared 800,000,000 bytes is smaller than the slack it replaces, so it does not move the demand and the row still refuses; a reservation that fits inside the rounding it was meant to make unnecessary must not report that it bought something.

`docs/ARCHITECTURE.md` is updated and re-stamped in the implementation commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsJAfuLU26NWbYpSLrWFHJ
