### PR TITLE
Reconcile family_restriction in the campaign checkpoint merge (#487)

### DIFF
--- a/tests/test_tessera_campaign_family_restriction.py
+++ b/tests/test_tessera_campaign_family_restriction.py
@@ -194,6 +194,36 @@ def test_fanout_merge_preserves_the_complete_structure_restriction():
         "policy": POLICY, "structure_by_unit": {"a": "dense", "b": "dense"}}
 
 
+def test_fanout_merge_unions_a_dense_row_and_a_routed_row():
+    """One campaign's rows never carry the same ``structure_by_unit``.
+
+    The map is keyed by the row's OWN selected units, so a dense row and a
+    routed row differ in it by construction.  Equality is required on
+    ``policy`` alone and the maps are unioned, the way ``units`` is unioned; a
+    whole-restriction equality check would make any census that mixes dense
+    and routed rows unmergeable (RobTand/prismaquant#487).
+    """
+    from tools.dispatch_tessera_campaign import merge_payloads
+    payloads = _restricted_payloads()
+    payloads["row-0001"]["provenance"]["family_restriction"]["structure_by_unit"] = {
+        "b": "routed_moe"}
+    merged = merge_payloads(payloads, census={"counts": {"a": 16384, "b": 16384}},
+                            capture_sha256="merged-digest")
+    assert merged["provenance"]["family_restriction"] == {
+        "policy": POLICY, "structure_by_unit": {"a": "dense", "b": "routed_moe"}}
+
+
+def test_fanout_merge_refuses_one_unit_claimed_by_two_rows():
+    """The union is not a silent overwrite: a repeated unit is a refusal."""
+    from tools.dispatch_tessera_campaign import merge_payloads, MergeRefused
+    payloads = _restricted_payloads()
+    payloads["row-0001"]["provenance"]["family_restriction"]["structure_by_unit"] = {
+        "a": "dense", "b": "routed_moe"}
+    with pytest.raises(MergeRefused, match="family restriction"):
+        merge_payloads(payloads, census={"counts": {"a": 16384, "b": 16384}},
+                       capture_sha256="merged-digest")
+
+
 @pytest.mark.parametrize("mutation", ["missing_policy", "different_policy", "missing_structure", "unknown_structure"])
 def test_fanout_merge_refuses_incompatible_or_incomplete_restrictions(mutation):
     from tools.dispatch_tessera_campaign import merge_payloads, MergeRefused

--- a/tests/test_tessera_campaign_merge_integrity.py
+++ b/tests/test_tessera_campaign_merge_integrity.py
@@ -25,6 +25,86 @@ def _journal(tmp_path):
     return row, manifest, unit_path(parts, "a")
 
 
+POLICY = {"schema": "prismaquant.tessera_campaign_family_restriction.v1",
+          "dense": ["TESSERA_BF16_K1", "TESSERA_E4M3_K1"],
+          "routed_moe": ["TESSERA_E4M3_K1"]}
+
+
+def _restricted_row(tmp_path, row_id, qname, structure, policy=POLICY):
+    """One row's journal, restricted to its own unit the way a campaign row is."""
+    from prismaquant.cost_stage_checkpoint import prepare_journal, write_unit
+
+    row = tmp_path / row_id
+    manifest = row / "cost.anchors.json"
+    identity = {"units": {qname: {"weight": "w" + qname}}}
+    if policy is not None:
+        identity["family_restriction"] = {
+            "policy": policy, "structure_by_unit": {qname: structure}}
+    parts, digest, _ = prepare_journal(
+        row / "cost.anchors.json.parts", stage="Tessera campaign", resume=True,
+        identity=identity, qnames=[qname], manifest_path=manifest)
+    write_unit(parts, stage="Tessera campaign", qname=qname,
+               identity_sha256=digest, state={"measured": {"rung": 1.0}})
+    return row
+
+
+def test_merge_checkpoint_unions_a_dense_row_and_a_routed_row(tmp_path):
+    """The journal side of the restriction is per-selection, so it reconciles.
+
+    A dense row and a routed row of one campaign carry different
+    ``structure_by_unit`` maps by construction. Requiring the whole
+    ``family_restriction`` to be equal refuses every census that fans dense
+    and routed units onto separate rows (RobTand/prismaquant#487).
+    """
+    import dispatch_tessera_campaign as dispatch
+
+    rows = {"row-0000": str(_restricted_row(tmp_path, "row-0000", "a", "dense")),
+            "row-0001": str(_restricted_row(tmp_path, "row-0001", "b", "routed_moe"))}
+    merged = dispatch.merge_checkpoint(rows, tmp_path / "merged" / "cost.anchors.json")
+    assert merged["identity"]["family_restriction"] == {
+        "policy": POLICY, "structure_by_unit": {"a": "dense", "b": "routed_moe"}}
+    assert sorted(merged["identity"]["units"]) == ["a", "b"]
+    assert [entry["qname"] for entry in merged["units"]] == ["a", "b"]
+
+
+def test_merge_checkpoint_refuses_a_conflicting_restricted_structure(tmp_path):
+    """The union is not an overwrite: one unit, two structures, is a refusal."""
+    import dispatch_tessera_campaign as dispatch
+
+    first = _restricted_row(tmp_path, "row-0000", "a", "dense")
+    second = _restricted_row(tmp_path, "row-0001", "b", "routed_moe")
+    manifest = second / "cost.anchors.json"
+    value = json.loads(manifest.read_text())
+    value["identity"]["family_restriction"]["structure_by_unit"]["a"] = "routed_moe"
+    manifest.write_text(json.dumps(value))
+    with pytest.raises(RuntimeError, match="a"):
+        dispatch.merge_checkpoint({"row-0000": str(first), "row-0001": str(second)},
+                                  tmp_path / "merged.json")
+
+
+def test_merge_checkpoint_refuses_a_restricted_row_beside_an_unrestricted_one(tmp_path):
+    """A restriction the other row never carried is a different campaign."""
+    import dispatch_tessera_campaign as dispatch
+
+    rows = {"row-0000": str(_restricted_row(tmp_path, "row-0000", "a", "dense")),
+            "row-0001": str(_restricted_row(tmp_path, "row-0001", "b", None,
+                                            policy=None))}
+    with pytest.raises(RuntimeError, match="restrict"):
+        dispatch.merge_checkpoint(rows, tmp_path / "merged.json")
+
+
+def test_merge_checkpoint_refuses_two_policies(tmp_path):
+    """Policy is the campaign-wide half and still has to be equal."""
+    import dispatch_tessera_campaign as dispatch
+
+    other = {**POLICY, "dense": ["TESSERA_E4M3_K1"]}
+    rows = {"row-0000": str(_restricted_row(tmp_path, "row-0000", "a", "dense")),
+            "row-0001": str(_restricted_row(tmp_path, "row-0001", "b", "routed_moe",
+                                            policy=other))}
+    with pytest.raises(RuntimeError, match="policy"):
+        dispatch.merge_checkpoint(rows, tmp_path / "merged.json")
+
+
 @pytest.mark.parametrize("field,value", [
     ("payload_sha256", "0" * 64),
     ("identity_sha256", "0" * 64),

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -112,6 +112,16 @@ SHARED_HESSIAN = (
 )
 
 
+#: Checkpoint-identity keys the merge RECONCILES instead of requiring equal.
+#: Every one of them is per-selection: it describes the units this row was
+#: given, not the campaign. Everything outside this set must already agree,
+#: because a difference there means the rows priced two different campaigns.
+RECONCILED_IDENTITY_KEYS = frozenset({
+    "units", "serving_scope", "expert_projection", "stack_sampling_identity",
+    "family_restriction",
+})
+
+
 class MergeRefused(RuntimeError):
     """The rows do not describe one campaign."""
 
@@ -1310,7 +1320,7 @@ def merge_checkpoint(row_dirs: dict, out_manifest: Path) -> dict:
             merged_identity["units"] = dict(identity["units"])
             continue
         for key in sorted(set(merged_identity) | set(identity)):
-            if key in {"units", "serving_scope", "expert_projection", "stack_sampling_identity"}:
+            if key in RECONCILED_IDENTITY_KEYS:
                 continue
             if (key not in merged_identity or key not in identity
                     or merged_identity[key] != identity[key]):
@@ -1332,6 +1342,11 @@ def merge_checkpoint(row_dirs: dict, out_manifest: Path) -> dict:
         merged_identity["expert_projection"] = _merge_projection(
             merged_identity.get("expert_projection"), identity.get("expert_projection"),
             row_id)
+        merged_identity["family_restriction"] = _merge_family_restriction(
+            merged_identity.get("family_restriction"),
+            identity.get("family_restriction"), row_id)
+        if merged_identity["family_restriction"] is None:
+            del merged_identity["family_restriction"]
     merged_identity["units"] = dict(sorted(merged_identity["units"].items()))
 
     canonical = canonical_json(merged_identity, where="merged campaign identity")
@@ -1390,6 +1405,32 @@ def merge_identity_migrations(per_row: dict) -> "list | None":
                            if k not in {"old_identity_sha256", "new_identity_sha256", "shards",
                                         "receipt_seals", "cost_seals", "run_id"}})
     return merged if present else None
+
+
+def _merge_family_restriction(left, right, row_id):
+    """One policy, and the union of the rows' per-unit structure maps.
+
+    ``structure_by_unit`` is keyed by the row's OWN selected units, so a dense
+    row and a routed row of one campaign never carry the same map. Comparing
+    the whole restriction for equality therefore refuses every census that
+    fans dense and routed units onto different rows, which is every GLM census
+    (RobTand/prismaquant#487). ``merge_payloads`` already reconciles the same
+    field this way; this is the journal side of it.
+    """
+    if left is None or right is None:
+        if left != right:
+            raise MergeRefused(
+                f"{row_id}: one row restricts families and another does not")
+        return left
+    if left["policy"] != right["policy"]:
+        raise MergeRefused(f"{row_id}: rows disagree on the family restriction policy")
+    for name in left["structure_by_unit"].keys() & right["structure_by_unit"].keys():
+        if left["structure_by_unit"][name] != right["structure_by_unit"][name]:
+            raise MergeRefused(
+                f"{row_id}: different restricted structure for {name}")
+    return {"policy": left["policy"],
+            "structure_by_unit": dict(sorted(
+                {**left["structure_by_unit"], **right["structure_by_unit"]}.items()))}
 
 
 def _merge_scope(left, right, row_id):


### PR DESCRIPTION
## What

`merge_checkpoint` reconciles the per-selection halves of a row's checkpoint identity and requires equality on everything else. `family_restriction` sat in the "everything else" half, but it is per-selection: `structure_by_unit` is keyed by the row's own units. A dense row and a routed row of one campaign therefore never carry the same value, and the merge refuses at `family_restriction`.

That blocks the 132-row GLM census merge and `reseal_campaign_identity verify --consumer-merge`.

`merge_payloads` already reconciles the same field correctly, requiring equality on `policy` and unioning `structure_by_unit`. This is the journal side of it. The two now agree.

The reconciled set becomes a named constant, `RECONCILED_IDENTITY_KEYS`, so the next per-selection field is added in one place.

## Correction to the issue

#487 named `merge_payloads` and cited its lines. That was the wrong function. `merge_payloads` has been right since `36c6ba8cb2`, and the frozen campaign source `pq-glm-selected-source-integration` carries that fix too, so the refusal observed in the rehearsal could only have come from `merge_checkpoint`.

## Evidence

Every submission through PrismaBuild from dl380g10, `pq-cpu312`, tag `x86`, priority -10.

**Green**, `tests/test_tessera_campaign_merge_integrity.py` plus the three neighbouring campaign suites:

```
4 files -> 1 shards, tags=['x86'], transport=pool
shard   0 ok       102 passed, 2 skipped, 14 warnings in 27.95s
1/1 shards green
```

**Red**, the fix alone reverted (the tests untouched):

```
FAILED test_merge_checkpoint_unions_a_dense_row_and_a_routed_row
FAILED test_merge_checkpoint_refuses_two_policies
2 failed, 13 passed
```

## Test coverage note

Every existing `merge_checkpoint` test merges a **single row**, so multi-row identity reconciliation had no coverage at all. Four tests are added here: the dense-plus-routed union, a conflicting structure for one unit, a restricted row beside an unrestricted one, and two policies. Two more cover the same union in `merge_payloads`, whose only existing fan-out test merges two rows that are both `dense` and so would not have caught a mixed-structure regression.

The two refusal tests pass in both arms: the old code also refuses, just with a less precise message. They are there to keep the union from turning into a silent overwrite.

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsJsJGJtE4CYHE9QKyRyiz