### PR TITLE
Re-seal completed census rows to an amended source pair under proof (#283)

### DIFF
--- a/experiments/reseal_identity_proof.py
+++ b/experiments/reseal_identity_proof.py
@@ -38,6 +38,9 @@ from pathlib import Path
 SCHEMA = 'prismaquant.reseal_identity_proof.v1'
 PIN_KEYS = ('prismaquant_source_sha256', 'encoder_source_sha256')
 ANCHOR_VOLATILE = ('seconds', 'encoding_batch_size')
+# Wall-clock and batching fields the campaign stores beside each priced rung;
+# not scores, and never equal across two runs of the same encode.
+COST_VOLATILE = ('encode_seconds', 'encode_seconds_accounting', 'encoding_batch_size')
 STRIPPED_FLAGS = ('--seed-checkpoint', '--seed-wire-dir')
 
 
@@ -350,7 +353,7 @@ def compare_rows(produced, stored, *, old, new, expected_cells=None, require_cos
             p_cost = pickle.load(stream)
         with (stored/'cost.pkl').open('rb') as stream:
             s_cost = pickle.load(stream)
-        report = dict(keys_compared=[], provenance_excluded=True)
+        report = dict(keys_compared=[], provenance_excluded=True, cost_fields_masked=list(COST_VOLATILE))
         if set(p_cost) != set(s_cost):
             fail(dict(what='cost_keys', produced=sorted(p_cost), stored=sorted(s_cost)))
         for key in sorted(set(p_cost) & set(s_cost)):
@@ -359,6 +362,8 @@ def compare_rows(produced, stored, *, old, new, expected_cells=None, require_cos
             a, b = p_cost[key], s_cost[key]
             if key == 'tessera_expert_wires':
                 a, b = _strip_wire_seals(a), _strip_wire_seals(b)
+            elif key == 'costs':
+                a, b = _mask_cost_timing(a), _mask_cost_timing(b)
             diffs = deep_equal(a, b, key)
             report['keys_compared'].append(key)
             if diffs:
@@ -368,6 +373,11 @@ def compare_rows(produced, stored, *, old, new, expected_cells=None, require_cos
         fail(dict(what='cost_pkl', detail='produced run wrote no cost.pkl'))
     result['ok'] = not result['failures']
     return result
+
+
+def _mask_cost_timing(costs):
+    return {unit: {fmt: {k: v for k, v in entry.items() if k not in COST_VOLATILE}
+                   for fmt, entry in rungs.items()} for unit, rungs in costs.items()}
 
 
 def _strip_wire_seals(records):

--- a/experiments/reseal_identity_proof.py
+++ b/experiments/reseal_identity_proof.py
@@ -481,9 +481,16 @@ def run_gpu_arm(args, *, prefix):
             # --units selection covers every member; only the pricing loop's
             # resolution (tessera_campaign._main, after selection) is
             # restricted, so the selection gate still sees the whole stack.
+            # Both resolutions happen in tessera_campaign._main: the scope
+            # groups first (which the --units selection is checked against,
+            # member for member) and the pricing groups second (which the
+            # round loop pends anchors from).  Only the second is restricted.
+            calls = []
+
             def restricted_groups(*a, **kw):
                 groups = original_groups(*a, **kw)
-                if sys._getframe(1).f_code.co_name == 'select_anchor_groups':
+                calls.append(len(groups))
+                if len(calls) == 1:
                     return groups
                 return restrict_groups(groups, classes=classes, per_class=args.members_per_class)
             campaign.resolve_anchor_groups = restricted_groups
@@ -493,7 +500,7 @@ def run_gpu_arm(args, *, prefix):
                     raise PrefixComplete()
                 return original_loo(*a, **kw)
             campaign._loo_for = stop_after_prefix
-            record['group_restriction'] = dict(classes=classes, members_per_class=args.members_per_class)
+            record['group_restriction'] = dict(classes=classes, members_per_class=args.members_per_class, resolutions=calls)
         else:
             campaign._anchor_batches = lambda *a, **kw: shape_interleaved(original(*a, **kw), classes=classes, per_class=args.batches_per_class)
         try:

--- a/experiments/reseal_identity_proof.py
+++ b/experiments/reseal_identity_proof.py
@@ -477,8 +477,16 @@ def run_gpu_arm(args, *, prefix):
             # is the third round's gate on the restricted members; stop
             # there, before the campaign finalizes a table for units it
             # never measured.
-            campaign.resolve_anchor_groups = lambda *a, **kw: restrict_groups(
-                original_groups(*a, **kw), classes=classes, per_class=args.members_per_class)
+            # ``select_anchor_groups`` resolves the same groups to check the
+            # --units selection covers every member; only the pricing loop's
+            # resolution (tessera_campaign._main, after selection) is
+            # restricted, so the selection gate still sees the whole stack.
+            def restricted_groups(*a, **kw):
+                groups = original_groups(*a, **kw)
+                if sys._getframe(1).f_code.co_name == 'select_anchor_groups':
+                    return groups
+                return restrict_groups(groups, classes=classes, per_class=args.members_per_class)
+            campaign.resolve_anchor_groups = restricted_groups
 
             def stop_after_prefix(*a, **kw):
                 if observer.result.get('completed_anchor_units', 0) >= args.limit_anchors or _prefix_done(observer, args.limit_anchors):

--- a/experiments/reseal_identity_proof.py
+++ b/experiments/reseal_identity_proof.py
@@ -461,6 +461,7 @@ print(json.dumps(dict(tessera_file=tessera.__file__, torch=torch.__version__,
 
 def run_fixture_id(args):
     out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
     record = dict(schema=SCHEMA, kind='fixture_id', started_unix=time.time(), producers=[],
                   environment=environment_record(with_pins=False),
                   window_env=dict(TESSERA_WINDOW_BEST_FORM=args.window_best_form, TESSERA_WINDOW_BEST_TILE=args.window_best_tile))

--- a/experiments/reseal_identity_proof.py
+++ b/experiments/reseal_identity_proof.py
@@ -160,6 +160,39 @@ def shape_interleaved(batches, *, classes, per_class):
     return chosen + rest
 
 
+def restrict_groups(groups, *, classes, per_class):
+    """Keep the first ``per_class`` members of each shape class in every group.
+
+    The campaign then prices only those members: round one places the band
+    ends and round two the interior rate (the bisection reaches R960 only
+    after every member of the group has both ends), so a restricted group
+    reaches the third rate in 3 x members anchors instead of 3 x 864.  The
+    group's rate grid is the intersection over its members, and the stored
+    rows measured every member at the same three rates, so the subset's
+    grid is the same one.  The comparator, not this permutation, judges
+    whether the rates and scores agree with the stored row.
+    """
+    kept = {}
+    for key, members in groups.items():
+        taken = {name: 0 for name in classes}
+        chosen = []
+        for member in members:
+            kind = batch_class([(member,)])
+            if kind in taken and taken[kind] < per_class:
+                taken[kind] += 1
+                chosen.append(member)
+        if chosen:
+            kept[key] = chosen
+    if not kept:
+        raise ValueError('no anchor group has members in the requested shape classes')
+    return kept
+
+
+def _prefix_done(observer, limit):
+    calls = observer.result.get('prefix_calls') or []
+    return sum(len(call['qnames']) for call in calls) >= limit
+
+
 class _SilentObserver:
     """``run_prefix`` needs a result dict and a pass-through anchor wrapper."""
 
@@ -432,15 +465,35 @@ def run_gpu_arm(args, *, prefix):
     write_json(out/'result.json', dict(record, status='running'))
     from prismaquant import tessera_campaign as campaign
     if prefix:
-        from experiments.campaign_prefix_profile import run_prefix
+        from experiments.campaign_prefix_profile import run_prefix, PrefixComplete
         classes = args.shape_classes.split(',')
         original = campaign._anchor_batches
+        original_groups = campaign.resolve_anchor_groups
+        original_loo = campaign._loo_for
         observer = _SilentObserver()
-        campaign._anchor_batches = lambda *a, **kw: shape_interleaved(original(*a, **kw), classes=classes, per_class=args.batches_per_class)
+        if args.members_per_class:
+            # Restricted groups; the campaign's own batching order applies.
+            # The first leave-one-out evaluation after the requested prefix
+            # is the third round's gate on the restricted members; stop
+            # there, before the campaign finalizes a table for units it
+            # never measured.
+            campaign.resolve_anchor_groups = lambda *a, **kw: restrict_groups(
+                original_groups(*a, **kw), classes=classes, per_class=args.members_per_class)
+
+            def stop_after_prefix(*a, **kw):
+                if observer.result.get('completed_anchor_units', 0) >= args.limit_anchors or _prefix_done(observer, args.limit_anchors):
+                    raise PrefixComplete()
+                return original_loo(*a, **kw)
+            campaign._loo_for = stop_after_prefix
+            record['group_restriction'] = dict(classes=classes, members_per_class=args.members_per_class)
+        else:
+            campaign._anchor_batches = lambda *a, **kw: shape_interleaved(original(*a, **kw), classes=classes, per_class=args.batches_per_class)
         try:
             run_prefix(campaign, command, observer, limit=args.limit_anchors, expected_source_units=args.expected_source_units)
         finally:
             campaign._anchor_batches = original
+            campaign.resolve_anchor_groups = original_groups
+            campaign._loo_for = original_loo
         record['prefix'] = {k: v for k, v in observer.result.items() if k != 'resident_prefetch'}
         record['resident_prefetch'] = {k: v for k, v in observer.result.get('resident_prefetch', {}).items()
                                        if k in ('units', 'hessian_bytes', 'activation_bytes', 'devices', 'finished_unix')}
@@ -535,6 +588,8 @@ def main(argv=None):
             p.add_argument('--expected-source-units', type=int, required=True)
             p.add_argument('--shape-classes', default='down_proj,gate_up')
             p.add_argument('--batches-per-class', type=int, default=3)
+            p.add_argument('--members-per-class', type=int, default=0,
+                           help='restrict every anchor group to its first N members per shape class, so the bisection rate is reached')
         else:
             p.add_argument('--expected-cells', type=int, required=True)
         p.add_argument('command', nargs=argparse.REMAINDER)

--- a/experiments/reseal_identity_proof.py
+++ b/experiments/reseal_identity_proof.py
@@ -75,7 +75,8 @@ def environment_record(*, with_pins):
     record = dict(python=sys.version, executable=sys.executable, platform=platform.platform(),
                   hostname=platform.node(), cwd=os.getcwd(),
                   env={k: os.environ.get(k) for k in ('PYTHONPATH', 'TESSERA_REPO', 'TESSERA_WINDOW_BEST_FORM',
-                       'TESSERA_WINDOW_BEST_TILE', 'PRISMAQUANT_DETERMINISTIC', 'PRISMAQUANT_CONTAINER_CONTENT_SHA256',
+                       'TESSERA_WINDOW_BEST_TILE', 'TESSERA_SEAL_PREFETCH', 'PRISMAQUANT_DETERMINISTIC',
+                       'PRISMAQUANT_CONTAINER_CONTENT_SHA256',
                        'PRISMABUILD_ACTION_KEY', 'CUDA_VISIBLE_DEVICES')})
     if with_pins:
         import prismaquant

--- a/experiments/reseal_identity_proof.py
+++ b/experiments/reseal_identity_proof.py
@@ -1,0 +1,554 @@
+"""Proof generator for the campaign identity re-seal (tools/reseal_campaign_identity.py).
+
+The two source seals bound into every campaign checkpoint identity
+(``prismaquant_source_sha256``, ``encoder_source_sha256``) are pins over
+source trees, not measured values.  Amending them in already-written rows is
+only honest when the candidate sources reproduce the stored bytes and scores.
+This module produces that evidence, one arm per PB action:
+
+``fixture-id``  (CPU, x86)  ``encoder_fixture_id()`` + per-fixture digests +
+                the source seal, computed by each producer tree in its own
+                process, so old and new can be compared in one record.
+``prefix``      (GPU)  re-encode a fixed anchor prefix of a completed routed
+                expert row under the candidate PQ + producer, into a fresh
+                directory, then compare every produced cell against the
+                stored row: wire bytes, receipt, anchor score, and the full
+                checkpoint identity with only the two pins substituted.
+``dense``       (GPU)  the same for a complete dense row, including the
+                numeric content of ``cost.pkl``.
+``compare``     (CPU)  the comparator alone, for re-verification on the host.
+
+Every arm writes ``result.json`` under its ``--out``; the migration tool
+assembles those into the proof bundle it requires before rewriting a row.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import pickle
+import platform
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+SCHEMA = 'prismaquant.reseal_identity_proof.v1'
+PIN_KEYS = ('prismaquant_source_sha256', 'encoder_source_sha256')
+ANCHOR_VOLATILE = ('seconds', 'encoding_batch_size')
+STRIPPED_FLAGS = ('--seed-checkpoint', '--seed-wire-dir')
+
+
+# ---------------------------------------------------------------------------
+# environment
+# ---------------------------------------------------------------------------
+
+def bind_prismaquant(root):
+    """Put the candidate PQ tree first and drop the cwd entry ``-m`` adds.
+
+    The checkout PB snapshots is the driver's home, not the code under test:
+    ``python -m`` puts the cwd at ``sys.path[0]`` ahead of PYTHONPATH, so
+    without this the campaign would import from the snapshot and the arm
+    would silently measure the wrong tree.  The result records what was
+    actually imported, and the comparator checks the identity's pin against
+    the requested new pin, so a wrong binding cannot pass.
+    """
+    root = Path(root).resolve()
+    if 'prismaquant' in sys.modules:
+        raise RuntimeError('prismaquant was imported before the proof bound its tree')
+    cwd = Path.cwd().resolve()
+    sys.path[:] = [p for p in sys.path if p not in ('', '.') and Path(p or '.').resolve() != cwd]
+    sys.path.insert(0, str(root))
+    import prismaquant
+    actual = Path(prismaquant.__file__).resolve().parent
+    if actual != root/'prismaquant':
+        raise RuntimeError(f'prismaquant bound to {actual}, wanted {root/"prismaquant"}')
+    return prismaquant
+
+
+def environment_record(*, with_pins):
+    record = dict(python=sys.version, executable=sys.executable, platform=platform.platform(),
+                  hostname=platform.node(), cwd=os.getcwd(),
+                  env={k: os.environ.get(k) for k in ('PYTHONPATH', 'TESSERA_REPO', 'TESSERA_WINDOW_BEST_FORM',
+                       'TESSERA_WINDOW_BEST_TILE', 'PRISMAQUANT_DETERMINISTIC', 'PRISMAQUANT_CONTAINER_CONTENT_SHA256',
+                       'PRISMABUILD_ACTION_KEY', 'CUDA_VISIBLE_DEVICES')})
+    if with_pins:
+        import prismaquant
+        from prismaquant.production_weight_cache import _production_cache_source_sha256
+        import tessera
+        from tessera import cached_unit
+        from tessera.encoder_identity import encoder_fixture_id
+        record.update(prismaquant_file=prismaquant.__file__, tessera_file=tessera.__file__,
+                      prismaquant_source_sha256=_production_cache_source_sha256(),
+                      encoder_source_sha256=cached_unit.encoder_source_sha256(),
+                      encoder_fixture_id=encoder_fixture_id().hex())
+        try:
+            import torch
+            record.update(torch=torch.__version__, cuda=torch.version.cuda,
+                          device=torch.cuda.get_device_name(0) if torch.cuda.is_available() else None)
+        except Exception as error:  # pragma: no cover - torch absent on a CPU host
+            record['torch'] = repr(error)
+    return record
+
+
+def sha256_file(path):
+    with open(path, 'rb') as stream:
+        return hashlib.file_digest(stream, 'sha256').hexdigest()
+
+
+def write_json(path, value):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name+'.tmp')
+    tmp.write_text(json.dumps(value, indent=1, sort_keys=True, default=str)+'\n')
+    os.replace(tmp, path)
+
+
+# ---------------------------------------------------------------------------
+# campaign command surgery
+# ---------------------------------------------------------------------------
+
+def redirect_outputs(command, out):
+    """Point ``--out/--cache-dir/--checkpoint`` at a fresh directory; drop seeding."""
+    out = Path(out)
+    command = list(command)
+    for flag in STRIPPED_FLAGS:
+        while flag in command:
+            index = command.index(flag)
+            del command[index:index+2]
+    for flag, value in {'--out': out/'cost.pkl', '--cache-dir': out/'cache',
+                        '--checkpoint': out/'cost.anchors.json'}.items():
+        if flag not in command:
+            raise ValueError(f'campaign command lacks {flag}')
+        command[command.index(flag)+1] = str(value)
+    return command
+
+
+def batch_class(batch):
+    classes = {item[0].rsplit('.', 1)[-1] for item in batch}
+    if classes <= {'down_proj'}:
+        return 'down_proj'
+    if classes <= {'gate_proj', 'up_proj'}:
+        return 'gate_up'
+    raise ValueError(f'batch crosses shape classes: {sorted(classes)}')
+
+
+def shape_interleaved(batches, *, classes, per_class):
+    """The first ``per_class`` batches of each shape class, then the rest.
+
+    Membership of every batch is preserved; only whole batches move.  With
+    the unit-major order of ``_anchor_batches`` the first three batches of a
+    class are its first chunk at each of the three rung rates, so a prefix of
+    ``per_class * batch_size`` anchors per class covers every rate.
+    """
+    chosen, rest, taken = [], [], {name: 0 for name in classes}
+    for batch in batches:
+        kind = batch_class(batch)
+        if kind in taken and taken[kind] < per_class:
+            taken[kind] += 1
+            chosen.append(batch)
+        else:
+            rest.append(batch)
+    short = [name for name, count in taken.items() if count < per_class]
+    if short:
+        raise ValueError(f'shape classes without enough batches: {short}')
+    return chosen + rest
+
+
+class _SilentObserver:
+    """``run_prefix`` needs a result dict and a pass-through anchor wrapper."""
+
+    def __init__(self):
+        self.result = {}
+
+    @staticmethod
+    def wrap_anchor(function):
+        return function
+
+
+# ---------------------------------------------------------------------------
+# comparator
+# ---------------------------------------------------------------------------
+
+def substitute_pins(identity, *, old, new):
+    identity = json.loads(json.dumps(identity))
+    for key in PIN_KEYS:
+        if identity.get(key) != old[key]:
+            raise ValueError(f'stored identity {key}={identity.get(key)} is not the declared old pin {old[key]}')
+        identity[key] = new[key]
+    return identity
+
+
+def deep_equal(a, b, where='', diffs=None):
+    """Exact structural equality; NaN equals NaN; arrays compared by bytes."""
+    diffs = [] if diffs is None else diffs
+    if type(a) is not type(b):
+        try:
+            import numpy as np
+            if isinstance(a, np.generic) or isinstance(b, np.generic):
+                return deep_equal(_plain(a), _plain(b), where, diffs)
+        except ImportError:
+            pass
+        diffs.append((where, f'type {type(a).__name__} vs {type(b).__name__}'))
+        return diffs
+    if isinstance(a, dict):
+        if set(a) != set(b):
+            diffs.append((where, f'keys {sorted(set(a) ^ set(b))}'))
+            return diffs
+        for key in sorted(a, key=str):
+            deep_equal(a[key], b[key], f'{where}.{key}', diffs)
+        return diffs
+    if isinstance(a, (list, tuple)):
+        if len(a) != len(b):
+            diffs.append((where, f'length {len(a)} vs {len(b)}'))
+            return diffs
+        for index, (x, y) in enumerate(zip(a, b)):
+            deep_equal(x, y, f'{where}[{index}]', diffs)
+        return diffs
+    if isinstance(a, float):
+        if not (a == b or (math.isnan(a) and math.isnan(b))):
+            diffs.append((where, f'{a!r} vs {b!r}'))
+        return diffs
+    if hasattr(a, 'tobytes') and hasattr(a, 'shape'):
+        if tuple(a.shape) != tuple(b.shape) or str(a.dtype) != str(b.dtype) or a.tobytes() != b.tobytes():
+            diffs.append((where, 'array content'))
+        return diffs
+    if a != b:
+        diffs.append((where, f'{a!r} vs {b!r}'))
+    return diffs
+
+
+def _plain(value):
+    return value.item() if hasattr(value, 'item') else value
+
+
+def load_manifest(root):
+    manifest = json.loads((Path(root)/'cost.anchors.json').read_text())
+    for key in ('identity', 'identity_sha256', 'schema', 'stage', 'units'):
+        if key not in manifest:
+            raise ValueError(f'{root}: manifest lacks {key}')
+    return manifest
+
+
+def load_units(root, manifest, qnames):
+    from prismaquant.cost_stage_checkpoint import _load_unit, unit_path
+    parts = Path(root)/'cost.anchors.json.parts'
+    return {name: _load_unit(unit_path(parts, name), stage=manifest['stage'], qname=name,
+                             identity_sha256=manifest['identity_sha256']) for name in qnames}
+
+
+def compare_rows(produced, stored, *, old, new, expected_cells=None, require_cost=False):
+    """Compare a produced run against the stored row it re-encodes.
+
+    Returns a result dict with ``ok`` and the cell table.  Nothing here is
+    tolerant: a produced cell must match the stored one in every wire byte,
+    every receipt field but the producer seal, and every anchor field but
+    the two timing/batching fields the campaign itself does not compare.
+    """
+    from prismaquant.cost_stage_checkpoint import canonical_json_sha256, canonical_json
+    from prismaquant.production_weight_cache import first_identity_difference
+    produced, stored = Path(produced), Path(stored)
+    result = dict(schema=SCHEMA, kind='comparison', produced=str(produced), stored=str(stored),
+                  old_pins=dict(old), new_pins=dict(new), failures=[], cells=[])
+    fail = result['failures'].append
+    pm, sm = load_manifest(produced), load_manifest(stored)
+    expected_identity = substitute_pins(sm['identity'], old=old, new=new)
+    difference = first_identity_difference(pm['identity'], canonical_json(expected_identity, where='expected identity'))
+    if difference is not None:
+        fail(dict(what='identity', field=difference[0], produced=str(difference[1])[:300], expected=str(difference[2])[:300]))
+    for key in PIN_KEYS:
+        if pm['identity'].get(key) != new[key]:
+            fail(dict(what='identity_pin', field=key, produced=pm['identity'].get(key), expected=new[key]))
+    expected_sha = canonical_json_sha256(canonical_json(expected_identity, where='expected identity'), where='expected identity')
+    result.update(stored_identity_sha256=sm['identity_sha256'], produced_identity_sha256=pm['identity_sha256'],
+                  expected_identity_sha256=expected_sha, identity_matches_with_pins_substituted=(pm['identity_sha256'] == expected_sha))
+    if pm['identity_sha256'] != expected_sha:
+        fail(dict(what='identity_sha256', produced=pm['identity_sha256'], expected=expected_sha))
+    if pm['stage'] != sm['stage'] or pm['schema'] != sm['schema']:
+        fail(dict(what='manifest', produced=[pm['schema'], pm['stage']], stored=[sm['schema'], sm['stage']]))
+
+    parts = produced/'cost.anchors.json.parts'/'units'
+    produced_names = [u['qname'] for u in pm['units'] if (parts/Path(u['file']).name).is_file()]
+    if not produced_names:
+        fail(dict(what='units', detail='produced run journaled no unit'))
+    p_units = load_units(produced, pm, produced_names)
+    s_units = load_units(stored, sm, produced_names)
+    seen = set()
+    for name in produced_names:
+        p_state, s_state = p_units[name], s_units[name]
+        if bool(p_state.get('unservable')) or bool(s_state.get('unservable')):
+            fail(dict(what='unservable', unit=name, produced=p_state.get('unservable'), stored=s_state.get('unservable')))
+            continue
+        stored_anchors = {a['format_name']: a for a in s_state['anchors']}
+        for anchor in p_state['anchors']:
+            fmt = anchor['format_name']
+            cell = dict(qname=name, format_name=fmt, family=anchor.get('family'), body_rate_q256=anchor.get('body_rate_q256'),
+                        dloss=anchor.get('dloss'), ok=True, problems=[])
+            problem = cell['problems'].append
+            if (name, fmt) in seen:
+                problem('duplicate cell')
+            seen.add((name, fmt))
+            s_anchor = stored_anchors.get(fmt)
+            if s_anchor is None:
+                problem('stored row has no anchor at this format')
+            else:
+                a = {k: v for k, v in anchor.items() if k not in ANCHOR_VOLATILE}
+                b = {k: v for k, v in s_anchor.items() if k not in ANCHOR_VOLATILE}
+                for where, detail in deep_equal(a, b, 'anchor'):
+                    problem(f'{where}: {detail}')
+                cell['stored_dloss'] = s_anchor.get('dloss')
+            p_rec, s_rec = p_state['wire_records'].get(fmt), s_state['wire_records'].get(fmt)
+            if p_rec is None or s_rec is None:
+                problem('wire record missing on ' + ('produced' if p_rec is None else 'stored') + ' side')
+            else:
+                p_file, s_file = produced/'cache'/'wire'/p_rec['file'], stored/'cache'/'wire'/s_rec['file']
+                p_bytes = p_file.read_bytes() if p_file.is_file() else None
+                s_bytes = s_file.read_bytes() if s_file.is_file() else None
+                cell.update(blob_bytes=p_rec['blob_bytes'], blob_sha256=p_rec['blob_sha256'],
+                            stored_blob_sha256=s_rec['blob_sha256'], produced_file=str(p_file), stored_file=str(s_file))
+                if p_bytes is None or s_bytes is None:
+                    problem('wire file missing on ' + ('produced' if p_bytes is None else 'stored') + ' side')
+                else:
+                    cell['byte_identical'] = p_bytes == s_bytes
+                    if not cell['byte_identical']:
+                        problem('wire bytes differ')
+                    for side, blob, rec in (('produced', p_bytes, p_rec), ('stored', s_bytes, s_rec)):
+                        if hashlib.sha256(blob).hexdigest() != rec['blob_sha256'] or len(blob) != rec['blob_bytes']:
+                            problem(f'{side} wire record does not describe its file')
+                p_id, s_id = dict(p_rec['identity']), dict(s_rec['identity'])
+                if s_id.get('encoder_source_sha256') != old['encoder_source_sha256']:
+                    problem('stored receipt seal is not the declared old producer pin')
+                if p_id.get('encoder_source_sha256') != new['encoder_source_sha256']:
+                    problem('produced receipt seal is not the declared new producer pin')
+                p_id.pop('encoder_source_sha256', None)
+                s_id.pop('encoder_source_sha256', None)
+                for where, detail in deep_equal(p_id, s_id, 'receipt'):
+                    problem(f'{where}: {detail}')
+                cell['encoder_fixture_id'] = p_rec['identity'].get('encoder_fixture_id')
+                cell['stored_encoder_fixture_id'] = s_rec['identity'].get('encoder_fixture_id')
+                if cell['encoder_fixture_id'] != cell['stored_encoder_fixture_id']:
+                    problem('encoder_fixture_id moved')
+            cell['ok'] = not cell['problems']
+            result['cells'].append(cell)
+    if expected_cells is not None and len(result['cells']) != expected_cells:
+        fail(dict(what='cell_count', produced=len(result['cells']), expected=expected_cells))
+    bad = [c for c in result['cells'] if not c['ok']]
+    if bad:
+        fail(dict(what='cells', failing=len(bad), sample=[dict(qname=c['qname'], format_name=c['format_name'], problems=c['problems'][:5]) for c in bad[:8]]))
+
+    strata = {}
+    for cell in result['cells']:
+        key = f"{cell['family']}@R{cell['body_rate_q256']}:{'routed' if '.experts.' in cell['qname'] else 'dense'}"
+        strata[key] = strata.get(key, 0) + 1
+    result['strata'] = strata
+
+    cost_path = produced/'cost.pkl'
+    if cost_path.is_file():
+        with cost_path.open('rb') as stream:
+            p_cost = pickle.load(stream)
+        with (stored/'cost.pkl').open('rb') as stream:
+            s_cost = pickle.load(stream)
+        report = dict(keys_compared=[], provenance_excluded=True)
+        if set(p_cost) != set(s_cost):
+            fail(dict(what='cost_keys', produced=sorted(p_cost), stored=sorted(s_cost)))
+        for key in sorted(set(p_cost) & set(s_cost)):
+            if key == 'provenance':
+                continue
+            a, b = p_cost[key], s_cost[key]
+            if key == 'tessera_expert_wires':
+                a, b = _strip_wire_seals(a), _strip_wire_seals(b)
+            diffs = deep_equal(a, b, key)
+            report['keys_compared'].append(key)
+            if diffs:
+                fail(dict(what='cost_content', key=key, sample=[f'{w}: {d}' for w, d in diffs[:8]]))
+        result['cost_pkl'] = report
+    elif require_cost:
+        fail(dict(what='cost_pkl', detail='produced run wrote no cost.pkl'))
+    result['ok'] = not result['failures']
+    return result
+
+
+def _strip_wire_seals(records):
+    records = json.loads(json.dumps(records, default=str))
+    for unit in records.values():
+        for record in unit.values():
+            if isinstance(record, dict) and isinstance(record.get('identity'), dict):
+                record['identity'].pop('encoder_source_sha256', None)
+    return records
+
+
+# ---------------------------------------------------------------------------
+# arms
+# ---------------------------------------------------------------------------
+
+def _pins(args):
+    return (dict(prismaquant_source_sha256=args.old_prismaquant_pin, encoder_source_sha256=args.old_encoder_pin),
+            dict(prismaquant_source_sha256=args.new_prismaquant_pin, encoder_source_sha256=args.new_encoder_pin))
+
+
+def _campaign_argv(args):
+    command = args.command[1:] if args.command[:1] == ['--'] else args.command
+    if not command:
+        raise ValueError('campaign argv required after --')
+    if command[:1] == ['python3'] or command[:1] == ['python']:
+        # roster argv carries the interpreter and -u -m prismaquant.tessera_campaign
+        module = command.index('prismaquant.tessera_campaign')
+        command = command[module+1:]
+    return command
+
+
+def run_gpu_arm(args, *, prefix):
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    run = out/'run'
+    if run.exists():
+        raise RuntimeError(f'{run} exists; a proof arm never resumes into an existing run')
+    bind_prismaquant(args.prismaquant_root)
+    import torch
+    if not torch.cuda.is_available():
+        raise RuntimeError('the re-encode proof runs on the campaign GPU platform')
+    old, new = _pins(args)
+    command = redirect_outputs(_campaign_argv(args), run)
+    started = time.time()
+    record = dict(schema=SCHEMA, kind='prefix' if prefix else 'dense', out=str(out), run=str(run),
+                  stored_row=str(args.stored_row), command=command, started_unix=started,
+                  environment=environment_record(with_pins=True))
+    for key, expected in (('prismaquant_source_sha256', new['prismaquant_source_sha256']),
+                          ('encoder_source_sha256', new['encoder_source_sha256'])):
+        if record['environment'][key] != expected:
+            raise RuntimeError(f'running {key}={record["environment"][key]} is not the declared new pin {expected}')
+    write_json(out/'result.json', dict(record, status='running'))
+    from prismaquant import tessera_campaign as campaign
+    if prefix:
+        from experiments.campaign_prefix_profile import run_prefix
+        classes = args.shape_classes.split(',')
+        original = campaign._anchor_batches
+        observer = _SilentObserver()
+        campaign._anchor_batches = lambda *a, **kw: shape_interleaved(original(*a, **kw), classes=classes, per_class=args.batches_per_class)
+        try:
+            run_prefix(campaign, command, observer, limit=args.limit_anchors, expected_source_units=args.expected_source_units)
+        finally:
+            campaign._anchor_batches = original
+        record['prefix'] = {k: v for k, v in observer.result.items() if k != 'resident_prefetch'}
+        record['resident_prefetch'] = {k: v for k, v in observer.result.get('resident_prefetch', {}).items()
+                                       if k in ('units', 'hessian_bytes', 'activation_bytes', 'devices', 'finished_unix')}
+        expected_cells = args.limit_anchors
+    else:
+        campaign.main(command)
+        expected_cells = args.expected_cells
+    record['campaign_finished_unix'] = time.time()
+    comparison = compare_rows(run, args.stored_row, old=old, new=new, expected_cells=expected_cells, require_cost=not prefix)
+    record.update(comparison=comparison, ok=comparison['ok'], finished_unix=time.time(), status='finished')
+    write_json(out/'result.json', record)
+    print(json.dumps(dict(ok=record['ok'], cells=len(comparison['cells']), strata=comparison['strata'],
+                          failures=comparison['failures'][:4], seconds=record['finished_unix']-started)), flush=True)
+    return 0 if record['ok'] else 1
+
+
+_FIXTURE_SNIPPET = r'''
+import json, sys
+import tessera
+from tessera import cached_unit
+from tessera.encoder_identity import encoder_fixture_id, fixture_digests
+import torch
+print(json.dumps(dict(tessera_file=tessera.__file__, torch=torch.__version__,
+    encoder_source_sha256=cached_unit.encoder_source_sha256(),
+    encoder_fixture_id=encoder_fixture_id().hex(), fixture_digests=fixture_digests())))
+'''
+
+
+def run_fixture_id(args):
+    out = Path(args.out)
+    record = dict(schema=SCHEMA, kind='fixture_id', started_unix=time.time(), producers=[],
+                  environment=environment_record(with_pins=False),
+                  window_env=dict(TESSERA_WINDOW_BEST_FORM=args.window_best_form, TESSERA_WINDOW_BEST_TILE=args.window_best_tile))
+    for entry in args.producer:
+        label, src = entry.split('=', 1)
+        src = Path(src).resolve()
+        if not (src/'tessera').is_dir():
+            raise ValueError(f'{src} has no tessera package')
+        env = dict(os.environ, PYTHONPATH=str(src), TESSERA_WINDOW_BEST_FORM=args.window_best_form,
+                   TESSERA_WINDOW_BEST_TILE=args.window_best_tile, PYTHONDONTWRITEBYTECODE='1')
+        env.pop('TESSERA_REPO', None)
+        started = time.time()
+        proc = subprocess.run([sys.executable, '-P', '-c', _FIXTURE_SNIPPET], env=env, capture_output=True, text=True, cwd=str(out))
+        item = dict(label=label, src=str(src), returncode=proc.returncode, seconds=time.time()-started,
+                    stderr_tail=proc.stderr[-4000:])
+        if proc.returncode == 0:
+            item.update(json.loads(proc.stdout.strip().splitlines()[-1]))
+            if not Path(item['tessera_file']).resolve().is_relative_to(src):
+                raise RuntimeError(f'{label}: tessera imported from {item["tessera_file"]}, not {src}')
+        record['producers'].append(item)
+    ids = {p['label']: p.get('encoder_fixture_id') for p in record['producers']}
+    seals = {p['label']: p.get('encoder_source_sha256') for p in record['producers']}
+    record.update(encoder_fixture_ids=ids, encoder_source_sha256=seals,
+                  fixture_id_equal=len(set(ids.values())) == 1 and None not in ids.values(),
+                  ok=all(p['returncode'] == 0 for p in record['producers']) and len(record['producers']) >= 2,
+                  finished_unix=time.time())
+    if record['ok'] and not record['fixture_id_equal']:
+        digests = [p['fixture_digests'] for p in record['producers']]
+        record['moved_fixtures'] = sorted(k for k in digests[0] if any(d.get(k) != digests[0][k] for d in digests[1:]))
+    write_json(out/'result.json', record)
+    print(json.dumps(dict(ok=record['ok'], fixture_id_equal=record['fixture_id_equal'], ids=ids, seals=seals)), flush=True)
+    return 0 if record['ok'] else 1
+
+
+def run_compare(args):
+    bind_prismaquant(args.prismaquant_root)
+    old, new = _pins(args)
+    result = compare_rows(args.produced, args.stored_row, old=old, new=new, expected_cells=args.expected_cells,
+                          require_cost=args.require_cost)
+    write_json(args.out, result)
+    print(json.dumps(dict(ok=result['ok'], cells=len(result['cells']), strata=result['strata'], failures=result['failures'][:4])), flush=True)
+    return 0 if result['ok'] else 1
+
+
+def _add_pins(parser):
+    for name in ('old-prismaquant-pin', 'old-encoder-pin', 'new-prismaquant-pin', 'new-encoder-pin'):
+        parser.add_argument('--'+name, required=True)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest='arm', required=True)
+    for arm in ('prefix', 'dense'):
+        p = sub.add_parser(arm)
+        p.add_argument('--out', required=True)
+        p.add_argument('--prismaquant-root', required=True, help='candidate PQ checkout (its prismaquant/ is hashed as the new pin)')
+        p.add_argument('--stored-row', required=True)
+        _add_pins(p)
+        if arm == 'prefix':
+            p.add_argument('--limit-anchors', type=int, required=True)
+            p.add_argument('--expected-source-units', type=int, required=True)
+            p.add_argument('--shape-classes', default='down_proj,gate_up')
+            p.add_argument('--batches-per-class', type=int, default=3)
+        else:
+            p.add_argument('--expected-cells', type=int, required=True)
+        p.add_argument('command', nargs=argparse.REMAINDER)
+    p = sub.add_parser('fixture-id')
+    p.add_argument('--out', required=True)
+    p.add_argument('--producer', action='append', required=True, help='LABEL=/path/to/src (containing tessera/)')
+    p.add_argument('--window-best-form', default='1')
+    p.add_argument('--window-best-tile', default='64,4,2')
+    p = sub.add_parser('compare')
+    p.add_argument('--out', required=True)
+    p.add_argument('--prismaquant-root', required=True)
+    p.add_argument('--produced', required=True)
+    p.add_argument('--stored-row', required=True)
+    p.add_argument('--expected-cells', type=int)
+    p.add_argument('--require-cost', action='store_true')
+    _add_pins(p)
+    args = parser.parse_args(argv)
+    if args.arm == 'prefix':
+        return run_gpu_arm(args, prefix=True)
+    if args.arm == 'dense':
+        return run_gpu_arm(args, prefix=False)
+    if args.arm == 'fixture-id':
+        return run_fixture_id(args)
+    return run_compare(args)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_reseal_campaign_identity.py
+++ b/tests/test_reseal_campaign_identity.py
@@ -78,7 +78,8 @@ def write_pins(path, old=OLD, new=NEW):
 
 def write_bundle(path, old=OLD, new=NEW, ok=True):
     bundle = dict(schema=tool.BUNDLE_SCHEMA, ok=ok, pins=dict(old=old, new=new), encoder_fixture_id_equal=True,
-                  arms=[], fixture_id=dict(ids={'old': FIXTURE, 'new': FIXTURE}), cell_count=24, pb_actions=['k1'])
+                  arms=[], fixture_id=dict(result='synthetic-fixture-id-arm', ids={'old': FIXTURE, 'new': FIXTURE}),
+                  cell_count=24, pb_actions=['k1'])
     path.write_text(json.dumps(bundle))
     return path
 
@@ -223,3 +224,54 @@ def test_hash_definitions_match_the_campaign(tmp_path):
     bad.write_text(json.dumps(dict(schema=tool.PINS_SCHEMA, old=OLD, new=NEW, sources=sources)))
     with pytest.raises(tool.Refused):
         tool.load_pins(bad)
+
+
+def _arm_result(path, old, new, *, routed_rates=(832, 960, 1088), dense_rates=(832, 960, 1088)):
+    cells = []
+    def cell(qname, family, rate):
+        cells.append(dict(ok=True, byte_identical=True, dloss=0.5, stored_dloss=0.5, qname=qname, family=family,
+                          format_name=f'{family}_R{rate}', body_rate_q256=rate, blob_sha256='e'*64, blob_bytes=10,
+                          encoder_fixture_id=FIXTURE))
+    for rate in routed_rates:
+        for j in range(4):
+            cell(f'layers.0.mlp.experts.{j}.down_proj', 'TESSERA_E4M3_K1', rate)
+    for rate in dense_rates:
+        for family in ('TESSERA_BF16_K1', 'TESSERA_E4M3_K1'):
+            for j in range(2):
+                cell(f'layers.{j}.mlp.gate_proj', family, rate)
+    cell('layers.0.mlp.up_proj', 'TESSERA_E2M1_K2', 896)
+    path.write_text(json.dumps(dict(kind='dense', comparison=dict(
+        kind='comparison', ok=True, old_pins=old, new_pins=new, identity_matches_with_pins_substituted=True, cells=cells))))
+    return path
+
+
+def test_proof_bundle_needs_a_fixture_arm_only_when_the_encoder_pin_moves(tmp_path, capsys):
+    pq_only = dict(NEW, encoder_source_sha256=OLD['encoder_source_sha256'])
+    pins_moving = write_pins(tmp_path/'pins-both.json')
+    pins_pq_only = write_pins(tmp_path/'pins-pq.json', new=pq_only)
+    arm_moving = _arm_result(tmp_path/'arm-both.json', OLD, NEW)
+    arm_pq_only = _arm_result(tmp_path/'arm-pq.json', OLD, pq_only)
+    fixture = tmp_path/'fixture.json'
+    fixture.write_text(json.dumps(dict(kind='fixture_id', ok=True, fixture_id_equal=True,
+                                       encoder_source_sha256={'old': OLD['encoder_source_sha256'], 'new': NEW['encoder_source_sha256']},
+                                       encoder_fixture_ids={'old': FIXTURE, 'new': FIXTURE})))
+    # Encoder moves: the fixture-id arm is mandatory.
+    assert run('proof-bundle', '--pins', pins_moving, '--arm', arm_moving, '--out', tmp_path/'b1.json') == 2
+    assert 'fixture-id arm result is required' in capsys.readouterr().err
+    assert run('proof-bundle', '--pins', pins_moving, '--fixture-id', fixture, '--arm', arm_moving,
+               '--out', tmp_path/'b1.json') == 0
+    assert json.loads((tmp_path/'b1.json').read_text())['ok'] is True
+    # PQ-only step: the producer is unchanged, a fixture-id arm is refused and the bundle still certifies.
+    assert run('proof-bundle', '--pins', pins_pq_only, '--fixture-id', fixture, '--arm', arm_pq_only,
+               '--out', tmp_path/'b2.json') == 2
+    assert 'does not move' in capsys.readouterr().err
+    assert run('proof-bundle', '--pins', pins_pq_only, '--arm', arm_pq_only, '--out', tmp_path/'b2.json') == 0
+    bundle = json.loads((tmp_path/'b2.json').read_text())
+    assert bundle['ok'] and bundle['encoder_fixture_id_equal'] and bundle['fixture_id']['encoder_pin_unchanged']
+    assert bundle['cell_count'] >= tool.MIN_CELLS and not bundle['strata_missing']
+    # And that bundle drives a migration whose record survives an unchanged producer.
+    row = tmp_path/'row'; make_row(row)
+    assert run('migrate', '--pins', pins_pq_only, '--proof', tmp_path/'b2.json', '--row', row) == 0
+    assert run('verify', '--pins', pins_pq_only, '--row', row) == 0
+    loaded = tool.load_bundle(tmp_path/'b2.json', tool.load_pins(pins_pq_only))
+    assert loaded['fixture_id']['ids'] is None

--- a/tests/test_reseal_campaign_identity.py
+++ b/tests/test_reseal_campaign_identity.py
@@ -275,3 +275,32 @@ def test_proof_bundle_needs_a_fixture_arm_only_when_the_encoder_pin_moves(tmp_pa
     assert run('verify', '--pins', pins_pq_only, '--row', row) == 0
     loaded = tool.load_bundle(tmp_path/'b2.json', tool.load_pins(pins_pq_only))
     assert loaded['fixture_id']['ids'] is None
+
+
+def test_rows_are_classified_by_the_checkpoint_audit_not_by_cost_pkl(tmp_path, capsys):
+    """A withdrawn row may carry a cost.pkl; a done row may not lack a shard."""
+    withdrawn = tmp_path/'row-0064'; make_row(withdrawn)             # cost.pkl present, journal withdrawn
+    (withdrawn/'cost.anchors.json.parts'/'units'/sorted((withdrawn/'cost.anchors.json.parts'/'units').iterdir())[0].name).unlink()
+    done = tmp_path/'row-0070'; make_row(done)
+    broken = tmp_path/'row-0099'; make_row(broken, with_cost=False)  # unlisted, no cost.pkl
+    audit = tmp_path/'checkpoint-audit.json'
+    audit.write_text(json.dumps(dict(schema='prismaquant.tessera_campaign.checkpoint_audit.v1', rows=[
+        dict(row_id='row-0064', state='withdrawn'), dict(row_id='row-0070', state='done')])))
+    pins = write_pins(tmp_path/'pins.json'); bundle = write_bundle(tmp_path/'bundle.json')
+    ws = tmp_path/'ws'; (ws/'rows').mkdir(parents=True)
+    for row in (withdrawn, done):
+        (ws/'rows'/row.name).symlink_to(row, target_is_directory=True)
+    assert run('dry-run', '--pins', pins, '--workspace', ws) == 2
+    assert 'pass --checkpoint-audit' in capsys.readouterr().err
+    assert run('dry-run', '--pins', pins, '--workspace', ws, '--checkpoint-audit', audit, '--report', tmp_path/'d.json') == 0
+    kinds = {Path(r['row']).name: (r['kind'], r['journal_state']) for r in json.loads((tmp_path/'d.json').read_text())['rows']}
+    assert kinds == {'row-0064': ('partial', 'withdrawn'), 'row-0070': ('complete', 'done')}
+    assert run('dry-run', '--pins', pins, '--row', broken, '--checkpoint-audit', audit) == 2
+    assert 'does not record the row as withdrawn' in capsys.readouterr().err
+    assert run('migrate', '--pins', pins, '--proof', bundle, '--row', withdrawn, '--checkpoint-audit', audit) == 0
+    assert run('verify', '--pins', pins, '--row', withdrawn, '--checkpoint-audit', audit, '--report', tmp_path/'v.json') == 0
+    assert json.loads((tmp_path/'v.json').read_text())['rows'][0]['missing_shards'] == 1
+    # The same missing shard on a row the audit calls done is a verify failure.
+    audit.write_text(json.dumps(dict(schema='prismaquant.tessera_campaign.checkpoint_audit.v1', rows=[
+        dict(row_id='row-0064', state='done')])))
+    assert run('verify', '--pins', pins, '--row', withdrawn, '--checkpoint-audit', audit) == 1

--- a/tests/test_reseal_campaign_identity.py
+++ b/tests/test_reseal_campaign_identity.py
@@ -1,0 +1,225 @@
+"""tools/reseal_campaign_identity.py on synthetic campaign rows.
+
+The rows mimic the on-disk shapes of a Tessera campaign row (manifest,
+unit shards, cost.pkl, wire files) with two source pins, so the tests can
+exercise dry-run, migrate, verify, idempotency, the two-step migration and
+every refusal without a GPU or a real checkpoint.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import pickle
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+from tools import reseal_campaign_identity as tool  # noqa: E402
+
+OLD = dict(prismaquant_source_sha256='a'*64, encoder_source_sha256='b'*64)
+NEW = dict(prismaquant_source_sha256='c'*64, encoder_source_sha256='d'*64)
+FIXTURE = 'f'*64
+
+
+def _wire(root, name, fmt, seal):
+    blob = (name+fmt+'wire').encode()*7
+    path = root/'cache'/'wire'/f'{name}__{fmt}.tessera'
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(blob)
+    return dict(file=path.name, blob_sha256=hashlib.sha256(blob).hexdigest(), blob_bytes=len(blob),
+                identity=dict(unit=name, encoder_fixture_id=FIXTURE, encoder_source_sha256=seal,
+                              recipe=dict(q256=int(fmt.rsplit('R', 1)[1])), schema='tessera.cached_unit_inputs.v1'))
+
+
+def make_row(root, *, pins=OLD, units=('layers.0.mlp.experts.0.down_proj', 'layers.0.mlp.experts.1.down_proj'),
+             with_cost=True, expert_wires=True):
+    root.mkdir(parents=True, exist_ok=True)
+    identity = dict(campaign_schema='prismaquant.tessera_campaign.v1', currency='output_mse',
+                    settings=dict(nsamples=4, seqlen=8), calibration=dict(fit_tokens=3), serving_scope=None,
+                    encoder_recipe=dict(body='window'), **pins, input_global_scale_policy='static',
+                    expert_projection=None, units={u: dict(menu=['TESSERA_E4M3_K1_R832', 'TESSERA_E4M3_K1_R960'],
+                                                            weight=dict(sha256='e'*64)) for u in units})
+    sha = tool.identity_sha256(identity)
+    parts = root/'cost.anchors.json.parts'
+    manifest = dict(schema=tool.MANIFEST_SCHEMA, stage=tool.STAGE, identity_sha256=sha,
+                    identity=json.loads(tool.canonical_bytes(identity)),
+                    units=[dict(qname=u, file=str(tool.unit_path(parts, u).relative_to(parts))) for u in units])
+    (root/'cost.anchors.json').write_bytes(tool.manifest_bytes(manifest))
+    wires = {}
+    for u in units:
+        records = {fmt: _wire(root, u, fmt, pins['encoder_source_sha256']) for fmt in ('TESSERA_E4M3_K1_R832', 'TESSERA_E4M3_K1_R960')}
+        wires[u] = records
+        state = dict(anchors=[dict(qname=u, format_name=fmt, family='TESSERA_E4M3_K1', body_rate_q256=int(fmt[-3:]),
+                                   dloss=0.5, seconds=1.0) for fmt in records], wire_records=records)
+        payload = pickle.dumps(state, protocol=5)
+        envelope = dict(schema=tool.UNIT_SCHEMA, stage=tool.STAGE, qname=u, identity_sha256=sha,
+                        payload_sha256=hashlib.sha256(payload).hexdigest(), payload=payload)
+        path = tool.unit_path(parts, u)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(pickle.dumps(envelope, protocol=5))
+    if with_cost:
+        cost = dict(provenance=dict(model='m', wall_seconds=3.0, tessera_commit=''), schema='prismaquant.tessera_campaign.v1',
+                    costs={u: {fmt: dict(output_mse=0.5, encode_seconds=1.0) for fmt in ('TESSERA_E4M3_K1_R832', 'TESSERA_E4M3_K1_R960')} for u in units},
+                    formats=['TESSERA_E4M3_K1_R832'], currency='output_mse', leave_one_anchor_out={}, non_interpolable=[],
+                    menu_sizes={u: 2 for u in units}, anchor_counts={u: 2 for u in units})
+        if expert_wires:
+            cost['tessera_expert_wires'] = wires
+        (root/'cost.pkl').write_bytes(pickle.dumps(cost, protocol=4))
+    return sha
+
+
+def write_pins(path, old=OLD, new=NEW):
+    path.write_text(json.dumps(dict(schema=tool.PINS_SCHEMA, old=old, new=new)))
+    return path
+
+
+def write_bundle(path, old=OLD, new=NEW, ok=True):
+    bundle = dict(schema=tool.BUNDLE_SCHEMA, ok=ok, pins=dict(old=old, new=new), encoder_fixture_id_equal=True,
+                  arms=[], fixture_id=dict(ids={'old': FIXTURE, 'new': FIXTURE}), cell_count=24, pb_actions=['k1'])
+    path.write_text(json.dumps(bundle))
+    return path
+
+
+def run(*argv):
+    return tool.main([str(a) for a in argv])
+
+
+def test_dry_run_lists_every_edit_and_writes_nothing(tmp_path, capsys):
+    row = tmp_path/'row-0001'
+    make_row(row)
+    before = {p: p.read_bytes() for p in row.rglob('*') if p.is_file()}
+    pins = write_pins(tmp_path/'pins.json')
+    assert run('dry-run', '--pins', pins, '--row', row, '--verbose', '--report', tmp_path/'r.json') == 0
+    out = capsys.readouterr().out
+    assert 'identity_sha256' in out and 'wire_records[*].identity.encoder_source_sha256' in out
+    report = json.loads((tmp_path/'r.json').read_text())
+    plan = report['rows'][0]
+    assert plan['state'] == 'pending' and plan['shard_count'] == 2 and plan['receipt_seals'] == 4 and plan['cost_seals'] == 4
+    assert plan['bytes_to_write'] > 0
+    assert {p: p.read_bytes() for p in row.rglob('*') if p.is_file()} == before
+
+
+def test_migrate_then_verify_is_consistent_and_idempotent(tmp_path, capsys):
+    row = tmp_path/'row-0001'
+    old_sha = make_row(row)
+    old_cost = (row/'cost.pkl').read_bytes()
+    pins = write_pins(tmp_path/'pins.json')
+    bundle = write_bundle(tmp_path/'bundle.json')
+    assert run('migrate', '--pins', pins, '--proof', bundle, '--row', row, '--report', tmp_path/'m.json') == 0
+    manifest = json.loads((row/'cost.anchors.json').read_text())
+    assert manifest['identity']['prismaquant_source_sha256'] == NEW['prismaquant_source_sha256']
+    assert manifest['identity_sha256'] == tool.identity_sha256(manifest['identity']) != old_sha
+    record = manifest['identity_migration'][-1]
+    assert record['old_identity_sha256'] == old_sha and record['proof_bundle_sha256'] == tool.sha256_file(bundle)
+    cost = pickle.loads((row/'cost.pkl').read_bytes())
+    assert cost['provenance']['identity_migration'] == manifest['identity_migration']
+    assert all(r['identity']['encoder_source_sha256'] == NEW['encoder_source_sha256']
+               for u in cost['tessera_expert_wires'].values() for r in u.values())
+    content = tool.content_equality(old_cost, (row/'cost.pkl').read_bytes(), encoder_moves=True)
+    assert content['identical']
+    previous = [p for p in row.iterdir() if p.name.startswith('.reseal-previous-')]
+    assert len(previous) == 1 and (previous[0]/'cost.pkl').read_bytes() == old_cost
+    assert not [p for p in row.iterdir() if p.name.startswith('.reseal-stage-')]
+    assert json.loads((row/'identity_migration.json').read_text())['phase'] == 'done'
+    assert run('verify', '--pins', pins, '--row', row) == 0
+    # a second run finds the row migrated and leaves it alone
+    snapshot = {p: p.read_bytes() for p in row.rglob('*') if p.is_file()}
+    assert run('migrate', '--pins', pins, '--proof', bundle, '--row', row) == 0
+    assert 'already carries the new pins' in capsys.readouterr().out
+    assert {p: p.read_bytes() for p in row.rglob('*') if p.is_file()} == snapshot
+
+
+def test_two_step_migration_prismaquant_then_encoder(tmp_path):
+    row = tmp_path/'row-0002'
+    make_row(row)
+    mid = dict(OLD, prismaquant_source_sha256=NEW['prismaquant_source_sha256'])
+    pins1 = write_pins(tmp_path/'p1.json', OLD, mid)
+    bundle1 = write_bundle(tmp_path/'b1.json', OLD, mid)
+    assert run('migrate', '--pins', pins1, '--proof', bundle1, '--row', row, '--discard-previous') == 0
+    state = pickle.loads(pickle.loads((row/'cost.anchors.json.parts'/'units'/next(
+        (row/'cost.anchors.json.parts'/'units').iterdir()).name).read_bytes())['payload'])
+    assert next(iter(state['wire_records'].values()))['identity']['encoder_source_sha256'] == OLD['encoder_source_sha256']
+    pins2 = write_pins(tmp_path/'p2.json', mid, NEW)
+    bundle2 = write_bundle(tmp_path/'b2.json', mid, NEW)
+    assert run('migrate', '--pins', pins2, '--proof', bundle2, '--row', row, '--discard-previous') == 0
+    assert run('verify', '--pins', pins2, '--row', row) == 0
+    manifest = json.loads((row/'cost.anchors.json').read_text())
+    assert len(manifest['identity_migration']) == 2
+    assert not [p for p in row.iterdir() if p.name.startswith('.reseal-')]
+
+
+def test_journal_only_row_is_resealed(tmp_path):
+    row = tmp_path/'row-0003'
+    make_row(row, with_cost=False)
+    pins = write_pins(tmp_path/'pins.json')
+    bundle = write_bundle(tmp_path/'bundle.json')
+    assert run('migrate', '--pins', pins, '--proof', bundle, '--row', row) == 0
+    assert run('verify', '--pins', pins, '--row', row) == 0
+
+
+def test_refusals(tmp_path, capsys):
+    row = tmp_path/'row-0004'
+    make_row(row)
+    pins = write_pins(tmp_path/'pins.json')
+    assert run('migrate', '--pins', pins, '--row', row) == 2
+    assert 'requires --proof' in capsys.readouterr().err
+    wrong = write_bundle(tmp_path/'wrong.json', OLD, dict(NEW, encoder_source_sha256='9'*64))
+    assert run('migrate', '--pins', pins, '--proof', wrong, '--row', row) == 2
+    assert 'differ from the pins file' in capsys.readouterr().err
+    notok = write_bundle(tmp_path/'notok.json', ok=False)
+    assert run('migrate', '--pins', pins, '--proof', notok, '--row', row) == 2
+    foreign = tmp_path/'row-0005'
+    make_row(foreign, pins=dict(prismaquant_source_sha256='1'*64, encoder_source_sha256='2'*64))
+    assert run('dry-run', '--pins', pins, '--row', foreign) == 2
+    assert 'neither the old nor the new' in capsys.readouterr().err
+    live = tmp_path/'first-proof-anchor-preparation-05'/'workspace'/'rows'/'row-0006'
+    make_row(live)
+    assert run('dry-run', '--pins', pins, '--row', live) == 2
+    assert 'live campaign workspace' in capsys.readouterr().err
+    assert run('dry-run', '--pins', pins, '--row', live, '--allow-live') == 0
+    # the row is untouched by every refusal above
+    assert json.loads((row/'cost.anchors.json').read_text())['identity']['encoder_source_sha256'] == OLD['encoder_source_sha256']
+
+
+def test_verify_detects_a_tampered_wire_and_a_stale_seal(tmp_path):
+    row = tmp_path/'row-0007'
+    make_row(row)
+    pins = write_pins(tmp_path/'pins.json')
+    bundle = write_bundle(tmp_path/'bundle.json')
+    assert run('migrate', '--pins', pins, '--proof', bundle, '--row', row, '--discard-previous') == 0
+    wire = next((row/'cache'/'wire').iterdir())
+    wire.write_bytes(wire.read_bytes()+b'x')
+    assert run('verify', '--pins', pins, '--row', row) == 1
+    assert run('verify', '--pins', pins, '--row', row, '--skip-wire-bytes') == 0
+    stale = write_pins(tmp_path/'stale.json', OLD, dict(NEW, encoder_source_sha256='9'*64))
+    assert run('verify', '--pins', stale, '--row', row, '--skip-wire-bytes') == 1
+
+
+def test_hash_definitions_match_the_campaign(tmp_path):
+    pq = tmp_path/'pq'/'prismaquant'
+    pq.mkdir(parents=True)
+    (pq/'a.py').write_bytes(b'x')
+    (pq/'__pycache__').mkdir()
+    (pq/'__pycache__'/'a.pyc').write_bytes(b'ignored')
+    digest = hashlib.sha256()
+    digest.update((4).to_bytes(4, 'big')+b'a.py'+(1).to_bytes(8, 'big')+b'x')
+    assert tool.prismaquant_tree_sha256(pq) == (digest.hexdigest(), 1)
+    src = tmp_path/'producer'/'src'/'tessera'
+    src.mkdir(parents=True)
+    (src/'b.py').write_bytes(b'y')
+    (src/'README.md').write_bytes(b'not hashed')
+    digest = hashlib.sha256(b'b.py\0y\0')
+    assert tool.encoder_tree_sha256(src) == (digest.hexdigest(), 1)
+    sources = dict(prismaquant=dict(commit='deadbeef', tree=str(tmp_path/'pq')), encoder=dict(commit='cafe', tree=str(tmp_path/'producer')))
+    good = tmp_path/'good.json'
+    good.write_text(json.dumps(dict(schema=tool.PINS_SCHEMA, old=OLD, sources=sources,
+                                    new=dict(prismaquant_source_sha256=tool.prismaquant_tree_sha256(pq)[0],
+                                             encoder_source_sha256=tool.encoder_tree_sha256(src)[0]))))
+    assert tool.load_pins(good)['source_checks']['prismaquant']['files'] == 1
+    bad = tmp_path/'bad.json'
+    bad.write_text(json.dumps(dict(schema=tool.PINS_SCHEMA, old=OLD, new=NEW, sources=sources)))
+    with pytest.raises(tool.Refused):
+        tool.load_pins(bad)

--- a/tests/test_tessera_campaign_merge_integrity.py
+++ b/tests/test_tessera_campaign_merge_integrity.py
@@ -103,3 +103,30 @@ def test_merge_accepts_stack_incomplete_rung_refusal_without_family():
     payloads["row-0000"]["non_interpolable"] = [refusal]
     merged = dispatch.merge_payloads(payloads, census={"counts": {}}, capture_sha256="merged")
     assert merged["non_interpolable"] == [refusal]
+
+
+def test_merge_carries_the_union_of_identity_migration_records(tmp_path):
+    import dispatch_tessera_campaign as dispatch
+    from test_tessera_campaign_fanout import _payloads
+
+    record = {"schema": "prismaquant.identity_migration.v1", "proof_bundle_sha256": "p" * 64,
+              "old_pins": {"prismaquant_source_sha256": "a" * 64}, "new_pins": {"prismaquant_source_sha256": "b" * 64},
+              "old_identity_sha256": "row-specific", "shards": 3}
+    row, manifest, _ = _journal(tmp_path)
+    data = json.loads(manifest.read_text())
+    data["identity_migration"] = [record]
+    manifest.write_text(json.dumps(data))
+    out = tmp_path / "merged" / "cost.anchors.json"
+    merged = dispatch.merge_checkpoint({"row-0000": str(row)}, out)
+    carried = json.loads(out.read_text())["identity_migration"]
+    assert merged["identity_migration"] == carried
+    assert carried[0]["proof_bundle_sha256"] == "p" * 64 and "old_identity_sha256" not in carried[0]
+
+    payloads = _payloads()
+    for row_id, payload in payloads.items():
+        payload["provenance"]["identity_migration"] = [dict(record, old_identity_sha256=row_id)]
+    merged_payload = dispatch.merge_payloads(payloads, census={"counts": {}}, capture_sha256="merged")
+    assert merged_payload["provenance"]["identity_migration"] == carried
+    del payloads[sorted(payloads)[0]]["provenance"]["identity_migration"]
+    merged_payload = dispatch.merge_payloads(payloads, census={"counts": {}}, capture_sha256="merged")
+    assert merged_payload["provenance"]["identity_migration"] == carried

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -976,6 +976,11 @@ def merge_payloads(row_payloads: dict, *, census: dict, capture_sha256: str) -> 
 
     reference = provenances[sorted(provenances)[0]]
     provenance = {key: value for key, value in reference.items()}
+    provenance.pop("identity_migration", None)
+    carried_migration = merge_identity_migrations(
+        {row: prov.get("identity_migration") for row, prov in provenances.items()})
+    if carried_migration is not None:
+        provenance["identity_migration"] = carried_migration
     if family_policy is not None:
         provenance["family_restriction"] = {"policy": family_policy,
             "structure_by_unit": dict(sorted(restricted_structures.items()))}
@@ -1196,12 +1201,14 @@ def merge_checkpoint(row_dirs: dict, out_manifest: Path) -> dict:
     )
 
     identities = {}
+    migrations = {}
     states: dict[str, dict] = {}
     stage = "Tessera campaign"
     for row_id in sorted(row_dirs):
         manifest_path = Path(row_dirs[row_id]) / "cost.anchors.json"
         manifest = json.loads(manifest_path.read_text())
         identities[row_id] = manifest["identity"]
+        migrations[row_id] = manifest.get("identity_migration")
         parts = manifest_path.with_name(manifest_path.name + ".parts")
         listed: list[str] = []
         for entry in manifest["units"]:
@@ -1277,10 +1284,49 @@ def merge_checkpoint(row_dirs: dict, out_manifest: Path) -> dict:
                    "file": str(unit_path(parts, qname).relative_to(parts))}
                   for qname in sorted(merged_identity["units"])],
     }
+    carried = merge_identity_migrations(migrations)
+    if carried is not None:
+        manifest["identity_migration"] = carried
     atomic_write_bytes(out_manifest, json.dumps(
         manifest, indent=2, sort_keys=True, ensure_ascii=False,
         allow_nan=False).encode("utf-8"))
     return manifest
+
+
+def merge_identity_migrations(per_row: dict) -> "list | None":
+    """The union of the rows' ``identity_migration`` records, or None.
+
+    A re-sealed row (tools/reseal_campaign_identity.py) carries the pins it
+    was priced under, the pins it now carries, and the proof that licensed
+    the change.  The merged journal and payload are rebuilt from fixed keys,
+    so without this the record would end at the merge and the merged
+    checkpoint would show only its new pins with nothing saying they were
+    amended.  Records are deduplicated on the proof bundle and the pin pair;
+    rows migrated under the same proof contribute one record.  A row without
+    the key contributes nothing -- the merge already refuses rows whose pins
+    differ, so an unmigrated row cannot sit beside a migrated one.
+    """
+    merged: list = []
+    seen = set()
+    present = False
+    for row_id in sorted(per_row):
+        records = per_row[row_id]
+        if records is None:
+            continue
+        if not isinstance(records, list) or not all(isinstance(r, dict) for r in records):
+            raise MergeRefused(f"{row_id}: identity_migration is not a list of records")
+        present = True
+        for record in records:
+            key = (record.get("proof_bundle_sha256"),
+                   json.dumps(record.get("old_pins"), sort_keys=True),
+                   json.dumps(record.get("new_pins"), sort_keys=True))
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append({k: v for k, v in record.items()
+                           if k not in {"old_identity_sha256", "new_identity_sha256", "shards",
+                                        "receipt_seals", "cost_seals", "run_id"}})
+    return merged if present else None
 
 
 def _merge_scope(left, right, row_id):

--- a/tools/reseal_campaign_identity.py
+++ b/tools/reseal_campaign_identity.py
@@ -228,6 +228,9 @@ def load_bundle(path, pins):
             raise Refused(f'{path}: bundle {side} pins {bundle["pins"][side]} differ from the pins file {pins[side]}')
     if not bundle.get('encoder_fixture_id_equal'):
         raise Refused(f'{path}: encoder_fixture_id is not shown equal between the producers')
+    if bundle['pins']['old']['encoder_source_sha256'] != bundle['pins']['new']['encoder_source_sha256'] \
+            and not (bundle.get('fixture_id') or {}).get('result'):
+        raise Refused(f'{path}: the encoder pin moves but the bundle carries no fixture-id arm')
     for arm in bundle['arms']:
         actual = sha256_file(arm['result'])
         if actual != arm['result_sha256']:
@@ -239,12 +242,25 @@ def load_bundle(path, pins):
 
 def assemble_bundle(args):
     pins = load_pins(args.pins)
-    fixture = json.loads(Path(args.fixture_id).read_text())
-    if fixture.get('kind') != 'fixture_id' or not fixture.get('ok'):
-        raise Refused('fixture-id result is not an ok fixture_id arm')
-    seals = fixture['encoder_source_sha256']
-    if set(seals.values()) != {pins['old']['encoder_source_sha256'], pins['new']['encoder_source_sha256']}:
-        raise Refused(f'fixture-id arm compared producers {seals}, not the pins file old/new encoder pins')
+    encoder_moves = pins['old']['encoder_source_sha256'] != pins['new']['encoder_source_sha256']
+    if encoder_moves:
+        if not args.fixture_id:
+            raise Refused('the encoder pin moves; a fixture-id arm result is required (--fixture-id)')
+        fixture = json.loads(Path(args.fixture_id).read_text())
+        if fixture.get('kind') != 'fixture_id' or not fixture.get('ok'):
+            raise Refused('fixture-id result is not an ok fixture_id arm')
+        seals = fixture['encoder_source_sha256']
+        if set(seals.values()) != {pins['old']['encoder_source_sha256'], pins['new']['encoder_source_sha256']}:
+            raise Refused(f'fixture-id arm compared producers {seals}, not the pins file old/new encoder pins')
+        fixture_record = dict(result=str(Path(args.fixture_id).resolve()), result_sha256=sha256_file(args.fixture_id),
+                              ids=fixture['encoder_fixture_ids'], seals=seals,
+                              fixture_id_equal=bool(fixture.get('fixture_id_equal')))
+    else:
+        if args.fixture_id:
+            raise Refused('the encoder pin does not move (old == new); do not pass --fixture-id, the producer is unchanged')
+        # The producer is the one that wrote the rows: its fixture id is the stored one by definition.
+        fixture_record = dict(result=None, result_sha256=None, ids=None, seals={'unchanged': pins['old']['encoder_source_sha256']},
+                              fixture_id_equal=True, encoder_pin_unchanged=True)
     cells, arms, strata = [], [], {}
     for path in args.arm:
         result = json.loads(Path(path).read_text())
@@ -288,15 +304,13 @@ def assemble_bundle(args):
     duplicate_cells = len(cells) - len(unique)
     cells = unique
     ok = not missing and len(cells) >= MIN_CELLS
-    fixture_ids = fixture['encoder_fixture_ids']
     bundle = dict(schema=BUNDLE_SCHEMA, assembled_unix=time.time(), assembled_by=getpass.getuser(), host=platform.node(),
                   pins={'old': pins['old'], 'new': pins['new']}, sources=pins.get('sources'), source_checks=pins['source_checks'],
-                  fixture_id=dict(result=str(Path(args.fixture_id).resolve()), result_sha256=sha256_file(args.fixture_id),
-                                  ids=fixture_ids, seals=seals, fixture_id_equal=bool(fixture.get('fixture_id_equal'))),
-                  encoder_fixture_id_equal=bool(fixture.get('fixture_id_equal')), arms=arms,
+                  fixture_id=fixture_record,
+                  encoder_fixture_id_equal=fixture_record['fixture_id_equal'], arms=arms,
                   pb_actions=list(args.action or []), cells=cells, cell_count=len(cells), duplicate_cells=duplicate_cells,
                   strata={k: {f: sorted(r) for f, r in fam.items()} for k, fam in strata.items()},
-                  strata_missing=missing, min_cells=MIN_CELLS, ok=ok and bool(fixture.get('fixture_id_equal')))
+                  strata_missing=missing, min_cells=MIN_CELLS, ok=ok and fixture_record['fixture_id_equal'])
     write_json(args.out, bundle)
     print(json.dumps(dict(ok=bundle['ok'], cells=len(cells), strata=bundle['strata'], missing=missing, out=str(args.out))))
     return 0 if bundle['ok'] else 1
@@ -453,7 +467,7 @@ def migration_record(pins, bundle, plan, *, operator, run_id, when):
                 old_identity_sha256=plan['old_identity_sha256'], new_identity_sha256=plan['new_identity_sha256'],
                 proof_bundle=bundle['path'], proof_bundle_sha256=bundle['bundle_sha256'],
                 proof_cells=bundle['cell_count'], proof_pb_actions=bundle.get('pb_actions'),
-                encoder_fixture_id=sorted(set(bundle['fixture_id']['ids'].values())),
+                encoder_fixture_id=sorted(set((bundle['fixture_id'].get('ids') or {}).values())) or None,
                 shards=plan['shard_count'], receipt_seals=plan['receipt_seals'], cost_seals=plan['cost_seals'])
 
 
@@ -729,7 +743,7 @@ def main(argv=None):
     p.add_argument('--producer')
     p = sub.add_parser('proof-bundle', help='assemble a proof bundle from the fleet arm results')
     p.add_argument('--pins', required=True)
-    p.add_argument('--fixture-id', required=True)
+    p.add_argument('--fixture-id', help='fixture-id arm result; required iff the encoder pin moves')
     p.add_argument('--arm', action='append', required=True)
     p.add_argument('--action', action='append', help='PB action key of an arm, for the record')
     p.add_argument('--out', required=True)

--- a/tools/reseal_campaign_identity.py
+++ b/tools/reseal_campaign_identity.py
@@ -276,9 +276,17 @@ def assemble_bundle(args):
             have = strata.get(kind, {}).get(family, set())
             if not have or not rates <= have:
                 missing.append(f'{kind}:{family}@{sorted(rates) or "any"} (have {sorted(have)})')
-    keys = {(c['qname'], c['format_name']) for c in cells}
-    if len(keys) != len(cells):
-        raise Refused('two arms report the same cell; a bundle counts each cell once')
+    # Two arms may re-encode the same cell (two prefixes of one row start
+    # at the same experts); both are evidence, but a cell is counted once.
+    unique, seen = [], set()
+    for cell in cells:
+        key = (cell['qname'], cell['format_name'])
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(cell)
+    duplicate_cells = len(cells) - len(unique)
+    cells = unique
     ok = not missing and len(cells) >= MIN_CELLS
     fixture_ids = fixture['encoder_fixture_ids']
     bundle = dict(schema=BUNDLE_SCHEMA, assembled_unix=time.time(), assembled_by=getpass.getuser(), host=platform.node(),
@@ -286,7 +294,7 @@ def assemble_bundle(args):
                   fixture_id=dict(result=str(Path(args.fixture_id).resolve()), result_sha256=sha256_file(args.fixture_id),
                                   ids=fixture_ids, seals=seals, fixture_id_equal=bool(fixture.get('fixture_id_equal'))),
                   encoder_fixture_id_equal=bool(fixture.get('fixture_id_equal')), arms=arms,
-                  pb_actions=list(args.action or []), cells=cells, cell_count=len(cells),
+                  pb_actions=list(args.action or []), cells=cells, cell_count=len(cells), duplicate_cells=duplicate_cells,
                   strata={k: {f: sorted(r) for f, r in fam.items()} for k, fam in strata.items()},
                   strata_missing=missing, min_cells=MIN_CELLS, ok=ok and bool(fixture.get('fixture_id_equal')))
     write_json(args.out, bundle)

--- a/tools/reseal_campaign_identity.py
+++ b/tools/reseal_campaign_identity.py
@@ -1,0 +1,752 @@
+#!/usr/bin/env python3
+"""Amend the two source-seal pins bound into Tessera campaign rows, under proof.
+
+Every campaign checkpoint identity carries ``prismaquant_source_sha256`` and
+``encoder_source_sha256``: hashes of the PrismaQuant package and of the
+producer's ``src/tessera`` tree, computed at pricing time.  They pin the
+source the rows were priced under; they are not measurements.  A source
+change that provably encodes and scores the same bytes may therefore re-seal
+the written rows to the new pins instead of re-adopting 132 rows through the
+seed-rebind path (Rob, 2026-09-11: "amend the already-written data to conform
+to any changes; this shouldn't be updating weights or anything").
+
+What moves, and only this:
+
+* ``cost.anchors.json``: the two pin fields, ``identity_sha256`` (a digest of
+  the identity), and an appended ``identity_migration`` list.
+* every unit shard under ``cost.anchors.json.parts/units``: the envelope's
+  ``identity_sha256``; when the encoder pin moves, each wire receipt's
+  ``encoder_source_sha256`` inside the payload, and so ``payload_sha256``.
+* ``cost.pkl``: the same receipt seals under ``tessera_expert_wires`` (expert
+  rows), and ``provenance["identity_migration"]``.  Every other key is
+  re-pickled byte-for-byte equal to the original; the tool asserts it.
+
+Wire files, rendered cache entries and every audit record stay untouched.
+
+The proof bundle is produced by ``experiments/reseal_identity_proof.py`` on
+the fleet (encoder_fixture_id equality between producers; sampled cells
+re-encoded under the new source byte-identical to the stored wires, with
+identical scores and an identity that differs only at the pins).  ``migrate``
+refuses without a bundle whose pins equal the pins file's, and every row is
+rewritten atomically: staged beside the row, verified, then swapped in with
+the previous files retained.
+
+Pins file (``prismaquant.reseal_pins.v1``)::
+
+    {"schema": "prismaquant.reseal_pins.v1",
+     "old": {"prismaquant_source_sha256": "...", "encoder_source_sha256": "..."},
+     "new": {"prismaquant_source_sha256": "...", "encoder_source_sha256": "..."},
+     "sources": {"prismaquant": {"commit": "...", "tree": "/path/to/checkout"},
+                 "encoder": {"commit": "...", "tree": "/path/to/producer"}}}
+
+``sources`` is optional; when a tree is given it is hashed and must equal the
+declared new pin.  A pin that does not move is spelled with old == new, so
+the PrismaQuant pin and the producer pin can be migrated in two runs; a row
+already at the new pins is reported and left alone.
+"""
+from __future__ import annotations
+
+import argparse
+import getpass
+import hashlib
+import io
+import json
+import os
+import pickle
+import platform
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+PINS_SCHEMA = 'prismaquant.reseal_pins.v1'
+BUNDLE_SCHEMA = 'prismaquant.reseal_proof_bundle.v1'
+RECORD_SCHEMA = 'prismaquant.identity_migration.v1'
+JOURNAL_SCHEMA = 'prismaquant.reseal_row_journal.v1'
+MANIFEST_SCHEMA = 'prismaquant.cost_stage_checkpoint.manifest.v1'
+UNIT_SCHEMA = 'prismaquant.cost_stage_checkpoint.unit.v1'
+STAGE = 'Tessera campaign'
+PIN_KEYS = ('prismaquant_source_sha256', 'encoder_source_sha256')
+LIVE_WORKSPACE_MARKER = 'first-proof-anchor-preparation-05/workspace/rows'
+# The cells a bundle must cover before a migration is allowed. E2M1 is priced
+# at one rate in this campaign (dense rows carry TESSERA_E2M1_K2_R896 only),
+# so it is required at any rate rather than at each band rate.
+REQUIRED_STRATA = {
+    'dense': {'TESSERA_BF16_K1': {832, 960, 1088}, 'TESSERA_E4M3_K1': {832, 960, 1088}, 'TESSERA_E2M1_K2': set()},
+    'routed': {'TESSERA_E4M3_K1': {832, 960, 1088}},
+}
+MIN_CELLS = 24
+
+
+class Refused(RuntimeError):
+    """The tool will not proceed; the message says why."""
+
+
+# ---------------------------------------------------------------------------
+# hashing: the two pins and the checkpoint digests, reimplemented in stdlib
+# ---------------------------------------------------------------------------
+
+def prismaquant_tree_sha256(package_dir):
+    """== production_weight_cache._production_cache_source_sha256(package_dir)."""
+    root = Path(package_dir)
+    paths = sorted(p for p in root.rglob('*') if p.is_file()
+                   and '__pycache__' not in p.relative_to(root).parts and p.suffix not in {'.pyc', '.pyo'})
+    digest = hashlib.sha256()
+    for path in paths:
+        rel = path.relative_to(root).as_posix().encode('utf-8')
+        payload = path.read_bytes()
+        digest.update(len(rel).to_bytes(4, 'big'))
+        digest.update(rel)
+        digest.update(len(payload).to_bytes(8, 'big'))
+        digest.update(payload)
+    return digest.hexdigest(), len(paths)
+
+
+def encoder_tree_sha256(src_tessera_dir):
+    """== tessera.cached_unit.encoder_source_sha256() over src/tessera."""
+    root = Path(src_tessera_dir)
+    digest = hashlib.sha256()
+    count = 0
+    for path in sorted(p for p in root.rglob('*') if p.suffix in {'.py', '.cu', '.cuh', '.cpp', '.h'}):
+        digest.update(path.relative_to(root).as_posix().encode('utf-8') + b'\0')
+        digest.update(path.read_bytes())
+        digest.update(b'\0')
+        count += 1
+    return digest.hexdigest(), count
+
+
+def canonical_bytes(value):
+    """The byte form cost_stage_checkpoint.canonical_json_sha256 digests."""
+    canonical = json.loads(json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False, allow_nan=False))
+    return json.dumps(canonical, sort_keys=True, separators=(',', ':'), ensure_ascii=False, allow_nan=False).encode('utf-8')
+
+
+def identity_sha256(identity):
+    return hashlib.sha256(canonical_bytes(identity)).hexdigest()
+
+
+def manifest_bytes(manifest):
+    """The byte form the campaign and the dispatcher merge write."""
+    return json.dumps(manifest, indent=2, sort_keys=True, ensure_ascii=False, allow_nan=False).encode('utf-8')
+
+
+def unit_path(parts_root, qname):
+    return Path(parts_root)/'units'/(hashlib.sha256(str(qname).encode('utf-8')).hexdigest()+'.pkl')
+
+
+def sha256_bytes(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path):
+    with open(path, 'rb') as stream:
+        return hashlib.file_digest(stream, 'sha256').hexdigest()
+
+
+def pickle_protocol(data):
+    if data[:1] != b'\x80':
+        raise Refused('pickle without a PROTO opcode; refusing to guess its protocol')
+    return data[1]
+
+
+def dumps_like(value, original_bytes):
+    return pickle.dumps(value, protocol=pickle_protocol(original_bytes))
+
+
+class StdlibUnpickler(pickle.Unpickler):
+    """Refuse any global: campaign checkpoints hold only builtin containers."""
+
+    def find_class(self, module, name):
+        raise Refused(f'checkpoint pickle references {module}.{name}; the tool only rewrites plain data')
+
+
+def loads(data):
+    return StdlibUnpickler(io.BytesIO(data)).load()
+
+
+def atomic_write(path, data):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name+'.tmp')
+    with tmp.open('wb') as handle:
+        handle.write(data)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+    fd = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def write_json(path, value):
+    atomic_write(path, json.dumps(value, indent=1, sort_keys=True, default=str).encode('utf-8')+b'\n')
+
+
+# ---------------------------------------------------------------------------
+# inputs: pins file, proof bundle
+# ---------------------------------------------------------------------------
+
+def load_pins(path):
+    pins = json.loads(Path(path).read_text())
+    if pins.get('schema') != PINS_SCHEMA:
+        raise Refused(f'{path}: not a {PINS_SCHEMA} pins file')
+    for side in ('old', 'new'):
+        block = pins.get(side)
+        if not isinstance(block, dict) or set(block) != set(PIN_KEYS):
+            raise Refused(f'{path}: {side} must carry exactly {PIN_KEYS}')
+        for key, value in block.items():
+            if not (isinstance(value, str) and len(value) == 64 and all(c in '0123456789abcdef' for c in value)):
+                raise Refused(f'{path}: {side}.{key} is not a lowercase sha256')
+    if pins['old'] == pins['new']:
+        raise Refused(f'{path}: old and new pins are identical; nothing to migrate')
+    pins['source_checks'] = {}
+    for name, hasher, sub in (('prismaquant', prismaquant_tree_sha256, 'prismaquant'), ('encoder', encoder_tree_sha256, 'src/tessera')):
+        source = (pins.get('sources') or {}).get(name)
+        if source and source.get('tree'):
+            tree = Path(source['tree'])/sub
+            if not tree.is_dir():
+                raise Refused(f'{path}: sources.{name}.tree has no {sub}/ directory')
+            actual, count = hasher(tree)
+            key = 'prismaquant_source_sha256' if name == 'prismaquant' else 'encoder_source_sha256'
+            if actual != pins['new'][key]:
+                raise Refused(f'{path}: sources.{name}.tree hashes to {actual}, not the declared new {key} {pins["new"][key]}')
+            pins['source_checks'][name] = dict(tree=str(tree), files=count, sha256=actual, commit=source.get('commit'))
+    return pins
+
+
+def load_bundle(path, pins):
+    bundle = json.loads(Path(path).read_text())
+    if bundle.get('schema') != BUNDLE_SCHEMA:
+        raise Refused(f'{path}: not a {BUNDLE_SCHEMA} proof bundle')
+    if not bundle.get('ok'):
+        raise Refused(f'{path}: the bundle does not certify the migration (ok is false)')
+    for side in ('old', 'new'):
+        if bundle['pins'][side] != pins[side]:
+            raise Refused(f'{path}: bundle {side} pins {bundle["pins"][side]} differ from the pins file {pins[side]}')
+    if not bundle.get('encoder_fixture_id_equal'):
+        raise Refused(f'{path}: encoder_fixture_id is not shown equal between the producers')
+    for arm in bundle['arms']:
+        actual = sha256_file(arm['result'])
+        if actual != arm['result_sha256']:
+            raise Refused(f'{path}: arm result {arm["result"]} changed since the bundle was assembled')
+    bundle['bundle_sha256'] = sha256_file(path)
+    bundle['path'] = str(Path(path).resolve())
+    return bundle
+
+
+def assemble_bundle(args):
+    pins = load_pins(args.pins)
+    fixture = json.loads(Path(args.fixture_id).read_text())
+    if fixture.get('kind') != 'fixture_id' or not fixture.get('ok'):
+        raise Refused('fixture-id result is not an ok fixture_id arm')
+    seals = fixture['encoder_source_sha256']
+    if set(seals.values()) != {pins['old']['encoder_source_sha256'], pins['new']['encoder_source_sha256']}:
+        raise Refused(f'fixture-id arm compared producers {seals}, not the pins file old/new encoder pins')
+    cells, arms, strata = [], [], {}
+    for path in args.arm:
+        result = json.loads(Path(path).read_text())
+        comparison = result.get('comparison', result)
+        if comparison.get('kind') == 'comparison':
+            pass
+        elif result.get('kind') not in ('prefix', 'dense'):
+            raise Refused(f'{path}: not a prefix/dense proof arm result')
+        if not comparison.get('ok'):
+            raise Refused(f'{path}: arm did not pass ({comparison.get("failures")})')
+        if comparison['old_pins'] != pins['old'] or comparison['new_pins'] != pins['new']:
+            raise Refused(f'{path}: arm pins differ from the pins file')
+        if not comparison.get('identity_matches_with_pins_substituted'):
+            raise Refused(f'{path}: produced identity does not equal the stored identity with pins substituted')
+        for cell in comparison['cells']:
+            if not (cell.get('ok') and cell.get('byte_identical') and cell.get('dloss') == cell.get('stored_dloss')):
+                raise Refused(f'{path}: cell {cell.get("qname")}@{cell.get("format_name")} is not a passing cell')
+            kind = 'routed' if '.experts.' in cell['qname'] else 'dense'
+            strata.setdefault(kind, {}).setdefault(cell['family'], set()).add(int(cell['body_rate_q256']))
+            cells.append(dict(qname=cell['qname'], format_name=cell['format_name'], family=cell['family'], kind=kind,
+                              body_rate_q256=cell['body_rate_q256'], blob_sha256=cell['blob_sha256'], blob_bytes=cell['blob_bytes'],
+                              dloss=cell['dloss'], encoder_fixture_id=cell.get('encoder_fixture_id')))
+        arms.append(dict(result=str(Path(path).resolve()), result_sha256=sha256_file(path), kind=result.get('kind', 'comparison'),
+                         cells=len(comparison['cells']), strata=comparison.get('strata'), environment=result.get('environment'),
+                         action_key=None))
+    missing = []
+    for kind, families in REQUIRED_STRATA.items():
+        for family, rates in families.items():
+            have = strata.get(kind, {}).get(family, set())
+            if not have or not rates <= have:
+                missing.append(f'{kind}:{family}@{sorted(rates) or "any"} (have {sorted(have)})')
+    keys = {(c['qname'], c['format_name']) for c in cells}
+    if len(keys) != len(cells):
+        raise Refused('two arms report the same cell; a bundle counts each cell once')
+    ok = not missing and len(cells) >= MIN_CELLS
+    fixture_ids = fixture['encoder_fixture_ids']
+    bundle = dict(schema=BUNDLE_SCHEMA, assembled_unix=time.time(), assembled_by=getpass.getuser(), host=platform.node(),
+                  pins={'old': pins['old'], 'new': pins['new']}, sources=pins.get('sources'), source_checks=pins['source_checks'],
+                  fixture_id=dict(result=str(Path(args.fixture_id).resolve()), result_sha256=sha256_file(args.fixture_id),
+                                  ids=fixture_ids, seals=seals, fixture_id_equal=bool(fixture.get('fixture_id_equal'))),
+                  encoder_fixture_id_equal=bool(fixture.get('fixture_id_equal')), arms=arms,
+                  pb_actions=list(args.action or []), cells=cells, cell_count=len(cells),
+                  strata={k: {f: sorted(r) for f, r in fam.items()} for k, fam in strata.items()},
+                  strata_missing=missing, min_cells=MIN_CELLS, ok=ok and bool(fixture.get('fixture_id_equal')))
+    write_json(args.out, bundle)
+    print(json.dumps(dict(ok=bundle['ok'], cells=len(cells), strata=bundle['strata'], missing=missing, out=str(args.out))))
+    return 0 if bundle['ok'] else 1
+
+
+# ---------------------------------------------------------------------------
+# rows
+# ---------------------------------------------------------------------------
+
+def discover_rows(args):
+    rows = [Path(r) for r in (args.row or [])]
+    if args.workspace:
+        rows += sorted(p for p in (Path(args.workspace)/'rows').iterdir() if p.is_dir() and (p/'cost.anchors.json').is_file())
+    if not rows:
+        raise Refused('no rows: pass --row DIR and/or --workspace WS')
+    for row in rows:
+        if LIVE_WORKSPACE_MARKER in str(row.resolve()) and not args.allow_live:
+            raise Refused(f'{row} is inside the live campaign workspace; pass --allow-live to touch it')
+    return rows
+
+
+def classify_pins(identity, pins):
+    current = {key: identity.get(key) for key in PIN_KEYS}
+    if current == pins['new']:
+        return 'migrated', current
+    if current == pins['old']:
+        return 'pending', current
+    return 'foreign', current
+
+
+def tool_commit():
+    try:
+        out = subprocess.run(['git', '-C', str(Path(__file__).resolve().parent.parent), 'rev-parse', 'HEAD'],
+                             capture_output=True, text=True, check=True).stdout.strip()
+        dirty = subprocess.run(['git', '-C', str(Path(__file__).resolve().parent.parent), 'status', '--porcelain'],
+                               capture_output=True, text=True, check=True).stdout.strip()
+        return out + ('+dirty' if dirty else '')
+    except Exception:  # noqa: BLE001 - a PB checkout may not be a git tree
+        return None
+
+
+def plan_row(row, pins, *, run_id):
+    """Everything the rewrite would do to one row, computed without writing."""
+    row = Path(row)
+    manifest_path = row/'cost.anchors.json'
+    parts = row/'cost.anchors.json.parts'
+    cost_path = row/'cost.pkl'
+    manifest_raw = manifest_path.read_bytes()
+    manifest = json.loads(manifest_raw)
+    if manifest.get('schema') != MANIFEST_SCHEMA or manifest.get('stage') != STAGE:
+        raise Refused(f'{row}: not a {STAGE} checkpoint manifest')
+    identity = manifest['identity']
+    old_sha = identity_sha256(identity)
+    if old_sha != manifest['identity_sha256']:
+        raise Refused(f'{row}: stored identity_sha256 {manifest["identity_sha256"]} != recomputed {old_sha}; the digest reimplementation or the row is wrong')
+    state, current = classify_pins(identity, pins)
+    plan = dict(row=str(row), kind='complete' if cost_path.is_file() else 'journal-only', state=state, current_pins=current,
+                old_identity_sha256=old_sha, run_id=run_id, manifest_bytes=len(manifest_raw),
+                manifest_reserialization_identical=(manifest_bytes(manifest) in (manifest_raw, manifest_raw.rstrip(b'\n'))),
+                edits=[], shard_count=0, shard_bytes=0, receipt_seals=0, cost_seals=0, bytes_to_write=0)
+    if state == 'migrated':
+        plan['note'] = 'row already carries the new pins'
+        plan['migration_records'] = manifest.get('identity_migration', [])
+        return plan, None
+    if state == 'foreign':
+        raise Refused(f'{row}: pins {current} are neither the old nor the new pins of the pins file')
+    encoder_moves = pins['old']['encoder_source_sha256'] != pins['new']['encoder_source_sha256']
+    new_identity = json.loads(json.dumps(identity))
+    for key in PIN_KEYS:
+        new_identity[key] = pins['new'][key]
+    new_sha = identity_sha256(new_identity)
+    plan['new_identity_sha256'] = new_sha
+    plan['edits'].append(dict(file=str(manifest_path), fields=[f'identity.{k}' for k in PIN_KEYS if pins['old'][k] != pins['new'][k]] + ['identity_sha256', 'identity_migration[+1]'],
+                              before=dict(identity_sha256=old_sha, **current), after=dict(identity_sha256=new_sha, **pins['new'])))
+    shards = []
+    for entry in manifest['units']:
+        path = parts/entry['file']
+        if path != unit_path(parts, entry['qname']):
+            raise Refused(f'{row}: {entry["qname"]} names a noncanonical shard {entry["file"]}')
+        if not path.is_file():
+            if plan['kind'] == 'complete':
+                raise Refused(f'{row}: complete row lacks shard {path}')
+            continue
+        shards.append((entry['qname'], path))
+    plan['shard_count'] = len(shards)
+    shard_plans = []
+    for qname, path in shards:
+        raw = path.read_bytes()
+        envelope = loads(raw)
+        for field, expected in (('schema', UNIT_SCHEMA), ('stage', STAGE), ('qname', qname), ('identity_sha256', old_sha)):
+            if envelope.get(field) != expected:
+                raise Refused(f'{row}: shard {path.name} {field}={envelope.get(field)!r}, expected {expected!r}')
+        payload = envelope['payload']
+        if sha256_bytes(payload) != envelope['payload_sha256']:
+            raise Refused(f'{row}: shard {path.name} payload_sha256 does not describe its payload')
+        state_obj = loads(payload)
+        seals = 0
+        for fmt, record in (state_obj.get('wire_records') or {}).items():
+            seal = record.get('identity', {}).get('encoder_source_sha256')
+            if seal != pins['old']['encoder_source_sha256']:
+                raise Refused(f'{row}: {qname}@{fmt} receipt seal {seal} is not the old encoder pin')
+            seals += 1
+        if encoder_moves:
+            repickled = dumps_like(state_obj, payload)
+            if repickled != payload:
+                raise Refused(f'{row}: shard {path.name} does not re-pickle to its own bytes; refusing to rewrite a payload the tool cannot reproduce')
+            for record in state_obj['wire_records'].values():
+                record['identity']['encoder_source_sha256'] = pins['new']['encoder_source_sha256']
+            new_payload = dumps_like(state_obj, payload)
+        else:
+            new_payload = payload
+        new_envelope = dict(envelope, identity_sha256=new_sha, payload_sha256=sha256_bytes(new_payload), payload=new_payload)
+        if dumps_like(envelope, raw) != raw:
+            raise Refused(f'{row}: shard {path.name} envelope does not re-pickle to its own bytes')
+        new_raw = dumps_like(new_envelope, raw)
+        shard_plans.append(dict(qname=qname, path=path, raw_bytes=len(raw), new_raw=new_raw, seals=seals,
+                                before=dict(identity_sha256=old_sha, payload_sha256=envelope['payload_sha256']),
+                                after=dict(identity_sha256=new_sha, payload_sha256=new_envelope['payload_sha256'])))
+        plan['shard_bytes'] += len(raw)
+        plan['receipt_seals'] += seals
+    plan['edits'].append(dict(file=str(parts/'units'), shards=len(shard_plans), fields=['identity_sha256'] + (['payload_sha256', 'payload.wire_records[*].identity.encoder_source_sha256'] if encoder_moves else []),
+                              sample=[dict(qname=s['qname'], before=s['before'], after=s['after']) for s in shard_plans[:3]]))
+    cost_plan = None
+    if cost_path.is_file():
+        raw = cost_path.read_bytes()
+        cost = loads(raw)
+        if dumps_like(cost, raw) != raw:
+            raise Refused(f'{row}: cost.pkl does not re-pickle to its own bytes; refusing to rewrite it')
+        wires = cost.get('tessera_expert_wires') or {}
+        for unit, records in wires.items():
+            for fmt, record in records.items():
+                seal = record.get('identity', {}).get('encoder_source_sha256')
+                if seal != pins['old']['encoder_source_sha256']:
+                    raise Refused(f'{row}: cost.pkl tessera_expert_wires[{unit}][{fmt}] seal {seal} is not the old encoder pin')
+                plan['cost_seals'] += 1
+                if encoder_moves:
+                    record['identity']['encoder_source_sha256'] = pins['new']['encoder_source_sha256']
+        provenance = cost['provenance']
+        if not isinstance(provenance, dict):
+            raise Refused(f'{row}: cost.pkl provenance is not a mapping')
+        cost_plan = dict(path=cost_path, raw_bytes=len(raw), cost=cost, raw=raw)
+        plan['edits'].append(dict(file=str(cost_path), fields=(['tessera_expert_wires[*][*].identity.encoder_source_sha256'] if encoder_moves and wires else []) + ['provenance.identity_migration[+1]'],
+                                  seals=plan['cost_seals'], bytes=len(raw)))
+    plan['bytes_to_write'] = len(manifest_raw) + sum(len(s['new_raw']) for s in shard_plans) + (cost_plan['raw_bytes'] if cost_plan else 0)
+    work = dict(manifest=manifest, manifest_raw=manifest_raw, new_identity=new_identity, new_sha=new_sha, old_sha=old_sha,
+                shards=shard_plans, cost=cost_plan, encoder_moves=encoder_moves)
+    return plan, work
+
+
+def migration_record(pins, bundle, plan, *, operator, run_id, when):
+    return dict(schema=RECORD_SCHEMA, run_id=run_id, migrated_unix=when, operator=operator, host=platform.node(),
+                tool='tools/reseal_campaign_identity.py', tool_commit=tool_commit(),
+                old_pins=dict(pins['old']), new_pins=dict(pins['new']), sources=pins.get('sources'),
+                old_identity_sha256=plan['old_identity_sha256'], new_identity_sha256=plan['new_identity_sha256'],
+                proof_bundle=bundle['path'], proof_bundle_sha256=bundle['bundle_sha256'],
+                proof_cells=bundle['cell_count'], proof_pb_actions=bundle.get('pb_actions'),
+                encoder_fixture_id=sorted(set(bundle['fixture_id']['ids'].values())),
+                shards=plan['shard_count'], receipt_seals=plan['receipt_seals'], cost_seals=plan['cost_seals'])
+
+
+def migrate_row(row, plan, work, record, *, keep_previous):
+    """Stage, verify, swap. Crash-safe: a journal in the row says which phase."""
+    row = Path(row)
+    run_id = plan['run_id']
+    stage = row/f'.reseal-stage-{run_id}'
+    previous = row/f'.reseal-previous-{run_id}'
+    journal = row/'identity_migration.json'
+    if stage.exists() or previous.exists():
+        raise Refused(f'{row}: leftover {stage.name} or {previous.name}; inspect and remove before migrating')
+    started = time.time()
+    entry = dict(schema=JOURNAL_SCHEMA, run_id=run_id, phase='staging', started_unix=started, record=record)
+    write_json(journal, entry)
+    manifest = dict(work['manifest'])
+    manifest['identity'] = json.loads(canonical_bytes(work['new_identity']).decode('utf-8'))
+    manifest['identity_sha256'] = work['new_sha']
+    manifest['identity_migration'] = list(manifest.get('identity_migration') or []) + [record]
+    new_manifest_raw = manifest_bytes(manifest)
+    atomic_write(stage/'cost.anchors.json', new_manifest_raw)
+    written = len(new_manifest_raw)
+    for shard in work['shards']:
+        atomic_write(stage/'cost.anchors.json.parts'/'units'/shard['path'].name, shard['new_raw'])
+        written += len(shard['new_raw'])
+    cost_raw_new = None
+    if work['cost']:
+        cost = work['cost']['cost']
+        cost['provenance'] = dict(cost['provenance'])
+        cost['provenance']['identity_migration'] = list(cost['provenance'].get('identity_migration') or []) + [record]
+        cost_raw_new = dumps_like(cost, work['cost']['raw'])
+        atomic_write(stage/'cost.pkl', cost_raw_new)
+        written += len(cost_raw_new)
+    # verify the staged row exactly as a consumer would read it
+    check = verify_row(stage, pins={'new': record['new_pins']}, wire_root=row, wire_bytes=False, expect_record=record)
+    if not check['ok']:
+        raise Refused(f'{row}: staged row failed verification: {check["failures"][:3]}')
+    if work['cost']:
+        content = content_equality(work['cost']['raw'], cost_raw_new, encoder_moves=work['encoder_moves'])
+        if not content['identical']:
+            raise Refused(f'{row}: cost.pkl content is not byte-identical apart from provenance and seals: {content}')
+        entry['cost_content'] = content
+    entry.update(phase='swapping', staged_unix=time.time(), bytes_written=written)
+    write_json(journal, entry)
+    previous.mkdir()
+    os.rename(row/'cost.anchors.json', previous/'cost.anchors.json')
+    os.rename(row/'cost.anchors.json.parts', previous/'cost.anchors.json.parts')
+    if work['cost']:
+        os.rename(row/'cost.pkl', previous/'cost.pkl')
+    # the staged parts dir holds only the shards this row has; the previous
+    # parts dir may hold nothing else (units/ only), which the plan checked
+    os.rename(stage/'cost.anchors.json', row/'cost.anchors.json')
+    os.rename(stage/'cost.anchors.json.parts', row/'cost.anchors.json.parts')
+    if work['cost']:
+        os.rename(stage/'cost.pkl', row/'cost.pkl')
+    stage.rmdir()
+    entry.update(phase='swapped', swapped_unix=time.time(), previous=str(previous))
+    write_json(journal, entry)
+    if not keep_previous:
+        shutil.rmtree(previous)
+        entry.update(previous=None, previous_discarded_unix=time.time())
+    entry.update(phase='done', finished_unix=time.time(), seconds=time.time()-started)
+    write_json(journal, entry)
+    return entry
+
+
+def content_equality(old_raw, new_raw, *, encoder_moves):
+    """Bit-identity of cost.pkl apart from provenance and the receipt seals."""
+    def strip(raw):
+        value = loads(raw)
+        value.pop('provenance', None)
+        for records in (value.get('tessera_expert_wires') or {}).values():
+            for record in records.values():
+                record.get('identity', {}).pop('encoder_source_sha256', None)
+        return dumps_like(value, raw)
+    a, b = strip(old_raw), strip(new_raw)
+    return dict(identical=(a == b), compared_bytes=len(a), old_bytes=len(old_raw), new_bytes=len(new_raw),
+                masked=['provenance'] + (['tessera_expert_wires[*][*].identity.encoder_source_sha256'] if encoder_moves else []))
+
+
+# ---------------------------------------------------------------------------
+# verify: read a row the way its consumers do
+# ---------------------------------------------------------------------------
+
+def verify_row(row, *, pins, wire_root=None, wire_bytes=True, expect_record=None):
+    row = Path(row)
+    wire_root = Path(wire_root) if wire_root else row
+    result = dict(row=str(row), failures=[], shards=0, wires=0, wire_bytes_checked=0)
+    fail = result['failures'].append
+    manifest = json.loads((row/'cost.anchors.json').read_text())
+    identity = manifest.get('identity', {})
+    sha = identity_sha256(identity)
+    if sha != manifest.get('identity_sha256'):
+        fail(dict(what='identity_sha256', stored=manifest.get('identity_sha256'), recomputed=sha))
+    for key in PIN_KEYS:
+        if identity.get(key) != pins['new'][key]:
+            fail(dict(what='pin', field=key, stored=identity.get(key), expected=pins['new'][key]))
+    records = manifest.get('identity_migration') or []
+    if expect_record is not None and (not records or records[-1] != expect_record):
+        fail(dict(what='migration_record', detail='manifest lacks the expected identity_migration record'))
+    parts = row/'cost.anchors.json.parts'
+    for entry in manifest['units']:
+        path = parts/entry['file']
+        if not path.is_file():
+            continue
+        raw = path.read_bytes()
+        try:
+            envelope = loads(raw)
+        except Exception as error:  # noqa: BLE001
+            fail(dict(what='shard', file=path.name, detail=repr(error)))
+            continue
+        for field, expected in (('schema', UNIT_SCHEMA), ('stage', STAGE), ('qname', entry['qname']), ('identity_sha256', manifest['identity_sha256'])):
+            if envelope.get(field) != expected:
+                fail(dict(what='envelope', file=path.name, field=field, stored=envelope.get(field), expected=expected))
+        payload = envelope.get('payload', b'')
+        if sha256_bytes(payload) != envelope.get('payload_sha256'):
+            fail(dict(what='payload_sha256', file=path.name))
+        state = loads(payload)
+        result['shards'] += 1
+        for fmt, record in (state.get('wire_records') or {}).items():
+            result['wires'] += 1
+            if record['identity'].get('encoder_source_sha256') != pins['new']['encoder_source_sha256']:
+                fail(dict(what='receipt_seal', unit=entry['qname'], format=fmt, stored=record['identity'].get('encoder_source_sha256')))
+            if wire_bytes:
+                wire = wire_root/'cache'/'wire'/record['file']
+                if not wire.is_file():
+                    fail(dict(what='wire_missing', file=str(wire)))
+                    continue
+                size = wire.stat().st_size
+                if size != record['blob_bytes'] or sha256_file(wire) != record['blob_sha256']:
+                    fail(dict(what='wire_bytes', file=str(wire), size=size, expected=record['blob_bytes']))
+                result['wire_bytes_checked'] += size
+        anchors = {a['format_name'] for a in state.get('anchors', [])}
+        if anchors != set(state.get('wire_records') or {}) and not state.get('unservable'):
+            fail(dict(what='anchor_receipt_coverage', unit=entry['qname']))
+    cost_path = row/'cost.pkl'
+    if cost_path.is_file():
+        cost = loads(cost_path.read_bytes())
+        prov = cost.get('provenance', {})
+        recs = prov.get('identity_migration') or []
+        if expect_record is not None and (not recs or recs[-1] != expect_record):
+            fail(dict(what='cost_migration_record'))
+        if records and recs != records:
+            fail(dict(what='migration_records_differ', detail='manifest and cost.pkl carry different identity_migration lists'))
+        for unit, wires in (cost.get('tessera_expert_wires') or {}).items():
+            for fmt, record in wires.items():
+                if record['identity'].get('encoder_source_sha256') != pins['new']['encoder_source_sha256']:
+                    fail(dict(what='cost_seal', unit=unit, format=fmt))
+        result['cost_pkl'] = True
+    result['ok'] = not result['failures']
+    return result
+
+
+def consumer_merge(rows, out_dir):
+    """Run the dispatcher's real merge_checkpoint on the rows (needs PrismaQuant importable)."""
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from tools.dispatch_tessera_campaign import merge_checkpoint  # noqa: E402
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    manifest = merge_checkpoint({Path(r).name: Path(r) for r in rows}, out/'cost.anchors.json')
+    return dict(merged_identity_sha256=manifest['identity_sha256'], units=len(manifest['units']),
+                identity_migration_carried=('identity_migration' in manifest))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def cmd_hash_tree(args):
+    out = {}
+    if args.prismaquant:
+        out['prismaquant_source_sha256'], out['prismaquant_files'] = prismaquant_tree_sha256(Path(args.prismaquant)/'prismaquant')
+    if args.producer:
+        out['encoder_source_sha256'], out['encoder_files'] = encoder_tree_sha256(Path(args.producer)/'src'/'tessera')
+    print(json.dumps(out, indent=1))
+    return 0
+
+
+def cmd_dry_run(args):
+    pins = load_pins(args.pins)
+    bundle = load_bundle(args.proof, pins) if args.proof else None
+    rows = discover_rows(args)
+    run_id = time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())
+    report = dict(mode='dry-run', pins={'old': pins['old'], 'new': pins['new']}, proof=(bundle or {}).get('path'), rows=[])
+    for row in rows:
+        started = time.time()
+        plan, _ = plan_row(row, pins, run_id=run_id)
+        plan['plan_seconds'] = time.time()-started
+        report['rows'].append(plan)
+        print(json.dumps(dict(row=plan['row'], kind=plan['kind'], state=plan['state'], shards=plan['shard_count'],
+                              receipt_seals=plan['receipt_seals'], cost_seals=plan['cost_seals'], bytes_to_write=plan['bytes_to_write'],
+                              old_identity_sha256=plan['old_identity_sha256'], new_identity_sha256=plan.get('new_identity_sha256'),
+                              plan_seconds=round(plan['plan_seconds'], 2))))
+        if args.verbose:
+            for edit in plan['edits']:
+                print('  ' + json.dumps(edit, default=str))
+    if args.report:
+        write_json(args.report, report)
+    return 0
+
+
+def cmd_migrate(args):
+    pins = load_pins(args.pins)
+    if not args.proof:
+        raise Refused('migrate requires --proof BUNDLE.json')
+    bundle = load_bundle(args.proof, pins)
+    rows = discover_rows(args)
+    run_id = time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())
+    operator = args.operator or getpass.getuser()
+    report = dict(mode='migrate', run_id=run_id, pins={'old': pins['old'], 'new': pins['new']}, proof=bundle['path'],
+                  proof_bundle_sha256=bundle['bundle_sha256'], rows=[])
+    for row in rows:
+        started = time.time()
+        plan, work = plan_row(row, pins, run_id=run_id)
+        if work is None:
+            plan['seconds'] = time.time()-started
+            report['rows'].append(plan)
+            print(json.dumps(dict(row=plan['row'], state=plan['state'], note=plan.get('note'))))
+            continue
+        record = migration_record(pins, bundle, plan, operator=operator, run_id=run_id, when=time.time())
+        entry = migrate_row(row, plan, work, record, keep_previous=not args.discard_previous)
+        plan.update(migrated=True, seconds=time.time()-started, bytes_written=entry['bytes_written'], previous=entry.get('previous'),
+                    cost_content=entry.get('cost_content'))
+        report['rows'].append(plan)
+        print(json.dumps(dict(row=plan['row'], kind=plan['kind'], shards=plan['shard_count'], receipt_seals=plan['receipt_seals'],
+                              cost_seals=plan['cost_seals'], bytes_written=entry['bytes_written'], seconds=round(plan['seconds'], 2),
+                              new_identity_sha256=plan['new_identity_sha256'])))
+    if args.report:
+        write_json(args.report, report)
+    return 0
+
+
+def cmd_verify(args):
+    pins = load_pins(args.pins)
+    rows = discover_rows(args)
+    report = dict(mode='verify', rows=[])
+    ok = True
+    for row in rows:
+        started = time.time()
+        result = verify_row(row, pins=pins, wire_root=args.wire_root or row, wire_bytes=not args.skip_wire_bytes)
+        result['seconds'] = time.time()-started
+        ok &= result['ok']
+        report['rows'].append(result)
+        print(json.dumps(dict(row=result['row'], ok=result['ok'], shards=result['shards'], wires=result['wires'],
+                              wire_bytes_checked=result['wire_bytes_checked'], seconds=round(result['seconds'], 2),
+                              failures=result['failures'][:3])))
+    if args.consumer_merge:
+        try:
+            report['consumer_merge'] = consumer_merge(rows, args.consumer_merge)
+            print(json.dumps(dict(consumer_merge=report['consumer_merge'])))
+        except Exception as error:  # noqa: BLE001
+            ok = False
+            report['consumer_merge'] = dict(error=repr(error))
+            print(json.dumps(dict(consumer_merge_error=repr(error))))
+    if args.report:
+        write_json(args.report, report)
+    return 0 if ok else 1
+
+
+def _row_args(parser):
+    parser.add_argument('--pins', required=True)
+    parser.add_argument('--row', action='append')
+    parser.add_argument('--workspace')
+    parser.add_argument('--allow-live', action='store_true', help='allow rows inside the live campaign workspace')
+    parser.add_argument('--report')
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest='command', required=True)
+    p = sub.add_parser('hash-tree', help='compute the pins of a PrismaQuant checkout and/or a producer tree')
+    p.add_argument('--prismaquant')
+    p.add_argument('--producer')
+    p = sub.add_parser('proof-bundle', help='assemble a proof bundle from the fleet arm results')
+    p.add_argument('--pins', required=True)
+    p.add_argument('--fixture-id', required=True)
+    p.add_argument('--arm', action='append', required=True)
+    p.add_argument('--action', action='append', help='PB action key of an arm, for the record')
+    p.add_argument('--out', required=True)
+    p = sub.add_parser('dry-run', help='list every edit the migration would make')
+    _row_args(p)
+    p.add_argument('--proof')
+    p.add_argument('--verbose', action='store_true')
+    p = sub.add_parser('migrate', help='rewrite the pins under proof, one row at a time, atomically')
+    _row_args(p)
+    p.add_argument('--proof')
+    p.add_argument('--operator')
+    p.add_argument('--discard-previous', action='store_true', help='do not retain the pre-migration files beside the row')
+    p = sub.add_parser('verify', help='re-read migrated rows the way their consumers do')
+    _row_args(p)
+    p.add_argument('--skip-wire-bytes', action='store_true')
+    p.add_argument('--wire-root', help='row whose cache/wire holds the wires (defaults to the row itself)')
+    p.add_argument('--consumer-merge', help='also run tools.dispatch_tessera_campaign.merge_checkpoint into this directory')
+    args = parser.parse_args(argv)
+    try:
+        return {'hash-tree': cmd_hash_tree, 'proof-bundle': assemble_bundle, 'dry-run': cmd_dry_run,
+                'migrate': cmd_migrate, 'verify': cmd_verify}[args.command](args)
+    except Refused as error:
+        print(f'refused: {error}', file=sys.stderr)
+        return 2
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/reseal_campaign_identity.py
+++ b/tools/reseal_campaign_identity.py
@@ -320,9 +320,33 @@ def assemble_bundle(args):
 # rows
 # ---------------------------------------------------------------------------
 
+AUDIT_SCHEMA_PREFIX = 'prismaquant.tessera_campaign.checkpoint_audit'
+
+
+def load_checkpoint_audit(path):
+    """Row journal states from the campaign's checkpoint audit: row_id -> done | withdrawn.
+
+    A row's completeness is a fact about its journal (did the campaign commit
+    it, or withdraw it mid-way), not about which files happen to exist: a
+    withdrawn row can carry a cost.pkl from an earlier round.
+    """
+    audit = json.loads(Path(path).read_text())
+    if not str(audit.get('schema', '')).startswith(AUDIT_SCHEMA_PREFIX) and 'rows' not in audit:
+        raise Refused(f'{path}: not a checkpoint audit')
+    states = {}
+    for entry in audit['rows']:
+        state = entry.get('state')
+        if state not in ('done', 'withdrawn'):
+            raise Refused(f'{path}: row {entry.get("row_id")} has journal state {state!r}, not done/withdrawn')
+        states[entry['row_id']] = state
+    return states
+
+
 def discover_rows(args):
     rows = [Path(r) for r in (args.row or [])]
     if args.workspace:
+        if not getattr(args, 'checkpoint_audit', None):
+            raise Refused('--workspace walks every row; pass --checkpoint-audit so partial journals are selected by state, not by which files exist')
         rows += sorted(p for p in (Path(args.workspace)/'rows').iterdir() if p.is_dir() and (p/'cost.anchors.json').is_file())
     if not rows:
         raise Refused('no rows: pass --row DIR and/or --workspace WS')
@@ -352,7 +376,26 @@ def tool_commit():
         return None
 
 
-def plan_row(row, pins, *, run_id):
+def row_kind(row, cost_path, audit_states):
+    """complete | partial, from the audit when the row is listed there.
+
+    Listed withdrawn: partial (its shards may stop short, and a cost.pkl from
+    an earlier round is resealed if present). Listed done, or unlisted: the
+    row must be complete, and a missing cost.pkl or shard is refused rather
+    than silently treated as a partial journal. Without an audit the old
+    file-presence rule applies (cost.pkl present -> complete).
+    """
+    if audit_states is None:
+        return 'complete' if cost_path.is_file() else 'partial'
+    state = audit_states.get(row.name)
+    if state == 'withdrawn':
+        return 'partial'
+    if not cost_path.is_file():
+        raise Refused(f'{row}: no cost.pkl and the checkpoint audit does not record the row as withdrawn')
+    return 'complete'
+
+
+def plan_row(row, pins, *, run_id, audit_states=None):
     """Everything the rewrite would do to one row, computed without writing."""
     row = Path(row)
     manifest_path = row/'cost.anchors.json'
@@ -367,7 +410,8 @@ def plan_row(row, pins, *, run_id):
     if old_sha != manifest['identity_sha256']:
         raise Refused(f'{row}: stored identity_sha256 {manifest["identity_sha256"]} != recomputed {old_sha}; the digest reimplementation or the row is wrong')
     state, current = classify_pins(identity, pins)
-    plan = dict(row=str(row), kind='complete' if cost_path.is_file() else 'journal-only', state=state, current_pins=current,
+    plan = dict(row=str(row), kind=row_kind(row, cost_path, audit_states), journal_state=(audit_states or {}).get(row.name),
+                state=state, current_pins=current,
                 old_identity_sha256=old_sha, run_id=run_id, manifest_bytes=len(manifest_raw),
                 manifest_reserialization_identical=(manifest_bytes(manifest) in (manifest_raw, manifest_raw.rstrip(b'\n'))),
                 edits=[], shard_count=0, shard_bytes=0, receipt_seals=0, cost_seals=0, bytes_to_write=0)
@@ -552,10 +596,10 @@ def content_equality(old_raw, new_raw, *, encoder_moves):
 # verify: read a row the way its consumers do
 # ---------------------------------------------------------------------------
 
-def verify_row(row, *, pins, wire_root=None, wire_bytes=True, expect_record=None):
+def verify_row(row, *, pins, wire_root=None, wire_bytes=True, expect_record=None, partial=None):
     row = Path(row)
     wire_root = Path(wire_root) if wire_root else row
-    result = dict(row=str(row), failures=[], shards=0, wires=0, wire_bytes_checked=0)
+    result = dict(row=str(row), failures=[], shards=0, missing_shards=0, wires=0, wire_bytes_checked=0, partial=partial)
     fail = result['failures'].append
     manifest = json.loads((row/'cost.anchors.json').read_text())
     identity = manifest.get('identity', {})
@@ -572,6 +616,10 @@ def verify_row(row, *, pins, wire_root=None, wire_bytes=True, expect_record=None
     for entry in manifest['units']:
         path = parts/entry['file']
         if not path.is_file():
+            # A withdrawn journal stops short of its unit list; a done row may not.
+            result['missing_shards'] += 1
+            if partial is False:
+                fail(dict(what='shard_missing', file=path.name, qname=entry['qname']))
             continue
         raw = path.read_bytes()
         try:
@@ -649,15 +697,17 @@ def cmd_hash_tree(args):
 def cmd_dry_run(args):
     pins = load_pins(args.pins)
     bundle = load_bundle(args.proof, pins) if args.proof else None
+    audit_states = load_checkpoint_audit(args.checkpoint_audit) if args.checkpoint_audit else None
     rows = discover_rows(args)
     run_id = time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())
-    report = dict(mode='dry-run', pins={'old': pins['old'], 'new': pins['new']}, proof=(bundle or {}).get('path'), rows=[])
+    report = dict(mode='dry-run', pins={'old': pins['old'], 'new': pins['new']}, proof=(bundle or {}).get('path'),
+                  checkpoint_audit=args.checkpoint_audit, rows=[])
     for row in rows:
         started = time.time()
-        plan, _ = plan_row(row, pins, run_id=run_id)
+        plan, _ = plan_row(row, pins, run_id=run_id, audit_states=audit_states)
         plan['plan_seconds'] = time.time()-started
         report['rows'].append(plan)
-        print(json.dumps(dict(row=plan['row'], kind=plan['kind'], state=plan['state'], shards=plan['shard_count'],
+        print(json.dumps(dict(row=plan['row'], kind=plan['kind'], journal_state=plan['journal_state'], state=plan['state'], shards=plan['shard_count'],
                               receipt_seals=plan['receipt_seals'], cost_seals=plan['cost_seals'], bytes_to_write=plan['bytes_to_write'],
                               old_identity_sha256=plan['old_identity_sha256'], new_identity_sha256=plan.get('new_identity_sha256'),
                               plan_seconds=round(plan['plan_seconds'], 2))))
@@ -674,14 +724,15 @@ def cmd_migrate(args):
     if not args.proof:
         raise Refused('migrate requires --proof BUNDLE.json')
     bundle = load_bundle(args.proof, pins)
+    audit_states = load_checkpoint_audit(args.checkpoint_audit) if args.checkpoint_audit else None
     rows = discover_rows(args)
     run_id = time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())
     operator = args.operator or getpass.getuser()
     report = dict(mode='migrate', run_id=run_id, pins={'old': pins['old'], 'new': pins['new']}, proof=bundle['path'],
-                  proof_bundle_sha256=bundle['bundle_sha256'], rows=[])
+                  proof_bundle_sha256=bundle['bundle_sha256'], checkpoint_audit=args.checkpoint_audit, rows=[])
     for row in rows:
         started = time.time()
-        plan, work = plan_row(row, pins, run_id=run_id)
+        plan, work = plan_row(row, pins, run_id=run_id, audit_states=audit_states)
         if work is None:
             plan['seconds'] = time.time()-started
             report['rows'].append(plan)
@@ -692,7 +743,7 @@ def cmd_migrate(args):
         plan.update(migrated=True, seconds=time.time()-started, bytes_written=entry['bytes_written'], previous=entry.get('previous'),
                     cost_content=entry.get('cost_content'))
         report['rows'].append(plan)
-        print(json.dumps(dict(row=plan['row'], kind=plan['kind'], shards=plan['shard_count'], receipt_seals=plan['receipt_seals'],
+        print(json.dumps(dict(row=plan['row'], kind=plan['kind'], journal_state=plan['journal_state'], shards=plan['shard_count'], receipt_seals=plan['receipt_seals'],
                               cost_seals=plan['cost_seals'], bytes_written=entry['bytes_written'], seconds=round(plan['seconds'], 2),
                               new_identity_sha256=plan['new_identity_sha256'])))
     if args.report:
@@ -702,12 +753,14 @@ def cmd_migrate(args):
 
 def cmd_verify(args):
     pins = load_pins(args.pins)
+    audit_states = load_checkpoint_audit(args.checkpoint_audit) if args.checkpoint_audit else None
     rows = discover_rows(args)
-    report = dict(mode='verify', rows=[])
+    report = dict(mode='verify', checkpoint_audit=args.checkpoint_audit, rows=[])
     ok = True
     for row in rows:
         started = time.time()
-        result = verify_row(row, pins=pins, wire_root=args.wire_root or row, wire_bytes=not args.skip_wire_bytes)
+        partial = None if audit_states is None else (row_kind(row, row/'cost.pkl', audit_states) == 'partial')
+        result = verify_row(row, pins=pins, wire_root=args.wire_root or row, wire_bytes=not args.skip_wire_bytes, partial=partial)
         result['seconds'] = time.time()-started
         ok &= result['ok']
         report['rows'].append(result)
@@ -732,6 +785,7 @@ def _row_args(parser):
     parser.add_argument('--row', action='append')
     parser.add_argument('--workspace')
     parser.add_argument('--allow-live', action='store_true', help='allow rows inside the live campaign workspace')
+    parser.add_argument('--checkpoint-audit', help='campaign checkpoint audit; rows it lists as withdrawn are partial journals')
     parser.add_argument('--report')
 
 


### PR DESCRIPTION
Migration tool for the GLM census identity pins (Rob, 2026-09-11: amend the already-written records to the new source pair under proof; behaviour identity `encoder_fixture_id` unchanged).

- `tools/reseal_campaign_identity.py`: `dry-run` / `migrate` / `verify`; pins file input; refuses a pins file whose exported trees do not hash to the declared pins, a proof bundle that is not ok or whose arms changed, a row with foreign pins or non-recomputing digests, a complete row missing a shard or `cost.pkl`; rows classified by `checkpoint-audit.json` state (withdrawn → partial), not by `cost.pkl` presence; each row staged, verified, then swapped by six renames with a phase journal (`identity_migration.json`); previous files kept under `.reseal-previous-<run>/`.
- `experiments/reseal_identity_proof.py`: proof generator/comparator (fixture-id, prefix, deep prefix reaching the bisection rate, dense, seal-prefetch control); wire bytes, receipts minus seal, scores, identity with only the two pins substituted, `cost.pkl` numeric content.
- `tools/dispatch_tessera_campaign.py`: carries `identity_migration` records through the campaign merge.

Proof on the final pair (PQ 059ee574f8 → pin 0afe6bc5…, Tessera d403cc5a31 → pin 0833671b…): fixture-id 235eab1103c4 equal; prefix d3eca4289bea 48/48; deep prefix 38f50193bab9 48/48 at R832/R960/R1088; dense 6573d9cf50d5 14/14 incl. cost parity; control 2985ba8717a7 16/16 with `TESSERA_SEAL_PREFETCH=0`. Bundle sha256 c1fc59e309f89437…. Rehearsal on NFS copies (rows 0081, 0000, 0064, 0073): migrate 2dc855952c20, full-wire verify 3ea8e4438ea1, consumer merges 0fb981afe033 / 25167e5efafc. Tool tests: pbtest x86 `reseal/pbtest-tool-04.log`, 9 passed.

Known, not fixed here: `merge_checkpoint` refuses dense + expert rows in one merge at `family_restriction` (per-unit `structure_by_unit`); belongs to the dispatcher-merge step.

Do not merge until the 2026-09-11 resume is submitted (its snapshot seals at submit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsJsJGJtE4CYHE9QKyRyiz