### PR TITLE
Routed-stack probe reduction: a size source, a transfer law, and provenance that does not lie (#495 parts 1-3)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,60 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-11 · `claude/row-head-parallel`. Stamps
+As of: 2026-09-11 · `claude/495-probe-reduction-schedule`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-11, `claude/495-probe-reduction-schedule`) for the routed
+stack **probe-reduction schedule**, parts 1-3 of RobTand/prismaquant#495
+(§4.10). Three changes, all opt-in or provenance-only:
+
+* `dispatch_tessera_campaign.py plan --stack-sample-sizes {probe,counts}`
+  chooses what the PPS draw is proportional to. `probe` is the default and a
+  plan written without the flag is byte-identical, field for field, to the
+  plans already on disk (gate:
+  `tests/test_tessera_stack_sample_sizes.py::test_the_default_draw_is_byte_for_byte_what_it_was`,
+  which rebuilds the pre-change record from the campaign's own primitives and
+  compares serialisations). `counts` draws on the census's per-expert
+  routed-row counts -- the only per-expert size that exists on a model with no
+  `h_trace_per_expert` probe, which is why the sampling path was unreachable on
+  GLM-5.3-Flash. A `counts` record names the source, carries the vector and its
+  digest, and suffixes `design` with `_counts`; `selection_stack_samples`
+  replays the draw on the declared vector and refuses a record whose declared
+  digest is not the draw's. The stack row's Fisher currency is untouched: the
+  allocator still multiplies by the probe's own `h_trace`, so `--stack-sample`
+  still requires `--probe`, and §5's "run without a probe" is **not** delivered
+  (see §12 debt).
+* `prismaquant/tessera_rate_surface.py` gains the **stack transfer law**:
+  `fit_stack_transfer_law(stacks_measured, hold_out)` pools per-projection OLS
+  slopes of `log2 mse(rate)` on `log2 mse(reference)` over every stack but the
+  held-out one, and `predict_stack_rates(stack, law)` fits that stack's own
+  per-projection intercept from its sampled experts and returns the predicted
+  totals plus a model error. `TesseraRateSurface` is untouched and dense units
+  keep three anchors. Gate: `tests/test_tessera_stack_transfer_law.py`.
+* **Provenance on a two-tier stack.** A rung encoded on every expert with
+  certainty now writes `cost_source: tessera_campaign_measured` rather than
+  `tessera_campaign_measured_stack_sample` -- it is a census, not an estimate,
+  and its Horvitz-Thompson variance is an exact zero, so the sampled spelling
+  was describing a draw that did not happen. That removes the `cost_source`
+  refusal in `tessera_joint_aura.load_measured_anchor_input`; it does **not**
+  make a stack row consumable there, because that reader matches the cost
+  roster, the checkpoint journal and the receipts against the census's source
+  units (`_same(set(payload["costs"]), names, "complete merged cost roster")`)
+  while a stack's cost key is the packed qname -- the same stack-to-member
+  indirection recorded as D35(iii) is still what stands between a census stack
+  and joint AURA. A rung encoded only on the transfer-law draw is
+  predicted and written `PROVENANCE_INTERPOLATED` /
+  `cost_source: tessera_campaign_interpolated` with a `transfer_law` block
+  (slopes, pooled stacks, intercepts, sample ids, n, residual sd, model error)
+  and **neither** `dloss_stderr` **nor** `estimator: horvitz_thompson`: those
+  describe a sampling design, and no design produced this value. The
+  pre-existing stack interpolation path leaked `estimator` onto its rows by
+  building their `sampled_experts` block by subtraction; it is now built from
+  an allowlist. Gate: `tests/test_tessera_stack_transfer_law_rows.py`.
+
+No cost-mode default, stage graph, format menu, serving lane, wire recipe or
+ship gate changes. Parts 4 (selective encode of the allocated winners) and 5
+(repair loop and regret gate) of #495 are not in this stamp, and no planner
+flag emits a two-tier schedule yet.
 
 Re-stamped (2026-09-11, `claude/row-head-parallel`) for the **row head on
 threads** (§4.10). With `--campaign-identity-bytes M` set,
@@ -9102,7 +9155,15 @@ Two properties make the numbers comparable with the rest of the menu:
   scope may not invent structure it was not given); the fix is to stop expanding
   the probe, not to teach the scope to guess.
 
-  **The row shape.** `cost_source: tessera_campaign_measured_stack_sample`,
+  **The row shape.** `cost_source: tessera_campaign_measured_stack_sample`
+  when the rung was estimated from a draw, and `tessera_campaign_measured`
+  when it covers every expert of the frame with certainty -- a census is not
+  an estimate, its Horvitz-Thompson variance is an exact zero, and spelling it
+  as a sample described a draw that did not happen (#495 part 3). That is a
+  truthfulness fix, not an unblocking one: the joint-AURA reader
+  (`tessera_joint_aura.load_measured_anchor_input`) refuses a stack row on the
+  roster comparison against the census's source units long before it reads
+  `cost_source`, and D35(iii) is where that indirection is tracked.
   `currency: output_mse_under_route_activation_contract` (unchanged), and
 
   ```
@@ -9162,10 +9223,53 @@ Two properties make the numbers comparable with the rest of the menu:
   average; a member claimed by two stacks; a packed parameter that carries its
   own measured anchors *and* a sampling record. A rung measured on only some of
   the drawn experts is recorded in `non_interpolable` rather than estimated from
-  a partial sample. Interpolation inside the measured bracket goes through the
+  a partial sample -- **unless** the stack declares a transfer-law tier and
+  that rung covers exactly it, in which case it is predicted rather than
+  refused (below). Interpolation inside the measured bracket goes through the
   same `TesseraRateSurface`, on the stack's own HT anchors, and inherits
   `cost_source: tessera_campaign_interpolated` so the existing
   `drop_interpolated_candidates_dominated_by_measured` guard applies unchanged.
+
+  **The two-tier schedule and the transfer law (#495 parts 2-3).** A
+  `StackExpertSample` may name `transfer_law_experts`: a strict subset of the
+  frame that was ALSO encoded at the rungs the stack was not censused at. The
+  offline study
+  ([glm_tessera_probe_reduction_regret_2026-09-10.md](results/glm_tessera_probe_reduction_regret_2026-09-10.md))
+  measured the schedule "census at 960 plus a 3% expert sample at 832 and
+  1088" at 0.004% mean / 0.000% p90 allocation regret at the campaign's byte
+  target, for 66% less routed anchor-encode time before the selective encode
+  of the winners (~45% net). `campaign_cost_payload` fits one pooled law per
+  family over every OTHER two-tier stack (`fit_stack_transfer_law`,
+  leave-one-stack-out, which is the hold-out every reported number in the
+  study was fitted under) and `_stack_cost_rows` predicts the missing rungs
+  from each expert's own censused reference value. A family with fewer than
+  two two-tier stacks, more than one censused rung, or a refused fit gets no
+  law, and its unmeasured rungs stay in `non_interpolable` rather than being
+  estimated from a partial draw.
+
+  A predicted row carries `PROVENANCE_INTERPOLATED`,
+  `cost_source: tessera_campaign_interpolated` and a `transfer_law` block
+  holding the pooled slopes, which stacks they were pooled over, this stack's
+  own intercepts, the sample ids, `n` and the pooled residual sd, plus a
+  `model_error` field. That field reports the **common-mode** term
+  (`residual_sd / sqrt(n)`, propagated over projections by their share of the
+  predicted total) as the stack total's error, because the intercept error is
+  shared by every expert in the stack and does not average away, while the
+  per-expert residual largely does; the per-expert term is reported beside it
+  under its own name. No lognormal smearing correction is applied to the point
+  estimate -- the regret that was measured is this uncorrected estimator's --
+  and the factor is reported as `smearing_factor_not_applied` so its size is
+  visible.
+
+  **A predicted row carries no sampling estimator.** `dloss_stderr` and
+  `estimator: horvitz_thompson` describe the variance of a design over
+  repeated draws; a regression's output has no such variance, and stamping one
+  on it would let a reader, or a hedge that later learns to read the field,
+  treat a model error as a measured spread. Both are absent from a
+  transfer-law row, and the `sampled_experts` block of every interpolated
+  stack row is now built from an explicit allowlist (`_STACK_DRAW_FIELDS`)
+  rather than by subtracting `members` from the measured row's block -- which
+  is how `estimator` used to reach rows that no estimator produced.
 
   **Two gaps, recorded not papered over.** A stack row carries no scalar
   `input_global_scale` and no `wire_bytes`: both are per-expert facts and a
@@ -13771,6 +13875,7 @@ New with the 2026-07-30 merge:
 | D33 | **OPEN 2026-09-02, narrowed twice.** Tessera is priced and rendered by name (§5.7), has a *declared* lane (§9.4, `lane_specs/tessera.json`), a real serving runtime of its own (`tessera.serving`, `quant_method: "tessera"`), and since **2026-09-03** a real `EXPORT_CONTAINER=tessera` arm in `run-pipeline.sh` that plans and encodes through Tessera's OWN tools under `TESSERA_REPO` (`plan_from_layer_config.py`, `export_tessera_serving.py`). **The "no exporter codec" half is re-scoped, not closed**: this repository still writes no Tessera bytes and deliberately never will — a wire recipe with two homes is how the two halves of one format drift apart — so the debt is now *the boundary*, not *the absence*: the two Tessera scripts the arm names live in `experiments/`, which their own README calls drivers rather than a supported interface. **Producer eligibility is no longer what is missing**: since 2026-09-04 the pin names an exact Tessera commit plus the SHA-256 of the `runtime_contract.json` it packages (re-pinned 2026-09-05 to Tessera master's tip `ba582d4…`, contract v22, lane schema v9; v21 landed at `b8b1cb38…` in Tessera #313 and the release `e78959ed…` carried v20), and the packaged contract's dense `device_qualified` cells are ADMITTED under it — what the pin now withholds is any *other* Tessera, which is also what the driver's preflight refuses on. Two residues are the honest remainder of the eligibility half. **First**, the contract's two `routed_moe` cells are decided by their own published `evidence.smoke.status`, which this repository reads and does not second-guess — a measured serving property, not a structural ban here; v17–v20 published `repetitive` and the status-only predicate refused them; v21 and the pinned v22 publish `recorded`. **What that status rests on became checkable at lane schema v9**: RobTand/tessera#327 (P1) reported that v21's `recorded` rested on a repetition rule that lived only in a dated measurements file, derived and checked by nothing and satisfiable by an empty completion; v9 puts the rule, the instrument, the reference and the rows in `smoke.record`, and this reader re-derives status and attribution through Tessera's own functions and refuses a published value they do not derive (`lane_eligibility._parse_smoke_record`, `tests/test_tessera_lane_v9.py`). **Second**, three dense `decode` cells carry `evidence.grade: "route_only"` — a route with no KL at all — which is admitted today and is a promotion question for Rob rather than a gate this repository may tighten on its own. No ship gate has been run on the lane, and no runner exists to run one: the lane's six declared gates are now RECORDED — `route.census` names a shipcard slot and the arm opens a lane-gated card (§7.1, §9.4, 2026-09-03) — so an un-run gate is an unfilled slot the publisher refuses on rather than a sentence nothing reads, but nothing spawns the container that would fill it. The `experiments/` boundary is likewise declared rather than fixed: both tools carry `stability: "unsupported_experiments"` and a `tracking_issue` on `lane_specs/tessera.json`, which makes the debt visible to a reader and a gate without promoting anything. Gridbook's Tessera lane (contract v14) is withdrawn and was never released. | `tessera_render.py` (`tessera_lane_attested`), `tessera_export_lane.py` (the arm's four gates), `run-pipeline.sh` (`EXPORT_CONTAINER=tessera`), `tessera_runtime/tessera_serving_runtime_pin.json` (commit + `contract_sha256`), `tessera_serving_runtime_pin.py` | Med | Moving the pin forward is ONE reviewed commit that edits the pin JSON and the reader's three pinned constants together, verified against a clean Tessera tree; the arm can build today at the pinned commit. Independently, and both still open under RobTand/prismaquant#119: promote the two named Tessera scripts from `experiments/` to a supported entry point so the boundary is an interface rather than a path — after which their `stability` becomes `supported` and the `tracking_issue` goes — and build the lane runner that executes a lane's declared gates in a fresh plugin container and fills the slots the card already opens. |
 | D34 | **The Gridbook lane is retired but its format/cost/render plumbing is not** (added 2026-09-02). The lane, its pins, exporter, serving profiles, ship-gate slots, 73 test modules (1,691 node IDs) and 27 documents were archived at `archive/gridbook_lane_2026-09-02/` and `EXPORT_CONTAINER=nvfp4_cb` now `exit 2`s (§3.5, §9.2) — so no CB rung can be exported or served, which is the property principle 9 cares about. What remains is the machinery that *prices and renders* those rungs: `cb_layout.py`, `nvfp4_cb_formats.py`, `nvfp4_cb_footprint.py`, `cb_ldlq*.py`, `cb_minchain.py`, `cb_warm_state.py`, `cb_banked_books.py`, `cb_learned_promotion.py`, `cb_anchored_cost.py`, `cb_ladder_cross_family.py`, `routed_moe_codebooks.py`, `mxfp4_widen.py`, `source_class_format_plan.py`, plus CB branches inside `production_weight_cache.py`, `allocator.py`, `format_registry.py`, `export_native_compressed.py`, `layer_config.py`, `lane_spec.py`, `serve_constraints.py` and `model_profiles/*`, and roughly 60 tests that exercise them. **Why it was left:** the excision is several hundred diffuse edits concentrated in exactly the files the continuous-menu branch is rewriting, and merging that against a live branch is more dangerous than the debt. **The risk it carries:** a `FORMATS` menu can still name a `*_CB_*` rung, the DP can still price it, and the only thing that stops it is the exporter and the `production-render-score` pairing guard — a *refusal*, not an *absence*. Four consequences are recorded separately because they are capability losses, not debt. (i) `FP8_BLOCK_UE8M0_SOURCE` is now `ROUTE_STATUS_BLOCKED` — its only route was the plugin. (ii) `MXFP4_SOURCE` keeps a backed stock-Marlin route but has no writer and no serving profile, and `MXFP8_UE8M0_G32` is the same shape — never a compressed-tensors scheme, written only by the CB *streaming* exporter, which is archived. Both keep a live `FormatSpec` and a working render; neither has a writer. (iii) **The `serving_lanes` block of a serving-profile spec now has zero live declarations.** `serving_profile_specs/nvfp4_cb.json` was the only spec that ever declared one (verified against `d263f54`), so the per-lane structured `route_status` / `activation_contract` / `fused_mid_m` table that principle 9 reads is a parser with nothing left to parse; the native lane's route status has always come from the source-passthrough contracts instead. The parser and its `route_status_source` machinery are kept because that is the shape the Tessera lane must declare in. (iv) **The sample-parallel incremental probe is unavailable**: its `prepare-run-contract` minter and its per-worker source-census revalidation were both built on `prismaquant/rtx4090_artifact_census.py`, the strict-Ada FP8-CB campaign's closed Qwen3.8-27B layout. `incremental_probe.py --global-calibration-tensor` now refuses up front rather than admitting a pre-retirement contract with one leg of its identity replay missing (`docs/design/sample_parallel_probe.md` carries the banner). Reviving it means giving the census a lane-independent source of truth. Two production observations were surfaced by the removal, deferred at the time, and **both fixed 2026-09-03** (RobTand/tessera#20): `check_serving_shape` failed **open** on an unknown profile id — it caught `FileNotFoundError` and resolved silently to `research`, which permits every shape, while `serving_lane_route`/`serving_lane_catalog`/`check_serving_format` all fail **closed**. It now returns the same `profile_mismatch` refusal `check_serving_format` does; `profile_id=None` still resolves to `research`, which is the declared default and loads, so no legal call changed. And `activation_pricing_branches["unrecorded"]` is re-homed as its own profile-independent test in `tests/test_serving_lane_metadata.py` rather than left riding a deleted CB test. A fifth item is dead-but-kept rather than lost: `shipcard.py`'s `safetensors_content_receipt` trio has no live caller since the strict-RTX4090 publication gate retired, and is kept so receipts already on disk stay readable. `ROLE_COMPOSITE_FUSED_SOURCE_EXEMPT` still exempts `DeepseekV4Profile` from declaring a fused-sibling source, but the lane that justified the exemption is gone; discharging it is a producer-behaviour decision, not a removal. | `archive/gridbook_lane_2026-09-02/README.md`; `docs/measurements/gridbook-lane-retired-2026-09-02.md`; §9.2 | MED | Excise the CB plumbing after the continuous-menu branch merges, in one commit whose diff is deletions plus the tests that go with them; or, if a codebook rung is wanted again for the Tessera lane, port the parts worth keeping deliberately rather than inheriting them. |
 | D35 | **A sampled expert stack has no priced A-side scale and no stack wire, and the research replay reader cannot read its rows** (added 2026-09-06, §4.10, RobTand/prismaquant#290). A stack-level Tessera cost row estimates the stack from a sample of its experts, so two per-expert facts have no scalar form on it. (i) `input_global_scale`: each expert carries its own calibrated static NVFP4 A scale, so a sampled stack has none, and `tessera_menu.priced_static_scales` therefore finds no value for a selected W4A4 stack -- `tessera_export_lane.require_priced_export_inputs` refuses it by name. That is the CORRECT refusal (a price with no bound scale is not exportable), and the fix belongs on the driver side: the calibration pass can compute a scale for every expert without encoding any of them, sampled or not. Until it does, W4A4 Tessera rungs on a sampled routed stack are priced but not exportable. (ii) `wire_bytes`: only a census has a full set of member wires, so a sampled stack is not in `wire_backed` and its per-member wire bytes live in the row's `sampled_experts` block. (iii) `tessera_anchored_surface.load_campaign_measurements`, the research replay reader, keys receipts per checkpoint unit and so refuses a stack payload at `unknown source unit`. It refuses loudly rather than mis-verifying, and it emits no allocator input, so nothing shippable depends on it -- but a replay of a sampled campaign is unavailable until the reader learns the stack-to-member indirection. | §4.10; `prismaquant/tessera_campaign.py` (`StackExpertSample`, `_stack_cost_rows`); `tessera_menu.priced_static_scales`; `tessera_export_lane.require_priced_export_inputs`; `tessera_anchored_surface.py:100` | MED | (i) have the campaign driver calibrate and carry a per-expert `input_global_scale` for the whole stack, then decide with Rob whether the exporter binds per expert or the serve takes a max-over-experts input scale (a fact about the Tessera plugin, so attested per principle 14, not assumed here); (ii)+(iii) teach the replay reader to resolve a stack row's receipts through its `sampled_experts.members` block, or state that sampled campaigns are not replayable. |
+| D36 | **The routed-stack probe reduction has a size source but not a weight source, and no planner emits a two-tier schedule** (added 2026-09-11, RobTand/prismaquant#495 parts 1-3). `--stack-sample-sizes counts` makes the PPS draw follow the census's routed-row counts, which is what #495 part 1 asked for, but `--stack-sample` still requires `--probe`: a `StackExpertSample` carries `h_trace`/`h_trace_per_expert` and `_validate_stack_sample` enforces that they sum to the multiplier the allocator applies, and there is no declared convention for a stack row whose weights are not Fisher. Writing counts into those fields would launder a routed-token proxy into the Fisher currency, which principle 2 and the study's own section 3.6 both refuse, so the report's "so it can run without a probe" is **not** delivered: it needs an explicit weight convention (uniform, or counts declared as such) that the cost row, the allocator's `predicted_dloss` branch and the HT estimator all agree on. Separately, `transfer_law_experts` is honoured by `selection_stack_samples` and `_stack_cost_rows`, but nothing writes it: the per-unit-class round-1 schedule (`round_one_rates`, §5 of the study) is #495 part 4/5 work and is not in this tree, so the two-tier path is reachable only from a hand-built sample. | `tools/dispatch_tessera_campaign.py` `sample_stack_groups`/`cmd_plan`; `prismaquant/tessera_campaign.py` `_validate_stack_sample`, `_stack_rate_evidence`, `_fit_stack_transfer_laws`; `tests/test_tessera_stack_sample_sizes.py` | MED | Declare a weight convention for a probeless stack row, then drop the `--probe` requirement under it; land #495 parts 4-5 to emit the schedule. |
 
 **Open items carried from session handovers.** Of the 41 items the handover census could not
 map to a verified closure, the prior FP4-CB fast-expander/Triton item is now closed by the

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -89,6 +89,8 @@ __all__ = [
     "SCHEMA",
     "UNITS_SCHEMA",
     "UNITS_SCHEMA_V2",
+    "STACK_SAMPLE_COUNTS_SUFFIX",
+    "STACK_SAMPLE_SIZE_SOURCES",
     "CampaignAnchor",
     "ExpertPopulation",
     "anchor_group_key",
@@ -830,6 +832,14 @@ class StackExpertSample:
     #: The draw's seed, and its design name, carried for reproduction.
     seed: int
     design: str = "pps_wor"
+    #: The second tier of a two-tier schedule: the experts that were ALSO
+    #: encoded at the rungs the stack was not censused at, from which the
+    #: transfer law fits this stack's intercept
+    #: (``docs/results/glm_tessera_probe_reduction_regret_2026-09-10.md``
+    #: section 5).  Empty means one tier, which is every schedule before it:
+    #: every rung is measured on every expert in ``sampled_experts`` or it is
+    #: not priced at all.
+    transfer_law_experts: tuple[int, ...] = ()
 
     @property
     def is_census(self) -> bool:
@@ -846,6 +856,7 @@ def stack_sample_from_probe(
     inclusion_prob,
     seed: int,
     design: str = "pps_wor",
+    transfer_law_experts=(),
 ) -> StackExpertSample:
     """Build a sampling record from the PROBE row and the model profile.
 
@@ -902,6 +913,7 @@ def stack_sample_from_probe(
         members=members,
         seed=int(seed),
         design=str(design),
+        transfer_law_experts=tuple(sorted(int(e) for e in transfer_law_experts)),
     )
 
 
@@ -974,6 +986,24 @@ def _validate_stack_sample(sample: StackExpertSample) -> None:
                 f"{q}: expert {e} inclusion probability {pi!r} outside (0, 1]")
         if pi == 1.0 and e not in sample.sampled_experts:
             raise StackSampleError(f"{q}: certainty expert {e} is absent from the sample")
+    if sample.transfer_law_experts:
+        law = set(sample.transfer_law_experts)
+        if len(law) != len(sample.transfer_law_experts):
+            raise StackSampleError(f"{q}: duplicate transfer-law expert id")
+        if not law <= set(sample.sampled_experts):
+            raise StackSampleError(
+                f"{q}: the transfer-law tier names experts the sample does not "
+                "measure; a stack's intercept is fitted on experts that were "
+                "encoded at BOTH the reference rung and the predicted one")
+        if law == set(sample.sampled_experts):
+            raise StackSampleError(
+                f"{q}: the transfer-law tier is the whole sample, so nothing "
+                "would be predicted; drop it rather than declare a law over a "
+                "census")
+        if len(law) < 2:
+            raise StackSampleError(
+                f"{q}: {len(law)} transfer-law expert(s); an intercept fitted "
+                "on one expert has no residual spread to report")
 
 
 def _stack_member_weight(sample: StackExpertSample, expert: int, roles: int) -> float:
@@ -1101,10 +1131,22 @@ def _stack_cost_rows(
     hessian_identity: dict,
     refused: list,
     wire_backed: "frozenset[str] | set[str]" = frozenset(),
+    transfer_law: "Mapping[str, object] | None" = None,
 ) -> "tuple[dict[str, dict], object]":
-    """Build every measured + interpolated row for one packed stack."""
+    """Build every measured + interpolated row for one packed stack.
+
+    ``transfer_law`` maps a family to the ``StackTransferLaw`` fitted on the
+    OTHER stacks of that family.  It is consulted only for a rung that covers
+    exactly ``sample.transfer_law_experts`` -- the second tier of a two-tier
+    schedule -- and its rows are model predictions, written with
+    ``PROVENANCE_INTERPOLATED`` and a ``transfer_law`` block and never with
+    the Horvitz-Thompson fields, which describe a draw this value did not come
+    from.  ``None`` (the default) leaves every schedule that measured one tier
+    behaving exactly as before.
+    """
     from .tessera_rate_surface import (
         PROVENANCE_INTERPOLATED, PROVENANCE_MEASURED, TesseraRateSurface,
+        predict_stack_rates,
     )
 
     _validate_stack_sample(sample)
@@ -1133,11 +1175,35 @@ def _stack_cost_rows(
 
     rows: dict[str, dict] = {}
     measured_by_family: dict[str, list[tuple[int, float, float]]] = {}
+    #: family -> [(format_name, rung), ...] measured on the law draw only.
+    law_tier: dict[str, list[tuple[str, int]]] = {}
+    law_experts = set(sample.transfer_law_experts)
     for format_name in sorted(by_format):
         per_expert = by_format[format_name]
         missing = [e for e in sample.sampled_experts
                    if len(per_expert.get(e, ())) != roles]
         if missing:
+            covered = {e for e in sample.sampled_experts
+                       if len(per_expert.get(e, ())) == roles}
+            if law_experts and covered == law_experts:
+                # The second tier of a two-tier schedule: this rung was encoded
+                # on the transfer-law draw only, by design.  It is priced by
+                # the law below, not by HT -- the drawn experts here fit an
+                # intercept, they do not stand in for the stack.
+                contributing = [a for e in sorted(covered) for a in per_expert[e]]
+                families = {a.family for a in contributing}
+                if len(families) != 1:
+                    raise StackSampleError(
+                        f"{q}/{format_name}: transfer-law tier spans families "
+                        f"{sorted(families)}")
+                rates = {int(a.body_rate_q256) for a in contributing}
+                if len(rates) != 1:
+                    raise StackSampleError(
+                        f"{q}/{format_name}: transfer-law tier spans rungs "
+                        f"{sorted(rates)}")
+                law_tier.setdefault(next(iter(families)), []).append(
+                    (format_name, rates.pop()))
+                continue
             # A rung measured on only some of the drawn experts is not a rung
             # this sample can price: HT needs every drawn unit's y_e.
             refused.append({
@@ -1172,7 +1238,18 @@ def _stack_cost_rows(
             # the stack's summed per-expert predicted dloss.
             "output_mse": total / h_stack,
             "output_mse_measured": True,
-            "cost_source": "tessera_campaign_measured_stack_sample",
+            # A rung encoded on EVERY expert of the stack with certainty is a
+            # census, not a sample: the value is the total, the HT variance is
+            # an exact zero, and nothing about it is an estimate.  It therefore
+            # carries the same ``cost_source`` a dense measured row does
+            # (#495 part 3).  That removes one refusal in
+            # ``tessera_joint_aura.load_measured_anchor_input`` but does not
+            # make a stack row consumable there: that reader matches the cost
+            # roster against the census's SOURCE units and a stack's key is the
+            # packed qname, which is debt D35(iii).  A rung covering only the
+            # draw keeps the sampled spelling.
+            "cost_source": ("tessera_campaign_measured" if sample.is_census
+                            else "tessera_campaign_measured_stack_sample"),
             "currency": CURRENCY,
             "tessera_provenance": PROVENANCE_MEASURED,
             "tessera_family": uniform["family"],
@@ -1248,6 +1325,12 @@ def _stack_cost_rows(
     surfaces: dict[str, object] = {}
     measured_names = set(rows)
     for family, points in measured_by_family.items():
+        if family in law_tier:
+            # A two-tier family has ONE censused rung, so there is no bracket
+            # to interpolate between and the transfer law below is what prices
+            # its other rungs.  Skipping here rather than letting the surface
+            # refuse keeps a designed schedule out of the refusal record.
+            continue
         ordered = sorted(points)
         try:
             surface = TesseraRateSurface(
@@ -1299,14 +1382,247 @@ def _stack_cost_rows(
                 },
                 # An interpolated stack row inherits the sample its bracketing
                 # anchors were estimated from; it is a prediction ABOUT that
-                # sample, so the sample travels with it.
+                # sample, so the sample travels with it -- but only the fields
+                # that describe the DRAW.  Built from an allowlist rather than
+                # by subtracting ``members``, because subtraction is how
+                # ``estimator: horvitz_thompson`` used to reach a row whose
+                # value no estimator produced (#495 part 3).
                 "sampled_experts": {
-                    **{k: v for k, v in template["sampled_experts"].items()
-                       if k != "members"},
+                    **_stack_draw_description(template["sampled_experts"]),
                     "interpolated_from": sorted(measured_names),
                 },
             }
+
+    # The transfer-law tier: rungs encoded on the law draw only, predicted for
+    # every expert from its own censused reference value.  Model predictions,
+    # so they carry a ``transfer_law`` block and none of the sampling fields.
+    for family, entries in sorted(law_tier.items()):
+        pair = None if transfer_law is None else transfer_law.get(family)
+        if pair is None:
+            for format_name, rung in entries:
+                refused.append({
+                    "qname": q, "family": family, "format_name": format_name,
+                    "reason": "stack_transfer_law_absent",
+                    "detail": (f"rung {rung} was encoded on the transfer-law "
+                               "draw only and no law was fitted for this "
+                               "family; the rung is left unpriced rather than "
+                               "estimated from a partial draw"),
+                })
+            continue
+        record, law, reference_format = pair
+        try:
+            prediction = predict_stack_rates(record, law)
+        except Exception as exc:
+            for format_name, rung in entries:
+                refused.append({
+                    "qname": q, "family": family, "format_name": format_name,
+                    "reason": "stack_transfer_law_refused",
+                    "detail": str(exc),
+                })
+            continue
+        h_stack = float(sample.stack_h_trace)
+        template = rows[reference_format]
+        law_block = law.as_dict()
+        for format_name, rung in entries:
+            if format_name in rows:
+                raise StackSampleError(
+                    f"{q}/{format_name}: a transfer-law rung may not overwrite "
+                    "a measured row")
+            if rung not in prediction["predicted"]:
+                refused.append({
+                    "qname": q, "family": family, "format_name": format_name,
+                    "reason": "stack_transfer_law_rung_unfitted",
+                    "detail": (f"rung {rung} is not in the fitted law "
+                               f"{list(law.target_q256)}"),
+                })
+                continue
+            rows[format_name] = {
+                "output_mse": prediction["predicted"][rung] / h_stack,
+                "output_mse_measured": False,
+                "cost_source": "tessera_campaign_interpolated",
+                "currency": CURRENCY,
+                "tessera_provenance": PROVENANCE_INTERPOLATED,
+                "tessera_family": family,
+                "tessera_body_rate_q256": rung,
+                "activation_contract": template["activation_contract"],
+                "activation_quantized": template["activation_quantized"],
+                "_packed_experts_module": sample.packed_experts_module,
+                "num_experts": sample.num_experts,
+                "hessian_identity": {
+                    **hessian_identity,
+                    "applied": bool(template["hessian_identity"]["applied"]),
+                },
+                # Everything the prediction rests on, on the row: the pooled
+                # slopes and which stacks they were pooled over, this stack's
+                # own intercepts, the experts that fitted them, how many there
+                # were, and the residual spread of the pooled fit.  A reader
+                # can refit it; that is the point of writing it down.
+                "transfer_law": {
+                    **law_block,
+                    "predicted_q256": rung,
+                    "reference_format_name": reference_format,
+                    "intercept": {p: float(v) for p, v in sorted(
+                        prediction["intercept"][rung].items())},
+                    "sample_experts": list(prediction["sample_experts"]),
+                    "n": int(prediction["intercept_sample_size"]),
+                    "model_error": prediction["model_error"][rung],
+                },
+                # The draw that fitted the intercept, described as a draw and
+                # nothing more.  No ``estimator`` and no ``dloss_stderr``: this
+                # value came from a regression, and a sampling error would be a
+                # claim about a design that did not produce it.
+                "sampled_experts": {
+                    **_stack_draw_description(template["sampled_experts"]),
+                    "transfer_law_experts": sorted(law_experts),
+                },
+            }
     return rows, surfaces
+
+
+#: The fields of a stack row's ``sampled_experts`` block that describe the
+#: DRAW rather than an estimate made from it.  ``estimator``,
+#: ``variance_estimator`` and ``n_random_stratum`` are deliberately absent:
+#: they name a Horvitz-Thompson computation, and a row whose value no
+#: estimator produced may not claim one (#495 part 3).
+_STACK_DRAW_FIELDS = (
+    "design", "seed", "n_experts", "n_sampled", "experts", "inclusion_prob",
+    "packed_param", "projections_per_expert", "h_trace_stack",
+    "h_trace_per_sampled_expert",
+)
+
+
+def _stack_draw_description(block: "Mapping[str, object]") -> dict:
+    """The draw's own fields, by allowlist -- never by subtraction."""
+    return {field: block[field] for field in _STACK_DRAW_FIELDS if field in block}
+
+
+def _stack_rate_evidence(sample: StackExpertSample, anchors, refused: list):
+    """One two-tier stack's evidence, per family, as a ``StackRateSample``.
+
+    A family qualifies only when exactly one of its rungs was encoded on every
+    expert of the frame (the census tier, which every prediction regresses on)
+    and at least one other was encoded on exactly the transfer-law draw.  A
+    family that fails either test is recorded and skipped: the rungs it does
+    hold are still priced by the measured path.
+
+    Returns ``{family: (record, reference_format_name)}``.
+    """
+    from .tessera_rate_surface import StackRateSample
+
+    if not sample.transfer_law_experts:
+        return {}
+    q = sample.packed_qname
+    roles = len(sample.members[sample.sampled_experts[0]])
+    projections = tuple(name.rsplit(".", 1)[-1]
+                        for name in sample.members[sample.sampled_experts[0]])
+    law_experts = tuple(sorted(sample.transfer_law_experts))
+    # (family, rung) -> {expert: {projection: mse}} plus the format name.
+    seen: dict[tuple[str, int], dict] = {}
+    names: dict[tuple[str, int], str] = {}
+    for expert in sample.sampled_experts:
+        members = sample.members[expert]
+        if len(members) != roles:
+            return {}
+        for index, member in enumerate(members):
+            for family_anchors in (anchors.get(member) or {}).values():
+                for anchor in family_anchors:
+                    key = (anchor.family, int(anchor.body_rate_q256))
+                    names.setdefault(key, anchor.format_name)
+                    seen.setdefault(key, {}).setdefault(
+                        expert, {})[projections[index]] = float(anchor.dloss)
+    frame = set(sample.sampled_experts)
+    law_set = set(law_experts)
+    records: dict[str, tuple] = {}
+    for family in sorted({key[0] for key in seen}):
+        census = [rung for (fam, rung), rows in sorted(seen.items())
+                  if fam == family
+                  and {e for e, row in rows.items() if len(row) == roles} == frame]
+        law_rungs = [rung for (fam, rung), rows in sorted(seen.items())
+                     if fam == family
+                     and {e for e, row in rows.items() if len(row) == roles} == law_set]
+        if not law_rungs:
+            continue
+        if len(census) != 1:
+            refused.append({
+                "qname": q, "family": family,
+                "reason": "stack_transfer_law_reference_missing",
+                "detail": (f"{len(census)} rung(s) of family {family} cover the "
+                           "whole frame; exactly one is needed, because every "
+                           "expert is predicted from its own measured "
+                           "reference value"),
+                "census_rungs": census,
+            })
+            continue
+        reference = census[0]
+        try:
+            record = StackRateSample(
+                stack=q, projections=projections,
+                experts=tuple(sample.sampled_experts),
+                reference_q256=reference,
+                reference_mse=seen[(family, reference)],
+                sampled_experts=law_experts,
+                sampled_mse={rung: {e: seen[(family, rung)][e] for e in law_experts}
+                             for rung in law_rungs},
+                weights={e: _stack_member_weight(sample, e, roles)
+                         for e in sample.sampled_experts},
+                currency=CURRENCY)
+        except Exception as exc:
+            refused.append({
+                "qname": q, "family": family,
+                "reason": "stack_transfer_law_refused",
+                "detail": str(exc),
+            })
+            continue
+        records[family] = (record, names[(family, reference)])
+    return records
+
+
+def _fit_stack_transfer_laws(samples, anchors, refused: list) -> dict:
+    """Fit one pooled law per family, leaving out the stack it will predict.
+
+    The slope pools every OTHER stack of the same family, which is exactly the
+    hold-out the study fitted every reported number under; a stack whose family
+    has no other two-tier stack gets no law, and its unmeasured rungs are left
+    unpriced rather than predicted from their own evidence.
+
+    Returns ``{packed_qname: {family: (record, law, reference_format_name)}}``.
+    """
+    from .tessera_rate_surface import fit_stack_transfer_law
+
+    evidence = {}
+    for packed_qname, sample in sorted(samples.items()):
+        found = _stack_rate_evidence(sample, anchors, refused)
+        if found:
+            evidence[packed_qname] = found
+    by_family: dict[str, dict[str, object]] = {}
+    for packed_qname, families in evidence.items():
+        for family, (record, _) in families.items():
+            by_family.setdefault(family, {})[packed_qname] = record
+    laws: dict[str, dict[str, tuple]] = {}
+    for packed_qname, families in evidence.items():
+        for family, (record, reference_format) in families.items():
+            population = by_family[family]
+            if len(population) < 2:
+                refused.append({
+                    "qname": packed_qname, "family": family,
+                    "reason": "stack_transfer_law_population_too_small",
+                    "detail": (f"family {family} has {len(population)} two-tier "
+                               "stack(s); a pooled slope needs at least one "
+                               "other stack to hold this one out against"),
+                })
+                continue
+            try:
+                law = fit_stack_transfer_law(population, hold_out=packed_qname)
+            except Exception as exc:
+                refused.append({
+                    "qname": packed_qname, "family": family,
+                    "reason": "stack_transfer_law_fit_refused",
+                    "detail": str(exc),
+                })
+                continue
+            laws.setdefault(packed_qname, {})[family] = (
+                record, law, reference_format)
+    return laws
 
 
 # ---------------------------------------------------------------------------
@@ -1519,9 +1835,11 @@ def campaign_cost_payload(
                 formats.add(rung.format_name)
         if rows:
             costs[qname] = rows
+    laws = _fit_stack_transfer_laws(samples, anchors, refused)
     for packed_qname, sample in sorted(samples.items()):
         stack_rows, stack_surfaces = _stack_cost_rows(
-            sample, anchors, menus, hessian_identity, refused, wire_backed=wire_backed)
+            sample, anchors, menus, hessian_identity, refused,
+            wire_backed=wire_backed, transfer_law=laws.get(packed_qname))
         if not stack_rows:
             continue
         costs[packed_qname] = stack_rows
@@ -3395,6 +3713,51 @@ def load_unit_selection(path) -> dict:
     return selection
 
 
+#: The size sources a stack draw may be proportional to.  ``probe`` is the
+#: per-expert Fisher vector, which is what the estimator's variance argument
+#: rests on; ``counts`` is the census's per-expert routed-row count, which is
+#: the ONLY per-expert size available when no probe exists -- a routed-token
+#: proxy for ``h_trace`` and never a substitute for it (RobTand/prismaquant#495
+#: part 1, and the report's section 3.6 bullet on sizes).
+STACK_SAMPLE_SIZE_SOURCES = ("probe", "counts")
+
+#: The design a ``counts``-sized draw declares, so a reader of ``units.json``
+#: can tell which vector the inclusion probabilities are proportional to
+#: without re-deriving it.
+STACK_SAMPLE_COUNTS_SUFFIX = "_counts"
+
+
+def _stack_draw_sizes(record: Mapping, sample: StackExpertSample) -> dict:
+    """The sizes a stack's draw was made proportional to.
+
+    A record that declares its own ``sizes`` replays on those; one that does
+    not is a probe-sized draw and replays on the Fisher vector, exactly as
+    every record written before #495 does.
+    """
+    sizes = record.get("sizes")
+    if sizes is None:
+        return {str(e): h for e, h in enumerate(sample.h_trace_per_expert)}
+    if str(sizes.get("source")) not in STACK_SAMPLE_SIZE_SOURCES:
+        raise StackSampleError(
+            f"{sample.packed_qname}: size source {sizes.get('source')!r} is "
+            f"not one of {list(STACK_SAMPLE_SIZE_SOURCES)}")
+    values = sizes.get("values")
+    if not isinstance(values, Mapping) or len(values) != sample.num_experts:
+        raise StackSampleError(
+            f"{sample.packed_qname}: a declared size vector must carry one "
+            f"value per expert ({sample.num_experts})")
+    return {str(e): float(values[str(e)]) for e in range(sample.num_experts)}
+
+
+def _stack_design(record: Mapping, draw: Mapping) -> str:
+    """The design name a draw carries, including which sizes it used."""
+    sizes = record.get("sizes")
+    method = str(draw["method"])
+    if sizes is None or str(sizes.get("source")) == "probe":
+        return method
+    return method + STACK_SAMPLE_COUNTS_SUFFIX
+
+
 def selection_stack_samples(selection: Mapping, profile) -> dict[str, StackExpertSample]:
     """Rehydrate packed probe/draw records and bind them to the whole group.
 
@@ -3420,16 +3783,25 @@ def selection_stack_samples(selection: Mapping, profile) -> dict[str, StackExper
                 name, record["probe_row"], profile,
                 sampled_experts=record["sampled_experts"],
                 inclusion_prob=record["inclusion_prob"], seed=record["seed"],
-                design=record["design"])
+                design=record["design"],
+                transfer_law_experts=record.get("transfer_law_experts", ()))
             _validate_stack_sample(sample)
             replay = draw_stack_sample(
-                {str(e): h for e, h in enumerate(sample.h_trace_per_expert)},
+                _stack_draw_sizes(record, sample),
                 len(sample.sampled_experts), seed=sample.seed, stack=name)
-            if (record.get("draw") != replay or sample.design != replay["method"]
+            if (record.get("draw") != replay
+                    or sample.design != _stack_design(record, replay)
                     or list(sample.sampled_experts) != sorted(int(e) for e in replay["units"])
                     or dict(sample.inclusion_prob) != {
                         int(e): p for e, p in replay["inclusion_probability"].items()}):
                 raise StackSampleError(f"{name}: packed draw receipt does not replay from probe and seed")
+            declared = record.get("sizes")
+            if declared is not None and str(declared.get("sha256")) != replay["size_sha256"]:
+                # The digest is what binds the DECLARED size vector to the one
+                # the draw was actually made proportional to; without it a
+                # record could name ``counts`` and carry a probe-sized draw.
+                raise StackSampleError(
+                    f"{name}: declared size digest does not match the draw's")
             if set(sample.inclusion_prob) != set(range(sample.num_experts)):
                 raise StackSampleError(f"{name}: selection needs full-frame inclusion probabilities")
             if entry["key"] != "s:" + sample.packed_experts_module:

--- a/prismaquant/tessera_rate_surface.py
+++ b/prismaquant/tessera_rate_surface.py
@@ -86,11 +86,16 @@ if TYPE_CHECKING:
     from tessera.export import WireRecipe
 
 __all__ = [
+    "STACK_TRANSFER_REFERENCE_Q256",
+    "StackRateSample",
+    "StackTransferLaw",
     "TesseraRateSurface",
     "allocation_regret",
     "densify_rate_surface",
     "fit_rate_surface",
+    "fit_stack_transfer_law",
     "leave_one_anchor_out",
+    "predict_stack_rates",
     "rate_surface_solver_menu",
     "uniform_column_schedule",
 ]
@@ -556,4 +561,453 @@ def allocation_regret(
         / len(on_truth),
         "assignment_interpolated": on_interpolated,
         "assignment_truth": on_truth,
+    }
+
+
+# ---------------------------------------------------------------------------
+# The stack transfer law
+# ---------------------------------------------------------------------------
+#
+# Everything above this line prices ONE unit from ITS OWN anchors: a dense
+# Linear measured at three rungs, interpolated between them.  A packed routed
+# MoE stack is a different shape of problem and needs a different instrument.
+#
+# Why a second instrument.  A routed stack is ONE rate decision covering every
+# expert in the layer (``allocator_candidates.aggregate_packed_serving_groups``
+# makes the packed group a single multi-choice DP item, and the pinned Tessera
+# contract's two ``routed_moe`` cells publish no per-expert rate licence), yet
+# a census pays 3 x E x R encodes to resolve it.  The offline regret study
+# ``docs/results/glm_tessera_probe_reduction_regret_2026-09-10.md`` measured
+# what happens if a stack is instead measured as a CENSUS at one reference
+# rung plus a small expert SAMPLE at the others, with the missing rungs
+# predicted per expert by
+#
+#     log2 mse_{e,p}(r) = a_{p,r} + b_{p,r} * log2 mse_{e,p}(reference)
+#
+# where ``b`` is pooled over the OTHER stacks (their per-stack spread is sd
+# 0.02-0.03 over 28 stacks, so pooling costs nothing) and ``a`` is fitted per
+# (stack, projection) from that stack's own sampled experts.  At a 3% sample
+# this reproduced the omniscient allocation to 0.004% mean / 0.000% p90
+# regret at the campaign's byte target and cut routed anchor-encode time by
+# 66% before the selective encode of the winners (~45% net).
+#
+# ``TesseraRateSurface`` is NOT this and must not be asked to be: it
+# interpolates one unit's own measured anchors and refuses to extrapolate.
+# Dense units keep three anchors and keep that surface (report section 4).
+#
+# What this is not.  These are MODEL PREDICTIONS -- not measurements, and not
+# sampling estimates.  The distinction has teeth here: a Horvitz-Thompson
+# ``dloss_stderr`` describes the variance of a DESIGN over repeated draws and
+# is meaningful only for a row whose value came from a draw.  A transfer-law
+# row's value came from a regression, so it carries a model error under its
+# own name and never an ``estimator`` or a ``dloss_stderr``
+# (RobTand/prismaquant#495 part 3).
+
+#: The rung a stack is censused at, and therefore the regressor every
+#: prediction is made from.  Named rather than spelled at the call sites,
+#: because the law is defined relative to whichever rung was censused.
+STACK_TRANSFER_REFERENCE_Q256 = 960
+
+
+def _check_positive_mse(stack, row, projections, where) -> None:
+    for projection in projections:
+        value = row.get(projection)
+        if value is None:
+            raise TesseraFormatError(
+                f"{stack}: {where} is missing projection {projection!r}")
+        value = float(value)
+        if not math.isfinite(value) or value <= 0.0:
+            raise TesseraFormatError(
+                f"{stack}: {where} projection {projection!r} is {value!r}; the "
+                "law is fitted in log2 space and a non-positive mse has no log")
+
+
+@dataclass(frozen=True, slots=True)
+class StackRateSample:
+    """One packed stack's evidence: a census at one rung, a sample at others.
+
+    ``reference_mse`` is expert -> projection -> ``output_mse`` at
+    ``reference_q256`` over EVERY expert in the stack (the census tier).
+    ``sampled_mse`` is q256 -> expert -> projection -> ``output_mse`` over the
+    drawn experts only (the transfer-law tier).
+
+    ``weights`` is the weight applied to EACH projection's mse, i.e. the
+    production ``h_trace_per_expert[e] / roles`` that
+    ``tessera_campaign._stack_member_weight`` applies, so that
+    ``sum_e weights[e] * sum_p mse_{e,p}`` reproduces exactly the total
+    ``_horvitz_thompson_stack`` estimates on the same evidence.  ``None`` means
+    uniform 1.0, which is the study's ``uniform`` weighting and the only
+    honest convention when no Fisher probe exists.
+    """
+
+    stack: str
+    projections: tuple[str, ...]
+    experts: tuple[int, ...]
+    reference_q256: int
+    reference_mse: "Mapping[int, Mapping[str, float]]"
+    sampled_experts: tuple[int, ...]
+    sampled_mse: "Mapping[int, Mapping[int, Mapping[str, float]]]"
+    weights: "Mapping[int, float] | None" = None
+    currency: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.projections:
+            raise TesseraFormatError(f"{self.stack}: a stack sample needs projections")
+        if len(set(self.projections)) != len(self.projections):
+            raise TesseraFormatError(f"{self.stack}: duplicate projection name")
+        if not self.experts:
+            raise TesseraFormatError(f"{self.stack}: a stack sample needs experts")
+        if len(set(self.experts)) != len(self.experts):
+            raise TesseraFormatError(f"{self.stack}: duplicate expert id")
+        if not self.sampled_experts:
+            raise TesseraFormatError(
+                f"{self.stack}: no sampled experts; the per-stack intercept is "
+                "fitted on the sample and cannot be fitted on nothing")
+        if not set(self.sampled_experts) <= set(self.experts):
+            raise TesseraFormatError(
+                f"{self.stack}: sampled experts are not a subset of the frame")
+        for expert in self.experts:
+            row = self.reference_mse.get(expert)
+            if not isinstance(row, Mapping):
+                raise TesseraFormatError(
+                    f"{self.stack}: expert {expert} has no reference row; the "
+                    f"reference rung {self.reference_q256} must be a census, "
+                    "because every expert's prediction is made from its own "
+                    "measured reference value")
+            _check_positive_mse(self.stack, row, self.projections,
+                                f"reference {self.reference_q256}")
+        if not self.sampled_mse:
+            raise TesseraFormatError(f"{self.stack}: no sampled rungs to fit")
+        for rate, by_expert in self.sampled_mse.items():
+            if int(rate) == int(self.reference_q256):
+                raise TesseraFormatError(
+                    f"{self.stack}: rung {rate} is the reference; a rung cannot "
+                    "be both the regressor and the prediction")
+            for expert in self.sampled_experts:
+                row = by_expert.get(expert)
+                if not isinstance(row, Mapping):
+                    raise TesseraFormatError(
+                        f"{self.stack}: sampled expert {expert} has no row at "
+                        f"rung {rate}; a rung measured on only some of the "
+                        "drawn experts cannot fit this stack's intercept")
+                _check_positive_mse(self.stack, row, self.projections,
+                                    f"rung {rate}")
+
+    @property
+    def target_q256(self) -> tuple[int, ...]:
+        return tuple(sorted(int(rate) for rate in self.sampled_mse))
+
+    def weight(self, expert: int) -> float:
+        return 1.0 if self.weights is None else float(self.weights[expert])
+
+    def reference_total(self) -> float:
+        """The weighted total at the censused rung -- the one measured total.
+
+        Only the reference rung covers every expert, so this is the only total
+        this record can state without a model.
+        """
+        return math.fsum(
+            self.weight(e) * math.fsum(
+                float(self.reference_mse[e][p]) for p in self.projections)
+            for e in self.experts)
+
+
+@dataclass(frozen=True, slots=True)
+class StackTransferLaw:
+    """Pooled per-projection slopes, and what their residuals were.
+
+    ``slope[rate][projection]`` is the OLS slope of ``log2 mse(rate)`` on
+    ``log2 mse(reference)`` over the pooled experts of every stack other than
+    ``held_out`` -- ONE pooled centring, exactly as the study fitted it, not a
+    fixed-effects fit.  ``residual_sd_log2`` is that fit's residual standard
+    deviation in log2 units: the per-expert pointwise MODEL error, and not a
+    sampling error of any design.
+    """
+
+    reference_q256: int
+    target_q256: tuple[int, ...]
+    projections: tuple[str, ...]
+    slope: "Mapping[int, Mapping[str, float]]"
+    residual_sd_log2: "Mapping[int, Mapping[str, float]]"
+    pooled_rows: "Mapping[int, int]"
+    pooled_stacks: tuple[str, ...]
+    held_out: str | None
+    currency: str = ""
+
+    def as_dict(self) -> dict:
+        """The JSON-portable form a cost row carries."""
+        return {
+            "reference_q256": int(self.reference_q256),
+            "target_q256": [int(r) for r in self.target_q256],
+            "projections": list(self.projections),
+            "slope": {str(r): {p: float(v) for p, v in sorted(row.items())}
+                      for r, row in sorted(self.slope.items())},
+            "residual_sd_log2": {
+                str(r): {p: float(v) for p, v in sorted(row.items())}
+                for r, row in sorted(self.residual_sd_log2.items())},
+            "pooled_rows": {str(r): int(n)
+                            for r, n in sorted(self.pooled_rows.items())},
+            "pooled_stacks": list(self.pooled_stacks),
+            "held_out": self.held_out,
+            "currency": self.currency,
+        }
+
+
+def _stack_rate_samples(stacks_measured) -> "dict[str, StackRateSample]":
+    if isinstance(stacks_measured, Mapping):
+        items = list(stacks_measured.values())
+    else:
+        items = list(stacks_measured)
+    samples: dict[str, StackRateSample] = {}
+    for sample in items:
+        if not isinstance(sample, StackRateSample):
+            raise TesseraFormatError(
+                "fit_stack_transfer_law takes StackRateSample records; "
+                f"got {type(sample).__name__}")
+        if sample.stack in samples:
+            raise TesseraFormatError(f"{sample.stack}: duplicate stack record")
+        samples[sample.stack] = sample
+    if not samples:
+        raise TesseraFormatError("no stack records to fit a transfer law on")
+    return samples
+
+
+def fit_stack_transfer_law(
+    stacks_measured: "Mapping[str, StackRateSample] | Sequence[StackRateSample]",
+    hold_out: str | None = None,
+) -> StackTransferLaw:
+    """Pool per-projection slopes over every stack except ``hold_out``.
+
+    The fit is the study's, reproduced rather than reinvented: for each target
+    rung and projection, concatenate the sampled experts of all the OTHER
+    stacks, centre ``log2 mse(reference)`` and ``log2 mse(rate)`` on one pooled
+    mean each, and take ``sum(xc*yc) / sum(xc*xc)``.  The pooled centring is
+    what leaves the intercept a per-stack quantity: the slope carries the
+    cross-expert shape, the intercept carries each stack's own level.
+
+    ``hold_out`` names the stack this law will be used to predict, which is
+    what keeps a prediction out of its own fit.  The study fitted every
+    reported number leave-one-stack-out and found the per-layer slope spread
+    (sd 0.02-0.03 over 28 stacks) small enough that the hold-out costs nothing.
+
+    Known sensitivity, stated rather than hidden.  ONE pooled centring is the
+    study's estimator and is reproduced here because the regret it measured is
+    this estimator's; but it is unbiased for ``b`` only when the pooled stacks'
+    per-stack intercepts are uncorrelated with their per-stack MEAN reference
+    level.  A population whose deeper layers sit both higher on the reference
+    axis and higher in intercept would tilt the pooled slope toward the
+    BETWEEN-stack relation, which is a different quantity from the
+    within-stack one the prediction uses.  A within-stack (fixed-effects)
+    centring would remove that, and would also change the estimator that was
+    validated, so it is not done here.  What the study offers against the risk
+    is evidence rather than an argument: the 28 per-layer slopes agree to sd
+    0.02-0.03, which a strong between-stack tilt would not survive.  Any
+    residual tilt inflates ``residual_sd_log2``, so the reported model error
+    errs conservatively.
+    """
+    samples = _stack_rate_samples(stacks_measured)
+    pooled = [s for name, s in samples.items() if name != hold_out]
+    if not pooled:
+        raise TesseraFormatError(
+            "a pooled slope needs at least one stack other than the held-out "
+            "one; a law fitted on the stack it predicts is not a hold-out")
+    references = {int(s.reference_q256) for s in pooled}
+    if len(references) != 1:
+        raise TesseraFormatError(
+            f"the pooled stacks disagree about the reference rung "
+            f"({sorted(references)}); a slope regressed on two different "
+            "regressors is not one slope")
+    reference_q256 = references.pop()
+    projections = pooled[0].projections
+    for sample in pooled:
+        if sample.projections != projections:
+            raise TesseraFormatError(
+                f"{sample.stack}: projections {sample.projections} differ from "
+                f"{projections}; a per-projection slope needs one projection set")
+    currencies = {s.currency for s in pooled}
+    if len(currencies) != 1:
+        raise TesseraFormatError(
+            f"the pooled stacks disagree about the currency "
+            f"({sorted(currencies)}); a law fitted across objectives prices "
+            "nothing")
+    targets = sorted(set.intersection(*(set(s.target_q256) for s in pooled)))
+    if not targets:
+        raise TesseraFormatError(
+            "the pooled stacks share no target rung; there is nothing to fit")
+
+    slope: dict[int, dict[str, float]] = {}
+    residual: dict[int, dict[str, float]] = {}
+    rows: dict[int, int] = {}
+    for rate in targets:
+        slope[rate], residual[rate] = {}, {}
+        for projection in projections:
+            xs: list[float] = []
+            ys: list[float] = []
+            for sample in pooled:
+                for expert in sample.sampled_experts:
+                    xs.append(math.log2(float(
+                        sample.reference_mse[expert][projection])))
+                    ys.append(math.log2(float(
+                        sample.sampled_mse[rate][expert][projection])))
+            count = len(xs)
+            if count < 3:
+                raise TesseraFormatError(
+                    f"rung {rate} projection {projection!r}: {count} pooled "
+                    "row(s); a slope and a residual spread need at least three")
+            x_mean = math.fsum(xs) / count
+            y_mean = math.fsum(ys) / count
+            sxx = math.fsum((x - x_mean) ** 2 for x in xs)
+            if sxx <= 0.0:
+                raise TesseraFormatError(
+                    f"rung {rate} projection {projection!r}: the reference "
+                    "values have no spread, so no slope is identified")
+            sxy = math.fsum((x - x_mean) * (y - y_mean)
+                            for x, y in zip(xs, ys))
+            b = sxy / sxx
+            slope[rate][projection] = float(b)
+            sse = math.fsum(((y - y_mean) - b * (x - x_mean)) ** 2
+                            for x, y in zip(xs, ys))
+            # n - 2: this fit estimated a slope and a pooled intercept.
+            residual[rate][projection] = float(math.sqrt(sse / (count - 2)))
+            rows[rate] = count
+    return StackTransferLaw(
+        reference_q256=reference_q256,
+        target_q256=tuple(targets),
+        projections=tuple(projections),
+        slope={r: dict(v) for r, v in slope.items()},
+        residual_sd_log2={r: dict(v) for r, v in residual.items()},
+        pooled_rows=dict(rows),
+        pooled_stacks=tuple(sorted(s.stack for s in pooled)),
+        held_out=hold_out,
+        currency=currencies.pop(),
+    )
+
+
+def predict_stack_rates(
+    stack: StackRateSample,
+    law: StackTransferLaw,
+) -> dict:
+    """The stack's total at each target rung, and what the model error is.
+
+    Per target rung and projection the intercept is
+    ``mean_{e in sample} (log2 mse_e(rate) - b * log2 mse_e(reference))``;
+    every expert in the frame is then predicted from its OWN measured
+    reference value, and the weighted per-expert predictions are summed.
+
+    The error field, and why it is what it is
+    -----------------------------------------
+    Two errors ride on this prediction and they behave differently under the
+    sum over E experts:
+
+    * the per-expert residual, sd ``residual_sd_log2``.  It is idiosyncratic,
+      so over a few hundred experts it largely averages away in the total.
+    * the intercept error, sd ``residual_sd_log2 / sqrt(n)`` on ``n`` sampled
+      experts.  It is COMMON to every expert in the stack -- one number shifts
+      the whole predicted curve -- so it does not average away at all, and it
+      is what the error on the stack TOTAL actually is.
+
+    ``model_error`` therefore reports the common-mode term as
+    ``stack_total_sd_log2`` (a root-sum-square over projections, each weighted
+    by its share of the predicted total, because the projections' intercepts
+    are fitted independently) and reports the pointwise per-expert term beside
+    it under its own name, so neither can be read as the other.  Both are
+    MODEL errors, in log2 units.  Neither is a sampling standard error and
+    neither may be written to ``dloss_stderr``.
+
+    No smearing correction.  ``sum_e 2^lhat`` underestimates ``E[sum_e mse]``
+    by roughly ``exp((sigma ln2)^2 / 2)`` under lognormal residuals, and that
+    factor is deliberately NOT applied: the regret the study measured is the
+    regret of this uncorrected estimator, and a correction fitted on the same
+    ``n`` points would move the number that was validated.  Its size is
+    reported as ``smearing_factor_not_applied`` so a reader can see it.
+    """
+    if int(stack.reference_q256) != int(law.reference_q256):
+        raise TesseraFormatError(
+            f"{stack.stack}: censused at {stack.reference_q256}, the law "
+            f"regresses on {law.reference_q256}")
+    if stack.projections != law.projections:
+        raise TesseraFormatError(
+            f"{stack.stack}: projections {stack.projections} are not the law's "
+            f"{law.projections}")
+    if stack.currency != law.currency:
+        raise TesseraFormatError(
+            f"{stack.stack}: currency {stack.currency!r} is not the law's "
+            f"{law.currency!r}")
+    if law.held_out is not None and law.held_out != stack.stack:
+        raise TesseraFormatError(
+            f"{stack.stack}: this law held out {law.held_out!r}; predicting one "
+            "stack from a law fitted with a different hold-out mixes designs")
+    if law.held_out is None and stack.stack in law.pooled_stacks:
+        raise TesseraFormatError(
+            f"{stack.stack}: the law pooled this stack's own experts; fit it "
+            "with hold_out=<this stack> before predicting it")
+    targets = [r for r in stack.target_q256 if r in law.target_q256]
+    if not targets:
+        raise TesseraFormatError(
+            f"{stack.stack}: the law fits {list(law.target_q256)} and this "
+            f"stack samples {list(stack.target_q256)}; no rung is predictable")
+
+    sampled = list(stack.sampled_experts)
+    n = len(sampled)
+    predicted: dict[int, float] = {}
+    per_expert: dict[int, dict[int, float]] = {}
+    intercepts: dict[int, dict[str, float]] = {}
+    errors: dict[int, dict] = {}
+    for rate in targets:
+        intercept: dict[str, float] = {}
+        share: dict[str, float] = {}
+        predictions: dict[int, dict[str, float]] = {e: {} for e in stack.experts}
+        for projection in stack.projections:
+            b = float(law.slope[rate][projection])
+            value = math.fsum(
+                math.log2(float(stack.sampled_mse[rate][e][projection]))
+                - b * math.log2(float(stack.reference_mse[e][projection]))
+                for e in sampled) / n
+            intercept[projection] = float(value)
+            for expert in stack.experts:
+                predictions[expert][projection] = 2.0 ** (
+                    value + b * math.log2(
+                        float(stack.reference_mse[expert][projection])))
+            share[projection] = math.fsum(
+                stack.weight(e) * predictions[e][projection]
+                for e in stack.experts)
+        total = math.fsum(share[p] for p in stack.projections)
+        if not math.isfinite(total) or total <= 0.0:
+            raise TesseraFormatError(
+                f"{stack.stack}: predicted total {total!r} at rung {rate} is "
+                "not a positive finite cost")
+        predicted[rate] = float(total)
+        per_expert[rate] = {
+            int(e): float(math.fsum(predictions[e][p] for p in stack.projections))
+            for e in stack.experts}
+        intercepts[rate] = intercept
+        pointwise = {p: float(law.residual_sd_log2[rate][p])
+                     for p in stack.projections}
+        common = math.sqrt(math.fsum(
+            ((share[p] / total) * (pointwise[p] / math.sqrt(n))) ** 2
+            for p in stack.projections))
+        worst = max(pointwise.values())
+        errors[rate] = {
+            # The stack TOTAL's own error: the common-mode intercept term.
+            "stack_total_sd_log2": float(common),
+            # The per-expert pointwise model error, named so it cannot be read
+            # as the line above.
+            "per_expert_residual_sd_log2": dict(sorted(pointwise.items())),
+            "intercept_sample_size": int(n),
+            "smearing_factor_not_applied": float(
+                math.exp((worst * math.log(2.0)) ** 2 / 2.0)),
+            "kind": "transfer_law_model_error_log2",
+            "is_sampling_error": False,
+        }
+    return {
+        "stack": stack.stack,
+        "reference_q256": int(stack.reference_q256),
+        "predicted": predicted,
+        "predicted_per_expert": per_expert,
+        "intercept": intercepts,
+        "slope": {rate: dict(law.slope[rate]) for rate in targets},
+        "sample_experts": [int(e) for e in sampled],
+        "intercept_sample_size": int(n),
+        "model_error": errors,
+        "currency": stack.currency,
     }

--- a/tests/test_tessera_stack_sample_cost.py
+++ b/tests/test_tessera_stack_sample_cost.py
@@ -228,7 +228,14 @@ def test_stack_row_prices_exactly_what_the_expanded_experts_would():
     assert predicted_dloss(probe["h_trace"], row["output_mse"]) == pytest.approx(
         expanded, rel=1e-12)
     assert row["dloss_stderr"] == 0.0
-    assert row["cost_source"] == "tessera_campaign_measured_stack_sample"
+    # A census: every expert encoded with certainty, so the value IS the total
+    # and nothing about it is an estimate.  It therefore spells its source the
+    # way a dense measured row does (RobTand/prismaquant#495 part 3); the
+    # remaining obstacle to joint AURA reading a stack row is the
+    # stack-to-member indirection, debt D35(iii), not this spelling.  A row
+    # estimated from a draw keeps the sampled spelling -- see
+    # ``test_a_drawn_rung_keeps_the_sampled_cost_source``.
+    assert row["cost_source"] == "tessera_campaign_measured"
     assert row["currency"] == campaign.CURRENCY
     assert "predicted_dloss" not in row and "weight_mse" not in row
 

--- a/tests/test_tessera_stack_sample_sizes.py
+++ b/tests/test_tessera_stack_sample_sizes.py
@@ -1,0 +1,208 @@
+"""``--stack-sample-sizes``: which per-expert vector the PPS draw follows.
+
+RobTand/prismaquant#495 part 1.  ``sample_stack_groups`` drew proportional to
+the probe's ``h_trace_per_expert``, and GLM-5.3-Flash has no probe carrying
+one -- so the sampling path was unreachable on the model it was written for
+and the campaign paid for a full census instead
+(``docs/results/glm_tessera_probe_reduction_regret_2026-09-10.md`` section 2,
+and section 3.6's bullet on sizes).  The census's per-expert routed-row counts
+are the only other per-expert size that exists.
+
+Two things are pinned:
+
+* the default is unchanged, and unchanged is demonstrated rather than
+  asserted: the test rebuilds the pre-change record from the campaign's own
+  primitives and compares the two serialisations byte for byte;
+* a ``counts`` draw says so.  ``counts`` is a routed-token proxy for
+  ``h_trace``, not ``h_trace``, so the record names the source, carries the
+  vector and its digest, and suffixes the design -- and the campaign's
+  rehydration refuses a record whose declared digest is not the digest of the
+  draw it carries.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'tools'))
+
+MODULE = "model.layers.18.feed_forward.experts"
+PACKED = f"{MODULE}.gate_up_proj"
+EXPERTS = 8
+ROLES = ("w1", "w3")
+
+
+def _dispatch():
+    return pytest.importorskip("dispatch_tessera_campaign")
+
+
+def _campaign():
+    return pytest.importorskip("prismaquant.tessera_campaign")
+
+
+def _profile():
+    from prismaquant.model_profiles.lfm2_moe import Lfm2MoeProfile
+    return Lfm2MoeProfile()
+
+
+def _members():
+    return sorted(f"{MODULE}.{expert}.{role}"
+                  for expert in range(EXPERTS) for role in ROLES)
+
+
+def _probe_rows(h):
+    return {PACKED: {
+        "h_trace": float(sum(h)),
+        "h_trace_per_expert": [float(v) for v in h],
+        "num_experts": EXPERTS,
+        "_packed_experts_module": MODULE,
+        "_packed_param": "gate_up_proj",
+        "out_features": 8, "in_features": 4,
+        "n_params": EXPERTS * 32,
+        "router_path": None, "expert_id": None,
+    }}
+
+
+#: Deliberately anti-correlated with the counts below, so a draw that followed
+#: the wrong vector cannot accidentally agree with one that followed the right
+#: one.
+H = [1.0, 9.0, 2.0, 8.0, 3.0, 7.0, 4.0, 6.0]
+COUNTS_PER_EXPERT = [900, 100, 800, 200, 700, 300, 600, 400]
+
+
+def _census():
+    counts = {}
+    for expert in range(EXPERTS):
+        for role in ROLES:
+            # Split the expert's count across its roles; the size is the sum.
+            counts[f"{MODULE}.{expert}.{role}"] = COUNTS_PER_EXPERT[expert] // 2
+    return {"counts": counts}
+
+
+def _expected_probe_record(campaign, *, n, seed, audit_rate):
+    """The record the pre-#495 code wrote, rebuilt from the same primitives.
+
+    This is the oracle for "the default is unchanged": it is the old function
+    body, minus the bookkeeping that surrounds it, so a byte comparison against
+    it is a regression check rather than a restatement of the new code.
+    """
+    frame = campaign.stack_sample_from_probe(
+        PACKED, _probe_rows(H)[PACKED], _profile(),
+        sampled_experts=range(EXPERTS),
+        inclusion_prob={e: 1.0 for e in range(EXPERTS)}, seed=seed,
+        design="census")
+    draw = campaign.draw_stack_sample(
+        {str(e): h for e, h in enumerate(frame.h_trace_per_expert)},
+        n, seed=seed, stack=PACKED)
+    audit = campaign.audit_subsample(draw["units"], rate=audit_rate, seed=seed,
+                                     stack=PACKED)
+    return {
+        "probe_row": {
+            "_packed_experts_module": frame.packed_experts_module,
+            "_packed_param": frame.packed_param,
+            "num_experts": frame.num_experts,
+            "h_trace": frame.stack_h_trace,
+            "h_trace_per_expert": list(frame.h_trace_per_expert),
+        },
+        "sampled_experts": sorted(int(e) for e in draw["units"]),
+        "inclusion_prob": dict(draw["inclusion_probability"]),
+        "seed": seed,
+        "design": draw["method"],
+        "draw": draw,
+        "audit_experts": sorted(int(e) for e in audit),
+    }
+
+
+def _sample(dispatch, **over):
+    kwargs = dict(profile=_profile(), stack_sample=3, seed=5, audit_rate=10)
+    kwargs.update(over)
+    return dispatch.sample_stack_groups(
+        {f"s:{MODULE}": _members()}, _probe_rows(H), **kwargs)
+
+
+def test_the_default_draw_is_byte_for_byte_what_it_was():
+    """No ``sizes`` argument: the same record, serialised identically."""
+    dispatch, campaign = _dispatch(), _campaign()
+    entry = _sample(dispatch)[f"s:{MODULE}"]
+    record = entry["stack_samples"][PACKED]
+    expected = _expected_probe_record(campaign, n=3, seed=5, audit_rate=10)
+    assert json.dumps(record, sort_keys=True) == json.dumps(
+        expected, sort_keys=True)
+    # And spelling ``probe`` explicitly is the same run, not a second one.
+    explicit = _sample(dispatch, sizes="probe")[f"s:{MODULE}"]
+    assert json.dumps(explicit, sort_keys=True) == json.dumps(
+        entry, sort_keys=True)
+    # The absent-flag record carries no size declaration at all, which is what
+    # keeps a plan written today identical to the plans already on disk.
+    assert "sizes" not in record
+
+
+def test_a_counts_draw_follows_the_counts_and_declares_them():
+    """The vector that drove the draw is named, carried and digested."""
+    dispatch, campaign = _dispatch(), _campaign()
+    entry = _sample(dispatch, sizes="counts", census=_census())[f"s:{MODULE}"]
+    record = entry["stack_samples"][PACKED]
+    assert record["design"] == (record["draw"]["method"]
+                                + campaign.STACK_SAMPLE_COUNTS_SUFFIX)
+    assert record["design"].endswith("_counts")
+    sizes = record["sizes"]
+    assert sizes["source"] == "counts"
+    assert sizes["sha256"] == record["draw"]["size_sha256"]
+    assert sizes["values"] == {str(e): float(COUNTS_PER_EXPERT[e])
+                               for e in range(EXPERTS)}
+    # The draw followed the counts, not the Fisher vector: with H and
+    # COUNTS_PER_EXPERT anti-correlated, the two draws cannot coincide.
+    probe_draw = _sample(dispatch)[f"s:{MODULE}"]["stack_samples"][PACKED]
+    assert record["sampled_experts"] != probe_draw["sampled_experts"]
+    # The Fisher currency is untouched: the stack row still multiplies by the
+    # probe's own h_trace, whatever the draw was proportional to.
+    assert record["probe_row"]["h_trace_per_expert"] == [float(v) for v in H]
+
+
+def test_a_counts_draw_survives_the_campaign_rehydration():
+    """``selection_stack_samples`` replays it on the declared sizes."""
+    dispatch, campaign = _dispatch(), _campaign()
+    entry = _sample(dispatch, sizes="counts", census=_census())[f"s:{MODULE}"]
+    selection = {"groups": [{"key": f"s:{MODULE}", "members": _members(), **entry}]}
+    samples = campaign.selection_stack_samples(selection, _profile())
+    sample = samples[PACKED]
+    assert sample.design.endswith(campaign.STACK_SAMPLE_COUNTS_SUFFIX)
+    assert list(sample.sampled_experts) == entry["stack_samples"][PACKED][
+        "sampled_experts"]
+
+
+def test_a_record_whose_declared_digest_is_not_the_draws_is_refused():
+    """The digest is what binds the named vector to the one actually used."""
+    dispatch, campaign = _dispatch(), _campaign()
+    entry = _sample(dispatch, sizes="counts", census=_census())[f"s:{MODULE}"]
+    record = dict(entry["stack_samples"][PACKED])
+    record["sizes"] = {**record["sizes"], "sha256": "0" * 64}
+    selection = {"groups": [{"key": f"s:{MODULE}", "members": _members(),
+                             **{**entry, "stack_samples": {PACKED: record}}}]}
+    with pytest.raises(campaign.StackSampleError, match="size digest"):
+        campaign.selection_stack_samples(selection, _profile())
+
+
+def test_counts_without_a_census_is_refused():
+    """A size source that names the census needs the census."""
+    dispatch = _dispatch()
+    with pytest.raises(RuntimeError, match="needs the census"):
+        _sample(dispatch, sizes="counts")
+
+
+def test_a_missing_expert_count_is_refused_rather_than_drawn_at_zero():
+    """An absent count would give an expert inclusion probability zero."""
+    dispatch = _dispatch()
+    census = _census()
+    census["counts"].pop(f"{MODULE}.3.w1")
+    with pytest.raises(RuntimeError, match="no row count"):
+        _sample(dispatch, sizes="counts", census=census)
+
+
+def test_an_unknown_size_source_is_refused():
+    dispatch = _dispatch()
+    with pytest.raises(RuntimeError, match="not one of"):
+        _sample(dispatch, sizes="h_trace", census=_census())

--- a/tests/test_tessera_stack_transfer_law.py
+++ b/tests/test_tessera_stack_transfer_law.py
@@ -1,0 +1,238 @@
+"""The stack transfer law: does it recover a known slope, and what is its error?
+
+RobTand/prismaquant#495 part 2.  The law predicts a packed routed stack's cost
+at the rungs it did NOT census, from the rung it did plus a small expert
+sample.  ``docs/results/glm_tessera_probe_reduction_regret_2026-09-10.md``
+section 3.2 defines it (schedule ``b_law``) and section 3.4 point 3 is why the
+slope may be pooled across stacks at all.
+
+The study's own per-expert rows live inside the frozen campaign workspace and
+are not reachable from a test, so the fixture here is synthetic with slopes
+that are known by construction -- which is the stronger check anyway: a fit
+that recovers a planted slope and a prediction that lands inside its own
+declared error are both falsifiable statements, and neither is available from
+a summary table.
+"""
+import math
+import random
+
+import pytest
+
+from prismaquant.tessera_rate_surface import (
+    STACK_TRANSFER_REFERENCE_Q256,
+    StackRateSample,
+    fit_stack_transfer_law,
+    predict_stack_rates,
+)
+from prismaquant.tessera_formats import TesseraFormatError
+
+#: The campaign's three rungs.  832 and 1088 are what the schedule stops
+#: censusing; 960 is the reference every prediction regresses on.
+REFERENCE = STACK_TRANSFER_REFERENCE_Q256
+TARGETS = (832, 1088)
+PROJECTIONS = ("gate_proj", "up_proj", "down_proj")
+
+#: The planted law, per (projection, rate).  Slopes near 1 with a level shift
+#: is the shape the study measured: a lower rung costs more, and the
+#: cross-expert ordering is nearly preserved.
+PLANTED = {
+    832: {"gate_proj": (1.06, 1.40), "up_proj": (1.03, 1.25),
+          "down_proj": (0.97, 1.55)},
+    1088: {"gate_proj": (0.94, -1.30), "up_proj": (0.98, -1.10),
+           "down_proj": (1.02, -1.45)},
+}
+
+
+def _stack(name, *, base, sampled, noise, rng, level=0.0):
+    """One stack whose experts obey ``PLANTED`` up to log2 noise of ``noise``.
+
+    ``base`` is a per-projection vector of log2 reference values shared by every
+    stack and PERMUTED per stack, so each stack has its own per-expert ordering
+    while all stacks share one mean reference level.  That is deliberate: the
+    pooled fit centres on a single mean over all the pooled stacks, so a
+    per-stack intercept that correlates with a per-stack mean reference level
+    biases the slope (see ``fit_stack_transfer_law``).  Holding the level common
+    and letting ``level`` move only the intercept isolates the property under
+    test -- the slope -- from that known sensitivity, which has its own test.
+    """
+    experts = len(base[PROJECTIONS[0]])
+    order = {projection: rng.sample(range(experts), experts)
+             for projection in PROJECTIONS}
+    reference = {
+        expert: {projection: 2.0 ** base[projection][order[projection][expert]]
+                 for projection in PROJECTIONS}
+        for expert in range(experts)}
+    sampled_mse = {}
+    for rate in TARGETS:
+        sampled_mse[rate] = {}
+        for expert in range(experts):
+            row = {}
+            for projection in PROJECTIONS:
+                slope, intercept = PLANTED[rate][projection]
+                row[projection] = 2.0 ** (
+                    intercept + level
+                    + slope * math.log2(reference[expert][projection])
+                    + rng.gauss(0.0, noise))
+            sampled_mse[rate][expert] = row
+    return StackRateSample(
+        stack=name,
+        projections=PROJECTIONS,
+        experts=tuple(range(experts)),
+        weights=None,
+        reference_q256=REFERENCE,
+        reference_mse=reference,
+        sampled_experts=tuple(sorted(sampled)),
+        sampled_mse=sampled_mse,
+        currency="output_mse_under_route_activation_contract",
+    )
+
+
+def _truth_total(stack, rate):
+    """The weighted total the census would have measured at ``rate``."""
+    return math.fsum(
+        stack.weight(expert) * math.fsum(
+            float(stack.sampled_mse[rate][expert][projection])
+            for projection in stack.projections)
+        for expert in stack.experts)
+
+
+def _base(rng, experts):
+    """One shared per-projection vector of log2 reference values."""
+    return {projection: [-9.0 + 0.35 * index + rng.gauss(0.0, 1.1)
+                         for _ in range(experts)]
+            for index, projection in enumerate(PROJECTIONS)}
+
+
+@pytest.fixture
+def population():
+    """Twelve stacks of 48 experts, 9 of them sampled -- the study's 3%-ish.
+
+    The held-out stack keeps its full frame at both target rungs so the test
+    can compare against a truth the law never saw; a production stack would
+    only ever hold the 9.
+    """
+    rng = random.Random(20260911)
+    base = _base(rng, 48)
+    stacks = {}
+    for index in range(12):
+        sampled = rng.sample(range(48), 9)
+        stacks[f"s:layer{index}"] = _stack(
+            f"s:layer{index}", base=base, sampled=sampled, noise=0.05,
+            rng=rng, level=0.03 * (index - 5.5))
+    return stacks
+
+
+def test_the_pooled_fit_recovers_the_planted_slopes(population):
+    """A slope pooled over eleven stacks lands on the one that generated them."""
+    law = fit_stack_transfer_law(population, hold_out="s:layer0")
+    assert law.reference_q256 == REFERENCE
+    assert law.target_q256 == TARGETS
+    assert "s:layer0" not in law.pooled_stacks
+    assert len(law.pooled_stacks) == 11
+    for rate in TARGETS:
+        # 11 stacks x 9 sampled experts.
+        assert law.pooled_rows[rate] == 99
+        for projection in PROJECTIONS:
+            planted = PLANTED[rate][projection][0]
+            assert law.slope[rate][projection] == pytest.approx(planted, abs=0.02)
+            # The residual carries the planted per-expert noise (0.05 log2) AND
+            # the between-stack intercept spread the pooled centring cannot
+            # absorb (sd ~0.1), so it is conservative by construction -- which
+            # is the direction an error field may err in.
+            assert 0.05 < law.residual_sd_log2[rate][projection] < 0.25
+
+
+def test_the_prediction_lands_inside_its_own_declared_model_error(population):
+    """Leave one stack out, predict its two rungs, check against the truth.
+
+    The claim being tested is the one the row will carry: the stack TOTAL's
+    error is the common-mode intercept term, so the realised |log2| error must
+    sit inside a few of those, not inside the per-expert residual.
+    """
+    for held_out, stack in sorted(population.items()):
+        law = fit_stack_transfer_law(population, hold_out=held_out)
+        result = predict_stack_rates(stack, law)
+        assert sorted(result["predicted"]) == list(TARGETS)
+        assert result["intercept_sample_size"] == 9
+        for rate in TARGETS:
+            truth = _truth_total(stack, rate)
+            error = abs(math.log2(result["predicted"][rate] / truth))
+            declared = result["model_error"][rate]["stack_total_sd_log2"]
+            assert declared > 0.0
+            assert error <= 3.0 * declared, (
+                f"{held_out} rung {rate}: |log2 pred/true| {error} exceeds "
+                f"three declared model sd ({declared})")
+            # And the prediction is actually good, not merely inside a
+            # generous bar: 9 experts fit this stack's own intercept, whose
+            # standard error is the planted 0.05 log2 over sqrt(9).
+            assert error <= 0.06, (
+                f"{held_out} rung {rate}: |log2 pred/true| {error}")
+
+
+def test_the_model_error_names_itself_and_denies_being_a_sampling_error(population):
+    """A reader, and a gate, must not be able to mistake it for an HT stderr."""
+    law = fit_stack_transfer_law(population, hold_out="s:layer3")
+    result = predict_stack_rates(population["s:layer3"], law)
+    for rate in TARGETS:
+        error = result["model_error"][rate]
+        assert error["kind"] == "transfer_law_model_error_log2"
+        assert error["is_sampling_error"] is False
+        assert set(error["per_expert_residual_sd_log2"]) == set(PROJECTIONS)
+        # The common-mode term is the per-expert one shrunk by sqrt(n): it is
+        # a different number, and smaller, for every stack in this fixture.
+        assert error["stack_total_sd_log2"] < min(
+            error["per_expert_residual_sd_log2"].values())
+        # Reported, never applied.
+        assert error["smearing_factor_not_applied"] > 1.0
+    assert "dloss_stderr" not in result
+    assert "estimator" not in result
+
+
+def test_a_law_refuses_to_predict_the_stack_it_pooled(population):
+    """Fitting without a hold-out and then predicting a member is refused."""
+    law = fit_stack_transfer_law(population)
+    with pytest.raises(TesseraFormatError, match="pooled this stack's own experts"):
+        predict_stack_rates(population["s:layer5"], law)
+    other = fit_stack_transfer_law(population, hold_out="s:layer5")
+    with pytest.raises(TesseraFormatError, match="held out"):
+        predict_stack_rates(population["s:layer6"], other)
+
+
+def test_a_stack_whose_reference_is_not_a_census_is_refused():
+    """Every expert is predicted from its own reference value, so all are needed."""
+    rng = random.Random(7)
+    stack = _stack("s:layer0", base=_base(rng, 6), sampled=[0, 1, 2],
+                   noise=0.01, rng=rng)
+    partial = dict(stack.reference_mse)
+    partial.pop(5)
+    with pytest.raises(TesseraFormatError, match="must be a census"):
+        StackRateSample(
+            stack=stack.stack, projections=stack.projections,
+            experts=stack.experts, reference_q256=REFERENCE,
+            reference_mse=partial, sampled_experts=stack.sampled_experts,
+            sampled_mse=stack.sampled_mse, currency=stack.currency)
+
+
+def test_weights_reproduce_the_campaign_total_convention(population):
+    """``sum_e w_e * sum_p mse`` -- the same product the HT path estimates."""
+    stack = population["s:layer1"]
+    weighted = StackRateSample(
+        stack=stack.stack, projections=stack.projections,
+        experts=stack.experts, reference_q256=REFERENCE,
+        reference_mse=stack.reference_mse,
+        sampled_experts=stack.sampled_experts, sampled_mse=stack.sampled_mse,
+        weights={e: 2.0 + e for e in stack.experts}, currency=stack.currency)
+    assert weighted.reference_total() == pytest.approx(math.fsum(
+        (2.0 + e) * math.fsum(stack.reference_mse[e][p] for p in PROJECTIONS)
+        for e in stack.experts))
+    law = fit_stack_transfer_law(population, hold_out=stack.stack)
+    plain = predict_stack_rates(stack, law)
+    scaled = predict_stack_rates(weighted, law)
+    for rate in TARGETS:
+        # The per-expert predictions do not depend on the weights; only the
+        # total does, and it does so exactly linearly.
+        assert scaled["predicted_per_expert"][rate] == pytest.approx(
+            plain["predicted_per_expert"][rate])
+        assert scaled["predicted"][rate] == pytest.approx(math.fsum(
+            (2.0 + e) * plain["predicted_per_expert"][rate][e]
+            for e in stack.experts))

--- a/tests/test_tessera_stack_transfer_law_rows.py
+++ b/tests/test_tessera_stack_transfer_law_rows.py
@@ -1,0 +1,258 @@
+"""Provenance on a two-tier stack: what a model-predicted row may and may not say.
+
+RobTand/prismaquant#495 part 3.  Under the schedule
+``docs/results/glm_tessera_probe_reduction_regret_2026-09-10.md`` section 5
+proposes, a routed stack is censused at one rung and sampled at the other two;
+the sampled rungs are then PREDICTED for every expert by the transfer law.
+
+Three claims are pinned here, and the third is the one that has teeth:
+
+* the censused rung is a measurement and says so
+  (``cost_source: tessera_campaign_measured``);
+* a predicted rung says it is a prediction
+  (``PROVENANCE_INTERPOLATED`` + ``cost_source: tessera_campaign_interpolated``)
+  and carries the whole law it was predicted by;
+* a predicted rung carries NEITHER ``dloss_stderr`` NOR
+  ``estimator: horvitz_thompson``.  Those describe the variance of a sampling
+  design over repeated draws.  A regression's output has no such variance, and
+  stamping one on it would let a reader -- or a UCB hedge that later learns to
+  read the field -- treat a model error as a measured spread.  The old code
+  built an interpolated row's ``sampled_experts`` block by subtracting
+  ``members`` from the measured row's, which carried ``estimator`` straight
+  onto it; the block is now built from an allowlist.
+"""
+from __future__ import annotations
+
+import math
+from types import SimpleNamespace
+
+import pytest
+
+MODULE_A = "model.layers.7.feed_forward.experts"
+MODULE_B = "model.layers.8.feed_forward.experts"
+#: The campaign's three rungs.  960 is censused; 832 and 1088 are predicted.
+REFERENCE = 960
+TARGETS = (832, 1088)
+#: The transfer-law draw: the experts that were also encoded at 832 and 1088.
+LAW_EXPERTS = (0, 2, 5, 7)
+EXPERTS = 12
+
+
+def _campaign():
+    return pytest.importorskip("prismaquant.tessera_campaign")
+
+
+def _profile():
+    from prismaquant.model_profiles.lfm2_moe import Lfm2MoeProfile
+    return Lfm2MoeProfile()
+
+
+def _probe_row(module, per_expert):
+    return {
+        "h_trace": float(math.fsum(per_expert)),
+        "h_trace_per_expert": [float(v) for v in per_expert],
+        "num_experts": len(per_expert),
+        "_packed_experts_module": module,
+        "_packed_param": "gate_up_proj",
+        "out_features": 8, "in_features": 4,
+        "n_params": len(per_expert) * 32,
+        "router_path": None, "expert_id": None,
+    }
+
+
+def _anchor(campaign, qname, q256, dloss):
+    return campaign.CampaignAnchor(
+        qname=qname, family="TESSERA_E2M1_K1",
+        format_name=f"TESSERA_E2M1_K1_R{q256}", body_rate_q256=q256,
+        dloss=float(dloss), dloss_stderr=0.0, memory_bytes=1024,
+        bits_per_param=4.0, activation_contract="bfloat16",
+        activation_quantized=False, wire_bytes=1100, seconds=1.0,
+        hessian_applied=True, input_global_scale=None)
+
+
+#: The law the fixture's experts obey exactly, per (rung, projection).  Exact
+#: rather than noisy so the assertions are about the WIRING -- which rows get
+#: written, with which provenance -- and not about a fit's luck; the fit's own
+#: statistics are tested in ``test_tessera_stack_transfer_law.py``.
+PLANTED = {832: {"w1": (1.05, 1.30), "w3": (0.95, 1.45)},
+           1088: {"w1": (0.96, -1.20), "w3": (1.04, -1.35)}}
+
+
+def _stack(campaign, module, *, offset, anchors):
+    """One two-tier stack: a 960 census, plus 832/1088 on the law draw only."""
+    h = [1.0 + 0.3 * expert for expert in range(EXPERTS)]
+    reference = {}
+    for expert in range(EXPERTS):
+        for index, role in enumerate(("w1", "w3")):
+            qname = f"{module}.{expert}.{role}"
+            value = 2.0 ** (-8.0 + offset + 0.21 * expert + 0.37 * index)
+            reference[(expert, role)] = value
+            anchors[qname] = {"TESSERA_E2M1_K1": [
+                _anchor(campaign, qname, REFERENCE, value)]}
+    for expert in LAW_EXPERTS:
+        for role in ("w1", "w3"):
+            qname = f"{module}.{expert}.{role}"
+            for rung in TARGETS:
+                slope, intercept = PLANTED[rung][role]
+                anchors[qname]["TESSERA_E2M1_K1"].append(_anchor(
+                    campaign, qname, rung,
+                    2.0 ** (intercept
+                            + slope * math.log2(reference[(expert, role)]))))
+    sample = campaign.stack_sample_from_probe(
+        f"{module}.gate_up_proj", _probe_row(module, h), _profile(),
+        sampled_experts=range(EXPERTS),
+        inclusion_prob={e: 1.0 for e in range(EXPERTS)}, seed=11,
+        design="census", transfer_law_experts=LAW_EXPERTS)
+    return sample, reference
+
+
+@pytest.fixture
+def payload():
+    """Two two-tier stacks, so each can be predicted by a law that held it out."""
+    campaign = _campaign()
+    anchors: dict = {}
+    samples = {}
+    for index, module in enumerate((MODULE_A, MODULE_B)):
+        sample, _ = _stack(campaign, module, offset=1.4 * index, anchors=anchors)
+        samples[sample.packed_qname] = sample
+    built = campaign.campaign_cost_payload(
+        anchors, {}, loo={},
+        provenance={"provenance": {"hessian": {"supplied": True}}},
+        stack_samples=samples)
+    return built
+
+
+def _rows(payload, module):
+    return payload["costs"][f"{module}.gate_up_proj"]
+
+
+def test_the_censused_rung_is_a_measurement(payload):
+    """960 covers every expert with certainty, so it is a census, not a sample."""
+    row = _rows(payload, MODULE_A)[f"TESSERA_E2M1_K1_R{REFERENCE}"]
+    assert row["cost_source"] == "tessera_campaign_measured"
+    assert row["output_mse_measured"] is True
+    assert row["tessera_provenance"] == "measured"
+    assert row["tessera_body_rate_q256"] == REFERENCE
+    # A census has an exactly-zero sampling error, and says which estimator
+    # produced it -- that is legitimate here, and only here.
+    assert row["dloss_stderr"] == 0.0
+    assert row["sampled_experts"]["estimator"] == "horvitz_thompson"
+    assert "transfer_law" not in row
+
+
+def test_a_drawn_rung_keeps_the_sampled_cost_source():
+    """A one-tier draw is an estimate and must not borrow the census spelling."""
+    campaign = _campaign()
+    h = [1.0 + expert for expert in range(4)]
+    anchors = {}
+    for expert in range(4):
+        for role in ("w1", "w3"):
+            qname = f"{MODULE_A}.{expert}.{role}"
+            anchors[qname] = {"TESSERA_E2M1_K1": [
+                _anchor(campaign, qname, REFERENCE, 0.01 * (expert + 1))]}
+    sample = campaign.stack_sample_from_probe(
+        f"{MODULE_A}.gate_up_proj", _probe_row(MODULE_A, h), _profile(),
+        sampled_experts=[0, 1, 2, 3],
+        inclusion_prob={0: 1.0, 1: 0.5, 2: 0.5, 3: 1.0}, seed=3)
+    built = campaign.campaign_cost_payload(
+        anchors, {}, loo={},
+        provenance={"provenance": {"hessian": {"supplied": True}}},
+        stack_samples={sample.packed_qname: sample})
+    row = built["costs"][f"{MODULE_A}.gate_up_proj"][
+        f"TESSERA_E2M1_K1_R{REFERENCE}"]
+    assert row["cost_source"] == "tessera_campaign_measured_stack_sample"
+
+
+@pytest.mark.parametrize("rung", TARGETS)
+def test_a_predicted_rung_declares_the_law_it_was_predicted_by(payload, rung):
+    """The whole law travels on the row: slopes, intercepts, ids, n, spread."""
+    from prismaquant.allocator_candidates import TESSERA_INTERPOLATED_COST_SOURCE
+    from prismaquant.tessera_rate_surface import PROVENANCE_INTERPOLATED
+
+    row = _rows(payload, MODULE_A)[f"TESSERA_E2M1_K1_R{rung}"]
+    assert row["cost_source"] == TESSERA_INTERPOLATED_COST_SOURCE
+    assert row["tessera_provenance"] == PROVENANCE_INTERPOLATED
+    assert row["output_mse_measured"] is False
+
+    law = row["transfer_law"]
+    assert law["predicted_q256"] == rung
+    assert law["reference_q256"] == REFERENCE
+    assert law["held_out"] == f"{MODULE_A}.gate_up_proj"
+    assert law["pooled_stacks"] == [f"{MODULE_B}.gate_up_proj"]
+    assert law["n"] == len(LAW_EXPERTS)
+    assert law["sample_experts"] == list(LAW_EXPERTS)
+    assert set(law["slope"][str(rung)]) == {"w1", "w3"}
+    assert set(law["intercept"]) == {"w1", "w3"}
+    assert set(law["residual_sd_log2"][str(rung)]) == {"w1", "w3"}
+    assert law["model_error"]["kind"] == "transfer_law_model_error_log2"
+    assert law["model_error"]["is_sampling_error"] is False
+    # The fixture's experts obey the planted law exactly, so the pooled slope
+    # is that law's and the prediction is the truth to floating point.
+    for role in ("w1", "w3"):
+        assert law["slope"][str(rung)][role] == pytest.approx(
+            PLANTED[rung][role][0], abs=1e-9)
+
+
+@pytest.mark.parametrize("rung", TARGETS)
+def test_a_predicted_rung_carries_no_sampling_estimator(payload, rung):
+    """The refusal this whole part exists for.
+
+    ``dloss_stderr`` and ``estimator: horvitz_thompson`` describe a draw.  This
+    value came from a regression over every expert's own censused reference,
+    not from a draw standing in for the stack, so neither field may appear --
+    at the top level or anywhere inside the block that describes the draw.
+    """
+    row = _rows(payload, MODULE_A)[f"TESSERA_E2M1_K1_R{rung}"]
+    assert "dloss_stderr" not in row
+    assert "dloss_stderr_currency" not in row
+    assert "estimator" not in row
+    block = row["sampled_experts"]
+    assert "estimator" not in block
+    assert "variance_estimator" not in block
+    assert "dloss_stderr" not in block
+    assert "n_random_stratum" not in block
+    # The draw is still described -- which experts, under what probability --
+    # because the intercept was fitted on them.
+    assert block["transfer_law_experts"] == list(LAW_EXPERTS)
+    assert block["design"] == "census"
+    assert set(block["inclusion_prob"]) == set(range(EXPERTS))
+
+
+def test_the_interpolated_surface_row_also_carries_no_estimator():
+    """The pre-existing stack interpolation path had the same leak.
+
+    Two measured rungs over one draw give a ``TesseraRateSurface``, and its
+    interpolated rows used to inherit ``estimator`` by subtraction.  Same rule:
+    a value no estimator produced may not name one.
+    """
+    campaign = _campaign()
+    h = [1.0 + expert for expert in range(4)]
+    anchors = {}
+    for expert in range(4):
+        for role in ("w1", "w3"):
+            qname = f"{MODULE_A}.{expert}.{role}"
+            anchors[qname] = {"TESSERA_E2M1_K1": [
+                _anchor(campaign, qname, 832, 0.02 * (expert + 1)),
+                _anchor(campaign, qname, 1088, 0.01 * (expert + 1))]}
+    sample = campaign.stack_sample_from_probe(
+        f"{MODULE_A}.gate_up_proj", _probe_row(MODULE_A, h), _profile(),
+        sampled_experts=[0, 1, 2, 3],
+        inclusion_prob={0: 1.0, 1: 0.5, 2: 0.5, 3: 1.0}, seed=3)
+    # The three fields ``_stack_menu`` and the interpolation loop read; a real
+    # ``MenuRung`` would drag a route admission and a TP gate into a test about
+    # provenance.
+    rungs = [SimpleNamespace(
+        family="TESSERA_E2M1_K1", format_name=f"TESSERA_E2M1_K1_R{REFERENCE}",
+        body_rate_q256=REFERENCE,
+        admission=SimpleNamespace(activation_contract="bfloat16"))]
+    built = campaign.campaign_cost_payload(
+        anchors, {f"{MODULE_A}.gate_up_proj": rungs}, loo={},
+        provenance={"provenance": {"hessian": {"supplied": True}}},
+        stack_samples={sample.packed_qname: sample})
+    row = built["costs"][f"{MODULE_A}.gate_up_proj"].get(
+        f"TESSERA_E2M1_K1_R{REFERENCE}")
+    assert row is not None, "the surface must price the bracketed rung"
+    assert row["cost_source"] == "tessera_campaign_interpolated"
+    assert "dloss_stderr" not in row
+    assert "estimator" not in row["sampled_experts"]
+    assert "variance_estimator" not in row["sampled_experts"]

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -554,18 +554,68 @@ def load_probe_h_trace(path) -> dict:
             if isinstance(row, dict) and row.get("_packed_experts_module")}
 
 
+def stack_expert_counts(census, frame) -> dict:
+    """Per-expert routed-row counts from the census, summed over projections.
+
+    The census counts every unit's calibration rows, so an expert's size is
+    the sum over its projections.  It is a routed-token proxy for ``h_trace``
+    and this function never calls it one: the caller records which vector a
+    draw was proportional to (``design``, ``sizes.source``), because "we drew
+    proportional to counts" and "we drew proportional to Fisher" are different
+    designs with different variance arguments, and only one of them needs a
+    probe to exist.
+    """
+    counts = census.get("counts") or {}
+    sizes = {}
+    for expert, members in sorted(frame.members.items()):
+        missing = [m for m in members if m not in counts]
+        if missing:
+            raise RuntimeError(
+                f"{frame.packed_qname}: the census has no row count for "
+                f"{missing[0]}; --stack-sample-sizes counts needs every "
+                "expert's own count, and a missing one would draw it with "
+                "probability zero")
+        sizes[str(int(expert))] = float(sum(int(counts[m]) for m in members))
+    if not any(value > 0.0 for value in sizes.values()):
+        raise RuntimeError(
+            f"{frame.packed_qname}: every expert's routed-row count is zero; "
+            "there is no size to draw proportional to")
+    return sizes
+
+
 def sample_stack_groups(groups, probe_rows, *, profile, stack_sample: int,
-                        seed: int, audit_rate: int) -> dict:
+                        seed: int, audit_rate: int, sizes: str = "probe",
+                        census=None) -> dict:
     """Draw once per profile-defined packed parameter, across all its roles.
 
     The same expert IDs and full-frame inclusion probabilities are persisted
     for every projection and rung. The original probe remains the allocator
     input; no per-expert expansion changes its topology or Fisher currency.
+
+    ``sizes`` chooses what the PPS draw is proportional to.  ``probe`` is the
+    per-expert Fisher vector and is the default, so a plan written without the
+    flag is byte-identical to every plan written before it.  ``counts`` draws
+    on the census's per-expert routed-row counts instead, which is the only
+    per-expert size that exists when a model has no probe with
+    ``h_trace_per_expert`` -- the case the sampling path was written for and
+    could not run on (RobTand/prismaquant#495 part 1).  A ``counts`` draw
+    declares itself: ``design`` gains a ``_counts`` suffix and the record
+    carries the size vector and its digest, so nothing has to infer from an
+    inclusion probability which vector produced it.
     """
     from prismaquant.tessera_campaign import (
+        STACK_SAMPLE_COUNTS_SUFFIX, STACK_SAMPLE_SIZE_SOURCES,
         audit_subsample, draw_stack_sample, stack_sample_from_probe,
         _validate_stack_sample, selection_stack_samples)
 
+    if sizes not in STACK_SAMPLE_SIZE_SOURCES:
+        raise RuntimeError(
+            f"--stack-sample-sizes {sizes}: not one of "
+            f"{list(STACK_SAMPLE_SIZE_SOURCES)}")
+    if sizes == "counts" and census is None:
+        raise RuntimeError(
+            "--stack-sample-sizes counts needs the census: the per-expert "
+            "sizes are its routed-row counts")
     sampled = {}
     for key, members in sorted(groups.items()):
         if not str(key).startswith("s:"):
@@ -579,9 +629,13 @@ def sample_stack_groups(groups, probe_rows, *, profile, stack_sample: int,
                 inclusion_prob={e: 1.0 for e in range(int(row["num_experts"]))},
                 seed=seed, design="census")
             _validate_stack_sample(frame)
-            draw = draw_stack_sample(
-                {str(e): h for e, h in enumerate(frame.h_trace_per_expert)},
-                stack_sample, seed=seed, stack=name)
+            if sizes == "counts":
+                size_vector = stack_expert_counts(census, frame)
+            else:
+                size_vector = {str(e): h
+                               for e, h in enumerate(frame.h_trace_per_expert)}
+            draw = draw_stack_sample(size_vector, stack_sample, seed=seed,
+                                     stack=name)
             audit_ids = audit_subsample(draw["units"], rate=audit_rate,
                                        seed=seed, stack=name)
             experts = sorted(int(e) for e in draw["units"])
@@ -597,8 +651,16 @@ def sample_stack_groups(groups, probe_rows, *, profile, stack_sample: int,
             records[name] = {
                 "probe_row": probe_row, "sampled_experts": experts,
                 "inclusion_prob": dict(draw["inclusion_probability"]),
-                "seed": seed, "design": draw["method"], "draw": draw,
+                "seed": seed,
+                "design": (draw["method"] if sizes == "probe"
+                           else draw["method"] + STACK_SAMPLE_COUNTS_SUFFIX),
+                "draw": draw,
                 "audit_experts": sorted(int(e) for e in audit_ids),
+                # Written only for a non-default size source, so a probe-sized
+                # plan stays byte-identical to the ones already on disk.
+                **({} if sizes == "probe" else {"sizes": {
+                    "source": sizes, "sha256": draw["size_sha256"],
+                    "values": dict(size_vector)}}),
             }
             for expert, names in frame.members.items():
                 for member in names:
@@ -691,15 +753,16 @@ def cmd_plan(args) -> int:
 
     stack_sample: dict[str, dict] = {}
     if args.stack_sample is not None:
+        size_source = getattr(args, "stack_sample_sizes", "probe") or "probe"
         if not args.probe:
             raise RuntimeError(
-                "--stack-sample needs --probe: the draw is proportional to "
-                "the packed probe's per-expert h_trace")
+                "--stack-sample needs --probe: the stack row's currency is the "
+                "packed probe's h_trace, whatever the draw is proportional to")
         from prismaquant.model_profiles import detect_profile
         stack_sample = sample_stack_groups(
             groups, load_probe_h_trace(args.probe), profile=detect_profile(spec["model"]),
             stack_sample=int(args.stack_sample), seed=int(args.stack_sample_seed),
-            audit_rate=int(args.audit_rate))
+            audit_rate=int(args.audit_rate), sizes=size_source, census=census)
         priced = sum(len(entry["sampled"]) for entry in stack_sample.values())
         frame = sum(len(groups[key]) for key in stack_sample)
         print(f"[dispatch] sampled {priced} of {frame} routed expert units "
@@ -824,6 +887,13 @@ def cmd_plan(args) -> int:
             "seed": int(args.stack_sample_seed),
             "audit_rate": int(args.audit_rate),
             "probe": (None if not args.probe else str(args.probe)),
+            # Which per-expert vector the draw was proportional to, written
+            # only when it is not the probe's Fisher vector -- so a plan made
+            # without the flag is byte-identical to the ones already on disk,
+            # and an absent field means ``probe`` exactly as an absent
+            # ``sizes`` block on a record does.
+            **({} if (getattr(args, "stack_sample_sizes", "probe") or "probe")
+               == "probe" else {"sizes": args.stack_sample_sizes}),
             "stacks": stack_sample,
         },
         "rows": planned,
@@ -1620,6 +1690,14 @@ def main(argv=None) -> int:
                       help="price each routed stack from this many experts "
                            "per role, drawn proportional to the probe's "
                            "h_trace. Unset prices every expert.")
+    plan.add_argument("--stack-sample-sizes", choices=("probe", "counts"),
+                      default="probe",
+                      help="what the PPS draw is proportional to: the probe's "
+                           "per-expert h_trace (the default, and what every "
+                           "plan on disk used), or the census's per-expert "
+                           "routed-row counts. counts is a routed-token proxy "
+                           "for h_trace, not h_trace; the draw records which "
+                           "one it used and the digest of the vector.")
     plan.add_argument("--stack-sample-seed", type=int, default=0,
                       help="the draw's seed; the same seed and the same probe "
                            "draw the same experts.")


### PR DESCRIPTION
Refs #495

Parts **1, 2 and 3** of the routed-stack probe-reduction schedule, implemented
against §5 of `docs/results/glm_tessera_probe_reduction_regret_2026-09-10.md`.
Parts **4** (selective encode of the allocated winners) and **5** (the repair
loop and its regret gate) are **not** in this PR.

## What lands

**Part 1 — a size source that does not need a probe.**
`dispatch_tessera_campaign.py plan --stack-sample-sizes {probe,counts}` chooses
the per-expert vector the PPS draw is proportional to. `probe` is the default,
and a plan written without the flag is byte-identical to the plans already on
disk — demonstrated, not asserted: `tests/test_tessera_stack_sample_sizes.py`
rebuilds the pre-change record from the campaign's own primitives
(`stack_sample_from_probe` + `draw_stack_sample` + `audit_subsample`) and
compares `json.dumps(..., sort_keys=True)`. `counts` draws on the census's
per-expert routed-row counts — the only per-expert size that exists on a model
with no `h_trace_per_expert`, which is why the sampling path was unreachable on
GLM-5.3-Flash. A `counts` record names the source, carries the vector and its
digest, and suffixes `design` with `_counts`; `selection_stack_samples` replays
the draw on the declared vector and refuses a record whose declared digest is
not the digest of the draw it carries.

**Part 2 — the transfer law.** `prismaquant/tessera_rate_surface.py` gains
`fit_stack_transfer_law(stacks_measured, hold_out)` — pooled per-projection OLS
slopes of `log2 mse(rate)` on `log2 mse(960)` over every stack but the held-out
one — and `predict_stack_rates(stack, law)`, which fits that stack's own
per-projection intercept from its sampled experts and returns the two predicted
stack costs (832, 1088) plus a model-error field. `TesseraRateSurface` is
untouched: dense units keep three anchors.

The model error reports the **common-mode intercept term** as the stack total's
error, because the intercept is shared by every expert and does not average away
over E, while the per-expert residual largely does. Both terms are reported,
under names that cannot be read as each other, and the error declares
`is_sampling_error: False`. No Duan smearing correction is applied — the regret
the study measured is this uncorrected estimator's — and the factor is reported
so its size is visible.

**Part 3 — provenance that does not lie.**
* A rung encoded on **every** expert of the frame writes
  `cost_source: tessera_campaign_measured`: it is a census, its Horvitz–Thompson
  variance is an exact zero, and the sampled spelling described a draw that did
  not happen.
* A rung encoded only on the transfer-law draw is written
  `PROVENANCE_INTERPOLATED` / `cost_source: tessera_campaign_interpolated` with
  a populated `transfer_law` block (slopes, pooled stacks, held-out stack,
  intercepts, sample ids, n, residual sd, model error) and carries **neither**
  `dloss_stderr` **nor** `estimator: horvitz_thompson`.
* The pre-existing stack interpolation path was leaking `estimator` onto its
  rows by building their `sampled_experts` block by subtracting `members` from
  the measured block; it is now built from an explicit allowlist. A test fails
  if either field reappears on any predicted row.

`docs/ARCHITECTURE.md` is re-stamped in the same commit (principle 13), with a
new debt row **D36**.

## Evidence

Full PrismaQuant suite through PrismaBuild on x86 (dl380g10, `pq-cpu312`,
8 shards × 4 workers, `--priority -10`), on this branch's head
`0a4cbf30be`:

| shard | result |
|---|---|
| 0 | ok — 1182 passed, 10 skipped, 56 warnings in 212.91s |
| 1 | ok — 952 passed, 38 skipped, 2 xfailed, 14 subtests passed in 428.71s |
| 2 | ok — 915 passed, 6 skipped in 711.77s |
| 3 | **rc=1** — 5 failed, 865 passed, 7 skipped in 69.67s |
| 4 | ok — 857 passed, 28 skipped in 98.44s |
| 5 | ok — 984 passed, 15 skipped, 163 subtests passed in 61.24s |
| 6 | ok — 911 passed, 8 skipped, 13 subtests passed in 386.62s |
| 7 | ok — 996 passed, 82 skipped, 1 xfailed, 2 subtests passed in 213.30s |

Shard 3's five failures are all in `tests/test_tessera_hessian_reference_handoff.py`
(`ActivationSource.__init__() got an unexpected keyword argument
'resident_hessians'`) and are **pre-existing on x86**: dl380g10's `pq-cpu312`
Tessera predates the frozen producer `d403cc5a31`. They were reproduced on the
unmodified base before any of this work.

Queue rows: `/mnt/shared/prismabuild-fleet/pb-queue/done|failed/<action_key>.json`;
receipts `/mnt/shared/prismabuild-fleet/cas/actions/v3/<2>/<action_key>.json`.
Action keys: `12c91bb1c473…`, `350166029820…`, `362616fa9100…`, `778f74df8387…`,
`937965e4a564…`, `a31124fd2e14…`, `ee769398648d…`, and the failing shard
`f4d88c96fb09…` (no cached action entry — non-zero exit is not cached).

## What §5 gets wrong, and what is not delivered

* §5 calls `prismaquant/tessera_rate_surface.py` a **new** module. It already
  existed (559 lines) for dense units; the law is added to it.
* §5's literal `design: "pps_wor_counts"` is not a string this code can write.
  `design` carries the draw's own method name
  (`randomized_systematic_pps_with_take_all_v1`), so the suffix is appended to
  that rather than replacing it; the test pins
  `record["design"] == record["draw"]["method"] + "_counts"`.
* **`--stack-sample` still requires `--probe`** (debt D36). A stack row's
  weights are the probe's Fisher vector, and there is no declared convention for
  a stack row whose weights are not Fisher; writing counts into
  `h_trace_per_expert` would launder a routed-token proxy into the Fisher
  currency. So §5's "so it can run without a probe" is **not** delivered here —
  it needs a weight convention the cost row, the allocator's `predicted_dloss`
  branch and the HT estimator all agree on.
* **Nothing emits a two-tier schedule yet** (debt D36). `transfer_law_experts`
  is honoured by `selection_stack_samples` and `_stack_cost_rows`, but no
  planner writes it: `round_one_rates` is part 4/5 work, so the two-tier path is
  reachable only from a hand-built sample.
* The census `cost_source` change is a truthfulness fix, **not** an unblocking
  one: `tessera_joint_aura.load_measured_anchor_input` matches the cost roster
  against the census's source units and a stack's cost key is the packed qname,
  so debt D35(iii) is still what stands between a census stack and joint AURA.
  An earlier draft of this branch claimed otherwise; the doc, the code comment
  and the commit message all say the true thing now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsJsJGJtE4CYHE9QKyRyiz



Closes #500
Refs #495 (parts 4-5 remain open there)
