### PR TITLE
Fix streamed Qwen rotary positions for Transformers 5.17

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,16 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-09 · `perf/glm-selected-source-snapshot`. Stamps
+As of: 2026-09-09 · `fix/qwen35-tf517-rotary-positions`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-09, `fix/qwen35-tf517-rotary-positions`) for the
+profile-owned `rotary_position_ids` hook at the shared streamed rotary call.
+Qwen3.5/3.6 supplies three identical rotary axes for two-dimensional text
+positions and preserves explicit three-axis inputs. This carries the model
+forward's expansion into streaming after Transformers 5.17 removed it from
+the rotary module. Mask and decoder-layer positions remain unchanged; other
+profiles pass rotary positions through. Gates: real Qwen hybrid integration
+and the existing rotary/mask tests. See #477.
 
 Re-stamped (2026-09-09, `perf/glm-selected-source-snapshot`) for
 `dispatch_tessera_campaign.py plan --seed-workspace`. A new plan can offer each

--- a/docs/measurements/qwen35-transformers-517-20260909/README.md
+++ b/docs/measurements/qwen35-transformers-517-20260909/README.md
@@ -1,0 +1,32 @@
+# Streamed Qwen rotary compatibility — 2026-09-09
+
+Transformers 5.17.0 moved text-position expansion out of Qwen3.5's rotary
+module and into its model forward. The streamed driver bypasses that forward,
+so passing `[batch, tokens]` directly to rotary raises `IndexError`.
+The shared `_compute_position_embeddings` helper now asks the model profile
+for rotary-only positions. Qwen supplies a three-axis view of text positions;
+explicit three-axis inputs are preserved. Mask and layer positions retain their
+original shape. Other profiles pass positions through.
+
+The real Qwen integration tests now exercise the shared streaming helper.
+Both padded and unpadded forwards compare its rotary output exactly against
+the native module with explicit three-axis positions. Explicit unequal axes
+are preserved, malformed axes refuse, and the original negative dense-mask
+test again reaches the attention layer. Existing mask, generic/multi-rope,
+streaming and architecture tests are included.
+
+PB reproduced the original three failures and then the same failures through
+the shared helper, before the repair. The repaired suite passed **70 tests
+without skips on each of Transformers 5.16.1 and 5.17.0**, plus compilation
+of the three changed modules. Runs used the existing scoped Python 3.12.11
+CPU environment on DL380; 5.17.0 was installed as a separate pinned overlay.
+Each validation action reserved four CPUs and 6 GiB, bounded native threads
+to one, and used priority -10. Actual terminal cleanup, CAS receipt/payload,
+and source were verified; `cpu-audit.json` contains action keys and hashes.
+The only later source difference was the architecture stamp's branch name.
+
+The original hosted CI run was
+https://github.com/RobTand/prismaquant/actions/runs/34397560209
+(three failures, 7538 passed, 207 skipped, three xfailed, 192 subtests passed).
+This is a shape-compatibility correction, not a GPU performance or model-quality
+measurement. Tracked by #477.

--- a/docs/measurements/qwen35-transformers-517-20260909/cpu-audit.json
+++ b/docs/measurements/qwen35-transformers-517-20260909/cpu-audit.json
@@ -1,0 +1,78 @@
+{
+  "schema": "prismaquant.qwen35_rotary_517_cpu_audit/1",
+  "before": [
+    {
+      "action": "a4894ddc35827e3b22cc3636bfae53c66477373f89ff9c1e5a6b8c3549991fc0",
+      "returncode": 1,
+      "cleanup_complete": true,
+      "source_snapshot": {
+        "commit": "71bf953cf65e24e7f771665cb375a68ba860df42",
+        "input": {
+          "bytes": 27790132,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "57ab309f7c014a68d7bf3eca1c7817644fdc6335b2627c58f6eed6f1ec9aa412"
+        },
+        "parent": "7f4069b294e3bd81d3e8e1dba8ad11a64ba1c297",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      },
+      "result": "3 failed, 2 passed; IndexError at native rotary with 2D positions"
+    },
+    {
+      "action": "b831e5bc28bc4004464beb72a991ae6490b690639cf3ab53474af895dc2cb057",
+      "returncode": 1,
+      "cleanup_complete": true,
+      "source_snapshot": {
+        "commit": "06f3a239604d6f312302db54ca1e6a012f8975d1",
+        "input": {
+          "bytes": 27779528,
+          "id": "pbrun.checkout-snapshot",
+          "sha256": "a0b18fb2b444a9f09dddc29cd126584ef5536334ff85ac257e25b2ac4eb30aa7"
+        },
+        "parent": "7f4069b294e3bd81d3e8e1dba8ad11a64ba1c297",
+        "refs": {},
+        "schema": "prismaquant.prismabuild.pbrun_checkout_snapshot.v2",
+        "subdirectory": "."
+      },
+      "result": "3 failed, 2 passed; IndexError at native rotary with 2D positions"
+    }
+  ],
+  "after": [
+    {
+      "action": "e0de25c8d30efec49623307ed09d2a4157e17b36a088429f6649256f4614b058",
+      "receipt": "734d4cd3f3c8fe6f900da48a17455266aa3ca0186a797b179543baaf4647de10",
+      "payload_sha256": "f53404a220d3729e362802fb616f0de264916454a85792fc77877479193e6c2c",
+      "snapshot": "b8d4b4a1927cdec036d82378cd5bc4366d4bbdb6",
+      "source_diff_from_commit": [
+        ".pbrun-closure.f0322bb303fa060a.json",
+        "docs/ARCHITECTURE.md"
+      ],
+      "stdout_tail": "Transformers 5.16.1\nbringing up nodes...\nbringing up nodes...\n\n......................................................................   [100%]\n=============================== warnings summary ===============================\n../../../../venvs/pq-cpu312/lib/python3.12/site-packages/_pytest/config/__init__.py:1345\n  /home/rob/venvs/pq-cpu312/lib/python3.12/site-packages/_pytest/config/__init__.py:1345: PytestAssertRewriteWarning: Module already imported so cannot be rewritten; anyio\n    self._mark_plugins_for_rewrite(hook, disable_autoload)\n\n../../../../venvs/pq-cpu312/lib/python3.12/site-packages/torch/jit/_script.py:362: 56 warnings\n  /home/rob/venvs/pq-cpu312/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.\n    warnings.warn(\n\n-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html\n70 passed, 57 warnings in 7.22s\n",
+      "source_review": "Only PB closure metadata and the architecture stamp branch-name correction differ; code/test bytes identical."
+    },
+    {
+      "action": "ec105f10bded49550ab2fc2fe516edd4f4385cd964ad0ff679bb4733ac89189b",
+      "receipt": "af0db8d0417be3c83b6251ddbade342c3b9d1bb2dbc3019b7c3d41979412c219",
+      "payload_sha256": "9582e0caf4f8b0c027e1cd9c1d5615e04ea9fdb22ef1d8b19a3506708a75beee",
+      "snapshot": "b09ee1fd6fdb99884ad7dd748bef6e92f4540061",
+      "source_diff_from_commit": [
+        ".pbrun-closure.40eedef2794fd25c.json",
+        "docs/ARCHITECTURE.md"
+      ],
+      "stdout_tail": "Transformers 5.17.0\nbringing up nodes...\nbringing up nodes...\n\n......................................................................   [100%]\n=============================== warnings summary ===============================\n../../../../venvs/pq-cpu312/lib/python3.12/site-packages/_pytest/config/__init__.py:1345\n  /home/rob/venvs/pq-cpu312/lib/python3.12/site-packages/_pytest/config/__init__.py:1345: PytestAssertRewriteWarning: Module already imported so cannot be rewritten; anyio\n    self._mark_plugins_for_rewrite(hook, disable_autoload)\n\n../../../../venvs/pq-cpu312/lib/python3.12/site-packages/torch/jit/_script.py:362: 56 warnings\n  /home/rob/venvs/pq-cpu312/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.\n    warnings.warn(\n\n-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html\n70 passed, 57 warnings in 7.18s\n",
+      "source_review": "Only PB closure metadata and the architecture stamp branch-name correction differ; code/test bytes identical."
+    }
+  ],
+  "scope": "CPU-only, Python3.12.11; Transformers5.16.1 and scoped5.17.0 overlay; each after action 4CPU/6GiB/native1/priority-10; 70passed0skip per version and py_compile for three touched modules.",
+  "hosted_regression": {
+    "run": 34397560209,
+    "transformers": "5.17.0",
+    "failed": 3,
+    "passed": 7538,
+    "skipped": 207,
+    "xfailed": 3,
+    "subtests_passed": 192
+  },
+  "interpretation": "Exact native three-axis rotary parity on real tiny random-weight Qwen hybrid forwards. No GPU, quality/bitrate or serving-speed claim."
+}

--- a/prismaquant/layer_streaming.py
+++ b/prismaquant/layer_streaming.py
@@ -2453,6 +2453,9 @@ def _compute_position_embeddings(base_model: nn.Module,
     rotary = _get_rotary(base_model)
     if rotary is None:
         return None
+    prepare_positions = getattr(profile, "rotary_position_ids", None)
+    if prepare_positions is not None:
+        position_ids = prepare_positions(position_ids)
     layer_types = getattr(rotary, "layer_types", None)
     with torch.no_grad():
         if layer_types:

--- a/prismaquant/model_profiles/base.py
+++ b/prismaquant/model_profiles/base.py
@@ -1276,6 +1276,14 @@ class ModelProfile(ABC):
         Default: False (single-rope path)."""
         return False
 
+    def rotary_position_ids(self, position_ids):
+        """Prepare rotary-only positions; mask and layer positions stay unchanged.
+
+        Default: pass through the caller's token positions. Multiaxis rotary
+        models can supply their native axis layout at this shared boundary.
+        """
+        return position_ids
+
     def rope_axis_for_layer_type(self, layer_type: str) -> str | None:
         """Map an attention-schedule layer type to a rope-table key.
 

--- a/prismaquant/model_profiles/qwen3_5.py
+++ b/prismaquant/model_profiles/qwen3_5.py
@@ -92,6 +92,19 @@ class Qwen3_5Profile(ModelProfile):
     def name(self) -> str:
         return "qwen3_5"
 
+    def rotary_position_ids(self, position_ids):
+        """Supply Qwen's three rotary axes for a text-only streamed pass.
+
+        Transformers 5.17 moved this expansion from rotary into the model
+        forward, which the streamed driver bypasses. An explicit multiaxis
+        input already carries its own positions and must be preserved.
+        """
+        if position_ids.ndim == 2:
+            return position_ids.unsqueeze(0).expand(3, -1, -1)
+        if position_ids.ndim == 3 and position_ids.shape[0] == 3:
+            return position_ids
+        raise ValueError("Qwen rotary positions require [batch, tokens] or [3, batch, tokens]")
+
     def _declared_moe_layout(self) -> str:
         """Classify the checkpoint's declared MoE entrypoint exactly.
 

--- a/tests/test_qwen35_linear_attention_integration.py
+++ b/tests/test_qwen35_linear_attention_integration.py
@@ -34,8 +34,10 @@ from transformers.models.qwen3_5.modeling_qwen3_5 import (
 from prismaquant.layer_streaming import (
     _call_layer,
     _compute_attention_mask,
+    _compute_position_embeddings,
     _layer_attention_type,
 )
+from prismaquant.model_profiles.qwen3_5 import Qwen3_5Profile
 
 
 @pytest.fixture(autouse=True)
@@ -101,6 +103,7 @@ def _tiny_hybrid():
         def __init__(self):
             super().__init__()
             self.config = cfg
+            self.rotary_emb = rotary
 
     return cfg, _Base(), layers, rotary
 
@@ -110,7 +113,10 @@ def _stream(base, layers, rotary, hidden, attention_mask):
         hidden.size(0), -1)
     masks = _compute_attention_mask(base, hidden, position_ids,
                                     attention_mask=attention_mask)
-    pe = rotary(hidden, position_ids)
+    pe = _compute_position_embeddings(base, hidden, position_ids, Qwen3_5Profile())
+    expected = rotary(hidden, position_ids.unsqueeze(0).expand(3, -1, -1))
+    for actual, reference in zip(pe, expected):
+        torch.testing.assert_close(actual, reference, rtol=0, atol=0)
     out = hidden
     for layer in layers:
         out = _call_layer(layer, out, position_embeddings=pe,
@@ -161,6 +167,22 @@ def test_streaming_forward_unpadded_batch():
     assert bool(torch.isfinite(out).all())
 
 
+def test_explicit_rotary_axes_are_preserved():
+    _, base, _, rotary = _tiny_hybrid()
+    hidden = torch.randn(2, 6, 64)
+    positions = torch.arange(36).reshape(3, 2, 6)
+    expected = rotary(hidden, positions)
+    actual = _compute_position_embeddings(base, hidden, positions, Qwen3_5Profile())
+    for first, second in zip(actual, expected):
+        torch.testing.assert_close(first, second, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("shape", [(6,), (2, 2, 6), (4, 2, 6)])
+def test_invalid_rotary_axes_refuse(shape):
+    with pytest.raises(ValueError, match="Qwen rotary positions"):
+        Qwen3_5Profile().rotary_position_ids(torch.zeros(shape, dtype=torch.long))
+
+
 @pytest.mark.skipif(
     not _GUARDLESS_MASK,
     reason="pre-5.15 apply_mask_to_padding_states still shape-guards "
@@ -169,10 +191,10 @@ def test_dense_mask_crashes_real_linear_layer():
     # Documents the pre-fix failure mode this branch removes: a dense
     # [1, 1, T, T] additive mask fed to a real GatedDeltaNet layer
     # broadcasts against hidden_states and raises a trailing-dim mismatch.
-    _, _, layers, rotary = _tiny_hybrid()
+    _, base, layers, rotary = _tiny_hybrid()
     hidden = torch.randn(1, 6, 64)
     position_ids = torch.arange(6).unsqueeze(0)
-    pe = rotary(hidden, position_ids)
+    pe = _compute_position_embeddings(base, hidden, position_ids, Qwen3_5Profile())
     dense = torch.zeros(1, 1, 6, 6)
     with pytest.raises(RuntimeError, match="must match the size"):
         layers[0](hidden_states=hidden, attention_mask=dense,


### PR DESCRIPTION
Closes #477

Transformers 5.17 moved Qwen's text-position expansion into the model forward. Streamed probes and costing bypass that forward, so their direct rotary call crashes on `[batch, tokens]`. Add a profile-owned rotary-position hook at the shared streaming boundary: Qwen receives three rotary axes, explicit axes are preserved, and mask/layer positions keep their original shape. Other profiles pass positions through.

The real Qwen integration tests now use the production helper and compare rotary results exactly against the native three-axis call. PB reproduced all three failures before the fix, then passed **70 tests without skips on each of Transformers 5.16.1 and 5.17.0**, including mask routing, other rotary types, streaming and architecture checks; the changed modules also compile. CPU actions used four workers, 6 GiB and native threads 1. Actual terminal cleanup, source snapshots and CAS receipts/payloads were verified. No GPU or performance claim is made.

Evidence and action hashes: `docs/measurements/qwen35-transformers-517-20260909/`. This repairs the dependency compatibility failure exposed by CI on #457; the TR3 scorer itself passed its tests.

Full [CI](https://github.com/RobTand/prismaquant/actions/runs/34400269994) passed on head `86e79bf1932e0edd83cb4a1ba97811e4ea31dc76`: 7545 passed, 207 skipped, 3 xfailed, and 192 subtests passed in 1340.53 s. Import and linked-issue checks passed. Merge tree `094ecf815c02fa66089f4c61f6e41af11086f8e8` was verified identical to the tested PR head.
