### PR TITLE
#283: pipeline the anchor-batch boundary — identity on the writer, sized hold, bind memo; #389 unit-major batches

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,6 +20,16 @@ receipt, no row, and the action stops. Outputs are unchanged byte for byte
 (gates: `tests/test_tessera_publication.py`, `tests/test_tessera_bound_identity.py`,
 `tests/test_tessera_campaign_publication_cli.py`).
 
+The identity reservation's planner now charges the retained per-unit hold as
+the fixed object term, the interpreter's own frozenset table size for the
+closed roster's borrowed format references, and the serialized receipt
+envelope; the roster transient (two closed rosters of per-format namespaces
+live during construction) is charged explicitly in the planning scratch. The
+former 1 KiB-per-format retained envelope charged an 864-unit GLM expert row
+~1.9 GB and pushed its admission past the box; the bound is exact in the
+interpreter's terms and is still tested against `observed_metadata_bytes` on
+every run. The 864-unit row now fits a 256 MiB reservation.
+
 Re-stamped (2026-09-10, `perf/glm-publication-transition-optimization`) for
 experimental `--campaign-identity-bytes N`. It is off when `N=0`. A positive
 value is a declared selected-source PB reservation; runtime derives the closed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,24 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-10 · `perf/glm-publication-transition-optimization`. Stamps
+As of: 2026-09-10 · `perf/glm-boundary-pipeline`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-10, `perf/glm-boundary-pipeline`) for the **batch-boundary
+pipeline** (§4.10): with `--publication-overlap-bytes N` and
+`--campaign-identity-bytes M` both set, every post-encode step of a batch that
+touches no device runs on the publisher's writer thread behind that batch's
+own files -- the render/wire writes, the per-anchor identity derived from the
+unit's sealed template (`_AnchorPublicationLedger.record(anchor, derive=...)`),
+the wire receipt read back off the published file, and the journal write --
+while the encode thread starts the next batch. The writer stays CPU/IO-only by
+contract: the producer's graph capture forbids surprise device work from
+another thread, so the render score and the device-to-host copy remain on the
+encode thread, and without a bound identity the producer's
+`encoding_input_identity` (which hashes the resident weight and Hessian)
+still runs there. A refused deferred identity is a publication failure: no
+receipt, no row, and the action stops. Outputs are unchanged byte for byte
+(gates: `tests/test_tessera_publication.py`, `tests/test_tessera_bound_identity.py`,
+`tests/test_tessera_campaign_publication_cli.py`).
 
 Re-stamped (2026-09-10, `perf/glm-publication-transition-optimization`) for
 experimental `--campaign-identity-bytes N`. It is off when `N=0`. A positive

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,6 +30,15 @@ former 1 KiB-per-format retained envelope charged an 864-unit GLM expert row
 interpreter's terms and is still tested against `observed_metadata_bytes` on
 every run. The 864-unit row now fits a 256 MiB reservation.
 
+Anchor batches are emitted unit-major (`_anchor_batches`): the chunks of one
+`(family, shape, dtype, device)` key are ordered by chunk position first and
+rung second, so consecutive batches encode the same expert units at successive
+rungs and the encoder memo -- sized to the batch width by the plan -- reuses
+each unit's block-LDL factorization across its rungs instead of refactorizing
+once per (unit, rung) with every other unit's batches in between
+(PrismaQuant #389). Batch membership, wire bytes, prices and the checkpoint
+identity are unchanged; only the order of encodes moves.
+
 Re-stamped (2026-09-10, `perf/glm-publication-transition-optimization`) for
 experimental `--campaign-identity-bytes N`. It is off when `N=0`. A positive
 value is a declared selected-source PB reservation; runtime derives the closed

--- a/experiments/campaign_identity_hold_measure.py
+++ b/experiments/campaign_identity_hold_measure.py
@@ -1,0 +1,166 @@
+"""Measure the campaign identity hold against its planned bound on CPU.
+
+A CPU action: build real ``_BoundCheckpointUnitIdentity`` holders through the
+campaign's own roster and planner over the GLM routed-expert closed roster
+(every ``TESSERA_E4M3_K1`` rung the family admits), at the row's unit shapes,
+and report ``observed_metadata_bytes`` per unit against the planned bound,
+the construction transient against the planned scratch, and the extrapolated
+864-unit reservation.  Synthetic weights and Hessians at the real shapes;
+the hash values are irrelevant to the object sizes and are not reported as
+identities of anything.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--out', required=True, type=Path)
+    parser.add_argument('--census', required=True, type=Path)
+    parser.add_argument('--units', nargs='+', default=[
+        'model.language_model.layers.28.mlp.experts.0.gate_proj',
+        'model.language_model.layers.28.mlp.experts.0.up_proj',
+        'model.language_model.layers.28.mlp.experts.0.down_proj'])
+    parser.add_argument('--row-units', type=int, default=864)
+    parser.add_argument('--reservation-bytes', type=int, default=256*1024**2)
+    args = parser.parse_args(argv)
+
+    import torch
+    from prismaquant import tessera_campaign as tc, tessera_hessian as th
+    from prismaquant.tessera_formats import get_tessera_family
+    from prismaquant.tessera_menu import expand_tessera_menu, MENU_READABLE
+
+    shapes = json.loads(args.census.read_text())['unit_shapes']
+    family = get_tessera_family('TESSERA_E4M3_K1')
+    weights, hessians, menus, projections = {}, {}, {}, {}
+    for name in args.units:
+        out_features, in_features = (int(v) for v in shapes[name])
+        generator = torch.Generator().manual_seed(len(name))
+        weights[name] = torch.randn(out_features, in_features, generator=generator).to(torch.bfloat16)
+        hessians[name] = torch.eye(in_features)
+        menus[name] = expand_tessera_menu((out_features, in_features), mode=MENU_READABLE,
+                                          families=(family,))
+        # A packed routed expert's projection record, as the campaign's
+        # projected_units carry it; the sizes are what matter here.
+        expert = int(name.split('.experts.')[1].split('.')[0])
+        projection = name.rsplit('.', 1)[-1]
+        projections[name] = dict(tensor=name + '.weight', source_tensor=name.rsplit('.experts.', 1)[0]
+            + '.experts.' + ('w13' if projection != 'down_proj' else 'w2') + '.weight',
+            source_layout='packed', source_slice={'expert': expert}, expert=expert,
+            projection=projection, group='w13' if projection != 'down_proj' else 'w2',
+            rows=out_features, cols=in_features)
+    source = th.activation_source(hessians, th.calibration_identity(
+        'identity-hold-measurement', [torch.arange(16).reshape(1, 16)], fit_tokens=16))
+    static_scales = {}
+    started = time.perf_counter()
+    bounds, scratch = tc._campaign_identity_metadata_plan(
+        weights=weights, menus=menus, calibration_source=source,
+        projected_units=projections, static_scales=static_scales)
+    plan_seconds = time.perf_counter() - started
+    report = dict(schema='prismaquant.campaign_identity_hold_measurement.v1',
+        python=sys.version, torch=torch.__version__, units={}, plan_seconds=plan_seconds,
+        planned_scratch_bytes=scratch, roster_widths={n: len(m) for n, m in menus.items()})
+    # Where the bind time goes: the per-format roster helpers, the producer's
+    # tensor hash (whose ``tobytes`` copy is also the construction peak), and
+    # the rest.  Wrapped on the modules the campaign resolves them from.
+    from tessera import cached_unit
+    from prismaquant import tessera_formats, tessera_render
+    timings = {}
+
+    def timed(owner, attr, label):
+        original = getattr(owner, attr)
+        def wrapped(*a, **k):
+            t = time.perf_counter()
+            try:
+                return original(*a, **k)
+            finally:
+                entry = timings.setdefault(label, [0, 0.0])
+                entry[0] += 1; entry[1] += time.perf_counter() - t
+        setattr(owner, attr, wrapped)
+        return owner, attr, original
+
+    restore = [timed(tessera_formats, 'tessera_wire_recipe', 'tessera_wire_recipe'),
+               timed(tessera_render, 'rung_accepts_hessian', 'rung_accepts_hessian'),
+               timed(cached_unit, 'tensor_identity', 'tensor_identity'),
+               timed(tc, '_checkpoint_anchor_identity', '_checkpoint_anchor_identity')]
+    tracemalloc.start()
+    held = {}
+    try:
+        for name in args.units:
+            timings.clear()
+            tracemalloc.reset_peak()
+            before = tracemalloc.get_traced_memory()[0]
+            t0 = time.perf_counter()
+            roster = tc._campaign_identity_anchor_roster(name, menus[name],
+                calibration_source=source, static_scales=static_scales)
+            roster_seconds = time.perf_counter() - t0
+            t0 = time.perf_counter()
+            held[name] = tc.bind_checkpoint_unit_identity(roster, source_weight=weights[name],
+                calibration_source=source, projected_unit=projections[name],
+                static_scales=static_scales, retain_source_receipt=False)
+            bind_seconds = time.perf_counter() - t0
+            split = {label: dict(calls=calls, seconds=seconds) for label, (calls, seconds) in timings.items()}
+            current, peak = tracemalloc.get_traced_memory()
+            del roster
+            observed = held[name].observed_metadata_bytes()
+            t1 = time.perf_counter()
+            derived = held[name].derive(source_weight=weights[name], qname=name,
+                format_name=menus[name][0].format_name, grid=family.payload_grid(),
+                rung=int(menus[name][0].body_rate_q256), activation=source,
+                projected_unit=projections[name])
+            derive_seconds = time.perf_counter() - t1
+            # The producer's tensor_identity makes one bytes() copy of the
+            # tensor it hashes; the Hessian's is the largest live transient
+            # of construction and exists on the historical per-anchor path
+            # too.  The roster's own transient is what is left after it.
+            hash_copy = max(weights[name].numel() * weights[name].element_size(),
+                            hessians[name].numel() * hessians[name].element_size())
+            transient = (peak - before) - (current - before)
+            report['units'][name] = dict(shape=shapes[name], formats=len(menus[name]),
+                planned_bound_bytes=bounds[name], observed_metadata_bytes=observed,
+                within_bound=observed <= bounds[name],
+                traced_retained_bytes=current - before, traced_construction_peak_bytes=peak - before,
+                construction_transient_bytes=transient,
+                producer_hash_copy_bytes=hash_copy,
+                roster_transient_bytes=max(0, transient - hash_copy),
+                roster_seconds=roster_seconds, bind_seconds=bind_seconds, bind_split=split,
+                derive_seconds=derive_seconds,
+                template_json_bytes=len(json.dumps(derived, sort_keys=True).encode()))
+    finally:
+        tracemalloc.stop()
+        for owner, attr, original in restore:
+            setattr(owner, attr, original)
+        for unit in held.values():
+            unit.close()
+    widest = max(report['units'].values(), key=lambda u: u['planned_bound_bytes'])
+    transient = max(u['roster_transient_bytes'] for u in report['units'].values())
+    report['row'] = dict(units=args.row_units, reservation_bytes=args.reservation_bytes,
+        planned_total_bytes=args.row_units * widest['planned_bound_bytes'] + scratch,
+        observed_extrapolated_bytes=args.row_units * max(
+            u['observed_metadata_bytes'] for u in report['units'].values()) + transient,
+        planned_fits_reservation=(args.row_units * widest['planned_bound_bytes'] + scratch
+                                  <= args.reservation_bytes),
+        scratch_covers_roster_transient=scratch >= transient,
+        producer_hash_copy_peak_bytes=max(u['producer_hash_copy_bytes'] for u in report['units'].values()))
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(report, indent=2, sort_keys=True) + '\n')
+    print(json.dumps(report['row']), flush=True)
+    for name, unit in report['units'].items():
+        print(json.dumps(dict(unit=name, **{k: unit[k] for k in (
+            'formats', 'planned_bound_bytes', 'observed_metadata_bytes', 'within_bound',
+            'construction_transient_bytes', 'roster_transient_bytes', 'roster_seconds',
+            'bind_seconds', 'bind_split', 'derive_seconds')})), flush=True)
+    if not all(u['within_bound'] for u in report['units'].values()):
+        raise SystemExit('observed identity metadata exceeded the planned bound')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/experiments/campaign_publication_ab.py
+++ b/experiments/campaign_publication_ab.py
@@ -104,7 +104,7 @@ def arm_order(identity_bytes=0, override=None):
             if identity else [(0, 0), (budget, 0), (budget, 0), (0, 0)])
 
 
-def prepare(spec_path, workspace, row_id, out, *, identity_bytes=0, order=None):
+def prepare(spec_path, workspace, row_id, out, *, identity_bytes=0, order=None, profiler_allowance_gib=2):
     """Write the plan.  ``identity_bytes`` > 0 adds the pipelined arms.
 
     v1 order was ``[0, B, B, 0]`` (synchronous, overlap, overlap,
@@ -116,6 +116,8 @@ def prepare(spec_path, workspace, row_id, out, *, identity_bytes=0, order=None):
     ``order`` overrides the arm list for a repeat run; an arm may be a
     ``(overlap, identity, anchor_batch_size)`` triple to run the same
     configuration at another batch width, checked in-plan for exact parity.
+    ``profiler_allowance_gib`` is the bounded CUDA trace plus its decoded
+    objects, charged on top of the workload; the trace cap is a quarter of it.
     """
     from tools.dispatch_tessera_campaign import load_spec, _streamed_resource_plan
     spec = load_spec(spec_path)
@@ -145,7 +147,10 @@ def prepare(spec_path, workspace, row_id, out, *, identity_bytes=0, order=None):
         plan['process_baseline_bytes'])/1024**3)
     if workload_memory > spec['box_memory_gb']:
         raise ValueError(f'comparison workload needs {workload_memory} GiB, above the recipe budget')
-    memory = workload_memory+2
+    allowance = int(profiler_allowance_gib)
+    if allowance < 1:
+        raise ValueError('the profiler allowance is at least 1 GiB')
+    memory = workload_memory+allowance
     inputs = [Path(spec_path), workspace/'plan.json', Path(plan['manifest']),
         Path(plan['census']), Path(row['units']),
         Path(command[command.index('--calibration-cache')+1])]
@@ -155,7 +160,7 @@ def prepare(spec_path, workspace, row_id, out, *, identity_bytes=0, order=None):
         limit_anchors=64, projection='gate_up', order=[list(arm) for arm in order],
         environment=spec['env'], container=spec['container'],
         requested_cpus=spec['cpus'], requested_memory_gib=memory, workload_memory_gib=workload_memory,
-        out=str(out/'native'), profiler_allowance_gib=2)
+        out=str(out/'native'), profiler_allowance_gib=allowance)
     out.mkdir(parents=True, exist_ok=True)
     write(out/'plan.json', value)
     print(json.dumps(dict(plan=str(out/'plan.json'), sha256=digest(out/'plan.json'),
@@ -356,7 +361,8 @@ def arm(plan, out, budget, identity=0, batch=None):
     memory = MemorySampler(out/'memory-samples.json')
     memory.start()
     observer = AnchorObserver(out/'profile', profile_calls=[0],
-        trace_max_bytes=512*1024**2, command=command, cuda_only=True, window_seconds=0.25)
+        trace_max_bytes=int(plan.get('profiler_allowance_gib', 2))*1024**3//4, command=command,
+        cuda_only=True, window_seconds=0.25)
     observer.result['python_sampler']['interval_seconds'] = 0.2
     try:
         with observer, instrument(campaign, recorder, plan['projection']):

--- a/experiments/campaign_publication_ab.py
+++ b/experiments/campaign_publication_ab.py
@@ -23,7 +23,41 @@ from experiments.campaign_batch_prefix_ab import prefix_state
 from experiments.selected_snapshot_scope_ab import digest, write
 
 
-def prepare(spec_path, workspace, row_id, out):
+SCHEMA_V1 = 'prismaquant.campaign_publication_ab.v1'
+SCHEMA_V2 = 'prismaquant.campaign_publication_ab.v2'
+OVERLAP_BUDGET = 256*1024**2
+
+
+def arm_flags(overlap, identity):
+    """The campaign flags one arm adds to the original synchronous recipe."""
+    flags = ['--publication-overlap-bytes', str(int(overlap))]
+    if int(identity) > 0:
+        flags += ['--campaign-identity-bytes', str(int(identity))]
+    return flags
+
+
+def plan_order(plan):
+    """Every arm as an ``(overlap_bytes, identity_bytes)`` pair, v1 included."""
+    if plan['schema'] == SCHEMA_V1:
+        return [(int(budget), 0) for budget in plan['order']]
+    if plan['schema'] != SCHEMA_V2:
+        raise ValueError('unknown publication comparison schema')
+    order = [tuple(int(v) for v in pair) for pair in plan['order']]
+    if any(len(pair) != 2 or min(pair) < 0 for pair in order):
+        raise ValueError('a v2 arm is an (overlap_bytes, identity_bytes) pair')
+    return order
+
+
+def prepare(spec_path, workspace, row_id, out, *, identity_bytes=0):
+    """Write the plan.  ``identity_bytes`` > 0 adds the pipelined arms.
+
+    v1 order was ``[0, B, B, 0]`` (synchronous, overlap, overlap,
+    synchronous).  With an identity reservation the order is
+    ``[(0,0), (B,0), (B,I), (B,I), (B,0)]``: the synchronous parity arm, the
+    overlap-only baseline, the pipelined arm twice, and the baseline again so
+    the box's drift across the run brackets both.  Memory is computed for
+    each distinct pair through the same dispatcher plan a row is admitted on.
+    """
     from tools.dispatch_tessera_campaign import load_spec, _streamed_resource_plan
     spec = load_spec(spec_path)
     workspace, out = Path(workspace), Path(out)
@@ -38,11 +72,16 @@ def prepare(spec_path, workspace, row_id, out):
     if '--publication-overlap-bytes' in command or '--seed-checkpoint' in command:
         raise ValueError('comparison requires the original fresh synchronous recipe')
     resources = {}
-    budget = 256*1024**2
-    for value in (0, budget):
+    budget = OVERLAP_BUDGET
+    identity = int(identity_bytes)
+    if identity < 0:
+        raise ValueError('identity bytes cannot be negative')
+    order = ([(0, 0), (budget, 0), (budget, identity), (budget, identity), (budget, 0)]
+             if identity else [(0, 0), (budget, 0), (budget, 0), (0, 0)])
+    for pair in sorted(set(order)):
         selected = copy.deepcopy(spec)
-        selected['campaign_argv'] += ['--publication-overlap-bytes', str(value)]
-        resources[str(value)] = _streamed_resource_plan(selected, census, row['members'], selected_source=True)
+        selected['campaign_argv'] += arm_flags(*pair)
+        resources['%d:%d' % pair] = _streamed_resource_plan(selected, census, row['members'], selected_source=True)
     # Existing measured process baseline plus a bounded CUDA trace and its
     # decoded profiler objects. This allowance is separate from staged bytes.
     workload_memory = math.ceil((max(r['memory_bytes'] for r in resources.values())+
@@ -53,17 +92,21 @@ def prepare(spec_path, workspace, row_id, out):
     inputs = [Path(spec_path), workspace/'plan.json', Path(plan['manifest']),
         Path(plan['census']), Path(row['units']),
         Path(command[command.index('--calibration-cache')+1])]
-    value = dict(schema='prismaquant.campaign_publication_ab.v1', command=command,
+    value = dict(schema=SCHEMA_V2, command=command,
         input_sha256={str(path): digest(path) for path in inputs}, resources=resources,
         row_id=row_id, groups=row['groups'], expected_source_units=864,
-        limit_anchors=64, projection='gate_up', order=[0, budget, budget, 0],
+        limit_anchors=64, projection='gate_up', order=[list(pair) for pair in order],
         environment=spec['env'], container=spec['container'],
         requested_cpus=spec['cpus'], requested_memory_gib=memory, workload_memory_gib=workload_memory,
         out=str(out/'native'), profiler_allowance_gib=2)
     out.mkdir(parents=True, exist_ok=True)
     write(out/'plan.json', value)
     print(json.dumps(dict(plan=str(out/'plan.json'), sha256=digest(out/'plan.json'),
-        memory_gib=memory, publication_staging_bytes={k:v['phases']['resident_anchors']['publication_staging_bytes']
+        memory_gib=memory, order=order,
+        resident_anchors_bytes={k: sum(v['phases']['resident_anchors'].values()) for k, v in resources.items()},
+        publication_staging_bytes={k:v['phases']['resident_anchors']['publication_staging_bytes']
+        for k,v in resources.items()},
+        campaign_identity_metadata_bytes={k:v['phases']['resident_anchors'].get('campaign_identity_metadata_bytes', 0)
         for k,v in resources.items()})), flush=True)
 
 
@@ -118,29 +161,73 @@ class PhaseRecorder:
 @contextmanager
 def instrument(campaign, recorder, projection):
     from prismaquant import production_weight_cache, perturbed_x_cache, cost_stage_checkpoint
+    from prismaquant.tessera_publication import BoundedPublisher
     targets = [
-        (campaign, name) for name in ('_checkpoint_anchor_identity', '_checkpoint_wire_record', '_finish_anchor')
+        (campaign, name) for name in ('_checkpoint_anchor_identity', '_checkpoint_wire_record', '_finish_anchor',
+                                      '_campaign_bound_identities', '_adopt_seed_checkpoint')
     ] + [
+        # The per-anchor derivation off a sealed template.  Its thread name
+        # in the record is the evidence of where the post-work ran.
+        (campaign._BoundCheckpointUnitIdentity, 'derive'),
         (production_weight_cache, '_store_rendered_weight_entry'),
         (production_weight_cache, '_canonical_rendered_weight_tensor'),
         (production_weight_cache, '_local_forward_render_score'),
         (perturbed_x_cache, 'release_activation_cache_file_pages'),
         (cost_stage_checkpoint, 'write_unit'),
     ]
+    from prismaquant import tessera_hessian
+    targets.append((tessera_hessian, 'encoder_kwargs'))
     originals = [(owner, name, getattr(owner, name)) for owner, name in targets]
     batches = campaign._anchor_batches
+    close = BoundedPublisher.close
+    memo = campaign._activation_kwargs_memo
+    memos = []
+
+    def memo_with_record(*a, **kw):
+        # The encoder memo (RobTand/prismaquant#389): its hit/miss counts are
+        # read at the end of the arm, so the profile carries the memo policy's
+        # measured effect and not only the factorization spans.
+        built = memo(*a, **kw)
+        memos.append(built)
+        return built
+
+    def close_with_stats(self):
+        # The prefix ends by exception, before the campaign would stamp the
+        # publisher's counters into provenance; take them at the close the
+        # unwind always performs.  ``submit_blocked_seconds`` is how long the
+        # encode thread waited on the byte budget, which is the writer
+        # backpressuring the encode, and it has to be reported if nonzero.
+        try:
+            stats = self.stats()
+        except Exception as error:  # pragma: no cover - diagnostic only
+            stats = dict(error=repr(error))
+        recorder.records.append(dict(phase='tessera_publication.BoundedPublisher.stats',
+            started_unix=time.time(), seconds=0.0, thread_cpu_seconds=0.0,
+            thread=threading.current_thread().name, qname=None, format_name=None, stats=stats))
+        return close(self)
+
     try:
         for owner, name, original in originals:
             setattr(owner, name, recorder.wrap(original, owner.__name__+'.'+name))
         campaign._anchor_batches = lambda *a, **kw: preferred_batches(batches(*a, **kw), projection)
+        campaign._activation_kwargs_memo = memo_with_record
+        BoundedPublisher.close = close_with_stats
         yield
     finally:
+        BoundedPublisher.close = close
         campaign._anchor_batches = batches
+        campaign._activation_kwargs_memo = memo
         for owner, name, original in originals:
             setattr(owner, name, original)
+        for built in memos:
+            info = built.cache_info()
+            recorder.records.append(dict(phase='tessera_campaign._activation_kwargs_memo.cache_info',
+                started_unix=time.time(), seconds=0.0, thread_cpu_seconds=0.0,
+                thread=threading.current_thread().name, qname=None, format_name=None,
+                cache_info=dict(hits=info.hits, misses=info.misses, maxsize=info.maxsize, currsize=info.currsize)))
 
 
-def arm(plan, out, budget):
+def arm(plan, out, budget, identity=0):
     import torch
     from experiments.campaign_prefix_profile import run_prefix
     from experiments.glm_full_capture_profile import AnchorObserver, selected_anchor_command
@@ -151,7 +238,7 @@ def arm(plan, out, budget):
     for flag, value in {'--out': out/'cost.pkl', '--cache-dir': out/'cache',
             '--checkpoint': out/'cost.anchors.json'}.items():
         command[command.index(flag)+1] = str(value)
-    command += ['--publication-overlap-bytes', str(budget)]
+    command += arm_flags(budget, identity)
     selected_anchor_command(command)
     recorder = PhaseRecorder()
     observer = AnchorObserver(out/'profile', profile_calls=[0],
@@ -173,8 +260,7 @@ def run(path, expected):
     if digest(path) != expected:
         raise ValueError('publication plan changed')
     p = json.loads(Path(path).read_text())
-    if p['schema'] != 'prismaquant.campaign_publication_ab.v1':
-        raise ValueError('unknown publication comparison schema')
+    order = plan_order(p)
     for name, sha in p['input_sha256'].items():
         if digest(name) != sha:
             raise ValueError('publication input changed: '+name)
@@ -183,16 +269,18 @@ def run(path, expected):
             raise ValueError('publication environment changed: '+name)
     root = Path(p['out']); root.mkdir(parents=True, exist_ok=False)
     rows, baseline = [], None
-    for index, budget in enumerate(p['order']):
+    for index, (budget, identity) in enumerate(order):
         out = root/f'arm-{index:02d}'; out.mkdir()
         command = [sys.executable, '-u', '-m', 'experiments.campaign_publication_ab', '--plan', str(path),
-            '--plan-sha256', expected, '--arm-out', str(out), '--budget', str(budget)]
+            '--plan-sha256', expected, '--arm-out', str(out), '--budget', str(budget),
+            '--identity-bytes', str(identity)]
         env = dict(os.environ, TRITON_CACHE_DIR=str(out/'triton'),
             TORCHINDUCTOR_CACHE_DIR=str(out/'inductor'))
         started = time.time()
         with (out/'command.log').open('x') as log:
             result = subprocess.run(command, env=env, stdout=log, stderr=subprocess.STDOUT)
-        row = dict(index=index, publication_overlap_bytes=budget, started_unix=started,
+        row = dict(index=index, publication_overlap_bytes=budget, campaign_identity_bytes=identity,
+            started_unix=started,
             finished_unix=time.time(), returncode=result.returncode, command=command)
         rows.append(row); write(out/'exit.json', row)
         if result.returncode:
@@ -222,11 +310,12 @@ def main():
     parser.add_argument('--plan-sha256', required=True)
     parser.add_argument('--arm-out', type=Path)
     parser.add_argument('--budget', type=int)
+    parser.add_argument('--identity-bytes', type=int, default=0)
     args = parser.parse_args()
     if args.arm_out:
         if digest(args.plan) != args.plan_sha256:
             raise ValueError('arm plan changed')
-        arm(json.loads(Path(args.plan).read_text()), args.arm_out, args.budget)
+        arm(json.loads(Path(args.plan).read_text()), args.arm_out, args.budget, args.identity_bytes)
     else:
         run(args.plan, args.plan_sha256)
 

--- a/experiments/campaign_publication_ab.py
+++ b/experiments/campaign_publication_ab.py
@@ -48,7 +48,7 @@ def plan_order(plan):
     return order
 
 
-def prepare(spec_path, workspace, row_id, out, *, identity_bytes=0):
+def prepare(spec_path, workspace, row_id, out, *, identity_bytes=0, order=None):
     """Write the plan.  ``identity_bytes`` > 0 adds the pipelined arms.
 
     v1 order was ``[0, B, B, 0]`` (synchronous, overlap, overlap,
@@ -57,6 +57,7 @@ def prepare(spec_path, workspace, row_id, out, *, identity_bytes=0):
     overlap-only baseline, the pipelined arm twice, and the baseline again so
     the box's drift across the run brackets both.  Memory is computed for
     each distinct pair through the same dispatcher plan a row is admitted on.
+    ``order`` overrides the arm list for a repeat run.
     """
     from tools.dispatch_tessera_campaign import load_spec, _streamed_resource_plan
     spec = load_spec(spec_path)
@@ -78,6 +79,13 @@ def prepare(spec_path, workspace, row_id, out, *, identity_bytes=0):
         raise ValueError('identity bytes cannot be negative')
     order = ([(0, 0), (budget, 0), (budget, identity), (budget, identity), (budget, 0)]
              if identity else [(0, 0), (budget, 0), (budget, 0), (0, 0)])
+    if order_override := order:
+        # A repeat of chosen arms (e.g. one more pipelined arm on a quiet
+        # server); its parity is checked offline against the original run's
+        # synchronous arm, since ``run`` compares only within one plan.
+        order = [tuple(int(v) for v in pair) for pair in order_override]
+        if any(len(pair) != 2 or min(pair) < 0 for pair in order):
+            raise ValueError('an arm is an (overlap_bytes, identity_bytes) pair')
     for pair in sorted(set(order)):
         selected = copy.deepcopy(spec)
         selected['campaign_argv'] += arm_flags(*pair)

--- a/experiments/campaign_publication_ab.py
+++ b/experiments/campaign_publication_ab.py
@@ -48,6 +48,26 @@ def plan_order(plan):
     return order
 
 
+def arm_order(identity_bytes=0, override=None):
+    """The arm list: the default matrix, or the caller's repeat of chosen arms.
+
+    A repeat (e.g. one more pipelined arm on a quiet server) has its parity
+    checked offline against the original run's synchronous arm, since ``run``
+    compares only within one plan.
+    """
+    identity = int(identity_bytes)
+    if identity < 0:
+        raise ValueError('identity bytes cannot be negative')
+    if override:
+        order = [tuple(int(v) for v in pair) for pair in override]
+        if any(len(pair) != 2 or min(pair) < 0 for pair in order):
+            raise ValueError('an arm is an (overlap_bytes, identity_bytes) pair')
+        return order
+    budget = OVERLAP_BUDGET
+    return ([(0, 0), (budget, 0), (budget, identity), (budget, identity), (budget, 0)]
+            if identity else [(0, 0), (budget, 0), (budget, 0), (0, 0)])
+
+
 def prepare(spec_path, workspace, row_id, out, *, identity_bytes=0, order=None):
     """Write the plan.  ``identity_bytes`` > 0 adds the pipelined arms.
 
@@ -73,19 +93,7 @@ def prepare(spec_path, workspace, row_id, out, *, identity_bytes=0, order=None):
     if '--publication-overlap-bytes' in command or '--seed-checkpoint' in command:
         raise ValueError('comparison requires the original fresh synchronous recipe')
     resources = {}
-    budget = OVERLAP_BUDGET
-    identity = int(identity_bytes)
-    if identity < 0:
-        raise ValueError('identity bytes cannot be negative')
-    order = ([(0, 0), (budget, 0), (budget, identity), (budget, identity), (budget, 0)]
-             if identity else [(0, 0), (budget, 0), (budget, 0), (0, 0)])
-    if order_override := order:
-        # A repeat of chosen arms (e.g. one more pipelined arm on a quiet
-        # server); its parity is checked offline against the original run's
-        # synchronous arm, since ``run`` compares only within one plan.
-        order = [tuple(int(v) for v in pair) for pair in order_override]
-        if any(len(pair) != 2 or min(pair) < 0 for pair in order):
-            raise ValueError('an arm is an (overlap_bytes, identity_bytes) pair')
+    order = arm_order(identity_bytes, order)
     for pair in sorted(set(order)):
         selected = copy.deepcopy(spec)
         selected['campaign_argv'] += arm_flags(*pair)

--- a/experiments/campaign_publication_ab.py
+++ b/experiments/campaign_publication_ab.py
@@ -25,7 +25,9 @@ from experiments.selected_snapshot_scope_ab import digest, write
 
 SCHEMA_V1 = 'prismaquant.campaign_publication_ab.v1'
 SCHEMA_V2 = 'prismaquant.campaign_publication_ab.v2'
+SCHEMA_V3 = 'prismaquant.campaign_publication_ab.v3'
 OVERLAP_BUDGET = 256*1024**2
+MEMORY_SAMPLE_SECONDS = 0.5
 
 
 def arm_flags(overlap, identity):
@@ -36,16 +38,49 @@ def arm_flags(overlap, identity):
     return flags
 
 
+def command_batch(command):
+    """The anchor batch width the original recipe runs at."""
+    command = list(command)
+    width = int(command[command.index('--anchor-batch-size')+1])
+    if width < 1:
+        raise ValueError('the recipe batch width must be positive')
+    return width
+
+
+def with_batch(order, default):
+    """Every arm as an ``(overlap_bytes, identity_bytes, batch)`` triple.
+
+    A pair keeps the recipe's width; a triple names its own, so one plan can
+    hold the same pipelined configuration at several widths and check them
+    against each other in-plan.  The width is not part of the checkpoint
+    identity (``tessera_campaign`` drops ``anchor_batch_size`` from the
+    identity settings), so ``prefix_state`` compares across widths exactly.
+    """
+    triples = []
+    for arm in order:
+        arm = tuple(int(v) for v in arm)
+        if len(arm) == 2:
+            arm += (int(default),)
+        if len(arm) != 3 or min(arm[:2]) < 0 or arm[2] < 1:
+            raise ValueError('an arm is (overlap_bytes, identity_bytes[, anchor_batch_size])')
+        triples.append(arm)
+    return triples
+
+
 def plan_order(plan):
-    """Every arm as an ``(overlap_bytes, identity_bytes)`` pair, v1 included."""
+    """Every arm as an ``(overlap_bytes, identity_bytes, batch)`` triple, v1/v2 included."""
+    default = command_batch(plan['command'])
     if plan['schema'] == SCHEMA_V1:
-        return [(int(budget), 0) for budget in plan['order']]
-    if plan['schema'] != SCHEMA_V2:
-        raise ValueError('unknown publication comparison schema')
-    order = [tuple(int(v) for v in pair) for pair in plan['order']]
-    if any(len(pair) != 2 or min(pair) < 0 for pair in order):
-        raise ValueError('a v2 arm is an (overlap_bytes, identity_bytes) pair')
-    return order
+        return with_batch([(int(budget), 0) for budget in plan['order']], default)
+    if plan['schema'] == SCHEMA_V2:
+        if any(len(pair) != 2 for pair in plan['order']):
+            raise ValueError('a v2 arm is an (overlap_bytes, identity_bytes) pair')
+        return with_batch(plan['order'], default)
+    if plan['schema'] == SCHEMA_V3:
+        if any(len(arm) != 3 for arm in plan['order']):
+            raise ValueError('a v3 arm is an (overlap_bytes, identity_bytes, anchor_batch_size) triple')
+        return with_batch(plan['order'], default)
+    raise ValueError('unknown publication comparison schema')
 
 
 def arm_order(identity_bytes=0, override=None):
@@ -59,9 +94,10 @@ def arm_order(identity_bytes=0, override=None):
     if identity < 0:
         raise ValueError('identity bytes cannot be negative')
     if override:
-        order = [tuple(int(v) for v in pair) for pair in override]
-        if any(len(pair) != 2 or min(pair) < 0 for pair in order):
-            raise ValueError('an arm is an (overlap_bytes, identity_bytes) pair')
+        order = [tuple(int(v) for v in arm) for arm in override]
+        if any(len(arm) not in (2, 3) or min(arm[:2]) < 0 or (len(arm) == 3 and arm[2] < 1)
+               for arm in order):
+            raise ValueError('an arm is (overlap_bytes, identity_bytes[, anchor_batch_size])')
         return order
     budget = OVERLAP_BUDGET
     return ([(0, 0), (budget, 0), (budget, identity), (budget, identity), (budget, 0)]
@@ -77,7 +113,9 @@ def prepare(spec_path, workspace, row_id, out, *, identity_bytes=0, order=None):
     overlap-only baseline, the pipelined arm twice, and the baseline again so
     the box's drift across the run brackets both.  Memory is computed for
     each distinct pair through the same dispatcher plan a row is admitted on.
-    ``order`` overrides the arm list for a repeat run.
+    ``order`` overrides the arm list for a repeat run; an arm may be a
+    ``(overlap, identity, anchor_batch_size)`` triple to run the same
+    configuration at another batch width, checked in-plan for exact parity.
     """
     from tools.dispatch_tessera_campaign import load_spec, _streamed_resource_plan
     spec = load_spec(spec_path)
@@ -93,11 +131,14 @@ def prepare(spec_path, workspace, row_id, out, *, identity_bytes=0, order=None):
     if '--publication-overlap-bytes' in command or '--seed-checkpoint' in command:
         raise ValueError('comparison requires the original fresh synchronous recipe')
     resources = {}
-    order = arm_order(identity_bytes, order)
-    for pair in sorted(set(order)):
+    order = with_batch(arm_order(identity_bytes, order), command_batch(command))
+    for budget, identity, batch in sorted(set(order)):
         selected = copy.deepcopy(spec)
-        selected['campaign_argv'] += arm_flags(*pair)
-        resources['%d:%d' % pair] = _streamed_resource_plan(selected, census, row['members'], selected_source=True)
+        argv = list(selected['campaign_argv'])
+        argv[argv.index('--anchor-batch-size')+1] = str(batch)
+        selected['campaign_argv'] = argv+arm_flags(budget, identity)
+        resources['%d:%d:%d' % (budget, identity, batch)] = _streamed_resource_plan(
+            selected, census, row['members'], selected_source=True)
     # Existing measured process baseline plus a bounded CUDA trace and its
     # decoded profiler objects. This allowance is separate from staged bytes.
     workload_memory = math.ceil((max(r['memory_bytes'] for r in resources.values())+
@@ -108,10 +149,10 @@ def prepare(spec_path, workspace, row_id, out, *, identity_bytes=0, order=None):
     inputs = [Path(spec_path), workspace/'plan.json', Path(plan['manifest']),
         Path(plan['census']), Path(row['units']),
         Path(command[command.index('--calibration-cache')+1])]
-    value = dict(schema=SCHEMA_V2, command=command,
+    value = dict(schema=SCHEMA_V3, command=command,
         input_sha256={str(path): digest(path) for path in inputs}, resources=resources,
         row_id=row_id, groups=row['groups'], expected_source_units=864,
-        limit_anchors=64, projection='gate_up', order=[list(pair) for pair in order],
+        limit_anchors=64, projection='gate_up', order=[list(arm) for arm in order],
         environment=spec['env'], container=spec['container'],
         requested_cpus=spec['cpus'], requested_memory_gib=memory, workload_memory_gib=workload_memory,
         out=str(out/'native'), profiler_allowance_gib=2)
@@ -243,7 +284,61 @@ def instrument(campaign, recorder, projection):
                 cache_info=dict(hits=info.hits, misses=info.misses, maxsize=info.maxsize, currsize=info.currsize)))
 
 
-def arm(plan, out, budget, identity=0):
+class MemorySampler(threading.Thread):
+    """Continuous process and box memory samples for one arm.
+
+    The guard's checkpoints see the process between phases; the peak of a
+    batch lives inside one.  This samples ``VmRSS``/``VmHWM`` of the arm
+    process, the box's ``MemAvailable`` (on GB10 that is the device budget
+    too), and the caching allocator's reserved bytes at a fixed cadence, and
+    keeps the peak of each.  It never synchronizes the device.
+    """
+    def __init__(self, path, interval=MEMORY_SAMPLE_SECONDS):
+        super().__init__(name='memory-sampler', daemon=True)
+        self.path, self.interval = Path(path), float(interval)
+        self.stopped = threading.Event()
+        self.samples = []
+
+    @staticmethod
+    def read():
+        sample = dict(unix=time.time())
+        for line in Path('/proc/self/status').read_text().splitlines():
+            if line.startswith(('VmRSS:', 'VmHWM:')):
+                sample[line.split(':')[0].lower()+'_bytes'] = int(line.split()[1])*1024
+        for line in Path('/proc/meminfo').read_text().splitlines():
+            if line.startswith('MemAvailable:'):
+                sample['mem_available_bytes'] = int(line.split()[1])*1024
+        try:
+            import torch
+            if torch.cuda.is_available():
+                sample['cuda_reserved_bytes'] = torch.cuda.memory_reserved()
+                sample['cuda_allocated_bytes'] = torch.cuda.memory_allocated()
+        except Exception:  # pragma: no cover - torch absent or device gone
+            pass
+        return sample
+
+    def run(self):
+        while not self.stopped.is_set():
+            self.samples.append(self.read())
+            self.stopped.wait(self.interval)
+
+    def summary(self):
+        keys = sorted({k for s in self.samples for k in s if k != 'unix'})
+        peak = {k: max(s[k] for s in self.samples if k in s) for k in keys}
+        peak['mem_available_bytes'] = min(s['mem_available_bytes'] for s in self.samples
+                                          if 'mem_available_bytes' in s) if self.samples else None
+        return dict(schema='prismaquant.publication_memory_samples.v1',
+            interval_seconds=self.interval, samples=len(self.samples),
+            peak=peak, note='peak is the max of each series, min for mem_available_bytes')
+
+    def close(self):
+        self.stopped.set()
+        self.join()
+        self.samples.append(self.read())
+        write(self.path, dict(self.summary(), series=self.samples))
+
+
+def arm(plan, out, budget, identity=0, batch=None):
     import torch
     from experiments.campaign_prefix_profile import run_prefix
     from experiments.glm_full_capture_profile import AnchorObserver, selected_anchor_command
@@ -254,9 +349,12 @@ def arm(plan, out, budget, identity=0):
     for flag, value in {'--out': out/'cost.pkl', '--cache-dir': out/'cache',
             '--checkpoint': out/'cost.anchors.json'}.items():
         command[command.index(flag)+1] = str(value)
+    command[command.index('--anchor-batch-size')+1] = str(int(batch or command_batch(command)))
     command += arm_flags(budget, identity)
     selected_anchor_command(command)
     recorder = PhaseRecorder()
+    memory = MemorySampler(out/'memory-samples.json')
+    memory.start()
     observer = AnchorObserver(out/'profile', profile_calls=[0],
         trace_max_bytes=512*1024**2, command=command, cuda_only=True, window_seconds=0.25)
     observer.result['python_sampler']['interval_seconds'] = 0.2
@@ -267,6 +365,7 @@ def arm(plan, out, budget, identity=0):
             if observer.result['resident_prefetch']['devices'] != ['cuda:0']:
                 raise RuntimeError('comparison inputs were not fully GPU resident')
     finally:
+        memory.close()
         write(out/'phase-profile.json', dict(schema='prismaquant.publication_phase_profile.v1',
             spans='Inclusive nested wall and thread CPU times; no added CUDA synchronization.',
             records=recorder.records))
@@ -285,18 +384,18 @@ def run(path, expected):
             raise ValueError('publication environment changed: '+name)
     root = Path(p['out']); root.mkdir(parents=True, exist_ok=False)
     rows, baseline = [], None
-    for index, (budget, identity) in enumerate(order):
+    for index, (budget, identity, batch) in enumerate(order):
         out = root/f'arm-{index:02d}'; out.mkdir()
         command = [sys.executable, '-u', '-m', 'experiments.campaign_publication_ab', '--plan', str(path),
             '--plan-sha256', expected, '--arm-out', str(out), '--budget', str(budget),
-            '--identity-bytes', str(identity)]
+            '--identity-bytes', str(identity), '--anchor-batch-size', str(batch)]
         env = dict(os.environ, TRITON_CACHE_DIR=str(out/'triton'),
             TORCHINDUCTOR_CACHE_DIR=str(out/'inductor'))
         started = time.time()
         with (out/'command.log').open('x') as log:
             result = subprocess.run(command, env=env, stdout=log, stderr=subprocess.STDOUT)
         row = dict(index=index, publication_overlap_bytes=budget, campaign_identity_bytes=identity,
-            started_unix=started,
+            anchor_batch_size=batch, started_unix=started,
             finished_unix=time.time(), returncode=result.returncode, command=command)
         rows.append(row); write(out/'exit.json', row)
         if result.returncode:
@@ -313,7 +412,9 @@ def run(path, expected):
             baseline = current
         elif current != baseline:
             raise ValueError('publication changed wire bytes, scoring, or checkpoint identity')
-        row.update(exact_parity=True, anchor_units=p['limit_anchors'], observer_result=str(files[0]))
+        memory = json.loads((out/'memory-samples.json').read_text())
+        row.update(exact_parity=True, anchor_units=p['limit_anchors'], observer_result=str(files[0]),
+            memory_peak=memory['peak'], memory_samples=memory['samples'])
         write(out/'parity.json', row); print(json.dumps(row), flush=True)
     write(root/'result.json', dict(schema=p['schema'], plan_sha256=expected,
         rows=rows, exact_parity=True, campaign_completed=False,
@@ -327,11 +428,14 @@ def main():
     parser.add_argument('--arm-out', type=Path)
     parser.add_argument('--budget', type=int)
     parser.add_argument('--identity-bytes', type=int, default=0)
+    parser.add_argument('--anchor-batch-size', type=int, default=None,
+        help='this arm\'s batch width; default is the recipe\'s')
     args = parser.parse_args()
     if args.arm_out:
         if digest(args.plan) != args.plan_sha256:
             raise ValueError('arm plan changed')
-        arm(json.loads(Path(args.plan).read_text()), args.arm_out, args.budget, args.identity_bytes)
+        arm(json.loads(Path(args.plan).read_text()), args.arm_out, args.budget, args.identity_bytes,
+            args.anchor_batch_size)
     else:
         run(args.plan, args.plan_sha256)
 

--- a/experiments/campaign_seed_rebind_timing.py
+++ b/experiments/campaign_seed_rebind_timing.py
@@ -1,0 +1,183 @@
+"""Time the seed-rebind of one completed campaign row, through the real CLI.
+
+A PrismaQuant source change moves ``prismaquant_source_sha256``, so a row
+priced under the old source cannot resume its own journal; its rows are
+offered to ``--seed-checkpoint`` one at a time and re-verified against this
+run's inputs (``_adopt_seed_checkpoint``).  This runs exactly that on one
+completed row -- the row's own argv with its outputs redirected, its original
+checkpoint and wire directory as the seed, and the rollout configuration's
+publication/identity flags -- and records where the time goes: the resident
+prefetch, the identity bind, the adoption (per-anchor identity and wire
+receipt re-verification, wire re-read bytes), and the final journal and cost
+write.  Nothing is encoded when every anchor is adopted, so the elapsed time
+is the rebind cost a rollout pays per row.
+
+``prepare`` sizes the action through the dispatcher's own plan for the row
+with the extra flags; ``run`` executes it inside the admitted action.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+from experiments.campaign_publication_ab import PhaseRecorder, arm_flags
+from experiments.selected_snapshot_scope_ab import digest, write
+
+SCHEMA = 'prismaquant.campaign_seed_rebind_timing.v1'
+
+
+def prepare(spec_path, workspace, row_id, out, *, overlap_bytes, identity_bytes):
+    from tools.dispatch_tessera_campaign import load_spec, _streamed_resource_plan
+    spec = load_spec(spec_path)
+    workspace, out = Path(workspace), Path(out)
+    plan = json.loads((workspace/'plan.json').read_text())
+    index, row = next((i, row) for i, row in enumerate(plan['rows']) if row['row_id'] == row_id)
+    census = json.loads(Path(plan['census']).read_text())
+    manifest = json.loads(Path(plan['manifest']).read_text())
+    original = manifest[index]['argv']
+    command = original[original.index('prismaquant.tessera_campaign')+1:]
+    if '--seed-checkpoint' in command or '--publication-overlap-bytes' in command:
+        raise ValueError('rebind timing requires the original fresh synchronous recipe')
+    checkpoint = Path(command[command.index('--checkpoint')+1])
+    if not checkpoint.is_file() or not checkpoint.with_name(checkpoint.name+'.parts').is_dir():
+        raise ValueError(f'{row_id} has no completed checkpoint to rebind')
+    cache_dir = Path(command[command.index('--cache-dir')+1])
+    selected = json.loads(json.dumps(spec))
+    selected['campaign_argv'] += arm_flags(overlap_bytes, identity_bytes)
+    resources = _streamed_resource_plan(selected, census, row['members'], selected_source=True)
+    memory = math.ceil((resources['memory_bytes']+plan['process_baseline_bytes'])/1024**3)
+    if memory > spec['box_memory_gb']:
+        raise ValueError(f'rebind workload needs {memory} GiB, above the recipe budget')
+    seed_units = sorted(p.name for p in (checkpoint.with_name(checkpoint.name+'.parts')/'units').iterdir())
+    inputs = [Path(spec_path), workspace/'plan.json', Path(plan['manifest']), Path(plan['census']),
+              Path(row['units']), checkpoint]
+    value = dict(schema=SCHEMA, command=command, row_id=row_id, groups=row['groups'],
+        seed_checkpoint=str(checkpoint), seed_wire_dir=str(cache_dir/'wire'),
+        seed_unit_shards=len(seed_units), seed_wire_files=sum(1 for _ in (cache_dir/'wire').iterdir()),
+        seed_wire_bytes=sum(p.stat().st_size for p in (cache_dir/'wire').iterdir() if p.is_file()),
+        input_sha256={str(path): digest(path) for path in inputs}, resources=resources,
+        overlap_bytes=int(overlap_bytes), identity_bytes=int(identity_bytes),
+        environment=spec['env'], container=spec['container'], requested_cpus=spec['cpus'],
+        requested_memory_gib=memory, out=str(out/'native'))
+    out.mkdir(parents=True, exist_ok=True)
+    write(out/'plan.json', value)
+    print(json.dumps(dict(plan=str(out/'plan.json'), sha256=digest(out/'plan.json'),
+        memory_gib=memory, seed_unit_shards=len(seed_units),
+        seed_wire_bytes=value['seed_wire_bytes'])), flush=True)
+
+
+def _proc_io():
+    try:
+        return {line.split(':')[0]: int(line.split(':')[1]) for line in Path('/proc/self/io').read_text().splitlines()}
+    except OSError:
+        return {}
+
+
+def run(path, expected):
+    if digest(path) != expected:
+        raise ValueError('rebind plan changed')
+    p = json.loads(Path(path).read_text())
+    if p['schema'] != SCHEMA:
+        raise ValueError('unknown rebind timing schema')
+    for name, sha in p['input_sha256'].items():
+        if digest(name) != sha:
+            raise ValueError('rebind input changed: '+name)
+    for name, value in p['environment'].items():
+        if os.environ.get(name) != value:
+            raise ValueError('rebind environment changed: '+name)
+    import torch
+    from prismaquant import tessera_campaign as campaign
+    from prismaquant import cost_stage_checkpoint
+    if not torch.cuda.is_available():
+        raise RuntimeError('rebind timing requires an admitted CUDA device')
+    out = Path(p['out']); out.mkdir(parents=True, exist_ok=False)
+    command = list(p['command'])
+    for flag, value in {'--out': out/'cost.pkl', '--cache-dir': out/'cache',
+            '--checkpoint': out/'cost.anchors.json'}.items():
+        command[command.index(flag)+1] = str(value)
+    command += ['--seed-checkpoint', p['seed_checkpoint'], '--seed-wire-dir', p['seed_wire_dir']]
+    command += arm_flags(p['overlap_bytes'], p['identity_bytes'])
+    recorder = PhaseRecorder(limit=200000)
+    targets = [(campaign, name) for name in (
+        '_prefetch_selected_capture', '_campaign_bound_identities', '_adopt_seed_checkpoint',
+        '_checkpoint_anchor_identity', '_checkpoint_wire_record', '_link_seed_wire',
+        '_campaign_checkpoint_identity', 'campaign_cost_payload')] + [
+        (campaign._BoundCheckpointUnitIdentity, 'derive'),
+        (cost_stage_checkpoint, 'write_unit'), (cost_stage_checkpoint, '_load_unit')]
+    originals = [(owner, name, getattr(owner, name)) for owner, name in targets]
+    io_before = _proc_io()
+    started = time.time(); wall = time.perf_counter()
+    returncode = None
+    try:
+        for owner, name, original in originals:
+            setattr(owner, name, recorder.wrap(original, owner.__name__+'.'+name))
+        returncode = campaign.main(command)
+    finally:
+        for owner, name, original in originals:
+            setattr(owner, name, original)
+        elapsed = time.perf_counter() - wall
+        io_after = _proc_io()
+        totals = {}
+        for record in recorder.records:
+            entry = totals.setdefault(record['phase'], dict(calls=0, seconds=0.0, thread_cpu_seconds=0.0,
+                threads=set(), first_started_unix=record['started_unix'], last_finished_unix=0.0))
+            entry['calls'] += 1
+            entry['seconds'] += record['seconds']
+            entry['thread_cpu_seconds'] += record['thread_cpu_seconds']
+            entry['threads'].add(record['thread'])
+            entry['first_started_unix'] = min(entry['first_started_unix'], record['started_unix'])
+            entry['last_finished_unix'] = max(entry['last_finished_unix'], record['started_unix']+record['seconds'])
+        for entry in totals.values():
+            entry['threads'] = sorted(entry['threads'])
+        summary = dict(schema='prismaquant.campaign_seed_rebind_timing_result.v1', plan_sha256=expected,
+            row_id=p['row_id'], returncode=returncode, started_unix=started, wall_seconds=elapsed,
+            command=command, phases=totals, process_io_delta={k: io_after.get(k, 0)-io_before.get(k, 0)
+                for k in set(io_before) | set(io_after)},
+            seed_wire_bytes=p['seed_wire_bytes'], seed_unit_shards=p['seed_unit_shards'],
+            cuda_reserved_peak_bytes=torch.cuda.max_memory_reserved() if torch.cuda.is_available() else None,
+            span_scope='Inclusive nested wall and thread CPU times per phase; adoption contains the per-anchor identity and receipt spans; do not sum across phases.')
+        write(out/'rebind-timing.json', summary)
+        write(out/'phase-profile.json', dict(schema='prismaquant.publication_phase_profile.v1',
+            spans='Inclusive nested wall and thread CPU times; no added CUDA synchronization.',
+            records=recorder.records))
+        print(json.dumps({k: v for k, v in summary.items() if k not in ('command', 'phases')}), flush=True)
+        for phase, entry in sorted(totals.items(), key=lambda kv: -kv[1]['seconds']):
+            print(json.dumps(dict(phase=phase, **entry)), flush=True)
+    if returncode != 0:
+        raise RuntimeError(f'rebind campaign returned {returncode}')
+    manifest = json.loads((out/'cost.anchors.json').read_text())
+    parts = out/'cost.anchors.json.parts'/'units'
+    adopted = sum(1 for _ in parts.iterdir())
+    if adopted != p['seed_unit_shards']:
+        raise RuntimeError(f'rebind journalled {adopted} units of {p["seed_unit_shards"]} seeded')
+    write(out/'result.json', dict(schema=SCHEMA, plan_sha256=expected, adopted_units=adopted,
+        identity_sha256=manifest['identity_sha256'], wall_seconds=elapsed,
+        scope='One completed row re-verified through --seed-checkpoint under a new package source; no anchor encoded.'))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest='mode', required=True)
+    prep = sub.add_parser('prepare')
+    prep.add_argument('--spec', required=True); prep.add_argument('--workspace', required=True)
+    prep.add_argument('--row-id', required=True); prep.add_argument('--out', required=True)
+    prep.add_argument('--overlap-bytes', type=int, default=268435456)
+    prep.add_argument('--identity-bytes', type=int, default=268435456)
+    execute = sub.add_parser('run')
+    execute.add_argument('--plan', required=True); execute.add_argument('--plan-sha256', required=True)
+    args = parser.parse_args()
+    if args.mode == 'prepare':
+        prepare(args.spec, args.workspace, args.row_id, args.out,
+                overlap_bytes=args.overlap_bytes, identity_bytes=args.identity_bytes)
+    else:
+        run(args.plan, args.plan_sha256)
+
+
+if __name__ == '__main__':
+    main()

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -696,7 +696,22 @@ def _measure_anchor_batch(*, qnames, weights, activations, format_name,
 
 
 def _anchor_batches(pending, *, weights, expert_members, batch_size):
-    """Bound compatible expert encodes inside this action; never assign hosts."""
+    """Bound compatible expert encodes inside this action; never assign hosts.
+
+    Membership is by ``(family, rung, shape, dtype, device)`` for expert
+    units and by ``(unit, family, rung)`` otherwise, as before.  The ORDER of
+    the batches is unit-major: the batches of one compatible key differ only
+    by rung, and the chunk at one position holds the same members at every
+    rung when the round pended every member at every rate (round one does,
+    per member in rate order), so consecutive batches encode the same units
+    at successive rungs.  The encoder memo is sized to the batch width
+    (``encoder_memo_capacity``), so that order is what lets a unit's block-LDL
+    factorization be reused across its rungs instead of refactorized once per
+    (unit, rung) with 864 batches of other units in between
+    (RobTand/prismaquant#389).  Rung-major emission -- every batch of rung A,
+    then every batch of rung B -- is what the insertion-ordered grouping
+    produced before, and with the memo at the batch width it hit nothing.
+    """
     if batch_size < 1:
         raise ValueError("anchor batch size must be positive")
     if batch_size == 1:
@@ -705,11 +720,24 @@ def _anchor_batches(pending, *, weights, expert_members, batch_size):
     for item in pending:
         name, family, rung = item
         weight = weights[name]
-        key = ((family, rung, tuple(weight.shape), weight.dtype, weight.device)
-               if name in expert_members else (name, family, rung))
-        groups.setdefault(key, []).append(item)
-    return [group[start:start + batch_size] for group in groups.values()
-            for start in range(0, len(group), batch_size)]
+        if name in expert_members:
+            base = (family, tuple(weight.shape), weight.dtype, weight.device)
+            key = (family, rung, *base[1:])
+        else:
+            base = key = (name, family, rung)
+        groups.setdefault(key, (base, []))[1].append(item)
+    # Sort key: the base (the key minus its rung) in first-appearance order,
+    # then the chunk position, then the rung in first-appearance order -- so
+    # chunk 0 of every rung of one base precedes chunk 1 of any of them.
+    base_rank, key_rank, chunks = {}, {}, []
+    for key, (base, group) in groups.items():
+        base_rank.setdefault(base, len(base_rank))
+        key_rank[key] = len(key_rank)
+        for position, start in enumerate(range(0, len(group), batch_size)):
+            chunks.append(((base_rank[base], position, key_rank[key]),
+                           group[start:start + batch_size]))
+    chunks.sort(key=lambda chunk: chunk[0])
+    return [batch for _rank, batch in chunks]
 
 
 # ---------------------------------------------------------------------------

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -2108,9 +2108,26 @@ class _AnchorPublicationLedger:
                 f"{len(self._staged)} anchor(s) already staged")
         self._publisher = publisher
 
-    def record(self, anchor, identity) -> None:
-        """Journal now, or when this anchor's own bytes have been written."""
+    def record(self, anchor, identity=None, *, derive=None) -> None:
+        """Journal now, or when this anchor's own bytes have been written.
+
+        ``identity`` is the anchor's producer input identity, already
+        computed.  ``derive`` is instead a zero-argument callable that
+        computes it, and the two are exclusive.  A caller passes ``derive``
+        only when the derivation touches no device: the writer is a CPU/IO
+        thread by contract (the producer's graph capture forbids surprise
+        device work from another thread while a capture may be running), so
+        an identity that hashes a resident weight or Hessian is computed on
+        the encode thread and handed over as a value.  With a publisher the
+        callable runs on the writer inside this anchor's receipt job, ahead
+        of the read-back it seals; without one it runs inline, here, exactly
+        where the value would have been computed.
+        """
+        if (identity is None) == (derive is None):
+            raise ValueError("record takes exactly one of identity or derive")
         if self._publisher is None:
+            if derive is not None:
+                identity = derive()
             self._journal(anchor, self._make_record(anchor, identity))
             return
         key = (anchor.qname, anchor.format_name)
@@ -2126,8 +2143,11 @@ class _AnchorPublicationLedger:
         def make():
             # Runs on the writer, behind this unit's own file job, so the
             # read-back inside the receipt call reads a file that exists and
-            # the encode thread never waits for it.
-            self._records[key] = self._make_record(anchor, identity)
+            # the encode thread never waits for it.  A deferred identity is
+            # derived first, on this thread, and a refusal there fails the
+            # publication the same way a refused read-back does.
+            sealed = identity if derive is None else derive()
+            self._records[key] = self._make_record(anchor, sealed)
 
         self._publisher.submit(PublicationJob(
             key=(RECEIPT_JOB, *key), charged_bytes=0, publish=make))
@@ -4986,6 +5006,12 @@ def _main(argv, *, source_scope) -> int:
         source_scope.callback(lambda: [unit.close() for unit in bound_checkpoint_units.values()])
     identity_metadata_observed_bytes = sum(unit.observed_metadata_bytes()
                                            for unit in bound_checkpoint_units.values())
+    if bound_checkpoint_units:
+        print(f"[campaign] campaign identity hold: {len(bound_checkpoint_units)} units, "
+              f"observed metadata {identity_metadata_observed_bytes} B, planned bound "
+              f"{sum(identity_metadata_bounds.values())} B + scratch "
+              f"{identity_planning_scratch_bytes} B, reserved {args.campaign_identity_bytes} B",
+              flush=True)
 
     # The resume identity, run level: everything a price is a function of,
     # including the static A-side contract (scales + policy) the W4A4 rows
@@ -5530,12 +5556,22 @@ def _main(argv, *, source_scope) -> int:
                     anchor_batch_growth.append(selected_guard.last[
                         'conservative_cgroup_plus_cuda_reserved_bytes'] - batch_floor)
                 for anchor in anchors:
-                    ledger.record(anchor, _checkpoint_anchor_identity(
-                        anchor, weights=weights, menus=menus,
-                        calibration_source=calibration_source, static_scales=static_scales,
-                        projected_units=projected_units,
-                        **({"bound_unit": bound_checkpoint_units[anchor.qname]}
-                           if bound_checkpoint_units else {})))
+                    identity_of = functools.partial(
+                        _checkpoint_anchor_identity, anchor, weights=weights,
+                        menus=menus, calibration_source=calibration_source,
+                        static_scales=static_scales, projected_units=projected_units)
+                    if bound_checkpoint_units:
+                        # Derived from the unit's sealed template: a deepcopy
+                        # and Tessera's wire_recipe, no tensor read.  The
+                        # writer does it behind this anchor's own files, so
+                        # the next batch's encode is not waiting on it.
+                        ledger.record(anchor, derive=functools.partial(
+                            identity_of, bound_unit=bound_checkpoint_units[anchor.qname]))
+                    else:
+                        # The producer's ``encoding_input_identity`` hashes
+                        # the resident weight and Hessian, which are device
+                        # tensors here: that stays on the encode thread.
+                        ledger.record(anchor, identity_of())
                 completed += len(anchors)
                 # Commit every joined quantum before advancing. The scalar mode
                 # keeps its existing ten-anchor flush cadence.

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -3842,15 +3842,52 @@ def campaign_population_block(**kwargs) -> dict:
 def _format_executes_static_activation_contract(format_name: str) -> bool:
     """Does this rung's route execute a STATIC activation contract?
 
-    The spec's answer (``FormatSpec.static_activation_contract``), which
-    ``synthesize_tessera_spec`` derives from the registry row the rung's route
-    names -- never a compare of that row's NAME against ``"NVFP4"`` (#205,
-    #221).  Same field ``_measure_anchor`` prices through, so the rung this
-    refuses to resume is exactly the rung it refuses to score.
+    The one derivation (#205, #221): the route names the registry row whose
+    contract it executes (``activation_source_format``) and the ROW owns the
+    answer (``FormatSpec.static_activation_contract``) -- never a compare of
+    that row's NAME against ``"NVFP4"``.  It is
+    ``tessera_formats.route_static_activation_contract`` off the same route
+    ``synthesize_tessera_spec`` stamps onto the rung's spec, so the rung this
+    refuses to resume is exactly the rung ``_measure_anchor`` prices.
+
+    The row is read live, every time: it is a dictionary lookup, and the
+    registry is what a test (or a lane) replaces when a second row gains a
+    contract.  What is memoised is the pure part -- canonical name to serving
+    route -- sized by the format key space: the closed-roster bind asks it
+    once per format per unit, 1,793 routes for each of an 864-unit row's
+    holders, measured at ~1.1 s per unit on the CPU worker when each ask
+    synthesized a whole spec, a GPU-idle startup phase of a quarter hour per
+    row.
     """
     from . import format_registry as fr
 
-    return fr.get_format(format_name).static_activation_contract is not None
+    canonical = fr.canonical_format_name(format_name)
+    row = fr.REGISTRY.get(canonical)
+    if row is not None:
+        return row.static_activation_contract is not None
+    if not fr.is_tessera_format_name(canonical):
+        fr.get_format(canonical)  # raises the registry's KeyError
+    from .tessera_formats import route_static_activation_contract
+
+    return route_static_activation_contract(_tessera_route_memo()(canonical)) is not None
+
+
+def _tessera_route(canonical: str):
+    from .tessera_formats import (
+        parse_tessera_format_name, tessera_serving_route, tessera_wire_recipe,
+    )
+
+    family, rung = parse_tessera_format_name(canonical)
+    return tessera_serving_route(family, tessera_wire_recipe(family, rung), rung)
+
+
+@functools.lru_cache(maxsize=1)
+def _tessera_route_memo():
+    # Built on first use so this module keeps importing without the Tessera
+    # package; the memo itself is sized by the format key space on its first
+    # call, the way every wire-recipe memo is.
+    from .tessera_formats import lazily_sized_cache, recipe_cache_bound
+    return lazily_sized_cache(recipe_cache_bound)(_tessera_route)
 
 
 def _require_resumable_anchor(anchor: CampaignAnchor, static_scales) -> None:

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -1897,11 +1897,31 @@ def _campaign_identity_anchor_roster(name, menu, *, calibration_source, static_s
 # deliberately stated as admission terms, not as a measurement: the live
 # `observed_metadata_bytes` diagnostic below tests the bound on each run.
 IDENTITY_HOLD_UNIT_OBJECT_BYTES = 32 * 1024
-IDENTITY_HOLD_FORMAT_REFERENCE_BYTES = 1024
 IDENTITY_HOLD_SERIALIZED_BYTE_MULTIPLIER = 8
 IDENTITY_HOLD_PLAN_MAPPING_ENTRY_BYTES = 256
 IDENTITY_HOLD_PLAN_UNIT_FIXED_BYTES = 4096
 IDENTITY_HOLD_PLAN_SERIALIZED_BYTE_MULTIPLIER = 4
+# The roster a holder is built from is transient: one ``SimpleNamespace`` per
+# closed-menu format with six attributes (`_campaign_identity_anchor_roster`),
+# plus the holder constructor's own one-attribute namespace per format, its
+# working tuple/sets, and the rung integers those carry.  Two rosters are live
+# at the peak, because the next unit's is built before the previous binding is
+# released.  The per-format figure is the interpreter's own object cost with
+# the six-slot instance dict counted at its CPython 3.12 size, rounded up.
+IDENTITY_ROSTER_TRANSIENT_FORMAT_BYTES = 1024
+IDENTITY_ROSTER_TRANSIENT_LIVE_ROSTERS = 2
+
+
+def _frozenset_table_bytes(entries: int) -> int:
+    """The interpreter's own size of a frozenset holding ``entries`` items.
+
+    The holder retains one frozenset of format-name references; the strings
+    are the menu's and pre-date the hold, so what it adds is the set's slot
+    table, which CPython sizes by a fill rule this asks the interpreter for
+    rather than restates.  ``observed_metadata_bytes`` counts the same table.
+    """
+    import sys
+    return sys.getsizeof(frozenset(range(int(entries))))
 
 
 def _campaign_identity_metadata_plan(*, weights, menus, calibration_source,
@@ -1910,34 +1930,45 @@ def _campaign_identity_metadata_plan(*, weights, menus, calibration_source,
 
     One unit retains a holder/result mapping, signatures, the producer receipt
     dictionaries, and a frozenset of references to every closed menu format.
-    The fixed object term covers the first three; the per-format term covers
-    frozenset slots and result mapping growth.  Receipt strings and dict keys
-    are bounded from known unit/format/settings/projection serialization
-    lengths, multiplied by the documented CPython object/slot envelope.
+    The fixed object term covers the first three; the frozenset term is the
+    interpreter's own table size for that many references.  Receipt strings
+    and dict keys are bounded from known unit/shape/settings/projection
+    serialization lengths, multiplied by the documented CPython object/slot
+    envelope.  The format names themselves are the menu's objects, borrowed by
+    reference, and the sealed template carries one recipe, not the roster, so
+    no per-format serialization is retained.
+
+    The second value is the planning-and-construction transient: the bound
+    map and its largest JSON string, plus the two closed rosters live while
+    holders are built (`IDENTITY_ROSTER_TRANSIENT_*`), which construction
+    materializes once per unit and frees before the next.
     """
     import json
     # The producer config owner may itself verify H commitments. Planning must
     # not invoke it before the one real receipt; reserve its bounded JSON
     # settings envelope in the fixed holder term instead.
     settings_bytes = 4096 if calibration_source is not None else 0
-    planned, largest_serialization = {}, 0
+    planned, largest_serialization, widest_roster = {}, 0, 0
     for name in sorted(weights):
         shape_bytes = len(json.dumps(list(weights[name].shape), separators=(",", ":")).encode())
-        format_bytes = sum(len(entry.format_name.encode()) for entry in menus[name])
         projection_bytes = len(json.dumps((projected_units or {}).get(name),
             sort_keys=True, separators=(",", ":"), allow_nan=False).encode())
         receipt_bytes = len(name.encode()) + shape_bytes + settings_bytes + projection_bytes
         planned[name] = (IDENTITY_HOLD_UNIT_OBJECT_BYTES +
-                         IDENTITY_HOLD_FORMAT_REFERENCE_BYTES * len(menus[name]) +
-                         IDENTITY_HOLD_SERIALIZED_BYTE_MULTIPLIER *
-                         (receipt_bytes + format_bytes))
-        largest_serialization = max(largest_serialization, receipt_bytes + format_bytes)
+                         _frozenset_table_bytes(len(menus[name])) +
+                         IDENTITY_HOLD_SERIALIZED_BYTE_MULTIPLIER * receipt_bytes)
+        largest_serialization = max(largest_serialization, receipt_bytes)
+        widest_roster = max(widest_roster, len(menus[name]))
     # `planned` remains live until holders are built. Each loop iteration also
     # materializes one shape/projection JSON string; its worst live string plus
-    # the map's entry table is a separate, pre-admitted planning transient.
+    # the map's entry table is a separate, pre-admitted planning transient, and
+    # so is the closed roster each holder is constructed from.
     scratch = (IDENTITY_HOLD_PLAN_UNIT_FIXED_BYTES +
                IDENTITY_HOLD_PLAN_MAPPING_ENTRY_BYTES * len(planned) +
-               IDENTITY_HOLD_PLAN_SERIALIZED_BYTE_MULTIPLIER * largest_serialization)
+               IDENTITY_HOLD_PLAN_SERIALIZED_BYTE_MULTIPLIER * largest_serialization +
+               IDENTITY_ROSTER_TRANSIENT_LIVE_ROSTERS * (
+                   IDENTITY_ROSTER_TRANSIENT_FORMAT_BYTES * widest_roster +
+                   _frozenset_table_bytes(widest_roster)))
     return planned, scratch
 
 

--- a/tests/test_campaign_publication_ab.py
+++ b/tests/test_campaign_publication_ab.py
@@ -1,7 +1,8 @@
 """The comparison must preserve compatible work and report truthful spans."""
 import pytest
 
-from experiments.campaign_publication_ab import preferred_batches, PhaseRecorder
+from experiments.campaign_publication_ab import (OVERLAP_BUDGET, arm_order, preferred_batches,
+    PhaseRecorder)
 
 
 def test_shape_permutation_preserves_whole_batches_and_internal_order():
@@ -34,3 +35,15 @@ def test_profile_keeps_original_error_and_records_failed_span():
     assert recorder.records[0]['phase'] == 'publication'
     assert recorder.records[0]['seconds'] >= 0
     assert recorder.records[0]['thread_cpu_seconds'] >= 0
+
+
+def test_a_repeat_order_replaces_the_default_matrix_instead_of_being_shadowed():
+    B, I = OVERLAP_BUDGET, 268435456
+    assert arm_order(I) == [(0, 0), (B, 0), (B, I), (B, I), (B, 0)]
+    assert arm_order(0) == [(0, 0), (B, 0), (B, 0), (0, 0)]
+    assert arm_order(I, [(B, I)]) == [(B, I)]
+    assert arm_order(I, [[B, I], [B, 0]]) == [(B, I), (B, 0)]
+    with pytest.raises(ValueError):
+        arm_order(I, [(B,)])
+    with pytest.raises(ValueError):
+        arm_order(I, [(B, -1)])

--- a/tests/test_campaign_publication_ab.py
+++ b/tests/test_campaign_publication_ab.py
@@ -1,8 +1,11 @@
 """The comparison must preserve compatible work and report truthful spans."""
 import pytest
 
-from experiments.campaign_publication_ab import (OVERLAP_BUDGET, arm_order, preferred_batches,
-    PhaseRecorder)
+import json
+import time
+
+from experiments.campaign_publication_ab import (OVERLAP_BUDGET, SCHEMA_V1, SCHEMA_V2, SCHEMA_V3,
+    MemorySampler, arm_order, command_batch, plan_order, preferred_batches, with_batch, PhaseRecorder)
 
 
 def test_shape_permutation_preserves_whole_batches_and_internal_order():
@@ -47,3 +50,38 @@ def test_a_repeat_order_replaces_the_default_matrix_instead_of_being_shadowed():
         arm_order(I, [(B,)])
     with pytest.raises(ValueError):
         arm_order(I, [(B, -1)])
+
+
+def test_batch_width_arms_keep_the_recipe_width_unless_named():
+    B, I = OVERLAP_BUDGET, 268435456
+    command = ['--foo', '--anchor-batch-size', '8', '--bar']
+    assert command_batch(command) == 8
+    assert with_batch([(0, 0), (B, I), (B, I, 16), [B, I, 32]], 8) == [(0, 0, 8), (B, I, 8), (B, I, 16), (B, I, 32)]
+    assert arm_order(I, [(B, I, 8), (B, I, 16)]) == [(B, I, 8), (B, I, 16)]
+    for bad in ([(B, I, 0)], [(B, I, 8, 1)], [(B,)]):
+        with pytest.raises(ValueError):
+            arm_order(I, bad)
+    with pytest.raises(ValueError):
+        with_batch([(B, I, 0)], 8)
+    assert plan_order(dict(schema=SCHEMA_V1, command=command, order=[0, B])) == [(0, 0, 8), (B, 0, 8)]
+    assert plan_order(dict(schema=SCHEMA_V2, command=command, order=[[0, 0], [B, I]])) == [(0, 0, 8), (B, I, 8)]
+    assert plan_order(dict(schema=SCHEMA_V3, command=command, order=[[B, I, 8], [B, I, 32]])) == [(B, I, 8), (B, I, 32)]
+    with pytest.raises(ValueError):
+        plan_order(dict(schema=SCHEMA_V3, command=command, order=[[B, I]]))
+    with pytest.raises(ValueError):
+        plan_order(dict(schema=SCHEMA_V2, command=command, order=[[B, I, 8]]))
+
+
+def test_memory_sampler_records_a_continuous_series_with_peaks(tmp_path):
+    sampler = MemorySampler(tmp_path/'memory-samples.json', interval=0.05)
+    sampler.start()
+    ballast = bytearray(64*1024**2)
+    ballast[::4096] = b'x'*len(ballast[::4096])
+    time.sleep(0.3)
+    sampler.close()
+    del ballast
+    record = json.loads((tmp_path/'memory-samples.json').read_text())
+    assert record['samples'] >= 4 and len(record['series']) == record['samples']
+    assert record['peak']['vmhwm_bytes'] >= record['peak']['vmrss_bytes'] > 64*1024**2
+    assert record['peak']['mem_available_bytes'] == min(s['mem_available_bytes'] for s in record['series'])
+    assert all(b['unix'] >= a['unix'] for a, b in zip(record['series'], record['series'][1:]))

--- a/tests/test_selected_source_authentication.py
+++ b/tests/test_selected_source_authentication.py
@@ -9,10 +9,15 @@ import pytest
 import torch
 
 
-def test_selected_campaign_hashes_only_consumed_shards_and_preserves_identity(
-    monkeypatch, tmp_path,
-):
-    """The public selected path must not hash an untouched payload shard."""
+def selected_source_fixture(monkeypatch, tmp_path, *, priced=False):
+    """One selected-source campaign on CPU: a real shard reader, a real capture.
+
+    Returns the campaign module, the full selected argv (streaming, units,
+    census, capture and its hash), and the observation lists the
+    authentication test reads.  ``priced`` gives the unit a one-rung menu so
+    the run encodes and journals one anchor instead of stopping at the
+    empty-menu refusal.
+    """
     import prismaquant
     from safetensors.torch import save_file
     from prismaquant import autoscale, cost_streaming, layer_streaming
@@ -20,7 +25,7 @@ def test_selected_campaign_hashes_only_consumed_shards_and_preserves_identity(
     from test_tessera_campaign_resume import _main_fixture, UNIT
 
     monkeypatch.setattr(torch.cuda, 'is_available', lambda: False)
-    campaign, _, argv, model, inputs = _main_fixture(monkeypatch, tmp_path)
+    campaign, _, argv, model, inputs = _main_fixture(monkeypatch, tmp_path, priced=priced)
     model.config = SimpleNamespace(_attn_implementation='eager')
     model.lm_head = torch.nn.Linear(256, 32, bias=False, dtype=torch.bfloat16)
     selected = model.model.layers[0].proj.weight.detach().clone()
@@ -109,12 +114,26 @@ def test_selected_campaign_hashes_only_consumed_shards_and_preserves_identity(
         groups=[dict(key='u:'+UNIT, members=[UNIT])])) )
     argv[argv.index('--model')+1] = str(source)
     argv[argv.index('--hessian')+1] = 'require'
-    assert campaign.main([*argv, '--attention-implementation', 'eager', '--streaming',
+    selected_argv = [*argv, '--attention-implementation', 'eager', '--streaming',
         '--streaming-cache-headroom-gb', '0', '--units', str(selection),
         '--calibration-census', str(census_path), '--calibration-cache', complete['path'],
         '--calibration-cache-sha256', complete['sha256'], '--nsamples', '32',
-        '--seqlen', '512', '--layer-stride', '1', '--max-act-rows', '4',
-        '--campaign-identity-bytes', '1048576']) == campaign.EXIT_EMPTY_MENU
+        '--seqlen', '512', '--layer-stride', '1', '--max-act-rows', '4']
+    state = dict(copied=copied, hashed=hashed, identities=identities, selected=selected,
+                 canonical=canonical, complete=complete, manifest_before=manifest_before,
+                 source=source)
+    return campaign, selected_argv, state
+
+
+def test_selected_campaign_hashes_only_consumed_shards_and_preserves_identity(
+    monkeypatch, tmp_path,
+):
+    """The public selected path must not hash an untouched payload shard."""
+    campaign, selected_argv, state = selected_source_fixture(monkeypatch, tmp_path)
+    copied, hashed, identities = state['copied'], state['hashed'], state['identities']
+    selected, canonical, complete = state['selected'], state['canonical'], state['complete']
+    manifest_before, source = state['manifest_before'], state['source']
+    assert campaign.main([*selected_argv, '--campaign-identity-bytes', '1048576']) == campaign.EXIT_EMPTY_MENU
     assert copied and torch.equal(copied[0], selected)
     assert identities and all(value == canonical for value in identities)
     assert hashlib.sha256(Path(complete['path']).read_bytes()).hexdigest() == complete['sha256']

--- a/tests/test_tessera_bound_identity.py
+++ b/tests/test_tessera_bound_identity.py
@@ -176,3 +176,51 @@ def test_campaign_identity_hold_closes_during_error_unwind():
             raise RuntimeError("publisher failed")
     with pytest.raises(ValueError, match="closed"):
         bound.campaign_inputs()
+
+
+def test_a_bound_identity_is_derived_on_the_writer_without_a_tensor_read(monkeypatch):
+    """The deferred derivation is device-free, so it may run on the writer.
+
+    The producer's graph-capture contract forbids surprise device work from
+    another thread while a capture may be running, so the writer is CPU/IO
+    only.  Binding hashes the weight and Hessian once, on the calling thread;
+    every derivation after that is a template copy plus Tessera's recipe and
+    reads no tensor on any thread.  The receipts it seals are the ones the
+    inline path computes.
+    """
+    import threading
+    from tessera import cached_unit
+    from prismaquant.tessera_publication import BoundedPublisher
+    tc, name, weight, hessian, source, anchors, projection, kwargs = fixture()
+    expected = [tc._checkpoint_anchor_identity(anchor, **kwargs) for anchor in anchors]
+    actual_hash = cached_unit.tensor_identity
+    hashed_on = []
+
+    def observed(value):
+        hashed_on.append(threading.current_thread().name)
+        return actual_hash(value)
+
+    monkeypatch.setattr(cached_unit, "tensor_identity", observed)
+    with tc.bind_checkpoint_unit_identity(anchors, source_weight=weight,
+            calibration_source=source, projected_unit=projection,
+            static_scales=kwargs["static_scales"]) as bound:
+        assert hashed_on and set(hashed_on) == {threading.current_thread().name}
+        hashed_on.clear()
+        journalled, derived_on = [], []
+        pub = BoundedPublisher(budget_bytes=1 << 20)
+        ledger = tc._AnchorPublicationLedger(publisher=pub,
+            make_record=lambda anchor, identity: identity,
+            journal_anchor=lambda anchor, record: journalled.append(record))
+        try:
+            for anchor in anchors:
+                def derive(anchor=anchor):
+                    derived_on.append(threading.current_thread().name)
+                    return tc._checkpoint_anchor_identity(anchor, **kwargs, bound_unit=bound)
+                ledger.record(anchor, derive=derive)
+            assert ledger.drain() == len(anchors)
+        finally:
+            pub.close()
+        assert journalled == expected
+        assert derived_on == ["tessera-publication"] * len(anchors)
+        assert hashed_on == [], "a deferred derivation read a tensor"
+

--- a/tests/test_tessera_bound_identity.py
+++ b/tests/test_tessera_bound_identity.py
@@ -224,3 +224,43 @@ def test_a_bound_identity_is_derived_on_the_writer_without_a_tensor_read(monkeyp
         assert derived_on == ["tessera-publication"] * len(anchors)
         assert hashed_on == [], "a deferred derivation read a tensor"
 
+
+def test_the_identity_plan_bounds_a_full_closed_roster_from_interpreter_facts():
+    """The per-unit bound holds at the GLM routed-expert roster width.
+
+    The retained per-format cost is one frozenset slot table, which is asked
+    of the interpreter rather than restated; the format strings and the menu
+    entries are borrowed.  The old 1 KiB-per-format envelope charged an
+    864-unit row ~1.9 GB and pushed its admission past the box; the bound
+    here has to hold the measured hold AND leave the row inside a 256 MiB
+    reservation, and the construction transient has to charge the closed
+    rosters it materializes.
+    """
+    import sys
+    from prismaquant.tessera_formats import get_tessera_family
+    tc, name, weight, hessian, source, anchors, projection, kwargs = fixture(projected=True)
+    family = get_tessera_family("TESSERA_E4M3_K1")
+    low, high = family.mathematical_q256_bounds
+    formats = [family.format_name(rung) for rung in range(low, high + 1)]
+    assert len(formats) == 1793, "the GLM routed-expert closed roster width"
+    menus = {name: [SimpleNamespace(format_name=fmt) for fmt in formats]}
+    bounds, scratch = tc._campaign_identity_metadata_plan(
+        weights=kwargs["weights"], menus=menus, calibration_source=source,
+        projected_units={name: projection}, static_scales=kwargs["static_scales"])
+    roster = tc._campaign_identity_anchor_roster(name, menus[name],
+        calibration_source=source, static_scales=kwargs["static_scales"])
+    assert len(roster) == len(formats)
+    with tc.bind_checkpoint_unit_identity(roster, source_weight=weight,
+            calibration_source=source, projected_unit=projection,
+            static_scales=kwargs["static_scales"], retain_source_receipt=False) as bound:
+        observed = bound.observed_metadata_bytes()
+        assert observed <= bounds[name], (observed, bounds[name])
+        # And the bound is a bound, not a multiple: the retained set table is
+        # the interpreter's own figure and everything else is the fixed and
+        # serialized envelope.
+        assert bounds[name] <= (tc.IDENTITY_HOLD_UNIT_OBJECT_BYTES
+                                + sys.getsizeof(frozenset(formats))
+                                + tc.IDENTITY_HOLD_SERIALIZED_BYTE_MULTIPLIER * 8192)
+    per_format = sys.getsizeof(roster[0]) + sys.getsizeof(vars(roster[0]))
+    assert scratch >= 2 * per_format * len(formats)
+    assert 864 * bounds[name] + scratch <= 256 * 1024 ** 2

--- a/tests/test_tessera_campaign_batch.py
+++ b/tests/test_tessera_campaign_batch.py
@@ -155,3 +155,48 @@ def test_requested_batch_refuses_old_producer_before_loading_model(monkeypatch, 
     with pytest.raises(RuntimeError, match="no encode_linears API"):
         campaign.main(["--model", "must-not-load", "--out", str(tmp_path / "cost.pkl"),
                        "--cache-dir", str(tmp_path / "cache"), "--anchor-batch-size", "4"])
+
+
+def test_batches_are_unit_major_so_a_batch_wide_memo_reuses_each_factorization():
+    """PrismaQuant #389: rung-major emission made every (unit, rung) refactorize.
+
+    The memo the campaign builds holds ``encoder_memo_capacity`` entries,
+    which the plan sizes to the batch width, and it is keyed on the unit (the
+    scale plane is constant across a family's rungs).  Emitting every batch
+    of rung A before any batch of rung B put 108 batches of other units
+    between one unit's rungs, so an 8-slot memo hit nothing.  Walking the
+    emitted order through a memo of exactly the batch width must miss once
+    per unit, not once per (unit, rung), while every batch still holds one
+    ``(family, rung, shape)`` key.
+    """
+    import functools
+
+    units = [f"model.layers.3.mlp.experts.{i}.up_proj" for i in range(20)]
+    weights = {name: torch.empty((2048, 4096)) for name in units}
+    weights["dense"] = torch.empty((16, 256))
+    rungs = (832, 960, 1088)
+    pending = [(name, "TESSERA_E4M3_K1", rung) for name in units for rung in rungs]
+    pending += [("dense", "TESSERA_E4M3_K1", 832), ("dense", "TESSERA_E4M3_K1", 1088)]
+    batch_size = 8
+    batches = campaign._anchor_batches(
+        pending, weights=weights, expert_members=set(units), batch_size=batch_size)
+    assert sorted(item for batch in batches for item in batch) == sorted(pending)
+    for batch in batches:
+        assert len({(family, rung, tuple(weights[name].shape)) for name, family, rung in batch}) == 1
+        assert len(batch) <= batch_size
+    misses = []
+
+    @functools.lru_cache(maxsize=batch_size)
+    def for_unit(name):
+        misses.append(name)
+        return name
+
+    for batch in batches:
+        for name, _family, _rung in batch:
+            for_unit(name)
+    assert misses == units + ["dense"], misses
+    assert for_unit.cache_info().hits == len(pending) - len(units) - 1
+    # The rungs of one chunk are consecutive, in the order the round pended them.
+    heads = [(batch[0][0], batch[0][2]) for batch in batches]
+    assert heads[:3] == [(units[0], 832), (units[0], 960), (units[0], 1088)]
+    assert heads[3:6] == [(units[8], 832), (units[8], 960), (units[8], 1088)]

--- a/tests/test_tessera_campaign_publication_cli.py
+++ b/tests/test_tessera_campaign_publication_cli.py
@@ -279,3 +279,120 @@ def test_a_fatal_encode_error_still_journals_the_batch_that_succeeded(
             wire = tmp_path / "cache" / "wire" / record["file"]
             assert wire.stat().st_size == record["blob_bytes"], (
                 "a row was committed against bytes that are not there")
+
+
+def test_the_post_work_of_one_batch_runs_while_the_next_batch_encodes(
+        monkeypatch, tmp_path):
+    """The overlap itself, held open by a barrier rather than sampled.
+
+    Batch one's receipt is made on the writer by reading its published wire
+    back.  Here that read-back is held until batch two's encode has BEGUN on
+    the encode thread; the run can only complete if the two really overlap.
+    On the synchronous path the same hold sits on the encode thread before
+    batch two, so the barrier times out and the assertion fails rather than
+    the shard hanging.
+    """
+    import threading
+
+    campaign, _render = _fixture(monkeypatch, tmp_path)
+    next_encode_started = threading.Event()
+    calls: list[str] = []
+    real_encode = campaign._encode_and_render
+
+    def encode(weight, format_name, **kwargs):
+        calls.append(format_name)
+        if len(calls) == 2:
+            next_encode_started.set()
+        return real_encode(weight, format_name, **kwargs)
+
+    monkeypatch.setattr(campaign, "_encode_and_render", encode)
+    held: list[dict] = []
+    real_record = campaign._checkpoint_wire_record
+
+    def record(anchor, wire_dir, identity, **kwargs):
+        if not held:
+            held.append(dict(thread=threading.current_thread().name,
+                             next_encode_started=next_encode_started.wait(20.0)))
+        return real_record(anchor, wire_dir, identity, **kwargs)
+
+    monkeypatch.setattr(campaign, "_checkpoint_wire_record", record)
+    assert campaign.main([
+        *_argv(tmp_path), "--publication-overlap-bytes", str(1 << 20)]) == 0
+    assert held == [dict(thread="tessera-publication", next_encode_started=True)]
+    from prismaquant.cost_stage_checkpoint import unit_path
+
+    root = tmp_path / "campaign.anchors.json.parts"
+    for unit in UNITS:
+        state = pickle.loads(pickle.loads(unit_path(root, unit).read_bytes())["payload"])
+        assert state["anchors"] and state["wire_records"]
+
+
+def test_the_pipelined_selected_path_prices_the_same_bytes_and_identities(
+        monkeypatch, tmp_path):
+    """Overlap plus a bound identity, on the selected-source path, vs neither.
+
+    This is the configuration the pipelined arm runs.  The bound identity is
+    derived on the writer (the thread name is asserted), and everything a
+    resume or an export reads -- the journal identity, each unit's envelope
+    digest, its anchor rows, its wire receipt and the wire bytes -- is the
+    synchronous path's, byte for byte.
+    """
+    import json
+    import threading
+    from test_selected_source_authentication import selected_source_fixture
+    from prismaquant.cost_stage_checkpoint import unit_path
+
+    from prismaquant import tessera_campaign
+
+    UNIT = "model.layers.0.proj"
+    runs: dict[str, dict] = {}
+    derived_on: list[tuple[str, str]] = []
+    current = ["none"]
+    real_derive = tessera_campaign._BoundCheckpointUnitIdentity.derive
+
+    def derive(self, **kwargs):
+        derived_on.append((current[0], threading.current_thread().name))
+        return real_derive(self, **kwargs)
+
+    monkeypatch.setattr(tessera_campaign._BoundCheckpointUnitIdentity, "derive", derive)
+    # One source, one census, one capture: the journal identity binds the
+    # model path by value, so the two arms price the same selection out of
+    # the same tree and differ only in where their outputs land.
+    campaign, argv, _state = selected_source_fixture(monkeypatch, tmp_path, priced=True)
+    for label, extra in (("sync", []), ("pipelined", [
+            "--publication-overlap-bytes", str(1 << 20),
+            "--campaign-identity-bytes", str(1 << 20)])):
+        root = tmp_path / label
+        root.mkdir()
+        arm_argv = list(argv)
+        for flag, leaf in (("--out", "cost.pkl"), ("--cache-dir", "cache"),
+                           ("--checkpoint", "campaign.anchors.json")):
+            arm_argv[arm_argv.index(flag) + 1] = str(root / leaf)
+        current[0] = label
+        assert campaign.main([*arm_argv, *extra]) == 0
+        manifest = json.loads((root / "campaign.anchors.json").read_text())
+        envelope = pickle.loads(unit_path(root / "campaign.anchors.json.parts", UNIT).read_bytes())
+        state = pickle.loads(envelope["payload"])
+        assert state["anchors"] and state["wire_records"]
+        wires = {name: (root / "cache" / "wire" / name).read_bytes()
+                 for name in (record["file"] for record in state["wire_records"].values())}
+        costs = _payload(root)["costs"][UNIT]
+        # The envelope's payload digest binds the anchor rows' wall-clock
+        # ``seconds``, so two runs never share it; everything else in the
+        # unit state is compared by value below.
+        runs[label] = dict(
+            identity_sha256=manifest["identity_sha256"],
+            envelope_identity=envelope["identity_sha256"],
+            anchors=[{k: v for k, v in row.items() if k not in ("seconds", "encoding_batch_size")}
+                     for row in state["anchors"]],
+            state={k: v for k, v in state.items() if k != "anchors"},
+            wire_records=state["wire_records"], wires=wires,
+            costs={fmt: {k: v for k, v in row.items() if k != "encode_seconds"}
+                   for fmt, row in costs.items()},
+            provenance=_payload(root)["provenance"])
+    assert derived_on == [("pipelined", "tessera-publication")], derived_on
+    assert runs["sync"]["provenance"]["publication_overlap"] is None
+    assert runs["pipelined"]["provenance"]["publication_overlap"]["failed"] is False
+    for key in ("identity_sha256", "envelope_identity", "anchors", "state",
+                "wire_records", "wires", "costs"):
+        assert runs["sync"][key] == runs["pipelined"][key], key

--- a/tests/test_tessera_publication.py
+++ b/tests/test_tessera_publication.py
@@ -703,3 +703,85 @@ def test_the_plan_charges_the_staging_bound_where_the_anchors_live(monkeypatch):
             if k not in {"publication_staging_bytes", "campaign_identity_metadata_bytes"}} == {
         k: v for k, v in off["phases"]["resident_anchors"].items()
         if k not in {"publication_staging_bytes", "campaign_identity_metadata_bytes"}}
+
+
+# ---------------------------------------------------------------------------
+# A deferred identity: post-work the writer does behind the anchor's own files
+# ---------------------------------------------------------------------------
+
+def test_a_deferred_identity_is_derived_on_the_writer_behind_the_files():
+    """``record(anchor, derive=...)`` runs the derivation inside the receipt job.
+
+    Ordering, not speed: the derivation must not run on the caller's thread,
+    must run after this anchor's file job, and must seal the receipt that is
+    journalled.  The thread name is the writer's, which is what a profile of
+    the real arm attributes the phase to.
+    """
+    journalled, order = [], []
+    barrier = threading.Event()
+    pub = _publisher()
+    ledger = _ledger(pub, journalled)
+    try:
+        _files_job(pub, "a.b", lambda: (barrier.wait(WAIT), order.append("files")))
+
+        def derive():
+            order.append(("derive", threading.current_thread().name))
+            return "id-a"
+
+        ledger.record(_Anchor("a.b"), derive=derive)
+        assert order == [], "the identity was derived on the encode thread"
+        assert ledger.apply_completed() == 0
+        barrier.set()
+        assert ledger.drain() == 1
+        assert order == ["files", ("derive", "tessera-publication")]
+        assert journalled == [("a.b", "record:id-a")]
+    finally:
+        barrier.set()
+        pub.close()
+
+
+def test_without_a_publisher_a_deferred_identity_is_derived_inline():
+    journalled, threads = [], []
+    ledger = _ledger(None, journalled)
+
+    def derive():
+        threads.append(threading.current_thread().name)
+        return "id-a"
+
+    ledger.record(_Anchor("a.b"), derive=derive)
+    assert threads == [threading.current_thread().name]
+    assert journalled == [("a.b", "record:id-a")]
+
+
+def test_record_takes_exactly_one_form_of_identity():
+    ledger = _ledger(None, [])
+    with pytest.raises(ValueError, match="exactly one"):
+        ledger.record(_Anchor("a.b"))
+    with pytest.raises(ValueError, match="exactly one"):
+        ledger.record(_Anchor("a.b"), "id-a", derive=lambda: "id-a")
+
+
+def test_a_refused_deferred_identity_fails_the_publication_and_journals_nothing():
+    """An identity gate that refuses on the writer is a publication failure.
+
+    On the synchronous path the same refusal raises on the encode thread
+    before anything is journalled.  Deferred, it is raised by the writer and
+    surfaces at the next barrier, and the anchor whose identity was refused
+    has no journal row: no receipt, no row.
+    """
+    journalled = []
+    pub = _publisher()
+    ledger = _ledger(pub, journalled)
+    try:
+        _files_job(pub, "a.b", lambda: None)
+
+        def derive():
+            raise RuntimeError("checkpoint anchor is outside the current menu")
+
+        ledger.record(_Anchor("a.b"), derive=derive)
+        with pytest.raises(PublicationError):
+            ledger.drain()
+        assert journalled == []
+        assert pub.failure is not None
+    finally:
+        pub.close()


### PR DESCRIPTION
Closes the campaign side of #283 (dead-GPU time at every anchor-batch boundary in `prismaquant/tessera_campaign.py`); the encoder-memo finding is #389 and lands here as its own commit.

## What changed

1. **Bound anchor identity derived on the publisher's writer** (`022e86bff2`). `_AnchorPublicationLedger.record(anchor, identity=None, *, derive=None)` takes a sealed identity or a `derive` callable; with a publisher, `derive` runs in the receipt job on the `tessera-publication` thread behind the batch's files, so the encode thread launches the next batch instead of hashing metadata. A refused deferred identity is a `PublicationError`: nothing journalled, the action stops. Score and D2H stay on the main thread (graph-capture contract).
2. **Identity hold sized from interpreter facts** (`bce758f951`). The planner charged an 864-unit row ~1.9 GB (1 KiB per format retained); the bound is now `sys.getsizeof`-derived — 199,528 B/unit planned vs 78,037 B observed — so a full row fits the 256 MiB `--campaign-identity-bytes` reservation at an honest 104 GiB.
3. **Bind-startup hot spot** (`6f84d8771e`). `_format_executes_static_activation_contract` synthesized a whole Tessera spec per format per unit (1,793 × 864): 1.13 s/unit, ~16 GPU-idle minutes per row. Registry rows are read live; only name→serving-route is memoised. 0.086 s/unit after; 114 s once per row.
4. **#389: unit-major anchor batches** (`09c72f2ca6`, separate commit). `_anchor_batches` keeps `(family, rung, shape, dtype, device)` membership and emits chunk k of every rung of one base before chunk k+1, so the batch-width memo reuses each unit's LDL across rungs (test: 21 misses instead of 62 on 20 units × 3 rungs). Per-miss refactorization measured at 10–70 ms → 0.3–2.3 % of a 5,206 s row; measure-only per the coordinator, no 3-rung GPU A/B.
5. **Harness** (`dead1c4c64`, `43d2465b60`, `1481c718b3`): `experiments/campaign_publication_ab.py` runs `(overlap, identity)` arms with in-plan `prefix_state` parity, publisher stats, bind/derive spans, torch trace + main-thread sampler; `experiments/campaign_seed_rebind_timing.py` times `--seed-checkpoint` adoption under a new source; `prepare(order=)` for repeats (the first form was shadowed by the default matrix — fixed and tested in `1481c718b3`).
6. **Batch widths in the harness** (`96b3012ef2`, `61d8460283`): a plan arm may name its own `--anchor-batch-size` (schema v3 triples), priced per width through the dispatcher's resource plan at prepare and checked in-plan by the same exact parity (the width is outside the checkpoint identity); every arm runs a 0.5 s memory sampler (VmRSS, VmHWM, MemAvailable, allocator reserved) whose peaks land in `parity.json`; the profiler allowance is a `prepare` parameter.

Branch rebased onto `perf/glm-publication-transition-optimization` at `dfd50a60ad` (#481, #482); clean, no file overlap.

`docs/ARCHITECTURE.md` updated in the same commits (pipeline, planner, batch order).

## Measured before/after

**Meter lag (instrument fact from W1c, PB `cf0626a7513e`, step-response calibration on a Spark).** GB10 `power.draw` has a 1.02 s half-rise, 1.52 s to 90 % and a 1.02 s half-fall; `utilization.gpu` crosses 50 %/90 % at 1.02 s. The kernel timeline of a memo-hit encode call is 73 % kernel-busy in its first 0.1 s and 90 % after, while the recorder still reads 19 W / 0.7 % util for 0.5 s and reaches 53 W only at +2.0 s. So roughly 1–1.5 s of every per-call "below 45 W" head in the decomposition is meter lag, not idle GPU: the real idle head is the capture-seal hash (~1.0 s on first-read calls) plus ~0.2 s LDL/driver, and the first call of a new rate pays a one-time ~1.2 s Triton compile. Run-level mean power and anchors/kJ are unaffected (the lag integrates out over a steady window), and the inter-call gap is wall-clock. **Read the headline as anchors/kJ + mean power + inter-call gap; the below-45 W fractions and the head/middle/tail split are a lagged view** — their differences between arms are still real (the same lag applies to every arm), their absolute values overstate idle time by ~1–1.5 s per call, and the <3 % target was set on that lagged scale.

**Lag-proof headline:** pipelined vs sync, same box and prefix — anchors/kJ 6.60 vs 6.55 (arms 02/00) and 6.86 vs 6.99 (pair), mean power 62.9 vs 59.7 W and 58.4 vs 54.3 W, inter-call gap 0.001 vs 0.82 s, steady window −5.9 % / −5.4 % at unchanged encode time per batch; energy per anchor flat within ±2 %. The below-45 W columns are the lagged view.

### Table (row-0063, 64-anchor gate/up prefix, batch width 8, GB10 140 W envelope; pqteld 0.5 s power recorder, trapezoid over the steady window; 45 W is a descriptive threshold, not a saturation definition)

| arm | overlap | identity | box | steady s | mean W | below-45 W | anchors/kJ | inter-call gap s | dip per call head/mid/tail/gap s | dl380g10 (NFS server) confound |
|---|---|---|---|---|---|---|---|---|---|---|
| 00 sync | 0 | 0 | sparklina | 143.2 | 59.7 | **19.8 %** | 6.55 | 0.822 | 2.11/0.00/0.94/0.80 | clean (load 30 tail of my shards, iowait 0.9 %) |
| 01 overlap | 256 MiB | 0 | sparklina | 171.9 | 51.8 | 34.3 % | 6.28 | 2.246 | 1.57/1.80/0.71/0.69 | **confounded**: my x86 pbtest shards (load 41, iowait 6.0 %, ARC misses 943/s) |
| 02 pipelined | 256 MiB | 256 MiB | sparklina | 134.8 | 62.9 | **14.3 %** | 6.60 | 0.001 | 2.52/0.03/0.03/0.11 | clean (load 20, iowait 0.4 %) |
| 03 pipelined | 256 MiB | 256 MiB | sparklina | 150.4 | 57.5 | 26.2 % | 6.48 | 0.001 | 1.80/1.03/0.40/0.37 | **confounded**: W2 `c56ff05dcbe3` 16-CPU job (iowait 6.6 %, ARC misses 629/s) |
| 04 overlap | 256 MiB | 0 | sparklina | 137.1 | 62.2 | **16.2 %** | 6.57 | 0.948 | 2.00/0.00/0.20/0.77 | clean (load 13, iowait 0.1 %) |
| pair sync (#389 prefix, tree `1481c718b3`) | 0 | 0 | sparklina | 147.8 | 54.3 | **18.7 %** | 6.99 | 0.819 | 2.03/0.00/0.91/0.77 | clean (load 8.7, iowait 1.7 %, ARC misses 2.7/s) |
| pair pipelined (same plan, in-plan parity) | 256 MiB | 256 MiB | sparklina | 139.7 | 58.4 | **13.8 %** | 6.86 | 0.001 | 1.96/0.00/0.56/0.14 | load 1.6, iowait 2.1 %, nfsd read 342 KB/s, ARC misses 989/s (another client; writer seconds unchanged) |
| repeat pipelined | 256 MiB | 256 MiB | **sparky** | 138.6 | 72.7 | **12.7 %** | 5.56 | 0.001 | 2.08/0.06/0.14/0.11 | clean, after Rob's ZFS/ARC tuning (load 4.6, iowait 0.18 %, ARC misses 35/s); **different prefix** (4 R832 + 4 R1088 batches under the #389 order) so mean W / J per anchor are not comparable, the fraction and the dip are |

Arms 00–04 ran before the dl380g10 ZFS tuning (epoch 1789090608), the repeat after. The overlap-only baseline (arm-04, = the live `resume-overlap-manifest.json` configuration) is 16.2 %; the pipelined arm is 14.3 % / 12.7 % / 13.8 % on the three clean samples (sync 19.8 % / 18.7 %), the per-boundary GPU dip 4.04 s → 2.76 s / 2.52 s / 2.75 s (the like-for-like number across boxes and prefixes; the fraction also moves with the batch length), the inter-call gap 0.82 s → 0.001 s, encoder time per batch unchanged (19.6 / 18.6 / 19.1 s; 20.3 / 19.8 s on the mixed R832/R1088 prefix). **The <3 % target is not met** and is not reachable from the campaign side (below).

**Parity.** Arms 00–04: `exact_parity: true` for every arm against the plan's sync arm (identity sha256, priced anchor state minus seconds, wire records, wire sha256/bytes). The sparky repeat shares 32 of 64 anchors with arm-00 and those 32 are byte-identical; its other 32 are R1088 (the #389 order changed the prefix) and its `identity_sha256` differs only in `prismaquant_source_sha256`. The same-tree (sync, pipelined) pair `ae955974c24a…` on sparklina, same 64-anchor prefix under the shipped #389 order: **`exact_parity: true` in-plan** (identity, per-anchor rows, wire records, wire sha256/bytes identical between the sync and the pipelined arm).

**#389 measured.** `_activation_kwargs_memo.cache_info` at arm close on the new order: 32 hits / 32 misses over 64 lookups (`currsize` 8/8) on all three arms that ran it — every R1088 chunk of an 8-unit batch reused the R832 factorization, the analytic 50 % for a 2-rung prefix; the remaining `encoder_kwargs` spans are 24 per arm, 2.0–2.9 s total.

**Batch width (coordinator's follow-up).** Priced through the dispatcher's plan: width 8 → 102 GiB workload, 16 → 103 GiB, **32 → 106 GiB, refused at prepare** (above the recipe's 104 GiB reservation: memo 2.15 GB + compatible batch weight 4.29 GB) — not a candidate for the resume's batch size unless the reservation changes. Width 16 ran as `[(B,I,8),(B,I,16)]` on sparklina (`d3a59b754df3…`, 104 GiB with a 1 GiB profiler allowance); primary comparison is anchors/kJ and encode wall per anchor (lag-proof), the below-45 W fraction is the lagged view: **`exact_parity: true` in-plan** (width 16 priced the same 64 anchors to the same identity, state, wire records and wire bytes as width 8 — the encoder is batch-width independent here; memo 32/32 at both widths). Width 8 → 16: **encode 2.515 → 2.288 s per anchor (−9.0 %), steady wall 2.532 → 2.325 s per anchor (−8.2 %), anchors/kJ 6.93 → 6.69 (−3.5 %, 144.3 → 149.5 J/anchor, inside the ±2.5 % width-8 scatter)**, mean power 57.0 → 64.3 W, below-45 W (lagged) 15.6 → 14.9 %, dip per anchor 0.40 → 0.35 s, peak CUDA reserved 64.8 → 70.1 GiB, box MemAvailable min 46.8 → 41.0 GiB, VmHWM 7.07 / 7.04 GiB (continuous 0.5 s sampler; VmRSS/VmHWM exclude the CUDA pool on GB10, so the peaks that bind against the reservation are MemAvailable min and allocator reserved), writer seconds per anchor unchanged. The per-call dip does not halve per doubling (3.16 → 5.55 s per call, 0.40 → 0.35 s per anchor): the head is fixed per call and amortises, the tail (producer wire-packing drain) is per unit and doubles. Cost: one 16-anchor batch charges 262.7 of the 268.4 MB budget, so `reserve` blocked the encode thread 0.66 s over three batches — width 16 needs the 512 MiB budget. n = 1 arm per width (3 steady batches at 16). Resume batch size: 16 with the 512 MiB budget and the 103 GiB plan; otherwise 8; 32 not admissible.

**Where the residual dip sits (profiler + sampler, `boundary-decomposition.json`).** Sync: 4.04 s below 45 W per call = head 2.11 (Viterbi ramp 1.26, capture-seal hash 0.54, driver/columns_of 0.2, LDL 0.06) + tail 0.94 (campaign `torch.save`/score) + gap 0.80 (identity). Pipelined: 2.76 s = head 2.51 (Viterbi ramp 1.34, seal hash 0.80, driver 0.14, columns_of 0.09, LDL 0.06) + tail 0.03 + gap 0.11 (one end-of-run drain). What remains is inside the frozen producer on the encode thread — the capture-seal hash of H on first read per unit, the Hessian regularize + block-LDL, and the Viterbi bind/ramp before the fused window kernel reaches steady power — plus ~1.05 s/batch of wire bit packing at the tail that never drops below 45 W (the GPU is still draining). Not addressable in PrismaQuant.

**Writer vs budget.** One 8-anchor batch stages 162 MB (3.43 MB wire + 16.9 MB rendered entry per anchor) = `peak_charged_bytes`; 256 MiB holds one batch, not two. `reserve` blocked only on arm-01 (6.2 s total, budget full under server load); on arm-03 the budget never filled and the loss was mid-batch with the writer's `torch.save` at 2.6 s/batch instead of 0.8 — a server-latency path the budget does not govern (mechanism unmeasured; GIL contention is the candidate). Recommendation: 512 MiB overlap (two batches, +256 MiB of the 102 GiB row) for the next campaign; local-NVMe staging + async copy if the mid-batch path matters.

**Rebind timing** (`experiments/campaign_seed_rebind_timing.py`, sparky, one 864-unit row): 515 s wall, 864/864 adopted, 105.9 GiB read, GPU idle — prefetch 126 s, bind 113.5 s, adopt 145 s (wire re-read 132 s, identity 101.7 s). 132 rows × 515 s ≈ 19 Spark-hours: **do not roll out to the 16 remaining rows; take the branch for the next campaign.**

## Tests

- x86 via pbtest (`/home/rob/venvs/pq-cpu312/bin/python`, dl380g10): `fe7b65aeac3b` `test_tessera_campaign_publication_cli.py` 8 passed; `05e33f90fe3f` `test_campaign_publication_ab.py` 7 passed; rebased tree: `59e2dbf660bb` `test_campaign_publication_ab.py` 9 passed, `c3b0eb3022df` 21 passed, `20da5b34795c` 36 passed 1 skipped, `96f01738a47c` 54 passed 5 skipped, `6a1b4036f013` 43 passed (all eight touched test files); earlier shards `d9b4c41b5273`/`8211391cecab`/`1b056acd4e2f` and `578ddc8d537d` green on the touched files (`tests/test_tessera_publication.py`, `test_tessera_bound_identity.py`, `test_tessera_campaign_batch.py`, `test_selected_source_authentication.py`, `test_static_activation_contract_one_home.py`, `test_tessera_campaign.py`).
- Spark/CUDA via pbtest (sparky, gb10, cu130 venv): `239dd95af9b2` 86 passed 1 skipped; `c06475766558` 64 passed; rebased tree: `f42ff6595156` 80 passed, `4089308077aa` 79 passed 1 skipped (same eight files).
- New tests: deferred identity behind the batch's files / inline without publisher / exactly-one-form / refused → `PublicationError`; planner bound from interpreter facts; pipelined selected path prices the same identity/envelope/anchors/state/wires/costs as the sync path; post-work of batch N runs on the writer while N+1 encodes; unit-major batches (#389); repeat-order override.

## PB receipts and evidence

- Five-arm harness `3e186e7488edd36ac047261e0e622ef11fefa9abf6ddb5ac724f7da19a684974`; sparky repeat `d70a80df5a23658fd5293ca07f5ebe0f01254c2c8ac08b269ae56a725f2c0287`; pair `ae955974c24a0c21ddafc8541be745cd7c38d5122e6f8b210853cdb7691a8a8f`; rebind `ecac56a93ad06b2015f91c5e3b424c7595689686a866aec893a501b2e46115d4`; batch-16 `d3a59b754df38a88d0d372d0dc94dde8f93af1403da27f073db5a5b4f5d2bc76` (prepare `5a3afa34fb73`; batch-32 prepare `006acdc90a74` refused; width pricing `85d3b971aa77`); prepares `f5919f3c370e`, `770c6cb11204`, `74a8b834aa6d`, `0af7b0bc7fec`; identity-hold measure `edf311a264e1`/`3d4148ac90be`/`ab1d46a3dc16`. All under `/mnt/shared/prismabuild-fleet/pb-queue/done/`.
- Evidence: `/mnt/shared/tessera-measurements/glm-canonical-census-20260908/boundary-pipeline-20260910/` (`plan.json`, `native/arm-0[0-4]/`, `repeat/`, `repeat-pair/`, `batch-16/`, `steady-summary.json`, `boundary-decomposition.json`, `netdata-dl380g10-windows.json`, `sparklina-power.csv`, `sparky-power.csv`, `identity-hold-measure.json`, `rebind/`). Report and analysis scripts: `/home/rob/tmp/glm-perf-20260910/w1a/REPORT.md`.

Not measured: a full 864 × 3-rung row with the pipeline; the #389 order on a 3-rung GPU row (2-rung prefix measured); batch width 32 (does not fit the reservation); the mid-batch stall mechanism under server load (needs a whole-process GIL sampler); producer-internal changes (frozen tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsJsJGJtE4CYHE9QKyRyiz
