### PR TITLE
Synthesize an adopted rung's missing render, and record that it was synthesized

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,45 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-12 · `pq/420-full-engine-report-consumer`. Stamps
+As of: 2026-09-12 · `fix/synthesize-adopted-renders`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-12, `fix/synthesize-adopted-renders`) for **synthesized
+renders on adopted joint-AURA rungs, recorded as synthesized** (#515). A rung
+the Tessera campaign adopted rather than encoded has a verified wire blob and
+no decoded PWC shard, which blocked
+`tessera_joint_aura.load_measured_anchor_input` on
+`original decoded PWC shard missing`. That shard is now synthesized from the
+wire through the one decode seam -- the bound reader's
+`read_unit_artifact` when a reader is declared, the module-level decoder
+otherwise -- and the refusal is kept for the cases that remain broken: no
+wire, a wire that does not decode, or a decode that is not the census BF16
+render. Synthesis costs an I/O and decode pass instead of a re-encode.
+
+What it does not buy is evidence about the encode, and the record says so.
+Every cell and every `verify_anchor_render` receipt carries a closed-vocabulary
+`render_origin` (`encoded | synthesized_from_wire`) and a second closed
+vocabulary, `render_comparison`, naming what the `torch.equal` leg established
+for that rung: `independent_render_vs_wire` for an encoded shard, and
+`wire_round_trip_only` for a synthesized one, where the comparison is
+`decode(wire)` against a shard written from `decode(wire)` and can only catch
+corruption between the write and the read. That leg still runs on both
+origins. The load-bearing, independent leg is unchanged:
+`verify_cached_unit` still checks the wire against an encoder identity
+re-derived from the streamed source weights and H, and it is what qualifies an
+adopted rung at all. Origin lives in a `prismaquant.tessera_joint_aura.
+render_origin.v1` marker written beside the shard, and written *before* it, so
+a crash between the two writes re-synthesizes rather than leaving a shard that
+reads as encoded; the campaign journals fresh and resumed wires through one
+receipt grammar, so nothing in the record itself distinguishes the two.
+The per-origin census travels into the prepared completion, the prepared PWC
+metadata, `results.json`, the joint payload's `tessera_joint_anchors` block and
+the allocation handoff's provenance, so "verify_anchor_render passed on all
+rungs" can never be read as "all renders were independently compared"
+(principle 12, applied to verification rather than route; principle 14's scope
+corollary). The prepared record is `prismaquant.tessera_joint_aura.prepared.v3`;
+a v2 preparation requires a fresh prepare. No format, default, wire or serving
+gate changes. Gate: `tests/test_tessera_joint_aura.py`,
+`tests/test_tessera_joint_allocation.py`.
 
 Re-stamped (2026-09-12, `pq/420-full-engine-report-consumer`) for the pure
 artifact consumer half of the fixed-resource admission design's "freeze and
@@ -1607,7 +1645,9 @@ token/capture artifacts. Only journaled measured wire cells enter the exact
 per-Linear format plan; interpolated MSE rows never become joint prices.
 Preparation derives the producer's encoding identity from actual streamed source
 weights and original prefetched Hessians, verifies original wire bytes, and
-requires their decoded BF16 values to equal original PWC shards. Fused-census
+requires their decoded BF16 values to equal original PWC shards (see the
+2026-09-12 `fix/synthesize-adopted-renders` stamp for what that comparison
+establishes on a rung whose shard was synthesized from its own wire). Fused-census
 maxima use the existing static-scale contract and must reproduce measured E2M1
 scales. The existing PWC indexes original absolute donor paths and owns prefetch
 and eviction; no encoder, cache store or dispatcher is added. A sealed prepared

--- a/prismaquant/tessera_joint_allocation.py
+++ b/prismaquant/tessera_joint_allocation.py
@@ -17,7 +17,10 @@ import pickle
 
 from .cluster_campaign import _atomic_write_new_bytes as atomic_write_bytes
 from .cost_stage_checkpoint import canonical_json_sha256
-from .tessera_joint_aura import PREPARED_SCHEMA, SCHEMA, _require, _same
+from .tessera_joint_aura import (
+    PREPARED_SCHEMA, RENDER_COMPARISON_BY_ORIGIN, SCHEMA, _require, _same,
+    cell_render_census, render_origin_census,
+)
 
 HANDOFF_SCHEMA = 'prismaquant.tessera_joint_allocation.v1'
 ROW_FIELDS = ('hessian_identity', 'tessera_family', 'tessera_body_rate_q256',
@@ -64,6 +67,16 @@ def bind_allocation_payload(joint, data, prepared, cache_metadata, *, plan_sha25
         _same(cache_metadata.get(key), prepared.get(key), f'prepared cache {key}')
     verified = cache_metadata.get('verified_cells', {})
     _same(set(verified), set(data.cells), 'prepared tensor receipt roster')
+    # Carried, not recomputed from file state: which rungs had an independent
+    # render/wire comparison and which had only the wire round-trip is a fact
+    # about the qualification that ran, and it travels with this table.
+    render_census = cell_render_census(data.cells)
+    _same(render_origin_census(receipt['render_origin'] for receipt in verified.values()),
+          render_census, 'prepared render origin census')
+    for key, value in render_census.items():
+        _same(cache_metadata.get(key), value, f'prepared cache {key}')
+        _same(prepared.get(key), value, f'prepared {key}')
+        _same(evidence.get(key), value, f'joint {key}')
     original = data.payload['provenance']
     calibration = prepared['calibration_input']
     original_draw = original['hessian']['calibration_identity']
@@ -97,6 +110,9 @@ def bind_allocation_payload(joint, data, prepared, cache_metadata, *, plan_sha25
             receipt = verified[pair]
             for key in ('source_weight', 'rendered_weight', 'activation'):
                 _same(operator[key], receipt[key], f'{name}@{fmt}: prepared {key}')
+            _same(receipt['render_comparison'],
+                  RENDER_COMPARISON_BY_ORIGIN[data.cells[pair]['render_origin']],
+                  f'{name}@{fmt}: prepared render comparison')
             record = data.cells[pair]['record']
             _same(receipt['wire_sha256'], record['blob_sha256'], f'{name}@{fmt}: original wire')
             source_record = data.manifest['identity']['units'][name]['weight']
@@ -142,6 +158,7 @@ def bind_allocation_payload(joint, data, prepared, cache_metadata, *, plan_sha25
         'units': len(roster), 'measured_cells': len(data.cells),
         'cost_fields': 'all_original_joint_fields_unchanged',
         'wire_validation': 'historical_prepared_identity; current_bytes_require_export_gate',
+        **render_census,
     }, 'joint provenance')
     _same(require_run_currency(result), currency, 'unchanged joint currency')
     return result

--- a/prismaquant/tessera_joint_aura.py
+++ b/prismaquant/tessera_joint_aura.py
@@ -24,7 +24,20 @@ from .cost_stage_checkpoint import (
 )
 
 SCHEMA = "prismaquant.tessera_joint_aura.plan.v1"
-PREPARED_SCHEMA = "prismaquant.tessera_joint_aura.prepared.v2"
+PREPARED_SCHEMA = "prismaquant.tessera_joint_aura.prepared.v3"
+RENDER_ORIGIN_SCHEMA = "prismaquant.tessera_joint_aura.render_origin.v1"
+# Closed vocabularies. ``render_origin`` says where the decoded PWC shard on
+# disk came from; ``render_comparison`` says what the ``torch.equal`` leg of
+# ``verify_anchor_render`` established for that rung. They are two different
+# facts and a record that collapses them claims verification it never had.
+RENDER_ORIGINS = ("encoded", "synthesized_from_wire")
+RENDER_COMPARISONS = ("independent_render_vs_wire", "wire_round_trip_only")
+# An encoded render is an independently produced tensor, so comparing it with
+# the decoded wire is evidence about the encode. A synthesized render was
+# written by decoding that same wire, so the comparison can only establish
+# that the ``.pt`` still round-trips to the bytes it was written from.
+RENDER_COMPARISON_BY_ORIGIN = {"encoded": "independent_render_vs_wire",
+                               "synthesized_from_wire": "wire_round_trip_only"}
 CAMPAIGN_SCHEMA = "prismaquant.tessera_campaign_cost.v1"
 CURRENCY = "output_mse_under_route_activation_contract"
 STAGE = "Tessera campaign"
@@ -78,7 +91,108 @@ class MeasuredAnchorInput:
         return dict(sizes)
 
 
-def load_measured_anchor_input(inputs, *, file_hash_workers=1, verify_payloads=True):
+def _render_origin_marker_path(render):
+    return Path(render).with_name(Path(render).name + ".render_origin.json")
+
+
+def render_origin_census(origins):
+    """Count each closed-vocabulary value, including the ones nobody used.
+
+    A census that omits the zero keeps a reader from telling "no synthesized
+    renders" apart from "this report does not say".
+    """
+    counts = {value: 0 for value in RENDER_ORIGINS}
+    comparisons = {value: 0 for value in RENDER_COMPARISONS}
+    for origin in origins:
+        _require(origin in RENDER_ORIGINS, f"unknown render origin {origin!r}")
+        counts[origin] += 1
+        comparisons[RENDER_COMPARISON_BY_ORIGIN[origin]] += 1
+    return {"render_origins": counts, "render_comparisons": comparisons}
+
+
+def cell_render_census(cells):
+    """The census of a cell mapping, from the field every cell must carry."""
+    origins = []
+    for pair, cell in sorted(cells.items()):
+        _require(isinstance(cell, dict) and "render_origin" in cell,
+                 f"{pair}: cell carries no render_origin")
+        origins.append(cell["render_origin"])
+    return render_origin_census(origins)
+
+
+def _decode_wire(blob, *, reader, device="cpu"):
+    """The one decode seam: the bound reader's, or the module-level decoder."""
+    if reader is not None:
+        return reader.read_unit_artifact(blob, device=device)
+    from tessera.unit_artifact import read_unit_artifact
+
+    return read_unit_artifact(blob, device=device)
+
+
+def _synthesize_render_from_wire(render, *, wire, record, name, fmt, shape, reader):
+    """Write the missing decoded PWC shard from the verified wire blob.
+
+    A rung this campaign adopted rather than encoded has its wire but no
+    ``.pt``. Re-encoding it costs GPU-hours on the critical path; decoding
+    the wire costs an I/O pass. What the decode cannot buy is evidence about
+    the encode, so the marker below is written FIRST: a crash between the two
+    writes leaves a marker with no shard, which the next load re-synthesizes,
+    whereas the other order would leave a shard that reads as ``encoded``.
+    """
+    import torch
+    from .production_weight_cache import _store_rendered_weight_entry
+
+    blob = Path(wire).read_bytes()
+    _same(hashlib.sha256(blob).hexdigest(), record["blob_sha256"],
+          f"{name}@{fmt}: wire checksum before synthesizing its render")
+    try:
+        decoded = _decode_wire(blob, reader=reader).to(torch.bfloat16)
+    except Exception as exc:
+        raise ValueError(f"{name}@{fmt}: original decoded PWC shard missing and "
+                         f"its wire does not decode: {exc}") from exc
+    _require(isinstance(decoded, torch.Tensor) and decoded.dtype == torch.bfloat16 and
+             list(decoded.shape) == list(shape) and bool(torch.isfinite(decoded).all()),
+             f"{name}@{fmt}: decoded wire is not the census BF16 render")
+    marker = _render_origin_marker_path(render)
+    Path(render).parent.mkdir(parents=True, exist_ok=True)
+    _json(marker, {"schema": RENDER_ORIGIN_SCHEMA, "render_origin": "synthesized_from_wire",
+                   "unit": name, "format_name": fmt, "wire_sha256": record["blob_sha256"],
+                   "wire_file": Path(wire).name})
+    _store_rendered_weight_entry(weights={}, cache_dir_path=Path(render).parent,
+                                 qname=name, fmt=fmt, tensor=decoded,
+                                 weight_dtype=torch.bfloat16, durable=True)
+    _require(Path(render).is_file(), f"{name}@{fmt}: synthesized render was not published")
+    return "synthesized_from_wire"
+
+
+def _resolve_render_origin(render, *, wire, record, name, fmt, shape, reader):
+    """Name where this rung's decoded PWC shard came from, never guess it.
+
+    The campaign journals fresh and resumed wires through one receipt grammar
+    (``_checkpoint_wire_record``), so nothing in the record distinguishes an
+    adopted rung from an encoded one. The marker beside the shard is the only
+    place that fact can live, and its absence beside an existing shard is the
+    campaign's own render.
+    """
+    render, marker = Path(render), _render_origin_marker_path(render)
+    if render.is_file():
+        if not marker.is_file():
+            return "encoded"
+        stamp = json.loads(marker.read_text())
+        _same(stamp.get("schema"), RENDER_ORIGIN_SCHEMA, f"{name}@{fmt}: render origin schema")
+        _same(stamp.get("render_origin"), "synthesized_from_wire",
+              f"{name}@{fmt}: marked render origin")
+        _same(stamp.get("unit"), name, f"{name}@{fmt}: marked render unit")
+        _same(stamp.get("format_name"), fmt, f"{name}@{fmt}: marked render format")
+        _same(stamp.get("wire_sha256"), record["blob_sha256"],
+              f"{name}@{fmt}: synthesized render names another wire")
+        return "synthesized_from_wire"
+    _require(Path(wire).is_file(), f"{name}@{fmt}: original decoded PWC shard missing")
+    return _synthesize_render_from_wire(render, wire=wire, record=record, name=name,
+                                        fmt=fmt, shape=shape, reader=reader)
+
+
+def load_measured_anchor_input(inputs, *, file_hash_workers=1, verify_payloads=True, reader=None):
     """Read a complete merged journal and select only its measured wire cells.
 
     The default hashes all payload files. Preparation may explicitly defer
@@ -86,6 +200,12 @@ def load_measured_anchor_input(inputs, *, file_hash_workers=1, verify_payloads=T
     roster gates still run here. Tensor/source/encoder verification occurs in
     ``prepare_cache`` using actual source weights and the original capture.
     Interpolated menu rows are deliberately excluded rather than converted.
+
+    A rung this campaign adopted has its wire but no decoded PWC shard. The
+    shard is synthesized from that wire here and every cell carries the
+    resulting ``render_origin``, so no later report can read "verified" as
+    "independently compared". ``reader`` is the same bound Tessera consumer
+    ``verify_anchor_render`` uses; there is one decode seam, not two.
     """
     from .production_weight_cache import _cache_weight_filename
     from tools.dispatch_tessera_campaign import _require_receipts
@@ -203,9 +323,11 @@ def load_measured_anchor_input(inputs, *, file_hash_workers=1, verify_payloads=T
             _require(not wire.is_symlink() and wire.resolve().parent == wire_dir.resolve(), f"{name}: escaping wire path")
             _same(wire.stat().st_size, record["blob_bytes"], f"{name}: wire size")
             render = owners[name] / "cache" / _cache_weight_filename(name, fmt)
-            _require(render.is_file(), f"{name}@{fmt}: original decoded PWC shard missing")
+            origin = _resolve_render_origin(render, wire=wire, record=record, name=name,
+                                            fmt=fmt, shape=census["unit_shapes"][name],
+                                            reader=reader)
             cells[name, fmt] = {"anchor": anchor, "record": record, "wire": str(wire.resolve()),
-                               "render": str(render.resolve())}
+                               "render": str(render.resolve()), "render_origin": origin}
         formats[name] = (*sorted(anchors), "BF16")
     if not verify_payloads:
         return MeasuredAnchorInput(dict(inputs), payload, manifest, census, plan, cells, formats)
@@ -256,14 +378,29 @@ def calibrated_maxima(data, profile):
 def verify_anchor_render(cell, source_weight, rendered_weight, *, calibration_source,
                          projected_unit, static_scales, bound_unit=None, reader=None,
                          release_file_pages=False):
-    """Re-derive encoder inputs from actual source/H and compare decoded bytes."""
+    """Re-derive encoder inputs from actual source/H and compare decoded bytes.
+
+    Two legs, and they do not establish the same thing. ``verify_cached_unit``
+    checks the wire against an encoder identity re-derived from the streamed
+    source weights and H; it is independent of anything the cache holds and it
+    is what qualifies an adopted rung at all. The ``torch.equal`` leg compares
+    the decoded wire with the render on disk: for an ``encoded`` rung that is
+    an independent render/wire agreement, and for a ``synthesized_from_wire``
+    rung the render was written by decoding that same wire, so it can only
+    establish that the shard still round-trips -- a corruption check between
+    the write and this read, not evidence about the encode. The returned
+    record names both facts so a reader never has to infer which one it holds.
+    """
     import torch
-    from tessera.unit_artifact import read_unit_artifact
     from . import tessera_campaign as tc
     from .production_weight_cache import _cb_cache_tensor_identity
 
     anchor = tc.CampaignAnchor(**cell["anchor"])
     name, fmt = anchor.qname, anchor.format_name
+    render_origin = cell.get("render_origin")
+    _require(render_origin in RENDER_ORIGINS,
+             f"{name}@{fmt}: cell carries no closed-vocabulary render_origin")
+    render_comparison = RENDER_COMPARISON_BY_ORIGIN[render_origin]
     _require(source_weight.dtype == rendered_weight.dtype == torch.bfloat16 and
              source_weight.ndim == 2 and rendered_weight.shape == source_weight.shape,
              f"{name}@{fmt}: source/render BF16 shape differs")
@@ -280,9 +417,15 @@ def verify_anchor_render(cell, source_weight, rendered_weight, *, calibration_so
     blob = wire_path.read_bytes()
     verifier = tc._checkpoint_identity_api() if reader is None else reader
     verifier.verify_cached_unit(blob, cell["record"], expected)
-    decode = read_unit_artifact if reader is None else reader.read_unit_artifact
-    decoded = decode(blob, device=str(rendered_weight.device)).to(torch.bfloat16)
-    _require(torch.equal(decoded, rendered_weight), f"{name}@{fmt}: decoded wire differs from original PWC render")
+    decoded = _decode_wire(blob, reader=reader,
+                           device=str(rendered_weight.device)).to(torch.bfloat16)
+    # Run on both origins. On a synthesized render it cannot fail as evidence
+    # about the encode, and it is still live evidence that the shard on disk
+    # decodes to the bytes it was written from.
+    _require(torch.equal(decoded, rendered_weight),
+             f"{name}@{fmt}: decoded wire differs from original PWC render"
+             if render_origin == "encoded" else
+             f"{name}@{fmt}: synthesized PWC render no longer decodes from its wire")
     del decoded
     if release_file_pages:
         from .perturbed_x_cache import release_activation_cache_file_pages
@@ -292,7 +435,8 @@ def verify_anchor_render(cell, source_weight, rendered_weight, *, calibration_so
             "rendered_weight": _cb_cache_tensor_identity(rendered_weight),
             "encoding_identity_sha256": canonical_json_sha256(expected, where="joint anchor encoding"),
             "wire_sha256": hashlib.sha256(blob).hexdigest(),
-            "render_file_sha256": cell["render_file_sha256"]}
+            "render_file_sha256": cell["render_file_sha256"],
+            "render_origin": render_origin, "render_comparison": render_comparison}
 
 
 def _live_targets(runner, names):
@@ -514,7 +658,14 @@ def prepare_cache(runner, data, *, capture, max_render_bytes, reader=None, file_
             targets.update({member.qname: member for member in refresh_packed_expert_projections(members, runner.profile)})
     _same(set(verified), set(data.cells), "complete qualified wire/render roster")
     cache.disable_file_load_receipts()
+    census_of_renders = cell_render_census(data.cells)
+    for pair, record in verified.items():
+        _same(record["render_origin"], data.cells[pair]["render_origin"],
+              f"{pair}: qualified render origin")
+    _same(render_origin_census(record["render_origin"] for record in verified.values()),
+          census_of_renders, "qualified render origin census")
     cache.metadata.update({"verified_cells": verified, "prefetch": telemetry,
+        **census_of_renders,
         **({'capture_load_execution': capture_load_execution} if capture_load_execution is not None else {}),
         **({"qualification_window": policy, "capture_resident_bytes": capture_sizes,
             "qualification_memory_guard": None if guard is None else guard.snapshot()}
@@ -709,13 +860,20 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False, source
         file_hash_workers = config.get("file_hash_workers", 1)
         _require(type(file_hash_workers) is int and 0 < file_hash_workers <= len(os.sched_getaffinity(0)),
                  "file_hash_workers exceeds PB-assigned CPU affinity")
-        data = load_measured_anchor_input(config["inputs"],
+        # The reader is bound first: synthesizing an adopted rung's missing
+        # render decodes its wire, and that decode must come from the same
+        # bound consumer the qualification leg uses, not a second one.
+        reader = load_declared_reader(config.get("reader"))
+        reader_identity = None if reader is None else reader.identity
+        data = load_measured_anchor_input(config["inputs"], reader=reader,
             **({} if file_hash_workers == 1 else {"file_hash_workers": file_hash_workers}),
             **({"verify_payloads": False} if command == "prepare" else {}))
         result["file_hash_workers"] = file_hash_workers
-        reader = load_declared_reader(config.get("reader"))
-        reader_identity = None if reader is None else reader.identity
         result["reader_identity"] = reader_identity
+        render_census = cell_render_census(data.cells)
+        # Stated whether or not this command reaches a completion: a run that
+        # dies still says how many of its renders were only ever round-tripped.
+        result.update(render_census)
         _same(config["model"], data.census["model"], "requested source model")
         _same(data.census["attention_implementation"], "eager", "qualified source attention")
         ids, calibration = load_calibration_input(config["calibration_input"]["path"],
@@ -775,17 +933,20 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False, source
                 "reader_identity": reader_identity, "projection_backend": projection_backend.identity,
                 "source_execution": source_execution, "calibration_input": calibration,
                 "production_cache": {"path": str(cache_path), "sha256": _sha(cache_path)},
-                "formats_by_qname": data.formats_by_qname, "measured_cells": len(data.cells)}
+                "formats_by_qname": data.formats_by_qname, "measured_cells": len(data.cells),
+                **render_census}
         else:
             _require(prepared is not None, "cost execution requires independently bound prepared inputs")
             completion = json.loads(_bound(prepared, "prepared anchors").read_text())
             _same(completion.get("schema"), PREPARED_SCHEMA,
-                  "prepared v2 schema required; legacy preparation requires fresh prepare and recompute")
+                  "prepared v3 schema required; legacy preparation requires fresh prepare and recompute")
             _same(completion.get("status"), "complete", "prepared completion")
             for key, value in (("plan_sha256", plan_sha256), ("implementation_sha256", implementation),
                                ("source_model_identity", source), ("source_execution", source_execution),
                                ("calibration_input", calibration), ("measured_cells", len(data.cells)),
                                ("reader_identity", reader_identity),
+                               ("render_origins", render_census["render_origins"]),
+                               ("render_comparisons", render_census["render_comparisons"]),
                                ("projection_backend", projection_backend.identity)):
                 _same(completion.get(key), value, f"prepared {key}")
             _same(completion["formats_by_qname"], {n: list(v) for n, v in data.formats_by_qname.items()},
@@ -797,7 +958,11 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False, source
             _same(cache.metadata.get("projection_backend"), projection_backend.identity, "prepared backend identity")
             _same(set(cache.metadata["verified_cells"]), set(data.cells), "prepared verified cell coverage")
             _same(cache.weights, {pair: cell["render"] for pair, cell in data.cells.items()}, "prepared original render paths")
+            for key in ("render_origins", "render_comparisons"):
+                _same(cache.metadata.get(key), render_census[key], f"prepared cache {key}")
             for pair, cell in data.cells.items():
+                _same(cache.metadata["verified_cells"][pair]["render_origin"], cell["render_origin"],
+                      f"{pair}: qualified render origin changed")
                 _same(cache.metadata["verified_cells"][pair]["render_file_sha256"], cell["render_file_sha256"],
                       f"{pair}: qualified render changed")
                 _same(cache.metadata["verified_cells"][pair]["wire_sha256"], cell["record"]["blob_sha256"],
@@ -826,7 +991,8 @@ def execute(command, config, *, plan_sha256, prepared=None, resume=False, source
                     _require(validate_joint_aura_entry(row), f"{name}: invalid measured joint cost")
             payload["provenance"]["tessera_joint_anchors"] = {
                 "plan_sha256": plan_sha256, "prepared": prepared, "inputs": data.inputs,
-                "calibration_input": calibration, "measured_cells": len(data.cells)}
+                "calibration_input": calibration, "measured_cells": len(data.cells),
+                **render_census}
             output = root / "joint-cost.pkl"
         torch.cuda.synchronize()
         result["peak_gpu_bytes"] = torch.cuda.max_memory_allocated()
@@ -882,7 +1048,9 @@ def main(argv=None):
         **({"source_transition": {"path": str(args.source_transition),
                                   "sha256": args.source_transition_sha256}}
            if args.source_transition is not None else {}))
-    print(json.dumps({key: result[key] for key in ("command", "passed", "units", "measured_cells")}))
+    print(json.dumps({key: result[key] for key in ("command", "passed", "units",
+                                                   "measured_cells", "render_origins",
+                                                   "render_comparisons")}))
     return 0
 
 

--- a/tests/test_joint_projection_backend.py
+++ b/tests/test_joint_projection_backend.py
@@ -185,7 +185,7 @@ def test_cost_refuses_legacy_or_backend_changed_preparation_before_cache_adoptio
     execution = {'fixture': 'source-execution'}
     data = SimpleNamespace(census={'model': 'fixture', 'attention_implementation': 'eager'},
         payload={'provenance': {'hessian': {'calibration_identity': draw}}},
-        layer_render_bytes=lambda _: {0: 64}, formats_by_qname={'unit': ['BF16']}, cells={('unit', 'BF16'): {}})
+        layer_render_bytes=lambda _: {0: 64}, formats_by_qname={'unit': ['BF16']}, cells={('unit', 'BF16'): {'render_origin': 'encoded'}})
     monkeypatch.setattr(bridge, 'load_measured_anchor_input', lambda *_args, **_kwargs: data)
     monkeypatch.setattr(calibration_data, 'load_calibration_input', lambda *_args, **_kwargs:
         (torch.zeros((512, 512), dtype=torch.int64), calibration))
@@ -200,7 +200,9 @@ def test_cost_refuses_legacy_or_backend_changed_preparation_before_cache_adoptio
     record = {'schema': 'prismaquant.tessera_joint_aura.prepared.v1' if legacy_schema else bridge.PREPARED_SCHEMA,
         'status': 'complete', 'plan_sha256': 'd' * 64, 'implementation_sha256': 'c' * 64,
         'source_model_identity': source, 'source_execution': execution, 'calibration_input': calibration,
-        'measured_cells': 1, 'reader_identity': None, 'projection_backend': {'name': 'foreign'}}
+        'measured_cells': 1, 'reader_identity': None, 'projection_backend': {'name': 'foreign'},
+        'render_origins': {'encoded': 1, 'synthesized_from_wire': 0},
+        'render_comparisons': {'independent_render_vs_wire': 1, 'wire_round_trip_only': 0}}
     path = tmp_path / 'prepared.json'
     path.write_text(json.dumps(record))
     with pytest.raises(ValueError, match='fresh prepare and recompute' if legacy_schema else 'prepared projection_backend'):

--- a/tests/test_joint_qualification_windows.py
+++ b/tests/test_joint_qualification_windows.py
@@ -44,7 +44,8 @@ def fixture(tmp_path, monkeypatch, *, fail_cell=False):
         for fmt in formats:
             path = tmp_path / (name + fmt + '.pt')
             torch.save(modules[name].weight.detach(), path)
-            cells[name, fmt] = dict(render=str(path), anchor={'qname': name, 'format_name': fmt})
+            cells[name, fmt] = dict(render=str(path), render_origin='encoded',
+                                    anchor={'qname': name, 'format_name': fmt})
     capture = dict(path=str(tmp_path / 'capture.json'), sha256='a' * 64)
     expected = dict(max_act_rows=4, calibration={'draw': 'same'}, units=names)
     data = SimpleNamespace(payload={'provenance': {'calibration_cache': capture,
@@ -90,7 +91,10 @@ def fixture(tmp_path, monkeypatch, *, fail_cell=False):
         observed.append(('verify', cell['anchor']['qname'], cell['anchor']['format_name']))
         if fail_cell:
             raise RuntimeError('intentional verification failure')
-        return {'render_file_sha256': cell['render_file_sha256']}
+        return {'render_file_sha256': cell['render_file_sha256'],
+                'render_origin': cell['render_origin'],
+                'render_comparison':
+                    bridge.RENDER_COMPARISON_BY_ORIGIN[cell['render_origin']]}
     monkeypatch.setattr(bridge, 'verify_anchor_render', verify)
     return runner, data, capture, events, live, observed
 
@@ -100,6 +104,9 @@ def test_qualification_releases_each_capture_and_window_preserving_roster(tmp_pa
     cache = bridge.prepare_cache(runner, data, capture=capture, max_render_bytes=10000,
         file_load_workers=1, qualification_window=policy())
     assert set(cache.metadata['verified_cells']) == set(data.cells)
+    assert cache.metadata['render_origins'] == {'encoded': 4, 'synthesized_from_wire': 0}
+    assert cache.metadata['render_comparisons'] == {
+        'independent_render_vs_wire': 4, 'wire_round_trip_only': 0}
     assert all(isinstance(value, str) for value in cache.weights.values())
     assert all(ref() is None for ref in live)
     assert len([row for row in observed if row[0] == 'bind']) == 2
@@ -134,3 +141,18 @@ def test_smaller_serialized_budget_plans_more_windows(tmp_path, monkeypatch):
         file_load_workers=2, qualification_window=config)
     windows = cache.metadata['prefetch'][0]['windows']
     assert len(windows) == 4 and all(len(window['keys']) == 1 for window in windows)
+
+
+def test_prepared_metadata_counts_a_synthesized_rung_apart(tmp_path, monkeypatch):
+    """A shard written from its own wire is never counted as independently
+    compared, and a receipt that disagrees with its cell refuses."""
+    runner, data, capture, _events, _live, _observed = fixture(tmp_path, monkeypatch)
+    pair = next(iter(data.cells))
+    data.cells[pair]['render_origin'] = 'synthesized_from_wire'
+    cache = bridge.prepare_cache(runner, data, capture=capture, max_render_bytes=10000,
+        file_load_workers=1, qualification_window=policy())
+    assert cache.metadata['render_origins'] == {'encoded': 3, 'synthesized_from_wire': 1}
+    assert cache.metadata['render_comparisons'] == {
+        'independent_render_vs_wire': 3, 'wire_round_trip_only': 1}
+    assert (cache.metadata['verified_cells'][pair]['render_comparison']
+            == 'wire_round_trip_only')

--- a/tests/test_tessera_joint_allocation.py
+++ b/tests/test_tessera_joint_allocation.py
@@ -43,8 +43,10 @@ def fixture(names=None):
         units[name] = {'weight': copy.deepcopy(record['identity']['source'])}
         verified[name, fmt] = {**{k: copy.deepcopy(op[k]) for k in ('source_weight', 'rendered_weight', 'activation')},
                                'wire_sha256': record['blob_sha256'],
+                               'render_origin': 'encoded',
+                               'render_comparison': 'independent_render_vs_wire',
                                'encoding_identity_sha256': canonical_json_sha256(record['identity'], where='fixture encoding')}
-        cells[name, fmt] = {'record': record}
+        cells[name, fmt] = {'record': record, 'render_origin': 'encoded'}
     probe = costs[names[0]][fmt]['probe_identity']
     prepared_binding = {'path': '/fixture/prepared.json', 'sha256': 'c'*64}
     inputs = {'merged_cost': {'path': '/fixture/anchors.pkl', 'sha256': 'd'*64}}
@@ -62,19 +64,25 @@ def fixture(names=None):
         census={'unit_shapes': {n: [2, 2] for n in names}}, manifest={'identity': {'units': units}})
     calibration = {'calibration_sha256': probe['calibration_sha256'], 'shape': [2, 4],
                    'provenance': copy.deepcopy(hessian['calibration_identity'])}
+    render_census = {'render_origins': {'encoded': len(cells), 'synthesized_from_wire': 0},
+                     'render_comparisons': {'independent_render_vs_wire': len(cells),
+                                            'wire_round_trip_only': 0}}
     prepared = {'schema': PREPARED_SCHEMA, 'status': 'complete', 'plan_sha256': '2'*64,
                 'source_model_identity': probe['source_model'], 'calibration_input': calibration,
                 'formats_by_qname': {n: list(fmts) for n, fmts in data.formats_by_qname.items()},
                 'measured_cells': len(cells), 'reader_identity': {'fixture': 'reader'},
+                **render_census,
                 'projection_backend': probe['arithmetic']['projection_backend']}
     metadata = {'schema': PREPARED_SCHEMA, 'inputs': inputs, 'verified_cells': verified,
+                **render_census,
                 'reader_identity': prepared['reader_identity'], 'projection_backend': prepared['projection_backend']}
     joint = {'schema': 'prismaquant.aura_cost.v1', 'stats': {n: {'h_trace': 1., 'n_params': 4,
                     'in_features': 2, 'out_features': 2} for n in names}, 'costs': costs,
              'formats': [fmt, 'BF16'], 'provenance': {'cost_mode': 'aura', 'joint_activation': True,
                 'cost_currency': 'joint_aura_predicted_dloss', 'tessera_joint_anchors': {
                     'plan_sha256': prepared['plan_sha256'], 'prepared': prepared_binding,
-                    'inputs': inputs, 'calibration_input': calibration, 'measured_cells': len(cells)}}}
+                    'inputs': inputs, 'calibration_input': calibration,
+                    'measured_cells': len(cells), **render_census}}}
     return joint, data, prepared, metadata, {'plan_sha256': prepared['plan_sha256'], 'prepared_binding': prepared_binding}
 
 
@@ -92,11 +100,16 @@ def test_handoff_preserves_all_joint_prices_and_identities():
     assert result['provenance']['cost_mode'] == 'aura'
     assert result['provenance']['hessian'] == data.payload['provenance']['hessian']
     assert result['provenance']['tessera_joint_allocation']['status'] == 'research_metadata_handoff'
+    handoff_block = result['provenance']['tessera_joint_allocation']
+    assert handoff_block['render_origins'] == {'encoded': len(data.cells), 'synthesized_from_wire': 0}
+    assert handoff_block['render_comparisons'] == {
+        'independent_render_vs_wire': len(data.cells), 'wire_round_trip_only': 0}
 
 
 @pytest.mark.parametrize('mutation', ['missing_unit', 'extra_format', 'source', 'render', 'activation',
     'wire', 'calibration', 'prepared', 'shape', 'overwritten_metadata', 'nonzero_bf16',
-    'encoding_identity', 'manifest_source'])
+    'encoding_identity', 'manifest_source', 'render_origin', 'render_origin_census',
+    'synthesized_claims_independent'])
 def test_handoff_refuses_changed_evidence(mutation):
     from prismaquant.tessera_joint_allocation import bind_allocation_payload
     joint, data, prepared, metadata, kwargs = fixture()
@@ -111,6 +124,19 @@ def test_handoff_refuses_changed_evidence(mutation):
     elif mutation == 'wire': metadata['verified_cells'][name, fmt]['wire_sha256'] = '8'*64
     elif mutation == 'encoding_identity': metadata['verified_cells'][name, fmt]['encoding_identity_sha256'] = '8'*64
     elif mutation == 'manifest_source': data.manifest['identity']['units'][name]['weight']['sha256'] = '8'*64
+    elif mutation == 'render_origin': data.cells[name, fmt]['render_origin'] = 'synthesized_from_wire'
+    elif mutation == 'render_origin_census':
+        prepared['render_origins'] = {'encoded': 0, 'synthesized_from_wire': len(data.cells)}
+    elif mutation == 'synthesized_claims_independent':
+        # One rung is honestly marked synthesized everywhere except in the
+        # receipt, which still claims an independent render/wire comparison.
+        census = {'render_origins': {'encoded': len(data.cells) - 1, 'synthesized_from_wire': 1},
+                  'render_comparisons': {'independent_render_vs_wire': len(data.cells) - 1,
+                                         'wire_round_trip_only': 1}}
+        data.cells[name, fmt]['render_origin'] = 'synthesized_from_wire'
+        metadata['verified_cells'][name, fmt]['render_origin'] = 'synthesized_from_wire'
+        for block in (prepared, metadata, joint['provenance']['tessera_joint_anchors']):
+            block.update(copy.deepcopy(census))
     elif mutation == 'calibration': prepared['calibration_input']['calibration_sha256'] = '7'*64
     elif mutation == 'prepared': kwargs['prepared_binding'] = {**kwargs['prepared_binding'], 'sha256': '6'*64}
     elif mutation == 'shape': joint['stats'][name]['n_params'] = 5

--- a/tests/test_tessera_joint_aura.py
+++ b/tests/test_tessera_joint_aura.py
@@ -120,7 +120,8 @@ def test_exact_measured_roster_excludes_interpolation(tmp_path):
 
 
 @pytest.mark.parametrize("mutation", ["missing_unit", "missing_shard", "unfinished_fleet",
-    "interpolated_anchor", "unreceipted_measured", "altered_wire", "missing_render",
+    "interpolated_anchor", "unreceipted_measured", "altered_wire",
+    "missing_render_undecodable_wire", "missing_render_and_wire",
     "wrong_source", "wrong_scale", "partial_fanout"])
 def test_incomplete_or_conflicting_anchor_evidence_refuses(tmp_path, mutation):
     config, names, fmt, payload, states = fixture(tmp_path)
@@ -141,9 +142,15 @@ def test_incomplete_or_conflicting_anchor_evidence_refuses(tmp_path, mutation):
         payload["costs"][names[0]]["TESSERA_E4M3_K1_R896"] = dict(payload["costs"][names[0]][fmt])
     elif mutation == "altered_wire":
         (Path(payload["provenance"]["wire_dir"]) / states[names[0]]["wire_records"][fmt]["file"]).write_bytes(b"changed")
-    elif mutation == "missing_render":
+    elif mutation in ("missing_render_undecodable_wire", "missing_render_and_wire"):
+        # Synthesis is the answer to a missing shard only when the wire behind
+        # it decodes. The fixture's wires are inert bytes, so this is the
+        # refusal that survives; removing the wire too is the other one.
         from prismaquant.production_weight_cache import _cache_weight_filename
         (tmp_path / "campaign/rows/row-0000/cache" / _cache_weight_filename(names[0], fmt)).unlink()
+        if mutation == "missing_render_and_wire":
+            (Path(payload["provenance"]["wire_dir"]) /
+             states[names[0]]["wire_records"][fmt]["file"]).unlink()
     elif mutation in {"wrong_source", "wrong_scale"}:
         state = states[names[0]]
         if mutation == "wrong_source":
@@ -216,7 +223,7 @@ def test_wire_verification_rederives_source_before_accepting_render(tmp_path, mo
         input_global_scale=None)
     wire = tmp_path / "fixture.wire"; wire.write_bytes(b"wire")
     cell = {"anchor": anchor, "record": {"expected": "derived"}, "wire": str(wire),
-            "render_file_sha256": "a" * 64}
+            "render_file_sha256": "a" * 64, "render_origin": "encoded"}
     seen = []
     def derive(value, *, weights, menus, calibration_source, static_scales, projected_units):
         assert value.qname == anchor["qname"]
@@ -234,8 +241,23 @@ def test_wire_verification_rederives_source_before_accepting_render(tmp_path, mo
                   projected_unit=expected_inputs["projection"], static_scales={})
     result = verify_anchor_render(cell, source, rendered, **kwargs)
     assert seen and result["wire_sha256"] == sha(wire)
+    assert result["render_origin"] == "encoded"
+    assert result["render_comparison"] == "independent_render_vs_wire"
     with pytest.raises(ValueError, match="decoded wire differs"):
         verify_anchor_render(cell, source, rendered + 1, **kwargs)
+    # A synthesized render's equality leg is the same call and a different
+    # claim; it can never report the independent comparison.
+    synthesized = {**cell, "render_origin": "synthesized_from_wire"}
+    assert (verify_anchor_render(synthesized, source, rendered, **kwargs)["render_comparison"]
+            == "wire_round_trip_only")
+    with pytest.raises(ValueError, match="no longer decodes from its wire"):
+        verify_anchor_render(synthesized, source, rendered + 1, **kwargs)
+    for origin in (None, "unknown", True):
+        with pytest.raises(ValueError, match="closed-vocabulary render_origin"):
+            verify_anchor_render({**cell, "render_origin": origin}, source, rendered, **kwargs)
+    with pytest.raises(ValueError, match="closed-vocabulary render_origin"):
+        verify_anchor_render({k: v for k, v in cell.items() if k != "render_origin"},
+                             source, rendered, **kwargs)
 
 
 @pytest.mark.parametrize("field,value", [("probe_microbatch", 0), ("n_probes", 1),
@@ -282,7 +304,7 @@ def test_execute_scopes_the_activation_scale_env_to_the_call(tmp_path, monkeypat
     draw = dict(fit_ids_sha256="a" * 64, text_sha256="b" * 64, nsamples=512, seqlen=512, seed=0)
     monkeypatch.setattr(gpu_guard, "require_cuda_hot_path", lambda *_args: None)
     monkeypatch.setattr(bridge, "load_measured_anchor_input", lambda _inputs, **_kwargs: SimpleNamespace(
-        census={"model": "fixture", "attention_implementation": "eager"},
+        census={"model": "fixture", "attention_implementation": "eager"}, cells={},
         payload={"provenance": {"hessian": {"calibration_identity": draw}}}))
     # Called after the write, so it is where the live value can be read.
     during = {}
@@ -312,7 +334,7 @@ def test_original_full_draw_refuses_subset_before_model_load(tmp_path, monkeypat
     draw = dict(fit_ids_sha256="a" * 64, text_sha256="b" * 64, nsamples=512, seqlen=512, seed=0)
     monkeypatch.setattr(gpu_guard, "require_cuda_hot_path", lambda *_args: None)
     monkeypatch.setattr(bridge, "load_measured_anchor_input", lambda _inputs, **_kwargs: SimpleNamespace(
-        census={"model": "fixture", "attention_implementation": "eager"},
+        census={"model": "fixture", "attention_implementation": "eager"}, cells={},
         payload={"provenance": {"hessian": {"calibration_identity": draw}}}))
     monkeypatch.setattr(calibration_data, "load_calibration_input", lambda *_args, **_kwargs:
         (torch.zeros((1, 512), dtype=torch.int64), {"provenance": {**draw, "nsamples": 1}}))
@@ -349,9 +371,10 @@ def test_explicit_source_prefetch_reaches_streamed_builder(tmp_path, monkeypatch
     draw = dict(fit_ids_sha256="a" * 64, text_sha256="b" * 64, nsamples=512, seqlen=512, seed=0)
     monkeypatch.setattr(gpu_guard, "require_cuda_hot_path", lambda *_args: None)
     def intake(_inputs, **kwargs):
-        assert kwargs == ({"verify_payloads": False} if command == "prepare" else {})
+        assert kwargs == {"reader": None,
+                          **({"verify_payloads": False} if command == "prepare" else {})}
         return SimpleNamespace(census={"model": "fixture", "attention_implementation": "eager"},
-            payload={"provenance": {"hessian": {"calibration_identity": draw}}})
+            cells={}, payload={"provenance": {"hessian": {"calibration_identity": draw}}})
     monkeypatch.setattr(bridge, "load_measured_anchor_input", intake)
     monkeypatch.setattr(calibration_data, "load_calibration_input", lambda *_args, **_kwargs:
         (torch.zeros((512, 512), dtype=torch.int64), {"provenance": draw}))
@@ -467,3 +490,165 @@ def test_prepare_refuses_oversized_later_render_before_loading_any_layer(tmp_pat
                                   ('later', 'fmt'): {'render': str(huge)}})
     with pytest.raises(ValueError, match='read buffer|shard|budget'):
         bridge._prepare_file_read_bound(data, max_render_bytes=4096)
+
+
+def _unlink_render(tmp_path, name, fmt):
+    from prismaquant.production_weight_cache import _cache_weight_filename
+
+    path = tmp_path / "campaign/rows/row-0000/cache" / _cache_weight_filename(name, fmt)
+    path.unlink()
+    return path
+
+
+def _decoder(monkeypatch, tensor):
+    """Bind the module-level decode seam to a fixed answer."""
+    from tessera import unit_artifact
+
+    seen = []
+
+    def decode(blob, device="cpu"):
+        seen.append((blob, device))
+        return tensor.clone() if hasattr(tensor, "clone") else tensor
+
+    monkeypatch.setattr(unit_artifact, "read_unit_artifact", decode)
+    return seen
+
+
+def test_adopted_rung_render_is_synthesized_from_its_wire_and_stays_marked(tmp_path, monkeypatch):
+    """An adopted rung's shard is written from its wire, and says so -- twice.
+
+    The second load is the prepare/run boundary: the ``.pt`` now exists, and
+    the origin must not quietly become ``encoded`` because of it.
+    """
+    import torch
+    from prismaquant import tessera_joint_aura as bridge
+
+    config, names, fmt, _payload, states = fixture(tmp_path)
+    render = _unlink_render(tmp_path, names[0], fmt)
+    decoded = torch.arange(16, dtype=torch.float32).reshape(4, 4).to(torch.bfloat16)
+    seen = _decoder(monkeypatch, decoded)
+
+    data = load(config)
+    assert data.cells[names[0], fmt]["render_origin"] == "synthesized_from_wire"
+    assert data.cells[names[1], fmt]["render_origin"] == "encoded"
+    assert bridge.cell_render_census(data.cells) == {
+        "render_origins": {"encoded": 1, "synthesized_from_wire": 1},
+        "render_comparisons": {"independent_render_vs_wire": 1, "wire_round_trip_only": 1}}
+    assert len(seen) == 1 and seen[0][0] == (tmp_path / "merged/cache/wire" /
+        states[names[0]]["wire_records"][fmt]["file"]).read_bytes()
+    assert render.is_file() and torch.equal(torch.load(render, weights_only=True), decoded)
+    marker = json.loads(bridge._render_origin_marker_path(render).read_text())
+    assert marker == {"schema": bridge.RENDER_ORIGIN_SCHEMA,
+                      "render_origin": "synthesized_from_wire", "unit": names[0],
+                      "format_name": fmt, "wire_file": names[0] + ".tessera",
+                      "wire_sha256": states[names[0]]["wire_records"][fmt]["blob_sha256"]}
+
+    again = load(config)
+    assert again.cells[names[0], fmt]["render_origin"] == "synthesized_from_wire"
+    assert again.cells[names[1], fmt]["render_origin"] == "encoded"
+    assert len(seen) == 1, "an existing shard must not be re-decoded"
+
+
+def test_synthesis_uses_the_bound_reader_when_one_is_declared(tmp_path, monkeypatch):
+    import torch
+    from types import SimpleNamespace
+    from prismaquant.tessera_joint_aura import load_measured_anchor_input
+
+    config, names, fmt, _payload, _states = fixture(tmp_path)
+    _unlink_render(tmp_path, names[0], fmt)
+    module_level = _decoder(monkeypatch, torch.zeros((4, 4), dtype=torch.bfloat16))
+    bound = []
+
+    def read(blob, device="cpu"):
+        bound.append(blob)
+        return torch.ones((4, 4), dtype=torch.bfloat16)
+
+    data = load_measured_anchor_input(config, reader=SimpleNamespace(read_unit_artifact=read))
+    assert bound and not module_level
+    assert data.cells[names[0], fmt]["render_origin"] == "synthesized_from_wire"
+
+
+@pytest.mark.parametrize("field,value", [("schema", "other"), ("unit", "elsewhere"),
+    ("format_name", "TESSERA_E4M3_K1_R768"), ("wire_sha256", "0" * 64),
+    ("render_origin", "encoded")])
+def test_a_render_origin_marker_that_names_another_rung_refuses(tmp_path, monkeypatch, field, value):
+    import torch
+    from prismaquant import tessera_joint_aura as bridge
+
+    config, names, fmt, _payload, _states = fixture(tmp_path)
+    render = _unlink_render(tmp_path, names[0], fmt)
+    _decoder(monkeypatch, torch.zeros((4, 4), dtype=torch.bfloat16))
+    load(config)
+    marker = bridge._render_origin_marker_path(render)
+    stamp = json.loads(marker.read_text())
+    stamp[field] = value
+    marker.write_text(json.dumps(stamp))
+    with pytest.raises(ValueError, match="marked render|render origin schema|names another wire"):
+        load(config)
+
+
+@pytest.mark.parametrize("answer", ["raises", "wrong_shape", "nonfinite", "not_a_tensor"])
+def test_a_wire_that_does_not_decode_to_the_census_render_still_refuses(tmp_path, monkeypatch, answer):
+    import torch
+    from tessera import unit_artifact
+
+    config, names, fmt, _payload, _states = fixture(tmp_path)
+    _unlink_render(tmp_path, names[0], fmt)
+    values = {"wrong_shape": torch.zeros((2, 8), dtype=torch.bfloat16),
+              "nonfinite": torch.full((4, 4), float("nan"), dtype=torch.bfloat16),
+              "not_a_tensor": None}
+
+    def decode(blob, device="cpu"):
+        if answer == "raises":
+            raise RuntimeError("undecodable")
+        return values[answer]
+
+    monkeypatch.setattr(unit_artifact, "read_unit_artifact", decode)
+    with pytest.raises(ValueError, match="does not decode|not the census BF16 render|NoneType"):
+        load(config)
+
+
+def test_a_corrupted_synthesized_shard_fails_its_round_trip_leg(tmp_path, monkeypatch):
+    """The equality leg is vacuous about the encode and live about the bytes."""
+    import torch
+    from types import SimpleNamespace
+    from prismaquant import tessera_campaign as tc
+    from prismaquant.tessera_joint_aura import verify_anchor_render
+    from tessera import unit_artifact
+
+    config, names, fmt, _payload, _states = fixture(tmp_path)
+    render = _unlink_render(tmp_path, names[0], fmt)
+    decoded = torch.arange(16, dtype=torch.float32).reshape(4, 4).to(torch.bfloat16)
+    _decoder(monkeypatch, decoded)
+    data = load(config)
+    cell = data.cells[names[0], fmt]
+    assert cell["render_origin"] == "synthesized_from_wire"
+
+    monkeypatch.setattr(tc, "_checkpoint_anchor_identity",
+                        lambda *_args, **_kwargs: {"expected": "derived"})
+    monkeypatch.setattr(tc, "_checkpoint_identity_api",
+                        lambda: SimpleNamespace(verify_cached_unit=lambda *_args: None))
+    monkeypatch.setattr(unit_artifact, "read_unit_artifact",
+                        lambda blob, device="cpu": decoded.clone())
+    source = torch.zeros((4, 4), dtype=torch.bfloat16)
+    kwargs = dict(calibration_source=None, projected_unit=None, static_scales={})
+    record = verify_anchor_render(cell, source, torch.load(render, weights_only=True), **kwargs)
+    assert record["render_comparison"] == "wire_round_trip_only"
+
+    # Corrupt the published shard: the same call now refuses, which is the
+    # only thing this leg was ever able to establish for a synthesized rung.
+    torch.save(decoded + 1, render)
+    with pytest.raises(ValueError, match="no longer decodes from its wire"):
+        verify_anchor_render(cell, source, torch.load(render, weights_only=True), **kwargs)
+
+
+def test_render_census_counts_every_vocabulary_value_and_refuses_unknown_ones():
+    from prismaquant.tessera_joint_aura import cell_render_census, render_origin_census
+
+    assert render_origin_census([]) == {
+        "render_origins": {"encoded": 0, "synthesized_from_wire": 0},
+        "render_comparisons": {"independent_render_vs_wire": 0, "wire_round_trip_only": 0}}
+    with pytest.raises(ValueError, match="unknown render origin"):
+        render_origin_census(["adopted"])
+    with pytest.raises(ValueError, match="carries no render_origin"):
+        cell_render_census({("unit", "fmt"): {}})


### PR DESCRIPTION
Closes #515.

## What this builds

`load_measured_anchor_input` refused with `<unit>@<fmt>: original decoded PWC shard missing` for rungs this campaign **adopted** rather than encoded: the wire blob exists and verifies, no `.pt` render is on disk, and the whole 45-layer joint AURA pass stood behind it.

**1. The shard is synthesized from the wire at the refusal site.** One decode seam, the same one the qualification leg uses: `reader.read_unit_artifact` when a reader is declared, the module-level `read_unit_artifact` otherwise. `execute` now binds the reader *before* the intake so synthesis and qualification decode through the same bound consumer. The bytes are written by the campaign's own `_store_rendered_weight_entry`, so a synthesized shard is byte-shaped like an encoded one. The refusal is kept for what is still broken: no wire, a wire that does not decode, or a decode that is not the census BF16 render (wrong shape, wrong dtype, nonfinite).

**2. Origin is marked, in a closed vocabulary, everywhere it travels.** Every cell and every `verify_anchor_render` receipt carries `render_origin ∈ {encoded, synthesized_from_wire}` — never a bare bool, never absent; `verify_anchor_render` refuses a cell that lacks it. Origin lives on disk in a `prismaquant.tessera_joint_aura.render_origin.v1` marker beside the shard, written **before** the shard, so a crash between the two writes re-synthesizes rather than leaving a shard that reads as `encoded`.

**3. The census reaches every report.** `render_origins` and `render_comparisons` counts (both keys always present, including the zero) go into the prepared completion, the prepared PWC metadata, `results.json` for both commands, `main()`'s stdout line, the joint payload's `tessera_joint_anchors` provenance and the allocation handoff's `tessera_joint_allocation` block. `run` refuses a prepared record whose census or per-pair origin disagrees with what it re-derives, and `bind_allocation_payload` refuses a receipt whose `render_comparison` disagrees with its cell's origin.

The prepared record becomes `prismaquant.tessera_joint_aura.prepared.v3`. A v2 preparation requires a fresh prepare, which the existing refusal message already says.

## What a synthesized rung's verification does and does not establish

Two legs, and they are not the same claim.

**Load-bearing, unchanged, independent:** `verifier.verify_cached_unit(blob, cell["record"], expected)`, where `expected = tc._checkpoint_anchor_identity(anchor, weights={name: source_weight}, ...)`. The wire is checked against an encoder identity re-derived from the actual streamed source weights and H — not from anything the cache holds. **This is what qualifies an adopted rung at all, and this PR does not touch it.**

**The `torch.equal(decoded, rendered_weight)` leg:**

| origin | `render_comparison` | what it establishes |
|---|---|---|
| `encoded` | `independent_render_vs_wire` | an independently produced render agrees with the decoded wire — evidence about the encode |
| `synthesized_from_wire` | `wire_round_trip_only` | the `.pt` on disk still decodes to the bytes it was written from — a corruption check on the round trip between the write and the read, and **no evidence about the encode** |

For a synthesized rung this compares `decode(wire)` with a shard written from `decode(wire)`. As evidence about the encode it cannot fail, so it is not recorded as such. It **still runs**, because the second meaning is live. A synthesized rung can never be reported as independently compared; a test asserts exactly that.

So: **"verify_anchor_render passed on all rungs" must be read as "the wire matched a re-derived encoder identity on all rungs, and N of them also had an independent render comparison"** — the census says which N. That is principle 12's honesty rule applied to verification rather than to route, with principle 14's scope corollary: the claim inherits the scope of what it was measured on.

## One thing worth knowing

The campaign journals fresh and resumed wires through **one** receipt grammar (`tessera_campaign._checkpoint_wire_record`), deliberately — so nothing in the journal or the cost payload distinguishes an adopted rung from an encoded one. The marker beside the shard is therefore the only place this fact can live, and an existing shard with no marker is read as the campaign's own render. If a future campaign records adoption in the journal, origin should be derived from that record and the marker demoted to a cross-check.

Synthesis writes into the campaign row `cache/` directories (the shard and its marker). `tessera_joint_allocation.handoff` also calls `load_measured_anchor_input`; by then the shards exist, so it synthesizes nothing, but the side effect is reachable from there too.

## Receipts

All through PrismaBuild at `--priority -10`, `--tag dl380g10`, `/home/rob/venvs/pq-cpu312/bin/python`. No GPU reserved; sparky's GPU stayed with the GLM campaign.

**Suites, final tree (`pbtest.py`, 6 shards over 10 files):** `6/6 shards green` — 274 passed, 5 skipped.

```
shard 0 ok  97 passed, 45 warnings in 9.04s
shard 1 ok  35 passed, 28 warnings in 8.24s
shard 2 ok  23 passed, 28 warnings in 8.81s
shard 3 ok  77 passed, 5 skipped, 28 warnings in 160.32s
shard 4 ok  16 passed, 28 warnings in 10.98s
shard 5 ok  26 passed, 28 warnings in 11.99s
```

Files: `test_tessera_joint_aura.py`, `test_tessera_joint_allocation.py`, `test_joint_qualification_windows.py`, `test_joint_projection_backend.py`, `test_joint_aura_source_transition.py`, `test_joint_operator_windows.py`, `test_glm_source_derivative.py`, `test_tessera_campaign.py`, `test_docs_staleness.py`, `test_architecture_doc.py`.

**Mutation check (`pbrun.py`, action key `f1a74226ea392e554071a2549dfa7dcd40caf676b3b0b9bbeceb1754423376cb`, rc=0, 43s on dl380g10).** A check that cannot fail is not a check, so each new assertion was shown to fail against a broken implementation:

```
[CAUGHT] synthesis reports itself as encoded: 2 failed
[CAUGHT] the origin marker is never written: 1 failed
[CAUGHT] every rung claims an independent comparison: 2 failed, 1 passed
[CAUGHT] the round-trip leg is skipped on a synthesized rung: 2 failed
[CAUGHT] the cell census stops distinguishing the origins: 2 failed
restored tree: 63 passed
```

The harness itself is not committed.

**New tests.** Synthesis marks the cell and the marker, and the origin survives a second load once the `.pt` exists (the prepare→run boundary) without re-decoding; the bound reader is used when declared and the module-level decoder is not; a marker naming another wire, unit, format, schema or origin refuses; a wire that raises, decodes to the wrong shape, decodes nonfinite, or decodes to a non-tensor refuses; a synthesized shard corrupted after publication fails the round-trip leg; a missing render whose wire is undecodable still refuses, as does a missing render with no wire; `verify_anchor_render` refuses an absent or unknown `render_origin`; and the allocation handoff refuses a receipt that reports a synthesized rung as independently compared.

**Docs.** `docs/ARCHITECTURE.md` re-stamped in the same commit (principle 13), and the 2026-09-07 joint-anchor-bridge stamp's "requires their decoded BF16 values to equal original PWC shards" now points at what that comparison establishes on a synthesized rung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmYxSxhmzbBcBoFTjbLi1G
