### PR TITLE
Load authenticated selected source weights and preserve compatible anchor work

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,18 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-09 · `perf/glm-selected-source-scope`. Stamps
+As of: 2026-09-09 · `perf/glm-selected-source-snapshot`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-09, `perf/glm-selected-source-snapshot`) for seed-score
+identity validation. `--seed-checkpoint` now requires a digest-bound source
+manifest and matching unit envelopes, then compares calibration, score currency,
+static-scale policy, actual per-unit scoring-row identity and input scale before
+linking that unit's wires or inheriting its measured error. Producer input and
+wire checks still apply. Menu and source-package changes can reuse compatible
+measurements; changed scoring activations cannot inherit old scores. Missing
+unit shards remain eligible for fresh pricing, preserving partial-checkpoint
+recovery. Gates: `tests/test_tessera_campaign_resume.py` and
+`tests/test_tessera_campaign_fanout.py`.
 
 Re-stamped (2026-09-09, `perf/glm-selected-source-scope`) for opt-in
 `--source-snapshot-policy selected-tensors-v1` in selected anchor rows that

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,8 +8,11 @@ Re-stamped (2026-09-09, `perf/glm-selected-source-snapshot`) for
 matching prior row's completed or partial checkpoint to the existing seed gates.
 The planner requires the same model, census, capture, group bundles, membership
 and sampling; it records the source plan digest and each available seed manifest
-identity. Unstarted rows price normally. Seed files retain their original owner;
-PB continues to own all admission, placement and retries. The runtime validates
+identity. These at-plan digests are provenance, not execution gates: the source
+may advance before adoption, and the runtime checks the then-current scoring
+inputs and wires. Group additions or changed bundles/sampling refuse the plan;
+a matching row without a checkpoint prices fresh. Seed files retain their original
+owner. PB continues to own all admission, placement and retries. The runtime validates
 the seed identity and wire bytes when adopting them. Gate:
 `tests/test_tessera_campaign_seed_workspace.py`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,16 @@
 As of: 2026-09-09 · `perf/glm-selected-source-snapshot`. Stamps
 follow, newest first, each recording its own branch and date.
 
+Re-stamped (2026-09-09, `perf/glm-selected-source-snapshot`) for
+`dispatch_tessera_campaign.py plan --seed-workspace`. A new plan can offer each
+matching prior row's completed or partial checkpoint to the existing seed gates.
+The planner requires the same model, census, capture, group bundles, membership
+and sampling; it records the source plan digest and each available seed manifest
+identity. Unstarted rows price normally. Seed files retain their original owner;
+PB continues to own all admission, placement and retries. The runtime validates
+the seed identity and wire bytes when adopting them. Gate:
+`tests/test_tessera_campaign_seed_workspace.py`.
+
 Re-stamped (2026-09-09, `perf/glm-selected-source-snapshot`) for seed-score
 identity validation. `--seed-checkpoint` now requires a digest-bound source
 manifest and matching unit envelopes, then compares calibration, score currency,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,35 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-09 · `claude/dispatch-process-baseline`. Stamps
+As of: 2026-09-09 · `perf/glm-selected-source-scope`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-09, `perf/glm-selected-source-scope`) for opt-in
+`--source-snapshot-policy selected-tensors-v1` in selected anchor rows that
+reuse a complete, SHA-bound capture. The default remains `whole-layer-v1`.
+The source-only mode builds the declared meta skeleton but materializes no
+head, embedding or vision tensors. Its one-shot selection narrows the existing
+`StreamingContext` maps before prefetch, using the same profile-derived
+source dependency closure as resource admission. The existing reader, layer
+cache, concat merger and expert packer remain the owners of source bytes.
+A selected projected expert requires its entire packed parent, including all
+expert indices and sibling projections; a concat target requires every source.
+Forward installation and full source-initialization attestation are refused.
+The selected source keys are compared with the admitted plan before reading
+and recorded in the source receipt. Source shard SHA256 authentication and
+held-descriptor mutation fences remain unchanged: consuming one tensor still
+authenticates its entire shard once per row. The initial policy supports
+unscaled floating checkpoints; scaled FP8/FP4 sources fail closed.
+
+Admission excludes unconsumed source tensors and nonbody materialization,
+retains selected H/X, encoder, packing and publication charges and the existing
+full-layer source-validation allowance, and preserves
+the full-header identity and decoder coverage check. Snapshot policy is an
+execution choice outside cost identity, like compatible batch width: source
+weight bytes, calibration, encoder policy, wire format and shipping gates do
+not change. Qualification requires selected weight parity and a complete
+matched-group GPU profile before claiming a production speedup. Gates:
+`tests/test_selected_snapshot_scope.py` and existing streaming, source
+authentication, selected-anchor and dispatcher admission tests.
 
 Re-stamped (2026-09-09, `claude/dispatch-process-baseline`) for the campaign
 dispatcher's explicit process-baseline reservation. A recipe may declare

--- a/docs/experiments/glm_selected_source_snapshot_20260909.md
+++ b/docs/experiments/glm_selected_source_snapshot_20260909.md
@@ -1,0 +1,103 @@
+# GLM selected source snapshot measurement — 2026-09-09
+
+The opt-in `selected-tensors-v1` source policy reduced complete-group wall time
+from 265.02 s to 236.40 s (1.121× throughput, 10.80% less time) and device energy
+from 6757.74 J to 6386.74 J (5.49% less energy, 1.058× anchors/J). All four arms
+matched the existing production group's 14 anchors, measured error, bit costs,
+and authenticated wire files exactly. This is one shared-expert gate/up group,
+not a routed-expert or end-to-end model-quality result.
+
+## Workload and environment
+
+The workload is GLM-5.3-Flash-BF16 layer 4 shared-expert gate/up: two Linears,
+three dense families (BF16 K1, E2M1 K2, E4M3 K1), rate band 832–1088, three
+initial anchors, adaptive anchor budget 12, and 512 retained scoring rows.
+It reuses the original 512 × 512 calibration capture, manifest SHA256
+`f4bcbf408d3aa81b04c1fabd1d2d7457176a95dcccdd5ed368800de5c37e277c`.
+No new source-model forwards or calibration draw were performed.
+
+PB selected Sparky, NVIDIA GB10, driver 595.84, Linux 6.17.0-1032-nvidia.
+The qualified producer image content digest is
+`eb8592abd71390231b49aba119e36f02ad91ea867b06df1c67af3833004d07bd`;
+PyTorch 2.13.0+cu130, CUDA 13.0; producer source and encoder settings are bound
+in the measurement plan. The action reserved six CPUs and 61 GiB total/shared
+GPU memory, including the control's 57 GiB demand and 4 GiB profiler allowance.
+PB preserved affinity and isolated the GPU measurement. Sparklina continued
+its existing expert-pricing action and has Netdata coverage for every arm.
+
+Each A/B/B/A arm ran in a fresh Python process with separate Triton/Inductor
+caches. The host page cache was shared. Both policies used identical profiling:
+main-thread stacks and `/proc/self/io` sampled each second, Netdata on both
+boxes every five seconds, and two bounded CUDA activity windows. Reported wall
+times include that instrumentation; they are not unprofiled production timings.
+
+| Arm | Source policy | Wall seconds | Device joules | Pre-anchor seconds |
+|---|---|---:|---:|---:|
+| A0 | Whole layer | 265.580 | 6658.49 | 64.43 |
+| B1 | Selected tensors | 235.768 | 6357.15 | 35.21 |
+| B2 | Selected tensors | 237.033 | 6416.33 | 35.68 |
+| A3 | Whole layer | 264.452 | 6856.99 | 63.56 |
+
+## What changed and what remains
+
+The shared streaming reader/cache now loads only the authenticated dependency
+closure needed for the selected weight snapshots. Head, embedding and vision
+weights remain meta; an expert view still requires its complete packed parent.
+Source-file authentication remains mandatory. Admission for this group falls
+from 57 to 42 GiB; the complete source-validation allowance remains charged.
+Actual concurrent throughput under the smaller reservation was not measured.
+
+The profiles place nearly all the improvement before the first anchor:
+63.99 → 35.44 s on average. The child's sampled `read_bytes` delta falls from
+47.64/47.71 GB to 6.162/6.163 GB, and `rchar` from 32.83/32.91 GB to
+7.276/7.279 GB. These are kernel process-I/O counters, not network-wire bytes.
+Main-thread samples in `wait` fall from 24 in the first control to 5/6 in the
+selected arms. The encoding phase is essentially unchanged.
+
+Device power averages 25.50 → 27.02 W and peaks around 40 W, well below the
+approximately 140 W envelope. The optimized steady-state BF16 CUDA window
+attributes 92.86% of recorded device time to `_step_best` (341,849 calls,
+4.721 µs average). This remains a candidate for further batching/kernel work;
+this source change does not establish saturated encoding. CUDA/CPU event
+correlation is not used because the activity-toggle warning makes it unreliable.
+GPU energy integrates the 0.5-second `pqteld` device-power samples over each
+arm with full temporal coverage and no gap above two seconds. It excludes
+whole-host electrical power.
+
+## Evidence and validation
+
+Artifacts live under
+`/mnt/shared/tessera-measurements/glm-canonical-census-20260908/selected-source-snapshot-optimization-03/`:
+`plan.json`, `native/result.json`, `native-analysis.json`,
+`native-power-window.json`, per-arm profiles and parity records, and
+`native-cas-source-audit.json`. The analysis script used is retained beside this
+evidence as `analyze-selected-source-ab.py`.
+
+Native PB action:
+`782b0a7b31cce8a79a4e9d38a70b6fa523b4231001c71f874c764091b0480615`.
+Its terminal exit is zero, scope cleanup complete, CAS receipt/payload verified,
+and source snapshot identical to `8f1cc63705` except PB closure metadata.
+Later commits tighten pre-I/O guards and seed-score identity; CPU regressions
+cover those changes. They do not change the measured encoder or source-copy path.
+
+The initial attempt in `selected-source-snapshot-optimization-02` failed because
+one steady-state trace exceeded its 256 MiB export cap. Its completed anchors
+were retained as negative evidence; it was not accepted as an A/B result.
+The successful run raised only that bound to 512 MiB. The bound checks exported
+bytes and is not a live profiler-memory limit.
+
+The source change's CPU suite passed 215 tests with one CUDA-only skip, followed
+by eight focused snapshot tests. Review regressions reproduced three failures;
+the guard fix passed 31 tests with one CUDA-only skip (PB `59d2c85f2425`).
+Seed-score validation reproduced adoption across changed scoring activations
+(PB `063e64c1d28c`), then passed 113 tests with two skips (`554c9024efc5`), plus
+an explicit unchanged-input adoption test (`d7a152352d31`). Workspace reuse
+passed six tests (`039b8e22935c`); integrated planner/docs checks passed 58
+(`451865c80e10`). Counts overlap and must not be summed. Actual source/receipt
+audits are stored with the evidence. No skipped check is represented as a pass.
+
+An independent finding, PrismaBuild #451, showed that the deployed terminal
+process-I/O aggregate can omit exited descendants. This report therefore uses
+the child's own sampled counters; the old aggregate is not treated as zero I/O.
+The GB10 fleet limit remains 104 GiB. Its reactive GPU guard cannot establish
+the user's requested guarantee for a higher hard aggregate cap (PB #450).

--- a/docs/experiments/glm_selected_source_snapshot_20260909.md
+++ b/docs/experiments/glm_selected_source_snapshot_20260909.md
@@ -90,7 +90,7 @@ The source change's CPU suite passed 215 tests with one CUDA-only skip, followed
 by eight focused snapshot tests. Review regressions reproduced three failures;
 the guard fix passed 31 tests with one CUDA-only skip (PB `59d2c85f2425`).
 Seed-score validation reproduced adoption across changed scoring activations
-(PB `063e64c1d28c`), then passed 113 tests with two skips (`554c9024efc5`), plus
+(PB `063e64c1d28c`), then passed 113 tests with two producer-projection-tool skips (`554c9024efc5`), plus
 an explicit unchanged-input adoption test (`d7a152352d31`). Workspace reuse
 passed six tests (`039b8e22935c`); integrated planner/docs checks passed 58
 (`451865c80e10`). Counts overlap and must not be summed. Actual source/receipt

--- a/experiments/selected_snapshot_scope_ab.py
+++ b/experiments/selected_snapshot_scope_ab.py
@@ -123,7 +123,7 @@ def run(path, expected):
         command += ['--source-snapshot-policy', policy]
         argv = [sys.executable, '-u', '-m', 'experiments.glm_full_capture_profile',
             '--evidence-out', str(out/'profile'), '--selected-anchors',
-            '--anchor-profile-calls', '0,3', '--anchor-trace-max-bytes', str(256*1024**2),
+            '--anchor-profile-calls', '0,3', '--anchor-trace-max-bytes', str(512*1024**2),
             '--anchor-cuda-only', '--anchor-profile-seconds', '2', '--', *command]
         environment = dict(os.environ, TRITON_CACHE_DIR=str(out/'triton'),
             TORCHINDUCTOR_CACHE_DIR=str(out/'inductor'))

--- a/experiments/selected_snapshot_scope_ab.py
+++ b/experiments/selected_snapshot_scope_ab.py
@@ -1,0 +1,177 @@
+"""Profile a complete campaign group under both source snapshot policies.
+
+Run prepare and run through PB. This calls the existing campaign and observer;
+there is no calibration, encoder, cache, or placement implementation here.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+
+def digest(path):
+    with Path(path).open('rb') as handle:
+        return hashlib.file_digest(handle, 'sha256').hexdigest()
+
+
+def write(path, value):
+    with Path(path).open('x') as handle:
+        json.dump(value, handle, sort_keys=True, indent=2, allow_nan=False)
+        handle.write('\n')
+
+
+def prepare(spec_path, workspace, row_id, out):
+    from tools.dispatch_tessera_campaign import load_spec, _streamed_resource_plan
+    spec = load_spec(spec_path)
+    workspace, out = Path(workspace), Path(out)
+    original = json.loads((workspace/'plan.json').read_text())
+    row = next(row for row in original['rows'] if row['row_id'] == row_id)
+    if len(row['groups']) != 1 or len(row['members']) != 2:
+        raise ValueError('this paired measurement requires one complete two-Linear group')
+    census = json.loads(Path(original['census']).read_text())
+    manifest = json.loads(Path(original['manifest']).read_text())
+    index = next(i for i, r in enumerate(original['rows']) if r['row_id'] == row_id)
+    template = manifest[index]['argv']
+    offset = template.index('prismaquant.tessera_campaign')+1
+    command = template[offset:]
+    resources = {}
+    for policy in ('whole-layer-v1', 'selected-tensors-v1'):
+        selected = copy.deepcopy(spec)
+        selected['campaign_argv'] += ['--source-snapshot-policy', policy]
+        resources[policy] = _streamed_resource_plan(selected, census, row['members'], selected_source=True)
+    _reference_identity, reference_states = priced_state(Path(row['dir']))
+    reference_sha = hashlib.sha256(json.dumps(reference_states, sort_keys=True,
+        separators=(',', ':'), allow_nan=False).encode()).hexdigest()
+    # Preserve the parent recipe's runtime baseline; profiler export can hold
+    # one bounded trace and its in-memory representation during finalization.
+    memory = math.ceil((max(r['memory_bytes'] for r in resources.values())+
+        original['process_baseline_bytes'])/1024**3)+4
+    if memory > spec['box_memory_gb']:
+        raise ValueError('paired source measurement exceeds the existing box budget')
+    bindings = {str(path): digest(path) for path in (
+        Path(spec_path), workspace/'plan.json', Path(original['manifest']),
+        Path(original['census']), Path(row['units']),
+        Path(command[command.index('--calibration-cache')+1]))}
+    plan = dict(schema='prismaquant.selected_snapshot_scope_ab.v1',
+        row_id=row_id, groups=row['groups'], members=row['members'], command=command,
+        reference_semantics_sha256=reference_sha,
+        container=spec['container'], environment=spec['env'], resources=resources,
+        input_sha256=bindings, requested_memory_gib=memory, requested_cpus=spec['cpus'],
+        order=['whole-layer-v1', 'selected-tensors-v1', 'selected-tensors-v1', 'whole-layer-v1'],
+        measurement_scope='Complete group, fresh Python process and compiler caches per arm; shared host page cache.',
+        out=str(out/'native'), expected_source_units=len(row['members']))
+    out.mkdir(parents=True, exist_ok=True)
+    write(out/'plan.json', plan)
+    print(json.dumps(dict(plan=str(out/'plan.json'), sha256=digest(out/'plan.json'),
+        memory_gib=memory, source_preparation_bytes={k:v['phases']['source_preparation']
+        for k,v in resources.items()})), flush=True)
+
+
+def priced_state(root):
+    from prismaquant.cost_stage_checkpoint import _load_unit, unit_path
+    path = root/'cost.anchors.json'
+    manifest = json.loads(path.read_text())
+    states = {}
+    for unit in manifest['units']:
+        name = unit['qname']
+        state = _load_unit(unit_path(path.with_name(path.name+'.parts'), name),
+            stage=manifest['stage'], qname=name, identity_sha256=manifest['identity_sha256'])
+        if not state['anchors'] or state.get('unservable'):
+            raise ValueError('paired group has empty or refused anchor state')
+        anchors = sorted(({k:v for k,v in row.items() if k != 'seconds'}
+                          for row in state['anchors']), key=lambda row: row['format_name'])
+        wires = state['wire_records']
+        for record in wires.values():
+            actual = root/'cache/wire'/record['file']
+            if (digest(actual) != record['blob_sha256'] or
+                    actual.stat().st_size != record['blob_bytes']):
+                raise ValueError('paired wire bytes differ from their journal')
+        states[name] = dict(anchors=anchors, wires=wires)
+    return manifest['identity_sha256'], states
+
+
+def run(path, expected):
+    if digest(path) != expected:
+        raise ValueError('paired measurement plan changed')
+    plan = json.loads(Path(path).read_text())
+    if plan['schema'] != 'prismaquant.selected_snapshot_scope_ab.v1':
+        raise ValueError('unknown paired source measurement schema')
+    for name, sha in plan['input_sha256'].items():
+        if digest(name) != sha:
+            raise ValueError('paired measurement input changed: '+name)
+    for name, value in plan['environment'].items():
+        if os.environ.get(name) != value:
+            raise ValueError('paired measurement environment changed: '+name)
+    root = Path(plan['out'])
+    root.mkdir(parents=True, exist_ok=False)
+    rows, baseline = [], None
+    for index, policy in enumerate(plan['order']):
+        out = root/f'arm-{index:02d}'
+        out.mkdir()
+        command = list(plan['command'])
+        for flag, value in {'--out': out/'cost.pkl', '--cache-dir': out/'cache',
+                            '--checkpoint': out/'cost.anchors.json'}.items():
+            command[command.index(flag)+1] = str(value)
+        command += ['--source-snapshot-policy', policy]
+        argv = [sys.executable, '-u', '-m', 'experiments.glm_full_capture_profile',
+            '--evidence-out', str(out/'profile'), '--selected-anchors',
+            '--anchor-profile-calls', '0,3', '--anchor-trace-max-bytes', str(256*1024**2),
+            '--anchor-cuda-only', '--anchor-profile-seconds', '2', '--', *command]
+        environment = dict(os.environ, TRITON_CACHE_DIR=str(out/'triton'),
+            TORCHINDUCTOR_CACHE_DIR=str(out/'inductor'))
+        started = time.time()
+        with (out/'command.log').open('x') as log:
+            result = subprocess.run(argv, env=environment, stdout=log, stderr=subprocess.STDOUT)
+        record = dict(index=index, policy=policy, started_unix=started,
+            finished_unix=time.time(), returncode=result.returncode, command=argv)
+        rows.append(record)
+        write(out/'exit.json', record)
+        if result.returncode:
+            raise RuntimeError(f'paired source arm {index} failed: {out}/command.log')
+        if not (out/'cost.pkl').is_file() or (out/'cost.pkl').stat().st_size == 0:
+            raise ValueError('paired campaign did not publish its cost output')
+        current = priced_state(out)
+        semantic_sha = hashlib.sha256(json.dumps(current[1], sort_keys=True,
+            separators=(',', ':'), allow_nan=False).encode()).hexdigest()
+        if semantic_sha != plan['reference_semantics_sha256']:
+            raise ValueError('paired anchors differ from the existing completed production group')
+        if len(current[1]) != plan['expected_source_units']:
+            raise ValueError('paired group lost selected units')
+        if baseline is None:
+            baseline = current
+        elif current != baseline:
+            raise ValueError('paired source identity, anchor quality/bpp, or wire differs')
+        record.update(exact_parity=True, units=len(current[1]),
+            anchors=sum(len(unit['anchors']) for unit in current[1].values()))
+        write(out/'parity.json', record)
+        print(json.dumps(record), flush=True)
+    write(root/'result.json', dict(schema=plan['schema'], plan_sha256=expected,
+        exact_parity=True, rows=rows, measurement_scope=plan['measurement_scope']))
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    sub = p.add_subparsers(dest='mode', required=True)
+    prep = sub.add_parser('prepare')
+    for name in ('spec', 'workspace', 'row-id', 'out'):
+        prep.add_argument('--'+name, required=True)
+    native = sub.add_parser('run')
+    native.add_argument('--plan', required=True)
+    native.add_argument('--plan-sha256', required=True)
+    args = p.parse_args()
+    if args.mode == 'prepare':
+        prepare(args.spec, args.workspace, args.row_id, args.out)
+    else:
+        run(args.plan, args.plan_sha256)
+
+
+if __name__ == '__main__':
+    main()

--- a/prismaquant/autoscale.py
+++ b/prismaquant/autoscale.py
@@ -111,7 +111,7 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
                                    nsamples, seqlen, max_act_rows, cache_slots,
                                    prefetch_workers, headroom_gb,
                                    capture_policy='legacy', capture_load_policy=None,
-                                   process_baseline_bytes=0):
+                                   process_baseline_bytes=0, selected_source_units=None):
     """Bound canonical capture using the shared loader's actual source layout.
 
     Headers and profile mappings determine source residency. Capture owns one
@@ -166,7 +166,18 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
     if live_probe is None or '.0.' not in live_probe:
         raise ValueError('profile cannot map the decoder prefix for resource admission')
     live_prefix = live_probe.rsplit('.0.', 1)[0]+'.'
+    selected_keys = None
+    if selected_source_units is not None:
+        from .layer_streaming import selected_weight_source_keys
+        mapped_keys = [profile.checkpoint_to_live_name(key, multimodal=multimodal)
+                       for key in header]
+        selected_keys = set(selected_weight_source_keys(
+            selected_source_units, profile, (key for key in mapped_keys if key is not None)))
+        if fp4_experts:
+            raise ValueError('selected tensor snapshots require unscaled floating source weights')
     body, fixed, pack, concat = {}, 0, {}, {}
+    covered_layers = set()
+    validation_raw_body = {}
     raw_body, max_element_bytes = {}, 4
     packed_regex = profile.per_expert_moe_regex()
     packed_pattern = (re.compile(packed_regex.removeprefix('re:')) if packed_regex else None)
@@ -178,6 +189,17 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
         name = profile.checkpoint_to_live_name(key, multimodal=multimodal)
         if name is None:
             continue
+        if name.startswith(live_prefix):
+            index = name[len(live_prefix):].split('.', 1)[0]
+            if not index.isdigit() or not 0 <= int(index) < layers:
+                raise ValueError(f'out-of-body source tensor is still live: {name}')
+            covered_layers.add(int(index))
+            begin, end = meta['data_offsets']
+            validation_raw_body[int(index)] = validation_raw_body.get(int(index), 0)+int(end)-int(begin)
+        if selected_keys is not None and name not in selected_keys:
+            continue
+        if selected_keys is not None and str(meta['dtype']).upper() not in ('BF16', 'F16', 'F32', 'F64'):
+            raise ValueError('selected tensor snapshots require unscaled floating source weights')
         shape = meta['shape']
         numel = math.prod(shape)
         begin, end = meta['data_offsets']
@@ -216,7 +238,7 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
             if any(name.endswith(suffix) for suffix in sources):
                 group = (layer, target)
                 concat[group] = concat.get(group, 0)+size
-    if set(body) != set(range(layers)):
+    if covered_layers != set(range(layers)):
         raise ValueError('source headers do not cover every decoder layer')
     # A final group is preallocated and filled directly; no per-expert fused
     # slabs survive. Charge all original packed-source bytes as a conservative
@@ -271,6 +293,9 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
         # a caller that declares a reservation and gets a plan back with no
         # record of it has been told the opposite of the truth.
         **_baseline_fields(process_baseline_bytes),
+        **({'source_tensor_keys': sorted(selected_keys),
+            'body_source_validation_bytes': {str(k): v for k, v in validation_raw_body.items()}}
+           if selected_keys is not None else {}),
         source_header_sha256=hashlib.sha256(json.dumps(header, sort_keys=True,
             separators=(',', ':')).encode()).hexdigest(),
         terms=terms, memory_bytes=sum(terms.values()), disk_bytes=disk,
@@ -355,7 +380,8 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
 def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
                               cache_slots, prefetch_workers, headroom_gb,
                               anchor_batch_size=1, capture_load_policy=None,
-                              publication_overlap_bytes=0, process_baseline_bytes=0):
+                              publication_overlap_bytes=0, process_baseline_bytes=0,
+                              source_snapshot_policy='whole-layer-v1'):
     """Bound selected-source preparation separately from resident encoding.
 
     This extends the source loader's header/dtype accounting. No source
@@ -414,10 +440,14 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
     capture_load_policy = normalize_verified_activation_load(capture_load_policy)
     if not unit_shapes or type(anchor_batch_size) is not int or anchor_batch_size < 1:
         raise ValueError('selected anchors require nonempty units and a positive batch size')
+    if source_snapshot_policy not in ('whole-layer-v1', 'selected-tensors-v1'):
+        raise ValueError('unknown selected source snapshot policy')
     source = streamed_calibration_resources(model_path, unit_shapes=unit_shapes,
         counts=counts, nsamples=1, seqlen=1, max_act_rows=max_act_rows,
         cache_slots=cache_slots, prefetch_workers=prefetch_workers,
-        headroom_gb=headroom_gb)
+        headroom_gb=headroom_gb,
+        **({'selected_source_units': tuple(unit_shapes)}
+           if source_snapshot_policy == 'selected-tensors-v1' else {}))
     prefix = source['live_layer_prefix']
     layers = sorted({str(int(name[len(prefix):].split('.', 1)[0])) for name in unit_shapes}, key=int)
     weights = sum(source['unit_source_weight_bytes'].values())
@@ -487,7 +517,12 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
         # whether that release is complete is the loader's contract, not a
         # term derivable from a shape.
         entry_validation_bytes=2*widest_capture_entry,
-        source_validation_bytes=sum(source['body_source_file_bytes'][k] for k in layers)+widest_weight,
+        # Narrowing tensor reads does not narrow whole-shard authentication.
+        # Retain the existing full-layer raw-page allowance, even when most
+        # tensor materialization is excluded. Do not infer a smaller hash/page
+        # footprint merely from a selected tensor's shape.
+        source_validation_bytes=sum(source.get('body_source_validation_bytes',
+            source['body_source_file_bytes'])[k] for k in layers)+widest_weight,
         # tessera_publication.BoundedPublisher's own bound, charged as itself.
         # Staged artifacts are host bytes waiting to be written: the CPU BF16
         # render (_canonical_rendered_weight_tensor) and the wire blob, live
@@ -541,6 +576,9 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
             capture_source_page_cache_bytes=capture_load_policy['max_buffer_bytes'],
             capture_load_scratch_bytes=capture_load_policy['max_scratch_bytes'])
     return dict(schema='prismaquant.selected_anchor_resources.v2', phases=phases,
+        **({'source_snapshot_policy': source_snapshot_policy,
+            'source_tensor_keys': source['source_tensor_keys']}
+           if source_snapshot_policy == 'selected-tensors-v1' else {}),
         **({'capture_load_policy': capture_load_policy} if capture_load_policy is not None else {}),
         memory_bytes=max(sum(phase.values()) for phase in phases.values()),
         selected_source_weight_bytes=weights, selected_layers=layers,

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -425,7 +425,7 @@ class StreamedCausalLM:
         return layer
 
     def snapshot_selected_weights(self, names, *, max_resident_bytes: int,
-                                  resource_check=None):
+                                  resource_check=None, expected_source_keys=None):
         """Copy selected source Linears from the existing resident layer cache.
 
         This is preparation for a consumer that already owns its ``weights``
@@ -470,6 +470,13 @@ class StreamedCausalLM:
         if required > max_resident_bytes:
             raise RuntimeError("selected source weights exceed their resident byte budget")
 
+        snapshot_only = getattr(self.context, 'source_snapshot_only', False)
+        if snapshot_only:
+            self.context.configure_selected_snapshot(names, self.profile)
+            if (expected_source_keys is not None and
+                    tuple(expected_source_keys) != self.context._snapshot_source_keys):
+                raise RuntimeError('snapshot source dependencies differ from the admitted plan')
+
         ordered = sorted(layers)
         window = max(1, min(self.prefetch_lookahead, self.context.max_cache_slots - 1))
         weights, records = {}, []
@@ -477,7 +484,8 @@ class StreamedCausalLM:
             self.context.schedule_prefetch(layer)
         for index, layer in enumerate(ordered):
             source = self.context.install(layer, require_prefetched=True,
-                                          prefetch_following=False)
+                                          prefetch_following=False,
+                                          **({'snapshot': True} if snapshot_only else {}))
             if index + window < len(ordered):
                 self.context.schedule_prefetch(ordered[index + window])
             live = {}
@@ -504,7 +512,10 @@ class StreamedCausalLM:
                 resource_check(f"after_selected_source_release:{layer}")
         return weights, dict(schema="prismaquant.selected_source_weights.v1",
             units=sorted(weights), layers=records, resident_bytes=required,
-            source_forward_count=0, packed_parent_storage_retained=False)
+            source_forward_count=0, packed_parent_storage_retained=False,
+            **({'source_snapshot_policy': 'selected-tensors-v1',
+                'source_tensor_keys': list(self.context._snapshot_source_keys),
+                'nonbody_materialized': False} if snapshot_only else {}))
 
     @contextmanager
     def pin_layer(self, layer: int) -> Iterator[None]:
@@ -540,6 +551,8 @@ class StreamedCausalLM:
             return head
 
     def _prepare(self, input_ids: torch.Tensor):
+        if getattr(self.context, 'source_snapshot_only', False):
+            raise RuntimeError('snapshot-only source cannot execute a forward')
         ids = input_ids.to(self.device)
         position_ids = torch.arange(
             ids.size(-1), device=self.device
@@ -886,6 +899,7 @@ def build_streamed_causal_lm(
     attn_implementation: str | None = None,
     source_authentication=None,
     source_derivative=None,
+    source_snapshot_only=False,
 ) -> StreamedCausalLM:
     """Build the repository's existing streaming context and wrap it."""
     from prismaquant.streaming_model import _build_streaming_context
@@ -902,6 +916,7 @@ def build_streamed_causal_lm(
         log_prefix="[cost-streaming]",
         attn_implementation=attn_implementation,
         **({'source_authentication': source_authentication} if source_authentication is not None else {}),
+        **({'source_snapshot_only': True} if source_snapshot_only else {}),
     )
     runner = None
     try:

--- a/prismaquant/cost_streaming.py
+++ b/prismaquant/cost_streaming.py
@@ -472,10 +472,14 @@ class StreamedCausalLM:
 
         snapshot_only = getattr(self.context, 'source_snapshot_only', False)
         if snapshot_only:
-            self.context.configure_selected_snapshot(names, self.profile)
-            if (expected_source_keys is not None and
-                    tuple(expected_source_keys) != self.context._snapshot_source_keys):
+            if expected_source_keys is None:
+                raise RuntimeError('snapshot requires admitted source keys before source I/O')
+            from .layer_streaming import selected_weight_source_keys
+            planned_keys = tuple(expected_source_keys)
+            actual_keys = selected_weight_source_keys(names, self.profile, self.context.weight_ckpt)
+            if planned_keys != actual_keys:
                 raise RuntimeError('snapshot source dependencies differ from the admitted plan')
+            self.context.configure_selected_snapshot(names, self.profile)
 
         ordered = sorted(layers)
         window = max(1, min(self.prefetch_lookahead, self.context.max_cache_slots - 1))

--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -1061,6 +1061,56 @@ def _merge_concat_sources(
     return produced
 
 
+def selected_weight_source_keys(unit_names, profile, source_keys):
+    """Resolve selected Linears to the existing reader's source dependencies.
+
+    A projected expert still needs its complete packed parent, including all
+    siblings required by the profile's packer. A concat target needs every
+    declared source. The same metadata closure sizes and executes snapshots;
+    it does not change packing, dequantization, or source authentication.
+    """
+    keys = set(source_keys)
+    names = tuple(unit_names)
+    if not names or len(names) != len(set(names)):
+        raise ValueError('selected source requires unique nonempty units')
+    regex = profile.per_expert_moe_regex()
+    pattern = re.compile(regex.removeprefix('re:')) if regex else None
+
+    def packed_parent(name):
+        if pattern is None or not (pattern.match(name) or
+                pattern.match(profile.to_vllm_internal_name(name))):
+            return None
+        owner, projection = name.rsplit('.', 1)
+        path, expert = owner.rsplit('.', 1)
+        parent = profile.packed_expert_parent_for_projection(projection)
+        return path+'.'+parent if expert.isdigit() and parent is not None else None
+
+    groups = tuple(profile.concat_merge_groups())
+    dependencies = {}
+    for key in sorted(keys):
+        target = packed_parent(key.removesuffix('.weight')) or key
+        for output, inputs, _dim in groups:
+            for suffix in inputs:
+                if key.endswith(suffix):
+                    target = key[:-len(suffix)]+output
+        dependencies.setdefault(target, set()).add(key)
+    selected = set()
+    for name in names:
+        target = packed_parent(name) or name+'.weight'
+        required = dependencies.get(target)
+        if not required:
+            raise RuntimeError(f'selected source has no checkpoint dependency for {name}')
+        if target in keys and required != {target}:
+            raise RuntimeError(f'selected source has ambiguous packed/merged inputs for {name}')
+        for output, inputs, _dim in groups:
+            if target.endswith(output) and target not in keys:
+                expected = {target[:-len(output)]+suffix for suffix in inputs}
+                if required != expected:
+                    raise RuntimeError(f'selected source has incomplete concat inputs for {name}')
+        selected.update(required)
+    return tuple(sorted(selected))
+
+
 def _build_concat_merger(model: nn.Module, weight_ckpt: dict[str, str]):
     """Return a callable that merges N->1 concat source tensors, or None.
 

--- a/prismaquant/streaming_model.py
+++ b/prismaquant/streaming_model.py
@@ -549,7 +549,8 @@ class StreamingContext:
                  prefetch_workers: int = 3,
                  prefetch_min_available_bytes: int = 0,
                  expert_packer=None,
-                 concat_merger=None, source_authentication=None):
+                 concat_merger=None, source_authentication=None,
+                 source_snapshot_only=False, source_fp4_experts=False):
         self.model = model
         self.base_model = base_model
         self.layers = layers
@@ -597,6 +598,8 @@ class StreamingContext:
         # behavior change). Built once in `_build_streaming_context`.
         self.concat_merger = concat_merger
         self.source_authentication = source_authentication
+        self.source_snapshot_only = source_snapshot_only
+        self.source_fp4_experts = source_fp4_experts
         self._inflight: dict[int, Any] = {}
         self._inflight_lock = threading.Lock()
         # Sequential-walk tracking for the automatic prefetch top-up.
@@ -623,12 +626,34 @@ class StreamingContext:
             int(self.layer_cache.dynamic_reserve_bytes or 0),
         )
 
+    def configure_selected_snapshot(self, names, profile):
+        """Narrow this source-only context before the existing cache loads it."""
+        from .layer_streaming import selected_weight_source_keys
+        if not getattr(self, 'source_snapshot_only', False):
+            raise RuntimeError('selected snapshot requires a source-only context')
+        if getattr(self, '_snapshot_source_keys', None) is not None or self._inflight:
+            raise RuntimeError('selected snapshot source is already configured or active')
+        keys = selected_weight_source_keys(names, profile, self.weight_ckpt)
+        # No prefetch or full-layer install is permitted before this transition.
+        self.weight_shard = {key: self.weight_shard[key] for key in keys}
+        self.weight_ckpt = {key: self.weight_ckpt[key] for key in keys}
+        self.estimated_layer_bytes, self._snapshot_layer_bytes = _estimate_layer_cache_bytes(
+            weight_shard=self.weight_shard, weight_ckpt=self.weight_ckpt,
+            layers_prefix=self.layers_prefix, num_layers=self.num_layers,
+            target_dtype=self.dtype, tensor_dtypes=self.buffer_dtypes,
+            fp4_experts=self.source_fp4_experts,
+            **({'source_authentication': self.source_authentication}
+               if self.source_authentication is not None else {}))
+        self._snapshot_source_keys = keys
+
     def configure_runtime_pressure_floor(self) -> int:
         floor = self.memory_pressure_floor_bytes()
         self.layer_cache.configure_pressure_threshold(floor)
         return floor
 
     def _prefetch_worker(self, L: int):
+        if getattr(self, 'source_snapshot_only', False) and not getattr(self, '_snapshot_source_keys', None):
+            raise RuntimeError('snapshot source must be configured before prefetch')
         # v20 fix #1: re-check memory + pre-evict before the read.
         # schedule_prefetch's check may be stale if the queue was deep,
         # and the cache's dynamic budget only kicks in at put() time —
@@ -828,6 +853,8 @@ class StreamingContext:
         loader so a broken schedule cannot silently turn a GPU-bound campaign
         into serialized NVMe I/O.
         """
+        if getattr(self, 'source_snapshot_only', False) and not getattr(self, '_snapshot_source_keys', None):
+            raise RuntimeError('snapshot source must be configured before reading')
         cached = self.layer_cache.get(L)
         if cached is not None:
             self._claim_inflight(L)
@@ -873,7 +900,9 @@ class StreamingContext:
         return tensors, "cold"
 
     def install(self, L: int, *, require_prefetched: bool = False,
-                prefetch_following: bool = True):
+                prefetch_following: bool = True, snapshot: bool = False):
+        if getattr(self, 'source_snapshot_only', False) and (not snapshot or prefetch_following):
+            raise RuntimeError('snapshot-only source cannot install a forward layer')
         tensors, src = self.ensure_loaded(
             L, require_prefetched=require_prefetched,
         )
@@ -898,6 +927,8 @@ class StreamingContext:
 
     def begin_source_initialization_audit(self):
         """Require actual source-state coverage for this complete traversal."""
+        if getattr(self, 'source_snapshot_only', False):
+            raise RuntimeError('snapshot-only source cannot attest full initialization')
         self._source_initialization_audit = _StreamingInitializationAudit(self)
 
     def source_initialization_contract(self):
@@ -1414,6 +1445,7 @@ def _build_streaming_context(model_path: str, *,
                              visual_requires_grad: bool = False,
                              attn_implementation: str | None = None,
                              source_authentication=None,
+                             source_snapshot_only: bool = False,
                              ) -> StreamingContext:
     """One-time setup: AutoConfig + empty skeleton, then manually
     materialize only the always-resident head pieces. Decoder layers
@@ -1438,7 +1470,15 @@ def _build_streaming_context(model_path: str, *,
     top-level config the auto class cannot resolve at all — a
     vision-language *wrapper* config — falls back to
     `_resolve_text_only_skeleton` instead of raising. No visual tower is
-    materialized on this path either way."""
+    materialized on this path either way.
+
+    ``source_snapshot_only`` requires authenticated source ownership. It keeps
+    all nonbody state on meta and allows only a one-shot selected snapshot;
+    forward installation and initialization attestation fail closed."""
+    if type(source_snapshot_only) is not bool:
+        raise TypeError('source_snapshot_only must be a bool')
+    if source_snapshot_only and source_authentication is None:
+        raise RuntimeError('snapshot-only source requires authenticated source ownership')
     if max_cache_slots is not None:
         if (
             isinstance(max_cache_slots, bool)
@@ -1521,78 +1561,81 @@ def _build_streaming_context(model_path: str, *,
     # instead of true weights (range ±0.2).
     fp8_scale_inv_map = _build_fp8_scale_inv_map(
         model_path, multimodal=multimodal, **authenticated)
+    if source_snapshot_only and (fp8_scale_inv_map or declared_fp4_expert_dtype(model_path)):
+        raise RuntimeError('selected tensor snapshots require unscaled floating source weights')
     if fp8_scale_inv_map:
         print(f"{log_prefix} fp8 scale_inv map: {len(fp8_scale_inv_map)} "
               f"weights will be dequanted inline at layer-load",
               flush=True)
 
-    head_pfxs = _head_prefixes(model, base_prefix)
-    loaded_head = _materialize(
-        model,
-        head_pfxs,
-        weight_shard,
-        weight_ckpt,
-        device,
-        dtype,
-        fp8_scale_inv_map=fp8_scale_inv_map,
-        **authenticated,
-    )
-    # Weight tying: a `tie_word_embeddings` checkpoint ships no
-    # `lm_head.weight`, so `_materialize` above has nothing to install and
-    # the head stays on meta — the first `model.lm_head(...)` (probe
-    # Phase-2 CE) or `m.weight.to(device)` (cost stage) then dies with
-    # "Cannot copy out of meta tensor". Resolve the alias through
-    # transformers' own embedding accessors (no name hardcoded: the VL
-    # wrapper's `model.language_model.embed_tokens` resolves like the
-    # plain `model.embed_tokens`).
-    resolve_tied_output_embedding(model, log_prefix=log_prefix)
-    _init_rotary_inplace(base_model, device, dtype)
-    print(f"{log_prefix} head materialized ({loaded_head} tensors, "
-          f"rotary re-init) in {time.time()-t0:.1f}s", flush=True)
+    if not source_snapshot_only:
+        head_pfxs = _head_prefixes(model, base_prefix)
+        loaded_head = _materialize(
+            model,
+            head_pfxs,
+            weight_shard,
+            weight_ckpt,
+            device,
+            dtype,
+            fp8_scale_inv_map=fp8_scale_inv_map,
+            **authenticated,
+        )
+        # Weight tying: a `tie_word_embeddings` checkpoint ships no
+        # `lm_head.weight`, so `_materialize` above has nothing to install and
+        # the head stays on meta — the first `model.lm_head(...)` (probe
+        # Phase-2 CE) or `m.weight.to(device)` (cost stage) then dies with
+        # "Cannot copy out of meta tensor". Resolve the alias through
+        # transformers' own embedding accessors (no name hardcoded: the VL
+        # wrapper's `model.language_model.embed_tokens` resolves like the
+        # plain `model.embed_tokens`).
+        resolve_tied_output_embedding(model, log_prefix=log_prefix)
+        _init_rotary_inplace(base_model, device, dtype)
+        print(f"{log_prefix} head materialized ({loaded_head} tensors, "
+              f"rotary re-init) in {time.time()-t0:.1f}s", flush=True)
 
-    # Constructor-derived NON-PERSISTENT head buffers (e.g. gemma4_unified's
-    # `embed_scale = sqrt(hidden)`) are absent from the checkpoint, so
-    # `_materialize` never assigns them and they stay on `meta` — and
-    # PrismaQuant suppresses skeleton `_initialize_weights` (prismaquant/__init__),
-    # so the modeling's `_init_weights` that would set them never runs. The
-    # first forward op (`embed_tokens(ids)` multiplies by `embed_scale`) then
-    # faults "Tensor on device meta". Re-create such buffers on `device` from
-    # the owning module's retained python scalar (`scalar_<attr>`). Generic
-    # (any arch following this pattern); scoped to non-`layers` modules since
-    # streaming decoder buffers load per shard. Persistent buffers (e.g.
-    # `layer_scalar`) come from the checkpoint and are untouched.
-    _meta_fixed = 0
-    for _bname, _buf in list(base_model.named_buffers(recurse=True)):
-        if _buf is None or not _buf.is_meta or _bname.split(".", 1)[0] == "layers":
-            continue
-        _mod_name, _, _attr = _bname.rpartition(".")
-        _owner = base_model.get_submodule(_mod_name) if _mod_name else base_model
-        if _attr not in getattr(_owner, "_non_persistent_buffers_set", set()):
-            continue  # persistent buffers are loaded from the checkpoint
-        _scalar = getattr(_owner, "scalar_" + _attr, None)
-        if _scalar is None:
-            continue
-        _owner.register_buffer(
-            _attr, torch.tensor(_scalar, device=device, dtype=_buf.dtype),
-            persistent=False)
-        _meta_fixed += 1
-    _stuck = [n for n, b in base_model.named_buffers(recurse=True)
-              if b is not None and b.is_meta and n.split(".", 1)[0] != "layers"]
-    if _stuck:
-        raise RuntimeError(
-            f"{log_prefix} head buffers left on meta after materialization "
-            f"(no scalar_ init source): {_stuck[:8]} — extend the "
-            f"non-persistent-buffer sweep in _build_streaming_context")
-    if _meta_fixed:
-        print(f"{log_prefix} materialized {_meta_fixed} non-persistent head "
-              f"buffer(s) off meta (e.g. embed_scale)", flush=True)
+        # Constructor-derived NON-PERSISTENT head buffers (e.g. gemma4_unified's
+        # `embed_scale = sqrt(hidden)`) are absent from the checkpoint, so
+        # `_materialize` never assigns them and they stay on `meta` — and
+        # PrismaQuant suppresses skeleton `_initialize_weights` (prismaquant/__init__),
+        # so the modeling's `_init_weights` that would set them never runs. The
+        # first forward op (`embed_tokens(ids)` multiplies by `embed_scale`) then
+        # faults "Tensor on device meta". Re-create such buffers on `device` from
+        # the owning module's retained python scalar (`scalar_<attr>`). Generic
+        # (any arch following this pattern); scoped to non-`layers` modules since
+        # streaming decoder buffers load per shard. Persistent buffers (e.g.
+        # `layer_scalar`) come from the checkpoint and are untouched.
+        _meta_fixed = 0
+        for _bname, _buf in list(base_model.named_buffers(recurse=True)):
+            if _buf is None or not _buf.is_meta or _bname.split(".", 1)[0] == "layers":
+                continue
+            _mod_name, _, _attr = _bname.rpartition(".")
+            _owner = base_model.get_submodule(_mod_name) if _mod_name else base_model
+            if _attr not in getattr(_owner, "_non_persistent_buffers_set", set()):
+                continue  # persistent buffers are loaded from the checkpoint
+            _scalar = getattr(_owner, "scalar_" + _attr, None)
+            if _scalar is None:
+                continue
+            _owner.register_buffer(
+                _attr, torch.tensor(_scalar, device=device, dtype=_buf.dtype),
+                persistent=False)
+            _meta_fixed += 1
+        _stuck = [n for n, b in base_model.named_buffers(recurse=True)
+                  if b is not None and b.is_meta and n.split(".", 1)[0] != "layers"]
+        if _stuck:
+            raise RuntimeError(
+                f"{log_prefix} head buffers left on meta after materialization "
+                f"(no scalar_ init source): {_stuck[:8]} — extend the "
+                f"non-persistent-buffer sweep in _build_streaming_context")
+        if _meta_fixed:
+            print(f"{log_prefix} materialized {_meta_fixed} non-persistent head "
+                  f"buffer(s) off meta (e.g. embed_scale)", flush=True)
 
     # Locate the visual module on the meta skeleton. When multimodal is
     # set, fully materialize the visual tower onto `device`; body
     # layers remain meta and stream per shard.
     visual_module = None
     visual_prefix: str | None = None
-    if multimodal:
+    if multimodal and not source_snapshot_only:
         visual_module, visual_prefix = _find_visual_module(model)
         if visual_module is not None and visual_prefix:
             remove_hook_from_module(visual_module, recurse=True)
@@ -1741,5 +1784,7 @@ def _build_streaming_context(model_path: str, *,
         prefetch_min_available_bytes=min_available_bytes,
         expert_packer=_build_expert_packer(model, weight_ckpt),
         concat_merger=concat_merger,
+        source_snapshot_only=source_snapshot_only,
+        source_fp4_experts=declared_fp4_expert_dtype(model_path),
         **authenticated,
     )

--- a/prismaquant/streaming_model.py
+++ b/prismaquant/streaming_model.py
@@ -631,20 +631,25 @@ class StreamingContext:
         from .layer_streaming import selected_weight_source_keys
         if not getattr(self, 'source_snapshot_only', False):
             raise RuntimeError('selected snapshot requires a source-only context')
-        if getattr(self, '_snapshot_source_keys', None) is not None or self._inflight:
-            raise RuntimeError('selected snapshot source is already configured or active')
-        keys = selected_weight_source_keys(names, profile, self.weight_ckpt)
-        # No prefetch or full-layer install is permitted before this transition.
-        self.weight_shard = {key: self.weight_shard[key] for key in keys}
-        self.weight_ckpt = {key: self.weight_ckpt[key] for key in keys}
-        self.estimated_layer_bytes, self._snapshot_layer_bytes = _estimate_layer_cache_bytes(
-            weight_shard=self.weight_shard, weight_ckpt=self.weight_ckpt,
-            layers_prefix=self.layers_prefix, num_layers=self.num_layers,
-            target_dtype=self.dtype, tensor_dtypes=self.buffer_dtypes,
-            fp4_experts=self.source_fp4_experts,
-            **({'source_authentication': self.source_authentication}
-               if self.source_authentication is not None else {}))
-        self._snapshot_source_keys = keys
+        with self._inflight_lock:
+            if getattr(self, '_snapshot_source_keys', None) is not None or self._inflight:
+                raise RuntimeError('selected snapshot source is already configured or active')
+            keys = selected_weight_source_keys(names, profile, self.weight_ckpt)
+            # Build the complete transition before committing any source state.
+            # Header/authentication failure leaves the original maps reusable.
+            shards = {key: self.weight_shard[key] for key in keys}
+            checkpoint_keys = {key: self.weight_ckpt[key] for key in keys}
+            estimated, layer_bytes = _estimate_layer_cache_bytes(
+                weight_shard=shards, weight_ckpt=checkpoint_keys,
+                layers_prefix=self.layers_prefix, num_layers=self.num_layers,
+                target_dtype=self.dtype, tensor_dtypes=self.buffer_dtypes,
+                fp4_experts=self.source_fp4_experts,
+                **({'source_authentication': self.source_authentication}
+                   if self.source_authentication is not None else {}))
+            self.weight_shard, self.weight_ckpt = shards, checkpoint_keys
+            self.estimated_layer_bytes = estimated
+            self._snapshot_layer_bytes = layer_bytes
+            self._snapshot_source_keys = keys
 
     def configure_runtime_pressure_floor(self) -> int:
         floor = self.memory_pressure_floor_bytes()
@@ -750,6 +755,10 @@ class StreamingContext:
         return released
 
     def schedule_prefetch(self, L: int):
+        if getattr(self, 'source_snapshot_only', False):
+            with self._inflight_lock:
+                if not getattr(self, '_snapshot_source_keys', None):
+                    raise RuntimeError('snapshot source must be configured before prefetch')
         # A one-slot policy is used by the DSv4 anchored-AURA campaign on a
         # unified-memory Spark.  Speculative loading while the current layer
         # is installed would create a second live source-weight plane even if

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -2026,7 +2026,8 @@ class _AnchorPublicationLedger:
 
 
 def _adopt_seed_checkpoint(manifest_path, wire_dir_arg, *, targets, wire_dir,
-                           adopt, admits, identity_sha256, validate_state=None) -> dict:
+                           adopt, admits, identity_sha256, expected_identity,
+                           validate_state=None) -> dict:
     """Offer another campaign's stored anchors to this run's row gates.
 
     A whole-scope campaign already priced rows this run would price again.  Its
@@ -2040,13 +2041,16 @@ def _adopt_seed_checkpoint(manifest_path, wire_dir_arg, *, targets, wire_dir,
     ``verify_cached_unit`` re-reads the blob and re-validates the wire against
     it.  A row that does not describe this run's bytes is refused by name.
 
-    What is inherited and not re-derived is the stored ``dloss`` -- the same
-    thing a resume of this run's own checkpoint inherits, for the same reason.
+    Stored ``dloss`` is inherited only after the seed's calibration, currency,
+    static-scale policy and actual per-unit scoring tensors match this run.
+    Producer input identity binds encoded bytes; it does not bind the X rows
+    used to measure decoded-weight error. The manifest and unit envelope are
+    authenticated through the existing checkpoint digest and loader.
 
     Returns the record stamped into provenance: which manifest, which identity
     it was written under, and which units were adopted.
     """
-    from .cost_stage_checkpoint import unit_path
+    from .cost_stage_checkpoint import unit_path, _load_unit, canonical_json_sha256
 
     manifest = Path(manifest_path)
     parts = manifest.with_name(manifest.name + ".parts")
@@ -2056,35 +2060,32 @@ def _adopt_seed_checkpoint(manifest_path, wire_dir_arg, *, targets, wire_dir,
     seed_wire = (Path(wire_dir_arg) if wire_dir_arg
                  else manifest.parent / "cache" / "wire")
     try:
-        seed_identity = json.loads(manifest.read_text()).get("identity_sha256")
+        seed_manifest = json.loads(manifest.read_text())
+        seed_identity = seed_manifest.get("identity_sha256")
+        seed_inputs = seed_manifest.get("identity")
+        if (not isinstance(seed_inputs, dict) or
+                canonical_json_sha256(seed_inputs, where='seed checkpoint identity') != seed_identity):
+            raise ValueError('seed checkpoint identity digest differs')
     except Exception as exc:
         raise RuntimeError(
             f"--seed-checkpoint {manifest}: unreadable manifest: {exc}") from exc
+    for field in ('currency', 'calibration', 'input_global_scale_policy'):
+        if (field not in seed_inputs or field not in expected_identity or
+                seed_inputs[field] != expected_identity[field]):
+            raise RuntimeError(f'seed checkpoint scoring identity mismatch at {field}')
     adopted: list[str] = []
     for name in targets:
         path = unit_path(parts, name)
         if not path.is_file():
             continue
-        try:
-            with path.open("rb") as handle:
-                envelope = pickle.load(handle)
-        except Exception as exc:
-            raise RuntimeError(
-                f"--seed-checkpoint {manifest}: unit shard for {name} is "
-                f"unreadable: {exc}") from exc
-        if not isinstance(envelope, Mapping) or envelope.get("qname") != name:
-            raise RuntimeError(
-                f"--seed-checkpoint {manifest}: unit shard for {name} is not "
-                "an envelope for that unit")
-        payload = envelope.get("payload")
-        import hashlib
-
-        if not isinstance(payload, bytes) or envelope.get("payload_sha256") != \
-                hashlib.sha256(payload).hexdigest():
-            raise RuntimeError(
-                f"--seed-checkpoint {manifest}: unit shard for {name} fails its "
-                "own payload digest")
-        state = pickle.loads(payload)
+        seed_unit = seed_inputs.get('units', {}).get(name, {})
+        current_unit = expected_identity.get('units', {}).get(name, {})
+        for field in ('scoring_rows', 'input_global_scale'):
+            if (field not in seed_unit or field not in current_unit or
+                    seed_unit[field] != current_unit[field]):
+                raise RuntimeError(f'seed checkpoint scoring identity mismatch at units.{name}.{field}')
+        state = _load_unit(path, stage='Tessera campaign', qname=name,
+                           identity_sha256=seed_identity)
         if validate_state is not None:
             validate_state(name, state)
         # Only the rows this run's menu admits get their bytes linked in.  An
@@ -4884,7 +4885,7 @@ def _main(argv, *, source_scope) -> int:
             wire_dir=wire_dir, adopt=adopt_state,
             admits=lambda name, fmt: any(
                 entry.format_name == fmt for entry in menus.get(name, ())),
-            identity_sha256=identity_sha256,
+            identity_sha256=identity_sha256, expected_identity=checkpoint_identity,
             validate_state=validate_seed_scope if args.family_restriction is not None else None)
         for name in seed_provenance["units"]:
             dirty_checkpoint_units.add(name)

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -1599,7 +1599,7 @@ def _campaign_checkpoint_identity(*, weights, acts, hessians, menus, args,
                  "units", "calibration_census", "census_out",
                  "capture_calibration_out", "calibration_cache", "calibration_cache_sha256",
                  "seed_checkpoint", "seed_wire_dir", "anchor_batch_size",
-                 "publication_overlap_bytes"):
+                 "publication_overlap_bytes", "source_snapshot_policy"):
         settings.pop(name, None)
     return {
         **({"family_restriction": {"policy": restriction,
@@ -4196,6 +4196,9 @@ def _main(argv, *, source_scope) -> int:
     ap.add_argument("--streaming", action="store_true",
                     help="Use the source layer cache for census/capture or selected anchors from a complete capture.")
     ap.add_argument("--streaming-cache-slots", type=int, default=2)
+    ap.add_argument("--source-snapshot-policy", default="whole-layer-v1",
+                    choices=("whole-layer-v1", "selected-tensors-v1"),
+                    help="selected-tensors-v1 loads authenticated weight dependencies only; requires selected streaming capture reuse")
     ap.add_argument("--streaming-prefetch-workers", type=int, default=1)
     ap.add_argument("--streaming-cache-headroom-gb", type=float, default=24)
     ap.add_argument("--streaming-capture-policy", default="legacy",
@@ -4222,6 +4225,8 @@ def _main(argv, *, source_scope) -> int:
     selected_source = bool(args.streaming and args.units and args.calibration_cache
                            and args.calibration_cache_sha256
                            and not (args.census_out or args.capture_calibration_out))
+    if args.source_snapshot_policy != 'whole-layer-v1' and not selected_source:
+        ap.error('--source-snapshot-policy requires selected streaming capture reuse')
     if args.capture_load_policy is not None and not (selected_source or (
             args.streaming and args.capture_calibration_out and
             args.streaming_capture_policy == 'shared-inputs-bounded-v1')):
@@ -4317,6 +4322,8 @@ def _main(argv, *, source_scope) -> int:
             prefetch_min_available_gb=args.streaming_cache_headroom_gb,
             prefetch_lookahead=args.streaming_cache_slots-1, require_prefetched_residency=True,
             attn_implementation=args.attention_implementation,
+            **({'source_snapshot_only': True}
+               if args.source_snapshot_policy == 'selected-tensors-v1' else {}),
             **({'source_authentication': source_authentication} if source_authentication is not None else {}))
         model = runner.model
     else:
@@ -4496,6 +4503,7 @@ def _main(argv, *, source_scope) -> int:
             headroom_gb=args.streaming_cache_headroom_gb,
             anchor_batch_size=args.anchor_batch_size,
             publication_overlap_bytes=args.publication_overlap_bytes,
+            source_snapshot_policy=args.source_snapshot_policy,
             **(dict(capture_load_policy=args.capture_load_policy)
                if args.capture_load_policy is not None else {}))
         if device == 'cuda':
@@ -4538,6 +4546,8 @@ def _main(argv, *, source_scope) -> int:
         try:
             selected_weights, selected_source_preparation = runner.snapshot_selected_weights(
                 targets, max_resident_bytes=selected_resources['selected_source_weight_bytes'],
+                **({'expected_source_keys': selected_resources['source_tensor_keys']}
+                   if args.source_snapshot_policy == 'selected-tensors-v1' else {}),
                 resource_check=None if selected_guard is None else selected_guard.check)
         finally:
             runner.shutdown()

--- a/tests/test_selected_snapshot_scope.py
+++ b/tests/test_selected_snapshot_scope.py
@@ -53,7 +53,8 @@ def test_selected_snapshot_reads_only_requested_dense_weights(tmp_path, monkeypa
                              require_prefetched_residency=True)
     names = ["model.layers.0.gate", "model.layers.0.up"]
     try:
-        weights, receipt = runner.snapshot_selected_weights(names, max_resident_bytes=96)
+        weights, receipt = runner.snapshot_selected_weights(names, max_resident_bytes=96,
+            expected_source_keys=tuple(name+".weight" for name in names))
         assert read == [name + ".weight" for name in names]
         assert receipt["source_forward_count"] == 0
         assert all(torch.equal(weights[name], source[name + ".weight"]) for name in names)
@@ -140,6 +141,11 @@ def test_glm_snapshot_preserves_source_bytes_without_head_or_unrelated_reads(
         with pytest.raises(RuntimeError, match='resident byte budget'):
             runner.snapshot_selected_weights([name], max_resident_bytes=1)
         assert reads == []
+        with pytest.raises(RuntimeError, match='admitted source keys'):
+            runner.snapshot_selected_weights([name],
+                max_resident_bytes=selected['selected_source_weight_bytes'])
+        assert reads == []
+        assert getattr(runner.context, '_snapshot_source_keys', None) is None
         weights, receipt = runner.snapshot_selected_weights([name],
             max_resident_bytes=selected['selected_source_weight_bytes'], expected_source_keys=keys)
         assert sorted(reads) == keys
@@ -191,3 +197,35 @@ def test_resource_policy_rejects_unknown_snapshot_policy():
         selected_anchor_resources('/does-not-exist', unit_shapes={'layers.0.a': [2, 2]},
             counts={'layers.0.a': 1}, max_act_rows=1, cache_slots=2,
             prefetch_workers=1, headroom_gb=0, source_snapshot_policy='typo')
+
+
+def test_failed_snapshot_configuration_preserves_source_maps(monkeypatch):
+    import threading
+    from prismaquant import streaming_model as sm
+    context = object.__new__(sm.StreamingContext)
+    context.source_snapshot_only = True
+    context._inflight = {}
+    context._inflight_lock = threading.Lock()
+    context.weight_shard = {'layers.0.a.weight': 'first', 'layers.0.b.weight': 'second'}
+    context.weight_ckpt = {key: key for key in context.weight_shard}
+    before = context.weight_shard.copy(), context.weight_ckpt.copy()
+    context.layers_prefix, context.num_layers = 'layers.', 1
+    context.dtype, context.buffer_dtypes = torch.float32, {}
+    context.source_fp4_experts, context.source_authentication = False, None
+    context.estimated_layer_bytes = 99
+    def fail_estimate(**kwargs):
+        raise OSError('unreadable source header')
+    monkeypatch.setattr(sm, '_estimate_layer_cache_bytes', fail_estimate)
+    profile = SimpleNamespace(per_expert_moe_regex=lambda: None, concat_merge_groups=lambda: ())
+    with pytest.raises(OSError, match='unreadable source header'):
+        context.configure_selected_snapshot(['layers.0.a'], profile)
+    assert (context.weight_shard, context.weight_ckpt) == before
+    assert context.estimated_layer_bytes == 99
+    assert getattr(context, '_snapshot_source_keys', None) is None
+    def estimate(**kwargs):
+        assert context._inflight_lock.locked()
+        return 4, {0: 4}
+    monkeypatch.setattr(sm, '_estimate_layer_cache_bytes', estimate)
+    context.configure_selected_snapshot(['layers.0.a'], profile)
+    assert context._snapshot_source_keys == ('layers.0.a.weight',)
+    assert context.estimated_layer_bytes == 4

--- a/tests/test_selected_snapshot_scope.py
+++ b/tests/test_selected_snapshot_scope.py
@@ -69,3 +69,125 @@ def test_snapshot_context_rejects_forward_install_before_reading(tmp_path):
     context.ensure_loaded = lambda *_a, **_k: pytest.fail("read source for a forbidden forward")
     with pytest.raises(RuntimeError, match="snapshot"):
         context.install(0)
+
+
+from test_glm_campaign_streaming import glm_checkpoint
+
+
+@pytest.mark.parametrize('selection', ['dense', 'expert'])
+def test_glm_snapshot_preserves_source_bytes_without_head_or_unrelated_reads(
+    glm_checkpoint, tmp_path, monkeypatch, selection,
+):
+    import hashlib
+    from prismaquant import autoscale, streaming_model as sm
+    from prismaquant.cost_streaming import build_streamed_causal_lm
+    from prismaquant.model_profiles.glm5_next import Glm5NextProfile
+    from prismaquant.routed_experts import profile_declared_packed_expert_projections
+    from prismaquant.tessera_calibration_cache import CaptureSourceAuthentication
+
+    reference, source = glm_checkpoint
+    profile = Glm5NextProfile()
+    if selection == 'expert':
+        member = next(m for m in profile_declared_packed_expert_projections(reference, profile)
+                      if m.qname.endswith('.gate_proj'))
+        name, expected = member.qname, member.weight.detach()
+    else:
+        name, module = next((n, m) for n, m in reference.named_modules()
+                            if isinstance(m, torch.nn.Linear) and '.shared_experts.gate_proj' in n)
+        expected = module.weight.detach()
+    shape = list(expected.shape)
+    options = dict(unit_shapes={name: shape}, counts={name: 2}, max_act_rows=2,
+                   cache_slots=2, prefetch_workers=1, headroom_gb=0)
+    whole = autoscale.selected_anchor_resources(source, **options)
+    selected = autoscale.selected_anchor_resources(source, **options,
+        source_snapshot_policy='selected-tensors-v1')
+    assert selected['source_header_sha256'] == whole['source_header_sha256']
+    before, after = (plan['phases']['source_preparation'] for plan in (whole, selected))
+    assert before['nonbody_source_bytes'] > after['nonbody_source_bytes'] == 0
+    assert after['source_window_bytes'] < before['source_window_bytes']
+    assert selected['phases']['resident_anchors']['source_validation_bytes'] == (
+        whole['phases']['resident_anchors']['source_validation_bytes'])
+    keys = selected['source_tensor_keys']
+    if selection == 'dense':
+        assert keys == [name+'.weight']
+        assert after['loader_transient_bytes'] == 0
+    else:
+        # A single projected gate owns the full gate/up parent, across experts.
+        expert_count = member.module.gate_up_proj.shape[0]
+        assert len(keys) == expert_count*2
+        assert all(k.endswith(('.gate_proj.weight', '.up_proj.weight')) for k in keys)
+        assert after['loader_transient_bytes'] > 0
+    digests = {path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+               for path in source.iterdir() if path.is_file()}
+    auth = CaptureSourceAuthentication(source,
+        dict(source_files=digests, census_sha256='a'*64), {}, manifest_sha256='b'*64)
+    reads = []
+    original = sm._read_layer_to_device
+    def observe(prefix, shards, *args, **kwargs):
+        reads.extend(key for key in shards if key.startswith(prefix))
+        return original(prefix, shards, *args, **kwargs)
+    monkeypatch.setattr(sm, '_read_layer_to_device', observe)
+    monkeypatch.setattr(sm, '_materialize', lambda *_a, **_k: pytest.fail('materialized nonbody source'))
+    runner = build_streamed_causal_lm(str(source), device=torch.device('cpu'),
+        dtype=torch.bfloat16, offload_folder=str(tmp_path/'offload'), profile=profile,
+        max_cache_slots=2, prefetch_workers=1, prefetch_min_available_gb=0,
+        cache_headroom_gb=0, prefetch_lookahead=1, require_prefetched_residency=True,
+        attn_implementation='eager', source_authentication=auth, source_snapshot_only=True)
+    try:
+        assert all(p.is_meta for p in runner.model.parameters())
+        with pytest.raises(RuntimeError, match='snapshot'):
+            runner.context.ensure_loaded(0)
+        with pytest.raises(RuntimeError, match='resident byte budget'):
+            runner.snapshot_selected_weights([name], max_resident_bytes=1)
+        assert reads == []
+        weights, receipt = runner.snapshot_selected_weights([name],
+            max_resident_bytes=selected['selected_source_weight_bytes'], expected_source_keys=keys)
+        assert sorted(reads) == keys
+        assert torch.equal(weights[name], expected.to(torch.bfloat16))
+        assert receipt['nonbody_materialized'] is False
+        assert all(p.is_meta for p in runner.model.parameters())
+        with pytest.raises(RuntimeError, match='snapshot'):
+            runner._prepare(torch.ones((1, 1), dtype=torch.long))
+        with pytest.raises(RuntimeError, match='snapshot'):
+            runner.context.begin_source_initialization_audit()
+    finally:
+        runner.shutdown()
+        auth.close()
+
+
+def test_dependency_closure_refuses_missing_and_ambiguous_concat():
+    from prismaquant.layer_streaming import selected_weight_source_keys
+    profile = SimpleNamespace(per_expert_moe_regex=lambda: None,
+        concat_merge_groups=lambda: (('conv.weight', ('q.weight', 'k.weight', 'v.weight'), 0),))
+    names = ['model.layers.0.conv']
+    keys = [f'model.layers.0.{label}.weight' for label in ('q', 'k', 'v')]
+    assert selected_weight_source_keys(names, profile, keys) == tuple(sorted(keys))
+    with pytest.raises(RuntimeError, match='incomplete concat'):
+        selected_weight_source_keys(names, profile, keys[:-1])
+    with pytest.raises(RuntimeError, match='ambiguous'):
+        selected_weight_source_keys(names, profile, keys+[names[0]+'.weight'])
+    with pytest.raises(RuntimeError, match='no checkpoint dependency'):
+        selected_weight_source_keys(['model.layers.0.missing'], profile, keys)
+
+
+def test_snapshot_builder_requires_authentication_before_source_io():
+    from prismaquant.streaming_model import _build_streaming_context
+    with pytest.raises(RuntimeError, match='authenticated'):
+        _build_streaming_context('/does-not-exist', device=torch.device('cpu'),
+            dtype=torch.bfloat16, offload_folder='/unused', source_snapshot_only=True)
+
+
+def test_native_packed_checkpoint_dependency_uses_the_complete_parent():
+    from prismaquant.layer_streaming import selected_weight_source_keys
+    from prismaquant.model_profiles.glm5_next import Glm5NextProfile
+    prefix = 'model.language_model.layers.4.mlp.experts.'
+    assert selected_weight_source_keys([prefix+'7.gate_proj'], Glm5NextProfile(),
+        [prefix+'gate_up_proj', prefix+'down_proj']) == (prefix+'gate_up_proj',)
+
+
+def test_resource_policy_rejects_unknown_snapshot_policy():
+    from prismaquant.autoscale import selected_anchor_resources
+    with pytest.raises(ValueError, match='snapshot policy'):
+        selected_anchor_resources('/does-not-exist', unit_shapes={'layers.0.a': [2, 2]},
+            counts={'layers.0.a': 1}, max_act_rows=1, cache_slots=2,
+            prefetch_workers=1, headroom_gb=0, source_snapshot_policy='typo')

--- a/tests/test_selected_snapshot_scope.py
+++ b/tests/test_selected_snapshot_scope.py
@@ -1,0 +1,71 @@
+"""A selected snapshot uses the shared prefetch cache without unrelated weights."""
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+
+def test_selected_snapshot_reads_only_requested_dense_weights(tmp_path, monkeypatch):
+    from prismaquant import layer_streaming as ls, streaming_model as sm
+    from prismaquant.cost_streaming import StreamedCausalLM
+
+    model = torch.nn.Module()
+    model.model = torch.nn.Module()
+    model.model.layers = torch.nn.ModuleList([torch.nn.Module()])
+    layer = model.model.layers[0]
+    for name in ("gate", "up", "unrelated"):
+        setattr(layer, name, torch.nn.Linear(4, 3, bias=False, device="meta"))
+    source = {f"model.layers.0.{name}.weight": torch.full((3, 4), float(i))
+              for i, name in enumerate(("gate", "up", "unrelated"), 1)}
+    path = tmp_path / "weights.safetensors"
+    save_file(source, path)
+    shards = {name: str(path) for name in source}
+    keys = {name: name for name in source}
+    read = []
+    original = sm._read_layer_to_device
+
+    def observe(prefix, shard_map, *args, **kwargs):
+        read.extend(name for name in shard_map if name.startswith(prefix))
+        return original(prefix, shard_map, *args, **kwargs)
+
+    monkeypatch.setattr(sm, "_read_layer_to_device", observe)
+    profile = SimpleNamespace(per_expert_moe_regex=lambda: None,
+                              concat_merge_groups=lambda: ())
+    from prismaquant import routed_experts
+    monkeypatch.setattr(routed_experts, "profile_declared_packed_expert_projections", lambda *_: [])
+    monkeypatch.setattr(routed_experts, "refresh_packed_expert_projections", lambda *_: [])
+    pool = ThreadPoolExecutor(max_workers=1)
+    context = sm.StreamingContext(
+        model=model, base_model=model.model, layers=model.model.layers,
+        layers_prefix="model.layers.", num_layers=1,
+        install_resolvers=[ls._build_install_resolver(model, "model.layers.0")],
+        weight_shard=shards, weight_ckpt=keys,
+        layer_cache=sm.LayerCache(max_bytes=1024**2, max_entries=2),
+        prefetch_pool=pool, device=torch.device("cpu"), dtype=torch.float32,
+        offload_folder=str(tmp_path / "offload"), estimated_layer_bytes=144,
+    )
+    # Before the implementation this source-only intent is ignored and the
+    # existing snapshot reads the unrelated tensor along with the requested two.
+    context.source_snapshot_only = True
+    runner = StreamedCausalLM(context, profile, prefetch_lookahead=1,
+                             require_prefetched_residency=True)
+    names = ["model.layers.0.gate", "model.layers.0.up"]
+    try:
+        weights, receipt = runner.snapshot_selected_weights(names, max_resident_bytes=96)
+        assert read == [name + ".weight" for name in names]
+        assert receipt["source_forward_count"] == 0
+        assert all(torch.equal(weights[name], source[name + ".weight"]) for name in names)
+        assert all(p.is_meta for p in model.parameters())
+    finally:
+        runner.shutdown()
+
+
+def test_snapshot_context_rejects_forward_install_before_reading(tmp_path):
+    from prismaquant.streaming_model import StreamingContext
+    context = object.__new__(StreamingContext)
+    context.source_snapshot_only = True
+    context.ensure_loaded = lambda *_a, **_k: pytest.fail("read source for a forbidden forward")
+    with pytest.raises(RuntimeError, match="snapshot"):
+        context.install(0)

--- a/tests/test_tessera_campaign_family_restriction.py
+++ b/tests/test_tessera_campaign_family_restriction.py
@@ -123,19 +123,24 @@ def test_seed_scope_refuses_before_linking_any_wire_from_the_unit(tmp_path):
     seed = tmp_path / "seed"
     (seed / "cache/wire").mkdir(parents=True)
     (seed / "cache/wire/anchor.wire").write_bytes(b"historical wire")
+    from prismaquant.cost_stage_checkpoint import canonical_json_sha256
+    seed_inputs = {'currency': 'output_mse', 'calibration': {},
+        'input_global_scale_policy': 'fixture',
+        'units': {'expert': {'scoring_rows': {'sha256': 'rows'}, 'input_global_scale': 1.0}}}
+    seed_sha = canonical_json_sha256(seed_inputs, where='seed fixture')
     parts = seed / "cost.anchors.json.parts"
     parts.mkdir()
-    write_unit(parts, stage="Tessera campaign", qname="expert", identity_sha256="old",
+    write_unit(parts, stage="Tessera campaign", qname="expert", identity_sha256=seed_sha,
                state=_seed_state(family="TESSERA_BF16_K1"))
     manifest = seed / "cost.anchors.json"
-    manifest.write_text(json.dumps({"identity_sha256": "old"}))
+    manifest.write_text(json.dumps({"identity_sha256": seed_sha, "identity": seed_inputs}))
     output = tmp_path / "wire"
     output.mkdir()
     adopted = []
     with pytest.raises(RuntimeError, match="family restriction"):
         campaign._adopt_seed_checkpoint(manifest, None, targets=["expert"], wire_dir=output,
             adopt=lambda *args, **kw: adopted.append(args), admits=lambda *args: True,
-            identity_sha256="new", validate_state=lambda name, state:
+            identity_sha256="new", expected_identity=seed_inputs, validate_state=lambda name, state:
                 campaign.require_seed_family_scope(name, state, family_restriction=POLICY,
                     structure_by_unit={"expert": "routed_moe"}, rate_band=(832, 1088)))
     assert not adopted and list(output.iterdir()) == []

--- a/tests/test_tessera_campaign_fanout.py
+++ b/tests/test_tessera_campaign_fanout.py
@@ -474,6 +474,11 @@ def test_a_seed_links_only_the_wire_bytes_its_adopter_will_price(tmp_path):
     (seed / "cache" / "wire").mkdir(parents=True)
     for name in ("priced.wire", "evidence.wire"):
         (seed / "cache" / "wire" / name).write_bytes(b"x")
+    from prismaquant.cost_stage_checkpoint import canonical_json_sha256
+    seed_inputs = {'currency': 'output_mse', 'calibration': {},
+        'input_global_scale_policy': 'fixture',
+        'units': {'a': {'scoring_rows': {'sha256': 'rows'}, 'input_global_scale': 1.0}}}
+    seed_sha = canonical_json_sha256(seed_inputs, where='seed fixture')
     parts = seed / "cost.anchors.json.parts"
     parts.mkdir()
     state = {
@@ -485,8 +490,8 @@ def test_a_seed_links_only_the_wire_bytes_its_adopter_will_price(tmp_path):
                          "OFF": {"file": "evidence.wire"}},
     }
     write_unit(parts, stage="Tessera campaign", qname="a",
-               identity_sha256="seed-identity", state=state)
-    (seed / "cost.anchors.json").write_text(json.dumps({"identity_sha256": "seed"}))
+               identity_sha256=seed_sha, state=state)
+    (seed / "cost.anchors.json").write_text(json.dumps({"identity_sha256": seed_sha, "identity": seed_inputs}))
 
     wire_dir = tmp_path / "run-wire"
     wire_dir.mkdir()
@@ -495,7 +500,7 @@ def test_a_seed_links_only_the_wire_bytes_its_adopter_will_price(tmp_path):
         seed / "cost.anchors.json", None, targets=["a"], wire_dir=wire_dir,
         adopt=lambda name, state, where: seen.update({name: state}),
         admits=lambda name, fmt: fmt == "ON",
-        identity_sha256="run-identity")
+        identity_sha256="run-identity", expected_identity=seed_inputs)
 
     assert sorted(p.name for p in wire_dir.iterdir()) == ["priced.wire"]
     # The adopter still gets the whole state: deciding what to do with the

--- a/tests/test_tessera_campaign_resume.py
+++ b/tests/test_tessera_campaign_resume.py
@@ -298,19 +298,27 @@ def test_main_refuses_missing_or_changed_priced_wire(monkeypatch, tmp_path, dama
     assert checkpoint.read_bytes() == original_manifest
 
 
-def test_seed_refuses_changed_scoring_rows_before_linking_wire(monkeypatch, tmp_path):
+@pytest.mark.parametrize('changed', [False, True])
+def test_seed_refuses_changed_scoring_rows_before_linking_wire(monkeypatch, tmp_path, changed):
     (campaign, checkpoint, argv, _model, inputs), _payload = _fresh_priced_campaign(
         monkeypatch, tmp_path, hessian=True)
     original_manifest = checkpoint.read_bytes()
     _forbid_reencode(monkeypatch, campaign)
     # The encoder still sees identical W, H, draw and static scale. Only the
     # bounded rows used to score its decoded weight have changed.
-    inputs['rows'][0, 0] += 1
+    if changed:
+        inputs['rows'][0, 0] += 1
     new_cache = tmp_path/'new-cache'
     argv[argv.index('--checkpoint')+1] = str(tmp_path/'new.anchors.json')
     argv[argv.index('--cache-dir')+1] = str(new_cache)
     argv[argv.index('--out')+1] = str(tmp_path/'new-cost.pkl')
-    with pytest.raises(RuntimeError, match='seed.*scoring_rows'):
-        campaign.main([*argv, '--seed-checkpoint', str(checkpoint)])
+    if changed:
+        with pytest.raises(RuntimeError, match='seed.*scoring_rows'):
+            campaign.main([*argv, '--seed-checkpoint', str(checkpoint)])
+        assert list((new_cache/'wire').glob('*.tessera')) == []
+    else:
+        assert campaign.main([*argv, '--seed-checkpoint', str(checkpoint)]) == 0
+        with (tmp_path/'new-cost.pkl').open('rb') as handle:
+            assert pickle.load(handle)['costs'] == _payload['costs']
+        assert list((new_cache/'wire').glob('*.tessera'))
     assert checkpoint.read_bytes() == original_manifest
-    assert list((new_cache/'wire').glob('*.tessera')) == []

--- a/tests/test_tessera_campaign_resume.py
+++ b/tests/test_tessera_campaign_resume.py
@@ -296,3 +296,21 @@ def test_main_refuses_missing_or_changed_priced_wire(monkeypatch, tmp_path, dama
     with pytest.raises(RuntimeError, match="checkpoint cached wire"):
         campaign.main(argv)
     assert checkpoint.read_bytes() == original_manifest
+
+
+def test_seed_refuses_changed_scoring_rows_before_linking_wire(monkeypatch, tmp_path):
+    (campaign, checkpoint, argv, _model, inputs), _payload = _fresh_priced_campaign(
+        monkeypatch, tmp_path, hessian=True)
+    original_manifest = checkpoint.read_bytes()
+    _forbid_reencode(monkeypatch, campaign)
+    # The encoder still sees identical W, H, draw and static scale. Only the
+    # bounded rows used to score its decoded weight have changed.
+    inputs['rows'][0, 0] += 1
+    new_cache = tmp_path/'new-cache'
+    argv[argv.index('--checkpoint')+1] = str(tmp_path/'new.anchors.json')
+    argv[argv.index('--cache-dir')+1] = str(new_cache)
+    argv[argv.index('--out')+1] = str(tmp_path/'new-cost.pkl')
+    with pytest.raises(RuntimeError, match='seed.*scoring_rows'):
+        campaign.main([*argv, '--seed-checkpoint', str(checkpoint)])
+    assert checkpoint.read_bytes() == original_manifest
+    assert list((new_cache/'wire').glob('*.tessera')) == []

--- a/tests/test_tessera_campaign_seed_workspace.py
+++ b/tests/test_tessera_campaign_seed_workspace.py
@@ -1,0 +1,78 @@
+"""Workspace migration preserves the row ownership and ordinary seed gates."""
+import copy
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def fixture(tmp_path):
+    import tools.dispatch_tessera_campaign as d
+    root = tmp_path/'seed'
+    root.mkdir()
+    census = {'model': '/model', 'anchor_groups': {'a': ['a'], 'b': ['b']}, 'layer_stride': 1,
+              'unit_shapes': {'a': [8, 8], 'b': [8, 8]}}
+    (root/'census.json').write_text(json.dumps(census))
+    rows = []
+    for name in ('a', 'b'):
+        row = root/name
+        row.mkdir()
+        selection = {'schema': d.UNITS_SCHEMA, 'model': '/model', 'layer_stride': 1,
+                     'groups': [{'key': name, 'members': [name]}]}
+        (row/'units.json').write_text(json.dumps(selection))
+        rows.append({'row_id': name, 'groups': [name], 'dir': str(row), 'units': str(row/'units.json')})
+    # A partial checkpoint has a manifest and may have only some unit shards.
+    (root/'a/cost.anchors.json').write_text(json.dumps({'identity_sha256': 'a'*64}))
+    plan = {'schema': d.PLAN_SCHEMA, 'model': '/model', 'census': str(root/'census.json'),
+            'calibration_cache': None, 'rows': rows}
+    (root/'plan.json').write_text(json.dumps(plan))
+    return d, root, census, plan
+
+
+def test_plan_reuses_partial_seed_and_prices_unstarted_row(tmp_path, monkeypatch):
+    d, root, census, _ = fixture(tmp_path)
+    workspace = tmp_path/'new'
+    workspace.mkdir()
+    (workspace/'census.json').write_text(json.dumps(census))
+    spec = {'model': '/model', 'campaign_argv': [], 'cwd': '/repo',
+            'python': 'python', 'env': {}}
+    monkeypatch.setattr(d, 'load_spec', lambda _: spec)
+    monkeypatch.setattr(d, '_row_memory_gb', lambda *a, **k: 1)
+    monkeypatch.setattr(d, '_row', lambda spec, argv, **kw: {'argv': argv, 'demand': {'mem_gb': 1}})
+    args = SimpleNamespace(spec='unused', workspace=str(workspace), calibration_cache=None,
+        stack_sample=None, seed_checkpoint=None, seed_wire_dir=None, seed_workspace=str(root),
+        groups_per_row=1, rows_per_box=1, timeout_s=60, stack_sample_seed=0, audit_rate=10, probe=None)
+    assert d.cmd_plan(args) == 0
+    manifest = json.loads((workspace/'manifest.json').read_text())
+    assert manifest[0]['argv'][manifest[0]['argv'].index('--seed-checkpoint')+1] == str(root/'a/cost.anchors.json')
+    assert '--seed-checkpoint' not in manifest[1]['argv']
+    plan = json.loads((workspace/'plan.json').read_text())
+    assert plan['rows'][0]['seed']['identity_sha256'] == 'a'*64
+    assert len(plan['seed_workspace']['plan_sha256']) == 64
+    before = (workspace/'manifest.json').read_bytes()
+    args.groups_per_row = 2
+    with pytest.raises(RuntimeError, match='selection differs'):
+        d.cmd_plan(args)
+    assert (workspace/'manifest.json').read_bytes() == before
+
+
+@pytest.mark.parametrize('field', ['model', 'census', 'capture', 'duplicate'])
+def test_seed_workspace_refuses_incompatible_source(tmp_path, field):
+    d, root, census, plan = fixture(tmp_path)
+    if field == 'model': plan['model'] = '/other'
+    elif field == 'census': census = {**census, 'layer_stride': 2}
+    elif field == 'capture': plan['calibration_cache'] = {'path': '/other', 'sha256': 'b'*64}
+    else: plan['rows'].append(copy.deepcopy(plan['rows'][0]))
+    (root/'plan.json').write_text(json.dumps(plan))
+    with pytest.raises(RuntimeError, match='seed workspace'):
+        d._seed_workspace_rows(root, census=census, calibration_cache=None)
+
+
+def test_seed_selection_refuses_changed_sample(tmp_path):
+    d, root, census, _ = fixture(tmp_path)
+    rows, _ = d._seed_workspace_rows(root, census=census, calibration_cache=None)
+    selection = json.loads((root/'a/units.json').read_text())
+    selection['groups'][0]['sampled'] = []
+    with pytest.raises(RuntimeError, match='selection differs'):
+        d._seed_for_selection(rows, ['a'], selection)

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -557,6 +557,42 @@ UNITS_SCHEMA = "prismaquant.tessera_campaign_units.v1"
 UNITS_SCHEMA_V2 = "prismaquant.tessera_campaign_units.v2"
 
 
+def _seed_workspace_rows(path, *, census, calibration_cache):
+    """Bind a previous plan; each matching row keeps its own checkpoint owner."""
+    import hashlib
+    root = Path(path).resolve()
+    plan_path = root/'plan.json'
+    raw = plan_path.read_bytes()
+    plan = json.loads(raw)
+    if (plan.get('schema') != PLAN_SCHEMA or plan.get('model') != census['model'] or
+            json.loads(Path(plan['census']).read_text()) != census or
+            plan.get('calibration_cache') != calibration_cache):
+        raise RuntimeError('seed workspace model, census or capture differs')
+    rows = {}
+    for row in plan['rows']:
+        key = tuple(sorted(row['groups']))
+        if not key or key in rows:
+            raise RuntimeError('seed workspace has empty or duplicate group bundles')
+        rows[key] = row
+    return rows, {'path': str(root), 'plan_sha256': hashlib.sha256(raw).hexdigest()}
+
+
+def _seed_for_selection(rows, bundle, selection):
+    """Only unchanged group membership and sampling may inherit this journal."""
+    import hashlib
+    row = rows.get(tuple(sorted(bundle)))
+    if row is None or json.loads(Path(row['units']).read_text()) != selection:
+        raise RuntimeError('seed workspace selection differs; preserve group bundles and sampling')
+    checkpoint = Path(row['dir'])/'cost.anchors.json'
+    if not checkpoint.is_file():
+        return None
+    raw = checkpoint.read_bytes()
+    manifest = json.loads(raw)
+    return {'checkpoint': str(checkpoint), 'wire_dir': str(Path(row['dir'])/'cache/wire'),
+            'manifest_sha256_at_plan': hashlib.sha256(raw).hexdigest(),
+            'identity_sha256': manifest['identity_sha256'], 'row_id': row['row_id']}
+
+
 def cmd_plan(args) -> int:
     spec = load_spec(Path(args.spec))
     workspace = Path(args.workspace)
@@ -570,6 +606,12 @@ def cmd_plan(args) -> int:
     selected_source = '--streaming' in spec['campaign_argv']
     if selected_source and calibration_cache is None:
         raise RuntimeError('streaming anchor rows require a hash-bound complete calibration cache')
+    seed_rows, seed_workspace = None, None
+    if getattr(args, 'seed_workspace', None):
+        if args.seed_checkpoint or args.seed_wire_dir:
+            raise RuntimeError('seed workspace is exclusive with a global seed checkpoint/wire directory')
+        seed_rows, seed_workspace = _seed_workspace_rows(args.seed_workspace,
+            census=census, calibration_cache=calibration_cache)
     groups = census["anchor_groups"]
     if not groups:
         raise RuntimeError("census reports no anchor group to price")
@@ -632,6 +674,11 @@ def cmd_plan(args) -> int:
         if calibration_cache:
             argv += ["--calibration-cache", calibration_cache["path"],
                      "--calibration-cache-sha256", calibration_cache["sha256"]]
+        row_seed = (_seed_for_selection(seed_rows, bundle, selection)
+                    if seed_rows is not None else None)
+        if row_seed is not None:
+            argv += ['--seed-checkpoint', row_seed['checkpoint'],
+                     '--seed-wire-dir', row_seed['wire_dir']]
         if args.seed_checkpoint:
             argv += ["--seed-checkpoint", str(args.seed_checkpoint)]
             if args.seed_wire_dir:
@@ -641,6 +688,7 @@ def cmd_plan(args) -> int:
                          timeout_s=int(args.timeout_s)))
         planned.append({"row_id": row_id, "groups": bundle, "members": sorted(members),
                         "dir": str(row_dir), "units": str(units_path),
+                        **({'seed': row_seed} if row_seed is not None else {}),
                         **({'resources': _streamed_resource_plan(spec, census, members,
                             selected_source=True)} if selected_source else {})})
 
@@ -689,6 +737,7 @@ def cmd_plan(args) -> int:
         # at. A reader of the plan sees the whole layout; a reader of the
         # manifest sees only what was submitted.
         "inadmissible_rows": inadmissible,
+        **({'seed_workspace': seed_workspace} if seed_workspace is not None else {}),
         "seed_checkpoint": (None if not args.seed_checkpoint
                             else str(args.seed_checkpoint)),
         # The draw itself, whole: which experts stand for their stack, under
@@ -1420,7 +1469,11 @@ def main(argv=None) -> int:
                            "anchor and a leave-one-out check.")
     plan.add_argument("--probe", default=None,
                       help="a probe pickle carrying per-expert h_trace.")
-    plan.add_argument("--seed-checkpoint", default=None,
+    seeds = plan.add_mutually_exclusive_group()
+    seeds.add_argument('--seed-workspace', default=None,
+                       help='reuse matching rows from a prior plan through the ordinary seed gates; '
+                            'completed and partial checkpoints are supported')
+    seeds.add_argument("--seed-checkpoint", default=None,
                       help="a campaign checkpoint whose measured anchors every "
                            "row may adopt, subject to its own row gates")
     plan.add_argument("--seed-wire-dir", default=None)

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -240,6 +240,7 @@ def _streamed_resource_plan(spec, census, members, *, selected_source=False):
     if selected_source:
         return selected_anchor_resources(spec['model'], **options,
             anchor_batch_size=argument('--anchor-batch-size', 1),
+            source_snapshot_policy=argument('--source-snapshot-policy', 'whole-layer-v1', str),
             # The row's own campaign will hold this many host bytes of staged
             # artifacts, so the box that admits the row has to be told. A
             # dispatcher that planned without it would size a worker for a


### PR DESCRIPTION
Selected capture-reuse rows materialized unrelated head, vision and full-layer weights before copying selected Linears. Add opt-in `--source-snapshot-policy selected-tensors-v1` using a shared dependency closure for admission and the existing streaming reader/cache. Full source-file authentication and complete expert/concat parents remain required. Source-only contexts require planned keys and refuse forwards; configuration commits atomically.

A complete GLM shared-expert gate/up group in interleaved A/B/B/A runs fell from 265.02 to 236.40 seconds (10.80% less time) and 6757.74 to 6386.74 GPU joules (5.49% less energy). All 14 anchors, quality/bpp and wire bytes matched the prior production group exactly. Its reservation falls from 57 to 42 GiB. This result covers source preparation for that group; encoding headroom remains and routed-expert speedup is unmeasured.

Separate commits fix a seed-reuse defect reproduced during migration: a stored score could survive changed scoring activations. Seed adoption now validates the manifest digest, unit envelope and actual scoring input identity before linking wires. `plan --seed-workspace` reuses matching completed/partial row journals through those gates, requiring the same census, capture, group membership and sampling. At-plan digests are provenance; execution validates the then-current compatible seed.

Validation through PrismaBuild: source suite 215 passed/1 CUDA-only skip; focused snapshot tests and red/green guard regressions; seed suite 113 passed/2 missing-tool skips, then both skipped projection tests passed after supplying the pinned producer source; unchanged-input seed adoption passed; workspace reuse 6 passed; integrated planner/docs checks 58 passed; final compile passed. Counts overlap. Native action `782b0a7b31cce8a79a4e9d38a70b6fa523b4231001c71f874c764091b0480615` exited zero with complete cleanup; CAS payloads and actual source were verified. Both-host Netdata, main-thread stacks, child I/O and CUDA traces support the measurement. Independent review findings are addressed.

Evidence, limits, negative oversized-trace attempt and receipt paths: [measurement report](docs/experiments/glm_selected_source_snapshot_20260909.md). Runtime defaults, format menu, calibration and producer recipe remain as documented; the selected-source mode is opt-in. The GLM pricing restart uses the qualified mode with the original capture and 42 existing seed journals.

Closes #474.
