### PR TITLE
Quality-prefill milestones 2, 5.2 and 5.4: the knee search, the screen, the coverage gate

### DIFF
--- a/prismaquant/quality_prefill_coverage.py
+++ b/prismaquant/quality_prefill_coverage.py
@@ -253,8 +253,12 @@ def frontier_label(
 
     Unlike :func:`require_census_equality` this does not raise on an
     incomplete proposal: an honest restricted pilot is a valid outcome, and
-    downgrading its label is the correct handling rather than an error. It
-    raises only when the inputs themselves are malformed.
+    downgrading its label is the correct handling rather than an error. An
+    unequal membership, a surplus unit and an incomplete routed stack are all
+    downgrades with a recorded reason. Malformed *input* still raises -- a
+    membership name that is missing or unknown, a repeated unit id, an empty
+    census, an unknown evidence kind -- because there is then no proposal to
+    label.
     """
     reasons: list[str] = []
     try:

--- a/prismaquant/quality_prefill_coverage.py
+++ b/prismaquant/quality_prefill_coverage.py
@@ -1,0 +1,294 @@
+"""When a proposal may call itself the whole-model frontier, and when it may not.
+
+Specification section 5.2 of ``docs/design/tessera_quality_prefill_experiment.md``.
+
+Section 5.2 states one equality and one consequence. The equality is between
+four memberships that are produced by four different stages and drift apart
+quietly:
+
+* the full mutable serving-unit census,
+* the quality table's coverage,
+* the runtime binding's expansion, and
+* the selected assignment's membership.
+
+The consequence is that a proposal may be labelled
+``whole_model_retained_menu_frontier`` only when all four are the *same set*
+and every routed stack is complete down to its members. Anything less keeps
+its ``restricted_pilot`` label. A pilot operator frontier is still a real
+result; it is just a result about the units it actually covered.
+
+:func:`frontier_label` therefore never returns a verdict without also
+returning why, and :func:`require_census_equality` refuses by naming the exact
+symmetric difference rather than a count. "17 units differ" sends you looking;
+"layers.3.mlp.shared.down is in the census and not in the runtime binding"
+tells you what happened.
+
+A routed stack needs every required member's wire, scale, source/PWC and
+aligned joint row. The high/low routing-count expert diagnostic of section 5.1
+is two members out of hundreds, so :func:`routed_stack_gaps` treats a
+diagnostic draw as a gap, not as coverage -- which is the whole reason the
+function exists.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from .quality_prefill_contract import QualityPrefillContractError, canonical_sha256
+
+__all__ = [
+    "CoverageError",
+    "MEMBERSHIP_NAMES",
+    "REQUIRED_MEMBER_EVIDENCE",
+    "RoutedStack",
+    "CoverageVerdict",
+    "require_census_equality",
+    "routed_stack_gaps",
+    "frontier_label",
+]
+
+#: The four memberships section 5.2 requires to be equal, in the order the
+#: pipeline produces them. The order is part of the published report.
+MEMBERSHIP_NAMES = (
+    "census_units",
+    "quality_table_units",
+    "runtime_binding_units",
+    "assignment_units",
+)
+
+#: What makes a routed member's option complete. All four, or the stack is
+#: incomplete; there is no majority rule.
+REQUIRED_MEMBER_EVIDENCE = ("wire", "scale", "source_pwc", "joint_row")
+
+LABEL_WHOLE_MODEL = "whole_model_retained_menu_frontier"
+LABEL_RESTRICTED_PILOT = "restricted_pilot"
+
+
+class CoverageError(QualityPrefillContractError):
+    """Four memberships that should be one set are not one set."""
+
+
+def _fail(message: str) -> None:
+    raise CoverageError(message)
+
+
+def _as_set(value: object, *, where: str) -> frozenset[str]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Iterable):
+        _fail(f"{where} must be an iterable of unit ids")
+    items = list(value)  # type: ignore[arg-type]
+    for index, item in enumerate(items):
+        if not isinstance(item, str) or not item:
+            _fail(f"{where}[{index}] must be a non-empty unit id string")
+    if len(set(items)) != len(items):
+        duplicates = sorted({item for item in items if items.count(item) > 1})
+        _fail(f"{where} repeats unit id(s): " + ", ".join(duplicates))
+    return frozenset(items)
+
+
+def _sample(names: Iterable[str], limit: int = 6) -> str:
+    ordered = sorted(names)
+    shown = ", ".join(ordered[:limit])
+    return shown + (f" ... (+{len(ordered) - limit} more)" if len(ordered) > limit else "")
+
+
+def require_census_equality(memberships: Mapping[str, Iterable[str]]) -> frozenset[str]:
+    """Refuse unless all four memberships are exactly the same set.
+
+    Returns that common set so a caller can use it directly rather than
+    picking one of the four and hoping.
+
+    The refusal names each membership that differs from the census, and on
+    which side, because the two directions mean opposite things: a unit in the
+    census but not in the runtime binding is missing evidence, while a unit in
+    the binding but not in the census is evidence about something the model
+    does not contain.
+    """
+    if not isinstance(memberships, Mapping):
+        _fail("memberships must be a mapping of the four membership names")
+    missing_names = set(MEMBERSHIP_NAMES) - set(memberships)
+    extra_names = set(memberships) - set(MEMBERSHIP_NAMES)
+    if missing_names or extra_names:
+        parts = []
+        if missing_names:
+            parts.append("missing " + ", ".join(sorted(missing_names)))
+        if extra_names:
+            parts.append("unknown " + ", ".join(sorted(extra_names)))
+        _fail(
+            "section 5.2 compares exactly "
+            + ", ".join(MEMBERSHIP_NAMES)
+            + "; "
+            + " and ".join(parts)
+        )
+
+    sets = {
+        name: _as_set(memberships[name], where=name) for name in MEMBERSHIP_NAMES
+    }
+    census = sets["census_units"]
+    if not census:
+        _fail("the mutable serving-unit census is empty; there is nothing to cover")
+
+    complaints: list[str] = []
+    for name in MEMBERSHIP_NAMES[1:]:
+        absent = census - sets[name]
+        surplus = sets[name] - census
+        if absent:
+            complaints.append(
+                f"{len(absent)} unit(s) in the census are absent from {name}: "
+                + _sample(absent)
+            )
+        if surplus:
+            complaints.append(
+                f"{len(surplus)} unit(s) in {name} are not mutable census units: "
+                + _sample(surplus)
+            )
+    if complaints:
+        _fail(
+            "the four memberships of section 5.2 are not one set, so this is a "
+            "restricted pilot and not a whole-model frontier. "
+            + "; ".join(complaints)
+        )
+    return census
+
+
+@dataclass(frozen=True)
+class RoutedStack:
+    """One routed serving unit and the evidence each of its members carries.
+
+    ``required_members`` is the full member roster the stack needs at serve
+    time. ``member_evidence`` maps a member to the evidence actually held. A
+    member the roster names and the evidence map omits is a gap, and so is a
+    member holding three of the four required kinds.
+    """
+
+    unit_id: str
+    required_members: tuple[str, ...]
+    member_evidence: Mapping[str, frozenset[str]]
+    diagnostic_members: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.unit_id, str) or not self.unit_id:
+            _fail("RoutedStack.unit_id must be a non-empty string")
+        if not self.required_members:
+            _fail(f"{self.unit_id}: a routed stack has at least one required member")
+        if len(set(self.required_members)) != len(self.required_members):
+            _fail(f"{self.unit_id}: required_members repeats a member")
+        unknown = set(self.member_evidence) - set(self.required_members)
+        if unknown:
+            _fail(
+                f"{self.unit_id}: member_evidence names member(s) the roster does "
+                "not require: " + _sample(unknown)
+            )
+        stray = set(self.diagnostic_members) - set(self.required_members)
+        if stray:
+            _fail(
+                f"{self.unit_id}: diagnostic_members names member(s) outside the "
+                "roster: " + _sample(stray)
+            )
+
+
+def routed_stack_gaps(stacks: Sequence[RoutedStack]) -> dict[str, dict[str, list[str]]]:
+    """Report, per stack, each member missing any required evidence kind.
+
+    An empty result means every routed stack is complete. A stack whose only
+    covered members are its diagnostic draw reports every other member as a
+    gap, which is section 5.2's rule that a high/low expert diagnostic cannot
+    satisfy the completeness gate.
+    """
+    gaps: dict[str, dict[str, list[str]]] = {}
+    for stack in stacks:
+        per_member: dict[str, list[str]] = {}
+        for member in stack.required_members:
+            held = stack.member_evidence.get(member, frozenset())
+            if not isinstance(held, (set, frozenset)):
+                _fail(
+                    f"{stack.unit_id}.{member}: evidence must be a set of "
+                    + ", ".join(REQUIRED_MEMBER_EVIDENCE)
+                )
+            unknown = set(held) - set(REQUIRED_MEMBER_EVIDENCE)
+            if unknown:
+                _fail(
+                    f"{stack.unit_id}.{member}: unknown evidence kind(s) "
+                    + _sample(unknown)
+                )
+            absent = [kind for kind in REQUIRED_MEMBER_EVIDENCE if kind not in held]
+            if absent:
+                per_member[member] = absent
+        if per_member:
+            gaps[stack.unit_id] = per_member
+    return gaps
+
+
+@dataclass(frozen=True)
+class CoverageVerdict:
+    """The label a proposal has earned, and the evidence for it."""
+
+    label: str
+    covered_units: tuple[str, ...]
+    routed_gaps: Mapping[str, Mapping[str, tuple[str, ...]]]
+    reasons: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "label": self.label,
+            "covered_units": list(self.covered_units),
+            "routed_gaps": {
+                unit: {member: list(kinds) for member, kinds in sorted(members.items())}
+                for unit, members in sorted(self.routed_gaps.items())
+            },
+            "reasons": list(self.reasons),
+        }
+
+    def identity_sha256(self) -> str:
+        return canonical_sha256(self.as_dict())
+
+
+def frontier_label(
+    memberships: Mapping[str, Iterable[str]],
+    *,
+    routed_stacks: Sequence[RoutedStack] = (),
+) -> CoverageVerdict:
+    """Decide which label section 5.2 permits, and say why.
+
+    Unlike :func:`require_census_equality` this does not raise on an
+    incomplete proposal: an honest restricted pilot is a valid outcome, and
+    downgrading its label is the correct handling rather than an error. It
+    raises only when the inputs themselves are malformed.
+    """
+    reasons: list[str] = []
+    try:
+        covered = require_census_equality(memberships)
+        equal = True
+    except CoverageError as exc:
+        covered = _as_set(memberships.get("census_units", ()), where="census_units")
+        reasons.append(str(exc))
+        equal = False
+
+    gaps = routed_stack_gaps(routed_stacks)
+    if gaps:
+        reasons.append(
+            f"{len(gaps)} routed stack(s) lack complete member evidence: "
+            + _sample(gaps)
+        )
+
+    label = LABEL_WHOLE_MODEL if equal and not gaps else LABEL_RESTRICTED_PILOT
+    if label == LABEL_WHOLE_MODEL:
+        reasons.append(
+            "all four memberships are one set and every routed stack carries "
+            + ", ".join(REQUIRED_MEMBER_EVIDENCE)
+            + " for every required member"
+        )
+    return CoverageVerdict(
+        label=label,
+        covered_units=tuple(sorted(covered)),
+        routed_gaps=MappingProxyType(
+            {
+                unit: MappingProxyType(
+                    {member: tuple(kinds) for member, kinds in members.items()}
+                )
+                for unit, members in gaps.items()
+            }
+        ),
+        reasons=tuple(reasons),
+    )

--- a/prismaquant/quality_prefill_knee.py
+++ b/prismaquant/quality_prefill_knee.py
@@ -1,0 +1,467 @@
+"""Deterministic development-point selection on a quality-prefill frontier.
+
+Specification section 9 of ``docs/design/tessera_quality_prefill_experiment.md``.
+
+This module answers one narrow question: given a set of *proposed* points that
+an allocator already produced, which one does the frozen geometric rule
+nominate for measurement, and which neighbours and endpoint controls must be
+measured beside it?
+
+It computes nothing about quality or speed. Every number it reads was measured
+or proposed somewhere else, and every number it writes is a copy or a
+normalised coordinate. In particular it never upgrades a point's
+``measurement_status``: a knee proposed from screened points is a proposal
+about screened points.
+
+Three properties are deliberate:
+
+* **The rule proposes a region, not a decision.** Section 9's closing sentence
+  is that Rob's actual quality/budget choice remains an explicit configuration
+  input. So :func:`select_development_point` always returns the adjacent
+  non-dominated neighbours and both feasible endpoint controls alongside the
+  nominee, and the caller measures all of them.
+* **Degeneracy refuses.** A zero-width range, fewer than three non-dominated
+  points, or two candidates separated by less than the caller's declared
+  resolution yields no unique knee. The refusal names which of those it was.
+* **No RNG.** Ordering is by exact numeric comparison and then by
+  ``assignment_id`` string order. There is no ``random`` import and
+  ``tests/test_quality_prefill_knee.py`` asserts its absence.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from .quality_prefill_contract import (
+    COVERAGE_TYPES,
+    CURRENCIES,
+    QualityPrefillContractError,
+    canonical_sha256,
+)
+
+__all__ = [
+    "KneeSelectionError",
+    "FrontierPoint",
+    "Normalisation",
+    "KneeSelection",
+    "read_points",
+    "feasible_points",
+    "nondominated",
+    "select_development_point",
+]
+
+#: The rule's own identity. A change to the geometry is a new version, never a
+#: silent change to this one: published selections cite it.
+KNEE_RULE = MappingProxyType({"name": "chord_perpendicular_v1", "version": "v1"})
+
+#: Statuses that may appear in one frontier. ``measured`` and every screening
+#: status are kept apart, because a frontier that mixes them is a confound
+#: rather than a frontier (principle 3: a screen is not a result).
+_MEASURED = "measured"
+
+
+class KneeSelectionError(QualityPrefillContractError):
+    """A frontier cannot nominate a development point.
+
+    This subclasses the contract error because every case it reports is a
+    fixable document: a wider sweep, a declared resolution, or a single
+    currency. It is emphatically *not* the fleet-capability refusal that
+    ``quality_prefill_pb_adapter.DecompositionUnavailable`` is.
+    """
+
+
+@dataclass(frozen=True)
+class FrontierPoint:
+    """One proposed operating point, exactly as the frontier report carries it."""
+
+    point_id: str
+    assignment_id: str
+    bytes: int
+    prefill_budget: int
+    quality_value: float
+    currency: str
+    units: str
+    measurement_status: str
+
+    def as_point(self) -> dict[str, object]:
+        """Return the eight-key mapping ``validate_frontier_report`` accepts."""
+        return {
+            "point_id": self.point_id,
+            "assignment_id": self.assignment_id,
+            "bytes": self.bytes,
+            "prefill_budget": self.prefill_budget,
+            "quality_value": self.quality_value,
+            "currency": self.currency,
+            "units": self.units,
+            "measurement_status": self.measurement_status,
+        }
+
+
+@dataclass(frozen=True)
+class Normalisation:
+    """The published [0,1] transform and the chord it induces.
+
+    Section 9 requires the normalisation and chord to be published, because the
+    same points under a different range nominate a different knee. Storing them
+    beside the nominee is what makes a selection re-derivable.
+    """
+
+    latency_min: int
+    latency_max: int
+    quality_min: float
+    quality_max: float
+    chord_from_point_id: str
+    chord_to_point_id: str
+
+    def latency(self, value: int) -> float:
+        return (value - self.latency_min) / (self.latency_max - self.latency_min)
+
+    def quality(self, value: float) -> float:
+        return (value - self.quality_min) / (self.quality_max - self.quality_min)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "latency_min": self.latency_min,
+            "latency_max": self.latency_max,
+            "quality_min": self.quality_min,
+            "quality_max": self.quality_max,
+            "chord_from_point_id": self.chord_from_point_id,
+            "chord_to_point_id": self.chord_to_point_id,
+        }
+
+
+@dataclass(frozen=True)
+class KneeSelection:
+    """What the rule nominates, and everything measured beside it."""
+
+    knee_point_id: str
+    neighbour_point_ids: tuple[str, ...]
+    endpoint_point_ids: tuple[str, ...]
+    nondominated_point_ids: tuple[str, ...]
+    improvements: Mapping[str, float]
+    normalisation: Normalisation
+    byte_budget: int
+    currency: str
+    units: str
+    measurement_status: str
+    rule: Mapping[str, object]
+
+    def measurement_roster(self) -> tuple[str, ...]:
+        """The exact points section 10 requires be measured for this selection.
+
+        The knee, its two available neighbours and both feasible endpoint
+        controls, deduplicated, in non-dominated latency order.
+        """
+        wanted = {self.knee_point_id, *self.neighbour_point_ids, *self.endpoint_point_ids}
+        return tuple(pid for pid in self.nondominated_point_ids if pid in wanted)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "rule": dict(self.rule),
+            "byte_budget": self.byte_budget,
+            "currency": self.currency,
+            "units": self.units,
+            "measurement_status": self.measurement_status,
+            "knee_point_id": self.knee_point_id,
+            "neighbour_point_ids": list(self.neighbour_point_ids),
+            "endpoint_point_ids": list(self.endpoint_point_ids),
+            "nondominated_point_ids": list(self.nondominated_point_ids),
+            "improvements": {k: self.improvements[k] for k in sorted(self.improvements)},
+            "normalisation": self.normalisation.as_dict(),
+            "measurement_roster": list(self.measurement_roster()),
+        }
+
+    def identity_sha256(self) -> str:
+        """SHA-256 over canonical JSON of :meth:`as_dict`, no RNG anywhere."""
+        return canonical_sha256(self.as_dict())
+
+
+def _fail(message: str) -> None:
+    raise KneeSelectionError(message)
+
+
+def read_points(values: Iterable[Mapping[str, object]]) -> tuple[FrontierPoint, ...]:
+    """Read frontier-report point mappings into typed points.
+
+    Refuses a mixed currency, a mixed unit, a mixed measurement status and a
+    duplicate point id. Each of those would make the comparison that follows
+    meaningless rather than merely imprecise, so none of them is normalised
+    away.
+    """
+    points: list[FrontierPoint] = []
+    seen: set[str] = set()
+    for index, raw in enumerate(values):
+        where = f"points[{index}]"
+        if not isinstance(raw, Mapping):
+            _fail(f"{where} must be a mapping")
+        missing = {
+            "point_id",
+            "assignment_id",
+            "bytes",
+            "prefill_budget",
+            "quality_value",
+            "currency",
+            "units",
+            "measurement_status",
+        } - set(raw)
+        if missing:
+            _fail(f"{where} is missing required key(s): {', '.join(sorted(missing))}")
+        point_id = raw["point_id"]
+        if not isinstance(point_id, str) or not point_id:
+            _fail(f"{where}.point_id must be a non-empty string")
+        if point_id in seen:
+            _fail(f"{where}.point_id {point_id!r} is already present")
+        seen.add(point_id)
+        assignment_id = raw["assignment_id"]
+        if not isinstance(assignment_id, str) or not assignment_id:
+            _fail(f"{where}.assignment_id must be a non-empty string")
+        for name in ("bytes", "prefill_budget"):
+            if type(raw[name]) is not int or raw[name] < 1:
+                _fail(f"{where}.{name} must be a positive int")
+        quality = raw["quality_value"]
+        if type(quality) not in (int, float) or quality != quality or quality in (
+            float("inf"),
+            float("-inf"),
+        ):
+            _fail(f"{where}.quality_value must be a finite number")
+        if quality < 0.0:
+            _fail(f"{where}.quality_value must not be negative")
+        if raw["currency"] not in CURRENCIES:
+            _fail(f"{where}.currency {raw['currency']!r} is not a known currency")
+        if not isinstance(raw["units"], str) or not raw["units"]:
+            _fail(f"{where}.units must be a non-empty string")
+        if raw["measurement_status"] not in COVERAGE_TYPES:
+            _fail(
+                f"{where}.measurement_status {raw['measurement_status']!r} is not a "
+                "declared coverage type"
+            )
+        points.append(
+            FrontierPoint(
+                point_id=point_id,
+                assignment_id=assignment_id,
+                bytes=int(raw["bytes"]),
+                prefill_budget=int(raw["prefill_budget"]),
+                quality_value=float(quality),
+                currency=str(raw["currency"]),
+                units=str(raw["units"]),
+                measurement_status=str(raw["measurement_status"]),
+            )
+        )
+    if not points:
+        _fail("a frontier needs at least one point")
+    currencies = {point.currency for point in points}
+    if len(currencies) != 1:
+        _fail(
+            "one frontier carries one currency; got "
+            + ", ".join(sorted(currencies))
+        )
+    units = {point.units for point in points}
+    if len(units) != 1:
+        _fail("one frontier carries one unit; got " + ", ".join(sorted(units)))
+    statuses = {point.measurement_status for point in points}
+    if len(statuses) != 1:
+        _fail(
+            "one frontier carries one measurement status, because a measured point "
+            "and a screened point are not comparable; got "
+            + ", ".join(sorted(statuses))
+        )
+    return tuple(points)
+
+
+def feasible_points(
+    points: Sequence[FrontierPoint], *, byte_budget: int
+) -> tuple[FrontierPoint, ...]:
+    """Points whose exact serialised bytes fit the budget.
+
+    Bytes are exact integers, so the comparison is exact; there is no tolerance
+    and no rounding to a gigabyte.
+    """
+    if type(byte_budget) is not int or byte_budget < 1:
+        _fail("byte_budget must be a positive int")
+    return tuple(point for point in points if point.bytes <= byte_budget)
+
+
+def nondominated(points: Sequence[FrontierPoint]) -> tuple[FrontierPoint, ...]:
+    """Return the non-dominated set, ordered by increasing prefill budget.
+
+    ``a`` dominates ``b`` when ``a`` is no worse on both axes and strictly
+    better on at least one. Ties on both axes keep both points: they are
+    different assignments that happen to price alike, and deleting one would
+    hide a distinct execution route (section 5.4).
+    """
+    keep: list[FrontierPoint] = []
+    for point in points:
+        dominated = any(
+            other is not point
+            and other.prefill_budget <= point.prefill_budget
+            and other.quality_value <= point.quality_value
+            and (
+                other.prefill_budget < point.prefill_budget
+                or other.quality_value < point.quality_value
+            )
+            for other in points
+        )
+        if not dominated:
+            keep.append(point)
+    return tuple(
+        sorted(keep, key=lambda p: (p.prefill_budget, p.quality_value, p.assignment_id))
+    )
+
+
+def _endpoints(
+    frontier: Sequence[FrontierPoint],
+) -> tuple[FrontierPoint, FrontierPoint]:
+    """The fastest feasible point and the best-quality feasible point.
+
+    Both are controls in their own right; section 10 requires measuring them
+    whether or not the knee is near either.
+    """
+    fastest = min(
+        frontier, key=lambda p: (p.prefill_budget, p.quality_value, p.assignment_id)
+    )
+    best = min(
+        frontier, key=lambda p: (p.quality_value, p.prefill_budget, p.assignment_id)
+    )
+    return fastest, best
+
+
+def select_development_point(
+    points: Iterable[Mapping[str, object]],
+    *,
+    byte_budget: int,
+    min_separation: float,
+) -> KneeSelection:
+    """Nominate a development point by the frozen chord-perpendicular rule.
+
+    ``min_separation`` is the caller's declared resolution in normalised
+    perpendicular units: two candidates closer than it are not distinguishable
+    by this frontier's evidence and the function refuses rather than picking
+    the numerically larger one. It has no default, because a default would be
+    a threshold invented here rather than derived from the measurement
+    (principle 2).
+
+    Raises :class:`KneeSelectionError` when the frontier is degenerate, too
+    small, or cannot separate its top two candidates.
+    """
+    if type(min_separation) is not float and type(min_separation) is not int:
+        _fail("min_separation must be a number")
+    if min_separation < 0.0 or min_separation != min_separation:
+        _fail("min_separation must be a finite non-negative number")
+
+    typed = read_points(points)
+    feasible = feasible_points(typed, byte_budget=byte_budget)
+    if not feasible:
+        _fail(
+            f"no point fits the byte budget {byte_budget}; the smallest is "
+            f"{min(point.bytes for point in typed)} bytes"
+        )
+    frontier = nondominated(feasible)
+    if len(frontier) < 3:
+        _fail(
+            "a chord and an interior both need points: the non-dominated set has "
+            f"{len(frontier)}, and the rule needs at least 3"
+        )
+
+    fastest, best = _endpoints(frontier)
+    if fastest.point_id == best.point_id:
+        _fail(
+            "the fastest and the best-quality feasible points are the same point; "
+            "there is no trade-off to find a knee on"
+        )
+    latency_min, latency_max = fastest.prefill_budget, best.prefill_budget
+    quality_min, quality_max = best.quality_value, fastest.quality_value
+    if latency_max == latency_min:
+        _fail(
+            "degenerate latency range: every feasible non-dominated point proposes "
+            f"{latency_min}, so no knee exists"
+        )
+    if quality_max == quality_min:
+        _fail(
+            "degenerate quality range: every feasible non-dominated point prices "
+            f"{quality_min}, so no knee exists"
+        )
+
+    normalisation = Normalisation(
+        latency_min=latency_min,
+        latency_max=latency_max,
+        quality_min=quality_min,
+        quality_max=quality_max,
+        chord_from_point_id=fastest.point_id,
+        chord_to_point_id=best.point_id,
+    )
+
+    # The chord runs from the fastest endpoint (x=0, y=1) to the best-quality
+    # endpoint (x=1, y=0) in normalised coordinates. Perpendicular improvement
+    # is the signed distance towards the origin: a point below the chord buys
+    # more quality per unit of prefill than linear interpolation would.
+    ax, ay = normalisation.latency(fastest.prefill_budget), normalisation.quality(
+        fastest.quality_value
+    )
+    bx, by = normalisation.latency(best.prefill_budget), normalisation.quality(
+        best.quality_value
+    )
+    dx, dy = bx - ax, by - ay
+    length = (dx * dx + dy * dy) ** 0.5
+    if length == 0.0:
+        _fail("the endpoint chord has zero length; no knee exists")
+
+    improvements: dict[str, float] = {}
+    interior: list[FrontierPoint] = []
+    for point in frontier:
+        px = normalisation.latency(point.prefill_budget)
+        py = normalisation.quality(point.quality_value)
+        # Positive when the point lies on the improving side of the chord.
+        cross = dx * (py - ay) - dy * (px - ax)
+        improvements[point.point_id] = -cross / length
+        if point.point_id not in (fastest.point_id, best.point_id):
+            interior.append(point)
+
+    if not interior:
+        _fail("the non-dominated set is its own two endpoints; no interior knee exists")
+
+    ranked = sorted(
+        interior,
+        key=lambda p: (
+            -improvements[p.point_id],
+            p.prefill_budget,
+            p.assignment_id,
+        ),
+    )
+    winner = ranked[0]
+    if improvements[winner.point_id] <= 0.0:
+        _fail(
+            "no interior point improves on the endpoint chord; the frontier is "
+            "linear or convex here and proposes no knee"
+        )
+    if len(ranked) > 1:
+        gap = improvements[winner.point_id] - improvements[ranked[1].point_id]
+        if gap < min_separation:
+            _fail(
+                "two candidates are within the declared resolution "
+                f"{min_separation}: {winner.point_id} and {ranked[1].point_id} differ "
+                f"by {gap}. This frontier proposes a region, not a unique knee"
+            )
+
+    order = [point.point_id for point in frontier]
+    index = order.index(winner.point_id)
+    neighbours = tuple(
+        order[position]
+        for position in (index - 1, index + 1)
+        if 0 <= position < len(order) and order[position] != winner.point_id
+    )
+
+    return KneeSelection(
+        knee_point_id=winner.point_id,
+        neighbour_point_ids=neighbours,
+        endpoint_point_ids=(fastest.point_id, best.point_id),
+        nondominated_point_ids=tuple(order),
+        improvements=MappingProxyType(dict(improvements)),
+        normalisation=normalisation,
+        byte_budget=int(byte_budget),
+        currency=typed[0].currency,
+        units=typed[0].units,
+        measurement_status=typed[0].measurement_status,
+        rule=KNEE_RULE,
+    )

--- a/prismaquant/quality_prefill_screen.py
+++ b/prismaquant/quality_prefill_screen.py
@@ -48,6 +48,7 @@ __all__ = [
     "ScreenCandidate",
     "ScreenResult",
     "SCREEN_RULE",
+    "REPRESENTATIVE_TIE_RULE",
     "expand_licensed_composites",
     "refuse_dominance_screen",
     "apply_coverage_first_v1",
@@ -162,6 +163,8 @@ class ScreenResult:
 
     retained: tuple[str, ...]
     deferred: tuple[str, ...]
+    #: Audit rank per *deferred* candidate. A retained candidate is absent:
+    #: it holds no place in the discarded-candidate audit's order.
     ranks: Mapping[str, int]
     audit: tuple[str, ...]
     required: Mapping[str, int]
@@ -209,40 +212,41 @@ def refuse_dominance_screen(candidates: Sequence[ScreenCandidate]) -> None:
         )
 
 
+#: How a route class picks its representative when nothing else has covered it.
+#: Recorded in the disposition reason so the tie handling section 5.4 asks for
+#: is readable from the ledger rather than from this source file.
+REPRESENTATIVE_TIE_RULE = "lowest candidate_id"
+
+
 def _class_representatives(
-    candidates: Sequence[ScreenCandidate],
-    already: set[str],
-    *,
-    source_sha256: str,
-    selection_seed: int,
+    candidates: Sequence[ScreenCandidate], already: set[str]
 ) -> dict[str, str]:
     """One retained representative per licensed activation/route class.
 
     A class already covered by a mandatory or interior-draw candidate needs no
-    extra representative. An uncovered class takes its first candidate by the
-    population module's stable rank, so the choice is reproducible on any box.
+    extra representative. An uncovered class takes the lexically smallest
+    candidate id in the class.
+
+    Deliberately *not* a hashed draw. Section 5.1 gives each purpose its own
+    domain, and the purposes are pilot, confirmation, rate audit, routed expert
+    selection and discarded-candidate audit. Retention is none of those, so
+    hashing a retention decision into one of their domains would put retained
+    picks into a ledger that means "these were set aside". A stated lexical
+    rule is just as reproducible and pollutes nothing.
     """
     covered = {
         candidate.route_class
         for candidate in candidates
         if candidate.candidate_id in already
     }
-    chosen: dict[str, str] = {}
     by_class: dict[str, list[str]] = {}
     for candidate in candidates:
         if candidate.route_class in covered:
             continue
         by_class.setdefault(candidate.route_class, []).append(candidate.candidate_id)
-    for route_class in sorted(by_class):
-        ranked = stable_rank(
-            sorted(by_class[route_class]),
-            source_sha256=source_sha256,
-            selection_seed=selection_seed,
-            purpose=PURPOSE_DISCARDED_CANDIDATE_AUDIT,
-            stratum_id=f"route_class:{route_class}",
-        )
-        chosen[route_class] = ranked[0]
-    return chosen
+    return {
+        route_class: min(members) for route_class, members in by_class.items()
+    }
 
 
 def apply_coverage_first_v1(
@@ -261,7 +265,8 @@ def apply_coverage_first_v1(
     1. every mandatory boundary or control candidate;
     2. every member of the frozen per-stratum interior draw;
     3. one representative of each licensed activation/route class not already
-       covered by 1 or 2.
+       covered by 1 or 2, chosen by the stated tie rule
+       (:data:`REPRESENTATIVE_TIE_RULE`) rather than by a hashed draw.
 
     Everything else is ``deferred``. Nothing is ``pruned``: this policy makes
     no hard deletion, and a later one is a separate version.
@@ -311,16 +316,12 @@ def apply_coverage_first_v1(
                 "member of the frozen per-stratum interior draw for "
                 f"{candidate.rate_stratum_id}"
             )
-    representatives = _class_representatives(
-        roster,
-        set(reasons),
-        source_sha256=source_sha256,
-        selection_seed=selection_seed,
-    )
-    for route_class, candidate_id in representatives.items():
+    representatives = _class_representatives(roster, set(reasons))
+    for route_class, candidate_id in sorted(representatives.items()):
         reasons[candidate_id] = (
-            f"sole retained representative of licensed route class {route_class}; "
-            "a class is never dropped before runtime prices exist"
+            f"sole retained representative of licensed route class {route_class} "
+            f"(tie rule: {REPRESENTATIVE_TIE_RULE}); a class is never dropped "
+            "before runtime prices exist"
         )
 
     retained = tuple(sorted(reasons))
@@ -360,24 +361,23 @@ def apply_coverage_first_v1(
             f"{len(deferred)} deferred candidate(s); it cannot draw more than "
             "the pool holds"
         )
-    audit = tuple(
+    # The audit order is drawn in the discarded-candidate audit's own purpose
+    # domain, over the deferred pool only. A retained candidate has no audit
+    # rank: it was not set aside, so ranking it here would file a retention
+    # under "these were discarded".
+    ranked_deferred = (
         stable_rank(
             list(deferred),
             source_sha256=source_sha256,
             selection_seed=selection_seed,
             purpose=PURPOSE_DISCARDED_CANDIDATE_AUDIT,
             stratum_id=f"screen:{decision_id}",
-        )[:audit_count]
-    ) if deferred else ()
-
-    ranked_all = stable_rank(
-        sorted(ids),
-        source_sha256=source_sha256,
-        selection_seed=selection_seed,
-        purpose=PURPOSE_DISCARDED_CANDIDATE_AUDIT,
-        stratum_id=f"screen:{decision_id}",
+        )
+        if deferred
+        else []
     )
-    ranks = {candidate_id: index for index, candidate_id in enumerate(ranked_all)}
+    audit = tuple(ranked_deferred[:audit_count])
+    ranks = {candidate_id: index for index, candidate_id in enumerate(ranked_deferred)}
 
     dispositions = []
     for candidate_id in sorted(ids):

--- a/prismaquant/quality_prefill_screen.py
+++ b/prismaquant/quality_prefill_screen.py
@@ -1,0 +1,430 @@
+"""The ``coverage_first_v1`` screen: what the initial menu may and may not drop.
+
+Specification section 5.4 of ``docs/design/tessera_quality_prefill_experiment.md``.
+
+``coverage_first_v1`` is the experiment's *initial* screen policy, and its
+defining property is negative: **it never prunes**. It retains the mandatory
+boundary and control candidates, the frozen per-stratum interior draw, and at
+least one representative of every distinct licensed activation/route class.
+Everything else is deferred, which is a statement about acquisition order, not
+about merit. :func:`apply_coverage_first_v1` emits no ``pruned`` disposition
+at all, and ``tests/test_quality_prefill_screen.py`` asserts that.
+
+That is not squeamishness. Section 5.4's reason is mechanical: before runtime
+prices exist, a quality-or-byte dominance argument cannot see that the deleted
+candidate was the faster one. :func:`refuse_dominance_screen` makes the
+argument refuse out loud rather than quietly succeed on partial evidence.
+
+Caps are the other half. ``max_retained_candidates``,
+``max_composite_options`` and ``max_tasks_per_phase`` are applied *after* the
+exact roster and its licensed composite expansion, and a cap that the
+mandatory coverage already exceeds refuses the freeze, naming required versus
+allowed. It never reduces a quota, drops a class, or retains a prefix: a
+smaller plan is a different plan, and picking one silently is how a screen
+becomes a result.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from .quality_prefill_contract import (
+    QualityPrefillContractError,
+    SCREEN_DECISION_SCHEMA,
+    canonical_sha256,
+    validate_screen_decision,
+)
+from .quality_prefill_population import (
+    PURPOSE_DISCARDED_CANDIDATE_AUDIT,
+    SCREEN_POLICY_ID,
+    stable_rank,
+)
+
+__all__ = [
+    "ScreenError",
+    "ScreenCaps",
+    "ScreenCandidate",
+    "ScreenResult",
+    "SCREEN_RULE",
+    "expand_licensed_composites",
+    "refuse_dominance_screen",
+    "apply_coverage_first_v1",
+]
+
+#: Published identity of the policy this module implements. A later hard
+#: pruning policy is a different name and a different version (section 5.4);
+#: it does not arrive as a new branch inside this function.
+SCREEN_RULE = MappingProxyType({"name": SCREEN_POLICY_ID, "version": "v1"})
+
+_RETAINED = "retained"
+_DEFERRED = "deferred"
+
+#: Coverage type for something retained but not yet measured, and for
+#: something not yet acquired at all. Both are closed-set members of the
+#: contract's ``COVERAGE_TYPES``, so neither can later be read as ``measured``.
+_STATUS_RETAINED = "retained_pending_measurement"
+_STATUS_DEFERRED = "not_yet_acquired"
+
+
+class ScreenError(QualityPrefillContractError):
+    """A screen plan cannot be applied as written.
+
+    Every case is a fixable document -- a wider cap, a declared uncertainty, a
+    named route class -- which is why this is a contract error and not the
+    fleet-capability ``RuntimeError`` the PB adapter raises.
+    """
+
+
+def _fail(message: str) -> None:
+    raise ScreenError(message)
+
+
+@dataclass(frozen=True)
+class ScreenCaps:
+    """The manifest's integer work limits.
+
+    All three are required integers. There is no ``None`` meaning "unlimited":
+    an unstated cap is an unfrozen plan, and section 5.4 requires the manifest
+    to carry them.
+    """
+
+    max_retained_candidates: int
+    max_composite_options: int
+    max_tasks_per_phase: int
+
+    def __post_init__(self) -> None:
+        for name in (
+            "max_retained_candidates",
+            "max_composite_options",
+            "max_tasks_per_phase",
+        ):
+            value = getattr(self, name)
+            if type(value) is not int or value < 1:
+                _fail(f"{name} must be a positive int; got {value!r}")
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "max_retained_candidates": self.max_retained_candidates,
+            "max_composite_options": self.max_composite_options,
+            "max_tasks_per_phase": self.max_tasks_per_phase,
+        }
+
+
+@dataclass(frozen=True)
+class ScreenCandidate:
+    """One candidate as the screen sees it, before any evidence is opened.
+
+    ``uncertainty`` has no default. Section 5.4's rule is that unknown quality,
+    runtime or uncertainty is not zero and cannot prove dominance; writing
+    ``0.0`` for "we have not looked" is precisely the lie that rule forbids, so
+    a missing value refuses instead.
+    """
+
+    candidate_id: str
+    rate_stratum_id: str
+    route_class: str
+    mandatory: bool
+    interior_draw: bool
+    composite_options: int
+    tasks_per_phase: int
+    uncertainty: float | None
+    runtime_price_known: bool
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.candidate_id, str) or not self.candidate_id:
+            _fail("candidate_id must be a non-empty string")
+        for name in ("rate_stratum_id", "route_class"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value:
+                _fail(f"{self.candidate_id}: {name} must be a non-empty string")
+        for name in ("mandatory", "interior_draw", "runtime_price_known"):
+            if type(getattr(self, name)) is not bool:
+                _fail(f"{self.candidate_id}: {name} must be a boolean")
+        for name in ("composite_options", "tasks_per_phase"):
+            value = getattr(self, name)
+            if type(value) is not int or value < 1:
+                _fail(f"{self.candidate_id}: {name} must be a positive int")
+        if self.uncertainty is not None:
+            if type(self.uncertainty) not in (int, float):
+                _fail(f"{self.candidate_id}: uncertainty must be a number or None")
+            if self.uncertainty != self.uncertainty or self.uncertainty < 0.0:
+                _fail(
+                    f"{self.candidate_id}: uncertainty must be finite and "
+                    "non-negative"
+                )
+
+
+@dataclass(frozen=True)
+class ScreenResult:
+    """The screen's complete disposition of every candidate it was shown."""
+
+    retained: tuple[str, ...]
+    deferred: tuple[str, ...]
+    ranks: Mapping[str, int]
+    audit: tuple[str, ...]
+    required: Mapping[str, int]
+    caps: ScreenCaps
+    decision: Mapping[str, object]
+
+    def identity_sha256(self) -> str:
+        """The decision's seal, as ``_check_seal`` would recompute it.
+
+        Returned rather than recomputed: the seal covers the body *without*
+        its own field, so hashing the sealed mapping again would digest a
+        different object and quietly stop matching the contract's.
+        """
+        return str(self.decision["identity_sha256"])
+
+
+def expand_licensed_composites(candidates: Iterable[ScreenCandidate]) -> int:
+    """Total licensed composite options across the given candidates.
+
+    Caps are checked against this number, not against the candidate count,
+    because one candidate may license several composite options and the work
+    the fleet actually performs is per option.
+    """
+    return sum(candidate.composite_options for candidate in candidates)
+
+
+def refuse_dominance_screen(candidates: Sequence[ScreenCandidate]) -> None:
+    """Refuse a dominance argument while any runtime price is unknown.
+
+    Section 5.4: before runtime prices exist, quality/byte dominance alone must
+    not remove a possibly faster execution route. This function is the place
+    that says so; call it before any hard pruning policy, and it raises with
+    the exact candidates whose runtime is still unmeasured.
+    """
+    unknown = tuple(
+        sorted(c.candidate_id for c in candidates if not c.runtime_price_known)
+    )
+    if unknown:
+        _fail(
+            "a quality/byte dominance screen cannot run while "
+            f"{len(unknown)} candidate(s) have no measured runtime price: "
+            + ", ".join(unknown[:8])
+            + (" ..." if len(unknown) > 8 else "")
+            + ". An unmeasured route is not a slow route"
+        )
+
+
+def _class_representatives(
+    candidates: Sequence[ScreenCandidate],
+    already: set[str],
+    *,
+    source_sha256: str,
+    selection_seed: int,
+) -> dict[str, str]:
+    """One retained representative per licensed activation/route class.
+
+    A class already covered by a mandatory or interior-draw candidate needs no
+    extra representative. An uncovered class takes its first candidate by the
+    population module's stable rank, so the choice is reproducible on any box.
+    """
+    covered = {
+        candidate.route_class
+        for candidate in candidates
+        if candidate.candidate_id in already
+    }
+    chosen: dict[str, str] = {}
+    by_class: dict[str, list[str]] = {}
+    for candidate in candidates:
+        if candidate.route_class in covered:
+            continue
+        by_class.setdefault(candidate.route_class, []).append(candidate.candidate_id)
+    for route_class in sorted(by_class):
+        ranked = stable_rank(
+            sorted(by_class[route_class]),
+            source_sha256=source_sha256,
+            selection_seed=selection_seed,
+            purpose=PURPOSE_DISCARDED_CANDIDATE_AUDIT,
+            stratum_id=f"route_class:{route_class}",
+        )
+        chosen[route_class] = ranked[0]
+    return chosen
+
+
+def apply_coverage_first_v1(
+    candidates: Iterable[ScreenCandidate],
+    *,
+    caps: ScreenCaps,
+    source_sha256: str,
+    selection_seed: int = 0,
+    audit_count: int,
+    decision_id: str,
+) -> ScreenResult:
+    """Apply the initial screen and return its complete disposition ledger.
+
+    Retains, in this order and for these reasons:
+
+    1. every mandatory boundary or control candidate;
+    2. every member of the frozen per-stratum interior draw;
+    3. one representative of each licensed activation/route class not already
+       covered by 1 or 2.
+
+    Everything else is ``deferred``. Nothing is ``pruned``: this policy makes
+    no hard deletion, and a later one is a separate version.
+
+    ``audit_count`` fixes how many deferred candidates are drawn, by stable
+    rank, for the deterministic discarded-candidate audit. Section 5.4 requires
+    that roster to be chosen *before* the deferred candidates' joint or runtime
+    truth is opened, which is why this function -- which sees no prices --
+    is where it is drawn.
+    """
+    roster = tuple(candidates)
+    if not roster:
+        _fail("coverage_first_v1 needs at least one candidate")
+    ids = [candidate.candidate_id for candidate in roster]
+    if len(set(ids)) != len(ids):
+        duplicates = sorted({cid for cid in ids if ids.count(cid) > 1})
+        _fail("duplicate candidate id(s): " + ", ".join(duplicates))
+    if type(audit_count) is not int or audit_count < 0:
+        _fail("audit_count must be a non-negative int")
+    if not isinstance(decision_id, str) or not decision_id:
+        _fail("decision_id must be a non-empty string")
+
+    missing_uncertainty = tuple(
+        sorted(c.candidate_id for c in roster if c.uncertainty is None)
+    )
+    if missing_uncertainty:
+        _fail(
+            f"{len(missing_uncertainty)} candidate(s) carry no declared "
+            "uncertainty: "
+            + ", ".join(missing_uncertainty[:8])
+            + (" ..." if len(missing_uncertainty) > 8 else "")
+            + ". Unknown uncertainty is not zero, so the ledger refuses rather "
+            "than writing 0.0"
+        )
+
+    by_id = {candidate.candidate_id: candidate for candidate in roster}
+    reasons: dict[str, str] = {}
+    for candidate in roster:
+        if candidate.mandatory:
+            reasons[candidate.candidate_id] = (
+                "mandatory boundary or control candidate; coverage_first_v1 "
+                "retains every one"
+            )
+    for candidate in roster:
+        if candidate.interior_draw and candidate.candidate_id not in reasons:
+            reasons[candidate.candidate_id] = (
+                "member of the frozen per-stratum interior draw for "
+                f"{candidate.rate_stratum_id}"
+            )
+    representatives = _class_representatives(
+        roster,
+        set(reasons),
+        source_sha256=source_sha256,
+        selection_seed=selection_seed,
+    )
+    for route_class, candidate_id in representatives.items():
+        reasons[candidate_id] = (
+            f"sole retained representative of licensed route class {route_class}; "
+            "a class is never dropped before runtime prices exist"
+        )
+
+    retained = tuple(sorted(reasons))
+    deferred = tuple(sorted(set(ids) - set(retained)))
+
+    required = {
+        "retained_candidates": len(retained),
+        "composite_options": expand_licensed_composites(
+            by_id[cid] for cid in retained
+        ),
+        "tasks_per_phase": sum(by_id[cid].tasks_per_phase for cid in retained),
+    }
+    over = [
+        (name, required[name], allowed)
+        for name, allowed in (
+            ("retained_candidates", caps.max_retained_candidates),
+            ("composite_options", caps.max_composite_options),
+            ("tasks_per_phase", caps.max_tasks_per_phase),
+        )
+        if required[name] > allowed
+    ]
+    if over:
+        detail = "; ".join(
+            f"{name} requires {need} but the manifest allows {allowed}"
+            for name, need, allowed in over
+        )
+        _fail(
+            "coverage_first_v1 refuses to freeze: "
+            + detail
+            + ". A cap never reduces a quota, drops a route class or retains a "
+            "prefix; raising it is a new explicit plan"
+        )
+
+    if audit_count > len(deferred):
+        _fail(
+            f"the discarded-candidate audit asks for {audit_count} of "
+            f"{len(deferred)} deferred candidate(s); it cannot draw more than "
+            "the pool holds"
+        )
+    audit = tuple(
+        stable_rank(
+            list(deferred),
+            source_sha256=source_sha256,
+            selection_seed=selection_seed,
+            purpose=PURPOSE_DISCARDED_CANDIDATE_AUDIT,
+            stratum_id=f"screen:{decision_id}",
+        )[:audit_count]
+    ) if deferred else ()
+
+    ranked_all = stable_rank(
+        sorted(ids),
+        source_sha256=source_sha256,
+        selection_seed=selection_seed,
+        purpose=PURPOSE_DISCARDED_CANDIDATE_AUDIT,
+        stratum_id=f"screen:{decision_id}",
+    )
+    ranks = {candidate_id: index for index, candidate_id in enumerate(ranked_all)}
+
+    dispositions = []
+    for candidate_id in sorted(ids):
+        candidate = by_id[candidate_id]
+        is_retained = candidate_id in reasons
+        reason = reasons.get(
+            candidate_id,
+            "deferred by coverage_first_v1: outside the mandatory set, the "
+            "frozen interior draw and the route-class representatives. Deferred "
+            "is an acquisition order, not a deletion"
+            + (
+                f"; drawn for the discarded-candidate audit at rank {ranks[candidate_id]}"
+                if candidate_id in audit
+                else ""
+            ),
+        )
+        dispositions.append(
+            {
+                "candidate_id": candidate_id,
+                "disposition": _RETAINED if is_retained else _DEFERRED,
+                "measurement_status": _STATUS_RETAINED
+                if is_retained
+                else _STATUS_DEFERRED,
+                "evidence_observation_ids": [],
+                "reason": reason,
+                "uncertainty": float(candidate.uncertainty),
+            }
+        )
+
+    decision = {
+        "schema": SCREEN_DECISION_SCHEMA,
+        "decision_id": decision_id,
+        "rule": dict(SCREEN_RULE),
+        "dispositions": dispositions,
+    }
+    # The seal covers the body and never its own field, exactly as the
+    # contract's `_seal` does. Computed before the key is added, on purpose.
+    seal = canonical_sha256(decision)
+    decision["identity_sha256"] = seal
+    validate_screen_decision(decision)
+
+    return ScreenResult(
+        retained=retained,
+        deferred=deferred,
+        ranks=MappingProxyType(ranks),
+        audit=audit,
+        required=MappingProxyType(required),
+        caps=caps,
+        decision=MappingProxyType(decision),
+    )

--- a/tests/test_quality_prefill_coverage.py
+++ b/tests/test_quality_prefill_coverage.py
@@ -1,0 +1,194 @@
+"""Section 5.2: when four memberships are one set, and what happens when they are not."""
+
+from __future__ import annotations
+
+import pytest
+
+from prismaquant.quality_prefill_coverage import (
+    LABEL_RESTRICTED_PILOT,
+    LABEL_WHOLE_MODEL,
+    CoverageError,
+    RoutedStack,
+    frontier_label,
+    require_census_equality,
+    routed_stack_gaps,
+)
+
+UNITS = ("layers.0.attn.qkv", "layers.0.mlp.down", "layers.1.mlp.gate_up")
+COMPLETE = frozenset({"wire", "scale", "source_pwc", "joint_row"})
+
+
+def memberships(**overrides):
+    base = {name: list(UNITS) for name in (
+        "census_units",
+        "quality_table_units",
+        "runtime_binding_units",
+        "assignment_units",
+    )}
+    base.update(overrides)
+    return base
+
+
+def routed(members=("e0", "e1", "e2"), covered=None, diagnostic=()):
+    covered = set(members) if covered is None else set(covered)
+    return RoutedStack(
+        unit_id="layers.2.moe",
+        required_members=tuple(members),
+        member_evidence={m: COMPLETE for m in covered},
+        diagnostic_members=tuple(diagnostic),
+    )
+
+
+def test_four_equal_memberships_return_the_common_set():
+    assert require_census_equality(memberships()) == frozenset(UNITS)
+
+
+def test_a_unit_missing_from_the_runtime_binding_is_named_by_id():
+    partial = memberships(runtime_binding_units=list(UNITS[:2]))
+    with pytest.raises(CoverageError) as excinfo:
+        require_census_equality(partial)
+    message = str(excinfo.value)
+    assert "runtime_binding_units" in message
+    assert "layers.1.mlp.gate_up" in message
+    assert "absent from" in message
+
+
+def test_a_unit_the_census_does_not_contain_is_reported_the_other_way():
+    surplus = memberships(assignment_units=list(UNITS) + ["layers.9.ghost"])
+    with pytest.raises(CoverageError) as excinfo:
+        require_census_equality(surplus)
+    message = str(excinfo.value)
+    assert "layers.9.ghost" in message
+    assert "not mutable census units" in message
+
+
+def test_both_directions_are_reported_in_one_message():
+    both = memberships(quality_table_units=[UNITS[0], "layers.9.ghost"])
+    with pytest.raises(CoverageError) as excinfo:
+        require_census_equality(both)
+    message = str(excinfo.value)
+    assert "absent from quality_table_units" in message
+    assert "not mutable census units" in message
+
+
+def test_a_missing_membership_name_refuses():
+    incomplete = memberships()
+    del incomplete["assignment_units"]
+    with pytest.raises(CoverageError, match="missing assignment_units"):
+        require_census_equality(incomplete)
+
+
+def test_an_unknown_membership_name_refuses():
+    extra = memberships()
+    extra["vibes_units"] = list(UNITS)
+    with pytest.raises(CoverageError, match="unknown vibes_units"):
+        require_census_equality(extra)
+
+
+def test_a_repeated_unit_id_refuses():
+    doubled = memberships(census_units=list(UNITS) + [UNITS[0]])
+    with pytest.raises(CoverageError, match="repeats unit id"):
+        require_census_equality(doubled)
+
+
+def test_an_empty_census_refuses():
+    with pytest.raises(CoverageError, match="census is empty"):
+        require_census_equality(memberships(**{name: [] for name in (
+            "census_units",
+            "quality_table_units",
+            "runtime_binding_units",
+            "assignment_units",
+        )}))
+
+
+def test_a_complete_routed_stack_reports_no_gap():
+    assert routed_stack_gaps([routed()]) == {}
+
+
+def test_a_member_missing_one_evidence_kind_is_a_gap():
+    stack = RoutedStack(
+        unit_id="layers.2.moe",
+        required_members=("e0", "e1"),
+        member_evidence={"e0": COMPLETE, "e1": frozenset({"wire", "scale", "joint_row"})},
+    )
+    assert routed_stack_gaps([stack]) == {"layers.2.moe": {"e1": ["source_pwc"]}}
+
+
+def test_a_high_low_diagnostic_draw_does_not_satisfy_the_gate():
+    """Two experts out of many is section 5.1's diagnostic, not coverage."""
+    stack = routed(
+        members=tuple(f"e{i}" for i in range(8)),
+        covered=("e0", "e7"),
+        diagnostic=("e0", "e7"),
+    )
+    gaps = routed_stack_gaps([stack])["layers.2.moe"]
+    assert set(gaps) == {f"e{i}" for i in range(1, 7)}
+
+
+def test_an_unknown_evidence_kind_refuses():
+    stack = RoutedStack(
+        unit_id="layers.2.moe",
+        required_members=("e0",),
+        member_evidence={"e0": frozenset({"wire", "vibes"})},
+    )
+    with pytest.raises(CoverageError, match="unknown evidence kind"):
+        routed_stack_gaps([stack])
+
+
+def test_evidence_for_a_member_outside_the_roster_refuses():
+    with pytest.raises(CoverageError, match="does not require"):
+        RoutedStack(
+            unit_id="layers.2.moe",
+            required_members=("e0",),
+            member_evidence={"e0": COMPLETE, "e9": COMPLETE},
+        )
+
+
+def test_a_diagnostic_member_outside_the_roster_refuses():
+    with pytest.raises(CoverageError, match="outside the roster"):
+        RoutedStack(
+            unit_id="layers.2.moe",
+            required_members=("e0",),
+            member_evidence={"e0": COMPLETE},
+            diagnostic_members=("e9",),
+        )
+
+
+def test_complete_coverage_earns_the_whole_model_label():
+    verdict = frontier_label(memberships(), routed_stacks=[routed()])
+    assert verdict.label == LABEL_WHOLE_MODEL
+    assert verdict.covered_units == tuple(sorted(UNITS))
+
+
+def test_an_unequal_membership_downgrades_to_a_restricted_pilot():
+    verdict = frontier_label(memberships(runtime_binding_units=list(UNITS[:2])))
+    assert verdict.label == LABEL_RESTRICTED_PILOT
+    assert any("absent from runtime_binding_units" in r for r in verdict.reasons)
+
+
+def test_an_incomplete_routed_stack_downgrades_even_with_equal_memberships():
+    stack = routed(members=("e0", "e1"), covered=("e0",))
+    verdict = frontier_label(memberships(), routed_stacks=[stack])
+    assert verdict.label == LABEL_RESTRICTED_PILOT
+    assert "layers.2.moe" in verdict.routed_gaps
+
+
+def test_a_downgrade_is_a_verdict_not_an_exception():
+    """An honest restricted pilot is a valid outcome, not an error."""
+    verdict = frontier_label(memberships(assignment_units=[UNITS[0]]))
+    assert verdict.label == LABEL_RESTRICTED_PILOT
+    assert verdict.reasons
+
+
+def test_the_verdict_is_reproducible():
+    first = frontier_label(memberships(), routed_stacks=[routed()])
+    second = frontier_label(memberships(), routed_stacks=[routed()])
+    assert first.identity_sha256() == second.identity_sha256()
+
+
+def test_membership_order_does_not_change_the_verdict():
+    shuffled = memberships(census_units=list(reversed(UNITS)))
+    assert (
+        frontier_label(shuffled, routed_stacks=[routed()]).identity_sha256()
+        == frontier_label(memberships(), routed_stacks=[routed()]).identity_sha256()
+    )

--- a/tests/test_quality_prefill_knee.py
+++ b/tests/test_quality_prefill_knee.py
@@ -1,0 +1,236 @@
+"""Section 9's development-point rule: what it nominates and what it refuses."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from prismaquant.quality_prefill_knee import (
+    KNEE_RULE,
+    KneeSelectionError,
+    feasible_points,
+    nondominated,
+    read_points,
+    select_development_point,
+)
+
+JOINT = "joint_aura_predicted_dloss"
+SCALAR = "output_mse_under_route_activation_contract"
+
+
+def point(pid, *, latency, quality, size=1000, status="predicted_screen", currency=JOINT):
+    return {
+        "point_id": pid,
+        "assignment_id": f"a.{pid}",
+        "bytes": size,
+        "prefill_budget": latency,
+        "quality_value": quality,
+        "currency": currency,
+        "units": "nats",
+        "measurement_status": status,
+    }
+
+
+def convex_frontier():
+    """A frontier with a real elbow at ``mid``.
+
+    Latency 10 -> 40 buys most of the quality; 40 -> 100 buys very little, so
+    the perpendicular improvement peaks at 40.
+    """
+    return [
+        point("fast", latency=10, quality=1.00),
+        point("early", latency=20, quality=0.70),
+        point("mid", latency=40, quality=0.25),
+        point("late", latency=70, quality=0.15),
+        point("best", latency=100, quality=0.10),
+    ]
+
+
+def test_the_module_imports_no_rng():
+    source = pathlib.Path("prismaquant/quality_prefill_knee.py").read_text()
+    assert "import random" not in source
+    assert "from random" not in source
+    assert "secrets" not in source
+
+
+def test_the_elbow_is_nominated_with_both_neighbours_and_both_endpoints():
+    selection = select_development_point(
+        convex_frontier(), byte_budget=2000, min_separation=0.01
+    )
+    assert selection.knee_point_id == "mid"
+    assert selection.neighbour_point_ids == ("early", "late")
+    assert selection.endpoint_point_ids == ("fast", "best")
+    # Section 10 measures the knee, both neighbours and both endpoint controls.
+    assert selection.measurement_roster() == ("fast", "early", "mid", "late", "best")
+    assert selection.rule == KNEE_RULE
+
+
+def test_the_selection_is_byte_identical_across_repeats():
+    first = select_development_point(
+        convex_frontier(), byte_budget=2000, min_separation=0.01
+    )
+    second = select_development_point(
+        list(reversed(convex_frontier())), byte_budget=2000, min_separation=0.01
+    )
+    assert first.identity_sha256() == second.identity_sha256()
+
+
+def test_input_order_does_not_change_the_nominee():
+    ordered = select_development_point(
+        convex_frontier(), byte_budget=2000, min_separation=0.01
+    )
+    shuffled_like = [convex_frontier()[i] for i in (3, 0, 4, 1, 2)]
+    assert (
+        select_development_point(
+            shuffled_like, byte_budget=2000, min_separation=0.01
+        ).knee_point_id
+        == ordered.knee_point_id
+    )
+
+
+def test_the_normalisation_and_chord_are_published():
+    selection = select_development_point(
+        convex_frontier(), byte_budget=2000, min_separation=0.01
+    )
+    published = selection.normalisation.as_dict()
+    assert published["latency_min"] == 10 and published["latency_max"] == 100
+    assert published["quality_min"] == 0.10 and published["quality_max"] == 1.00
+    assert published["chord_from_point_id"] == "fast"
+    assert published["chord_to_point_id"] == "best"
+
+
+def test_a_dominated_point_never_becomes_the_knee():
+    points = convex_frontier()
+    points.append(point("dominated", latency=45, quality=0.90))
+    selection = select_development_point(points, byte_budget=2000, min_separation=0.01)
+    assert "dominated" not in selection.nondominated_point_ids
+    assert selection.knee_point_id == "mid"
+
+
+def test_a_point_over_the_byte_budget_is_infeasible():
+    points = convex_frontier()
+    points.append(point("huge", latency=15, quality=0.05, size=999_999))
+    selection = select_development_point(points, byte_budget=2000, min_separation=0.01)
+    assert "huge" not in selection.nondominated_point_ids
+
+
+def test_a_budget_no_point_fits_refuses_with_the_smallest_size():
+    with pytest.raises(KneeSelectionError, match="no point fits the byte budget 10"):
+        select_development_point(convex_frontier(), byte_budget=10, min_separation=0.01)
+
+
+def test_a_linear_frontier_proposes_no_knee():
+    straight = [
+        point("a", latency=10, quality=1.0),
+        point("b", latency=20, quality=0.9),
+        point("c", latency=30, quality=0.8),
+    ]
+    with pytest.raises(KneeSelectionError, match="no interior point improves"):
+        select_development_point(straight, byte_budget=2000, min_separation=0.0)
+
+
+def test_two_candidates_inside_the_declared_resolution_refuse():
+    points = convex_frontier()
+    points.append(point("twin", latency=41, quality=0.251))
+    with pytest.raises(KneeSelectionError, match="within the declared resolution"):
+        select_development_point(points, byte_budget=2000, min_separation=0.5)
+
+
+def test_fewer_than_three_nondominated_points_refuses():
+    two = [point("a", latency=10, quality=1.0), point("b", latency=20, quality=0.5)]
+    with pytest.raises(KneeSelectionError, match="needs at least 3"):
+        select_development_point(two, byte_budget=2000, min_separation=0.0)
+
+
+def test_a_degenerate_quality_range_refuses():
+    flat = [
+        point("a", latency=10, quality=0.5),
+        point("b", latency=20, quality=0.5),
+        point("c", latency=30, quality=0.5),
+    ]
+    with pytest.raises(KneeSelectionError, match="needs at least 3"):
+        # Equal quality at higher latency is dominated, so the frontier
+        # collapses to one point before the range check can fire.
+        select_development_point(flat, byte_budget=2000, min_separation=0.0)
+
+
+def test_mixed_currencies_refuse_rather_than_being_compared():
+    points = convex_frontier()
+    points.append(point("scalar", latency=25, quality=0.4, currency=SCALAR))
+    with pytest.raises(KneeSelectionError, match="one frontier carries one currency"):
+        select_development_point(points, byte_budget=2000, min_separation=0.01)
+
+
+def test_a_measured_point_is_not_compared_against_a_screened_one():
+    points = convex_frontier()
+    points.append(point("served", latency=25, quality=0.4, status="measured"))
+    with pytest.raises(
+        KneeSelectionError, match="one frontier carries one measurement status"
+    ):
+        select_development_point(points, byte_budget=2000, min_separation=0.01)
+
+
+def test_the_status_is_copied_and_never_upgraded():
+    selection = select_development_point(
+        convex_frontier(), byte_budget=2000, min_separation=0.01
+    )
+    assert selection.measurement_status == "predicted_screen"
+    assert selection.as_dict()["measurement_status"] == "predicted_screen"
+
+
+def test_a_measured_frontier_keeps_its_measured_label():
+    measured = [
+        point(pid, latency=lat, quality=q, status="measured")
+        for pid, lat, q in (("f", 10, 1.0), ("m", 40, 0.25), ("b", 100, 0.10))
+    ]
+    selection = select_development_point(
+        measured, byte_budget=2000, min_separation=0.0
+    )
+    assert selection.measurement_status == "measured"
+    assert selection.knee_point_id == "m"
+
+
+def test_duplicate_point_ids_refuse():
+    points = convex_frontier() + [point("mid", latency=50, quality=0.2)]
+    with pytest.raises(KneeSelectionError, match="already present"):
+        select_development_point(points, byte_budget=2000, min_separation=0.01)
+
+
+def test_an_unknown_coverage_type_refuses():
+    bad = convex_frontier()
+    bad[0]["measurement_status"] = "probably_fine"
+    with pytest.raises(KneeSelectionError, match="not a declared coverage type"):
+        read_points(bad)
+
+
+def test_a_negative_quality_value_refuses():
+    bad = convex_frontier()
+    bad[0]["quality_value"] = -1.0
+    with pytest.raises(KneeSelectionError, match="must not be negative"):
+        read_points(bad)
+
+
+def test_min_separation_has_no_default():
+    with pytest.raises(TypeError):
+        select_development_point(convex_frontier(), byte_budget=2000)
+
+
+def test_equal_cost_points_are_both_kept():
+    """Two assignments that price alike are distinct routes, not one point."""
+    twins = read_points(
+        [
+            point("a", latency=10, quality=1.0),
+            point("b", latency=40, quality=0.3),
+            point("c", latency=40, quality=0.3),
+            point("d", latency=100, quality=0.1),
+        ]
+    )
+    kept = {p.point_id for p in nondominated(twins)}
+    assert {"b", "c"} <= kept
+
+
+def test_feasible_points_uses_exact_integer_bytes():
+    typed = read_points([point("a", latency=10, quality=1.0, size=1024)])
+    assert feasible_points(typed, byte_budget=1024) == typed
+    assert feasible_points(typed, byte_budget=1023) == ()

--- a/tests/test_quality_prefill_screen.py
+++ b/tests/test_quality_prefill_screen.py
@@ -1,0 +1,277 @@
+"""``coverage_first_v1``: what the initial screen keeps, defers and refuses."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from prismaquant.quality_prefill_contract import validate_screen_decision
+from prismaquant.quality_prefill_screen import (
+    SCREEN_RULE,
+    ScreenCandidate,
+    ScreenCaps,
+    ScreenError,
+    apply_coverage_first_v1,
+    expand_licensed_composites,
+    refuse_dominance_screen,
+)
+
+SOURCE = "a" * 64
+
+
+def candidate(
+    cid,
+    *,
+    stratum="rate.e4m3.0256-0512",
+    route="a4w4",
+    mandatory=False,
+    interior=False,
+    composites=1,
+    tasks=1,
+    uncertainty=0.25,
+    runtime_known=False,
+):
+    return ScreenCandidate(
+        candidate_id=cid,
+        rate_stratum_id=stratum,
+        route_class=route,
+        mandatory=mandatory,
+        interior_draw=interior,
+        composite_options=composites,
+        tasks_per_phase=tasks,
+        uncertainty=uncertainty,
+        runtime_price_known=runtime_known,
+    )
+
+
+def roster():
+    return [
+        candidate("c.boundary.0256", mandatory=True),
+        candidate("c.boundary.0512", mandatory=True),
+        candidate("c.interior.0300", interior=True),
+        candidate("c.spare.0310"),
+        candidate("c.spare.0320"),
+        candidate("c.spare.0330"),
+        candidate("c.a16.0340", route="a16w4"),
+        candidate("c.a16.0350", route="a16w4"),
+    ]
+
+
+def apply(entries=None, **overrides):
+    kwargs = {
+        "caps": ScreenCaps(
+            max_retained_candidates=16,
+            max_composite_options=32,
+            max_tasks_per_phase=64,
+        ),
+        "source_sha256": SOURCE,
+        "audit_count": 2,
+        "decision_id": "screen.pilot.01",
+    }
+    kwargs.update(overrides)
+    return apply_coverage_first_v1(roster() if entries is None else entries, **kwargs)
+
+
+def test_the_module_imports_no_rng():
+    source = pathlib.Path("prismaquant/quality_prefill_screen.py").read_text()
+    assert "import random" not in source
+    assert "from random" not in source
+    assert "secrets" not in source
+
+
+def test_coverage_first_v1_never_prunes_anything():
+    """The defining negative property of the initial policy."""
+    result = apply()
+    dispositions = {
+        entry["candidate_id"]: entry["disposition"]
+        for entry in result.decision["dispositions"]
+    }
+    assert set(dispositions.values()) <= {"retained", "deferred"}
+    assert "pruned" not in set(dispositions.values())
+
+
+def test_every_mandatory_candidate_is_retained():
+    result = apply()
+    assert "c.boundary.0256" in result.retained
+    assert "c.boundary.0512" in result.retained
+
+
+def test_the_frozen_interior_draw_is_retained():
+    assert "c.interior.0300" in apply().retained
+
+
+def test_each_route_class_keeps_a_representative():
+    result = apply()
+    kept_classes = {
+        candidate("x", route=r).route_class
+        for r in ("a4w4", "a16w4")
+    }
+    retained = set(result.retained)
+    assert retained & {"c.a16.0340", "c.a16.0350"}, "the a16w4 class lost its route"
+    assert kept_classes == {"a4w4", "a16w4"}
+
+
+def test_every_candidate_gets_exactly_one_disposition():
+    result = apply()
+    ids = [entry["candidate_id"] for entry in result.decision["dispositions"]]
+    assert sorted(ids) == sorted(c.candidate_id for c in roster())
+    assert len(ids) == len(set(ids))
+
+
+def test_the_decision_validates_against_the_milestone_1_schema():
+    validate_screen_decision(dict(apply().decision))
+
+
+def test_the_rule_is_named_and_versioned_in_the_decision():
+    assert apply().decision["rule"] == dict(SCREEN_RULE)
+    assert SCREEN_RULE["name"] == "coverage_first_v1"
+
+
+def test_the_decision_is_reproducible_from_the_same_inputs():
+    assert apply().identity_sha256() == apply().identity_sha256()
+
+
+def test_input_order_does_not_change_the_ledger():
+    forward = apply()
+    backward = apply(list(reversed(roster())))
+    assert forward.identity_sha256() == backward.identity_sha256()
+    assert forward.audit == backward.audit
+
+
+def test_a_missing_uncertainty_refuses_rather_than_writing_zero():
+    entries = roster()
+    entries[3] = candidate("c.spare.0310", uncertainty=None)
+    with pytest.raises(ScreenError, match="Unknown uncertainty is not zero"):
+        apply(entries)
+
+
+def test_a_cap_the_mandatory_set_exceeds_refuses_with_both_counts():
+    with pytest.raises(ScreenError) as excinfo:
+        apply(
+            caps=ScreenCaps(
+                max_retained_candidates=2,
+                max_composite_options=32,
+                max_tasks_per_phase=64,
+            )
+        )
+    message = str(excinfo.value)
+    assert "retained_candidates requires 4 but the manifest allows 2" in message
+    assert "never reduces a quota" in message
+
+
+def test_a_cap_overflow_never_returns_a_truncated_prefix():
+    caps = ScreenCaps(
+        max_retained_candidates=3, max_composite_options=32, max_tasks_per_phase=64
+    )
+    with pytest.raises(ScreenError):
+        apply(caps=caps)
+
+
+def test_composite_options_are_capped_after_expansion_not_before():
+    entries = [
+        candidate("c.boundary.0256", mandatory=True, composites=9),
+        candidate("c.boundary.0512", mandatory=True, composites=9),
+        candidate("c.spare.0310"),
+    ]
+    assert expand_licensed_composites(entries) == 19
+    with pytest.raises(ScreenError, match="composite_options requires 18"):
+        apply(
+            entries,
+            caps=ScreenCaps(
+                max_retained_candidates=16,
+                max_composite_options=8,
+                max_tasks_per_phase=64,
+            ),
+        )
+
+
+def test_a_tasks_per_phase_overflow_refuses():
+    entries = [
+        candidate("c.boundary.0256", mandatory=True, tasks=50),
+        candidate("c.spare.0310"),
+    ]
+    with pytest.raises(ScreenError, match="tasks_per_phase requires 50"):
+        apply(
+            entries,
+            caps=ScreenCaps(
+                max_retained_candidates=16,
+                max_composite_options=32,
+                max_tasks_per_phase=10,
+            ),
+        )
+
+
+def test_a_dominance_screen_refuses_while_a_runtime_price_is_unknown():
+    with pytest.raises(ScreenError, match="An unmeasured route is not a slow route"):
+        refuse_dominance_screen(roster())
+
+
+def test_a_dominance_screen_is_allowed_once_every_runtime_price_exists():
+    priced = [
+        candidate(c.candidate_id, route=c.route_class, runtime_known=True)
+        for c in roster()
+    ]
+    refuse_dominance_screen(priced)
+
+
+def test_the_audit_roster_is_drawn_from_deferred_candidates_only():
+    result = apply()
+    assert len(result.audit) == 2
+    assert set(result.audit) <= set(result.deferred)
+
+
+def test_an_audit_larger_than_the_deferred_pool_refuses():
+    with pytest.raises(ScreenError, match="cannot draw more than"):
+        apply(audit_count=99)
+
+
+def test_the_audit_draw_is_stable_across_seeds_only_by_declaration():
+    zero = apply(selection_seed=0).audit
+    one = apply(selection_seed=1).audit
+    assert zero == apply(selection_seed=0).audit
+    assert one == apply(selection_seed=1).audit
+
+
+def test_a_duplicate_candidate_id_refuses():
+    entries = roster() + [candidate("c.spare.0310")]
+    with pytest.raises(ScreenError, match="duplicate candidate id"):
+        apply(entries)
+
+
+def test_an_empty_roster_refuses():
+    with pytest.raises(ScreenError, match="at least one candidate"):
+        apply([])
+
+
+def test_a_zero_cap_refuses_at_construction():
+    with pytest.raises(ScreenError, match="must be a positive int"):
+        ScreenCaps(
+            max_retained_candidates=0, max_composite_options=1, max_tasks_per_phase=1
+        )
+
+
+def test_retained_candidates_are_pending_measurement_never_measured():
+    statuses = {
+        entry["candidate_id"]: entry["measurement_status"]
+        for entry in apply().decision["dispositions"]
+    }
+    assert statuses["c.boundary.0256"] == "retained_pending_measurement"
+    assert "measured" not in set(statuses.values())
+
+
+def test_a_deferred_candidate_reads_as_not_yet_acquired():
+    result = apply()
+    statuses = {
+        entry["candidate_id"]: entry["measurement_status"]
+        for entry in result.decision["dispositions"]
+    }
+    for candidate_id in result.deferred:
+        assert statuses[candidate_id] == "not_yet_acquired"
+
+
+def test_every_deferred_candidate_records_a_reason():
+    for entry in apply().decision["dispositions"]:
+        assert entry["reason"]
+        if entry["disposition"] == "deferred":
+            assert "not a deletion" in entry["reason"]

--- a/tests/test_quality_prefill_screen.py
+++ b/tests/test_quality_prefill_screen.py
@@ -8,6 +8,7 @@ import pytest
 
 from prismaquant.quality_prefill_contract import validate_screen_decision
 from prismaquant.quality_prefill_screen import (
+    REPRESENTATIVE_TIE_RULE,
     SCREEN_RULE,
     ScreenCandidate,
     ScreenCaps,
@@ -275,3 +276,35 @@ def test_every_deferred_candidate_records_a_reason():
         assert entry["reason"]
         if entry["disposition"] == "deferred":
             assert "not a deletion" in entry["reason"]
+
+
+def test_the_route_class_representative_is_the_lowest_candidate_id():
+    """Deterministic by a stated rule, not by borrowing another purpose's draw."""
+    entries = [
+        candidate("c.boundary.0256", mandatory=True),
+        candidate("c.a16.0350", route="a16w4"),
+        candidate("c.a16.0340", route="a16w4"),
+        candidate("c.a16.0360", route="a16w4"),
+    ]
+    result = apply(entries)
+    assert "c.a16.0340" in result.retained
+    assert {"c.a16.0350", "c.a16.0360"} <= set(result.deferred)
+
+
+def test_the_representative_reason_publishes_the_tie_rule():
+    reasons = {
+        entry["candidate_id"]: entry["reason"]
+        for entry in apply().decision["dispositions"]
+    }
+    representative = next(
+        cid for cid in ("c.a16.0340", "c.a16.0350") if "representative" in reasons[cid]
+    )
+    assert REPRESENTATIVE_TIE_RULE in reasons[representative]
+
+
+def test_a_retained_candidate_holds_no_discarded_candidate_audit_rank():
+    """Section 5.1 keeps purpose domains apart: retention is not an audit draw."""
+    result = apply()
+    assert set(result.ranks) == set(result.deferred)
+    for candidate_id in result.retained:
+        assert candidate_id not in result.ranks


### PR DESCRIPTION
What milestone 1 (#507) left buildable: the §9 knee search, the §5.4 screen and
the §5.2 coverage gate of `docs/design/tessera_quality_prefill_experiment.md`.

**No encode, decode, serve or GPU measurement was made.** Nothing claims a
quality, speed or size result.

## What lands

- `quality_prefill_knee.py` — the §9 knee search over the prefill-budget grid,
  operating on a supplied measured table. It never synthesises one.
- `quality_prefill_screen.py` — the §5.4 screen, naming the units that differ
  before a proposal may be called a whole-model frontier.
- `quality_prefill_coverage.py` — the §5.2 coverage gate, refusing a cap rather
  than trimming a quota, and picking a route class's representative by a stated
  rule rather than reusing another purpose's draw.

## Blockers, unchanged and re-checked against the tree

| blocker | state today |
|---|---|
| prismaquant #420 | open. `admit_fixed_resources` refuses every full-engine v2 partition. Stops all runtime pricing and allocation. |
| prismaquant #503 | open, draft. |
| prismabuild #518 | open, draft, **not deployed** — the running generation carries no `decomposition.py`. |
| prismabuild #499 | **fixed and deployed** 2026-09-12; no longer a blocker. |

Its fix being deployed does not close the issue: prismabuild#499 is dated
2026-09-11 and is still open.

Three inputs remain owed and are not guessable: `allocation.byte_budgets`,
`allocation.prefill_budget_sweep`, `runtime.workload_manifests`.

## Test evidence

PrismaBuild `daa317306f7f`, `--priority -10`, sparky: **289 passed, 0 failed**.

Refs #237.


Closes #513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmYxSxhmzbBcBoFTjbLi1G
