### PR TITLE
Record bounded server-cache warm-up and GLM loading-gap evidence

### DIFF
--- a/docs/experiments/glm_server_cache_and_idle_windows_20260909.md
+++ b/docs/experiments/glm_server_cache_and_idle_windows_20260909.md
@@ -1,0 +1,89 @@
+# GLM server cache and GPU gaps — 2026-09-09
+
+A bounded warm-up read 66.089 GiB of an existing queued group's source and
+calibration files through dl380g10's ZFS cache. A subsequent read of the same
+four source shards transferred 19.985 GiB to Sparklina in 5.801 s: **3.445 GiB/s**
+while normal pricing continued. Client NFS READ counters increased by
+21.470 GB, consistent with the 21.459 GB diagnostic plus concurrent traffic;
+this was not merely a client page-cache read. The four shards read locally on
+the server in 6.219 s. These are observed warm-data rates, not an isolated
+before/after speedup or a claim about full capture-prefetch time.
+
+The server uses a four-disk RAIDZ1 pool, an NVMe L2ARC and a ZFS ARC configured
+with a 240 GiB maximum. Before the warm-up, a 20.044 s observation found
+10.006 GB of L2ARC reads and approximately zero HDD reads. That observation
+identifies an NVMe-backed interval; the aggregate demand-cache hit percentage
+alone would hide data supplied by predictive prefetch. It does not establish
+that every slow read has the same cause.
+
+The warm-up selected the existing `row-0045` layer-10 expert group: 864 capture
+files (46.104 GiB) and four complete source shards (19.985 GiB). It read each
+file once on the storage server with four 8 MiB buffers. It created no new
+weight/cache format and changed no quantization input. It took 183.240 s;
+ARC size changed from 192.843 to 186.539 GiB as other cache activity continued.
+Reading a file warms the existing cache but does not pin it or guarantee its
+continued residency. The warm-up overlapped other pricing activity and may
+have competed with it for storage. No live cache limit was changed.
+
+## Observed GPU gaps
+
+The recent fifteen-minute Sparklina window had 32.06% of samples below 15 W,
+but included preparation before its first batch. The row logged resident
+calibration at 13:28:57 UTC and completed its first eight anchors at 13:31:13.
+Over the following 595 s covered by the recorder, power averaged 68.36 W;
+0.084% of samples were below 15 W and 0.504% reported zero GPU activity.
+Sparky's separate fifteen-minute window averaged 73.39 W and had no samples
+below 15 W. Low-power thresholds are descriptive screens, not a proof that
+no kernel ran, and GB10 utilization percentage is not a saturation measure.
+
+A separately recorded 64-anchor expert prefix spent 241.049 s before its first
+anchor and 157.229 s in its eight batches and finalization. The six unprofiled
+batches took approximately 17.6–17.9 s each, with about 0.3 s between calls.
+Their sampled low-power beginnings often coincide with a main thread waiting
+for the native Viterbi GPU work, so power alone cannot label those intervals
+CPU idle. Occasional tail samples showed render/wire publication. This prefix
+is not a completed pricing group and does not establish an end-to-end idle
+fraction.
+
+The proposed eight-versus-sixteen batch comparison did not qualify: the first
+control completed 64 anchors, but its second two-second CUDA trace exceeded
+its 128 MiB export limit (283,292,151 bytes). No width-16 arm ran. Analysis of a
+retained representative trace showed CUDA/runtime activity ending near the
+requested two seconds; there was no evidence that the timer retained an
+entire call. No batch-width change was promoted. Two attempts to attach an
+external sampler to a live contained row failed on privilege/ptrace restrictions;
+no permissions or containment settings were weakened. Attribution above uses
+the existing in-process samples, actual container timestamps, NFS counters and
+host telemetry.
+
+## Reproduction and evidence
+
+All file-warming and transfer-diagnostic execution went through PrismaBuild. The warm-up reserved
+four CPUs and 70 GiB for possible server-cache footprint; its attempt scope peaked at
+108 MiB. The local four-shard follow-up reserved four CPUs and 24 GiB. The
+client diagnostic reserved four CPUs and 2 GiB, retaining only four 8 MiB
+buffers and advising consumed client pages away. It ran on Sparklina, with
+its current pricing job present; it did not reserve or execute GPU work.
+
+The warm-up helper is `experiments/server_cache_prime.py`. Exact file plans,
+commands, per-file results, `/proc` counters, Netdata series for all three
+hosts, and CAS/source audits are under:
+
+`/mnt/shared/tessera-measurements/glm-canonical-census-20260908/server-read-investigation-01/`
+
+PB actions are `6871ff44168539853c2d3573133823f4648996fd24f900dbb91808daa50ebb9c`
+(warm-up), `d388343d6dfdb0be5697c8dd1432e26dbe2e7c7bb8003a6de1b02fb5febdfae1`
+(local follow-up), and
+`9367379a579236259b4407fdf0eb4f26ab7b7959a75c3e91add5230884bfa24a` (client).
+Actual actions exited zero, cleanup completed, and result/source CAS was
+verified. The warm-up's py-spy process exited 1 after its child ended but
+retained a usable 4,014-sample profile; the payload's successful exit is
+independently recorded. The two follow-up profilers exited zero. The deployed
+PB terminal process-I/O aggregate has the known exited-child omission (#451),
+so this report uses the workload's own counters and NFS evidence.
+
+GPU-window artifacts are under `live-pricing-gap-observation-02/` and
+`expert-batch-width-optimization-01/` beside that directory. Source weights,
+the original calibration capture, production batch width, and the 104 GiB
+Spark limits remain unchanged. All original pricing rows were returned to the
+ordinary PB queue after the bounded measurement window.

--- a/experiments/server_cache_prime.py
+++ b/experiments/server_cache_prime.py
@@ -1,0 +1,69 @@
+"""Read one explicit existing file set into the server's ordinary ZFS cache."""
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import os
+from pathlib import Path
+import socket
+import time
+
+
+def arc():
+    return {v[0]:int(v[2]) for line in Path('/proc/spl/kstat/zfs/arcstats').read_text().splitlines()[2:]
+            if len(v:=line.split())==3}
+
+
+def main():
+    parser=argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--plan',required=True)
+    parser.add_argument('--plan-sha256',required=True)
+    args=parser.parse_args()
+    raw=Path(args.plan).read_bytes()
+    if hashlib.sha256(raw).hexdigest()!=args.plan_sha256:
+        raise ValueError('prime plan changed')
+    plan=json.loads(raw)
+    if plan['schema']!='prismaquant.server_cache_prime.v1' or socket.gethostname()!='dl380g10':
+        raise ValueError('priming requires the declared storage server')
+    files=plan['files']
+    if len({r['local_path'] for r in files})!=len(files) or sum(r['bytes'] for r in files)!=plan['total_bytes']:
+        raise ValueError('prime plan is not a unique bounded file set')
+    if not 0<plan['total_bytes']<=67*1024**3:
+        raise ValueError('prime file set exceeds the admitted cache allowance')
+    for row in files:
+        path=Path(row['local_path'])
+        if not path.is_relative_to('/storage_pool/shared') or path.resolve()!=path:
+            raise ValueError('prime path escapes the local shared dataset')
+        st=path.stat()
+        if (st.st_size,st.st_mtime_ns)!=(row['bytes'],row['mtime_ns']):
+            raise ValueError('prime input metadata changed')
+    started=time.time()
+    output=Path(plan['output'])
+    before=dict(unix=started,arc=arc(),diskstats=Path('/proc/diskstats').read_text(),
+        meminfo=Path('/proc/meminfo').read_text(),process_io=Path('/proc/self/io').read_text())
+    output.with_suffix('.started.json').write_text(json.dumps(before,indent=2)+'\n')
+    def read(row):
+        path=Path(row['local_path']);t=time.time();count=0;buffer=bytearray(8*1024**2)
+        with path.open('rb',buffering=0) as stream:
+            st=os.fstat(stream.fileno())
+            if (st.st_size,st.st_mtime_ns)!=(row['bytes'],row['mtime_ns']):
+                raise ValueError('prime input changed before reading')
+            while size:=stream.readinto(buffer):count+=size
+            end=os.fstat(stream.fileno())
+        if (end.st_size,end.st_mtime_ns)!=(st.st_size,st.st_mtime_ns) or count!=row['bytes']:
+            raise ValueError('prime input changed while reading')
+        return dict(path=str(path),bytes=count,started_unix=t,finished_unix=time.time())
+    # Four independent read streams feed the existing four-disk/NVMe ZFS pool.
+    # No bytes are retained by this process beyond its four 8 MiB buffers.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+        rows=list(pool.map(read,files))
+    after=dict(unix=time.time(),arc=arc(),diskstats=Path('/proc/diskstats').read_text(),
+        meminfo=Path('/proc/meminfo').read_text(),process_io=Path('/proc/self/io').read_text())
+    result=dict(schema=plan['schema'],plan_sha256=args.plan_sha256,scope=plan['scope'],
+        files=rows,before=before,after=after,bytes_read=sum(r['bytes'] for r in rows),
+        seconds=after['unix']-started,cache_retention_guaranteed=False)
+    with output.open('x') as stream:json.dump(result,stream,indent=2);stream.write('\n')
+    print(json.dumps({k:result[k] for k in ('bytes_read','seconds','cache_retention_guaranteed')}))
+
+
+if __name__=='__main__':main()


### PR DESCRIPTION
Record the requested dl380g10 cache warm-up and distinguish loading pauses from steady expert encoding. A bounded helper reads an explicit existing file set through the server's ordinary ZFS cache; it does not change quantization inputs or add an application cache.

The warm-up read 66.089 GiB. A follow-up four-shard transfer delivered 19.985 GiB to Sparklina in 5.801 seconds during live pricing, with NFS counters confirming network reads. The report records the workload, concurrent load, profiles, CAS/source audits, cache-retention limits, and the failed batch-width measurement without presenting it as a speedup.

Validation: PB compile check; three completed PB read actions with real output and receipt/source verification. This is an explicit diagnostic utility and evidence report, not automatic production prewarming.

Fixes #476.
