### PR TITLE
Price a row until it stops committing anchors, not until a clock runs out

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,28 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-09 · `fix/qwen35-tf517-rotary-positions`. Stamps
+As of: 2026-09-10 · `claude/480-campaign-progress`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-10, `claude/480-campaign-progress`) for the campaign
+execution contract. `dispatch_tessera_campaign.py plan` no longer seals a
+14,400 s deadline into every pricing row; `--timeout-s` is unset by default
+and seals only when asked for. Rows instead declare the phases they walk and
+the quiet each is allowed -- `startup=3600 pricing=900 finalize=1800`, from a
+least-squares fit of elapsed time against committed batches over the 23
+completed full 864-unit GLM rows in the fleet's terminal records (18.4 s per
+committed batch, 943 s outside the pricing loop, every full-length row within
+±180 s) -- and `tessera_campaign` reports its committed anchor count through
+`prismaquant/prismabuild_progress.py` after each journal flush, once the
+shards are durable. A row that keeps committing is given no total-duration
+limit; one that stops ends within 6,300 s, less than half the limit that
+killed row-0050 and row-0065 mid-round. The container wrapper carries the
+progress channel in and refuses at launch when the file would land outside a
+writable declared mount. Requires the PrismaBuild generation carrying
+RobTand/prismabuild#480; an older fleet refuses these rows at submit rather
+than admitting and killing them. No cost currency, wire recipe, format menu,
+serving pin or ship-gate change. Gates:
+`tests/test_campaign_progress_replaces_the_blanket_timeout.py`,
+`tests/test_tessera_campaign_container.py`.
 
 Re-stamped (2026-09-09, `fix/qwen35-tf517-rotary-positions`) for the
 profile-owned `rotary_position_ids` hook at the shared streamed rotary call.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@ and seals only when asked for. Rows instead declare the phases they walk and
 the quiet each is allowed -- `startup=3600 pricing=900 finalize=1800`, from a
 least-squares fit of elapsed time against committed batches over the 23
 completed 864-unit GLM rows in the fleet's terminal records (18.6728 s per
-committed batch, 836.1 s outside the pricing loop, greatest absolute residual
+committed batch, an 836.1 s fitted intercept, greatest absolute residual
 160.5 s; [reproducible evidence](measurements/pq480_progress_grace_fit_2026-09-10.md))
 -- and `tessera_campaign` reports its committed anchor count through
 `prismaquant/prismabuild_progress.py` after each journal flush, once the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,9 +9,10 @@ execution contract. `dispatch_tessera_campaign.py plan` no longer seals a
 and seals only when asked for. Rows instead declare the phases they walk and
 the quiet each is allowed -- `startup=3600 pricing=900 finalize=1800`, from a
 least-squares fit of elapsed time against committed batches over the 23
-completed full 864-unit GLM rows in the fleet's terminal records (18.4 s per
-committed batch, 943 s outside the pricing loop, every full-length row within
-±180 s) -- and `tessera_campaign` reports its committed anchor count through
+completed 864-unit GLM rows in the fleet's terminal records (18.6728 s per
+committed batch, 836.1 s outside the pricing loop, greatest absolute residual
+160.5 s; [reproducible evidence](measurements/pq480_progress_grace_fit_2026-09-10.md))
+-- and `tessera_campaign` reports its committed anchor count through
 `prismaquant/prismabuild_progress.py` after each journal flush, once the
 shards are durable. A row that keeps committing is given no total-duration
 limit; one that stops ends within 6,300 s, less than half the limit that

--- a/docs/measurements/artifacts/pq480_progress_grace_fit_2026-09-10.json
+++ b/docs/measurements/artifacts/pq480_progress_grace_fit_2026-09-10.json
@@ -1,0 +1,175 @@
+{
+  "fit": {
+    "max_abs_residual_s": 160.45635778753422,
+    "nonpricing_intercept_s": 836.1036216758985,
+    "s_per_committed_batch": 18.672808072814316
+  },
+  "root_action_records": "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-05/root-action-records-current.json",
+  "root_action_records_sha256": "03d6bf9f988ca7f514b37bea7d0e6001b45c44831fa7900b87162c06f5232387",
+  "rows": [
+    {
+      "action_key": "07112bb456a7764cd29d6f1347e18e4819abc43b99119b85ac7fdc4b7fa439cd",
+      "committed_batches": 324,
+      "elapsed_s": 6798.253107786179,
+      "row_id": "row-0045",
+      "terminal_sha256": "5cd53427489684d9f0caf71fa131a46bfb2d5553986d3cf0f2e2113d13067f38"
+    },
+    {
+      "action_key": "57dc5ebec89c958db06f296875355c437aab801ee897045ed6dbab931f59e00e",
+      "committed_batches": 324,
+      "elapsed_s": 6972.428298473358,
+      "row_id": "row-0046",
+      "terminal_sha256": "5a853e82f959aeab5a5e2bf5b683c09f0b1f372437bc81fdb08c33e7f22ece00"
+    },
+    {
+      "action_key": "40f304a06889b04140d194251887423858589283ae4b31b4715918242e687a09",
+      "committed_batches": 324,
+      "elapsed_s": 6865.7722108364105,
+      "row_id": "row-0047",
+      "terminal_sha256": "7cebd120fc538cd9e96dd344e9afe3bf75449c4446c408bc3f7df566c1d0155a"
+    },
+    {
+      "action_key": "395f2c532b8e7d9d0f0e037da6adbebc0457076f61b570e2391c2155741811a1",
+      "committed_batches": 324,
+      "elapsed_s": 6916.049420595169,
+      "row_id": "row-0048",
+      "terminal_sha256": "458e91f091584f03c14f86065a9915a56e882817489578133d98da676b37a489"
+    },
+    {
+      "action_key": "d68dc93df3535df4caa5d0b10e2e5ec27a389d9be0f285c6755b852075c7b264",
+      "committed_batches": 324,
+      "elapsed_s": 6831.945533514023,
+      "row_id": "row-0049",
+      "terminal_sha256": "c625835470ad244303aa492a416de53df8291b4178037673701b44eb6389f48a"
+    },
+    {
+      "action_key": "a554fbe070c6be5e0641f5604960f1d54c26cf6b2958b5020b764c52894d4101",
+      "committed_batches": 324,
+      "elapsed_s": 6823.746243476868,
+      "row_id": "row-0051",
+      "terminal_sha256": "677759f2508a1e3f815245c20a2bcd8bac911ed59b751696764f91df0121cb54"
+    },
+    {
+      "action_key": "7efa07f205e37f0f6b2436f4368c3a819863105d4a05a1e51aff4dc65c9ab729",
+      "committed_batches": 324,
+      "elapsed_s": 6865.4573969841,
+      "row_id": "row-0052",
+      "terminal_sha256": "13ea82e15f0dd0f7fcb05d5b1f8bc22fdd053da41efc52aa292e8e2262e6744e"
+    },
+    {
+      "action_key": "067d15b4f46541d11b2726f17b1fba5e65fa4a20ee0c1c1dd8811c5d0ce69479",
+      "committed_batches": 324,
+      "elapsed_s": 6855.5337789058685,
+      "row_id": "row-0053",
+      "terminal_sha256": "50095537b3834d9df33169ac0a35cdb222b70bbbc29e49ab3e9e305df0fdfb46"
+    },
+    {
+      "action_key": "51b75b8bbc194fc235902b1f7dafae634a192626c94dcf7599512af873f82fd8",
+      "committed_batches": 324,
+      "elapsed_s": 6895.5982892513275,
+      "row_id": "row-0054",
+      "terminal_sha256": "947545b689db74500d5dd9040d03cd4fe57818f777c2b10d332e7ba1f7e636be"
+    },
+    {
+      "action_key": "d6e56eb86aa0fe88e98bbc28956767fc5cf038e32fa5a2f0d60aeaa59bfc5be0",
+      "committed_batches": 127,
+      "elapsed_s": 3152.9787952899933,
+      "row_id": "row-0056",
+      "terminal_sha256": "0cb553a2208356038195ba5b3650c8e4af757b7bb3bda16a7c24856b5eb0eff1"
+    },
+    {
+      "action_key": "7debd25c7f505998170134273da93bd470d4d709e42dda48cb413d2bfe74c308",
+      "committed_batches": 324,
+      "elapsed_s": 6859.284213066101,
+      "row_id": "row-0057",
+      "terminal_sha256": "9031250df47bbdc780d5ecff81f2b46839dfbaec374fc198a4e895a3f67dbdff"
+    },
+    {
+      "action_key": "91a61ce8f577444f84640407702f99a2977be0b4bdf1b0f30489215e6d66d1b4",
+      "committed_batches": 324,
+      "elapsed_s": 6875.033477544785,
+      "row_id": "row-0058",
+      "terminal_sha256": "5c17364175e3fb671b3f33efae0d24e17dc6a337237346529965d84463c02a4e"
+    },
+    {
+      "action_key": "802adbf90236c8078337ee4c836d21df11b83bb362e252dc0512b98a25527467",
+      "committed_batches": 324,
+      "elapsed_s": 6849.5007700920105,
+      "row_id": "row-0059",
+      "terminal_sha256": "356c20c1bda594d9eee9516d2f91ce7c3797972ad784cc4062438c28908b61c1"
+    },
+    {
+      "action_key": "cd9b02eb7f472c54b84e1c886543f8f24c17c13dceb1ea89ec6489347243a453",
+      "committed_batches": 324,
+      "elapsed_s": 6870.30470085144,
+      "row_id": "row-0061",
+      "terminal_sha256": "9231c05ebbcbc2d95cd8e4022596a72b202e7797419b35c677e9eb7f9ccffef5"
+    },
+    {
+      "action_key": "b175b7470f516306834257fd961c330a16c95e3f58cf089a159f9540a45aec54",
+      "committed_batches": 324,
+      "elapsed_s": 6867.248278141022,
+      "row_id": "row-0062",
+      "terminal_sha256": "51bbbe35b40e39b8b37bd1265fb5198b509f866e7c58bf99c9059a089027f97e"
+    },
+    {
+      "action_key": "185a47da7ae83ad375b104a0a00cce11ade61d35eb938ccfb3c2684272fd3d47",
+      "committed_batches": 324,
+      "elapsed_s": 6864.798607349396,
+      "row_id": "row-0066",
+      "terminal_sha256": "29987dc0b02990506f04f22a43ed16049bbeae1a3cc205c88c8a8e516404580a"
+    },
+    {
+      "action_key": "c7b36fa417eb444adda1d41560e0eda6455117f2b7dd3d3cee2d765a801c9410",
+      "committed_batches": 324,
+      "elapsed_s": 6863.208530426025,
+      "row_id": "row-0067",
+      "terminal_sha256": "85530b4fed9bd5dca074028c6444f8d093dc03fe5eaa10f872f45f52bead2917"
+    },
+    {
+      "action_key": "1cf14c035ca089e375923a9a88115b425308452553cc03218972f99b812b0db9",
+      "committed_batches": 324,
+      "elapsed_s": 6941.04490852356,
+      "row_id": "row-0068",
+      "terminal_sha256": "6bea9bdae2eeea4c565961a1cc35786b4b6f3025cd1207da55c06edcd11a8a41"
+    },
+    {
+      "action_key": "82175a1a999fa47bd8232f00633cc36529a0e484db460e1ff5d62413ee9fec15",
+      "committed_batches": 324,
+      "elapsed_s": 6905.880634307861,
+      "row_id": "row-0069",
+      "terminal_sha256": "991d9aeda913a93a331ef8f3b75e00c926d72012b3019aa1b234e3ffcf222205"
+    },
+    {
+      "action_key": "f4e10dee189d9f2ee2c17d88c40648125229c64ed957ee7c1838fdc627d58538",
+      "committed_batches": 257,
+      "elapsed_s": 5795.471654176712,
+      "row_id": "row-0070",
+      "terminal_sha256": "2bac8788742de3c29769365fe53c5a59b5a6c8a617535d61f5dee3e618a8e1da"
+    },
+    {
+      "action_key": "7033672872bb0d4a05367a5c2c054a56821a5eecfaf24ef447f9094b16a91bf0",
+      "committed_batches": 324,
+      "elapsed_s": 6915.469630241394,
+      "row_id": "row-0072",
+      "terminal_sha256": "99656cb3b6ab4270b44fe8569f4f5b783e0b99e8e71a8aedf7ebd1422665d2af"
+    },
+    {
+      "action_key": "30e2a421214c66b22e10a0aba8a00522741a0e0fb3fea04894b62dd0e0319b4a",
+      "committed_batches": 324,
+      "elapsed_s": 6975.5473692417145,
+      "row_id": "row-0074",
+      "terminal_sha256": "b35abc0401e619e6d65d2e80b1ff573f5a1a94de19e9809e55ad32cd0f40618f"
+    },
+    {
+      "action_key": "5aa5b4ab831b305f583d687bafa46cbc283bbbd270d452beb757d951976f78d5",
+      "committed_batches": 324,
+      "elapsed_s": 6889.971876859665,
+      "row_id": "row-0081",
+      "terminal_sha256": "c99b17f8e086b0b50e776833722a95f6ac3fb1a4c721ae8b42a5f5c6620968bd"
+    }
+  ],
+  "schema": "prismaquant.tessera_progress_grace_fit.v1",
+  "selection": "successful rows with final '864 units, 2592 priced rungs'",
+  "terminal_directory": "/mnt/shared/prismabuild-fleet/pb-queue/done"
+}

--- a/docs/measurements/pq480_progress_grace_fit_2026-09-10.md
+++ b/docs/measurements/pq480_progress_grace_fit_2026-09-10.md
@@ -37,14 +37,18 @@ Ordinary least squares of elapsed seconds on committed batches gives:
 | Quantity | Seconds |
 | --- | ---: |
 | Per committed batch | 18.672808072814316 |
-| Non-pricing intercept | 836.1036216758985 |
+| Fitted intercept | 836.1036216758985 |
 | Largest absolute residual | 160.45635778753422 |
 
 `pricing=900` therefore allows 48.20 fitted batch intervals. The fitted
-non-pricing interval plus its largest observed residual is 996.56 seconds;
+intercept plus its largest observed residual is 996.56 seconds;
 both `startup=3600` and `finalize=1800` exceed it. Together the phase quiet
 limits are 6,300 seconds, below the 14,400-second blanket deadline that
 previously terminated rows despite their committed-anchor progress.
+
+The intercept estimates time outside pricing; it is not a direct measurement
+of the longest startup, pricing or finalization gap. The allowances are
+chosen margins informed by this fit, not measured worst-case bounds.
 
 The extractor deliberately fails if retained data no longer selects exactly
 23 rows, or if those rows do not vary in committed batch count. Re-run it when

--- a/docs/measurements/pq480_progress_grace_fit_2026-09-10.md
+++ b/docs/measurements/pq480_progress_grace_fit_2026-09-10.md
@@ -1,0 +1,51 @@
+# PQ-480 progress-grace fit — 2026-09-10
+
+This record explains the watchdog allowances in
+`tools/dispatch_tessera_campaign.py` for the completed GLM pricing workload.
+It is a measurement of that workload, rather than an assertion that its
+cadence applies to another campaign.
+
+## Input and selection
+
+The source is the retained root-action record
+`/mnt/shared/tessera-measurements/glm-canonical-census-20260908/first-proof-anchor-preparation-05/root-action-records-current.json`,
+whose SHA-256 is
+`03d6bf9f988ca7f514b37bea7d0e6001b45c44831fa7900b87162c06f5232387`.
+For every `done` action it names, the extractor reads the corresponding
+`/mnt/shared/prismabuild-fleet/pb-queue/done/<action-key>.json` terminal
+record. It selects records whose final campaign line says `864 units, 2592
+priced rungs`, counts their durable `[campaign] ... batch=` lines, and takes
+`detail.elapsed_s` as elapsed wall time. The selection has 23 rows.
+
+The committed [JSON artifact](artifacts/pq480_progress_grace_fit_2026-09-10.json)
+contains every selected row ID, action key, terminal-record SHA-256, batch
+count, and elapsed time. It is the exact stdout from:
+
+```bash
+python tools/derive_tessera_progress_grace.py > docs/measurements/artifacts/pq480_progress_grace_fit_2026-09-10.json
+```
+
+The command was admitted by PrismaBuild as action
+`eca3426e3a1eccc5a4d8a26c3fb7964da19b439648328c5b7fc1eaf97d630878` on
+`dl380g10`, returned 0, and published CAS receipt
+`8f99bc54a962267d3e94cfa160ebafbf5a4dd12eb621f71e556d1faf224df8c1`.
+
+## Fit and allowance
+
+Ordinary least squares of elapsed seconds on committed batches gives:
+
+| Quantity | Seconds |
+| --- | ---: |
+| Per committed batch | 18.672808072814316 |
+| Non-pricing intercept | 836.1036216758985 |
+| Largest absolute residual | 160.45635778753422 |
+
+`pricing=900` therefore allows 48.20 fitted batch intervals. The fitted
+non-pricing interval plus its largest observed residual is 996.56 seconds;
+both `startup=3600` and `finalize=1800` exceed it. Together the phase quiet
+limits are 6,300 seconds, below the 14,400-second blanket deadline that
+previously terminated rows despite their committed-anchor progress.
+
+The extractor deliberately fails if retained data no longer selects exactly
+23 rows, or if those rows do not vary in committed batch count. Re-run it when
+the campaign changes instead of treating these values as a generic timeout.

--- a/prismaquant/prismabuild_progress.py
+++ b/prismaquant/prismabuild_progress.py
@@ -1,0 +1,76 @@
+"""Report committed pricing work to PrismaBuild's stall watchdog.
+
+PrismaBuild bounds an action either by how long it has run or by how long it
+has gone without committing work, and which of the two it uses is a property
+of the sealed request (``prismabuild.action_progress_policy.v1``, PB #480).
+A campaign row that declares the progress contract is not killed for taking a
+long time; it is killed for stopping.  This is the half of that the row owes:
+the report that says it has not stopped.
+
+Written against the *wire format* rather than against ``prismabuild.core``.
+The pricing rows execute inside a pinned producer image, and making an
+already-qualified image depend on PrismaBuild being importable inside it
+would put a serving-side dependency in front of every campaign.  The record
+is four fields and a token; the schema string below is the contract.
+
+Report only what is **durable**.  ``tessera_campaign`` calls this after the
+identity-bound journal shard is on disk, never on entering a batch: a counter
+that ran ahead of the work it stands for would keep a broken row alive, which
+is the one thing the watchdog exists not to do.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+
+#: The record schema PrismaBuild's ``ProgressWatch`` accepts.  A record with
+#: any other value here is not advancement, so this string is a contract with
+#: the deployed fleet generation and not a label.
+RECORD_SCHEMA = "prismabuild.action_progress.v1"
+
+PATH_ENV = "PRISMABUILD_ACTION_PROGRESS_PATH"
+TOKEN_ENV = "PRISMABUILD_ACTION_PROGRESS_TOKEN"
+
+
+def report(phase: str, units_completed: int, *, unit: str = "anchors") -> bool:
+    """Say that ``units_completed`` units are durably committed in ``phase``.
+
+    ``units_completed`` must be monotone across the whole run -- a resumed row
+    continues from what its journal already holds rather than restarting at
+    zero -- and ``phase`` must be one the submitted row declared.  Neither is
+    checked here: the worker refuses what it cannot accept and says why on the
+    receipt, and a second opinion computed from a stale copy of the policy
+    would only disagree with it.
+
+    Returns whether a record was written.  ``False`` when the row was not
+    admitted under the contract, which is the ordinary case for every
+    campaign that does not declare phases, so callers may call unconditionally.
+    Never raises: a row must not fail because it could not describe itself.
+    """
+
+    destination = os.environ.get(PATH_ENV) or ""
+    token = os.environ.get(TOKEN_ENV) or ""
+    if not destination or not token:
+        return False
+    record = {
+        "schema": RECORD_SCHEMA,
+        "token": token,
+        "phase": str(phase),
+        "units_completed": int(units_completed),
+        "unit": str(unit),
+        "reported_unix": time.time(),
+    }
+    path = Path(destination)
+    try:
+        temporary = path.parent / f".{path.name}.{os.getpid()}.tmp"
+        temporary.write_text(json.dumps(record, sort_keys=True) + "\n",
+                             encoding="utf-8")
+        os.replace(temporary, path)
+    except OSError:
+        # A box that cannot write to its own queue directory reads as a stall,
+        # which is the honest verdict rather than a reason to stop pricing.
+        return False
+    return True

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -5340,6 +5340,14 @@ def _main(argv, *, source_scope) -> int:
         # the row says it has reached that phase and is bounded by the
         # finalization allowance its submission declared rather than by the
         # pricing loop's, which is much shorter.
+        #
+        # The drain below still calls ``flush_checkpoint``, which reports
+        # "pricing" again after this.  Neither outcome shortens the allowance:
+        # an unchanged count is refused as replayed, and a higher one is
+        # accepted while the watchdog keeps finalize's grace, because the
+        # allowance follows the furthest phase entered and never an earlier
+        # name.  What such a record does change is the phase the observation
+        # displays, so a late drain can read "pricing" while finalize governs.
         report_progress("finalize", sum(
             len(anchors) for by_format in measured.values()
             for anchors in by_format.values()))

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -4757,6 +4757,7 @@ def _main(argv, *, source_scope) -> int:
         return 0
 
     from .cost_stage_checkpoint import prepare_journal, write_unit
+    from .prismabuild_progress import report as report_progress
 
     # The resume identity, run level: everything a price is a function of,
     # including the static A-side contract (scales + policy) the W4A4 rows
@@ -5008,10 +5009,23 @@ def _main(argv, *, source_scope) -> int:
         if not states:
             return
 
+        # The count this reports is every anchor the run holds, not the ones
+        # this flush touched: a resumed row continues from the shards its
+        # journal already carries, and a counter that restarted at zero would
+        # read as a regression to the watchdog and be refused.
+        committed = sum(len(anchors)
+                        for by_format in measured.values()
+                        for anchors in by_format.values())
+
         def write():
             for name, state in states:
                 write_unit(journal, stage="Tessera campaign", qname=name,
                            identity_sha256=identity_sha256, state=state)
+            # After the shards are on disk, never before.  This is what tells
+            # PrismaBuild the row is working rather than merely running, and
+            # it must not be able to say so on behalf of work that has not
+            # landed (PB #480).
+            report_progress("pricing", committed)
 
         ledger.submit_checkpoint(write)
 
@@ -5321,6 +5335,14 @@ def _main(argv, *, source_scope) -> int:
                     "all pending anchors failed; successful anchors are journaled. "
                     "Refusing to repeat unchanged work; retry after resolving the failure.")
 
+        # Finalization is quiet on purpose -- the last drain, the leave-one-out
+        # checks and the cost payload commit nothing the journal counts -- so
+        # the row says it has reached that phase and is bounded by the
+        # finalization allowance its submission declared rather than by the
+        # pricing loop's, which is much shorter.
+        report_progress("finalize", sum(
+            len(anchors) for by_format in measured.values()
+            for anchors in by_format.values()))
         publication_stats = None
         if publisher is not None:
             # The last barrier, and where a writer failure nothing else looked at

--- a/tests/test_campaign_progress_replaces_the_blanket_timeout.py
+++ b/tests/test_campaign_progress_replaces_the_blanket_timeout.py
@@ -12,6 +12,7 @@ import json
 import os
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -49,6 +50,39 @@ def test_an_explicitly_asked_for_deadline_is_still_sealed():
     # Both, and they compose: the hard deadline caps the cost, the phases end
     # a row that stops early.
     assert row["progress_phases"][1] == "pricing=900"
+
+
+def test_nonpricing_rows_do_not_promise_anchor_progress():
+    """Census/capture exit before the pricing journal reporter is available."""
+
+    row = dispatch._row(spec(), [], mem_gb=48, timeout_s=7200,
+                        progress_phases=())
+    assert row["timeout_s"] == 7200
+    assert "progress_phases" not in row
+
+
+def test_census_and_capture_keep_their_deadlines_without_anchor_progress(tmp_path):
+    model = tmp_path / "model"
+    model.mkdir()
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps({
+        **spec(), "model": str(model), "cwd": str(tmp_path),
+    }))
+    args = SimpleNamespace(spec=str(spec_path), workspace=str(tmp_path),
+                           timeout_s=7200, submit=False)
+
+    assert dispatch.cmd_census(args) == 0
+    census_row = json.loads((tmp_path / "census-manifest.json").read_text())[0]
+    assert census_row["timeout_s"] == 7200
+    assert "progress_phases" not in census_row
+
+    (tmp_path / "census.json").write_text(json.dumps({
+        "model": str(model), "counts": {}, "unit_shapes": {},
+    }))
+    assert dispatch.cmd_capture(args) == 0
+    capture_row = json.loads((tmp_path / "capture-manifest.json").read_text())[0]
+    assert capture_row["timeout_s"] == 7200
+    assert "progress_phases" not in capture_row
 
 
 def test_the_declared_quiet_is_shorter_than_the_limit_that_killed_the_rows():

--- a/tests/test_campaign_progress_replaces_the_blanket_timeout.py
+++ b/tests/test_campaign_progress_replaces_the_blanket_timeout.py
@@ -94,10 +94,19 @@ def test_the_declared_quiet_is_shorter_than_the_limit_that_killed_the_rows():
 
 
 def test_the_pricing_allowance_covers_the_measured_commit_cadence():
-    """18.4 s per committed batch, fitted over 23 completed 864-unit rows."""
+    """The retained-record fit measured 18.672808 s per committed batch."""
 
     pricing = dict(dispatch.CAMPAIGN_PROGRESS_PHASES)["pricing"]
-    assert pricing > 40 * 18.4
+    assert pricing / 18.672808072814316 > 48
+
+
+def test_nonpricing_allowances_cover_the_fit_and_its_largest_residual():
+    """Both cover 836.10 s outside pricing plus a 160.46 s residual."""
+
+    phases = dict(dispatch.CAMPAIGN_PROGRESS_PHASES)
+    required = 836.1036216758985 + 160.45635778753422
+    assert phases["startup"] > required
+    assert phases["finalize"] > required
 
 
 # -- the report ------------------------------------------------------------

--- a/tests/test_campaign_progress_replaces_the_blanket_timeout.py
+++ b/tests/test_campaign_progress_replaces_the_blanket_timeout.py
@@ -1,0 +1,138 @@
+"""A pricing row is bounded by whether it is committing anchors, not by a clock.
+
+Two GLM-5.3 rows were killed at a 14,400 s limit this dispatcher sealed into
+every row, while both were still journalling anchors -- 5,952 and 5,920 of
+them durably on disk at the moment the worker signalled them (PrismaBuild
+#480).  The seal is gone; what replaces it is a declaration of the phases a
+row walks and the quiet it is allowed in each, and a report the campaign makes
+after every journal flush.
+"""
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+import dispatch_tessera_campaign as dispatch
+
+from prismaquant import prismabuild_progress
+
+
+def spec():
+    return {
+        "model": "/mnt/shared/model", "cwd": "/original/checkout",
+        "python": "python3", "campaign_argv": [],
+        "env": {"PYTHONPATH": ".:/producer/src"},
+        "container": {"image": "qualified:fixed", "mounts": [
+            {"source": "/mnt/shared", "target": "/mnt/shared"},
+            {"source": "/producer", "target": "/producer", "readonly": True},
+        ]},
+    }
+
+
+# -- the seal --------------------------------------------------------------
+
+def test_a_row_seals_no_deadline_of_its_own(tmp_path):
+    row = dispatch._row(spec(), ["--units", "/mnt/shared/units.json"],
+                        mem_gb=48, timeout_s=None)
+    assert "timeout_s" not in row
+    assert row["progress_phases"] == ["startup=3600", "pricing=900",
+                                      "finalize=1800"]
+
+
+def test_an_explicitly_asked_for_deadline_is_still_sealed():
+    row = dispatch._row(spec(), [], mem_gb=48, timeout_s=86400)
+    assert row["timeout_s"] == 86400
+    # Both, and they compose: the hard deadline caps the cost, the phases end
+    # a row that stops early.
+    assert row["progress_phases"][1] == "pricing=900"
+
+
+def test_the_declared_quiet_is_shorter_than_the_limit_that_killed_the_rows():
+    """The bound got *tighter*; what changed is what it is a bound on."""
+
+    total = sum(grace for _, grace in dispatch.CAMPAIGN_PROGRESS_PHASES)
+    assert total == 6300
+    assert total < 14400
+
+
+def test_the_pricing_allowance_covers_the_measured_commit_cadence():
+    """18.4 s per committed batch, fitted over 23 completed 864-unit rows."""
+
+    pricing = dict(dispatch.CAMPAIGN_PROGRESS_PHASES)["pricing"]
+    assert pricing > 40 * 18.4
+
+
+# -- the report ------------------------------------------------------------
+
+def test_the_reporter_writes_the_record_prismabuild_accepts(tmp_path, monkeypatch):
+    path = tmp_path / "key.progress"
+    monkeypatch.setenv(prismabuild_progress.PATH_ENV, str(path))
+    monkeypatch.setenv(prismabuild_progress.TOKEN_ENV, "minted-token")
+    assert prismabuild_progress.report("pricing", 5920) is True
+    record = json.loads(path.read_text())
+    assert record["schema"] == "prismabuild.action_progress.v1"
+    assert record["token"] == "minted-token"
+    assert record["phase"] == "pricing"
+    assert record["units_completed"] == 5920
+    assert record["unit"] == "anchors"
+    assert isinstance(record["reported_unix"], float)
+
+
+def test_a_row_that_was_not_admitted_under_the_contract_reports_nothing(monkeypatch):
+    monkeypatch.delenv(prismabuild_progress.PATH_ENV, raising=False)
+    monkeypatch.delenv(prismabuild_progress.TOKEN_ENV, raising=False)
+    assert prismabuild_progress.report("pricing", 1) is False
+
+
+def test_an_unwritable_destination_does_not_fail_the_row(tmp_path, monkeypatch):
+    monkeypatch.setenv(prismabuild_progress.PATH_ENV,
+                       str(tmp_path / "absent" / "key.progress"))
+    monkeypatch.setenv(prismabuild_progress.TOKEN_ENV, "t")
+    assert prismabuild_progress.report("pricing", 1) is False
+
+
+# -- the channel into the container ---------------------------------------
+
+def test_the_container_carries_the_progress_channel(monkeypatch):
+    runner = importlib.import_module("tools.tessera_campaign_container")
+    monkeypatch.setenv(prismabuild_progress.PATH_ENV,
+                       "/mnt/shared/prismabuild-fleet/pb-queue/claimed/k.progress")
+    monkeypatch.setenv(prismabuild_progress.TOKEN_ENV, "minted-token")
+    argv = runner.docker_command(spec(), ["python3"], cwd="/snapshot", uid=1,
+                                 gid=1, image_id="sha256:x", environ=os.environ)
+    assert (f"{prismabuild_progress.PATH_ENV}="
+            "/mnt/shared/prismabuild-fleet/pb-queue/claimed/k.progress") in argv
+    assert f"{prismabuild_progress.TOKEN_ENV}=minted-token" in argv
+
+
+def test_a_progress_file_outside_a_writable_mount_is_refused(monkeypatch):
+    """Silence the worker cannot tell from a stall is worth failing at launch."""
+
+    runner = importlib.import_module("tools.tessera_campaign_container")
+    monkeypatch.setenv(prismabuild_progress.PATH_ENV, "/var/queue/k.progress")
+    monkeypatch.setenv(prismabuild_progress.TOKEN_ENV, "t")
+    with pytest.raises(RuntimeError, match="not inside any writable"):
+        runner.docker_command(spec(), ["python3"], cwd="/snapshot", uid=1,
+                              gid=1, image_id="sha256:x", environ=os.environ)
+
+
+def test_a_readonly_mount_is_not_somewhere_to_report(monkeypatch):
+    runner = importlib.import_module("tools.tessera_campaign_container")
+    monkeypatch.setenv(prismabuild_progress.PATH_ENV, "/producer/k.progress")
+    monkeypatch.setenv(prismabuild_progress.TOKEN_ENV, "t")
+    with pytest.raises(RuntimeError, match="not inside any writable"):
+        runner.docker_command(spec(), ["python3"], cwd="/snapshot", uid=1,
+                              gid=1, image_id="sha256:x", environ=os.environ)
+
+
+def test_a_row_without_the_contract_adds_no_container_environment(monkeypatch):
+    runner = importlib.import_module("tools.tessera_campaign_container")
+    monkeypatch.delenv(prismabuild_progress.PATH_ENV, raising=False)
+    monkeypatch.delenv(prismabuild_progress.TOKEN_ENV, raising=False)
+    argv = runner.docker_command(spec(), ["python3"], cwd="/snapshot", uid=1,
+                                 gid=1, image_id="sha256:x", environ=os.environ)
+    assert not [entry for entry in argv if entry.startswith("PRISMABUILD_")]

--- a/tools/derive_tessera_progress_grace.py
+++ b/tools/derive_tessera_progress_grace.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Derive Tessera pricing watchdog evidence from retained PB terminal records.
+
+The GLM campaign's completed rows retain both the terminal wall time and the
+campaign's durable-batch log lines.  This tool makes the selection and linear
+fit explicit so a phase allowance is reviewable rather than a number copied
+from a PR body.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+
+
+DEFAULT_ROOT = Path(
+    "/mnt/shared/tessera-measurements/glm-canonical-census-20260908/"
+    "first-proof-anchor-preparation-05/root-action-records-current.json"
+)
+DEFAULT_TERMINALS = Path("/mnt/shared/prismabuild-fleet/pb-queue/done")
+FINAL = re.compile(r"cost\.pkl: (\d+) units, (\d+) priced rungs")
+BATCH = re.compile(r"^\[campaign\] r\d+ \d+/\d+ batch=", re.MULTILINE)
+ROW = re.compile(r"workspace/rows/(row-\d+)")
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def fit(rows: list[dict[str, object]]) -> dict[str, float]:
+    n = len(rows)
+    xs = [float(row["committed_batches"]) for row in rows]
+    ys = [float(row["elapsed_s"]) for row in rows]
+    mean_x, mean_y = sum(xs) / n, sum(ys) / n
+    denominator = sum((x - mean_x) ** 2 for x in xs)
+    if denominator == 0:
+        raise RuntimeError("selected rows have no batch-count variation")
+    slope = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys)) / denominator
+    intercept = mean_y - slope * mean_x
+    residuals = [y - (intercept + slope * x) for x, y in zip(xs, ys)]
+    return {
+        "s_per_committed_batch": slope,
+        "nonpricing_intercept_s": intercept,
+        "max_abs_residual_s": max(abs(value) for value in residuals),
+    }
+
+
+def derive(root_path: Path, terminals: Path) -> dict[str, object]:
+    root = json.loads(root_path.read_text(encoding="utf-8"))
+    rows: list[dict[str, object]] = []
+    for action in root["actions"]:
+        if action.get("state") != "done":
+            continue
+        key = str(action["action_key"])
+        terminal = terminals / f"{key}.json"
+        if not terminal.is_file():
+            continue
+        payload = json.loads(terminal.read_text(encoding="utf-8"))
+        detail = payload.get("detail") or {}
+        stdout = detail.get("stdout")
+        elapsed = detail.get("elapsed_s")
+        if not isinstance(stdout, str) or not isinstance(elapsed, (int, float)):
+            continue
+        final = FINAL.search(stdout)
+        if final is None or final.groups() != ("864", "2592"):
+            continue
+        row = ROW.search(stdout)
+        if row is None:
+            raise RuntimeError(f"{key}: completed GLM row has no row identity")
+        rows.append({
+            "row_id": row.group(1),
+            "action_key": key,
+            "terminal_sha256": sha256(terminal),
+            "committed_batches": len(BATCH.findall(stdout)),
+            "elapsed_s": float(elapsed),
+        })
+    rows.sort(key=lambda item: str(item["row_id"]))
+    if len(rows) != 23:
+        raise RuntimeError(f"expected 23 completed 864-unit/2592-rung rows, found {len(rows)}")
+    return {
+        "schema": "prismaquant.tessera_progress_grace_fit.v1",
+        "root_action_records": str(root_path),
+        "root_action_records_sha256": sha256(root_path),
+        "terminal_directory": str(terminals),
+        "selection": "successful rows with final '864 units, 2592 priced rungs'",
+        "rows": rows,
+        "fit": fit(rows),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root-action-records", type=Path, default=DEFAULT_ROOT)
+    parser.add_argument("--terminals", type=Path, default=DEFAULT_TERMINALS)
+    args = parser.parse_args()
+    print(json.dumps(derive(args.root_action_records, args.terminals), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -303,7 +303,24 @@ def partition_rows_by_fit(row_memory_gb: "dict[str, int]", per_box: int,
     return admissible, declined
 
 
-def _row(spec: dict, argv: list[str], *, mem_gb: int, timeout_s: int,
+#: The quiet a pricing row is allowed in each phase, in the order it walks
+#: them.  Measured, not chosen: a least-squares fit of ``elapsed_s`` against
+#: committed batches over the 23 completed full 864-unit GLM pricing rows in
+#: the fleet's terminal records (2026-09-10) gives 18.4 s of wall clock per
+#: committed batch and 943 s of everything that is not the pricing loop --
+#: source and calibration load, activations, and the finalization tail --
+#: with every full-length row inside +-180 s of that fit.
+#:
+#: So: ``pricing`` is 49x the measured commit cadence, and ``startup`` and
+#: ``finalize`` are each larger than the whole 943 s of non-pricing quiet the
+#: fit attributes to both together.  The sum, 6300 s, is the longest a row can
+#: run having committed nothing -- less than half the 14,400 s that killed
+#: row-0050 and row-0065 while they were committing anchors every 18 s.
+CAMPAIGN_PROGRESS_PHASES = (("startup", 3600), ("pricing", 900), ("finalize", 1800))
+
+
+def _row(spec: dict, argv: list[str], *, mem_gb: int, timeout_s: int | None,
+         progress_phases: tuple[tuple[str, int], ...] = CAMPAIGN_PROGRESS_PHASES,
          module: str = "prismaquant.tessera_campaign") -> dict:
     env = dict(spec['env'])
     policy_flag = '--streaming-capture-policy'
@@ -328,13 +345,25 @@ def _row(spec: dict, argv: list[str], *, mem_gb: int, timeout_s: int,
         "demand": {"gpu": 1, "cpu": int(spec.get("cpus", 4)), "mem_gb": int(mem_gb)},
         "env": env,
         "tags": list(spec.get("tags", ["gb10"])),
-        "timeout_s": int(timeout_s),
         # A row is one memoized action and a retry re-runs the same argv over
         # the same checkpoint, which is exactly what the journal is for.  The
         # policy is sealed into the action key, so it is spelled even though
         # pbcampaign submits every row detached and cannot retry one itself.
         "retry_safe": True,
     }
+    if progress_phases:
+        # What bounds this row is whether it is still committing anchors, not
+        # how long it has been running.  ``tessera_campaign`` reports each
+        # journal flush through ``prismaquant.prismabuild_progress``; PB then
+        # applies no total-duration limit while the count advances, and ends
+        # the row within the declared allowance when it stops.
+        row["progress_phases"] = [f"{name}={grace}" for name, grace in progress_phases]
+    if timeout_s is not None:
+        # Only when somebody asked for one.  A blanket default here is what
+        # sealed 14,400 s into every pricing row and killed two of them mid
+        # round (PB #480); the ceiling a row needs is not a property of the
+        # dispatcher.
+        row["timeout_s"] = int(timeout_s)
     return row
 
 
@@ -685,7 +714,8 @@ def cmd_plan(args) -> int:
                 argv += ["--seed-wire-dir", str(args.seed_wire_dir)]
         rows.append(_row(spec, argv,
                          mem_gb=_row_memory_gb(spec, members, census, selected_source=selected_source),
-                         timeout_s=int(args.timeout_s)))
+                         timeout_s=(None if args.timeout_s is None
+                                    else int(args.timeout_s))))
         planned.append({"row_id": row_id, "groups": bundle, "members": sorted(members),
                         "dir": str(row_dir), "units": str(units_path),
                         **({'seed': row_seed} if row_seed is not None else {}),
@@ -1456,7 +1486,15 @@ def main(argv=None) -> int:
                            "that does not fit is left out of the manifest and "
                            "recorded in the plan, and only a plan with no "
                            "admissible row at all refuses.")
-    plan.add_argument("--timeout-s", type=int, default=14400)
+    plan.add_argument("--timeout-s", type=int, default=None,
+                      help="a hard wall-clock deadline for every row, ending "
+                           "it whatever it is doing. Unset by default: rows "
+                           "declare the phases they walk and the quiet they "
+                           "are allowed in each instead, so a row that keeps "
+                           "committing anchors keeps running and one that "
+                           "stops ends within "
+                           f"{sum(g for _, g in CAMPAIGN_PROGRESS_PHASES)}s. "
+                           "Set it only to cap a row's cost deliberately")
     plan.add_argument("--stack-sample", type=int, default=None,
                       help="price each routed stack from this many experts "
                            "per role, drawn proportional to the probe's "

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -406,6 +406,9 @@ def cmd_census(args) -> int:
          *spec["campaign_argv"]],
         mem_gb=_row_memory_gb(spec, [], {}),
         timeout_s=int(args.timeout_s),
+        # Census exits before the pricing journal/reporter exists.  Its
+        # explicit wall-clock deadline is the only bound it declares.
+        progress_phases=(),
     )
     manifest.write_text(json.dumps([row], indent=2) + "\n")
     if '--streaming' in spec['campaign_argv']:
@@ -434,7 +437,10 @@ def cmd_capture(args) -> int:
         "--capture-calibration-out", str(workspace / "calibration-cache"),
         *spec["campaign_argv"]],
         mem_gb=_row_memory_gb(spec, sorted(census["counts"]), census),
-        timeout_s=int(args.timeout_s))
+        timeout_s=int(args.timeout_s),
+        # Capture is likewise not an anchor-pricing row and makes no durable
+        # anchor-counter reports.
+        progress_phases=())
     manifest.write_text(json.dumps([row], indent=2) + "\n")
     if '--streaming' in spec['campaign_argv']:
         (workspace/'capture-resources.json').write_text(json.dumps(

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -318,7 +318,7 @@ def partition_rows_by_fit(row_memory_gb: "dict[str, int]", per_box: int,
 
 
 #: The quiet a pricing row is allowed in each phase, in the order it walks
-#: them.  Measured, not chosen: a least-squares fit of ``elapsed_s`` against
+#: them. Chosen with margin from a least-squares fit of ``elapsed_s`` against
 #: committed batches over the 23 completed 864-unit GLM pricing rows in the
 #: fleet's terminal records (2026-09-10) gives 18.6728 s of wall clock per
 #: committed batch and an 836.1 s non-pricing intercept; the greatest absolute

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -464,6 +464,12 @@ def _pbcampaign(manifest: Path, *, wait_s: int, receipts: Path | None = None) ->
     every row reports a key, the host it executed on and its exit status, and
     ``merge`` refuses without it.  A submission acknowledgement is not a result.
     """
+    # No ``--transport``: the fleet's own default carries these rows, and the
+    # rows say what they need.  Every row declares progress phases, which
+    # ``pbcampaign`` refuses at manifest load on SLURM because the stall
+    # watchdog is the pull-queue worker's.  Pinning ``--transport pool`` here
+    # would instead submit into a queue a cut-over fleet might not drain; the
+    # refusal is the outcome we want, and it names the reason.
     command = [sys.executable, str(PBCAMPAIGN), "--wait-s", str(wait_s), str(manifest)]
     print("[dispatch] " + " ".join(command), flush=True)
     completed = subprocess.run(command, check=False, text=True,

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -319,15 +319,15 @@ def partition_rows_by_fit(row_memory_gb: "dict[str, int]", per_box: int,
 
 #: The quiet a pricing row is allowed in each phase, in the order it walks
 #: them.  Measured, not chosen: a least-squares fit of ``elapsed_s`` against
-#: committed batches over the 23 completed full 864-unit GLM pricing rows in
-#: the fleet's terminal records (2026-09-10) gives 18.4 s of wall clock per
-#: committed batch and 943 s of everything that is not the pricing loop --
-#: source and calibration load, activations, and the finalization tail --
-#: with every full-length row inside +-180 s of that fit.
+#: committed batches over the 23 completed 864-unit GLM pricing rows in the
+#: fleet's terminal records (2026-09-10) gives 18.6728 s of wall clock per
+#: committed batch and an 836.1 s non-pricing intercept; the greatest absolute
+#: residual is 160.5 s. The retained-record extraction and its exact row and
+#: terminal hashes are committed in ``docs/measurements/pq480_progress_grace_fit_2026-09-10.md``.
 #:
-#: So: ``pricing`` is 49x the measured commit cadence, and ``startup`` and
-#: ``finalize`` are each larger than the whole 943 s of non-pricing quiet the
-#: fit attributes to both together.  The sum, 6300 s, is the longest a row can
+#: So: ``pricing`` permits 48.2 fitted commit intervals, and ``startup`` and
+#: ``finalize`` each exceed the fitted non-pricing interval including its
+#: greatest residual (996.6 s). The sum, 6300 s, is the longest a row can
 #: run having committed nothing -- less than half the 14,400 s that killed
 #: row-0050 and row-0065 while they were committing anchors every 18 s.
 #:

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -330,6 +330,12 @@ def partition_rows_by_fit(row_memory_gb: "dict[str, int]", per_box: int,
 #: fit attributes to both together.  The sum, 6300 s, is the longest a row can
 #: run having committed nothing -- less than half the 14,400 s that killed
 #: row-0050 and row-0065 while they were committing anchors every 18 s.
+#:
+#: There is no flag to override this, on purpose: the number is a measurement
+#: of one workload and a flag would invite a guess.  A campaign whose rows
+#: measurably behave differently edits its planned manifest -- ``plan`` writes
+#: ``progress_phases`` into every row and ``submit`` reads it back -- or
+#: re-fits this constant against its own terminal records.
 CAMPAIGN_PROGRESS_PHASES = (("startup", 3600), ("pricing", 900), ("finalize", 1800))
 
 

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -54,6 +54,20 @@ against it, so a seeded row adopts only bytes it would itself have encoded.
 The adaptive state needs nothing else -- ``grid``, the leave-one-out error and
 the stop reason are all recomputed from the anchor set at the top of every
 round -- so adopting the anchors resumes the group exactly where it stood.
+
+Rows planned before the progress contract
+-----------------------------------------
+Nothing migrates in place.  A row already in ``ready/`` was sealed with its
+own ``execution_timeout_s``; that request is immutable and stays exactly as
+it is, still bounded by the number it was submitted with.  The stall policy
+is sealed too, so a plan made after it produces different action keys, and a
+key that has never been priced is not a cache hit.  What carries the work
+across is the journal rather than the queue: the new row resumes from the
+same identity-bound ``cost_stage_checkpoint`` directory (or is handed the
+monolith's anchors with ``--seed-workspace`` / ``--seed-checkpoint``), so the
+anchors already committed under the old key are re-adopted rather than
+re-measured.  Withdraw the old rows once the new ones are running; do not
+edit them.
 """
 from __future__ import annotations
 

--- a/tools/tessera_campaign_container.py
+++ b/tools/tessera_campaign_container.py
@@ -14,6 +14,7 @@ import re
 import subprocess
 
 from tools.container_runtime_identity import image_content_sha256
+from prismaquant.prismabuild_progress import PATH_ENV, TOKEN_ENV
 
 
 def validate_container(spec: dict) -> None:
@@ -97,9 +98,6 @@ def gpu_attachment(spec: dict, *, cpu_only: bool, environ) -> tuple:
         if value == "":
             return False, f"{source} declares no visible device"
     return True, "no declaration withheld the device"
-
-
-from prismaquant.prismabuild_progress import PATH_ENV, TOKEN_ENV
 
 
 def progress_environment(spec: dict, environ) -> dict:

--- a/tools/tessera_campaign_container.py
+++ b/tools/tessera_campaign_container.py
@@ -99,8 +99,41 @@ def gpu_attachment(spec: dict, *, cpu_only: bool, environ) -> tuple:
     return True, "no declaration withheld the device"
 
 
+from prismaquant.prismabuild_progress import PATH_ENV, TOKEN_ENV
+
+
+def progress_environment(spec: dict, environ) -> dict:
+    """The PrismaBuild progress channel this container needs, if any.
+
+    The container is launched with the declared ``env`` and nothing else, so
+    without this the row inside it cannot report advancement, PB sees a silent
+    action and ends it within the startup allowance -- a stall watchdog killing
+    exactly the working rows it was added to save (PB #480).
+
+    Refused rather than dropped when the file's directory is not inside a
+    writable declared mount.  A report written into the container's own
+    ephemeral filesystem is invisible to the worker and indistinguishable from
+    not reporting at all, and failing at launch is far cheaper than failing an
+    hour into a pricing round.
+    """
+
+    path, token = environ.get(PATH_ENV), environ.get(TOKEN_ENV)
+    if not path or not token:
+        return {}
+    directory = PurePosixPath(path).parent
+    for mount in spec["container"].get("mounts", []):
+        target = PurePosixPath(mount["target"])
+        if (directory == target or target in directory.parents) and not mount.get("readonly", False):
+            return {PATH_ENV: str(path), TOKEN_ENV: str(token)}
+    raise RuntimeError(
+        f"the PrismaBuild progress file {path} is not inside any writable "
+        "container mount, so this row could not report the anchors it commits "
+        "and would be ended as a stall; declare a mount covering it")
+
+
 def docker_command(spec: dict, command: list[str], *, cwd: str,
-                   uid: int, gid: int, image_id: str, content_sha256=None, with_gpu=True) -> list[str]:
+                   uid: int, gid: int, image_id: str, content_sha256=None,
+                   with_gpu=True, environ=None) -> list[str]:
     validate_container(spec)
     argv = ["docker", "run", "--rm", *(["--gpus", "all"] if with_gpu else []), "--ipc=host",
             "--user", f"{uid}:{gid}", "--workdir", "/workspace",
@@ -111,7 +144,9 @@ def docker_command(spec: dict, command: list[str], *, cwd: str,
         if mount.get("readonly", False):
             value += ",readonly"
         argv += ["--mount", value]
-    for key, value in sorted(spec.get("env", {}).items()):
+    forwarded = {**spec.get("env", {}),
+                 **progress_environment(spec, environ if environ is not None else {})}
+    for key, value in sorted(forwarded.items()):
         argv += ["--env", f"{key}={value}"]
     if content_sha256 is not None:
         argv += ['--env', 'PRISMAQUANT_CONTAINER_CONTENT_SHA256=' + content_sha256]
@@ -169,7 +204,8 @@ def main(argv=None) -> int:
                       "gpu_attached": with_gpu, "gpu_decision": gpu_reason}), flush=True)
     docker = docker_command(spec, command, cwd=str(Path.cwd()),
                             uid=os.getuid(), gid=os.getgid(), image_id=image_id,
-                            content_sha256=content_digest, with_gpu=with_gpu)
+                            content_sha256=content_digest, with_gpu=with_gpu,
+                            environ=os.environ)
     os.execvp(docker[0], docker)
     return 1  # exec never returns
 


### PR DESCRIPTION
Closes #480. Paired with RobTand/prismabuild#481 and tracked through deployment in RobTand/prismabuild#480.

Tessera pricing rows previously sealed a default 14,400-second deadline that killed rows while they were committing anchors. Pricing now declares startup/pricing/finalize stall allowances and reports its cumulative durable-anchor count after the identity-bound journal flush. An explicitly requested hard deadline remains binding. Census and calibration capture retain their deadlines and do not declare anchor progress, since they exit before the reporter starts.

The container forwards the per-attempt channel through writable declared mounts. Existing sealed requests and checkpoint identity remain immutable. New progress rows require the published PB watchdog generation before admission.

The [retained fit](docs/measurements/pq480_progress_grace_fit_2026-09-10.md) names 23 completed rows and their terminal hashes, with an executable extractor: 18.6728 seconds/batch, 836.1-second intercept and 160.5-second maximum residual. These workload-specific estimates inform chosen margins; they do not directly measure longest phase gaps.

PB validation at priority -10 with bounded native threads:

- Original census/capture regression reproduced in action `d90bff19c068543914dc194d6c8333da520e9d5c93f7b526f47d3838c8b2e456`.
- Reporter, dispatcher and manifest tests: 32 passed, receipt `41ca3087414d8873693923eaaf77a0dd3c654f597858f825e2614636568f4b6b`, action `fc4bc080b7a1d6a80aafd782ee3a194befd00e9d77df787fed748eba67e84540`.
- Final allowance/dispatch tests: 14 passed, 14 deprecation warnings, no skips; receipt `860aae0276435afaa40a0bcfa5c0420cfb15ac7308ab522c0f07d7ff5f831e82`, action `6df7bc5213eeda556a7576fd889d4b08b04edb30d221ac1ddd5a6d2e76292545`.
- Fit extraction returned 0 under PB, receipt `8f99bc54a962267d3e94cfa160ebafbf5a4dd12eb621f71e556d1faf224df8c1`. The coordinator independently checked all 23 terminal hashes/statuses and successful CAS payloads.
