### PR TITLE
Stop the paired worker on every path, and repeat the call that diverges

### DIFF
--- a/tests/test_exl3_grouped_down_replay.py
+++ b/tests/test_exl3_grouped_down_replay.py
@@ -1,0 +1,594 @@
+"""The replay fires on one boundary, once, and reports what it saw.
+
+Every kernel here is a fake, and deliberately so.  The real one runs on a GPU
+this suite does not have, and the questions these tests ask are not about it:
+whether the shot is spent on a warmup, whether a difference is reported when
+one exists, whether the served output is checked rather than assumed.  A fake
+that returns different bytes on the second call is the only way to see the
+reporting path at all, since a real kernel cannot be made to differ on demand.
+
+The fixture uses the real ABI, read from ``exl3_fat_moe.cu:599-655``: half
+``h2``, int64 pointer tables, float32 ``out``, int64 ``row_token``, half
+``row_weight``, int32 segment tables.  A fixture in convenient dtypes would
+have hidden the two dtype-shaped defects this file now guards, and the pointer
+tables are not weight bodies, which is why every one of the ten arguments is
+hashed whole.
+
+Where a test asserts that a check bites, it changes the driver -- the fake
+kernel's behaviour, or the state object's shape -- rather than the recorded
+result.  A fixture edited into the shape the check wants proves the fixture.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch   # imported, not importorskip'd: a torchless runner must go red
+               # rather than report a green suite of skips
+
+TOOLS = Path(__file__).resolve().parents[1] / "tools"
+sys.path.insert(0, str(TOOLS))
+import exl3_grouped_down_replay as replay_mod  # noqa: E402
+
+
+ROWS = 8
+K = 32          # h2 columns; the kernel requires a multiple of 32
+N = 256         # out columns; the kernel requires a multiple of 256
+SEGS = 2
+
+
+class _Capture:
+    """The owner's contract, not a convenience.
+
+    ``PromptLogitsCapture`` has no ``armed`` attribute.  Its armed state is
+    ``window_id is not None``: ``arm()`` sets it, ``finish()`` clears it.  This
+    stand-in carries exactly that, so a hook that reads anything else fails
+    here the way it would fail against the real object.
+    """
+
+    def __init__(self, rank=0, world_size=2):
+        self.rank = rank
+        self.world_size = world_size
+        self.window_id = None
+
+    def arm(self, window_id):
+        self.window_id = window_id
+
+    def finish(self):
+        self.window_id = None
+
+
+class _Boundary(torch.nn.Module):
+    """A module that calls the extension the way Glm5NextMoE does."""
+
+    def __init__(self, ext, kernel_args):
+        super().__init__()
+        self.ext = ext
+        self.kernel_args = kernel_args
+
+    def forward(self, x):
+        self.ext.exl3_fat_moe_down(*self.kernel_args)
+        return x
+
+
+class _Model(torch.nn.Module):
+    def __init__(self, boundary):
+        super().__init__()
+        self.mlp = boundary
+
+    def forward(self, x):
+        return self.mlp(x)
+
+
+class _Ext:
+    """A stand-in extension module whose entry point can be swapped."""
+
+    def __init__(self, kernel):
+        self.exl3_fat_moe_down = kernel
+
+
+def _args(rows=ROWS):
+    """Ten positional arguments in ABI order and ABI dtypes."""
+    return (
+        torch.zeros(rows, K, dtype=torch.float16),                 # h2, half
+        torch.tensor([0x7f00, 0x7f80], dtype=torch.int64),         # down_ptrs
+        torch.tensor([0x7e00, 0x7e80], dtype=torch.int64),         # down_svh_ptrs
+        torch.zeros(rows, N, dtype=torch.float32),                 # out, float
+        torch.arange(rows, dtype=torch.int64),                     # row_token
+        torch.ones(rows, dtype=torch.float16),                     # row_weight
+        torch.zeros(SEGS, dtype=torch.int32),                      # seg_expert
+        torch.zeros(SEGS, dtype=torch.int32),                      # seg_row0
+        torch.full((SEGS,), rows // SEGS, dtype=torch.int32),      # seg_rows
+        torch.tensor([SEGS], dtype=torch.int32),                   # num_segs
+    )
+
+
+def _deterministic(*args):
+    args[3].add_(1.0)
+    return None
+
+
+def _make(kernel, args=None, state=None, armed=True, **kwargs):
+    args = args if args is not None else _args()
+    ext = _Ext(kernel)
+    model = _Model(_Boundary(ext, args))
+    state = state if state is not None else _Capture()
+    if armed and state.window_id is None:
+        state.arm("w0")
+    replay_mod.install(model, ext, state, module_name="mlp", **kwargs)
+    return model, ext, state, args
+
+
+# --------------------------------------------------------------------------
+# The armed contract.  Reading an attribute the owner does not have leaves the
+# hook permanently disarmed against the real object.
+# --------------------------------------------------------------------------
+
+def test_a_scored_window_at_the_named_boundary_fires_once():
+    model, ext, _, _ = _make(_deterministic, repeats=3, required_rows=ROWS)
+    model(torch.zeros(1))
+    record = replay_mod.uninstall(model, ext)
+    assert record is not None
+    assert record["module"] == "mlp"
+    assert len(record["replays"]) == 3
+    assert record["window_id"] == "w0"
+
+
+def test_an_unarmed_capture_does_not_consume_the_shot():
+    """A warmup runs the same code with no window armed.  If it could fire,
+    the one shot would be spent before any scored request."""
+    model, ext, _, _ = _make(_deterministic, armed=False, required_rows=ROWS)
+    replay = model._tr3_grouped_down_replay
+    model(torch.zeros(1))
+    assert replay_mod.uninstall(model, ext) is None
+    assert any("not armed" in reason for reason in replay.declined)
+
+
+def test_a_finished_window_disarms_and_a_later_call_cannot_fire():
+    model, ext, state, _ = _make(_deterministic, repeats=2, required_rows=ROWS)
+    state.finish()
+    model(torch.zeros(1))
+    assert replay_mod.uninstall(model, ext) is None
+
+
+def test_an_armed_attribute_is_not_the_contract():
+    """The owner has no `armed` attribute.  A state that carries one but has
+    no window must still be treated as unarmed, or the hook is reading a
+    contract the real object does not implement."""
+
+    class _Impostor:
+        rank = 0
+        world_size = 1
+        armed = True
+        window_id = None
+
+    model, ext, _, _ = _make(_deterministic, state=_Impostor(), armed=False,
+                             required_rows=ROWS)
+    model(torch.zeros(1))
+    assert replay_mod.uninstall(model, ext) is None
+
+
+def test_a_wrong_row_count_does_not_consume_the_shot():
+    """A chunked prefill or a decode step is a different request."""
+    model, ext, _, _ = _make(_deterministic, required_rows=ROWS + 1)
+    model(torch.zeros(1))
+    assert replay_mod.uninstall(model, ext) is None
+
+
+def test_a_call_outside_the_named_boundary_does_not_fire():
+    """Other layers call the same entry point.  Only the named one counts."""
+    args = _args()
+    ext = _Ext(_deterministic)
+    model = _Model(_Boundary(ext, args))
+    state = _Capture()
+    state.arm("w0")
+    replay_mod.install(model, ext, state, module_name="mlp", required_rows=ROWS)
+    # Call the extension directly, as another layer would: no hook has run, so
+    # the replay is not inside its boundary.
+    ext.exl3_fat_moe_down(*args)
+    assert replay_mod.uninstall(model, ext) is None
+
+
+def test_the_shot_is_spent_only_once_across_repeated_windows():
+    model, ext, state, _ = _make(_deterministic, repeats=2, required_rows=ROWS)
+    model(torch.zeros(1))
+    first = model._tr3_grouped_down_replay.record
+    state.finish()
+    state.arm("w1")
+    model(torch.zeros(1))
+    assert model._tr3_grouped_down_replay.record is first
+    replay_mod.uninstall(model, ext)
+
+
+def test_the_real_capture_arms_this_hook_when_it_is_available():
+    """The stand-in above encodes the contract; this checks the contract was
+    read off the real class and not off the stand-in."""
+    scorer = Path("/home/rob/tmp/pq-tr3-repeatability/experiments/glm_tr3_full_vocab.py")
+    if not scorer.is_file():
+        pytest.skip(f"the scorer is not on this host: {scorer}")
+    source = scorer.read_text()
+    assert "self.window_id = None" in source
+    assert "self.window_id, self.teacher = window_id, teacher" in source
+    assert "def armed" not in source, "the owner grew an armed property; re-read it"
+
+
+# --------------------------------------------------------------------------
+# Coverage of the arguments.  All ten, whole, before and after.
+# --------------------------------------------------------------------------
+
+def test_every_one_of_the_ten_arguments_is_hashed_whole():
+    model, ext, _, _ = _make(_deterministic, repeats=2, required_rows=ROWS)
+    model(torch.zeros(1))
+    record = replay_mod.uninstall(model, ext)
+    assert list(record["inputs_before"]) == list(replay_mod.ARGUMENT_NAMES)
+    for name, entry in record["inputs_before"].items():
+        assert entry["hashed"] is True, name
+        assert len(entry["sha256"]) == 64, name
+
+
+def test_the_pointer_tables_say_what_their_hash_does_not_cover():
+    """Equal hashes mean the same device addresses were passed.  The bytes at
+    those addresses are never read here, and a reader must not have to know
+    the ABI to know that."""
+    model, ext, _, _ = _make(_deterministic, repeats=2, required_rows=ROWS)
+    model(torch.zeros(1))
+    record = replay_mod.uninstall(model, ext)
+    assert record["pointed_to_weight_bytes_hashed"] is False
+    for name in ("down_ptrs", "down_svh_ptrs"):
+        entry = record["inputs_before"][name]
+        assert entry["holds"] == "device addresses"
+        assert entry["pointed_to_bytes_hashed"] is False
+    assert "pointed_to_bytes_hashed" not in record["inputs_before"]["h2"]
+
+
+def test_a_half_activation_is_hashed_rather_than_identified():
+    """h2 is half, and an earlier size-threshold policy left it pointer-only,
+    so input stability could not rule out content mutation."""
+    entry = replay_mod.describe(torch.zeros(2048, 4096, dtype=torch.float16),
+                                name="h2")
+    assert entry["hashed"] is True
+    assert entry["dtype"] == "torch.float16"
+
+
+def test_a_mutated_argument_is_reported_whatever_its_dtype():
+    for index, name in ((0, "h2"), (4, "row_token"), (6, "seg_expert")):
+        def mutating(*args, _i=index):
+            args[_i].add_(1)
+
+        model, ext, _, _ = _make(mutating, repeats=2, required_rows=ROWS)
+        model(torch.zeros(1))
+        record = replay_mod.uninstall(model, ext)
+        assert record["inputs_stable"] is False, name
+        assert (record["inputs_before"][name]["sha256"]
+                != record["inputs_after"][name]["sha256"]), name
+
+
+def test_stable_inputs_are_reported_stable():
+    model, ext, _, _ = _make(_deterministic, repeats=2, required_rows=ROWS)
+    model(torch.zeros(1))
+    record = replay_mod.uninstall(model, ext)
+    assert record["inputs_stable"] is True
+
+
+def test_a_small_integer_table_carries_its_values():
+    table = torch.tensor([3, 1, 4, 1], dtype=torch.int32)
+    record = replay_mod.describe(table, name="seg_expert")
+    assert record["values"] == [3, 1, 4, 1]
+
+
+def test_the_hash_reads_the_stored_bits():
+    a = torch.tensor([0.0], dtype=torch.float32)
+    b = torch.tensor([-0.0], dtype=torch.float32)
+    assert replay_mod.describe(a, name="x")["sha256"] != \
+        replay_mod.describe(b, name="x")["sha256"]
+
+
+# --------------------------------------------------------------------------
+# Reporting: a difference must show, and an absence must not read as a verdict.
+# --------------------------------------------------------------------------
+
+def test_a_kernel_that_returns_the_same_bytes_reports_one_digest():
+    model, ext, _, _ = _make(_deterministic, repeats=4, required_rows=ROWS)
+    model(torch.zeros(1))
+    record = replay_mod.uninstall(model, ext)
+    assert record["distinct_replay_digests"] == 1
+    for entry in record["replays"][1:]:
+        assert entry["vs_first_replay"]["bitwise_identical"] is True
+
+
+def test_an_all_identical_result_is_not_reported_as_a_determinism_verdict():
+    model, ext, _, _ = _make(_deterministic, repeats=2, required_rows=ROWS)
+    model(torch.zeros(1))
+    text = replay_mod.uninstall(model, ext)["interpretation"]
+    assert "not a determinism verdict" in text
+    assert "names no cause" in text
+    assert "bounds nothing else" in text
+    assert "device addresses" in text
+    assert "inputs_stable" in text
+
+
+def test_a_clean_run_supports_the_same_input_reading():
+    model, ext, _, _ = _make(_deterministic, repeats=2, required_rows=ROWS)
+    model(torch.zeros(1))
+    record = replay_mod.uninstall(model, ext)
+    assert record["same_input_inference_supported"] is True
+
+
+def test_a_mutated_argument_withdraws_the_same_input_reading():
+    """Differing digests under changing arguments say nothing about the
+    kernel, so the record must not let that read as 'same inputs'."""
+    def mutating(*args):
+        args[6].add_(1)
+
+    model, ext, _, _ = _make(mutating, repeats=2, required_rows=ROWS)
+    model(torch.zeros(1))
+    record = replay_mod.uninstall(model, ext)
+    assert record["inputs_stable"] is False
+    assert record["same_input_inference_supported"] is False
+
+
+def test_a_non_finite_result_withdraws_the_same_input_reading():
+    """A magnitude beside a NaN is not a magnitude."""
+    def nan_out(*args):
+        args[3].fill_(float("nan"))
+
+    model, ext, _, _ = _make(nan_out, repeats=2, required_rows=ROWS)
+    model(torch.zeros(1))
+    record = replay_mod.uninstall(model, ext)
+    assert record["inputs_stable"] is True
+    assert record["same_input_inference_supported"] is False
+
+
+def test_a_kernel_that_differs_is_reported_as_differing():
+    calls = {"n": 0}
+
+    def drifting(*args):
+        calls["n"] += 1
+        args[3].add_(float(calls["n"]))
+
+    model, ext, _, _ = _make(drifting, repeats=3, required_rows=ROWS)
+    model(torch.zeros(1))
+    record = replay_mod.uninstall(model, ext)
+    assert record["distinct_replay_digests"] == 3
+    later = record["replays"][1]["vs_first_replay"]
+    assert later["bitwise_identical"] is False
+    assert later["fp32_differing_elements"] == ROWS * N
+    assert later["fp32_max_abs_delta"] > 0.0
+
+
+def test_a_difference_too_small_to_survive_bf16_is_reported_as_both():
+    """The number that reaches the next layer and the number the kernel
+    produced are different numbers, and reporting one would hide which."""
+    calls = {"n": 0}
+
+    def tiny_drift(*args):
+        calls["n"] += 1
+        args[3].fill_(1.0)
+        # Call 1 is the real one and call 2 is the first replay; the drift is
+        # applied from the second replay on, so the two replays differ.
+        if calls["n"] >= 3:
+            args[3][0, 0] += 2.0 ** -20     # far below one bf16 step at 1.0
+
+    model, ext, _, _ = _make(tiny_drift, repeats=2, required_rows=ROWS)
+    model(torch.zeros(1))
+    second = replay_mod.uninstall(model, ext)["replays"][1]["vs_first_replay"]
+    assert second["fp32_differing_elements"] == 1
+    assert second["identical_fp32"] is False
+    assert second["bf16_differing_elements"] == 0
+    assert second["identical_bf16"] is True
+
+
+# --------------------------------------------------------------------------
+# The BF16 ULP metric, including across zero.
+# --------------------------------------------------------------------------
+
+def _next_bf16_up(value):
+    """The next representable bfloat16 above ``value``, by bit pattern.
+
+    Derived rather than written as a constant: bfloat16 keeps 7 mantissa bits,
+    so the step at 1.0 is 2 ** -7, and a hand-written 2 ** -8 is half a step
+    that rounds back to where it started.
+    """
+    bits = torch.tensor([value], dtype=torch.bfloat16).view(torch.int16)
+    return (bits + 1).view(torch.bfloat16).float().item()
+
+
+def _compare_scalars(a, b):
+    return replay_mod.compare(torch.tensor([a], dtype=torch.float32),
+                              torch.tensor([b], dtype=torch.float32))
+
+
+def test_a_one_ulp_bf16_difference_is_counted_as_one_ulp():
+    step = _next_bf16_up(1.0) - 1.0
+    assert step == 2.0 ** -7, "bfloat16 keeps 7 mantissa bits"
+    result = _compare_scalars(1.0, 1.0 + step)
+    assert result["bf16_differing_elements"] == 1
+    assert result["bf16_max_ulp_delta"] == 1
+    assert result["bf16_max_abs_delta"] == pytest.approx(step)
+
+
+def test_a_two_ulp_difference_is_counted_as_two():
+    """A ULP count that always read 1 would pass the test above."""
+    step = _next_bf16_up(1.0) - 1.0
+    assert _compare_scalars(1.0, 1.0 + 2 * step)["bf16_max_ulp_delta"] == 2
+
+
+def test_adjacent_values_either_side_of_zero_are_two_ulp_apart():
+    """Reading the bit pattern as a signed int16 makes these 65534 apart: the
+    pattern grows as a negative value falls, so the raw difference is nonsense
+    across the sign boundary."""
+    smallest = torch.tensor([1], dtype=torch.int16).view(torch.bfloat16).float().item()
+    result = _compare_scalars(-smallest, smallest)
+    assert result["bf16_max_ulp_delta"] == 2
+
+
+def test_one_step_below_zero_is_one_ulp_not_thirty_two_thousand():
+    smallest = torch.tensor([1], dtype=torch.int16).view(torch.bfloat16).float().item()
+    assert _compare_scalars(0.0, -smallest)["bf16_max_ulp_delta"] == 1
+
+
+def test_negative_values_one_step_apart_are_one_ulp_apart():
+    """Signed-int16 ordering is reversed for negatives, so this is the case a
+    raw subtraction gets wrong in the other direction."""
+    step = _next_bf16_up(1.0) - 1.0
+    assert _compare_scalars(-1.0, -(1.0 + step))["bf16_max_ulp_delta"] == 1
+
+
+def test_signed_zeros_are_zero_ulp_apart_and_still_not_bit_identical():
+    result = _compare_scalars(0.0, -0.0)
+    assert result["bf16_max_ulp_delta"] == 0
+    assert result["identical_fp32"] is True          # numerically equal
+    assert result["bitwise_identical"] is False      # different stored bits
+
+
+# --------------------------------------------------------------------------
+# Finiteness, and the served output.
+# --------------------------------------------------------------------------
+
+def test_a_max_delta_over_a_tensor_holding_a_nan_says_so():
+    """A max over NaN is not a magnitude and must not read as one."""
+    reference = torch.zeros(4, dtype=torch.float32)
+    candidate = torch.zeros(4, dtype=torch.float32)
+    candidate[0] = float("nan")
+    result = replay_mod.compare(reference, candidate)
+    assert result["candidate_finite"]["all_finite"] is False
+    assert result["candidate_finite"]["finite_elements"] == 3
+    assert result["fp32_max_abs_delta_over_finite_only"] is True
+
+
+def test_a_finite_fp32_that_overflows_the_bf16_cast_is_reported():
+    """BF16 has FP32's exponent range but 7 mantissa bits, so a finite FP32
+    just under the top of the range rounds UP to infinity here.  FP32
+    finiteness does not answer the BF16 question."""
+    big = torch.tensor([3.4e38], dtype=torch.float32)
+    assert torch.isfinite(big).all()
+    assert not torch.isfinite(big.to(torch.bfloat16)).all(), "no overflow to see"
+    result = replay_mod.compare(torch.zeros(1, dtype=torch.float32), big)
+    assert result["candidate_finite"]["all_finite"] is True
+    assert result["candidate_bf16_finite"]["all_finite"] is False
+    assert result["bf16_max_over_finite_only"] is True
+
+
+def test_a_bf16_ulp_distance_is_not_taken_over_an_infinity():
+    """A ULP distance counts representable steps, which infinities do not
+    have.  Only the pairs where both sides are finite are counted."""
+    step = _next_bf16_up(1.0) - 1.0
+    reference = torch.tensor([1.0, 3.4e38], dtype=torch.float32)
+    candidate = torch.tensor([1.0 + step, 0.0], dtype=torch.float32)
+    result = replay_mod.compare(reference, candidate)
+    assert result["bf16_max_ulp_delta"] == 1
+    assert result["bf16_max_over_finite_only"] is True
+
+
+def test_finite_comparisons_are_not_marked_finite_only():
+    result = _compare_scalars(1.0, 2.0)
+    assert result["bf16_max_over_finite_only"] is False
+    assert result["reference_bf16_finite"]["all_finite"] is True
+
+
+def test_two_bit_identical_nans_are_reported_identical():
+    """torch.equal calls these different, which is why the check is a hash."""
+    nan = torch.full((4,), float("nan"), dtype=torch.float32)
+    assert replay_mod.compare(nan, nan.clone())["bitwise_identical"] is True
+    assert torch.equal(nan, nan.clone()) is False
+
+
+def test_the_served_output_is_confirmed_unchanged_by_hash():
+    model, ext, _, args = _make(_deterministic, repeats=2, required_rows=ROWS)
+    served_before = args[3].clone()
+    model(torch.zeros(1))
+    record = replay_mod.uninstall(model, ext)
+    assert record["original_out_unchanged_after_replays"] is True
+    assert (record["original_out_before"]["fp32_sha256"]
+            == record["original_out_after"]["fp32_sha256"])
+    assert record["original_out_before"]["bf16_sha256"]
+    assert torch.equal(args[3], served_before + 1.0)
+
+
+def test_a_probe_that_wrote_through_to_the_served_output_is_caught():
+    """The check has to bite, so the driver is changed rather than the record:
+    this kernel keeps a reference to the first output it was given and writes
+    to it on every later call, which is what a write-through would look like."""
+    seen = {}
+
+    def leaky(*args):
+        out = args[3]
+        if "first" not in seen:
+            seen["first"] = out
+        else:
+            seen["first"].add_(100.0)
+        out.add_(1.0)
+
+    model, ext, _, _ = _make(leaky, repeats=2, required_rows=ROWS)
+    model(torch.zeros(1))
+    record = replay_mod.uninstall(model, ext)
+    assert record["original_out_unchanged_after_replays"] is False
+    assert (record["original_out_before"]["fp32_sha256"]
+            != record["original_out_after"]["fp32_sha256"])
+
+
+def test_a_served_output_changed_only_in_sign_of_zero_is_caught():
+    """torch.equal would call this unchanged; the stored bits differ."""
+    seen = {}
+
+    def sign_flip(*args):
+        out = args[3]
+        if "first" not in seen:
+            seen["first"] = out
+            out.fill_(0.0)
+        else:
+            seen["first"].fill_(-0.0)
+
+    model, ext, _, _ = _make(sign_flip, repeats=2, required_rows=ROWS)
+    model(torch.zeros(1))
+    record = replay_mod.uninstall(model, ext)
+    assert record["original_out_unchanged_after_replays"] is False
+
+
+# --------------------------------------------------------------------------
+# Install and uninstall.
+# --------------------------------------------------------------------------
+
+def test_uninstall_restores_the_entry_point():
+    model, ext, _, _ = _make(_deterministic, required_rows=ROWS)
+    assert ext.exl3_fat_moe_down is not _deterministic
+    replay_mod.uninstall(model, ext)
+    assert ext.exl3_fat_moe_down is _deterministic
+    assert not hasattr(model, "_tr3_grouped_down_replay")
+
+
+def test_a_second_install_is_refused_rather_than_wrapping_twice():
+    model, ext, state, _ = _make(_deterministic, required_rows=ROWS)
+    with pytest.raises(ValueError, match="already has"):
+        replay_mod.install(model, ext, state, module_name="mlp")
+    replay_mod.uninstall(model, ext)
+
+
+def test_an_unknown_boundary_is_refused_at_install():
+    ext = _Ext(_deterministic)
+    model = _Model(_Boundary(ext, _args()))
+    with pytest.raises(ValueError, match="not a module"):
+        replay_mod.install(model, ext, _Capture(), module_name="layers.99.mlp")
+
+
+def test_a_call_with_the_wrong_arity_is_left_alone():
+    """The wrap is on a C entry point; a different arity is a different call."""
+    model, ext, _, args = _make(_deterministic, required_rows=ROWS)
+    ext.exl3_fat_moe_down(*args[:9])
+    assert replay_mod.uninstall(model, ext) is None
+
+
+def test_fewer_than_two_repeats_compares_nothing():
+    with pytest.raises(ValueError, match="compares nothing"):
+        replay_mod.GroupedDownReplay(_Capture(), repeats=1)
+
+
+def test_the_record_serializes_and_refuses_a_non_finite_value():
+    model, ext, _, _ = _make(_deterministic, repeats=2, required_rows=ROWS)
+    model(torch.zeros(1))
+    record = replay_mod.uninstall(model, ext)
+    text = replay_mod.result_json(record)
+    assert replay_mod.REPLAY_SCHEMA in text
+    record["replays"][0]["vs_original"]["fp32_max_abs_delta"] = float("nan")
+    with pytest.raises(ValueError):
+        replay_mod.result_json(record)

--- a/tests/test_glm_offline_worker_lifecycle.py
+++ b/tests/test_glm_offline_worker_lifecycle.py
@@ -1,0 +1,468 @@
+"""The paired worker is stopped on every path that ends the offline launcher.
+
+A native happy-path launch cannot show any of this.  It exercises exactly one
+ending -- head exits zero, worker stops -- and the endings that leaked the box
+are the other ones: an interrupted wait, a stop that failed, a launch that died
+between starting the worker and starting the head, a worker box that could not
+be reached at all.  So the shell the patcher emits is run directly here with
+the worker box stubbed, and each ending is asked what it did.
+
+The text under test is the patcher's own ``WORKER_ID_PATCH`` and
+``WORKER_ID_TAIL_PATCH``, spliced together the way the patcher splices them
+into start.sh.  Paraphrasing them here would test the paraphrase.
+
+Two distinctions carry most of these cases.  A docker or ssh failure is not
+absence: only docker saying the container does not exist proves the worker is
+gone, and everything else means this run may still own a running worker.  And
+a cleanup failure has to reach the exit status, because a launcher that
+reports success while a worker holds the box has told the caller the opposite
+of the truth.
+"""
+
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCHER = ROOT / "tools" / "glm_offline" / "patch_start_for_offline.py"
+RECIPE = Path("/home/rob/tmp/exl3-inventory/miaai-recipe/start.sh")
+
+sys.path.insert(0, str(PATCHER.parent))
+import patch_start_for_offline as patcher  # noqa: E402
+
+CID = "a" * 64
+
+# The recipe's own docker run is a line continuation; these stand in for the
+# flags between the patched first line and the patched last one.
+_MIDDLE = (
+    "        --gpus all --network host --ipc host \\\n"
+    "        -v '$MODEL_DIR:$MODEL_DIR:ro' \\\n"
+)
+
+HARNESS_HEAD = r"""
+set -uo pipefail
+LOGDIR="$TMP/logs"
+WORKER_SSH=stub-worker
+CONTAINER_WORKER=glm53-exl3-worker
+MODEL_DIR=/model
+IMAGE=stub-image
+log() { echo "[log] $*"; }
+die() { echo "[die] $*" >&2; exit 1; }
+
+# The worker box.  SCENARIO decides what it reports.  Every command the cleanup
+# can issue is answered, so an unhandled one surfaces as a failure rather than
+# as a silent success.
+worker_ssh() {
+  local cmd="$*"
+  case "$cmd" in
+    *"docker run -d"*)
+        case "$SCENARIO" in
+          nocid)    return 0 ;;
+          badcid)   echo "docker: invalid reference format."; return 0 ;;
+          shortcid) echo "abc123"; return 0 ;;
+          upcaseid) echo "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                    return 0 ;;
+          injectid) echo "\$(touch $TMP/PWNED)"; return 0 ;;
+          banner)   echo "Warning: Permanently added host" ;;
+          trailer)  echo "$LIVE_CID"; echo "Connection to host closed."; return 0 ;;
+        esac
+        echo "$LIVE_CID"
+        return 0 ;;
+    *"inspect -f"*)
+        case "$SCENARIO" in
+          gone)        echo "Error: No such object: $LIVE_CID" >&2; return 1 ;;
+          unreachable) echo "ssh: connect to host stub-worker port 22: No route to host" >&2
+                       return 255 ;;
+        esac
+        echo "$LIVE_CID"; return 0 ;;
+    *"--format 'status"*) echo "status=running exit=0"; return 0 ;;
+    *"docker logs"*)      echo "worker log line"; return 0 ;;
+    *"docker stop"*)
+        echo "attempt" >> "$TMP/stop-attempts"
+        if [ "$SCENARIO" = "stopfail" ]; then return 1; fi
+        if [ "$SCENARIO" = "stopfail_then_ok" ] \
+           && [ "$(wc -l < "$TMP/stop-attempts")" = "1" ]; then return 1; fi
+        echo "$LIVE_CID" >> "$TMP/stopped"; return 0 ;;
+  esac
+  echo "UNHANDLED: $cmd" >&2
+  return 1
+}
+"""
+
+HARNESS_TAIL = r"""
+# What the launcher does once the worker exists is the scenario's business.
+case "${ENDING:-none}" in
+  interrupted)
+      log "waiting for the head"
+      kill -INT $$
+      log "TRAP DID NOT EXIT"; exit 9 ;;
+  terminated)
+      log "waiting for the head"
+      kill -TERM $$
+      log "TRAP DID NOT EXIT"; exit 9 ;;
+  partial)  die "the head container failed to start" ;;
+  headfail) log "the head exited nonzero"; exit 7 ;;
+  complete)
+      offline_stop_paired_worker || true
+      if [ "${offline_cleanup_rc:-0}" != "0" ]; then
+          die "head exit 0 and the artifact is present, but the paired worker was not stopped; it still holds ${WORKER_SSH}"
+      fi
+      log "offline run complete"
+      exit 0 ;;
+esac
+"""
+
+
+def _harness_text():
+    return (HARNESS_HEAD
+            + patcher.WORKER_ID_PATCH
+            + _MIDDLE
+            + patcher.WORKER_ID_TAIL_PATCH
+            + HARNESS_TAIL)
+
+
+def _run(tmp_path, scenario, ending, offline=True):
+    script = tmp_path / "harness.sh"
+    script.write_text(_harness_text())
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "TMP": str(tmp_path),
+        "SCENARIO": scenario,
+        "ENDING": ending,
+        "LIVE_CID": CID,
+        "OFFLINE_ENTRY": "/opt/glm53/offline_head.py" if offline else "",
+    }
+    return subprocess.run(["bash", str(script)], capture_output=True,
+                          text=True, env=env, timeout=60)
+
+
+def _lines(tmp_path, name):
+    path = tmp_path / name
+    return path.read_text().split() if path.exists() else []
+
+
+def _stops(tmp_path):
+    return _lines(tmp_path, "stopped")
+
+
+def _attempts(tmp_path):
+    return _lines(tmp_path, "stop-attempts")
+
+
+def test_the_spliced_harness_is_valid_shell(tmp_path):
+    """If this fails every other test below is testing a syntax error."""
+    script = tmp_path / "harness.sh"
+    script.write_text(_harness_text())
+    check = subprocess.run(["bash", "-n", str(script)], capture_output=True, text=True)
+    assert check.returncode == 0, check.stderr
+
+
+# --------------------------------------------------------------------------
+# The endings.
+# --------------------------------------------------------------------------
+
+def test_an_ordinary_ending_stops_the_worker_and_keeps_its_evidence(tmp_path):
+    result = _run(tmp_path, "normal", "complete")
+    assert result.returncode == 0, result.stderr
+    assert _stops(tmp_path) == [CID]
+    assert "offline run complete" in result.stdout
+    # The reason to want a worker's state is usually the reason it had to be
+    # stopped, so state and log are taken before the stop, not after it.
+    assert (tmp_path / "logs" / "worker-final-state.txt").read_text().strip()
+    assert (tmp_path / "logs" / "worker-final.log").read_text().strip()
+
+
+def test_an_interrupt_stops_the_worker_and_exits_as_the_signal(tmp_path):
+    """A handler that only cleans up turns Ctrl-C into a zero exit, and the
+    caller can no longer tell the run was interrupted."""
+    result = _run(tmp_path, "normal", "interrupted")
+    assert _stops(tmp_path) == [CID], "an interrupt left the worker running"
+    assert result.returncode == 128 + signal.SIGINT
+    assert "TRAP DID NOT EXIT" not in result.stdout
+
+
+def test_a_termination_stops_the_worker_and_exits_as_the_signal(tmp_path):
+    result = _run(tmp_path, "normal", "terminated")
+    assert _stops(tmp_path) == [CID]
+    assert result.returncode == 128 + signal.SIGTERM
+    assert "TRAP DID NOT EXIT" not in result.stdout
+
+
+def test_a_launch_that_dies_before_the_head_still_stops_the_worker(tmp_path):
+    """Registering cleanup after launch_cluster returns covered only a launch
+    that had already fully succeeded, which was never the failing case."""
+    result = _run(tmp_path, "normal", "partial")
+    assert _stops(tmp_path) == [CID], "a partial launch left the worker running"
+    assert result.returncode == 1
+
+
+# --------------------------------------------------------------------------
+# A cleanup failure reaches the exit status, and does not overwrite a more
+# specific one.
+# --------------------------------------------------------------------------
+
+def test_a_stop_that_fails_cannot_end_in_run_complete(tmp_path):
+    result = _run(tmp_path, "stopfail", "complete")
+    assert result.returncode != 0, "a worker still holding the box exited zero"
+    assert "offline run complete" not in result.stdout
+    assert "did NOT stop" in result.stdout
+    assert _stops(tmp_path) == []
+
+
+def test_a_stop_that_fails_after_a_clean_head_exit_still_fails_the_run(tmp_path):
+    """The EXIT path, not the explicit call: nothing else would catch this."""
+    result = _run(tmp_path, "stopfail", "none")
+    assert result.returncode == 75
+    assert "exiting 75" in result.stdout
+
+
+def test_a_failed_stop_does_not_overwrite_the_heads_own_failure(tmp_path):
+    """A nonzero head status is the more specific failure and survives."""
+    result = _run(tmp_path, "stopfail", "headfail")
+    assert result.returncode == 7
+    assert "did NOT stop" in result.stdout
+
+
+def test_a_failed_stop_keeps_the_id_and_says_the_run_still_owns_it(tmp_path):
+    result = _run(tmp_path, "stopfail", "none")
+    assert "still owns" in result.stdout
+    assert CID in result.stdout
+
+
+def test_a_failed_stop_is_retried_at_exit(tmp_path):
+    """Keeping the id is what makes a retry possible; clearing it before the
+    stop made a transient failure permanent."""
+    result = _run(tmp_path, "stopfail_then_ok", "complete")
+    assert len(_attempts(tmp_path)) == 2
+    assert _stops(tmp_path) == [CID]
+    assert result.returncode == 1, "the run still reports that it had to retry"
+
+
+def test_a_failed_stop_keeps_the_worker_evidence_it_managed_to_take(tmp_path):
+    """State and log are captured before the stop is attempted, so the run that
+    most needs them is the one that still gets them."""
+    _run(tmp_path, "stopfail", "complete")
+    assert (tmp_path / "logs" / "worker-final-state.txt").read_text().strip()
+
+
+# --------------------------------------------------------------------------
+# Absence is proven, never inferred from a failure to ask.
+# --------------------------------------------------------------------------
+
+def test_a_worker_docker_says_does_not_exist_is_treated_as_gone(tmp_path):
+    result = _run(tmp_path, "gone", "complete")
+    assert result.returncode == 0, result.stderr
+    assert "no such container" in result.stdout
+    assert _attempts(tmp_path) == []
+
+
+def test_an_unreachable_worker_box_is_not_treated_as_a_stopped_worker(tmp_path):
+    """A dropped link, a down daemon or a refused login says nothing about
+    whether the worker is running.  Reading it as absence is how a leaked
+    worker gets reported as a clean run."""
+    result = _run(tmp_path, "unreachable", "complete")
+    assert result.returncode != 0
+    assert "NOT evidence the worker stopped" in result.stdout
+    assert "could not reach stub-worker" in result.stdout
+    assert _attempts(tmp_path) == [], "it tried to stop a worker it could not see"
+
+
+def test_an_unreachable_box_at_exit_fails_a_run_that_otherwise_succeeded(tmp_path):
+    result = _run(tmp_path, "unreachable", "none")
+    assert result.returncode == 75
+
+
+# --------------------------------------------------------------------------
+# The id.
+# --------------------------------------------------------------------------
+
+def test_a_worker_started_without_a_usable_id_fails_the_run_closed(tmp_path):
+    """Warning and continuing would leave a container running that this run
+    cannot name, which is exactly the state the whole change exists to
+    prevent."""
+    result = _run(tmp_path, "nocid", "complete")
+    assert result.returncode != 0
+    assert "printed no 64-hex container id" in result.stderr
+    assert "glm53-exl3-worker" in result.stderr, "it must name what to remove by hand"
+    assert "offline run complete" not in result.stdout
+
+
+def test_the_id_survives_ssh_noise_before_it(tmp_path):
+    """worker_ssh is ssh, and ssh writes banners to stdout."""
+    result = _run(tmp_path, "banner", "complete")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _stops(tmp_path) == [CID]
+
+
+def test_the_id_survives_ssh_noise_after_it(tmp_path):
+    """Taking the last LINE would take the trailer.  The id is the last line
+    that is an id."""
+    result = _run(tmp_path, "trailer", "complete")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _stops(tmp_path) == [CID]
+
+
+@pytest.mark.parametrize("scenario", ["badcid", "shortcid", "upcaseid"])
+def test_a_malformed_id_fails_the_run_closed(tmp_path, scenario):
+    """A container id is exactly 64 lowercase hex.  Anything else names the
+    wrong thing, or nothing, and must not reach a docker stop."""
+    result = _run(tmp_path, scenario, "complete")
+    assert result.returncode != 0
+    assert "printed no 64-hex container id" in result.stderr
+    assert _attempts(tmp_path) == []
+
+
+def test_a_malformed_id_is_never_interpolated_into_a_remote_command(tmp_path):
+    """The id is pasted into a command that runs on another box.  A string
+    that is not an id must be rejected before it gets there."""
+    result = _run(tmp_path, "injectid", "complete")
+    assert result.returncode != 0
+    assert not (tmp_path / "PWNED").exists()
+    assert _attempts(tmp_path) == []
+
+
+def test_the_die_message_shows_what_docker_actually_printed(tmp_path):
+    """A run that fails closed here is a run someone has to clean up by hand,
+    and the first thing they need is what came back."""
+    result = _run(tmp_path, "badcid", "complete")
+    assert "invalid reference format" in result.stderr
+
+
+def test_the_worker_is_not_stopped_twice(tmp_path):
+    """The ending calls cleanup and then the EXIT trap fires.  A successful
+    stop clears the id, so the second call has nothing to stop; a second stop
+    would target an id this run no longer owns."""
+    result = _run(tmp_path, "normal", "complete")
+    assert result.returncode == 0
+    assert len(_attempts(tmp_path)) == 1
+
+
+def test_a_serving_launch_registers_no_trap(tmp_path):
+    """Only the offline branch has a head that exits by design.  A served
+    cluster's worker is supposed to outlive launch_cluster."""
+    result = _run(tmp_path, "normal", "headfail", offline=False)
+    assert result.returncode == 7
+    assert _attempts(tmp_path) == []
+
+
+def test_the_id_comes_from_docker_run_not_from_a_later_name_lookup():
+    """A name resolved later can name a LATER run's worker that reused it, and
+    stopping that is worse than leaking this one."""
+    assert patcher.WORKER_ID_PATCH.startswith('    offline_worker_cid="$(')
+    assert "docker run -d" in patcher.WORKER_ID_PATCH
+    body = patcher.WORKER_ID_TAIL_PATCH.split("offline_stop_paired_worker()")[1]
+    body = body.split("offline_on_signal()")[0]
+    assert "$CONTAINER_WORKER" not in body
+    assert "docker inspect -f '{{.Id}}' '$_cid'" in body
+
+
+# --------------------------------------------------------------------------
+# Patch application.
+#
+# The recipe is a third-party file that lives outside this repo and is not
+# vendored, so most of these run against a stand-in built from the patcher's
+# own anchors, in the order the real file has them (worker docker run at
+# start.sh:1303-1335, head docker run at :1338).  That keeps the ordering and
+# refusal behaviour covered on any runner instead of skipping wherever the
+# recipe is absent.  The two tests that need the real file say so and skip.
+# --------------------------------------------------------------------------
+
+def _stand_in_recipe():
+    """A minimal start.sh carrying each anchor exactly once, in file order."""
+    a = dict((label, anchor) for label, anchor, _ in patcher.PATCHES)
+    return (
+        "#!/usr/bin/env bash\n"
+        + a['KV_CACHE_DTYPE forced empty']
+        + '\nexec vllm serve "${MODEL_DIR}" "${ARGS[@]}"\n'
+        + '\nexec vllm serve "${MODEL_DIR}" "${ARGS[@]}"\n'
+        + a['head exec swap']
+        + a['offline mounts and MODEL_DIR']
+        + a['paired worker id at creation']
+        + "        --gpus all \\\n"
+        + a['worker /model bind']
+        + a['paired worker cleanup registration']
+        + a['head docker run mounts']
+        + "        --entrypoint bash \"$IMAGE\" /start.sh >/dev/null\n"
+        + "}\n"
+        + a['offline completion branch']
+        + "        :\n    fi\n"
+    )
+
+
+def test_the_stand_in_carries_every_anchor_exactly_once():
+    """If it drifts from the anchors it is no longer a stand-in for anything."""
+    text = _stand_in_recipe()
+    for label, anchor, _ in patcher.PATCHES:
+        assert text.count(anchor) == 1, f"{label}: stand-in has drifted"
+
+
+def test_cleanup_is_registered_before_the_head_is_started():
+    """Ordering is the whole coverage argument, and it is an ordering between
+    two separate patches, so it is asserted on the emitted text."""
+    generated = patcher.apply_patches(_stand_in_recipe())
+    register = generated.index("trap offline_on_exit EXIT")
+    head_run = generated.index('docker run -d --name "$CONTAINER_HEAD"')
+    assert register < head_run
+
+
+def test_the_id_is_captured_before_cleanup_is_registered():
+    generated = patcher.apply_patches(_stand_in_recipe())
+    capture = generated.index('offline_worker_cid="$(worker_ssh')
+    register = generated.index("trap offline_on_exit EXIT")
+    assert capture < register
+
+
+def test_a_moved_anchor_stops_the_launch_rather_than_patching_partially():
+    """A start.sh that took four of eight substitutions would launch the served
+    configuration under an offline name."""
+    text = _stand_in_recipe().replace(patcher.WORKER_ID_ANCHOR, "# moved\n")
+    with pytest.raises(patcher.PatchError) as exc:
+        patcher.apply_patches(text)
+    assert "do not launch" in str(exc.value)
+    assert "paired worker id at creation" in str(exc.value)
+
+
+def test_a_duplicated_anchor_is_refused_too():
+    """Two matches is as wrong as none: replace() would take both."""
+    text = _stand_in_recipe() + patcher.LAUNCH_ANCHOR
+    with pytest.raises(patcher.PatchError, match="matched 2 times"):
+        patcher.apply_patches(text)
+
+
+def test_a_lost_worker_exec_is_refused_after_the_patches_apply():
+    """The worker must still join as a worker.  Every anchor can match and this
+    can still be wrong, so it is checked separately."""
+    text = _stand_in_recipe().replace(
+        'exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"', 'exec something_else\n', 1)
+    with pytest.raises(patcher.PatchError, match="inner-script execs"):
+        patcher.apply_patches(text)
+
+
+def _recipe_text():
+    if not RECIPE.is_file():
+        pytest.skip(f"the external GLM recipe is not on this host: {RECIPE}")
+    return RECIPE.read_text()
+
+
+def test_every_anchor_matches_the_real_recipe_exactly_once():
+    """The anchors are literal text from a file this repo does not own, so a
+    recipe update is a silent break unless something checks the real file."""
+    text = _recipe_text()
+    for label, anchor, _ in patcher.PATCHES:
+        assert text.count(anchor) == 1, f"{label}: anchor no longer matches once"
+
+
+def test_the_generated_launcher_is_valid_shell(tmp_path):
+    _recipe_text()
+    generated = tmp_path / "generated.sh"
+    run = subprocess.run(
+        [sys.executable, str(PATCHER), str(RECIPE), str(generated)],
+        capture_output=True, text=True, timeout=120)
+    assert run.returncode == 0, run.stderr
+    assert f"({len(patcher.PATCHES)} patches applied)" in run.stdout
+    check = subprocess.run(["bash", "-n", str(generated)],
+                           capture_output=True, text=True)
+    assert check.returncode == 0, check.stderr

--- a/tools/exl3_grouped_down_replay.py
+++ b/tools/exl3_grouped_down_replay.py
@@ -1,0 +1,432 @@
+"""Repeat one grouped-down call on its own live arguments, and say what changed.
+
+The EXL3 forward takes two values from one prompt.  Whole-tensor boundary
+hashes place the earliest whole-batch difference at the first routed MoE layer,
+inside ``Glm5NextMoE``.  Every *observed boundary tensor* it consumes is equal
+across repeats; its output is not.  Observed is the load-bearing word: the
+boundary hooks record the tensors passed at module boundaries, and a pointer
+table's bytes being equal says the same device addresses were passed, not that
+the weight bytes behind those addresses are equal.  Nothing here establishes
+content equality of memory this process never reads.
+
+This repeats the one call that produces that output, on the arguments that call
+actually received, and reports what differs.  It answers exactly one question:
+does ``exl3_fat_moe_down`` return the same bytes when invoked again on the same
+live tensors?  The routing is among those tensors, so a difference cannot be
+explained by a different expert selection -- selection is an input here, not a
+variable.  Equally, nothing here infers route identity from boundary logits.
+
+It does NOT answer whether the kernel is deterministic.  N identical replays
+bound how often a difference appears at this shape and this occupancy, and
+bound nothing else.  An all-identical result is not an exoneration and is
+reported as what it is.  It also says nothing about gather or gate/up, which it
+does not repeat, and it names no cause.
+
+The served result is the first, real call.  The probe writes only into buffers
+it allocates, and the original output is hashed before the replays and hashed
+again after, so "untouched" is a measurement.  Hashes rather than
+``torch.equal``, which reports two bit-identical NaNs as different and ``+0.0``
+and ``-0.0`` as the same.
+
+The ABI, read from ``exl3_fat_moe.cu:599-655`` rather than assumed:
+
+    0 h2            half   [rows_cap, K]  contiguous CUDA
+    1 down_ptrs     int64  [n_exp]        POINTER TABLE, not a weight body
+    2 down_svh_ptrs int64  [n_exp]        POINTER TABLE, not a weight body
+    3 out           float  [tokens, N]    the destination
+    4 row_token     int64  [rows_cap]
+    5 row_weight    half   [rows_cap]
+    6 seg_expert    int32  [n_seg]
+    7 seg_row0      int32  [n_seg]
+    8 seg_rows      int32  [n_seg]
+    9 num_segs      int32  [1]
+
+All ten are small: the two pointer tables hold device addresses, so the weight
+bytes they name are never passed to this entry point and are never hashed.
+That is recorded on the result rather than left to be inferred.  ``rows_cap``
+may exceed the used row count, so the tables can carry unused capacity; byte
+equality of the whole passed tensor is still what is asked for.
+"""
+
+import hashlib
+import json
+
+
+REPLAY_SCHEMA = "prismaquant.exl3_grouped_down_replay/2"
+
+# The boundary the whole-tensor comparison selected.  Named, not inferred from
+# execution order: an ordering assumption would silently follow a change in
+# which layers are routed.
+DEFAULT_MODULE = "model.layers.3.mlp"
+DEFAULT_REPEATS = 8
+# The scorer's CONTEXT_LENGTH is the MoE input row count, so a whole prompt
+# window arrives here as exactly that many rows.  (CONTEXT_LENGTH - 1 is the
+# prediction count, which is a different number and not this one.)  A call with
+# any other row count is a different request -- a warmup, a chunk, a decode
+# step -- and must not consume the one shot.
+DEFAULT_REQUIRED_ROWS = 2048
+
+# Positional names, in ABI order.  A dict would not carry the order, and the
+# order is what identifies an argument here.
+ARGUMENT_NAMES = ("h2", "down_ptrs", "down_svh_ptrs", "out", "row_token",
+                  "row_weight", "seg_expert", "seg_row0", "seg_rows",
+                  "num_segs")
+
+# Which arguments hold device addresses rather than values.  Their bytes are
+# hashed like everything else -- the same addresses being passed is a real
+# thing to check -- but this diagnostic does not read or hash what they point
+# at, so it says nothing about those bytes.
+POINTER_TABLES = ("down_ptrs", "down_svh_ptrs")
+
+# Small integer tables get their values recorded outright, so a reader can
+# compare two runs without re-deriving anything.
+_VALUES_MAX_ELEMENTS = 4096
+
+
+def _tensor_bytes(tensor):
+    """The tensor's own bytes, contiguous, on host.
+
+    A byte view rather than ``numpy()``, which raises on some of the dtypes
+    this sees and which would hash a converted value rather than the stored
+    bit pattern.  Bit patterns are what a bit-identity question is about.
+    """
+    import torch
+
+    flat = tensor.detach().contiguous().cpu().reshape(-1)
+    return flat.view(torch.uint8).numpy().tobytes()
+
+
+def _hash(tensor):
+    return hashlib.sha256(_tensor_bytes(tensor)).hexdigest()
+
+
+def describe(tensor, *, name):
+    """Identity, full-byte hash, and what the hash does and does not cover."""
+    record = {
+        "name": name,
+        "dtype": str(tensor.dtype),
+        "shape": list(tensor.shape),
+        "device": str(tensor.device),
+        "data_ptr": int(tensor.data_ptr()),
+        "nbytes": int(tensor.numel() * tensor.element_size()),
+        "contiguous": bool(tensor.is_contiguous()),
+        "hashed": True,
+        "sha256": _hash(tensor),
+    }
+    if name in POINTER_TABLES:
+        # Said on the record, because a reader comparing two runs would
+        # otherwise have to know the ABI to know what this hash covers.
+        record["holds"] = "device addresses"
+        record["pointed_to_bytes_hashed"] = False
+    if not tensor.dtype.is_floating_point and tensor.numel() <= _VALUES_MAX_ELEMENTS:
+        record["values"] = tensor.detach().cpu().tolist()
+    return record
+
+
+def _bf16_order(tensor):
+    """A monotonic integer key over bfloat16, correct across the sign boundary.
+
+    Reading the raw int16 bit pattern as a signed integer is wrong for
+    negatives: the pattern grows as the value falls, and ``+0.0`` (0x0000) and
+    ``-0.0`` (0x8000) read 32768 apart while being adjacent -- in fact equal.
+    The usual total-order key fixes both: keep the pattern for non-negatives,
+    and map a negative pattern ``u`` to ``0x8000 - u``.
+    """
+    import torch
+
+    bits = tensor.view(torch.int16).to(torch.int32) & 0xFFFF
+    return torch.where(bits >= 0x8000, 0x8000 - bits, bits)
+
+
+def _finite(tensor):
+    import torch
+
+    finite = int(torch.isfinite(tensor).sum().item())
+    total = int(tensor.numel())
+    return {"finite_elements": finite, "elements": total,
+            "all_finite": finite == total}
+
+
+def compare(reference, candidate):
+    """FP32 difference, and the BF16 difference that survives the cast.
+
+    Both, because the cast at the end of the fused MoE is where most FP32
+    ordering differences disappear.  How many survive it is the number that
+    reaches the next layer; how many exist before it is the number the kernel
+    produced.  Reporting one would hide which.
+
+    Every count is reported beside a finiteness status, because a max delta
+    over a tensor containing a NaN is not a magnitude and must not read as one.
+    """
+    import torch
+
+    result = {
+        "reference_sha256": _hash(reference),
+        "candidate_sha256": _hash(candidate),
+        "bitwise_identical": _hash(reference) == _hash(candidate),
+        "reference_finite": _finite(reference),
+        "candidate_finite": _finite(candidate),
+    }
+
+    differing = reference.ne(candidate)
+    count = int(differing.sum().item())
+    result["fp32_differing_elements"] = count
+    result["fp32_elements"] = int(reference.numel())
+    result["identical_fp32"] = count == 0
+    delta = (reference - candidate).abs()
+    finite_delta = delta[torch.isfinite(delta)]
+    result["fp32_max_abs_delta"] = (
+        float(finite_delta.max().item()) if finite_delta.numel() else 0.0)
+    result["fp32_max_abs_delta_over_finite_only"] = bool(
+        finite_delta.numel() != delta.numel())
+
+    ref16 = reference.to(torch.bfloat16)
+    can16 = candidate.to(torch.bfloat16)
+    # Its own question, not inherited from FP32.  BF16 has FP32's exponent
+    # range but 7 mantissa bits, so a finite FP32 just under the top of the
+    # range rounds UP to infinity on this cast.  Reading FP32 finiteness as
+    # BF16 finiteness would report a magnitude over an infinity.
+    result["reference_bf16_finite"] = _finite(ref16)
+    result["candidate_bf16_finite"] = _finite(can16)
+
+    count16 = int(ref16.ne(can16).sum().item())
+    result["bf16_differing_elements"] = count16
+    result["identical_bf16"] = count16 == 0
+    result["bf16_max_abs_delta"] = 0.0
+    result["bf16_max_ulp_delta"] = 0
+    both16_finite = torch.isfinite(ref16) & torch.isfinite(can16)
+    result["bf16_max_over_finite_only"] = bool(
+        int(both16_finite.sum().item()) != int(ref16.numel()))
+    if count16 and bool(both16_finite.any().item()):
+        delta16 = (ref16.float() - can16.float()).abs()[both16_finite]
+        result["bf16_max_abs_delta"] = float(delta16.max().item())
+        # A ULP distance is a count of representable steps, which infinities
+        # and NaNs do not have.  Taken over the pairs where both are finite.
+        ulp = (_bf16_order(ref16) - _bf16_order(can16)).abs()[both16_finite]
+        result["bf16_max_ulp_delta"] = int(ulp.max().item())
+    return result
+
+
+class GroupedDownReplay:
+    """One armed shot at one boundary, or nothing at all.
+
+    Arming is deliberately narrow.  The capture state says whether a request is
+    a scored one, so an engine warmup cannot consume the shot; the module hook
+    says whether this call belongs to the named boundary, so call ordering is
+    not assumed; and the row count says whether this is the whole prompt window
+    rather than a chunk.  All three must hold.
+    """
+
+    def __init__(self, state, *, module_name=DEFAULT_MODULE,
+                 repeats=DEFAULT_REPEATS, required_rows=DEFAULT_REQUIRED_ROWS):
+        if int(repeats) < 2:
+            raise ValueError("a replay of fewer than two calls compares nothing")
+        if int(required_rows) < 1:
+            raise ValueError("required_rows must be a positive row count")
+        self.state = state
+        self.module_name = str(module_name)
+        self.repeats = int(repeats)
+        self.required_rows = int(required_rows)
+        self.inside = False
+        self.fired = False
+        self.record = None
+        self.declined = []
+
+    def armed(self):
+        """True only inside a scored request.
+
+        The owner's armed state is ``window_id is not None``: ``arm()`` sets it
+        and ``finish()`` clears it.  ``PromptLogitsCapture`` has no ``armed``
+        attribute, and reading one would leave this permanently disarmed
+        against the real object while passing happily against a stand-in that
+        invented the attribute.  The contract is the window id.
+        """
+        return getattr(self.state, "window_id", None) is not None
+
+    def should_fire(self, out):
+        if self.fired or not self.inside:
+            return False
+        if not self.armed():
+            self.declined.append("not armed: request is not a scored window")
+            return False
+        if out.dim() != 2 or int(out.shape[0]) != self.required_rows:
+            self.declined.append(
+                f"row count {list(out.shape)} is not the {self.required_rows}-row window")
+            return False
+        return True
+
+    def run(self, fn, args):
+        """Replay ``fn`` on ``args``, into buffers this allocates.
+
+        Storage, stated rather than implied.  Three output-shaped FP32 buffers
+        are live at once: the retained clone of the original output, the
+        retained clone of the first replay that later replays are compared
+        against, and the current probe.  At ``[2048, 4096]`` FP32 that is about
+        32 MB each, so about 96 MB resident for the length of the loop, plus
+        two BF16 copies of half that transiently inside ``compare``.  Nothing
+        is kept after the record is built.
+        """
+        import torch
+
+        out = args[3]
+        before = {name: describe(value, name=name)
+                  for name, value in zip(ARGUMENT_NAMES, args)}
+
+        # Retained, because "the original is unchanged" has to be checked
+        # against something after the replays run.
+        original = out.detach().clone()
+        original_before = {
+            "fp32_sha256": _hash(original),
+            "bf16_sha256": _hash(original.to(torch.bfloat16)),
+            "fp32_finite": _finite(original),
+        }
+
+        replays = []
+        first = None
+        for index in range(self.repeats):
+            probe = torch.zeros_like(out)
+            fn(args[0], args[1], args[2], probe, *args[4:])
+            entry = {"index": index, "sha256": _hash(probe),
+                     "finite": _finite(probe)}
+            if first is None:
+                first = probe.detach().clone()
+            else:
+                entry["vs_first_replay"] = compare(first, probe)
+            entry["vs_original"] = compare(original, probe)
+            replays.append(entry)
+            del probe
+
+        after = {name: describe(value, name=name)
+                 for name, value in zip(ARGUMENT_NAMES, args)}
+        original_after = {
+            "fp32_sha256": _hash(out),
+            "bf16_sha256": _hash(out.to(torch.bfloat16)),
+            "fp32_finite": _finite(out),
+        }
+        # Hashes, not torch.equal: it calls two bit-identical NaNs different
+        # and calls +0.0 and -0.0 the same, and this is a bit-identity check.
+        unchanged = (original_before["fp32_sha256"] == original_after["fp32_sha256"])
+
+        distinct = sorted({entry["sha256"] for entry in replays})
+
+        self.record = {
+            "schema": REPLAY_SCHEMA,
+            "module": self.module_name,
+            "rank": int(getattr(self.state, "rank", -1)),
+            "world_size": int(getattr(self.state, "world_size", -1)),
+            "window_id": getattr(self.state, "window_id", None),
+            "repeats": self.repeats,
+            "required_rows": self.required_rows,
+            "argument_names": list(ARGUMENT_NAMES),
+            "pointer_table_arguments": list(POINTER_TABLES),
+            "pointed_to_weight_bytes_hashed": False,
+            "original_out_before": original_before,
+            "original_out_after": original_after,
+            "original_out_unchanged_after_replays": unchanged,
+            "inputs_before": before,
+            "inputs_after": after,
+            "inputs_stable": _inputs_stable(before, after),
+            "replays": replays,
+            "distinct_replay_digests": len(distinct),
+            # The two conditions the interpretation names, evaluated here so a
+            # reader does not have to assemble them from the entries.
+            "same_input_inference_supported": bool(
+                _inputs_stable(before, after)
+                and all(entry["finite"]["all_finite"] for entry in replays)
+                and original_before["fp32_finite"]["all_finite"]),
+            "interpretation": (
+                "distinct_replay_digests > 1 means this call returned different "
+                "bytes across repeats.  Reading that as 'different output on the "
+                "same arguments' requires inputs_stable to be true and the "
+                "compared outputs to be finite; with inputs_stable false the "
+                "arguments changed under the call and the digests say nothing "
+                "about the kernel, and a non-finite result makes the magnitudes "
+                "beside it meaningless.  A value of 1 bounds how often a "
+                "difference appears at this shape and occupancy over this many "
+                "repeats and bounds nothing else; it is not a determinism "
+                "verdict, does not cover gather or gate/up, and names no cause.  "
+                "down_ptrs and down_svh_ptrs hold device addresses: equal hashes "
+                "mean the same addresses were passed, and this diagnostic does "
+                "not read or hash the bytes they point at."),
+        }
+        self.fired = True
+        return self.record
+
+
+def _inputs_stable(before, after):
+    """Whether every recorded argument still reads the same at the end.
+
+    Full-byte hashes, so this is content equality of what was passed.  It is
+    not content equality of what a pointer table points at: this diagnostic
+    does not read those bytes, and ``pointed_to_bytes_hashed`` says so on each
+    entry.
+    """
+    if set(before) != set(after):
+        return False
+    return all(before[name] == after[name] for name in before)
+
+
+def install(model, ext, state, *, module_name=DEFAULT_MODULE,
+            repeats=DEFAULT_REPEATS, required_rows=DEFAULT_REQUIRED_ROWS):
+    """Wrap the extension entry point and mark the boundary that owns it.
+
+    The wrap is on ``exl3_fat_moe_down`` itself rather than on its caller, so
+    the replay sees the arguments the real call received instead of arguments
+    rebuilt from the same inputs.  Rebuilding them would put the table
+    construction inside the thing under test.
+    """
+    if getattr(model, "_tr3_grouped_down_replay", None) is not None:
+        raise ValueError("candidate already has a grouped-down replay hook")
+    replay = GroupedDownReplay(state, module_name=module_name, repeats=repeats,
+                               required_rows=required_rows)
+    target = None
+    for name, module in model.named_modules():
+        if name == module_name or name.endswith("." + module_name):
+            target = module
+            break
+    if target is None:
+        raise ValueError(f"replay boundary {module_name!r} is not a module of this model")
+
+    def enter(_module, _args):
+        replay.inside = True
+
+    def leave(_module, _args, output):
+        replay.inside = False
+        return output
+
+    handles = [target.register_forward_pre_hook(enter),
+               target.register_forward_hook(leave)]
+
+    original = ext.exl3_fat_moe_down
+
+    def wrapped(*args):
+        result = original(*args)
+        if len(args) == len(ARGUMENT_NAMES) and replay.should_fire(args[3]):
+            replay.run(original, args)
+        return result
+
+    ext.exl3_fat_moe_down = wrapped
+    model._tr3_grouped_down_replay = replay
+    model._tr3_grouped_down_handles = handles
+    model._tr3_grouped_down_original = original
+    return {"module": module_name, "repeats": repeats,
+            "required_rows": required_rows, "schema": REPLAY_SCHEMA}
+
+
+def uninstall(model, ext):
+    """Put the entry point back, so a second install is not a second wrap."""
+    original = getattr(model, "_tr3_grouped_down_original", None)
+    if original is not None:
+        ext.exl3_fat_moe_down = original
+    for handle in getattr(model, "_tr3_grouped_down_handles", []) or []:
+        handle.remove()
+    record = getattr(model, "_tr3_grouped_down_replay", None)
+    for attribute in ("_tr3_grouped_down_replay", "_tr3_grouped_down_handles",
+                      "_tr3_grouped_down_original"):
+        if hasattr(model, attribute):
+            delattr(model, attribute)
+    return None if record is None else record.record
+
+
+def result_json(record):
+    return json.dumps(record, sort_keys=True, indent=2, allow_nan=False)

--- a/tools/glm_offline/patch_start_for_offline.py
+++ b/tools/glm_offline/patch_start_for_offline.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+r"""Generate an offline-scoring variant of the MiaAI recipe's start.sh.
+
+The original is never edited.  Every substitution below must match exactly
+once or this exits non-zero, so a recipe update that moves one of these
+anchors stops the launch instead of silently launching the served
+configuration under an offline name.
+
+What the five patches do, and why each one is needed rather than an export:
+
+  KV       `KV_CACHE_DTYPE` is not in start.sh's caller-wins list
+           (start.sh:60-82), so `.env`'s `fp8` would win over any export.  We
+           force the empty string, which is what asks the engine for `auto`.
+           That is a request, not an observation: the runtime's
+           mla_attention.py can still select fp8_ds_mla for the sparse
+           backend, so the reading is recorded as requested-auto with the
+           actual dtype unmeasured.
+
+  EXEC     the head's inner script is regenerated on every run
+           (start.sh:983), so a frozen copy of it goes stale.  We let the
+           recipe generate it in full -- every overlay patch, every preamble
+           line -- and swap only its terminal `exec vllm serve` for our
+           entrypoint.  The worker's identical exec at start.sh:1185 is
+           untouched: it must still join as a worker.
+
+  LAUNCH   the mounts and `MODEL_DIR` are settled at the top of
+           `launch_cluster`, BEFORE serve_env is assembled (start.sh:1282) and
+           before the worker's docker run (start.sh:1303).  serve_env carries
+           MODEL_DIR to the worker, so a later override would reach the head
+           only and the two ranks would name different models.
+
+  WORKER   the worker needs the same /model bind at the same path.  Both ranks
+           load the artifact themselves; only the head runs the entrypoint.
+
+  RUN      the head docker run has no bind for our entrypoint, the panel, the
+           token files or an output directory, and its `-v` list is literal.
+           `offline_mounts` carries `-e` entries too, so one insertion point
+           serves both; the array is expanded where docker takes either.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+KV_ANCHOR = 'KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"\n'
+KV_PATCH = KV_ANCHOR + (
+    '# offline scoring: forced AFTER the line above, not before it.  That line\n'
+    "# uses ${VAR:-default}, which substitutes on empty as well as on unset, so\n"
+    '# an empty value settled any earlier is quietly restored to fp8.  .env pins\n'
+    '# fp8 and KV_CACHE_DTYPE is not in the caller-wins block (start.sh:60-82),\n'
+    '# so nothing an operator exports reaches here either.\n'
+    '#\n'
+    '# Empty omits the flag (start.sh:1010,1114), which ASKS the engine for\n'
+    '# `auto`.  A request, not an observation: mla_attention.py can still select\n'
+    '# fp8_ds_mla for the sparse backend.\n'
+    '#\n'
+    '# OFFLINE_KV_CACHE_DTYPE is the deliberate opt-out, for asking for a dtype\n'
+    '# on purpose rather than inheriting one by accident.\n'
+    'KV_CACHE_DTYPE="${OFFLINE_KV_CACHE_DTYPE-}"\n'
+)
+
+EXEC_ANCHOR = '    chmod +x "$HEAD_SCRIPT" "$WORKER_SCRIPT"\n'
+EXEC_PATCH = EXEC_ANCHOR + (
+    "    # offline scoring: keep every generated preamble line, swap only the\n"
+    "    # head's terminal exec.  The worker's identical exec is not touched.\n"
+    '    if [ -n "${OFFLINE_ENTRY:-}" ]; then\n'
+    '        sed -i "s|^exec vllm serve .*|exec python3 ${OFFLINE_ENTRY}|" '
+    '"$HEAD_SCRIPT"\n'
+    '        grep -qx "exec python3 ${OFFLINE_ENTRY}" "$HEAD_SCRIPT" \\\n'
+    '            || die "offline: the head exec swap did not take"\n'
+    '    fi\n'
+)
+
+LAUNCH_ANCHOR = 'launch_cluster() {\n'
+LAUNCH_PATCH = LAUNCH_ANCHOR + (
+    '    # offline scoring: settled here, before serve_env is assembled\n'
+    '    # (start.sh:1282) and before the worker launches (start.sh:1303).\n'
+    '    # serve_env carries MODEL_DIR to the worker, so a later override\n'
+    '    # would reach the head alone and the ranks would disagree.\n'
+    '    offline_mounts=()\n'
+    '    offline_worker_mounts=""\n'
+    '    if [ -n "${OFFLINE_MODEL_HOST:-}" ]; then\n'
+    '        [ -d "${OFFLINE_MODEL_HOST}" ] \\\n'
+    '            || die "OFFLINE_MODEL_HOST is not a directory: ${OFFLINE_MODEL_HOST}"\n'
+    '        offline_mounts+=(-v "${OFFLINE_MODEL_HOST}:/model:ro")\n'
+    '        offline_worker_mounts="-v ${OFFLINE_MODEL_HOST}:/model:ro"\n'
+    '        MODEL_DIR=/model\n'
+    '    fi\n'
+    '    if [ -n "${OFFLINE_ENTRY_HOST:-}" ]; then\n'
+    '        offline_mounts+=(-v "${OFFLINE_ENTRY_HOST}:${OFFLINE_ENTRY}:ro")\n'
+    '    fi\n'
+    '    if [ -n "${OFFLINE_PANEL_HOST:-}" ]; then\n'
+    '        offline_mounts+=(-v "${OFFLINE_PANEL_HOST}:/opt/glm53/panel.json:ro")\n'
+    '    fi\n'
+    '    if [ -n "${OFFLINE_INVENTORY_HOST:-}" ]; then\n'
+    '        # Bound at its OWN absolute path.  The panel handoff carries\n'
+    '        # absolute host tokens_path values with a sha256 beside each one;\n'
+    '        # binding the tree elsewhere would need those rewritten, and a\n'
+    '        # rewritten path is not the object the digest names.\n'
+    '        offline_mounts+=(-v "${OFFLINE_INVENTORY_HOST}:${OFFLINE_INVENTORY_HOST}:ro")\n'
+    '    fi\n'
+    '    if [ -n "${OFFLINE_OUT_HOST:-}" ]; then\n'
+    '        offline_mounts+=(-v "${OFFLINE_OUT_HOST}:/out")\n'
+    '    fi\n'
+    '    # Placeholder-entry inputs only.  The sealed adapter reads\n'
+    '    # /out/scorer-args.json and takes the rest from argv, so these are\n'
+    '    # passed only when a caller sets them.\n'
+    '    [ -n "${PANEL_JSON:-}" ] && offline_mounts+=(-e "PANEL_JSON=${PANEL_JSON}")\n'
+    '    [ -n "${OUT_JSON:-}" ] && offline_mounts+=(-e "OUT_JSON=${OUT_JSON}")\n'
+    '    # Noether needs scorer, source, teacher and candidate-cache mounts on\n'
+    '    # top of these.  They go in through here, one docker -v spec per line,\n'
+    '    # so adding one is a variable rather than another patch anchor:\n'
+    '    #   OFFLINE_EXTRA_MOUNTS=$\'/a/b:/a/b:ro\\n/c:/d:ro\'\n'
+    '    # Each spec is checked for a readable host side first, because a bad\n'
+    '    # bind that docker accepts becomes an empty directory inside, and an\n'
+    '    # empty directory is the failure that looks like a missing file much\n'
+    '    # later and somewhere else.\n'
+    '    while IFS= read -r _spec; do\n'
+    '        [ -n "$_spec" ] || continue\n'
+    '        [ -e "${_spec%%:*}" ] \\\n'
+    '            || die "OFFLINE_EXTRA_MOUNTS: no such host path: ${_spec%%:*}"\n'
+    '        offline_mounts+=(-v "$_spec")\n'
+    '    done <<< "${OFFLINE_EXTRA_MOUNTS:-}"\n'
+    '    while IFS= read -r _spec; do\n'
+    '        [ -n "$_spec" ] || continue\n'
+    '        [ -e "${_spec%%:*}" ] \\\n'
+    '            || die "OFFLINE_EXTRA_WORKER_MOUNTS: no such host path: ${_spec%%:*}"\n'
+    '        offline_worker_mounts="${offline_worker_mounts} -v $_spec"\n'
+    '    done <<< "${OFFLINE_EXTRA_WORKER_MOUNTS:-}"\n'
+    '    # serve_env (start.sh:1282) is a fixed name list.  Anything outside it\n'
+    '    # cannot reach the worker that way, and the adapter needs six names on\n'
+    '    # BOTH ranks (PYTHONPATH, PYTHONDONTWRITEBYTECODE, PRISMAQUANT_TMPDIR\n'
+    '    # and the three thread caps): the RPC imports and the BLAS calls happen\n'
+    "    # on the workers too, not only on the head.  One NAME=VALUE per line.\n"
+    '    while IFS= read -r _env; do\n'
+    '        [ -n "$_env" ] || continue\n'
+    '        case "$_env" in\n'
+    '            *=*) ;;\n'
+    '            *) die "OFFLINE_EXTRA_ENV needs NAME=VALUE, got: $_env" ;;\n'
+    '        esac\n'
+    '        offline_mounts+=(-e "$_env")\n'
+    '        offline_worker_mounts="${offline_worker_mounts} -e $_env"\n'
+    '    done <<< "${OFFLINE_EXTRA_ENV:-}"\n'
+)
+
+WORKER_ANCHOR = '        ${worker_preload} \\\n'
+WORKER_PATCH = '        ${offline_worker_mounts} \\\n' + WORKER_ANCHOR
+
+RUN_ANCHOR = '    docker run -d --name "$CONTAINER_HEAD" \\\n'
+RUN_PATCH = RUN_ANCHOR + '        "${offline_mounts[@]}" \\\n'
+
+COMPLETE_ANCHOR = """    launch_cluster
+    if wait_for_health; then
+"""
+# The offline head is SUPPOSED to exit: it scores, writes its JSON and stops,
+# and never opens $PORT.  wait_for_health (start.sh:1435-1437) treats any head
+# exit as a failure, exit 0 included, so without this branch a perfect run is
+# reported as "server did not become healthy" and the launcher's exit status
+# says nothing about the result.  Wait for the exit instead and judge it on the
+# two things the run actually produces: the head's exit code and the artifact.
+# post_ready_warmup and on_ready are skipped entirely -- both speak HTTP to a
+# server that by design never listens.
+# ---------------------------------------------------------------------------
+# Paired-worker lifecycle
+# ---------------------------------------------------------------------------
+# The offline head exits by design, so `wait_for_health` never runs and nothing
+# downstream ever stopped the worker.  It held the worker box at 115 GB of
+# 121 GB after two runs in one morning, both times until someone stopped it by
+# hand.  A launcher that leaves half its cluster running has not finished.
+#
+# Four things this has to get right, and a first attempt got none of the last
+# three:
+#
+#   identity   The id comes from `docker run -d` itself, which prints the id of
+#              the container it created.  Resolving `$CONTAINER_WORKER` by name
+#              later can name a LATER run's worker that reused it, and stopping
+#              that is worse than leaking this one.  It is validated as exactly
+#              64 lowercase hex before anything is done with it: ssh writes
+#              banners to stdout, and a non-id string must never be
+#              interpolated into a remote `docker stop`.
+#   coverage   Registered at creation, before the head is even started, so a
+#              failure between the two -- the head's `docker run`, a preflight
+#              inside it, anything -- still stops the worker.  Registering
+#              after `launch_cluster` returns covers only a launch that fully
+#              succeeded, which is the case that was already fine.
+#   interrupt  EXIT/INT/TERM, because the common way to end a long wait is
+#              Ctrl-C, and that path took no cleanup at all.
+#   honesty    A stop that fails must not be able to end in "run complete".
+#              The head's own status stays separate and is still reported; the
+#              launcher's exit status becomes nonzero, because a worker still
+#              holding the box is not a finished run.  A docker or ssh failure
+#              is not absence, a missing id fails the run closed rather than
+#              warning, and a failed stop keeps the id so ownership can be
+#              reported and the stop retried at exit.
+WORKER_ID_ANCHOR = "    worker_ssh \"docker run -d --name '$CONTAINER_WORKER' \\\n"
+WORKER_ID_PATCH = "    offline_worker_cid=\"$(worker_ssh \"docker run -d --name '$CONTAINER_WORKER' \\\n"
+
+WORKER_ID_TAIL_ANCHOR = "        --entrypoint bash '$IMAGE' /start.sh\" >/dev/null\n"
+WORKER_ID_TAIL_PATCH = (
+    "        --entrypoint bash '$IMAGE' /start.sh\")\"\n"
+    "    offline_worker_run_out=\"$(printf '%s' \"$offline_worker_cid\" | tr -d '\\r')\"\n"
+    "    # A container id is exactly 64 lowercase hex characters.  Take the last\n"
+    "    # line that IS one, rather than the last line: ssh writes banners and\n"
+    "    # warnings to stdout, before and after, and anything that is not an id\n"
+    "    # must never reach a docker stop -- both because it would name the wrong\n"
+    "    # thing and because it would be interpolated into a remote command.\n"
+    "    offline_worker_cid=\"$(printf '%s\\n' \"$offline_worker_run_out\" \\\n"
+    "        | grep -E '^[0-9a-f]{64}$' | tail -n 1 || true)\"\n"
+    "    offline_cleanup_rc=0\n"
+    "    # Registered here, one statement after the worker exists and before the\n"
+    "    # head is started, so every later failure path is covered.\n"
+    "    #\n"
+    "    # A docker or ssh failure is NOT absence.  Only docker saying the\n"
+    "    # container does not exist proves the worker is gone; an unreachable\n"
+    "    # daemon, a dropped link or a refused login means the worker may well\n"
+    "    # still be running and this run still owns it.  The id is therefore\n"
+    "    # cleared only on a proven stop or a proven absence, and kept otherwise,\n"
+    "    # so ownership can be reported and the stop retried at exit.\n"
+    "    offline_stop_paired_worker() {\n"
+    "        [ -n \"${offline_worker_cid:-}\" ] || return 0\n"
+    "        _cid=\"$offline_worker_cid\"\n"
+    "        _out=\"$(worker_ssh \"docker inspect -f '{{.Id}}' '$_cid'\" 2>&1)\" && _rc=0 || _rc=$?\n"
+    "        if [ \"$_rc\" != 0 ]; then\n"
+    "            case \"$_out\" in\n"
+    "                *'No such object'*|*'No such container'*)\n"
+    "                    log \"paired worker ${_cid:0:12} is gone; docker reports no such container\"\n"
+    "                    offline_worker_cid=\"\"\n"
+    "                    return 0 ;;\n"
+    "                *)\n"
+    "                    offline_cleanup_rc=1\n"
+    "                    log \"could not reach ${WORKER_SSH} to check paired worker ${_cid:0:12}: $_out\"\n"
+    "                    log \"this is NOT evidence the worker stopped; the id is retained and this run still owns $_cid\"\n"
+    "                    return 1 ;;\n"
+    "            esac\n"
+    "        fi\n"
+    "        mkdir -p \"$LOGDIR\" 2>/dev/null || true\n"
+    "        worker_ssh \"docker inspect '$_cid' --format 'status={{.State.Status}} exit={{.State.ExitCode}} started={{.State.StartedAt}} pid={{.State.Pid}}'\" \\\n"
+    "            > \"$LOGDIR/worker-final-state.txt\" 2>&1 || true\n"
+    "        worker_ssh \"docker logs --tail 200 '$_cid'\" \\\n"
+    "            > \"$LOGDIR/worker-final.log\" 2>&1 || true\n"
+    "        if worker_ssh \"docker stop -t 60 '$_cid' >/dev/null && docker rm '$_cid' >/dev/null\"; then\n"
+    "            log \"paired worker ${_cid:0:12} stopped; state and last 200 lines in $LOGDIR/\"\n"
+    "            offline_worker_cid=\"\"\n"
+    "            return 0\n"
+    "        fi\n"
+    "        offline_cleanup_rc=1\n"
+    "        log \"paired worker ${_cid:0:12} did NOT stop; it is still on ${WORKER_SSH}\"\n"
+    "        log \"the id is retained and this run still owns $_cid\"\n"
+    "        return 1\n"
+    "    }\n"
+    "    # A signal handler that only cleans up turns an interrupt into a\n"
+    "    # zero exit, so the caller cannot tell it was interrupted.  Exit as the\n"
+    "    # signal would have.\n"
+    "    offline_on_signal() {\n"
+    "        _sig=\"$1\"; _num=\"$2\"\n"
+    "        log \"caught ${_sig}: stopping the paired worker before exiting\"\n"
+    "        offline_stop_paired_worker || true\n"
+    "        trap - EXIT INT TERM\n"
+    "        exit \"$((128 + _num))\"\n"
+    "    }\n"
+    "    # A cleanup failure at exit must reach the exit status.  The head's own\n"
+    "    # status is preserved when it is already nonzero, because that is the\n"
+    "    # more specific failure; a zero one is replaced, because a worker still\n"
+    "    # holding the box is not a finished run.\n"
+    "    offline_on_exit() {\n"
+    "        _status=$?\n"
+    "        trap - EXIT INT TERM\n"
+    "        if ! offline_stop_paired_worker; then\n"
+    "            if [ \"$_status\" = 0 ]; then\n"
+    "                _status=75\n"
+    "                log \"exiting 75: the run finished but the paired worker was not stopped\"\n"
+    "            fi\n"
+    "        fi\n"
+    "        exit \"$_status\"\n"
+    "    }\n"
+    "    if [ -n \"${OFFLINE_ENTRY:-}\" ]; then\n"
+    "        if [ -z \"$offline_worker_cid\" ]; then\n"
+    "            die \"docker run started a worker on ${WORKER_SSH} but printed no 64-hex container id; this run cannot stop what it cannot name. Last line was: $(printf '%s' \"$offline_worker_run_out\" | tail -n 1). Check for a container named ${CONTAINER_WORKER} there and remove it by hand\"\n"
+    "        fi\n"
+    "        log \"offline entry: paired worker is ${offline_worker_cid:0:12} on ${WORKER_SSH}\"\n"
+    "        trap offline_on_exit EXIT\n"
+    "        trap 'offline_on_signal INT 2' INT\n"
+    "        trap 'offline_on_signal TERM 15' TERM\n"
+    "    fi\n")
+
+COMPLETE_ANCHOR = """    launch_cluster
+    if wait_for_health; then
+"""
+# The offline head is SUPPOSED to exit: it scores, writes its JSON and stops,
+# and never opens $PORT.  wait_for_health (start.sh:1435-1437) treats any head
+# exit as a failure, exit 0 included, so without this branch a perfect run is
+# reported as "server did not become healthy" and the launcher's exit status
+# says nothing about the result.  Wait for the exit instead and judge it on the
+# two things the run actually produces: the head's exit code and the artifact.
+# post_ready_warmup and on_ready are skipped entirely -- both speak HTTP to a
+# server that by design never listens.
+COMPLETE_PATCH = """    launch_cluster
+    if [ -n "${OFFLINE_ENTRY:-}" ]; then
+        log "offline entry: waiting for the head to finish; it never opens ${PORT}"
+        docker logs -f --tail 0 "$CONTAINER_HEAD" 2>&1 &
+        offline_logpid=$!
+        offline_rc=0
+        docker wait "$CONTAINER_HEAD" >/dev/null 2>&1 || offline_rc=255
+        [ "$offline_rc" = 255 ] || offline_rc="$(docker inspect "$CONTAINER_HEAD" --format '{{.State.ExitCode}}' 2>/dev/null || echo 255)"
+        kill "$offline_logpid" 2>/dev/null || true
+        collect_failure_logs
+        offline_stop_paired_worker || true
+        if [ "$offline_rc" = "0" ] && [ -s "${OFFLINE_RESULT_HOST}" ]; then
+            log "offline run complete: head exit 0, $(wc -c <"${OFFLINE_RESULT_HOST}") bytes in ${OFFLINE_RESULT_HOST}"
+            log "sha256 $(sha256sum "${OFFLINE_RESULT_HOST}" | cut -d' ' -f1)"
+            if [ "${offline_cleanup_rc:-0}" != "0" ]; then
+                die "head exit 0 and the artifact is present, but the paired worker was not stopped; it still holds ${WORKER_SSH}"
+            fi
+            return
+        fi
+        if [ -s "${OFFLINE_RESULT_HOST}" ]; then offline_seen=present; else offline_seen=absent; fi
+        echo "---- last 60 lines of head log ($LOGDIR/head.log) ----"
+        tail -n 60 "$LOGDIR/head.log" || true
+        die "offline run failed: head exit ${offline_rc}, result ${offline_seen} at ${OFFLINE_RESULT_HOST}; full logs in $LOGDIR/"
+    fi
+    if wait_for_health; then
+"""
+
+PATCHES = [
+    ('KV_CACHE_DTYPE forced empty', KV_ANCHOR, KV_PATCH),
+    ('head exec swap', EXEC_ANCHOR, EXEC_PATCH),
+    ('offline mounts and MODEL_DIR', LAUNCH_ANCHOR, LAUNCH_PATCH),
+    ('worker /model bind', WORKER_ANCHOR, WORKER_PATCH),
+    ('head docker run mounts', RUN_ANCHOR, RUN_PATCH),
+    ('paired worker id at creation', WORKER_ID_ANCHOR, WORKER_ID_PATCH),
+    ('paired worker cleanup registration', WORKER_ID_TAIL_ANCHOR, WORKER_ID_TAIL_PATCH),
+    ('offline completion branch', COMPLETE_ANCHOR, COMPLETE_PATCH),
+]
+
+def apply_patches(text):
+    """Return the offline variant of ``text``, or raise ``PatchError``.
+
+    Every anchor must match exactly once.  A recipe update that moves one is a
+    launch-stopping error rather than a silent partial patch, because a start.sh
+    that took four of eight substitutions launches the served configuration
+    under an offline name.
+    """
+    for label, anchor, replacement in PATCHES:
+        found = text.count(anchor)
+        if found != 1:
+            raise PatchError(
+                f'offline patch {label!r}: anchor matched {found} times, '
+                f'expected exactly 1.  start.sh has moved; do not launch.')
+        text = text.replace(anchor, replacement)
+
+    # The worker's exec must survive verbatim: the swap above is applied to the
+    # generated head file at run time, not to this text, but assert it anyway so
+    # a future patch that reached into the heredoc is caught here.
+    if text.count('exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"') != 2:
+        raise PatchError(
+            'offline patch: the two inner-script execs are no longer both '
+            'present; do not launch.')
+    return text
+
+
+class PatchError(RuntimeError):
+    """An anchor did not match exactly once, or an invariant did not hold."""
+
+
+def main(argv):
+    source, dest = Path(argv[1]), Path(argv[2])
+    try:
+        text = apply_patches(source.read_text())
+    except PatchError as exc:
+        sys.exit(str(exc))
+    dest.write_text(text)
+    dest.chmod(0o755)
+    print(f'wrote {dest} ({len(PATCHES)} patches applied)')
+
+
+if __name__ == '__main__':
+    main(sys.argv)


### PR DESCRIPTION
Closes RobTand/prismaquant#471.

Two commits, two modules, each with the tests a native run cannot produce.

## `738bb20521` — the launcher stops the worker it started

`tools/glm_offline/patch_start_for_offline.py` generates the offline-scoring variant of the external MiaAI recipe's `start.sh`. The recipe is never edited, and every anchor must match exactly once or the patch exits non-zero: a `start.sh` that took four of eight substitutions would launch the served configuration under an offline name.

The offline head exits by design, so `wait_for_health` never runs and nothing downstream ever reached the worker. It held the worker box at 115 GB of 121 GB after two runs in one morning.

| | before | now |
|---|---|---|
| identity | container **name**, resolved later | the id `docker run -d` printed |
| reading it | the last stdout line | the last line that **is** 64 lowercase hex |
| no usable id | warn, continue | `die`, quoting what docker printed and naming the container to remove by hand |
| coverage | registered after `launch_cluster` returns | registered before the head starts |
| interrupt | none | `INT`/`TERM` stop the worker, then exit 130 / 143 |
| inspect or ssh fails | read as "already gone" | only `No such object`/`No such container` proves absence |
| stop fails | logged, id cleared, run complete | id retained, ownership stated, retried at exit |
| exit status | head's only | head's if nonzero, else 75 |

The distinction underneath most of these: a docker or ssh failure is not absence. An unreachable daemon, a dropped link or a refused login says nothing about whether the worker is running, and reading it as absence is how a leaked worker gets reported as a clean run.

Worker state and the last 200 log lines are taken **before** the stop is attempted, so the run that most needs them still gets them.

The module gained a `main()` so its constants can be read without running it. Output for the five pre-existing patches is unchanged.

## `680a3cafe4` — the layer-3 call is repeated on its own live arguments

`tools/exl3_grouped_down_replay.py` repeats one `exl3_fat_moe_down` call at `model.layers.3.mlp`, where whole-tensor hashes place the earliest whole-batch difference. It wraps the extension entry point rather than its caller, so the replay sees the arguments the real call received; rebuilding them would put the table construction inside the thing under test. The routing is among those arguments, so a difference cannot be a different expert selection.

**The ABI is read from `exl3_fat_moe.cu:599-655`, not assumed:** half `h2`, int64 `down_ptrs`/`down_svh_ptrs`, float `out`, int64 `row_token`, half `row_weight`, int32 segments. All ten arguments are small and all ten are hashed whole, before and after. `down_ptrs` and `down_svh_ptrs` are **pointer tables, not weight bodies**: equal hashes mean the same device addresses were passed, and the bytes at those addresses are never read here. `pointed_to_weight_bytes_hashed: false` is on the record, and each table entry carries `holds: device addresses`.

**Arming consumes the owner's real contract.** `PromptLogitsCapture` has no `armed` attribute; its armed state is `window_id is not None`. A hook reading anything else is permanently disarmed against the real object while passing against a stand-in that invented the attribute — which is exactly what happened, reproduced red on both TP ranks before this commit.

**BF16 ULP uses a monotonic ordered encoding.** Reading the raw int16 pattern as a signed integer is wrong across the sign boundary: the pattern grows as a negative value falls, and `+0.0`/`-0.0` read 32768 apart while being numerically equal. Tested at one and two ULP, either side of zero, one step below zero, among negatives, and at signed zeros.

**BF16 finiteness is asked separately from FP32 finiteness.** BF16 has FP32's exponent range but 7 mantissa bits, so a finite FP32 just under the top of the range rounds *up* to infinity on the cast. Maxima and ULP distances are taken only where both sides are finite, and say so when they were narrowed.

**Reading differing digests as "different output on the same arguments" needs two conditions**, so the record computes them rather than leaving a reader to assemble them: the arguments hashed equal before and after, and the compared outputs are finite. Differing digests under arguments that changed under the call say nothing about the kernel.

**Identity is a hash, not `torch.equal`,** which calls two bit-identical NaNs different and `+0.0`/`-0.0` the same. Every count carries a finiteness status, because a max delta over a tensor holding a NaN is not a magnitude.

Storage stated: three output-shaped FP32 buffers live at once — retained original, retained first replay, current probe — about 96 MB at `[2048, 4096]`.

What it does not claim is in the record it emits: an all-identical result bounds how often a difference appears at this shape and occupancy over this many repeats and bounds nothing else, is not a determinism verdict, does not cover gather or gate/up, and names no cause.

## Tests

The lifecycle tests splice the patcher's own `WORKER_ID_PATCH` and `WORKER_ID_TAIL_PATCH` the way the patcher splices them and run the result with the worker box stubbed; paraphrasing that shell into the test would have tested the paraphrase. Anchor and ordering behaviour runs against a stand-in `start.sh` built from the patcher's own anchors in real file order, so it is covered on any runner instead of skipping wherever the third-party recipe is absent.

The replay tests use fake kernels, because a real one cannot be made to differ on demand and the questions are about the reporting path. The fixture uses the real ABI dtypes; a fixture in convenient dtypes would have hidden two of the defects this file now guards. Where a test asserts a check bites, it changes the kernel's behaviour or the state object's shape rather than the recorded result.

Through PrismaBuild on `dl380g10`, tags `['x86']`, `--priority -10`, at `680a3cafe4`, 2/2 shards green:

| file | action | snapshot | result |
|---|---|---|---|
| `test_glm_offline_worker_lifecycle.py` | `3a04e2409ae57f51602507640026b2ed986dd28ca3ac5006c2c9384b22b04927` | `a44b8d62ea47df3066cabdb5747743461d2f1af0b57361d873ccf07906f129b8` | 31 passed 2 skipped |
| `test_exl3_grouped_down_replay.py` | `64063f2549c4a6d9a6250fdf4cbeafde7abccce0014e96a61950603a718a97b3` | `a9ad83769b74ead05ee7633558cf154d51b1ecba162e3fc87b97f9eaca118b84` | 41 passed 1 skipped |

The skips are the three tests that read host-local files absent on the x86 worker: the MiaAI recipe, and the scorer whose class contract one test re-reads.

Nothing here changes pipeline defaults, the stage graph, the format menu, the plugin contract, serving-lane defaults or ship gates, so `docs/ARCHITECTURE.md` is unchanged.

The replay has not been run against the real kernel. That needs a GPU launch, which is held during the pricing campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsJAfuLU26NWbYpSLrWFHJ
