### PR TITLE
campaign: streaming residency knobs leave the checkpoint identity; reseal tool drops them

### DIFF
--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -1610,6 +1610,13 @@ def _campaign_checkpoint_identity(*, weights, acts, hessians, menus, args,
     # metadata for retaining the same producer receipt. Neither changes the
     # receipt, so binding either would make scheduling wear an identity's clothes.
     #
+    # ``streaming_cache_slots``, ``streaming_prefetch_workers`` and
+    # ``streaming_cache_headroom_gb`` size the layer cache, its prefetch pool and
+    # the free-memory floor it keeps (`cost_streaming.build_streamed_causal_lm`); every
+    # captured activation, Hessian and wire is the same object at any of their
+    # values, so they are scheduling too.  ``streaming`` itself and
+    # ``streaming_capture_policy`` stay bound: they choose what is captured.
+    #
     # ``units``, ``calibration_census`` and ``census_out`` are locations too,
     # and each one's load-bearing content is already bound by value somewhere
     # in this identity: the selection by the ``units`` map below (which holds
@@ -1628,7 +1635,8 @@ def _campaign_checkpoint_identity(*, weights, acts, hessians, menus, args,
                  "capture_calibration_out", "calibration_cache", "calibration_cache_sha256",
                  "seed_checkpoint", "seed_wire_dir", "anchor_batch_size",
                  "publication_overlap_bytes", "campaign_identity_bytes",
-                 "source_snapshot_policy"):
+                 "source_snapshot_policy", "streaming_cache_slots",
+                 "streaming_prefetch_workers", "streaming_cache_headroom_gb"):
         settings.pop(name, None)
     return {
         **({"family_restriction": {"policy": restriction,

--- a/tests/test_reseal_campaign_identity.py
+++ b/tests/test_reseal_campaign_identity.py
@@ -35,10 +35,11 @@ def _wire(root, name, fmt, seal):
 
 
 def make_row(root, *, pins=OLD, units=('layers.0.mlp.experts.0.down_proj', 'layers.0.mlp.experts.1.down_proj'),
-             with_cost=True, expert_wires=True):
+             with_cost=True, expert_wires=True, settings=None):
     root.mkdir(parents=True, exist_ok=True)
     identity = dict(campaign_schema='prismaquant.tessera_campaign.v1', currency='output_mse',
-                    settings=dict(nsamples=4, seqlen=8), calibration=dict(fit_tokens=3), serving_scope=None,
+                    settings=dict(settings if settings is not None else dict(nsamples=4, seqlen=8)),
+                    calibration=dict(fit_tokens=3), serving_scope=None,
                     encoder_recipe=dict(body='window'), **pins, input_global_scale_policy='static',
                     expert_projection=None, units={u: dict(menu=['TESSERA_E4M3_K1_R832', 'TESSERA_E4M3_K1_R960'],
                                                             weight=dict(sha256='e'*64)) for u in units})
@@ -71,8 +72,11 @@ def make_row(root, *, pins=OLD, units=('layers.0.mlp.experts.0.down_proj', 'laye
     return sha
 
 
-def write_pins(path, old=OLD, new=NEW):
-    path.write_text(json.dumps(dict(schema=tool.PINS_SCHEMA, old=old, new=new)))
+def write_pins(path, old=OLD, new=NEW, drop_settings=None):
+    pins = dict(schema=tool.PINS_SCHEMA, old=old, new=new)
+    if drop_settings is not None:
+        pins['drop_settings'] = list(drop_settings)
+    path.write_text(json.dumps(pins))
     return path
 
 
@@ -304,3 +308,75 @@ def test_rows_are_classified_by_the_checkpoint_audit_not_by_cost_pkl(tmp_path, c
     audit.write_text(json.dumps(dict(schema='prismaquant.tessera_campaign.checkpoint_audit.v1', rows=[
         dict(row_id='row-0064', state='done')])))
     assert run('verify', '--pins', pins, '--row', withdrawn, '--checkpoint-audit', audit) == 1
+
+
+# ---------------------------------------------------------------------------
+# Settings that leave the identity (scheduling knobs a later pin stopped binding)
+# ---------------------------------------------------------------------------
+
+KNOBS = dict(streaming_cache_headroom_gb=24.0, streaming_cache_slots=2, streaming_prefetch_workers=1)
+BOUND = dict(nsamples=4, seqlen=8, streaming=True, streaming_capture_policy='legacy', **KNOBS)
+
+
+def test_dropped_settings_leave_the_identity_and_land_in_the_record(tmp_path, capsys):
+    row = tmp_path/'row-0007'
+    old_sha = make_row(row, settings=BOUND)
+    pins = write_pins(tmp_path/'pins.json', drop_settings=list(KNOBS))
+    bundle = write_bundle(tmp_path/'bundle.json')
+    assert run('dry-run', '--pins', pins, '--row', row, '--verbose', '--report', tmp_path/'d.json') == 0
+    out = capsys.readouterr().out
+    assert 'identity.settings.streaming_cache_headroom_gb' in out
+    plan = json.loads((tmp_path/'d.json').read_text())
+    assert plan['drop_settings'] == list(KNOBS) and plan['rows'][0]['dropped_settings'] == KNOBS
+    assert run('migrate', '--pins', pins, '--proof', bundle, '--row', row) == 0
+    manifest = json.loads((row/'cost.anchors.json').read_text())
+    identity = manifest['identity']
+    assert not set(KNOBS) & set(identity['settings'])
+    assert identity['settings'] == dict(nsamples=4, seqlen=8, streaming=True, streaming_capture_policy='legacy')
+    assert identity['prismaquant_source_sha256'] == NEW['prismaquant_source_sha256']
+    assert manifest['identity_sha256'] == tool.identity_sha256(identity) != old_sha
+    record = manifest['identity_migration'][-1]
+    assert record['dropped_settings'] == KNOBS
+    # every shard is resealed to the new digest and the migrated row verifies against the same pins file
+    for entry in manifest['units']:
+        envelope = pickle.loads((row/'cost.anchors.json.parts'/entry['file']).read_bytes())
+        assert envelope['identity_sha256'] == manifest['identity_sha256']
+    assert run('verify', '--pins', pins, '--row', row) == 0
+    snapshot = {p: p.read_bytes() for p in row.rglob('*') if p.is_file()}
+    assert run('migrate', '--pins', pins, '--proof', bundle, '--row', row) == 0
+    assert 'already carries the new pins' in capsys.readouterr().out
+    assert {p: p.read_bytes() for p in row.rglob('*') if p.is_file()} == snapshot
+
+
+def test_a_row_without_the_dropped_setting_is_foreign_and_a_bound_one_fails_verify(tmp_path, capsys):
+    pins = write_pins(tmp_path/'pins.json', drop_settings=['streaming_cache_headroom_gb'])
+    missing = tmp_path/'row-0008'
+    make_row(missing, settings=dict(nsamples=4, seqlen=8))
+    assert run('dry-run', '--pins', pins, '--row', missing) == 2
+    assert 'neither the old nor the new' in capsys.readouterr().err
+    # a row that already carries the new pins but still binds the setting is not migrated either
+    stale = tmp_path/'row-0009'
+    make_row(stale, pins=NEW, settings=BOUND)
+    assert run('dry-run', '--pins', pins, '--row', stale) == 2
+    assert run('verify', '--pins', pins, '--row', stale) == 1
+    assert 'dropped_setting_still_bound' in capsys.readouterr().out
+    # the pins file itself is checked
+    bad = tmp_path/'bad.json'
+    bad.write_text(json.dumps(dict(schema=tool.PINS_SCHEMA, old=OLD, new=NEW, drop_settings=['a', 'a'])))
+    assert run('dry-run', '--pins', bad, '--row', stale) == 2
+    assert 'distinct' in capsys.readouterr().err
+
+
+def test_a_settings_only_migration_keeps_the_pins(tmp_path):
+    row = tmp_path/'row-0010'
+    make_row(row, pins=NEW, settings=BOUND)
+    same = write_pins(tmp_path/'same.json', old=NEW, new=NEW, drop_settings=['streaming_cache_headroom_gb'])
+    bundle = write_bundle(tmp_path/'bundle.json', old=NEW, new=NEW)
+    assert run('migrate', '--pins', same, '--proof', bundle, '--row', row) == 0
+    identity = json.loads((row/'cost.anchors.json').read_text())['identity']
+    assert 'streaming_cache_headroom_gb' not in identity['settings'] and 'streaming_cache_slots' in identity['settings']
+    assert run('verify', '--pins', same, '--row', row) == 0
+    # without a drop list, identical pins are still refused
+    none = tmp_path/'none.json'
+    none.write_text(json.dumps(dict(schema=tool.PINS_SCHEMA, old=NEW, new=NEW)))
+    assert run('dry-run', '--pins', none, '--row', row) == 2

--- a/tests/test_tessera_campaign_fanout.py
+++ b/tests/test_tessera_campaign_fanout.py
@@ -162,6 +162,52 @@ def test_the_checkpoint_identity_covers_only_the_selected_units(monkeypatch):
     assert left["settings"] == right["settings"] == whole["settings"]
 
 
+def test_streaming_residency_knobs_are_scheduling_not_identity(monkeypatch):
+    """Cache slots, prefetch workers and the free-memory floor change no receipt;
+    the capture policy and the streaming switch do."""
+    import argparse
+    from prismaquant import tessera_campaign as tc
+
+    class Api:
+        @staticmethod
+        def encoder_source_sha256():
+            return "encoder"
+
+        @staticmethod
+        def tensor_identity(tensor):
+            return {"id": tensor}
+
+    monkeypatch.setattr(tc, "_checkpoint_identity_api", lambda: Api)
+    monkeypatch.setattr(tc.th, "encoder_recipe", lambda: {"recipe": 1})
+    monkeypatch.setattr(
+        "prismaquant.production_weight_cache._production_cache_source_sha256",
+        lambda: "package")
+
+    def identity(**overrides):
+        args = argparse.Namespace(
+            model="m", layer_stride=1, out="o", cache_dir="c", checkpoint="k",
+            deadline_seconds=0.0, units="path", calibration_census=None,
+            census_out=None, seed_checkpoint=None, seed_wire_dir=None,
+            streaming=True, streaming_capture_policy="legacy",
+            streaming_cache_headroom_gb=24.0, streaming_cache_slots=2,
+            streaming_prefetch_workers=1, anchor_batch_size=8)
+        for name, value in overrides.items():
+            setattr(args, name, value)
+        return tc._campaign_checkpoint_identity(
+            weights={"a": "wa"}, acts={"a": None}, hessians={"a": None},
+            menus={"a": []}, args=args, calibration_identity={"text_sha256": "t"},
+            serving_scope=None, static_scales={}, static_scale_policy="policy")
+
+    base = identity()
+    for name in ("streaming_cache_headroom_gb", "streaming_cache_slots",
+                 "streaming_prefetch_workers", "anchor_batch_size"):
+        assert name not in base["settings"]
+    assert identity(streaming_cache_headroom_gb=12.0, streaming_cache_slots=6,
+                    streaming_prefetch_workers=4, anchor_batch_size=32) == base
+    assert identity(streaming_capture_policy="strict") != base
+    assert identity(streaming=False) != base
+
+
 # ---------------------------------------------------------------------------
 # The census
 # ---------------------------------------------------------------------------

--- a/tools/reseal_campaign_identity.py
+++ b/tools/reseal_campaign_identity.py
@@ -200,8 +200,12 @@ def load_pins(path):
         for key, value in block.items():
             if not (isinstance(value, str) and len(value) == 64 and all(c in '0123456789abcdef' for c in value)):
                 raise Refused(f'{path}: {side}.{key} is not a lowercase sha256')
-    if pins['old'] == pins['new']:
-        raise Refused(f'{path}: old and new pins are identical; nothing to migrate')
+    drop = pins.get('drop_settings') or []
+    if not isinstance(drop, list) or any(not (isinstance(k, str) and k) for k in drop) or len(set(drop)) != len(drop):
+        raise Refused(f'{path}: drop_settings must be a list of distinct, non-empty setting names')
+    pins['drop_settings'] = tuple(drop)
+    if pins['old'] == pins['new'] and not drop:
+        raise Refused(f'{path}: old and new pins are identical and no setting is dropped; nothing to migrate')
     pins['source_checks'] = {}
     for name, hasher, sub in (('prismaquant', prismaquant_tree_sha256, 'prismaquant'), ('encoder', encoder_tree_sha256, 'src/tessera')):
         source = (pins.get('sources') or {}).get(name)
@@ -357,10 +361,15 @@ def discover_rows(args):
 
 
 def classify_pins(identity, pins):
+    """'pending' rows carry the old pins and every setting the pins file drops;
+    'migrated' rows carry the new pins and none of them; anything else is foreign."""
     current = {key: identity.get(key) for key in PIN_KEYS}
-    if current == pins['new']:
+    settings = identity.get('settings')
+    drop = tuple(pins.get('drop_settings') or ())
+    present = tuple(k for k in drop if isinstance(settings, dict) and k in settings)
+    if current == pins['new'] and not present:
         return 'migrated', current
-    if current == pins['old']:
+    if current == pins['old'] and present == drop:
         return 'pending', current
     return 'foreign', current
 
@@ -420,15 +429,22 @@ def plan_row(row, pins, *, run_id, audit_states=None):
         plan['migration_records'] = manifest.get('identity_migration', [])
         return plan, None
     if state == 'foreign':
-        raise Refused(f'{row}: pins {current} are neither the old nor the new pins of the pins file')
+        raise Refused(f'{row}: pins {current} with settings {sorted(identity.get("settings") or {})} are neither the old nor the new '
+                      f'(pins, dropped settings {list(pins.get("drop_settings") or ())}) of the pins file')
     encoder_moves = pins['old']['encoder_source_sha256'] != pins['new']['encoder_source_sha256']
     new_identity = json.loads(json.dumps(identity))
     for key in PIN_KEYS:
         new_identity[key] = pins['new'][key]
+    # Settings the campaign no longer binds (scheduling knobs that never touched
+    # a receipt) leave the identity; their values are kept in the migration record.
+    dropped = {k: new_identity['settings'].pop(k) for k in pins.get('drop_settings') or ()}
+    plan['dropped_settings'] = dropped
     new_sha = identity_sha256(new_identity)
     plan['new_identity_sha256'] = new_sha
-    plan['edits'].append(dict(file=str(manifest_path), fields=[f'identity.{k}' for k in PIN_KEYS if pins['old'][k] != pins['new'][k]] + ['identity_sha256', 'identity_migration[+1]'],
-                              before=dict(identity_sha256=old_sha, **current), after=dict(identity_sha256=new_sha, **pins['new'])))
+    plan['edits'].append(dict(file=str(manifest_path), fields=[f'identity.{k}' for k in PIN_KEYS if pins['old'][k] != pins['new'][k]]
+                              + [f'identity.settings.{k}' for k in dropped] + ['identity_sha256', 'identity_migration[+1]'],
+                              before=dict(identity_sha256=old_sha, **current, **({'settings': dropped} if dropped else {})),
+                              after=dict(identity_sha256=new_sha, **pins['new'])))
     shards = []
     for entry in manifest['units']:
         path = parts/entry['file']
@@ -508,6 +524,7 @@ def migration_record(pins, bundle, plan, *, operator, run_id, when):
     return dict(schema=RECORD_SCHEMA, run_id=run_id, migrated_unix=when, operator=operator, host=platform.node(),
                 tool='tools/reseal_campaign_identity.py', tool_commit=tool_commit(),
                 old_pins=dict(pins['old']), new_pins=dict(pins['new']), sources=pins.get('sources'),
+                dropped_settings=dict(plan.get('dropped_settings') or {}),
                 old_identity_sha256=plan['old_identity_sha256'], new_identity_sha256=plan['new_identity_sha256'],
                 proof_bundle=bundle['path'], proof_bundle_sha256=bundle['bundle_sha256'],
                 proof_cells=bundle['cell_count'], proof_pb_actions=bundle.get('pb_actions'),
@@ -546,7 +563,8 @@ def migrate_row(row, plan, work, record, *, keep_previous):
         atomic_write(stage/'cost.pkl', cost_raw_new)
         written += len(cost_raw_new)
     # verify the staged row exactly as a consumer would read it
-    check = verify_row(stage, pins={'new': record['new_pins']}, wire_root=row, wire_bytes=False, expect_record=record)
+    check = verify_row(stage, pins={'new': record['new_pins'], 'drop_settings': tuple(record.get('dropped_settings') or ())},
+                       wire_root=row, wire_bytes=False, expect_record=record)
     if not check['ok']:
         raise Refused(f'{row}: staged row failed verification: {check["failures"][:3]}')
     if work['cost']:
@@ -609,6 +627,9 @@ def verify_row(row, *, pins, wire_root=None, wire_bytes=True, expect_record=None
     for key in PIN_KEYS:
         if identity.get(key) != pins['new'][key]:
             fail(dict(what='pin', field=key, stored=identity.get(key), expected=pins['new'][key]))
+    for key in pins.get('drop_settings') or ():
+        if key in (identity.get('settings') or {}):
+            fail(dict(what='dropped_setting_still_bound', field=key, stored=identity['settings'][key]))
     records = manifest.get('identity_migration') or []
     if expect_record is not None and (not records or records[-1] != expect_record):
         fail(dict(what='migration_record', detail='manifest lacks the expected identity_migration record'))
@@ -700,7 +721,7 @@ def cmd_dry_run(args):
     audit_states = load_checkpoint_audit(args.checkpoint_audit) if args.checkpoint_audit else None
     rows = discover_rows(args)
     run_id = time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())
-    report = dict(mode='dry-run', pins={'old': pins['old'], 'new': pins['new']}, proof=(bundle or {}).get('path'),
+    report = dict(mode='dry-run', pins={'old': pins['old'], 'new': pins['new']}, drop_settings=list(pins['drop_settings']), proof=(bundle or {}).get('path'),
                   checkpoint_audit=args.checkpoint_audit, rows=[])
     for row in rows:
         started = time.time()
@@ -728,7 +749,7 @@ def cmd_migrate(args):
     rows = discover_rows(args)
     run_id = time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())
     operator = args.operator or getpass.getuser()
-    report = dict(mode='migrate', run_id=run_id, pins={'old': pins['old'], 'new': pins['new']}, proof=bundle['path'],
+    report = dict(mode='migrate', run_id=run_id, pins={'old': pins['old'], 'new': pins['new']}, drop_settings=list(pins['drop_settings']), proof=bundle['path'],
                   proof_bundle_sha256=bundle['bundle_sha256'], checkpoint_audit=args.checkpoint_audit, rows=[])
     for row in rows:
         started = time.time()


### PR DESCRIPTION
## What

- `prismaquant/tessera_campaign.py::_campaign_checkpoint_identity` pops `streaming_cache_slots`, `streaming_prefetch_workers` and `streaming_cache_headroom_gb` from the bound settings. They size the layer cache, its prefetch pool and the free-memory floor the row keeps (`cost_streaming.build_streamed_causal_lm`); no captured activation, Hessian or wire differs at any of their values. `streaming` and `streaming_capture_policy` stay bound (they choose what is captured).
- `tools/reseal_campaign_identity.py` learns the matching identity delta: a pins file may carry `drop_settings`; a pending row must bind every listed setting and a migrated row none (`classify_pins`); the values leave `identity.settings` and are recorded in the migration record (`dropped_settings`); `verify` refuses a dropped setting that is still bound; a settings-only migration with unchanged pins is allowed, identical pins without a drop list are still refused.

## Why

The live GLM census rows are priced at 104 GiB, of which 24 GiB is `declared_headroom_bytes` — the whole slack between the priced plan and the measured rows (sparky MemAvailable min 33.5 GB, lina 36.2 GB at width 16 → rows use ~83–85 GB). Width 32 (`--anchor-batch-size 32`, already identity-neutral) prices at 106 GiB under a 24 GiB floor and does not fit the gb10 reservation; a 12 GiB floor does. With the floor bound into the identity, lowering it needed a new identity for every completed row for a value that never touched a receipt. This PR makes the floor a resubmission flag, and gives the reseal migration (the #486 ruling: completed rows may be resealed under GPU proof) the ability to carry completed rows across the pin move this change itself causes.

## Tests

- `tests/test_tessera_campaign_fanout.py::test_streaming_residency_knobs_are_scheduling_not_identity` — the three knobs (and `anchor_batch_size`) change nothing; `streaming_capture_policy` and `streaming` still do.
- `tests/test_reseal_campaign_identity.py` — three new tests: dry-run lists `identity.settings.<knob>`, migrate removes the keys, records the values, reseals every shard, verifies and is idempotent; a row missing the knob or still binding it after the pin move is foreign / fails verify; a settings-only migration keeps the pins.
- PrismaBuild receipts (x86, `pq-cpu312`, priority −10): pending, will be appended below.

## Deployment

Not part of the frozen campaign source; the live rows keep running under d403cc5a31. The next reseal cycle (one migration) carries `drop_settings` for the three knobs together with the new `prismaquant_source_sha256`; the resubmission of the ready rows then declares `--streaming-cache-headroom-gb 12` with a width-32 arm measured first (memory peak, J/anchor, `exact_parity`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsJsJGJtE4CYHE9QKyRyiz