### PR TITLE
Compare the reseal proof against the identity migrate will write

### DIFF
--- a/experiments/reseal_identity_proof.py
+++ b/experiments/reseal_identity_proof.py
@@ -209,12 +209,28 @@ class _SilentObserver:
 # comparator
 # ---------------------------------------------------------------------------
 
-def substitute_pins(identity, *, old, new):
+def substitute_pins(identity, *, old, new, drop=()):
+    """The identity the migration will write: new pins, dropped settings gone.
+
+    ``drop`` is the pins file's ``drop_settings``: scheduling knobs the new
+    source no longer binds. ``reseal_campaign_identity.migrate`` pops exactly
+    these from ``identity['settings']``, so the proof has to pop them too --
+    otherwise it compares the produced row against an identity the migration
+    is not going to produce, and a correct run fails on a field neither side
+    disputes. A name that is not bound is refused rather than ignored, so a
+    typo in the pins file cannot quietly weaken the comparison.
+    """
     identity = json.loads(json.dumps(identity))
     for key in PIN_KEYS:
         if identity.get(key) != old[key]:
             raise ValueError(f'stored identity {key}={identity.get(key)} is not the declared old pin {old[key]}')
         identity[key] = new[key]
+    settings = identity.get('settings') or {}
+    missing = [key for key in drop if key not in settings]
+    if missing:
+        raise ValueError(f'stored identity binds no setting(s) {missing}, so they cannot be dropped')
+    for key in drop:
+        settings.pop(key)
     return identity
 
 
@@ -276,7 +292,8 @@ def load_units(root, manifest, qnames):
                              identity_sha256=manifest['identity_sha256']) for name in qnames}
 
 
-def compare_rows(produced, stored, *, old, new, expected_cells=None, require_cost=False):
+def compare_rows(produced, stored, *, old, new, expected_cells=None, require_cost=False,
+                 drop_settings=()):
     """Compare a produced run against the stored row it re-encodes.
 
     Returns a result dict with ``ok`` and the cell table.  Nothing here is
@@ -287,11 +304,13 @@ def compare_rows(produced, stored, *, old, new, expected_cells=None, require_cos
     from prismaquant.cost_stage_checkpoint import canonical_json_sha256, canonical_json
     from prismaquant.production_weight_cache import first_identity_difference
     produced, stored = Path(produced), Path(stored)
+    drop_settings = tuple(drop_settings)
     result = dict(schema=SCHEMA, kind='comparison', produced=str(produced), stored=str(stored),
-                  old_pins=dict(old), new_pins=dict(new), failures=[], cells=[])
+                  old_pins=dict(old), new_pins=dict(new), dropped_settings=list(drop_settings),
+                  failures=[], cells=[])
     fail = result['failures'].append
     pm, sm = load_manifest(produced), load_manifest(stored)
-    expected_identity = substitute_pins(sm['identity'], old=old, new=new)
+    expected_identity = substitute_pins(sm['identity'], old=old, new=new, drop=drop_settings)
     difference = first_identity_difference(pm['identity'], canonical_json(expected_identity, where='expected identity'))
     if difference is not None:
         fail(dict(what='identity', field=difference[0], produced=str(difference[1])[:300], expected=str(difference[2])[:300]))
@@ -518,7 +537,8 @@ def run_gpu_arm(args, *, prefix):
         campaign.main(command)
         expected_cells = args.expected_cells
     record['campaign_finished_unix'] = time.time()
-    comparison = compare_rows(run, args.stored_row, old=old, new=new, expected_cells=expected_cells, require_cost=not prefix)
+    comparison = compare_rows(run, args.stored_row, old=old, new=new, expected_cells=expected_cells,
+                              require_cost=not prefix, drop_settings=args.drop_setting)
     record.update(comparison=comparison, ok=comparison['ok'], finished_unix=time.time(), status='finished')
     write_json(out/'result.json', record)
     print(json.dumps(dict(ok=record['ok'], cells=len(comparison['cells']), strata=comparison['strata'],
@@ -579,7 +599,7 @@ def run_compare(args):
     bind_prismaquant(args.prismaquant_root)
     old, new = _pins(args)
     result = compare_rows(args.produced, args.stored_row, old=old, new=new, expected_cells=args.expected_cells,
-                          require_cost=args.require_cost)
+                          require_cost=args.require_cost, drop_settings=args.drop_setting)
     write_json(args.out, result)
     print(json.dumps(dict(ok=result['ok'], cells=len(result['cells']), strata=result['strata'], failures=result['failures'][:4])), flush=True)
     return 0 if result['ok'] else 1
@@ -588,6 +608,10 @@ def run_compare(args):
 def _add_pins(parser):
     for name in ('old-prismaquant-pin', 'old-encoder-pin', 'new-prismaquant-pin', 'new-encoder-pin'):
         parser.add_argument('--'+name, required=True)
+    parser.add_argument('--drop-setting', action='append', default=[], metavar='NAME',
+                        help='a settings key the migration drops (the pins file\'s '
+                             'drop_settings); repeatable. The expected identity has it '
+                             'removed, so the arm compares against what migrate writes')
 
 
 def main(argv=None):

--- a/tests/test_reseal_campaign_identity.py
+++ b/tests/test_reseal_campaign_identity.py
@@ -230,7 +230,8 @@ def test_hash_definitions_match_the_campaign(tmp_path):
         tool.load_pins(bad)
 
 
-def _arm_result(path, old, new, *, routed_rates=(832, 960, 1088), dense_rates=(832, 960, 1088)):
+def _arm_result(path, old, new, *, routed_rates=(832, 960, 1088), dense_rates=(832, 960, 1088),
+                dropped=()):
     cells = []
     def cell(qname, family, rate):
         cells.append(dict(ok=True, byte_identical=True, dloss=0.5, stored_dloss=0.5, qname=qname, family=family,
@@ -245,7 +246,8 @@ def _arm_result(path, old, new, *, routed_rates=(832, 960, 1088), dense_rates=(8
                 cell(f'layers.{j}.mlp.gate_proj', family, rate)
     cell('layers.0.mlp.up_proj', 'TESSERA_E2M1_K2', 896)
     path.write_text(json.dumps(dict(kind='dense', comparison=dict(
-        kind='comparison', ok=True, old_pins=old, new_pins=new, identity_matches_with_pins_substituted=True, cells=cells))))
+        kind='comparison', ok=True, old_pins=old, new_pins=new, identity_matches_with_pins_substituted=True,
+        dropped_settings=list(dropped), cells=cells))))
     return path
 
 
@@ -279,6 +281,47 @@ def test_proof_bundle_needs_a_fixture_arm_only_when_the_encoder_pin_moves(tmp_pa
     assert run('verify', '--pins', pins_pq_only, '--row', row) == 0
     loaded = tool.load_bundle(tmp_path/'b2.json', tool.load_pins(pins_pq_only))
     assert loaded['fixture_id']['ids'] is None
+
+
+def test_proof_bundle_requires_the_arm_to_have_dropped_what_the_pins_drop(tmp_path, capsys):
+    """An arm proves the migration it compared against, not a neighbouring one.
+
+    ``migrate`` pops ``drop_settings`` from the identity it writes. An arm that
+    did not pop them compared the produced row against a different identity, so
+    its pass says nothing about this migration. A result that predates the
+    field reads as "dropped nothing" and is refused the same way.
+    """
+    pq_only = dict(NEW, encoder_source_sha256=OLD['encoder_source_sha256'])
+    pins = write_pins(tmp_path/'pins.json', new=pq_only, drop_settings=list(KNOBS))
+    silent = _arm_result(tmp_path/'arm-silent.json', OLD, pq_only)
+    assert run('proof-bundle', '--pins', pins, '--arm', silent, '--out', tmp_path/'b.json') == 2
+    assert 'dropped settings' in capsys.readouterr().err
+    partial = _arm_result(tmp_path/'arm-partial.json', OLD, pq_only, dropped=list(KNOBS)[:1])
+    assert run('proof-bundle', '--pins', pins, '--arm', partial, '--out', tmp_path/'b.json') == 2
+    assert 'dropped settings' in capsys.readouterr().err
+    matching = _arm_result(tmp_path/'arm-drop.json', OLD, pq_only, dropped=list(KNOBS))
+    assert run('proof-bundle', '--pins', pins, '--arm', matching, '--out', tmp_path/'b.json') == 0
+    assert json.loads((tmp_path/'b.json').read_text())['ok'] is True
+
+
+def test_proof_expects_the_identity_the_migration_will_write(tmp_path):
+    """``substitute_pins`` drops the same settings ``migrate`` pops.
+
+    Without this the arm compares a produced row that no longer binds a
+    scheduling knob against a stored identity that still does, and a correct
+    run fails on a field neither side disputes.
+    """
+    import importlib
+    proof = importlib.import_module('experiments.reseal_identity_proof')
+    stored = dict(OLD, settings={'nsamples': 4, **{knob: 24.0 for knob in KNOBS}})
+    expected = proof.substitute_pins(stored, old=OLD, new=NEW, drop=list(KNOBS))
+    assert expected['settings'] == {'nsamples': 4}
+    assert expected['prismaquant_source_sha256'] == NEW['prismaquant_source_sha256']
+    # Untouched without the list, which is what the previous behaviour was.
+    assert set(proof.substitute_pins(stored, old=OLD, new=NEW)['settings']) == {'nsamples', *KNOBS}
+    # A name the row never bound is a refusal, not a silent no-op.
+    with pytest.raises(ValueError, match='cannot be dropped'):
+        proof.substitute_pins(stored, old=OLD, new=NEW, drop=('not_a_setting',))
 
 
 def test_rows_are_classified_by_the_checkpoint_audit_not_by_cost_pkl(tmp_path, capsys):

--- a/tools/reseal_campaign_identity.py
+++ b/tools/reseal_campaign_identity.py
@@ -277,6 +277,14 @@ def assemble_bundle(args):
             raise Refused(f'{path}: arm did not pass ({comparison.get("failures")})')
         if comparison['old_pins'] != pins['old'] or comparison['new_pins'] != pins['new']:
             raise Refused(f'{path}: arm pins differ from the pins file')
+        # The arm has to have compared against the identity ``migrate`` will
+        # write, dropped settings and all.  An arm that dropped nothing proves
+        # a different migration than the one this pins file describes, and an
+        # older result that predates the field reads as "dropped nothing".
+        declared = tuple(sorted(comparison.get('dropped_settings') or ()))
+        if declared != tuple(sorted(pins['drop_settings'])):
+            raise Refused(f'{path}: arm dropped settings {list(declared)}, the pins file '
+                          f'drops {sorted(pins["drop_settings"])}')
         if not comparison.get('identity_matches_with_pins_substituted'):
             raise Refused(f'{path}: produced identity does not equal the stored identity with pins substituted')
         for cell in comparison['cells']:


### PR DESCRIPTION
## What

The pins file declares `drop_settings`: scheduling knobs the new source no longer binds. `reseal_campaign_identity migrate` pops them from the identity it writes, and `verify` refuses a row that still binds one. The GPU proof arm did not. It built its expected identity by substituting pins into the stored identity and left the dropped settings in place, so a correct run fails on a field neither side disputes.

## Measured, not theorised

The `prefix-deep` arm for the `3a9ac3be37` pin move reproduced **all 48 cells byte-identically** with matching `dloss` and full routed `832/960/1088` coverage, and still reported `ok: false` on exactly this:

| field | expected | produced |
|---|---|---|
| `settings.streaming_cache_headroom_gb` | `24.0` | absent |

PB action `4feb89f4b205`, result at `identity-reseal-20260911/proof/prefix-deep-row0081-pq3a9ac3be37-encd403cc5a31/result.json`.

## Change

- `substitute_pins` takes `drop` and pops the same keys `migrate` pops. A name the stored identity never bound is refused rather than ignored, so a typo in the pins file cannot quietly weaken the comparison.
- `--drop-setting NAME`, repeatable, on the `prefix`, `dense` and `compare` arms. The arm records what it dropped in its result.
- `proof-bundle` requires each arm's `dropped_settings` to equal the pins file's `drop_settings`. Without that an arm could pass by proving a neighbouring migration, and an older result that predates the field reads as "dropped nothing" and is refused rather than silently accepted.

## Evidence

PrismaBuild from dl380g10, `pq-cpu312`, tag `x86`, priority -10:

```
1 files -> 1 shards, tags=['x86'], transport=pool
shard   0 ok       14 passed, 14 warnings in 13.21s
1/1 shards green
```

Three new tests: the bundle refusing a silent arm and a partial one and accepting a matching one, and `substitute_pins` dropping, leaving alone without the list, and refusing an unbound name.

Nothing under `prismaquant/` changes, so the `prismaquant_source_sha256` pin is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsJsJGJtE4CYHE9QKyRyiz

Closes #498
