### PR TITLE
One RateDomain, and the reason the two strict readers stay apart

### DIFF
--- a/docs/measurements/quality-prefill-milestone-1-2026-09-12.md
+++ b/docs/measurements/quality-prefill-milestone-1-2026-09-12.md
@@ -116,6 +116,48 @@ names all three rather than defaulting: `allocation.byte_budgets`,
   load") while a document hashed into a sealed action key needs closed key sets
   and one canonical byte spelling. They meet at `SchemaValidationError`.
   Converging them is a follow-up, not a completed item.
+
+### 5.1 Disposition, 2026-09-12
+
+Appended, not rewritten: the entries above are what shipped at milestone 1.
+
+- **`RateDomain`: merged.** One definition, in
+  `quality_prefill_population`, imported by `tessera_legal_domain`. The type
+  had to land on package C's side rather than A's: `tessera_formats` raises at
+  *import* when the `tessera` package is absent, so a definition in A would
+  make C unimportable without a Tessera checkout, and C is pure. A keeps the
+  derivation (`legal_rate_domain`, `rate_domain_payload`), which is what "A
+  owns the domain" meant. Three consequences, recorded rather than smoothed:
+  A's three construction refusals now raise `PopulationSelectionError` instead
+  of `TesseraFormatError` — nothing in the tree guards a `RateDomain`
+  construction with `except TesseraFormatError`; A's unused `RateDomain.
+  as_dict` is gone, because it returned *lists* and `RateDomain(**as_dict())`
+  built a domain that compared unequal to the derived one while passing every
+  check; and `__post_init__` now refuses a non-tuple field, which is that same
+  hazard turned into a refusal, with a test on each side.
+- **Two strict readers: not merged, deliberately.** They are two contracts,
+  not two copies, and their refusals differ in five places where a union would
+  weaken one of them: the contract caps integers at `2**63 - 1` and the
+  adapter does not; the contract's `_sequence` takes a `list` and admits an
+  empty one, the adapter's takes any non-string `Sequence` and refuses empty;
+  the contract decodes `str` only, the adapter also `bytes`; the adapter's
+  error subclasses `schemas.SchemaValidationError` and the contract's does
+  not, which `tests/test_quality_prefill_pb_adapter.py` pins; and the
+  identifier grammars are different languages — PrismaBuild's
+  `[a-z0-9][a-z0-9._/-]{0,255}` against PrismaQuant's
+  `[a-z0-9][a-z0-9._:-]{0,127}` — because the adapter's ids reach a sealed
+  PB action key. A reader parameterized over all five would be the sixteenth
+  private strict reader in this tree, not a consolidation of the two. The
+  actual cause is the repo-wide one the adapter's own module docstring names:
+  at least fifteen modules carry a private strict reader, each raising its own
+  error type. That is the follow-up, and it is larger than this work package.
+- **Test-environment finding.** `tests/test_quality_prefill_dry_run.py` opened
+  with `pytest.importorskip("prismaquant.tessera_legal_domain")`, which never
+  worked: a missing `tessera` makes `tessera_formats` raise
+  `TesseraFormatError` (a `ValueError`), not `ImportError`, so the file
+  errored at collection instead of skipping. Both `importorskip` calls there,
+  and the stale one in `test_tessera_legal_domain.py` that guarded against
+  package C "not being on this branch yet", are now plain imports.
 - **The L20 shared-down confirmation exclusion is vacuous at the real N.** With
   42 eligible layers, shared-down draws confirmation from a third that does not
   contain L20. The guard is implemented and tested; only the L10 half was
@@ -138,3 +180,29 @@ All test runs through PrismaBuild at `--priority -10` on sparky, CPU-only.
 | canonicalizer regression (20 callers in main) | `70c17d0a9cab` | 490 passed, 1 pre-existing failure, 3 skipped |
 | that failure on clean main, unmodified | `609e77a2808d` | 1 failed, 10 passed — pre-existing |
 | spec merge, docs currency | `391c99ea4b4c` | 19 passed |
+
+### 6.1 Evidence for §5.1, 2026-09-12
+
+Same routing, `--priority -10`, `--cpus 1 --demand mem_gb=2` (sized from a
+measured 1,124,140 KB max RSS, not from habit — `torch` import dominates).
+The interpreter is `/home/rob/venvs/pq-cu130/bin/python` with
+`PYTHONPATH=.:/home/rob/tessera/src`: `pq-cpu312` does not exist on this box,
+and no venv here has both `pytest` and an importable `tessera`. Tessera is the
+working checkout at `a9eb572e1`, which is **neither** pin — the seven failures
+below are that fact, not this change.
+
+| tree | action key | result |
+|---|---|---|
+| before, `a1fd6e1ceb` | `3a213fba1e55` | 7 failed, 204 passed, 0 skipped |
+| after | `4187a60dd835` | 7 failed, 208 passed, 0 skipped |
+| docs currency (`test_docs_staleness`, `test_architecture_doc`) | `ad0098364785` | 19 passed |
+
+The seven are the same seven, all in `tests/test_tessera_legal_domain.py`, all
+pin-attestation: the ledger at this checkout has no `TESSERA_E4M3_K1_R1024`
+dense cell, and `test_the_importable_tessera_is_a_pin_and_not_the_working_
+checkout` says in its own name what the environment is. The four new passes are
+the four tests added here. No skips in either run, so no refusal was skipped
+past; the join test in particular no longer *can* skip.
+
+This subsection postdates the receipt it records — the amend that added it
+touched this file only.

--- a/prismaquant/quality_prefill_population.py
+++ b/prismaquant/quality_prefill_population.py
@@ -869,13 +869,24 @@ def population_freeze_digest(selection: PopulationSelection) -> str:
 # --------------------------------------------------------------------------
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class RateDomain:
-    """The legal rate domain of one family.
+    """The legal rate domain of one family: the single definition of it.
 
-    Work package A owns the derivation of this object from the frozen producer
-    grammar and packaged reader contract (§2.1). Work package C consumes it
-    through :data:`LegalRateDomainProvider` and never re-derives it.
+    Work package A owns the *derivation*: ``tessera_legal_domain.
+    legal_rate_domain`` walks the frozen producer grammar and packaged reader
+    contract (§2.1) and returns this class. Work package C consumes it
+    through :data:`LegalRateDomainProvider` and never re-derives it. Owning the
+    derivation is not owning the type, so the type lives here, in the package
+    that has no Tessera dependency: ``tessera_formats`` refuses to import
+    without the ``tessera`` package, and a duplicate class in A was the price
+    of keeping C importable without it. A imports this one instead.
+
+    ``rates`` and ``transition_rates`` are tuples, refused when they are not.
+    A domain rebuilt from JSON arrives carrying lists, and a list-valued copy
+    compares unequal to the derived domain while passing every other check —
+    a difference that would surface as a silent mismatch rather than a
+    refusal.
     """
 
     family: str
@@ -883,6 +894,13 @@ class RateDomain:
     transition_rates: tuple[int, ...]
 
     def __post_init__(self) -> None:
+        for name in ("rates", "transition_rates"):
+            if type(getattr(self, name)) is not tuple:
+                raise PopulationSelectionError(
+                    f"rate domain for family {self.family!r} must carry "
+                    f"{name} as a tuple, not a "
+                    f"{type(getattr(self, name)).__name__}"
+                )
         if not self.rates:
             raise PopulationSelectionError(
                 f"rate domain for family {self.family!r} is empty"

--- a/prismaquant/tessera_legal_domain.py
+++ b/prismaquant/tessera_legal_domain.py
@@ -47,6 +47,7 @@ from dataclasses import dataclass
 from fractions import Fraction
 from typing import Mapping, Sequence
 
+from .quality_prefill_population import RateDomain as _RateDomain
 from .tessera_formats import (
     TesseraFamily,
     TesseraFormatError,
@@ -907,38 +908,16 @@ def resolver_transitions(
     return tuple(transitions)
 
 
-@dataclass(frozen=True, slots=True)
-class RateDomain:
-    """One family's complete legal rate domain and its resolver transitions.
-
-    The narrow object work package A hands work package C
-    (``quality_prefill_population.RateDomain``): same three fields, same names,
-    same order, same refusals, so the payload constructs that class directly.
-    A owns both values; everything C does with them is C's.
-    """
-
-    family: str
-    rates: tuple[int, ...]
-    transition_rates: tuple[int, ...]
-
-    def __post_init__(self) -> None:
-        if not self.rates:
-            raise TesseraFormatError(
-                f"rate domain for family {self.family!r} is empty")
-        if tuple(sorted(set(self.rates))) != tuple(self.rates):
-            raise TesseraFormatError(
-                f"rate domain for family {self.family!r} must be sorted and unique")
-        stray = sorted(set(self.transition_rates) - set(self.rates))
-        if stray:
-            raise TesseraFormatError(
-                f"family {self.family!r} declares transition rates outside its "
-                f"legal domain: {stray}")
-
-    def as_dict(self) -> dict[str, object]:
-        return {
-            "family": self.family, "rates": list(self.rates),
-            "transition_rates": list(self.transition_rates),
-        }
+#: The narrow object work package A hands work package C — one class, defined
+#: in C (:class:`prismaquant.quality_prefill_population.RateDomain`) and
+#: imported here. A owns the derivation below; C owns the type, because C has
+#: no Tessera dependency and this module has one at import time, so a shared
+#: definition can only live on C's side. Its refusals — empty, unsorted or
+#: duplicated rates, a transition outside the domain, a non-tuple field — are
+#: C's and raise ``PopulationSelectionError``; this module previously raised
+#: :class:`~prismaquant.tessera_formats.TesseraFormatError` for the first
+#: three, and nothing in the tree guarded those constructions with it.
+RateDomain = _RateDomain
 
 
 def legal_rate_domain(

--- a/tests/test_quality_prefill_dry_run.py
+++ b/tests/test_quality_prefill_dry_run.py
@@ -6,11 +6,14 @@ table was first computed by hand-joining work package A's domain to work
 package C's builder in a throwaway script, which is exactly the kind of number
 this repository retracts: nobody could re-derive it.
 
-This file is the join, committed. It also pins the seam between the two
-structurally identical ``RateDomain`` dataclasses (debt item 1 of the report's
-§5): A hands C plain data through ``rate_domain_payload``, C constructs its own
-class from it, and if either side's field set moves this test fails rather than
-the report going quietly stale.
+This file is the join, committed. It also pins the seam that used to run
+between two structurally identical ``RateDomain`` dataclasses (debt item 1 of
+the report's §5, paid 2026-09-12): there is now one class, defined in package C
+and imported by package A, and A still hands C plain data through
+``rate_domain_payload``. The payload is still the seam -- it is what a frozen
+document carries -- so this test still builds the domain from the payload and
+checks it against the grammar-derived one, and a field renamed on either side
+still fails here rather than the report going quietly stale.
 
 ``source_sha256`` is the grammar digest -- the bytes the legal domain is
 actually derived from -- so the selection hash is anchored in the tree and the
@@ -21,11 +24,8 @@ from __future__ import annotations
 
 import pytest
 
-domain = pytest.importorskip(
-    "prismaquant.tessera_legal_domain",
-    reason="requires a pinned Tessera on the path (see the report's §1)",
-)
-population = pytest.importorskip("prismaquant.quality_prefill_population")
+from prismaquant import quality_prefill_population as population
+from prismaquant import tessera_legal_domain as domain
 
 
 # The report's §3 table, keyed by family. Legal counts are independently
@@ -84,18 +84,24 @@ def test_the_roster_is_a_superset_of_the_mandatory_set_and_stays_legal():
         assert set(built.roster) <= legal
 
 
-def test_the_two_rate_domain_classes_are_distinct_but_the_payload_joins_them():
-    """Debt item 1, pinned: the duplication is real and the seam is the fix.
+def test_one_rate_domain_class_and_the_payload_still_joins_through_it():
+    """Debt item 1, paid: one class, and the payload seam still checked.
 
-    If the classes are ever merged this test should be deleted along with the
-    report's debt entry -- but until then, a field renamed on one side must
-    fail here rather than in a hand-run script nobody kept.
+    The merge removes the duplicate, not the seam.  A frozen plan carries the
+    domain as data, so the round trip that matters is grammar -> payload ->
+    class -> equality with the grammar-derived domain, and that is what runs
+    here.  A field renamed on either side still fails in this test rather than
+    in a hand-run script nobody kept.
     """
-    assert domain.RateDomain is not population.RateDomain
+    assert domain.RateDomain is population.RateDomain
     for family in domain.PRIMARY_FAMILIES:
         payload = domain.rate_domain_payload(family)
         assert set(payload) == {"family", "rates", "transition_rates"}
-        theirs = population.RateDomain(**payload)
-        mine = domain.legal_rate_domain(family)
-        assert theirs.rates == mine.rates
-        assert theirs.transition_rates == mine.transition_rates
+        rebuilt = population.RateDomain(**payload)
+        derived = domain.legal_rate_domain(family)
+        assert rebuilt == derived
+        assert rebuilt.rates == derived.rates
+        assert rebuilt.transition_rates == derived.transition_rates
+        # The builder is the consumer; the payload has to satisfy it, not just
+        # construct.
+        assert set(population.mandatory_rates(rebuilt)) <= set(derived.rates)

--- a/tests/test_quality_prefill_population.py
+++ b/tests/test_quality_prefill_population.py
@@ -307,6 +307,22 @@ def test_rate_domain_refuses_a_transition_outside_the_legal_domain():
         RateDomain(family="E4M3_K1", rates=(256, 257), transition_rates=(999,))
 
 
+@pytest.mark.parametrize("field", ["rates", "transition_rates"])
+def test_rate_domain_refuses_a_list_where_a_tuple_belongs(field):
+    """A domain rebuilt from JSON carries lists and would compare unequal.
+
+    Every other check passes on a list-valued copy -- sorted, unique, no stray
+    transition -- so without this refusal the mismatch shows up as a silent
+    inequality against the derived domain rather than as an error.
+    """
+    fields = {
+        "family": "E4M3_K1", "rates": (256, 257), "transition_rates": (257,),
+    }
+    fields[field] = list(fields[field])
+    with pytest.raises(PopulationSelectionError, match="tuple"):
+        RateDomain(**fields)
+
+
 # ------------------------------------------- criterion 7: the hash input ---
 
 

--- a/tests/test_tessera_legal_domain.py
+++ b/tests/test_tessera_legal_domain.py
@@ -20,6 +20,7 @@ from fractions import Fraction
 
 import pytest
 
+from prismaquant import quality_prefill_population as population
 from prismaquant import tessera_legal_domain as domain
 from prismaquant.tessera_formats import (
     family_q256_bounds,
@@ -521,6 +522,15 @@ def test_rate_domain_has_the_pinned_three_fields_in_order():
     assert names == ("family", "rates", "transition_rates")
 
 
+def test_the_provider_type_is_package_c_s_own_class():
+    """One definition, not two that happen to agree.
+
+    The field-order test above passed while there were two classes; this is
+    what makes it impossible for them to drift apart again.
+    """
+    assert domain.RateDomain is population.RateDomain
+
+
 @pytest.mark.parametrize("family, count", [(E4, 1793), (BF, 3841)])
 def test_provider_returns_the_full_sorted_unique_domain(family, count):
     provided = domain.legal_rate_domain(family)
@@ -540,9 +550,27 @@ def test_provider_returns_the_full_sorted_unique_domain(family, count):
     ],
 )
 def test_rate_domain_refuses_the_same_inputs_package_c_refuses(bad):
-    """Empty, unsorted, duplicated, and a transition outside the domain."""
-    with pytest.raises(Exception):
+    """Empty, unsorted, duplicated, and a transition outside the domain.
+
+    The concrete type is named rather than ``Exception``: these refusals moved
+    from ``TesseraFormatError`` to package C's error when the two classes were
+    merged, and a bare ``Exception`` would have let that pass unremarked.
+    """
+    with pytest.raises(population.PopulationSelectionError):
         domain.RateDomain(**bad)
+
+
+def test_rate_domain_refuses_a_payload_whose_arrays_arrived_as_lists():
+    """A JSON round trip hands back lists; an unequal domain is not a domain.
+
+    ``rate_domain_payload`` produces tuples, so this only fires on a domain
+    rebuilt from a document -- which is exactly where a silent inequality
+    would be hardest to see.
+    """
+    payload = dict(domain.rate_domain_payload(E4))
+    payload["rates"] = list(payload["rates"])
+    with pytest.raises(population.PopulationSelectionError):
+        domain.RateDomain(**payload)
 
 
 def test_a_transition_names_the_first_rate_of_the_new_regime():
@@ -609,17 +637,13 @@ def test_rate_domain_payload_constructs_the_dataclass():
     assert rebuilt == domain.legal_rate_domain(E4)
 
 
-def test_payload_satisfies_package_c_when_package_c_is_importable():
-    """The real compatibility check, when both packages are on one branch.
+def test_payload_satisfies_package_c():
+    """The real compatibility check: both packages are on one branch.
 
-    Skipped -- and therefore certifying nothing -- while work package C lives
-    on its own branch.  It exists so the join is checked by a test at merge
-    rather than by two matching docstrings.
+    The ``importorskip`` this used to open with dated from when work package C
+    lived on its own branch.  C is here, so the guard could only hide a real
+    break, and it is now a plain import at the top of the file.
     """
-    population = pytest.importorskip(
-        "prismaquant.quality_prefill_population",
-        reason="work package C is not on this branch yet",
-    )
     for family in domain.PRIMARY_FAMILIES:
         theirs = population.RateDomain(**domain.rate_domain_payload(family))
         assert theirs.rates == domain.legal_rate_domain(family).rates


### PR DESCRIPTION
Pays the first of the two debts #507 recorded in its own body.

**One `RateDomain`.** Packages A and C carried structurally identical
dataclasses; they are now one, and the payload seam that joins them keeps its
test.

**The two strict readers stay apart, and the reason is now written down.**
`quality_prefill_contract` and `quality_prefill_pb_adapter` were the other
recorded debt. Merging them would have cost five refusal deltas that are each
deliberate — they are documented at the seam rather than dissolved. A reader
that refuses less than it did is not a simplification.

## Test evidence

PrismaBuild `4187a60dd835`, `--priority -10`, sparky: **208 passed** against a
204-passed baseline on `origin/main`, with the **same 7 pre-existing
pin-attestation failures** on both sides — measured, not inferred. The branch
adds 4 passing tests and no new failure.

Refs #237.


Closes #514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmYxSxhmzbBcBoFTjbLi1G
