### PR TITLE
Derive every campaign row's read set at submit, and refuse a row without one

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,31 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-12 · `pq/420-admit-fixed-resources`. Stamps
+As of: 2026-09-12 · `claude/518-data-manifest-at-submit`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-12, `claude/518-data-manifest-at-submit`) for the campaign
+submit path (#518). **`dispatch_tessera_campaign.py submit` now derives a
+PrismaBuild data manifest for every row and refuses a row whose read set it
+cannot derive.** Only the producer knows what a row reads, and a row that
+reaches the fleet without that list is invisible to PrismaBuild's prewarm
+loop: measured on sparky, row-0074 started against cold spindles at 26 MB/s
+over 64 GB, about 40 minutes of idle GPU, while a server-side warm of the same
+bytes ran at 1,653 MB/s and dropped the client to 0.21 ms per RPC
+(2026-09-12). The manifest names the row's capture files, the byte extents of
+its members' weights inside the safetensors shards, and the seed wire the
+row's own `--seed-wire-dir` argv points at, in that order -- the order the row
+reads them. The seed bytes are new: the producer used to resolve them from
+the campaign's own plan, which for a re-planned campaign names a different
+workspace, so every manifest declared `seeds: 0` while the row read 9.4-19 GB
+of wire at 41 MB/s (row-0065, 2026-09-12). `submit` writes the manifests under
+`WORKSPACE/data-manifests/` and submits `WORKSPACE/manifest.submitted.json`;
+`plan` still owns `manifest.json` and is not rewritten. The campaign argv is
+byte-identical with and without the manifest -- the manifest is a `pbrun`
+input, outside the campaign's checkpoint identity -- and `produced_by` carries
+no clock reading or hostname, because `pbrun` seals the manifest's digest into
+the action key and a field that drifted would re-key a finished row. Gates:
+`tests/test_glm_data_manifest_at_submit.py`,
+`tests/test_glm_data_manifest_matches_the_prismabuild_contract.py`.
 
 Re-stamped (2026-09-12, `pq/420-admit-fixed-resources`) for the consumer half
 of the fixed-resource admission design's last prerequisite row, "integrate
@@ -9124,7 +9148,15 @@ whose `menu_mode` disagrees.
 `tools/dispatch_tessera_campaign.py` is `census` / `plan` / `submit` / `merge`
 over `pbcampaign`. Rows are portable (no host pin), GPU-demanding, not
 exclusive, `retry_safe`, and carry a memory demand computed from the
-checkpoint's size and the selection's shapes. Re-running the manifest **is**
+checkpoint's size and the selection's shapes. `submit` gives every row a data
+manifest -- the exact shared-mount files and byte extents the row will read,
+built by `experiments/glm_data_manifests.py` from the row's units file and its
+own argv -- and refuses a row whose read set it cannot derive, because a row
+without one is invisible to PrismaBuild's prewarm loop and starts against cold
+spindles. The manifest is a `pbrun` input and leaves the campaign argv
+byte-identical; it is written under `WORKSPACE/data-manifests/` and the rows
+that name it under `WORKSPACE/manifest.submitted.json`, so `plan`'s
+`manifest.json` is never rewritten. Re-running the manifest **is**
 the resume -- a finished row is a CAS hit and a running row is re-attached --
 so nothing here decides what to skip, and a row may not carry
 `--deadline-seconds`, which stops a run mid-round and would price a different

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,9 @@ row's own `--seed-wire-dir` argv points at, in that order -- the order the row
 reads them. The seed bytes are new: the producer used to resolve them from
 the campaign's own plan, which for a re-planned campaign names a different
 workspace, so every manifest declared `seeds: 0` while the row read 9.4-19 GB
-of wire at 41 MB/s (row-0065, 2026-09-12). `submit` writes the manifests under
+of wire at 41 MB/s (row-0065, 2026-09-12). A row that names a seed directory
+and finds nothing readable in it is refused rather than submitted with
+`seeds: 0`. `submit` writes the manifests under
 `WORKSPACE/data-manifests/` and submits `WORKSPACE/manifest.submitted.json`;
 `plan` still owns `manifest.json` and is not rewritten. The campaign argv is
 byte-identical with and without the manifest -- the manifest is a `pbrun`
@@ -9153,7 +9155,9 @@ manifest -- the exact shared-mount files and byte extents the row will read,
 built by `experiments/glm_data_manifests.py` from the row's units file and its
 own argv -- and refuses a row whose read set it cannot derive, because a row
 without one is invisible to PrismaBuild's prewarm loop and starts against cold
-spindles. The manifest is a `pbrun` input and leaves the campaign argv
+spindles. A row whose argv names `--seed-wire-dir` and whose directory yields
+no readable file is refused for the same reason: zero seed bytes against a
+named directory is a broken read set, not an empty one. The manifest is a `pbrun` input and leaves the campaign argv
 byte-identical; it is written under `WORKSPACE/data-manifests/` and the rows
 that name it under `WORKSPACE/manifest.submitted.json`, so `plan`'s
 `manifest.json` is never rewritten. Re-running the manifest **is**

--- a/experiments/README-glm-arc-prewarm.md
+++ b/experiments/README-glm-arc-prewarm.md
@@ -72,9 +72,21 @@ manifest, in the order `prefetch_capture` consumes them (sorted member name);
 the byte ranges of the layer's selected weight tensors inside the safetensors
 shards, parsed from each shard's header and coalesced to 1 MiB record
 boundaries, because `--source-snapshot-policy selected-tensors-v1` reads ranges
-rather than whole shards; and the seed checkpoint's manifest and unit shards
-when the row declares one. The 16 remaining rows declare no seed checkpoint, so
-that term is zero for them.
+rather than whole shards; and the seed bytes the row's own argv names --
+`--seed-checkpoint` with its `.parts` shards, and every regular file under the
+directory `--seed-wire-dir` names, enumerated with one `os.walk` of that
+directory and nothing above it.
+
+The seed term is read off the argv, not off the campaign's plan. A row seeded
+from a `--seed-workspace` records its seed in `plan.json`; a campaign seeded
+from the global `--seed-checkpoint` / `--seed-wire-dir` flags records neither
+per row, and the directory those flags name belongs to a different workspace.
+Reading the plan is what made every manifest of `extension-r1024-02` declare
+`seeds: 0` while the row spent minutes hashing 9.4-19 GB of wire at 41 MB/s off
+cold spindles (row-0065, 2026-09-12). Seeds come last in `entries`, after the
+captures and the weight extents, because that is the order the row reads them:
+`prewarm_loop`'s reader walks the list in order and can stop at a byte budget,
+so a warm cut short loses the bytes the row reads last.
 
 **Safety.** It holds off while any claimed row is still inside its own load
 phase, detected by the immutable `capture-load-execution-<sha>.json` the row

--- a/experiments/README-glm-arc-prewarm.md
+++ b/experiments/README-glm-arc-prewarm.md
@@ -74,8 +74,11 @@ shards, parsed from each shard's header and coalesced to 1 MiB record
 boundaries, because `--source-snapshot-policy selected-tensors-v1` reads ranges
 rather than whole shards; and the seed bytes the row's own argv names --
 `--seed-checkpoint` with its `.parts` shards, and every regular file under the
-directory `--seed-wire-dir` names, enumerated with one `os.walk` of that
-directory and nothing above it.
+directory `--seed-wire-dir` names, enumerated with `os.scandir` of that
+directory and the directories below it, and nothing above it. A row whose
+named wire directory yields no readable file is refused rather than submitted
+with `seeds: 0`, counting that directory's own files so a checkpoint that
+exists cannot stand in for a missing wire.
 
 The seed term is read off the argv, not off the campaign's plan. A row seeded
 from a `--seed-workspace` records its seed in `plan.json`; a campaign seeded

--- a/experiments/glm_arc_prewarm.py
+++ b/experiments/glm_arc_prewarm.py
@@ -168,19 +168,24 @@ def _files_under(path: str) -> list[tuple[str, int]]:
     """Every regular file at ``path``, named exactly, largest scope one tree.
 
     ``path`` is a single directory (or file) the row's argv names.  It is
-    walked with one ``os.walk`` of that named directory and nothing above it:
-    a search rooted at a parent would be a recursive scan of the shared mount,
-    which is the RPC storm that stalls the fleet's GPU clients.  Symlinks are
-    not followed -- ``os.walk`` does not descend them, and a symlinked leaf is
-    dropped rather than declared, because the prewarm reader opens every entry
-    ``O_NOFOLLOW`` and would refuse it anyway.
+    enumerated with ``os.scandir`` of that named directory and the directories
+    below it, and nothing above it: a search rooted at a parent would be a
+    recursive scan of the shared mount, which is the RPC storm that stalls the
+    fleet's GPU clients.  ``scandir`` also carries the attributes the NFS
+    READDIRPLUS reply already returned, so a 5,920-file seed wire costs one
+    round of directory reads rather than one ``stat`` per file.
+
+    The named root is followed if it is a symlink -- a campaign may point
+    ``--seed-wire-dir`` at a link -- but leaves are not: the prewarm reader
+    opens every entry ``O_NOFOLLOW``, so a symlinked leaf would only ever
+    record an error, and it is dropped rather than declared.
 
     Paths come back in the shared namespace the manifest declares, even when
     the sizes were taken through the local pool mount.
     """
     local = to_pool(path)
     try:
-        info = os.lstat(local)
+        info = os.stat(local)
     except OSError:
         return []
     if statmod.S_ISREG(info.st_mode):
@@ -188,19 +193,28 @@ def _files_under(path: str) -> list[tuple[str, int]]:
     if not statmod.S_ISDIR(info.st_mode):
         return []
     out: list[tuple[str, int]] = []
-    for root, dirs, files in os.walk(local):
-        dirs.sort()
-        for name in sorted(files):
-            full = os.path.join(root, name)
+    pending = [local]
+    while pending:
+        directory = pending.pop()
+        try:
+            with os.scandir(directory) as scan:
+                items = list(scan)
+        except OSError:
+            continue
+        for item in items:
             try:
-                leaf = os.lstat(full)
+                if item.is_dir(follow_symlinks=False):
+                    pending.append(item.path)
+                    continue
+                if not item.is_file(follow_symlinks=False):
+                    continue
+                size = item.stat(follow_symlinks=False).st_size
             except OSError:
                 continue
-            if not statmod.S_ISREG(leaf.st_mode) or leaf.st_size <= 0:
+            if size <= 0:
                 continue
-            relative = os.path.relpath(full, local)
-            out.append((os.path.normpath(os.path.join(path, relative)),
-                        leaf.st_size))
+            relative = os.path.relpath(item.path, local)
+            out.append((os.path.normpath(os.path.join(path, relative)), size))
     return sorted(out)
 
 

--- a/experiments/glm_arc_prewarm.py
+++ b/experiments/glm_arc_prewarm.py
@@ -63,6 +63,7 @@ import json
 import os
 import queue
 import re
+import stat as statmod
 import sys
 import threading
 import time
@@ -140,6 +141,69 @@ def to_pool(path: str) -> str:
     return path
 
 
+#: The two campaign flags that name bytes a seeded row reads before it prices
+#: anything.  They are read off the row's argv because that is the only record
+#: that always carries them; see ``Campaign.seed_reads``.
+SEED_CHECKPOINT_FLAG = "--seed-checkpoint"
+SEED_WIRE_DIR_FLAG = "--seed-wire-dir"
+
+
+def argv_value(argv, flag: str) -> "str | None":
+    """The value a row's argv gives ``flag``, in either spelling, or None.
+
+    The last spelling wins, matching ``argparse``: a campaign that appends a
+    global ``--seed-checkpoint`` after a per-row one runs with the last.
+    """
+    items = [str(a) for a in argv]
+    found = None
+    for index, item in enumerate(items):
+        if item == flag and index + 1 < len(items):
+            found = items[index + 1]
+        elif item.startswith(flag + "="):
+            found = item[len(flag) + 1:]
+    return found
+
+
+def _files_under(path: str) -> list[tuple[str, int]]:
+    """Every regular file at ``path``, named exactly, largest scope one tree.
+
+    ``path`` is a single directory (or file) the row's argv names.  It is
+    walked with one ``os.walk`` of that named directory and nothing above it:
+    a search rooted at a parent would be a recursive scan of the shared mount,
+    which is the RPC storm that stalls the fleet's GPU clients.  Symlinks are
+    not followed -- ``os.walk`` does not descend them, and a symlinked leaf is
+    dropped rather than declared, because the prewarm reader opens every entry
+    ``O_NOFOLLOW`` and would refuse it anyway.
+
+    Paths come back in the shared namespace the manifest declares, even when
+    the sizes were taken through the local pool mount.
+    """
+    local = to_pool(path)
+    try:
+        info = os.lstat(local)
+    except OSError:
+        return []
+    if statmod.S_ISREG(info.st_mode):
+        return [(path, info.st_size)] if info.st_size > 0 else []
+    if not statmod.S_ISDIR(info.st_mode):
+        return []
+    out: list[tuple[str, int]] = []
+    for root, dirs, files in os.walk(local):
+        dirs.sort()
+        for name in sorted(files):
+            full = os.path.join(root, name)
+            try:
+                leaf = os.lstat(full)
+            except OSError:
+                continue
+            if not statmod.S_ISREG(leaf.st_mode) or leaf.st_size <= 0:
+                continue
+            relative = os.path.relpath(full, local)
+            out.append((os.path.normpath(os.path.join(path, relative)),
+                        leaf.st_size))
+    return sorted(out)
+
+
 # ------------------------------------------------------------ campaign model
 
 
@@ -154,13 +218,24 @@ class Campaign:
         self.plan = plan
         self.rows = {r["row_id"]: r for r in plan["rows"]}
         self.model_dir = plan["model"]
-        cap = plan["calibration_cache"]["path"]
+        cache = plan.get("calibration_cache") or {}
+        cap = cache.get("path")
         self.capture_manifest_path = cap
-        manifest = _json(cap)
-        if manifest is None:
-            raise SystemExit(f"unreadable capture manifest: {cap}")
-        self.capture_root = os.path.dirname(cap)
-        self.entries = manifest["entries"]
+        if cap is None:
+            # A campaign planned without a hash-bound calibration cache reads
+            # no capture files at all.  That is a read set with one part
+            # missing, not an unreadable campaign, and saying so here is what
+            # lets the submit-time gate refuse a row whose manifest is
+            # genuinely unbuildable rather than every row of a shape that
+            # never had captures.
+            self.capture_root = workspace
+            self.entries = {}
+        else:
+            manifest = _json(cap)
+            if manifest is None:
+                raise SystemExit(f"unreadable capture manifest: {cap}")
+            self.capture_root = os.path.dirname(cap)
+            self.entries = manifest["entries"]
         self._units_cache: dict[str, list[str]] = {}
         self._header_cache: dict[str, dict] = {}
         self._weight_map = None
@@ -268,32 +343,50 @@ class Campaign:
                 out.append((path, a, b - a))
         return out
 
-    def seed_reads(self, row_id: str) -> list[tuple[str, int]]:
-        """Seed-checkpoint reads, when the row's argv declares one.
+    def seed_reads(self, row_id: str, argv: "list | None" = None
+                   ) -> list[tuple[str, int]]:
+        """The seed bytes the row will read, taken from the argv that runs it.
 
-        The 16 remaining rows carry no ``--seed-checkpoint``, so this is empty
-        for them; it is kept because a re-planned campaign may reinstate it.
+        Two reads, and the argv is the only place that names both.  A seeded
+        row is handed ``--seed-checkpoint`` (the anchors it adopts, small) and
+        ``--seed-wire-dir`` (the cached wire it re-verifies, 9.4-19 GB of
+        ``.tessera`` blobs).  The plan's own ``rows[i].seed`` carries them only
+        for a row seeded from a ``--seed-workspace``; a campaign seeded from
+        the global ``--seed-checkpoint`` / ``--seed-wire-dir`` flags records
+        neither per row, and the directory those flags name belongs to a
+        *different* workspace than this campaign's.
+
+        Reading the plan instead of the argv is what made every manifest of
+        ``extension-r1024-02`` say ``seeds: 0`` while the row spent minutes
+        hashing its wire directory at 41 MB/s off cold spindles (row-0065,
+        2026-09-12).  With no argv the plan is still consulted, so the daemon
+        modes that never had one keep working.
         """
-        seed = self.rows[row_id].get("seed") or {}
-        ckpt = seed.get("checkpoint")
-        if not ckpt:
-            return []
-        out = []
-        for path in (ckpt, ckpt + ".parts"):
-            p = to_pool(path)
-            if os.path.isfile(p):
-                out.append((path, os.stat(p).st_size))
-            elif os.path.isdir(p):
-                for entry in sorted(os.listdir(p)):
-                    f = os.path.join(p, entry)
-                    if os.path.isfile(f):
-                        out.append((os.path.join(path, entry), os.stat(f).st_size))
-        return out
+        ckpt, wire_dir = None, None
+        if argv is not None:
+            ckpt = argv_value(argv, SEED_CHECKPOINT_FLAG)
+            wire_dir = argv_value(argv, SEED_WIRE_DIR_FLAG)
+        if ckpt is None and wire_dir is None:
+            seed = self.rows[row_id].get("seed") or {}
+            ckpt, wire_dir = seed.get("checkpoint"), seed.get("wire_dir")
+        out: list[tuple[str, int]] = []
+        for path in ((ckpt, ckpt + ".parts") if ckpt else ()):
+            out += _files_under(path)
+        if wire_dir:
+            out += _files_under(wire_dir)
+        # A path declared twice is refused by the manifest contract, and the
+        # checkpoint's ``.parts`` directory can sit inside the wire directory.
+        seen, unique = set(), []
+        for path, size in out:
+            if path not in seen:
+                seen.add(path)
+                unique.append((path, size))
+        return unique
 
-    def row_plan(self, row_id: str) -> dict:
+    def row_plan(self, row_id: str, argv: "list | None" = None) -> dict:
         caps = self.capture_files(row_id)
         ext = self.weight_extents(row_id)
-        seeds = self.seed_reads(row_id)
+        seeds = self.seed_reads(row_id, argv)
         return {
             "row_id": row_id,
             "group": self.rows[row_id]["groups"][0],

--- a/experiments/glm_data_manifests.py
+++ b/experiments/glm_data_manifests.py
@@ -49,18 +49,77 @@ import argparse
 import hashlib
 import json
 import os
-import re
-import socket
 import subprocess
 import sys
-import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from glm_arc_prewarm import CAMPAIGN_BASE, Campaign, UNITS_RE  # noqa: E402
+from glm_arc_prewarm import (  # noqa: E402
+    CAMPAIGN_BASE, Campaign, SEED_WIRE_DIR_FLAG, UNITS_RE, argv_value)
 
 SCHEMA = "prismaquant.prismabuild.data_manifest.v1"
 SHARED_MOUNT = "/mnt/shared"
+
+#: ``prismabuild.core._DATA_MANIFEST_KEYS`` and ``_DATA_MANIFEST_ENTRY_KEYS``,
+#: restated because PrismaBuild is not importable from the environments that
+#: build a manifest.  ``validate_data_manifest`` builds both through
+#: ``_exact_mapping``: an unknown key is a refusal, not an ignored extra.
+MANIFEST_KEYS = frozenset({"schema", "produced_by", "mount_prefix", "entries",
+                           "entry_count", "total_bytes", "annotations"})
+ENTRY_KEYS = frozenset({"path", "offset", "bytes", "sha256"})
+
+
+def check_manifest(manifest: dict, *, where: str = "data manifest") -> dict:
+    """Refuse here what PrismaBuild would refuse at submission.
+
+    The producer is in this repo and the validator is in PrismaBuild, so a
+    manifest that drifts breaks nothing in either tree: it surfaces as a
+    refused submission, after the campaign was laid out.  These are the same
+    four rules ``prismabuild.core.validate_data_manifest`` applies, and they
+    are cheap enough to apply to every row at submit time.
+    """
+    if set(manifest) != set(MANIFEST_KEYS):
+        raise SystemExit(
+            f"{where}: fields differ: "
+            f"missing={sorted(MANIFEST_KEYS - set(manifest))}, "
+            f"extra={sorted(set(manifest) - MANIFEST_KEYS)}")
+    if manifest["schema"] != SCHEMA:
+        raise SystemExit(f"{where}: schema must be {SCHEMA}")
+    for field in ("produced_by", "annotations"):
+        if not isinstance(manifest[field], dict):
+            raise SystemExit(f"{where}: {field} must be an object")
+    prefix = manifest["mount_prefix"]
+    if not prefix.startswith("/") or prefix != os.path.normpath(prefix):
+        raise SystemExit(f"{where}: mount_prefix must be a normalized absolute path")
+    if prefix == "/":
+        raise SystemExit(f"{where}: mount_prefix must name a mount, not the root")
+    entries = manifest["entries"]
+    if not isinstance(entries, list) or not entries:
+        raise SystemExit(f"{where}: entries must be a non-empty array")
+    seen: set[tuple[str, int]] = set()
+    total = 0
+    for index, entry in enumerate(entries):
+        at = f"{where} entries[{index}]"
+        if set(entry) != set(ENTRY_KEYS):
+            raise SystemExit(f"{at}: fields differ")
+        path, offset, size = entry["path"], entry["offset"], entry["bytes"]
+        if not path.startswith(prefix + "/"):
+            raise SystemExit(f"{at}: {path} is outside {prefix}")
+        if os.path.normpath(path) != path:
+            raise SystemExit(f"{at}: {path} is not normalized")
+        if not isinstance(offset, int) or offset < 0:
+            raise SystemExit(f"{at}: offset must be a non-negative integer")
+        if not isinstance(size, int) or size <= 0:
+            raise SystemExit(f"{at}: bytes must be positive")
+        if (path, offset) in seen:
+            raise SystemExit(f"{at}: repeats a (path, offset)")
+        seen.add((path, offset))
+        total += size
+    if manifest["entry_count"] != len(entries):
+        raise SystemExit(f"{where}: entry_count disagrees with entries")
+    if manifest["total_bytes"] != total:
+        raise SystemExit(f"{where}: total_bytes disagrees with entries")
+    return manifest
 
 
 def sha256_file(path: str) -> str:
@@ -133,21 +192,37 @@ def row_id_of(row: dict) -> str | None:
     return found.pop() if len(found) == 1 else None
 
 
-def build_manifest(campaign: Campaign, row_id: str, produced_by: dict) -> dict:
+def build_manifest(campaign: Campaign, row_id: str, produced_by: dict,
+                   argv: "list | None" = None) -> dict:
     """One row's read set, in the order the row consumes it.
 
     Captures come first because ``prefetch_capture`` runs before the layer's
-    weights are touched; within each group the order is the consumer's own.
+    weights are touched; the seed wire the row re-verifies comes last, for the
+    same reason -- within each group the order is the consumer's own, and the
+    prewarm reader walks ``entries`` in order, so a warm cut short by ARC
+    headroom is cut at the end of the row's own read, not in the middle of its
+    captures.
+
+    ``argv`` is the row's own command line.  It is what names
+    ``--seed-wire-dir``, and reading the plan instead is what made every
+    manifest of ``extension-r1024-02`` declare ``seeds: 0`` while the row read
+    9.4-19 GB of wire off cold spindles at 41 MB/s.
     """
-    plan = campaign.row_plan(row_id)
+    plan = campaign.row_plan(row_id, argv)
     entries = []
     for path, size in plan["_captures"]:
         entries.append({"path": path, "offset": 0, "bytes": int(size), "sha256": None})
     for path, offset, length in plan["_extents"]:
         entries.append({"path": path, "offset": int(offset), "bytes": int(length),
                         "sha256": None})
+    phases = [{"name": "captures", "bytes": plan["capture_bytes"],
+               "cumulative_bytes": plan["capture_bytes"]},
+              {"name": "weight_extents", "bytes": plan["weight_bytes"],
+               "cumulative_bytes": plan["capture_bytes"] + plan["weight_bytes"]}]
     for path, size in plan["_seeds"]:
         entries.append({"path": path, "offset": 0, "bytes": int(size), "sha256": None})
+    phases.append({"name": "seeds", "bytes": plan["seed_bytes"],
+                   "cumulative_bytes": plan["total_bytes"]})
     for e in entries:
         if not e["path"].startswith(SHARED_MOUNT + "/"):
             raise SystemExit(f"{row_id}: entry outside the shared mount: {e['path']}")
@@ -156,7 +231,7 @@ def build_manifest(campaign: Campaign, row_id: str, produced_by: dict) -> dict:
     # The key set is the one ``prismabuild.core.validate_data_manifest``
     # accepts exactly; everything this campaign knows and PrismaBuild does not
     # goes under ``annotations``, which the contract carries but never reads.
-    return {
+    manifest = {
         "schema": SCHEMA,
         "produced_by": produced_by,
         "mount_prefix": SHARED_MOUNT,
@@ -178,10 +253,43 @@ def build_manifest(campaign: Campaign, row_id: str, produced_by: dict) -> dict:
                 "weight_extents": plan["weight_bytes"],
                 "seeds": plan["seed_bytes"],
             },
+            # The directory the row's argv named, so a reader can tell a row
+            # that declared no seeds from one whose seed directory was empty
+            # or unreadable when the manifest was built.
+            "seed_wire_dir": (None if argv is None
+                              else argv_value(argv, SEED_WIRE_DIR_FLAG)),
+            # Where one phase of the row's read ends and the next begins, as a
+            # running byte sum over ``entries``.  The prewarm reader walks the
+            # list in order and can stop at a byte budget, so a consumer that
+            # warms only what fits has a boundary to stop on that is a
+            # property of the row's read order rather than a guess.  Carried,
+            # not read: PrismaBuild reads only ``annotations.row_id`` today.
+            "phases": phases,
         },
         "entry_count": len(entries),
         "total_bytes": plan["total_bytes"],
         "entries": entries,
+    }
+    return check_manifest(manifest, where=row_id)
+
+
+def deterministic_provenance(workspace: str, campaign: Campaign,
+                             size_source: str) -> dict:
+    """``produced_by`` that two submissions of one campaign agree on, byte for byte.
+
+    ``pbrun`` ingests the manifest as a content-addressed input and seals its
+    digest into the action key, so a field that changes between runs -- a
+    hostname, a clock reading -- gives the same row a new key on every submit.
+    That is not a cosmetic loss: a finished row stops being a cache hit and is
+    re-run, which is the opposite of what re-running ``submit`` is for.  Every
+    field here is a property of the campaign and the tree, not of the run.
+    """
+    return {
+        "tool": "prismaquant/experiments/glm_data_manifests.py",
+        "commit": git_commit(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "workspace": workspace,
+        "capture_manifest": campaign.capture_manifest_path,
+        "size_source": size_source,
     }
 
 
@@ -211,15 +319,8 @@ def main() -> int:
 
     sizes = None if args.stat else load_sizes(args.sizes_cache)
     campaign = CachedSizeCampaign(args.workspace, sizes)
-    produced_by = {
-        "tool": "prismaquant/experiments/glm_data_manifests.py",
-        "commit": git_commit(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
-        "workspace": args.workspace,
-        "capture_manifest": campaign.capture_manifest_path,
-        "size_source": "stat" if args.stat else args.sizes_cache,
-        "host": socket.gethostname(),
-        "unix": int(time.time()),
-    }
+    produced_by = deterministic_provenance(
+        args.workspace, campaign, "stat" if args.stat else args.sizes_cache)
 
     out_rows = []
     report = []
@@ -229,7 +330,7 @@ def main() -> int:
             raise SystemExit(f"{src}: a row's argv names no single units/row-XXXX.json")
         if rid not in campaign.rows:
             raise SystemExit(f"{src}: {rid} is not a row of {args.workspace}/plan.json")
-        man = build_manifest(campaign, rid, produced_by)
+        man = build_manifest(campaign, rid, produced_by, row.get("argv"))
         path = os.path.join(args.out_dir, f"{rid}.data-manifest.json")
         blob = json.dumps(man, indent=1, sort_keys=False).encode() + b"\n"
         if not args.dry_run:
@@ -249,8 +350,10 @@ def main() -> int:
             "total_bytes": man["total_bytes"],
             "captures": man["annotations"]["counts"]["captures"],
             "weight_extents": man["annotations"]["counts"]["weight_extents"],
+            "seeds": man["annotations"]["counts"]["seeds"],
             "capture_bytes": man["annotations"]["bytes"]["captures"],
             "weight_bytes": man["annotations"]["bytes"]["weight_extents"],
+            "seed_bytes": man["annotations"]["bytes"]["seeds"],
         })
 
     out_blob = json.dumps(out_rows, indent=1).encode() + b"\n"

--- a/experiments/glm_data_manifests.py
+++ b/experiments/glm_data_manifests.py
@@ -68,6 +68,16 @@ MANIFEST_KEYS = frozenset({"schema", "produced_by", "mount_prefix", "entries",
                            "entry_count", "total_bytes", "annotations"})
 ENTRY_KEYS = frozenset({"path", "offset", "bytes", "sha256"})
 
+#: ``prismabuild.core.DATA_MANIFEST_MAX_ENTRIES`` and
+#: ``DATA_MANIFEST_MAX_BYTES``: ``validate_data_manifest`` refuses a longer
+#: entry list and ``load_data_manifest`` refuses a larger file.  A routed GLM
+#: row is about 870 capture and weight entries plus a 5,920-file seed wire, so
+#: roughly 6,800 entries and 2 MB -- well inside both, but the ceilings belong
+#: here so a future read set that crosses one is refused by the producer
+#: rather than by the fleet.
+MAX_ENTRIES = 1_000_000
+MAX_MANIFEST_BYTES = 64 * 1024 * 1024
+
 
 def check_manifest(manifest: dict, *, where: str = "data manifest") -> dict:
     """Refuse here what PrismaBuild would refuse at submission.
@@ -96,6 +106,8 @@ def check_manifest(manifest: dict, *, where: str = "data manifest") -> dict:
     entries = manifest["entries"]
     if not isinstance(entries, list) or not entries:
         raise SystemExit(f"{where}: entries must be a non-empty array")
+    if len(entries) > MAX_ENTRIES:
+        raise SystemExit(f"{where}: entries exceed {MAX_ENTRIES}")
     seen: set[tuple[str, int]] = set()
     total = 0
     for index, entry in enumerate(entries):
@@ -120,6 +132,20 @@ def check_manifest(manifest: dict, *, where: str = "data manifest") -> dict:
     if manifest["total_bytes"] != total:
         raise SystemExit(f"{where}: total_bytes disagrees with entries")
     return manifest
+
+
+def check_manifest_bytes(blob: bytes, *, where: str = "data manifest") -> bytes:
+    """Refuse a manifest file PrismaBuild would refuse to read at all.
+
+    ``load_data_manifest`` stats the file before it parses it, so an oversized
+    manifest fails at submission with nothing validated.  Checking the bytes
+    the producer is about to write keeps that refusal here.
+    """
+    if len(blob) > MAX_MANIFEST_BYTES:
+        raise SystemExit(
+            f"{where}: manifest file is {len(blob)} bytes, over the "
+            f"{MAX_MANIFEST_BYTES}-byte limit")
+    return blob
 
 
 def sha256_file(path: str) -> str:
@@ -223,6 +249,17 @@ def build_manifest(campaign: Campaign, row_id: str, produced_by: dict,
         entries.append({"path": path, "offset": 0, "bytes": int(size), "sha256": None})
     phases.append({"name": "seeds", "bytes": plan["seed_bytes"],
                    "cumulative_bytes": plan["total_bytes"]})
+    named_seed_dir = None if argv is None else argv_value(argv, SEED_WIRE_DIR_FLAG)
+    if named_seed_dir and not plan["seed_files"]:
+        # The defect this gate exists for produced exactly this shape: a row
+        # that reads 9.4-19 GB of wire, and a manifest that says ``seeds: 0``.
+        # A miss count of zero against a directory the row names is a broken
+        # read set, not an empty one, so it fails closed here rather than
+        # warming nothing at 41 MB/s.
+        raise SystemExit(
+            f"{row_id}: argv names {SEED_WIRE_DIR_FLAG} {named_seed_dir} but no "
+            "readable file was found there; refusing to declare a read set "
+            "that omits the row's seed wire")
     for e in entries:
         if not e["path"].startswith(SHARED_MOUNT + "/"):
             raise SystemExit(f"{row_id}: entry outside the shared mount: {e['path']}")

--- a/experiments/glm_data_manifests.py
+++ b/experiments/glm_data_manifests.py
@@ -250,7 +250,15 @@ def build_manifest(campaign: Campaign, row_id: str, produced_by: dict,
     phases.append({"name": "seeds", "bytes": plan["seed_bytes"],
                    "cumulative_bytes": plan["total_bytes"]})
     named_seed_dir = None if argv is None else argv_value(argv, SEED_WIRE_DIR_FLAG)
-    if named_seed_dir and not plan["seed_files"]:
+    # The wire directory's own files, not the row's seed total: a row carries
+    # ``--seed-checkpoint`` as well, and counting both together would let a
+    # present checkpoint mask an empty wire directory -- the same silent zero
+    # with one extra file in it.
+    wire_root = None if not named_seed_dir else os.path.normpath(named_seed_dir)
+    from_wire = [] if wire_root is None else [
+        path for path, _ in plan["_seeds"]
+        if path == wire_root or path.startswith(wire_root.rstrip("/") + "/")]
+    if named_seed_dir and not from_wire:
         # The defect this gate exists for produced exactly this shape: a row
         # that reads 9.4-19 GB of wire, and a manifest that says ``seeds: 0``.
         # A miss count of zero against a directory the row names is a broken

--- a/tests/test_campaign_demand_derivation.py
+++ b/tests/test_campaign_demand_derivation.py
@@ -307,6 +307,13 @@ def test_submit_refuses_an_under_declared_manifest_before_submitting_it(
     submitted = []
     monkeypatch.setattr(dispatch, '_pbcampaign',
                         lambda *a, **k: submitted.append(a) or 0)
+    # ``submit`` runs a second, independent gate: every row gets the data
+    # manifest the fleet warms it from (#518). This fixture's model is a bare
+    # path with no shards behind it, so there is no read set to derive; the
+    # demand gate is what this test is about, and the two are exercised
+    # together by ``tests/test_tessera_campaign_fanout.py``.
+    monkeypatch.setattr(dispatch, 'attach_data_manifests',
+                        lambda workspace, rows, **kw: rows)
     derived = dispatch._row_memory_demand(spec, ['layers.0.proj'], census,
                                           selected_source=True)['mem_gb']
     (tmp_path / 'manifest.json').write_text(json.dumps(

--- a/tests/test_glm_data_manifest_at_submit.py
+++ b/tests/test_glm_data_manifest_at_submit.py
@@ -257,7 +257,9 @@ def test_a_row_whose_read_set_cannot_be_derived_is_refused(
         dispatch.attach_data_manifests(workspace, [unplanned])
 
 
-def test_every_submitted_row_carries_a_manifest(tmp_path, shared_mount):
+def test_every_submitted_row_carries_a_manifest(
+    tmp_path, shared_mount, monkeypatch,
+):
     workspace, units, seed_dir = _workspace(tmp_path)
     rows = [_row(units, seed_dir)]
     (workspace / "manifest.json").write_text(json.dumps(rows, indent=2) + "\n")
@@ -267,12 +269,11 @@ def test_every_submitted_row_carries_a_manifest(tmp_path, shared_mount):
         calls["manifest"] = manifest
         return 0
 
-    dispatch._pbcampaign = _record
-    try:
-        assert dispatch.cmd_submit(
-            type("Args", (), {"workspace": str(workspace), "wait_s": 1})) == 0
-    finally:
-        del dispatch._pbcampaign
+    # ``monkeypatch`` restores the real helper; deleting the attribute instead
+    # would leave the module without it for every later test in the process.
+    monkeypatch.setattr(dispatch, "_pbcampaign", _record)
+    assert dispatch.cmd_submit(
+        type("Args", (), {"workspace": str(workspace), "wait_s": 1})) == 0
 
     submitted = json.loads(Path(calls["manifest"]).read_text())
     assert submitted, "nothing was submitted"
@@ -280,3 +281,72 @@ def test_every_submitted_row_carries_a_manifest(tmp_path, shared_mount):
     # What ``plan`` wrote is not what was submitted, and is left alone.
     assert Path(calls["manifest"]).name == dispatch.SUBMITTED_MANIFEST
     assert json.loads((workspace / "manifest.json").read_text()) == rows
+
+
+def test_a_seed_wire_directory_reached_through_a_symlink_is_still_declared(
+    tmp_path, shared_mount,
+):
+    """A row may name a link; the bytes behind it are the bytes it reads."""
+
+    workspace, units, seed_dir = _workspace(tmp_path)
+    link = tmp_path / "seed-wire-link"
+    link.symlink_to(seed_dir)
+    campaign = glm_data_manifests.Campaign(str(workspace))
+
+    manifest = glm_data_manifests.build_manifest(
+        campaign, "row-0000", {"tool": "test"}, _row(units, link)["argv"])
+
+    assert manifest["annotations"]["counts"]["seeds"] == len(SEED_WIRE)
+    assert manifest["annotations"]["bytes"]["seeds"] == sum(SEED_WIRE.values())
+    declared = {entry["path"] for entry in manifest["entries"]}
+    assert str(link / "unit-0000.tessera") in declared
+
+
+def test_a_row_whose_named_seed_wire_yields_nothing_is_refused(
+    tmp_path, shared_mount,
+):
+    """Zero seeds against a named directory is the defect, not an empty row.
+
+    This is the exact shape row-0065 shipped: a manifest declaring
+    ``seeds: 0`` for a row that went on to read 9.4-19 GB of wire at 41 MB/s.
+    Whatever the cause -- a missing directory, a permission error, a renamed
+    campaign -- the submit path refuses it instead of warming nothing.
+    """
+    workspace, units, seed_dir = _workspace(tmp_path)
+
+    absent = _row(units, tmp_path / "never-written")
+    with pytest.raises(SystemExit, match="no readable file was found"):
+        dispatch.attach_data_manifests(workspace, [absent])
+
+    empty = tmp_path / "empty-wire"
+    empty.mkdir()
+    with pytest.raises(SystemExit, match="no readable file was found"):
+        dispatch.attach_data_manifests(workspace, [_row(units, empty)])
+
+
+def test_the_producer_restates_the_limits_prismabuild_enforces(
+    tmp_path, shared_mount, monkeypatch,
+):
+    """The ceilings live with the producer, not only in the fleet.
+
+    ``validate_data_manifest`` refuses more than
+    ``DATA_MANIFEST_MAX_ENTRIES`` entries and ``load_data_manifest`` refuses a
+    file over ``DATA_MANIFEST_MAX_BYTES``, both before anything is warmed.
+    """
+    assert glm_data_manifests.MAX_ENTRIES == 1_000_000
+    assert glm_data_manifests.MAX_MANIFEST_BYTES == 64 * 1024 * 1024
+
+    workspace, units, seed_dir = _workspace(tmp_path)
+    campaign = glm_data_manifests.Campaign(str(workspace))
+    manifest = glm_data_manifests.build_manifest(
+        campaign, "row-0000", {"tool": "test"}, _row(units, seed_dir)["argv"])
+
+    # The real ceilings are far above any GLM row, so the refusal is exercised
+    # by lowering them rather than by building a million entries.
+    monkeypatch.setattr(glm_data_manifests, "MAX_ENTRIES", 1)
+    with pytest.raises(SystemExit, match="entries exceed 1"):
+        glm_data_manifests.check_manifest(manifest)
+    with pytest.raises(SystemExit, match="over the"):
+        glm_data_manifests.check_manifest_bytes(
+            b"x" * (glm_data_manifests.MAX_MANIFEST_BYTES + 1))
+    assert glm_data_manifests.check_manifest_bytes(b"{}") == b"{}"

--- a/tests/test_glm_data_manifest_at_submit.py
+++ b/tests/test_glm_data_manifest_at_submit.py
@@ -1,0 +1,282 @@
+"""Every submitted row carries the byte list the fleet needs to warm it.
+
+A campaign row that reaches PrismaBuild without a data manifest is invisible
+to the fleet's prewarm loop, and the row then starts against cold spindles:
+26 MB/s over 64 GB on sparky (row-0074, 2026-09-12), about 40 minutes of idle
+GPU.  Only the producer knows a row's read set, so ``submit`` derives one for
+every row and refuses a row whose read set it cannot derive.
+
+Two properties are load-bearing and neither is visible from the dispatcher
+alone:
+
+* the seed bytes come from the row's own ``--seed-wire-dir`` argv.  Reading
+  the plan instead is what made every manifest of ``extension-r1024-02``
+  declare ``seeds: 0`` while the row read 9.4-19 GB of wire at 41 MB/s
+  (row-0065, 2026-09-12);
+* the campaign argv is byte-identical with and without the manifest.  The
+  manifest is a ``pbrun`` input; the campaign's own checkpoint identity is the
+  argv, and a manifest that perturbed it would re-key work already committed.
+
+Nothing here touches the shared mount: the campaign, its captures, its shard
+and its seed wire directory are all built under ``tmp_path``.
+"""
+
+import json
+import struct
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+import dispatch_tessera_campaign as dispatch  # noqa: E402
+
+from experiments import glm_data_manifests  # noqa: E402
+from experiments.glm_arc_prewarm import RECORD_SIZE  # noqa: E402
+
+MEMBER = "model.layers.0.mlp.experts.0.down_proj"
+TENSOR_BYTES = 4 * RECORD_SIZE
+CAPTURE_BYTES = 2 * RECORD_SIZE
+
+#: A seed wire directory the way a row's ``--seed-wire-dir`` finds it: blobs
+#: at the top, blobs one level down, and one entry that is not a regular file.
+SEED_WIRE = {
+    "unit-0000.tessera": 3 << 20,
+    "unit-0001.tessera": 5 << 20,
+    "parts/unit-0002.tessera": 7 << 20,
+}
+
+
+def _workspace(tmp_path):
+    """A one-row campaign on disk, plus the seed wire its argv will name."""
+
+    model = tmp_path / "model"
+    model.mkdir()
+    header = json.dumps({
+        MEMBER + ".weight": {"dtype": "F8_E4M3", "shape": [TENSOR_BYTES],
+                             "data_offsets": [0, TENSOR_BYTES]},
+    }).encode()
+    shard = model / "model-00001-of-00001.safetensors"
+    shard.write_bytes(
+        struct.pack("<Q", len(header)) + header + b"\0" * TENSOR_BYTES)
+    (model / "model.safetensors.index.json").write_text(json.dumps(
+        {"weight_map": {MEMBER + ".weight": shard.name}}))
+
+    workspace = tmp_path / "workspace"
+    captures = workspace / "calibration-cache"
+    (captures / "inputs").mkdir(parents=True)
+    (captures / "inputs" / "member.pt").write_bytes(b"\0" * CAPTURE_BYTES)
+    capture_manifest = captures / "capture_manifest.json"
+    capture_manifest.write_text(json.dumps(
+        {"entries": {MEMBER: {"path": "inputs/member.pt"}}}))
+
+    units = workspace / "units" / "row-0000.json"
+    units.parent.mkdir(parents=True)
+    units.write_text(json.dumps({"groups": [{"members": [MEMBER]}]}))
+
+    (workspace / "plan.json").write_text(json.dumps({
+        "model": str(model),
+        "calibration_cache": {"path": str(capture_manifest)},
+        "rows": [{"row_id": "row-0000", "units": str(units),
+                  "groups": ["expert-group-0"]}],
+    }))
+
+    seed_dir = tmp_path / "other-campaign" / "rows" / "row-0000" / "cache" / "wire"
+    for name, size in SEED_WIRE.items():
+        blob = seed_dir / name
+        blob.parent.mkdir(parents=True, exist_ok=True)
+        blob.write_bytes(b"\0" * size)
+    # A dangling symlink beside the blobs: the prewarm reader opens every
+    # entry O_NOFOLLOW, so a manifest that declared one would only ever record
+    # an error against it.
+    (seed_dir / "unit-0003.tessera").symlink_to(seed_dir / "absent.tessera")
+
+    return workspace, units, seed_dir
+
+
+def _row(units, seed_dir, *, extra=()):
+    """The pbcampaign row ``plan`` writes, in the shape ``submit`` reads."""
+
+    return {
+        "argv": ["python3", "-u", "-m", "prismaquant.tessera_campaign",
+                 "--units", str(units),
+                 "--seed-wire-dir", str(seed_dir),
+                 *extra],
+        "cwd": "/home/rob/prismaquant",
+        "demand": {"gpu": 1, "cpu": 4, "mem_gb": 104},
+        "env": {},
+        "tags": ["gb10"],
+        "retry_safe": True,
+    }
+
+
+@pytest.fixture
+def shared_mount(tmp_path, monkeypatch):
+    """Treat the fixture's root as the shared mount the manifest declares."""
+
+    monkeypatch.setattr(glm_data_manifests, "SHARED_MOUNT", str(tmp_path))
+    return tmp_path
+
+
+def test_seed_entries_come_from_the_rows_seed_wire_dir_argv(
+    tmp_path, shared_mount,
+):
+    workspace, units, seed_dir = _workspace(tmp_path)
+    campaign = glm_data_manifests.Campaign(str(workspace))
+    row = _row(units, seed_dir)
+
+    manifest = glm_data_manifests.build_manifest(
+        campaign, "row-0000", {"tool": "test"}, row["argv"])
+
+    declared = {entry["path"]: entry["bytes"] for entry in manifest["entries"]}
+    for name, size in SEED_WIRE.items():
+        assert declared.get(str(seed_dir / name)) == size, name
+    assert manifest["annotations"]["counts"]["seeds"] == len(SEED_WIRE)
+    assert manifest["annotations"]["bytes"]["seeds"] == sum(SEED_WIRE.values())
+    assert manifest["annotations"]["seed_wire_dir"] == str(seed_dir)
+    # The symlink is named in the directory and absent from the manifest.
+    assert str(seed_dir / "unit-0003.tessera") not in declared
+
+    # And this is the defect: the plan names no seed for this row, so a
+    # manifest built without the argv declares none of those bytes.
+    blind = glm_data_manifests.build_manifest(
+        campaign, "row-0000", {"tool": "test"})
+    assert blind["annotations"]["counts"]["seeds"] == 0
+    assert blind["total_bytes"] < manifest["total_bytes"]
+    assert manifest["total_bytes"] - blind["total_bytes"] == sum(SEED_WIRE.values())
+
+
+def test_the_seed_wire_is_declared_last_so_a_short_warm_keeps_the_captures(
+    tmp_path, shared_mount,
+):
+    """Entry order is the row's own read order, and the reader honours it.
+
+    ``prewarm_loop.Reader`` walks ``entries`` in order and stops when ARC
+    headroom runs out, so a warm cut short must lose the bytes the row reads
+    last -- its seed wire -- rather than the captures it opens first.
+    """
+    workspace, units, seed_dir = _workspace(tmp_path)
+    campaign = glm_data_manifests.Campaign(str(workspace))
+
+    manifest = glm_data_manifests.build_manifest(
+        campaign, "row-0000", {"tool": "test"}, _row(units, seed_dir)["argv"])
+
+    seeds = {str(seed_dir / name) for name in SEED_WIRE}
+    paths = [entry["path"] for entry in manifest["entries"]]
+    first_seed = min(paths.index(path) for path in paths if path in seeds)
+    assert all(path in seeds for path in paths[first_seed:])
+
+    # ``annotations.phases`` names that boundary in bytes, so a consumer that
+    # warms a prefix does not have to re-derive it from the paths.
+    phases = manifest["annotations"]["phases"]
+    assert [phase["name"] for phase in phases] == [
+        "captures", "weight_extents", "seeds"]
+    assert phases[-1]["cumulative_bytes"] == manifest["total_bytes"]
+    assert sum(entry["bytes"] for entry in manifest["entries"][:first_seed]) == (
+        phases[1]["cumulative_bytes"])
+    assert phases[-1]["bytes"] == sum(SEED_WIRE.values())
+
+
+def test_attaching_a_manifest_leaves_the_campaign_argv_byte_identical(
+    tmp_path, shared_mount,
+):
+    workspace, units, seed_dir = _workspace(tmp_path)
+    row = _row(units, seed_dir)
+    before = json.dumps(row, sort_keys=True)
+
+    attached = dispatch.attach_data_manifests(workspace, [row])
+
+    assert len(attached) == 1
+    assert json.dumps(row, sort_keys=True) == before, "the planned row was mutated"
+    assert attached[0]["argv"] == row["argv"]
+    assert json.dumps(attached[0]["argv"]) == json.dumps(row["argv"])
+    assert set(attached[0]) - set(row) == {"data_manifest"}
+    assert all(attached[0][field] == row[field] for field in row)
+    assert Path(attached[0]["data_manifest"]).is_file()
+
+
+def test_the_attached_manifest_is_what_prismabuild_accepts(
+    tmp_path, shared_mount,
+):
+    workspace, units, seed_dir = _workspace(tmp_path)
+
+    attached = dispatch.attach_data_manifests(
+        workspace, [_row(units, seed_dir)])
+
+    written = json.loads(Path(attached[0]["data_manifest"]).read_text())
+    assert set(written) == set(glm_data_manifests.MANIFEST_KEYS)
+    assert written["schema"] == "prismaquant.prismabuild.data_manifest.v1"
+    for entry in written["entries"]:
+        assert set(entry) == set(glm_data_manifests.ENTRY_KEYS)
+    # The producer's own restatement of the contract, applied to the bytes on
+    # disk rather than to the object that was written.
+    glm_data_manifests.check_manifest(written, where="row-0000")
+
+
+def test_two_submissions_of_one_campaign_write_identical_manifest_bytes(
+    tmp_path, shared_mount,
+):
+    """The manifest is sealed into the action key, so it must not drift.
+
+    ``pbrun`` ingests the manifest as a content-addressed input.  A hostname
+    or a clock reading in ``produced_by`` would give the same row a new action
+    key on every submit, and a finished row would stop being a cache hit --
+    the opposite of what re-running ``submit`` is for.
+    """
+    workspace, units, seed_dir = _workspace(tmp_path)
+    row = _row(units, seed_dir)
+
+    first = dispatch.attach_data_manifests(workspace, [row])
+    before = Path(first[0]["data_manifest"]).read_bytes()
+    second = dispatch.attach_data_manifests(workspace, [row])
+    after = Path(second[0]["data_manifest"]).read_bytes()
+
+    assert first[0]["data_manifest"] == second[0]["data_manifest"]
+    assert before == after
+    assert b"unix" not in before and b"host" not in before
+
+
+def test_a_row_whose_read_set_cannot_be_derived_is_refused(
+    tmp_path, shared_mount,
+):
+    workspace, units, seed_dir = _workspace(tmp_path)
+
+    nameless = _row(units, seed_dir)
+    nameless["argv"] = [item for item in nameless["argv"]
+                        if "units" not in str(item)]
+    with pytest.raises(RuntimeError, match="no single units"):
+        dispatch.attach_data_manifests(workspace, [nameless])
+
+    ambiguous = _row(units, seed_dir,
+                     extra=["--resume-units", str(units.parent / "row-0007.json")])
+    with pytest.raises(RuntimeError, match="no single units"):
+        dispatch.attach_data_manifests(workspace, [ambiguous])
+
+    unplanned = _row(units.parent / "row-0009.json", seed_dir)
+    with pytest.raises(RuntimeError, match="not a row of"):
+        dispatch.attach_data_manifests(workspace, [unplanned])
+
+
+def test_every_submitted_row_carries_a_manifest(tmp_path, shared_mount):
+    workspace, units, seed_dir = _workspace(tmp_path)
+    rows = [_row(units, seed_dir)]
+    (workspace / "manifest.json").write_text(json.dumps(rows, indent=2) + "\n")
+    calls = {}
+
+    def _record(manifest, *, wait_s, receipts=None):
+        calls["manifest"] = manifest
+        return 0
+
+    dispatch._pbcampaign = _record
+    try:
+        assert dispatch.cmd_submit(
+            type("Args", (), {"workspace": str(workspace), "wait_s": 1})) == 0
+    finally:
+        del dispatch._pbcampaign
+
+    submitted = json.loads(Path(calls["manifest"]).read_text())
+    assert submitted, "nothing was submitted"
+    assert all(row.get("data_manifest") for row in submitted)
+    # What ``plan`` wrote is not what was submitted, and is left alone.
+    assert Path(calls["manifest"]).name == dispatch.SUBMITTED_MANIFEST
+    assert json.loads((workspace / "manifest.json").read_text()) == rows

--- a/tests/test_glm_data_manifest_at_submit.py
+++ b/tests/test_glm_data_manifest_at_submit.py
@@ -313,15 +313,28 @@ def test_a_row_whose_named_seed_wire_yields_nothing_is_refused(
     campaign -- the submit path refuses it instead of warming nothing.
     """
     workspace, units, seed_dir = _workspace(tmp_path)
+    # A checkpoint the row also names, and that exists: the row's seed total
+    # is then non-zero even with an empty wire directory, so the gate has to
+    # look at the wire directory's own files.
+    checkpoint = tmp_path / "seed-checkpoint.safetensors"
+    checkpoint.write_bytes(b"\0" * (1 << 20))
+    named = ["--seed-checkpoint", str(checkpoint)]
 
-    absent = _row(units, tmp_path / "never-written")
+    absent = _row(units, tmp_path / "never-written", extra=named)
     with pytest.raises(SystemExit, match="no readable file was found"):
         dispatch.attach_data_manifests(workspace, [absent])
 
     empty = tmp_path / "empty-wire"
     empty.mkdir()
     with pytest.raises(SystemExit, match="no readable file was found"):
-        dispatch.attach_data_manifests(workspace, [_row(units, empty)])
+        dispatch.attach_data_manifests(workspace, [_row(units, empty, extra=named)])
+
+    # The checkpoint on its own is still declared when the wire directory has
+    # something in it, so the gate refuses the missing wire, not the pairing.
+    ok = dispatch.attach_data_manifests(
+        workspace, [_row(units, seed_dir, extra=named)])
+    manifest = json.loads(Path(ok[0]["data_manifest"]).read_text())
+    assert manifest["annotations"]["counts"]["seeds"] == len(SEED_WIRE) + 1
 
 
 def test_the_producer_restates_the_limits_prismabuild_enforces(

--- a/tests/test_tessera_campaign_fanout.py
+++ b/tests/test_tessera_campaign_fanout.py
@@ -603,6 +603,33 @@ _NARROW_COLUMNS = 16384
 _WIDE_COLUMNS = 131072
 
 
+def _write_model(model, shapes):
+    """The shard the census names, with the tensors it says are in it.
+
+    ``submit`` derives each row's read set from the model the plan names, so a
+    campaign whose model directory is empty has nothing to declare and is
+    refused. A row that reads nothing is not a shape production has: a Tessera
+    row exists to encode weights it reads off these shards. The fixture writes
+    them, at the shapes the census states, so the rows it plans are rows the
+    submit path can price.
+    """
+    import struct
+
+    header, offset = {}, 0
+    for name in sorted(shapes):
+        rows, columns = shapes[name]
+        size = rows * columns * 2  # bf16
+        header[name + ".weight"] = {
+            "dtype": "BF16", "shape": [rows, columns],
+            "data_offsets": [offset, offset + size]}
+        offset += size
+    blob = json.dumps(header).encode()
+    shard = model / "model-00001-of-00001.safetensors"
+    shard.write_bytes(struct.pack("<Q", len(blob)) + blob + b"\0" * offset)
+    (model / "model.safetensors.index.json").write_text(json.dumps(
+        {"weight_map": {key: shard.name for key in header}}))
+
+
 def _partition_workspace(tmp_path, *, wide=True, box_memory_gb=104):
     """A census whose last anchor group is far wider than the others."""
     model = tmp_path / "model"
@@ -612,6 +639,7 @@ def _partition_workspace(tmp_path, *, wide=True, box_memory_gb=104):
     shapes = {name: [8, _NARROW_COLUMNS] for names in groups.values()
               for name in names}
     shapes["wide"] = [8, _WIDE_COLUMNS]
+    _write_model(model, shapes)
     workspace = tmp_path / "campaign"
     workspace.mkdir()
     (workspace / "census.json").write_text(json.dumps({
@@ -733,6 +761,12 @@ def test_submit_hands_the_fleet_the_admissible_rows_only(tmp_path, monkeypatch):
         return types.SimpleNamespace(returncode=0, stdout="")
 
     monkeypatch.setattr(dispatch.subprocess, "run", fake_run)
+    # Every manifest entry must sit under the mount the manifest declares, and
+    # the fleet warms only the shared mount. The fixture's campaign is the
+    # shared mount for the length of this test.
+    from experiments import glm_data_manifests
+    monkeypatch.setattr(glm_data_manifests, "SHARED_MOUNT", str(tmp_path))
+
     args = types.SimpleNamespace(workspace=workspace, wait_s=1)
     assert dispatch.cmd_submit(args) == 0
 
@@ -741,6 +775,11 @@ def test_submit_hands_the_fleet_the_admissible_rows_only(tmp_path, monkeypatch):
     assert [row["argv"][row["argv"].index("--units") + 1].split("/")[-1]
             for row in submitted] == ["row-0000.json", "row-0001.json",
                                       "row-0002.json"]
+    # And each of them carries the byte list the fleet needs to warm it.
+    for row in submitted:
+        manifest = json.loads(pathlib.Path(row["data_manifest"]).read_text())
+        assert manifest["entries"], "a submitted row declared no bytes"
+        assert manifest["total_bytes"] > 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tessera_campaign_fanout.py
+++ b/tests/test_tessera_campaign_fanout.py
@@ -770,8 +770,13 @@ def test_submit_hands_the_fleet_the_admissible_rows_only(tmp_path, monkeypatch):
     args = types.SimpleNamespace(workspace=workspace, wait_s=1)
     assert dispatch.cmd_submit(args) == 0
 
-    assert len(seen) == 1
-    submitted = json.loads(pathlib.Path(seen[0][-1]).read_text())
+    # ``submit`` also asks git for the tree it built the manifests from, so
+    # the submission is picked out by name rather than by being the only
+    # subprocess the run makes.
+    submissions = [command for command in seen
+                   if any("pbcampaign" in str(word) for word in command)]
+    assert len(submissions) == 1
+    submitted = json.loads(pathlib.Path(submissions[0][-1]).read_text())
     assert [row["argv"][row["argv"].index("--units") + 1].split("/")[-1]
             for row in submitted] == ["row-0000.json", "row-0001.json",
                                       "row-0002.json"]

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -963,8 +963,10 @@ def attach_data_manifests(workspace: Path, rows: list[dict], *,
         manifest = producer.build_manifest(
             campaign, row_id, provenance, row.get("argv"))
         path = out_dir / f"{row_id}.data-manifest.json"
-        path.write_bytes(
-            json.dumps(manifest, indent=1, sort_keys=False).encode() + b"\n")
+        blob = producer.check_manifest_bytes(
+            json.dumps(manifest, indent=1, sort_keys=False).encode() + b"\n",
+            where=row_id)
+        path.write_bytes(blob)
         attached.append({**row, "data_manifest": str(path)})
 
     missing = [producer.row_id_of(row) for row in attached
@@ -980,7 +982,9 @@ def cmd_submit(args) -> int:
     rows = attach_data_manifests(workspace, rows)
     submitted = workspace / SUBMITTED_MANIFEST
     submitted.write_text(json.dumps(rows, indent=2) + "\n")
-    print(f"[dispatch] data manifests attached to {len(rows)} rows -> {submitted}")
+    plural = "" if len(rows) == 1 else "s"
+    print(f"[dispatch] data manifests attached to {len(rows)} row{plural} "
+          f"-> {submitted}")
     # Re-running the manifest IS the resume: a finished row is a cache hit and
     # a running row is re-attached, both by pbcampaign itself.  The manifests
     # are a deterministic function of the campaign and the tree, so a second

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -904,11 +904,88 @@ def cmd_plan(args) -> int:
     return 0
 
 
+#: Where ``submit`` writes the per-row read sets and the manifest that names
+#: them.  Both are derived, so both are rewritten on every submit and neither
+#: is the planned ``manifest.json``: ``plan`` owns that file.
+DATA_MANIFEST_DIR = "data-manifests"
+SUBMITTED_MANIFEST = "manifest.submitted.json"
+
+
+def _manifest_producer():
+    """The campaign's data-manifest producer, imported from ``experiments/``.
+
+    It is imported here rather than at module load because it reads the
+    campaign's plan and capture manifest, which only ``submit`` needs.
+    """
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    from experiments import glm_data_manifests
+
+    return glm_data_manifests
+
+
+def attach_data_manifests(workspace: Path, rows: list[dict], *,
+                          out_dir: Path | None = None) -> list[dict]:
+    """Give every row the byte list PrismaBuild needs to warm it, or refuse.
+
+    Only the producer knows a row's read set: the capture files its members
+    name, the byte extents of those members' weights inside the safetensors
+    shards, and the seed wire the row's own argv points at.  Without that list
+    a row is invisible to the fleet's prewarm loop and starts against cold
+    spindles -- measured at 26 MB/s over 64 GB on sparky (row-0074,
+    2026-09-12), about 40 minutes of idle GPU per row.
+
+    The manifest is a ``pbrun`` input, not part of the campaign's own
+    checkpoint identity, so the row's ``argv`` is returned byte-identical to
+    what ``plan`` wrote; only the ``data_manifest`` key is added.  A row whose
+    manifest cannot be built is refused here, where the reason is readable,
+    rather than submitted blind.
+    """
+    producer = _manifest_producer()
+    campaign = producer.Campaign(str(workspace))
+    provenance = producer.deterministic_provenance(
+        str(workspace), campaign, "stat")
+    out_dir = out_dir or workspace / DATA_MANIFEST_DIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    attached: list[dict] = []
+    for index, row in enumerate(rows):
+        row_id = producer.row_id_of(row)
+        if row_id is None:
+            raise RuntimeError(
+                f"row {index} names no single units/row-XXXX.json in its argv, "
+                "so its read set cannot be derived; refusing to submit it "
+                "without a data manifest")
+        if row_id not in campaign.rows:
+            raise RuntimeError(
+                f"{row_id} is not a row of {workspace}/plan.json")
+        manifest = producer.build_manifest(
+            campaign, row_id, provenance, row.get("argv"))
+        path = out_dir / f"{row_id}.data-manifest.json"
+        path.write_bytes(
+            json.dumps(manifest, indent=1, sort_keys=False).encode() + b"\n")
+        attached.append({**row, "data_manifest": str(path)})
+
+    missing = [producer.row_id_of(row) for row in attached
+               if not row.get("data_manifest")]
+    if missing:
+        raise RuntimeError(f"rows without a data manifest: {missing}")
+    return attached
+
+
 def cmd_submit(args) -> int:
     workspace = Path(args.workspace)
+    rows = json.loads((workspace / "manifest.json").read_text())
+    rows = attach_data_manifests(workspace, rows)
+    submitted = workspace / SUBMITTED_MANIFEST
+    submitted.write_text(json.dumps(rows, indent=2) + "\n")
+    print(f"[dispatch] data manifests attached to {len(rows)} rows -> {submitted}")
     # Re-running the manifest IS the resume: a finished row is a cache hit and
-    # a running row is re-attached, both by pbcampaign itself.
-    return _pbcampaign(workspace / "manifest.json", wait_s=args.wait_s,
+    # a running row is re-attached, both by pbcampaign itself.  The manifests
+    # are a deterministic function of the campaign and the tree, so a second
+    # submit addresses the same action keys as the first.
+    return _pbcampaign(submitted, wait_s=args.wait_s,
                        receipts=workspace / "receipts.json")
 
 


### PR DESCRIPTION
Closes #518

## What changed

`dispatch_tessera_campaign.py submit` now derives a PrismaBuild data manifest
for every row and refuses a row whose read set it cannot derive. The manifest
names the row's capture files, the byte extents of its members' weights inside
the safetensors shards, and the seed bytes the row's own argv points at, in the
order the row reads them.

`submit` writes the manifests under `WORKSPACE/data-manifests/` and submits
`WORKSPACE/manifest.submitted.json`. `plan` keeps ownership of `manifest.json`
and it is never rewritten.

## The seed gap

`Campaign.seed_reads` resolved seeds from the campaign's own `plan.json`. That
carries a seed only for a row planned from a `--seed-workspace`; a campaign
seeded from the global `--seed-checkpoint` / `--seed-wire-dir` flags records
none per row, and the directory those flags name belongs to a different
workspace. So every manifest of `extension-r1024-02` declared `seeds: 0` while
the row spent minutes hashing 9.4-19 GB of wire at 41 MB/s, 8.51 ms/op,
~0.7 in flight (row-0065, 2026-09-12).

The seed set now comes off the row's `--seed-checkpoint` and `--seed-wire-dir`
argv. The wire directory is enumerated with one `os.walk` of that named
directory and nothing above it: a search rooted at a parent is the RPC storm
that stalls both Sparks. Symlinked leaves are dropped rather than declared,
because the prewarm reader opens every entry `O_NOFOLLOW` and would only ever
record an error against one.

## Seeds go in `entries`, and what that costs

Read before deciding: `prewarm_loop.cycle` (`tools/prewarm_loop.py:1000-1007`)
refuses a manifest larger than its remaining budget **wholesale** — it warms
nothing, and the check runs before `Reader.read(budget_bytes=...)`
(`:696-771`), which does stop in producer order. `pbrun` accepts one manifest
per action (`pbrun.py:4304`), so a second manifest is not expressible, and PB
reads only `annotations.row_id` (`prewarm_loop.py:845-848`), so an
`annotations` group is a label, not a mechanism. There is no producer-side
formulation that gets a partial warm out of the deployed loop.

Seeds are still declared in `entries`, for two reasons:

* they are bytes the row reads, and `claimed_reserve`
  (`prewarm_loop.py:868-897`) protects a running row with its **declared**
  `total_bytes`. A manifest that omitted the seeds would leave a running row's
  seed bytes evictable by the next warm — under-declaring corrupts the budget
  it was meant to fit;
* the manifest is sealed into the action key, so an annotations-now /
  entries-later two-step would re-key every row at the flip.

The honest cost: a routed row's manifest rises from ~64 GB to 74-87 GB. The
"prewarm goes dark" reading of that is wrong — `claimed_reserve` counts only
claims younger than `--claim-grace-min` (20 min) and `warmed_reserve` only
completed warms of still-unclaimed rows, so protection decays. One live claim
plus one lookahead row (the `--lookahead` default is 1) is 160 GB against the
206 GB budget and fits. **The risk that remains:** two claims inside one
20-minute grace window leave 46 GB, and a lookahead row is then refused
wholesale — including the 64 GB that warms reliably today. If a slot frees
inside that window the row runs fully cold: about 52 min of idle GPU instead of
about 12. The window clears itself.

`annotations.phases` now carries the running byte sum at each phase boundary
(captures, weight_extents, seeds) so a loop that learns to warm a prefix has a
boundary to stop on, and the entry order already puts the captures first.

Two follow-ups this PR does not do. They belong in PrismaBuild, and they are
listed here rather than filed as issues -- filing them is the next step, not
something this PR did:

1. PB: in `cycle()`, replace `if total > budget: skip` with
   `Reader.read(entries, budget_bytes=budget)`, record `partial`, count
   partials in `warmed_reserve`, and let `already_warm` recognise a prefix.
2. Re-measure the load phase on the first warmed-seed rows and set
   `--claim-grace-min` from the measurement, as its own help text asks
   ("set it to the load phase you measured"). No number is proposed here: set
   it below the true load phase and the next warm evicts a running row's unread
   bytes.

Also not done, and named rather than silently skipped: the seed entries are the
files in the directory, not `targets x admitted formats` computed from
`_adopt_seed_checkpoint`. Enumerating the directory is what the issue asks for
and it has no coupling to campaign internals; a menu that admits fewer rates
than the seed workspace produced would over-declare, and measuring whether it
does requires reading the live seed wire directories, which is not available
while the campaign is running.

## Size, against the limits the contract sets

A routed GLM row's manifest is about 870 capture and weight entries plus a
5,920-file seed wire, so roughly 6,800 entries and 2 MB on disk.
`prismabuild.core` refuses more than `DATA_MANIFEST_MAX_ENTRIES` = 1,000,000
entries (`core.py:153`, checked in `validate_data_manifest`) and a file over
`DATA_MANIFEST_MAX_BYTES` = 64 MiB (`core.py:152`, checked in
`load_data_manifest` before it parses anything). A real row is two orders of
magnitude inside both, so declaring the seed wire in `entries` does not
approach either limit. Both ceilings are now restated in the producer's own
`check_manifest` / `check_manifest_bytes`, so a future read set that crossed
one is refused where it is built rather than after the campaign is laid out.

## Failing closed on a named seed directory

`seeds: 0` is the shape the defect shipped, so it is no longer a valid
manifest: a row whose argv names `--seed-wire-dir` and whose directory yields
no readable file is refused at submit, whatever the cause -- absent directory,
permission error, renamed campaign. The gate counts the entries under that
directory, not the row's seed total: a row names `--seed-checkpoint` too, and
`seed_reads` returns one deduped list over both, so a checkpoint that exists
would otherwise satisfy the gate while the wire directory was empty -- the same
silent zero with one extra file in it (measured on the fixture: seed total 1,
files under the named directory 0). The enumerator follows the named root if it
is a symlink (a campaign may point the flag at a link) and never follows a
leaf, because the prewarm reader opens every entry `O_NOFOLLOW`. It walks the
named directory with `os.scandir` and `entry.stat(follow_symlinks=False)`,
which reuses the attributes the NFS READDIRPLUS reply already carried: one
round of directory reads for a 5,920-file wire rather than two metadata RPCs
per file, across 19 rows.

## Two gates at submit, and how they compose

`submit` refuses twice before any row reaches the fleet, in this order:

1. #522's demand check re-derives every planned row's `mem_gb` from its own
   argv and refuses an under-declared or over-capacity row.
2. This PR's read-set gate gives every row its data manifest and refuses a row
   whose read set it cannot derive.

They are independent -- one reads `demand`, the other reads the bytes the row
will open -- and attaching a manifest changes neither `argv` nor `demand`, so
what the demand check verified is what is submitted. Each gate's unit test
stands the other one down, because neither fixture can satisfy both (the
demand fixture's model is the bare path `/source` with no shards behind it;
the read-set fixture's plan is written by hand and names no spec), and the
composition is covered end to end by
`tests/test_tessera_campaign_fanout.py::test_submit_hands_the_fleet_the_admissible_rows_only`,
which plans a real campaign and submits it through both.

That fanout test found the gate's first real consequence: its fixture planned
rows against an empty model directory, so the manifest had no entries and
PrismaBuild refuses an empty entry list. The refusal is right and the fixture
was the unrealistic half -- a Tessera row exists to encode weights it reads off
those shards, so a row that reads nothing is not a shape production has, and
submitting it would hand the fleet a row it cannot warm. The fixture now writes
the shard the census names, at the shapes the census states, and the test
asserts every submitted row carries a non-empty byte list.

## Determinism, and why it matters here

`produced_by` loses its hostname and clock reading. `pbrun` ingests the
manifest as a content-addressed input and seals its digest into the action key
(`pbrun.py:4304-4370`), so a field that changed between runs would give a
finished row a new action key on every submit — the opposite of what re-running
`submit` is for. A test pins two submissions to byte-identical manifests.

**Disposition of rows already READY with a seedless manifest:** their manifest
digest changes, so a resubmit mints new action keys. Leave in-flight rows on
their existing keys and let them finish; the next planned campaign picks up the
new shape. Do not resubmit a running row to attach a manifest to it.

## The argv is untouched

The manifest is a `pbrun` input, outside the campaign's own checkpoint
identity. `attach_data_manifests` returns the planned row with exactly one key
added and the `argv` list unchanged, asserted byte for byte.

## Receipts

All test runs through `pbtest.py` on dl380g10, `pq-cpu312`, `--priority -10`.
Every action's `detail.returncode` is 0 and `status` is `executed`.

Re-run at head `d4172e0e`, which merges `origin/main` (#526). Every earlier
run is superseded and nothing is carried forward from an older head. Each
summary line below was read from the action's own `00000001.stdout.*.log`.

| action_key | file | summary |
|---|---|---|
| `7723f333da4d069653fd23397ee7ff70722007ae89826fd11c6418d53cb0117f` | `tests/test_glm_data_manifest_at_submit.py` | 10 passed, 14 warnings in 6.30s |
| `b5ab4f874050edef468811c5526de08f22044eb2c6b5d6fbe29a8b580bc29f51` | `tests/test_tessera_campaign_fanout.py` | 40 passed, 14 warnings in 11.84s |
| `00ccbf0b903084630368441a39443b2435b4c47dc75aec5535a64d1972c34c70` | `tests/test_campaign_demand_derivation.py` | 14 passed, 14 warnings in 6.02s |
| `60c666da58ed0767f5b9aceb11acf551bffcb61dab514858244c3ab3ab705302` | `tests/test_glm_arc_prewarm_weight_extents.py` | 1 passed, 14 warnings in 6.33s |
| `fe4b5421d36abf488bb340977af00aacd20fa33dbe4a05efa1266a279c40b3c7` | `tests/test_glm_data_manifest_matches_the_prismabuild_contract.py` | 1 passed, 14 warnings in 6.43s |
| `5888adf9268e72790ffcf991c406918de2cde407a64393545aad64407bcf4645` | `tests/test_docs_staleness.py` | 6 passed, 14 warnings in 9.01s |
| `1c3c3b7a07dac07292b7eb7abb7a03417bb563394b6e40ae572c392ac935fd7e` | `tests/test_architecture_doc.py` | 13 passed, 14 warnings in 6.89s |
| `e442d139e117efe5f4a58b48638e7844a2a0588d79f86d4840040e07ca6a6edd` | `tests/test_campaign_progress_replaces_the_blanket_timeout.py` | 14 passed, 14 warnings in 7.72s |
| `ac661feeff6f4f4b4b38c3e927252e2844127c65926e089f266c02e6b95b17fc` | `tests/test_tessera_campaign_merge_integrity.py` | 15 passed, 14 warnings in 6.80s |
| `afdfbd46091de730a14a6ded189619533f396069fde18306de7b80d0497877cc` | `tests/test_tessera_selected_source.py` | 22 passed, 1 skipped, 14 warnings in 10.79s |
| `9e596985e918f4c81b10e8d043c377ceb0a57f21031e767095044190c3828121` | `tests/test_tessera_calibration_cache.py` | 34 passed, 14 warnings in 10.64s |

Each attempt record is
`/mnt/shared/prismabuild-fleet/pb-queue/attempts/<action_key>/<hash>/00000001.json`
with its stdout log beside it, and `detail.returncode` is 0 on every one.

The one skip is pre-existing and in a file this PR does not touch:
`test_tessera_selected_source.py:255`, `skipif not torch.cuda.is_available()`,
reason "real encoder memo qualification requires CUDA". The shards ran on
dl380g10, which has no GPU.

## Acceptance item not met

The issue asks for **one routed row's startup MB/s and RPC rtt with the
manifest, against the 26 MB/s / 11.18 ms baseline**. That is not in this PR and
no number is offered for it. Both Sparks' GPUs are committed to the running GLM
campaign and this work may not run there, so the measurement cannot be taken
without displacing live rows. It needs one routed row submitted through the new
path with `/proc/self/mountstats` read at startup.

## Consultation

One sub-question went to `fable-medium`: whether the seed wire belongs in
`entries` or in an `annotations` group, given a consumer that refuses an
over-budget manifest wholesale. Outcome: `entries`, seeds last, plus
`annotations.phases`. It corrected the reading of `protected` that this PR's
risk paragraph now states -- protection decays because `claimed_reserve`
counts only claims inside the grace window -- and argued that under-declaring
`total_bytes` under-protects a running row's seed bytes, since a claim reserves
only what the manifest declares. Its further suggestion, computing seed entries
from `targets x admits()` instead of enumerating the directory, was declined
for the reason given above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmYxSxhmzbBcBoFTjbLi1G

