### PR TITLE
Derive the campaign row's memory demand from the plan it checks itself against

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,56 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-12 · `pq/420-admit-fixed-resources`. Stamps
+As of: 2026-09-12 · `claude/522-derive-mem-gb-from-plan`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-12, `claude/522-derive-mem-gb-from-plan`) for the campaign
+dispatcher's derived memory demand (#522). **A row's `demand.mem_gb` now
+carries every term of the predicate the row will check itself against**, and a
+manifest that does not is refused before submission rather than after
+admission.
+
+Three terms, one `ceil`: the phase plan's `memory_bytes`, the process floor,
+and the guard's physical margin.
+
+* **The floor.** `process_baseline_bytes` on the campaign spec now defaults to
+  `DEFAULT_PROCESS_BASELINE_BYTES` = 1,150,000,000 rather than to `0`. That is
+  the top of the range of floors the GLM `extension-r1024-02` rows measured for
+  themselves on 2026-09-12 (rows 0058, 0061, 0062, 0063, 0066, 0074, 0079:
+  0.88-1.15 GB), so it covers the worst reading rather than the average one. A
+  spec still overrides it, including with `0`, and `baseline_policy` says which
+  of the two a plan carries: `explicit-spec-reservation-measured-in-row` for a
+  spec's number and `measured-fleet-default-reservation-measured-in-row` for
+  this default. The reservation is still charged on the demand and never inside
+  `memory_bytes`.
+* **The margin.** `CaptureMemoryGuard` refuses at `cap - margin_bytes`, so a
+  demand covering plan and floor alone still buys an admission the row's first
+  `check` declines. The dispatcher reads `CaptureMemoryGuard.MARGIN_BYTES`, now
+  a class attribute, instead of restating 2 GiB.
+* **The check.** `dispatch_tessera_campaign.py check` recomputes each manifest
+  row's demand **from the row's own argv**, not from the planning spec, and
+  refuses a row whose declared `demand.mem_gb` is below the derived value or
+  whose derived value exceeds a declared GPU-box capacity (`--box-memory-gb`,
+  else the spec's `box_memory_gb`). `submit` runs the same check first and
+  refuses to submit an unverifiable manifest. Both refusals name plan, floor,
+  margin, derived and declared bytes.
+
+Consequence, stated rather than engineered around: the relaunch rows derive
+108.63 GB + 1.15 GB + 2 GiB = 105 GiB, above the 104 GiB a Spark declares.
+Those rows are now refused at submit instead of dying about twenty seconds
+after admission. Making them fit is a plan-term or a box question, not an
+allowance to shrink.
+
+The row's own refusals now print their arithmetic. `memory_admission_detail`
+returns `plan_bytes`, `cap_bytes`, `baseline_bytes` (absent where no reading
+has been taken) and `slack_bytes`; both cgroup-admission refusals in
+`tessera_campaign.py` embed it, and the selected-anchor refusal also writes
+`<cache-dir>/selected-anchor-memory-refusal.json` with the guard snapshot.
+Three rows died on this predicate on 2026-09-12 and the cause had to be
+recovered by unpickling completed rows' `cost.pkl`.
+
+Gates: `tests/test_campaign_demand_derivation.py`,
+`tests/test_tessera_selected_source.py`,
+`tests/test_tessera_campaign_fanout.py`.
 
 Re-stamped (2026-09-12, `pq/420-admit-fixed-resources`) for the consumer half
 of the fixed-resource admission design's last prerequisite row, "integrate
@@ -401,10 +450,12 @@ dispatcher's explicit process-baseline reservation. A recipe may declare
 demand, in both the streaming and resident-source branches, and never inside
 `memory_bytes`. `baseline_policy` gains
 `explicit-spec-reservation-measured-in-row` for a plan that carries one, and
-the plan records the integer beside `row_memory_gb`. The default is `0`, which preserves
-every row's resource demand exactly; the plan file itself is not byte-identical,
-since it now carries `process_baseline_bytes: 0`. The runtime's measured
-fail-closed guard is unchanged.
+the plan records the integer beside `row_memory_gb`. The default was `0`, which
+preserved every row's resource demand exactly; the plan file itself was not
+byte-identical, since it carries `process_baseline_bytes`. The runtime's
+measured fail-closed guard is unchanged. **Superseded on 2026-09-12 (#522):
+the default is now the measured fleet floor, and the guard's margin is charged
+beside it. See the newest stamp.**
 
 Re-stamped (2026-09-09, `fix/glm-resident-hessian-source`) for resident
 Hessian commitment reuse in the selected campaign's existing opt-in
@@ -559,8 +610,9 @@ the cap less the baseline instead of with the raw cap. The guard's own refusal
 arithmetic is unchanged: its readings are already absolute. No pre-run baseline
 is derived for the dispatcher, which never enters the box a row lands on, but a
 recipe may **declare** one: `process_baseline_bytes` on the campaign spec, a
-non-negative integer of bytes defaulting to `0`. `load_spec` refuses anything
-else, `bool` included, before a row is derived. `_row_memory_gb` adds it to the
+non-negative integer of bytes. It defaulted to `0` here and defaults to the
+measured fleet floor since #522; the newest stamp carries the current rule.
+`load_spec` refuses anything else, `bool` included, before a row is derived. `_row_memory_gb` adds it to the
 demand in **both** branches, streaming and resident-source, since a process
 floor exists either way; it is never summed into `memory_bytes`, because the
 demand becomes a cap of exactly that many GiB while the row compares its plan
@@ -568,9 +620,11 @@ with the cap less its measured floor, so a reservation folded into the plan
 would inflate both sides and net to zero. That is why `headroom_gb`, a term
 inside `memory_bytes`, could not close this gap. `baseline_policy` records
 which pre-run term a plan has:
-`declared-headroom-pre-run-measured-in-row` when nothing is declared, and
-`explicit-spec-reservation-measured-in-row` beside the integer when one is, so
-an absent reservation cannot read as coverage. The row's own first
+`declared-headroom-pre-run-measured-in-row` when nothing is reserved,
+`explicit-spec-reservation-measured-in-row` beside the integer when a spec
+declares one, and `measured-fleet-default-reservation-measured-in-row` when the
+dispatcher supplied its measured default (#522), so an absent reservation
+cannot read as coverage and an inherited one cannot read as a spec's choice. The row's own first
 `CaptureMemoryGuard.check` remains the only measured floor of the three.
 Rounding was not a reservation: `ceil` leaves at most one GiB of slack and the
 floor measured on this fleet is 1,062,359,040 bytes, 0.9894 GiB, so before this
@@ -2064,8 +2118,8 @@ three scope-wide answers no shard may re-derive (the calibration row counts
 behind `fit_tokens`, the fused-unified activation maxima behind
 `input_global_scale`, and the producer's whole-scope expert projection);
 `--seed-checkpoint` offers an in-flight campaign's anchors to this run's own
-row gates. `tools/dispatch_tessera_campaign.py` is census/plan/submit/merge
-over `pbcampaign`, and the merge unions disjoint captures into the object a
+row gates. `tools/dispatch_tessera_campaign.py` is
+census/plan/check/submit/merge over `pbcampaign`, and the merge unions disjoint captures into the object a
 whole-scope run writes, recomputes its digest and refuses on any identity the
 rows do not already share. A row whose rung this run's menu does not admit is
 carried as `unservable` evidence rather than refused or priced, and
@@ -9121,10 +9175,13 @@ RobTand/prismaquant#284, and a fanned-out run selects it the way it selects any
 campaign flag, through the spec's `campaign_argv`, with `merge` refusing rows
 whose `menu_mode` disagrees.
 
-`tools/dispatch_tessera_campaign.py` is `census` / `plan` / `submit` / `merge`
-over `pbcampaign`. Rows are portable (no host pin), GPU-demanding, not
-exclusive, `retry_safe`, and carry a memory demand computed from the
-checkpoint's size and the selection's shapes. Re-running the manifest **is**
+`tools/dispatch_tessera_campaign.py` is `census` / `plan` / `check` /
+`submit` / `merge` over `pbcampaign`. Rows are portable (no host pin), GPU-demanding, not
+exclusive, `retry_safe`, and carry a memory demand computed from the phase
+plan the row checks itself against, plus the measured process floor and the
+guard's margin (#522). `check` re-derives that demand from a manifest row's
+own argv and refuses an under-declared or over-capacity row; `submit` runs it
+first. Re-running the manifest **is**
 the resume -- a finished row is a CAS hit and a running row is re-attached --
 so nothing here decides what to skip, and a row may not carry
 `--deadline-seconds`, which stops a run mid-round and would price a different

--- a/prismaquant/autoscale.py
+++ b/prismaquant/autoscale.py
@@ -78,6 +78,15 @@ def require_bounded_capture_environment(environ):
 # predicate, which is exactly what declared headroom already does.
 BASELINE_POLICY_DECLARED_HEADROOM = 'declared-headroom-pre-run-measured-in-row'
 BASELINE_POLICY_EXPLICIT_RESERVATION = 'explicit-spec-reservation-measured-in-row'
+# A reservation the caller took from a measured fleet default rather than from
+# a spec that asked for it.  It is a separate value because a reader of a plan
+# has to be able to tell the two apart: one row's operator chose the number,
+# the other inherited a number measured on other rows.  Both are reservations,
+# and neither is the floor the row measures for itself.
+BASELINE_POLICY_MEASURED_DEFAULT_RESERVATION = (
+    'measured-fleet-default-reservation-measured-in-row')
+RESERVATION_BASELINE_POLICIES = (BASELINE_POLICY_EXPLICIT_RESERVATION,
+                                 BASELINE_POLICY_MEASURED_DEFAULT_RESERVATION)
 
 
 def validate_process_baseline_bytes(value, *, where='process_baseline_bytes'):
@@ -93,25 +102,42 @@ def validate_process_baseline_bytes(value, *, where='process_baseline_bytes'):
     return value
 
 
-def _baseline_fields(process_baseline_bytes):
+def validate_process_baseline_policy(policy, *, where='process_baseline_policy'):
+    """A reservation names where it came from, or it is not one."""
+    if policy not in RESERVATION_BASELINE_POLICIES:
+        raise RuntimeError(
+            f'{where} must be one of {list(RESERVATION_BASELINE_POLICIES)}, '
+            f'not {policy!r}')
+    return policy
+
+
+def _baseline_fields(process_baseline_bytes,
+                     policy=BASELINE_POLICY_EXPLICIT_RESERVATION):
     """What a plan records about its pre-run term, and only what is true.
 
     Zero is the legacy default and emits nothing at all, so a reader can tell a
     declared reservation from the absence of one.  A plan that reserved nothing
     must not be able to report coverage it does not have.
+
+    ``policy`` says where the reservation came from.  The default is the
+    caller's own number; a caller that supplied a measured fleet default passes
+    ``BASELINE_POLICY_MEASURED_DEFAULT_RESERVATION`` instead, so the plan does
+    not report a spec reservation the spec never made.
     """
     validate_process_baseline_bytes(process_baseline_bytes)
+    validate_process_baseline_policy(policy)
     if not process_baseline_bytes:
         return {}
     return dict(process_baseline_bytes=process_baseline_bytes,
-                baseline_policy=BASELINE_POLICY_EXPLICIT_RESERVATION)
+                baseline_policy=policy)
 
 
 def streamed_calibration_resources(model_path, *, unit_shapes, counts,
                                    nsamples, seqlen, max_act_rows, cache_slots,
                                    prefetch_workers, headroom_gb,
                                    capture_policy='legacy', capture_load_policy=None,
-                                   process_baseline_bytes=0, selected_source_units=None):
+                                   process_baseline_bytes=0, selected_source_units=None,
+                                   process_baseline_policy=BASELINE_POLICY_EXPLICIT_RESERVATION):
     """Bound canonical capture using the shared loader's actual source layout.
 
     Headers and profile mappings determine source residency. Capture owns one
@@ -126,6 +152,7 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
     # below: a caller that declares a malformed reservation must be
     # refused before it is handed a plan that silently ignored it.
     validate_process_baseline_bytes(process_baseline_bytes)
+    validate_process_baseline_policy(process_baseline_policy)
     import math
     from .artifact_completeness import read_artifact_header
     from .model_profiles import detect_profile
@@ -292,7 +319,7 @@ def streamed_calibration_resources(model_path, *, unit_shapes, counts,
         # On the v1 result, so the legacy early return below carries it too:
         # a caller that declares a reservation and gets a plan back with no
         # record of it has been told the opposite of the truth.
-        **_baseline_fields(process_baseline_bytes),
+        **_baseline_fields(process_baseline_bytes, process_baseline_policy),
         **({'source_tensor_keys': sorted(selected_keys),
             'body_source_validation_bytes': {str(k): v for k, v in validation_raw_body.items()}}
            if selected_keys is not None else {}),
@@ -382,7 +409,8 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
                               anchor_batch_size=1, capture_load_policy=None,
                               publication_overlap_bytes=0, campaign_identity_bytes=0,
                               campaign_identity_threads=1,
-                              process_baseline_bytes=0, source_snapshot_policy='whole-layer-v1'):
+                              process_baseline_bytes=0, source_snapshot_policy='whole-layer-v1',
+                              process_baseline_policy=BASELINE_POLICY_EXPLICIT_RESERVATION):
     """Bound selected-source preparation separately from resident encoding.
 
     This extends the source loader's header/dtype accounting. No source
@@ -436,6 +464,7 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
     steady-state step against the plan (RobTand/prismaquant#390).
     """
     validate_process_baseline_bytes(process_baseline_bytes)
+    validate_process_baseline_policy(process_baseline_policy)
     import math
     from .perturbed_x_cache import normalize_verified_activation_load
     capture_load_policy = normalize_verified_activation_load(capture_load_policy)
@@ -616,7 +645,7 @@ def selected_anchor_resources(model_path, *, unit_shapes, counts, max_act_rows,
         # reservation replaces this value and is emitted beside it, so an
         # absent reservation cannot read as coverage.
         **{'baseline_policy': BASELINE_POLICY_DECLARED_HEADROOM,
-           **_baseline_fields(process_baseline_bytes)},
+           **_baseline_fields(process_baseline_bytes, process_baseline_policy)},
         source_forward_count=0)
 
 

--- a/prismaquant/memory_management.py
+++ b/prismaquant/memory_management.py
@@ -36,7 +36,16 @@ class CaptureMemoryGuard:
     ``peak_checkpoint`` and ``peak_by_checkpoint_prefix`` say where the peak
     was observed, so a plan that undercharges is attributable from one
     receipt instead of a rerun.
+
+    ``MARGIN_BYTES`` is that physical safety margin as a class attribute so a
+    producer that sizes the cgroup cap a row will run under reads the number
+    this guard refuses on instead of restating it. A second copy of it would
+    drift, and the drift would show up as a row that PrismaBuild admits and
+    the guard then refuses.
     """
+
+    #: Physical safety margin held back from the cgroup cap on every check.
+    MARGIN_BYTES = 2*1024**3
 
     def __init__(self, device, *, cgroup_root=Path('/sys/fs/cgroup'),
                  membership=Path('/proc/self/cgroup')):
@@ -64,7 +73,7 @@ class CaptureMemoryGuard:
         if not limits:
             raise RuntimeError('bounded capture requires a finite cgroup memory budget')
         self.cap_bytes, self.scope = min(limits, key=lambda pair: pair[0])
-        self.margin_bytes = 2*1024**3
+        self.margin_bytes = self.MARGIN_BYTES
         self.host_floor_bytes = 8*1024**3
         if self.cap_bytes <= self.margin_bytes:
             raise RuntimeError('capture budget cannot hold its physical safety margin')

--- a/prismaquant/tessera_campaign.py
+++ b/prismaquant/tessera_campaign.py
@@ -4579,6 +4579,27 @@ def _save_hessian_capture_with_page_release(payload, path, *, resource_check=Non
             'page release would be silently skipped (RobTand/prismaquant#396)')
 
 
+def memory_admission_detail(*, plan_bytes, cap_bytes, baseline_bytes=None):
+    """Every term of a cgroup admission predicate, as numbers.
+
+    The predicate is ``plan > cap - baseline``: a phase plan states deltas, the
+    cap is absolute, and the baseline is the floor the row measured for itself.
+    A refusal that prints only its verdict leaves the cause to be recovered by
+    unpickling a completed row's ``cost.pkl``, which is what three rows of the
+    GLM extension cost on 2026-09-12 (RobTand/prismaquant#522).
+
+    ``slack_bytes`` is what the plan had left; negative is the shortfall.
+    ``baseline_bytes`` is absent, not zero, where no reading has been taken:
+    zero would read as a floor that was measured and found empty.
+    """
+    detail = dict(plan_bytes=int(plan_bytes), cap_bytes=int(cap_bytes))
+    if baseline_bytes is not None:
+        detail['baseline_bytes'] = int(baseline_bytes)
+    detail['slack_bytes'] = (int(cap_bytes) - int(baseline_bytes or 0)
+                             - int(plan_bytes))
+    return detail
+
+
 def write_export_inputs(cache_dir: Path, *, hessians, hessian_rows,
                         hessian_identity, static_scales, static_scale_policy,
                         release_file_pages=False, resource_check=None,
@@ -4785,7 +4806,16 @@ def _run_streamed_calibration(args, runner, profile, *, mode, population,
             headroom_gb=args.streaming_cache_headroom_gb, capture_policy=capture_policy,
             capture_load_policy=capture_load_policy)
         if resources['memory_bytes'] > guard.cap_bytes:
-            raise RuntimeError('capture cgroup budget is smaller than its checked phase plan')
+            # The numbers, not just the verdict: a row that dies here is
+            # otherwise diagnosable only by unpickling a completed row's
+            # cost.pkl (RobTand/prismaquant#522). This predicate is the
+            # capture path's, so it carries no baseline term -- the guard has
+            # taken no reading yet.
+            raise RuntimeError(
+                'capture cgroup budget is smaller than its checked phase plan: '
+                + json.dumps(memory_admission_detail(
+                    plan_bytes=resources['memory_bytes'],
+                    cap_bytes=guard.cap_bytes), sort_keys=True))
         additional = max(sum(value for key, value in phase.items() if key not in
             ('nonbody_source_bytes', 'declared_headroom_bytes'))
             for phase in resources['phases'].values())
@@ -5414,7 +5444,24 @@ def _main(argv, *, source_scope) -> int:
             selected_guard.check('before_selected_capture_identity')
             if (selected_resources['memory_bytes'] >
                     selected_guard.cap_bytes - selected_guard.baseline_bytes()):
-                raise RuntimeError('selected anchor cgroup budget is smaller than its checked phase plan')
+                # Every term of the predicate, in the message and on disk.
+                # Three rows died here on 2026-09-12 with 8-13 MB of slack and
+                # the message named none of it, so the cause had to be
+                # recovered by unpickling completed rows' cost.pkl
+                # (RobTand/prismaquant#522).
+                detail = memory_admission_detail(
+                    plan_bytes=selected_resources['memory_bytes'],
+                    cap_bytes=selected_guard.cap_bytes,
+                    baseline_bytes=selected_guard.baseline_bytes())
+                from .cost_stage_checkpoint import atomic_write_bytes
+                atomic_write_bytes(
+                    cache_dir/'selected-anchor-memory-refusal.json',
+                    (json.dumps(dict(detail,
+                                     memory_guard=selected_guard.snapshot()),
+                                indent=2, sort_keys=True)+'\n').encode())
+                raise RuntimeError(
+                    'selected anchor cgroup budget is smaller than its checked '
+                    'phase plan: ' + json.dumps(detail, sort_keys=True))
     if args.capture_calibration_out or args.calibration_cache:
         from . import tessera_calibration_cache as calibration_store
         hi, lo = census_token_counts(census, {})

--- a/tests/test_campaign_demand_derivation.py
+++ b/tests/test_campaign_demand_derivation.py
@@ -1,0 +1,381 @@
+"""The dispatcher's memory demand, derived from the plan the row checks itself against.
+
+A campaign row states a PrismaBuild memory demand; PrismaBuild turns that
+number into a cgroup cap; the row then refuses unless its own phase plan fits
+under that cap less the floor it measures for itself, and its guard refuses
+again at ``cap - margin``. Three quantities, two of them outside the plan, and
+until RobTand/prismaquant#522 the demand carried neither.
+
+Everything here runs on an injected plan. No model files, no NFS, no GPU: what
+is under test is the arithmetic that joins the demand to the predicate, not any
+measurement of a real checkpoint.
+"""
+from __future__ import annotations
+
+import json
+import math
+
+import pytest
+
+GIB = 1024 ** 3
+
+# A plan whose rounding slack sits below the measured process floor, so the
+# demand is only right if it charges the floor rather than inheriting it from
+# ``ceil``. Both example rows inspected for #390 were on this side of the line.
+PLAN_BYTES = 20 * GIB + 173_741_824
+
+# The relaunch row this issue was filed on: ``extension-r1024-02`` row-0074,
+# whose selected-anchor plan measured 108.63 GB while its manifest declared
+# ``mem_gb: 102``.
+GLM_ROW_0074_PLAN_BYTES = 108_630_000_000
+
+
+def _dispatch():
+    from tools import dispatch_tessera_campaign as dispatch
+    return dispatch
+
+
+def _margin_bytes():
+    from prismaquant.memory_management import CaptureMemoryGuard
+    return CaptureMemoryGuard.MARGIN_BYTES
+
+
+def _fixed_plan(monkeypatch, plan_bytes=PLAN_BYTES):
+    """Inject the phase plan, so the derivation is the only variable."""
+    dispatch = _dispatch()
+    monkeypatch.setattr(dispatch, '_streamed_resource_plan',
+        lambda spec, census, members, *, selected_source: dict(
+            memory_bytes=plan_bytes, selected_layers=['0'],
+            baseline_policy='declared-headroom-pre-run-measured-in-row'))
+    return dispatch
+
+
+def _census(tmp_path):
+    census = dict(model='/source',
+                  anchor_groups={'u:layers.0.proj': ['layers.0.proj']},
+                  layer_stride=1, unit_shapes={'layers.0.proj': [3, 4]},
+                  counts={'layers.0.proj': 9})
+    (tmp_path / 'census.json').write_text(json.dumps(census))
+    return census
+
+
+def _units_file(tmp_path, name='row-0000.json'):
+    path = tmp_path / name
+    path.write_text(json.dumps({
+        'schema': 'prismaquant.tessera_campaign_units.v1', 'model': '/source',
+        'layer_stride': 1,
+        'groups': [{'key': 'u:layers.0.proj', 'members': ['layers.0.proj']}]}))
+    return path
+
+
+def _manifest_row(tmp_path, *, mem_gb, extra_argv=()):
+    units = _units_file(tmp_path)
+    return {
+        'argv': ['python3', '-u', '-m', 'prismaquant.tessera_campaign',
+                 '--model', '/source', '--units', str(units), '--streaming',
+                 *extra_argv],
+        'cwd': str(tmp_path),
+        'demand': {'gpu': 1, 'cpu': 4, 'mem_gb': int(mem_gb)},
+        'env': {},
+        'tags': ['gb10'],
+    }
+
+
+def _spec(tmp_path, **extra):
+    spec = dict(model='/source', campaign_argv=['--streaming'], cwd=str(tmp_path),
+                python='python3', env={}, cpus=1, **extra)
+    (tmp_path / 'spec.json').write_text(json.dumps(spec))
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# the derivation
+# ---------------------------------------------------------------------------
+
+def test_the_demand_is_the_plan_plus_the_measured_floor_plus_the_guard_margin(
+        monkeypatch, tmp_path):
+    """Three terms, and the demand is short without any one of them.
+
+    The plan is deltas; the floor is what the process already held before the
+    first delta; the margin is what the guard holds back from the cap on every
+    check. A demand covering only the first is admitted and then refused by the
+    row itself.
+    """
+    dispatch = _fixed_plan(monkeypatch)
+    spec = _spec(tmp_path)
+    demand = dispatch._row_memory_demand(spec, ['layers.0.proj'], _census(tmp_path),
+                                         selected_source=True)
+    expected_bytes = (PLAN_BYTES + dispatch.DEFAULT_PROCESS_BASELINE_BYTES
+                      + _margin_bytes())
+    assert demand['plan_bytes'] == PLAN_BYTES
+    assert demand['process_baseline_bytes'] == dispatch.DEFAULT_PROCESS_BASELINE_BYTES
+    assert demand['guard_margin_bytes'] == _margin_bytes()
+    assert demand['demand_bytes'] == expected_bytes
+    assert demand['mem_gb'] == math.ceil(expected_bytes / GIB)
+    assert dispatch._row_memory_gb(spec, ['layers.0.proj'], _census(tmp_path),
+                                   selected_source=True) == demand['mem_gb']
+
+
+def test_the_margin_is_read_from_the_guard_rather_than_restated(monkeypatch, tmp_path):
+    """Move the guard's margin and the demand moves with it.
+
+    A second copy of 2 GiB would pass every assertion above and still drift the
+    day the guard's margin changes, so what is tested is the coupling: the
+    constant is mutated on the guard, not in the fixture.
+    """
+    from prismaquant import memory_management
+    dispatch = _fixed_plan(monkeypatch)
+    spec = _spec(tmp_path)
+    census = _census(tmp_path)
+    before = dispatch._row_memory_demand(spec, ['layers.0.proj'], census,
+                                         selected_source=True)
+    monkeypatch.setattr(memory_management.CaptureMemoryGuard, 'MARGIN_BYTES',
+                        memory_management.CaptureMemoryGuard.MARGIN_BYTES + 4 * GIB)
+    after = dispatch._row_memory_demand(spec, ['layers.0.proj'], census,
+                                        selected_source=True)
+    assert after['guard_margin_bytes'] - before['guard_margin_bytes'] == 4 * GIB
+    assert after['demand_bytes'] - before['demand_bytes'] == 4 * GIB
+    assert after['mem_gb'] - before['mem_gb'] == 4
+
+
+def test_a_spec_reservation_overrides_the_fleet_default_and_the_plan_says_which(
+        monkeypatch, tmp_path):
+    """A reader of a plan can tell an operator's number from this tool's.
+
+    The default is a reading taken on other rows of another campaign. A spec
+    that knows its own box overrides it, including with zero, and the
+    ``baseline_policy`` names which of the two the plan carries.
+    """
+    from prismaquant import autoscale
+    dispatch = _fixed_plan(monkeypatch)
+    census = _census(tmp_path)
+
+    default_bytes, default_policy = dispatch._process_baseline(_spec(tmp_path))
+    assert default_bytes == dispatch.DEFAULT_PROCESS_BASELINE_BYTES
+    assert default_policy == autoscale.BASELINE_POLICY_MEASURED_DEFAULT_RESERVATION
+
+    declared_bytes, declared_policy = dispatch._process_baseline(
+        _spec(tmp_path, process_baseline_bytes=3 * GIB))
+    assert declared_bytes == 3 * GIB
+    assert declared_policy == autoscale.BASELINE_POLICY_EXPLICIT_RESERVATION
+
+    # A declared zero is a choice, not an absence: it reserves nothing and says
+    # the spec asked for nothing.
+    zero_bytes, zero_policy = dispatch._process_baseline(
+        _spec(tmp_path, process_baseline_bytes=0))
+    assert zero_bytes == 0
+    assert zero_policy == autoscale.BASELINE_POLICY_EXPLICIT_RESERVATION
+    assert dispatch._row_memory_demand(
+        _spec(tmp_path, process_baseline_bytes=0), ['layers.0.proj'], census,
+        selected_source=True)['demand_bytes'] == PLAN_BYTES + _margin_bytes()
+
+
+def test_the_resident_source_branch_charges_the_same_two_terms(monkeypatch, tmp_path):
+    """A floor and a margin exist whether or not the row streams."""
+    dispatch = _dispatch()
+    monkeypatch.setattr(dispatch, '_model_bytes', lambda model: 10 * GIB)
+    census = dict(unit_shapes={'layers.0.proj': [4, 8]})
+    spec = dict(model='/source', campaign_argv=[], headroom_gb=3, max_act_rows=2)
+    body = 10 * GIB + 8 ** 2 * 4 + 8 * 2 * 4
+    demand = dispatch._row_memory_demand(spec, ['layers.0.proj'], census)
+    assert demand['plan_bytes'] == body
+    assert demand['mem_gb'] == math.ceil(
+        (body + dispatch.DEFAULT_PROCESS_BASELINE_BYTES + _margin_bytes()) / GIB) + 3
+
+
+# ---------------------------------------------------------------------------
+# the check
+# ---------------------------------------------------------------------------
+
+def test_an_under_declared_row_is_refused_and_the_message_carries_the_numbers(
+        monkeypatch, tmp_path):
+    """The refusal names every term, because the operator has to fix one of them."""
+    dispatch = _fixed_plan(monkeypatch)
+    spec = _spec(tmp_path)
+    census = _census(tmp_path)
+    derived = dispatch._row_memory_demand(spec, ['layers.0.proj'], census,
+                                          selected_source=True)['mem_gb']
+    row = _manifest_row(tmp_path, mem_gb=derived - 1)
+    with pytest.raises(dispatch.DemandRefused) as refusal:
+        dispatch.verify_row_demand(spec, census, row, label='row-0000')
+    message = str(refusal.value)
+    for number in (PLAN_BYTES, dispatch.DEFAULT_PROCESS_BASELINE_BYTES,
+                   _margin_bytes(),
+                   PLAN_BYTES + dispatch.DEFAULT_PROCESS_BASELINE_BYTES + _margin_bytes(),
+                   (derived - 1) * GIB):
+        assert str(number) in message, f'{number} is missing from {message!r}'
+    assert 'row-0000' in message
+    assert str(derived) in message
+
+
+def test_a_row_declaring_what_it_derives_passes(monkeypatch, tmp_path):
+    dispatch = _fixed_plan(monkeypatch)
+    spec, census = _spec(tmp_path), _census(tmp_path)
+    derived = dispatch._row_memory_demand(spec, ['layers.0.proj'], census,
+                                          selected_source=True)['mem_gb']
+    record = dispatch.verify_row_demand(spec, census,
+                                        _manifest_row(tmp_path, mem_gb=derived),
+                                        label='row-0000')
+    assert record['mem_gb'] == derived == record['declared_mem_gb']
+    assert record['declared_bytes'] == derived * GIB
+
+
+def test_the_check_reads_the_rows_own_argv_not_the_specs(monkeypatch, tmp_path):
+    """The defect was a manifest argv the planning spec never had.
+
+    ``--publication-overlap-bytes`` reached the relaunch rows through the
+    manifest while the spec kept ``mem_gb: 102``. A check that re-derived from
+    the spec would have agreed with the manifest and refused nothing.
+    """
+    dispatch = _dispatch()
+    seen = {}
+
+    def plan(spec, census, members, *, selected_source):
+        seen['argv'] = list(spec['campaign_argv'])
+        overlap = ('--publication-overlap-bytes' in spec['campaign_argv'])
+        return dict(memory_bytes=PLAN_BYTES + (2 * GIB if overlap else 0),
+                    selected_layers=['0'])
+
+    monkeypatch.setattr(dispatch, '_streamed_resource_plan', plan)
+    spec, census = _spec(tmp_path), _census(tmp_path)
+    row = _manifest_row(tmp_path, mem_gb=999, extra_argv=(
+        '--publication-overlap-bytes', '2147483648'))
+    record = dispatch.verify_row_demand(spec, census, row, label='row-0000')
+    assert '--publication-overlap-bytes' in seen['argv']
+    assert record['plan_bytes'] == PLAN_BYTES + 2 * GIB
+
+
+def test_a_row_wider_than_the_declared_box_is_refused(monkeypatch, tmp_path):
+    """Capacity is a parameter, so the test never reads the fleet's files."""
+    dispatch = _fixed_plan(monkeypatch)
+    spec, census = _spec(tmp_path), _census(tmp_path)
+    derived = dispatch._row_memory_demand(spec, ['layers.0.proj'], census,
+                                          selected_source=True)['mem_gb']
+    row = _manifest_row(tmp_path, mem_gb=derived)
+    assert dispatch.verify_row_demand(spec, census, row, label='row-0000',
+                                      box_memory_gb=derived)['mem_gb'] == derived
+    with pytest.raises(dispatch.DemandRefused, match='no admission can come'):
+        dispatch.verify_row_demand(spec, census, row, label='row-0000',
+                                   box_memory_gb=derived - 1)
+
+
+def test_the_relaunch_row_is_now_refused_at_submit_rather_than_after_admission(
+        monkeypatch, tmp_path):
+    """The consequence, stated as a test rather than left to be discovered.
+
+    Row-0074's plan measured 108.63 GB. Charged the worst floor this fleet has
+    measured and the guard's own margin, it derives 105 GiB, which is above the
+    104 GiB a Spark declares. Under this rule the row is refused at submit
+    instead of dying twenty seconds after admission. That is the intended
+    outcome: the allowance is not shrunk to make the row fit.
+    """
+    dispatch = _fixed_plan(monkeypatch, plan_bytes=GLM_ROW_0074_PLAN_BYTES)
+    spec, census = _spec(tmp_path), _census(tmp_path)
+    demand = dispatch._row_memory_demand(spec, ['layers.0.proj'], census,
+                                         selected_source=True)
+    assert demand['mem_gb'] == 105
+    with pytest.raises(dispatch.DemandRefused, match='no admission can come'):
+        dispatch.verify_row_demand(spec, census,
+                                   _manifest_row(tmp_path, mem_gb=102),
+                                   label='row-0074', box_memory_gb=104)
+
+
+def test_every_under_declared_row_is_named_at_once(monkeypatch, tmp_path):
+    dispatch = _fixed_plan(monkeypatch)
+    spec, census = _spec(tmp_path), _census(tmp_path)
+    derived = dispatch._row_memory_demand(spec, ['layers.0.proj'], census,
+                                          selected_source=True)['mem_gb']
+    rows = [_manifest_row(tmp_path, mem_gb=derived),
+            _manifest_row(tmp_path, mem_gb=derived - 1),
+            _manifest_row(tmp_path, mem_gb=1)]
+    with pytest.raises(dispatch.DemandRefused) as refusal:
+        dispatch.verify_manifest_demands(spec, census, rows)
+    assert '2 of 3 rows' in str(refusal.value)
+    assert dispatch.verify_manifest_demands(
+        spec, census, rows[:1])[0]["mem_gb"] == derived
+
+
+# ---------------------------------------------------------------------------
+# the submit path
+# ---------------------------------------------------------------------------
+
+def test_submit_refuses_an_under_declared_manifest_before_submitting_it(
+        monkeypatch, tmp_path):
+    """Nothing reaches pbcampaign that the row's own guard would decline."""
+    dispatch = _fixed_plan(monkeypatch)
+    spec, census = _spec(tmp_path), _census(tmp_path)
+    submitted = []
+    monkeypatch.setattr(dispatch, '_pbcampaign',
+                        lambda *a, **k: submitted.append(a) or 0)
+    derived = dispatch._row_memory_demand(spec, ['layers.0.proj'], census,
+                                          selected_source=True)['mem_gb']
+    (tmp_path / 'manifest.json').write_text(json.dumps(
+        [_manifest_row(tmp_path, mem_gb=derived - 1)]))
+    (tmp_path / 'plan.json').write_text(json.dumps(
+        {'spec': str(tmp_path / 'spec.json'), 'census': str(tmp_path / 'census.json')}))
+    with pytest.raises(dispatch.DemandRefused):
+        dispatch.main(['submit', '--workspace', str(tmp_path)])
+    assert submitted == []
+
+    (tmp_path / 'manifest.json').write_text(json.dumps(
+        [_manifest_row(tmp_path, mem_gb=derived)]))
+    assert dispatch.main(['submit', '--workspace', str(tmp_path)]) == 0
+    assert len(submitted) == 1
+
+
+def test_submit_refuses_rather_than_skipping_the_check_it_cannot_run(tmp_path):
+    """An unverifiable manifest is refused, not submitted unchecked."""
+    dispatch = _dispatch()
+    (tmp_path / 'manifest.json').write_text('[]')
+    (tmp_path / 'plan.json').write_text(json.dumps({'model': '/source'}))
+    with pytest.raises(dispatch.DemandRefused, match='neither --spec'):
+        dispatch.main(['submit', '--workspace', str(tmp_path)])
+
+
+def test_check_reports_every_row_it_verified(monkeypatch, tmp_path, capsys):
+    dispatch = _fixed_plan(monkeypatch)
+    spec, census = _spec(tmp_path), _census(tmp_path)
+    derived = dispatch._row_memory_demand(spec, ['layers.0.proj'], census,
+                                          selected_source=True)['mem_gb']
+    (tmp_path / 'manifest.json').write_text(json.dumps(
+        [_manifest_row(tmp_path, mem_gb=derived)]))
+    assert dispatch.main(['check', '--workspace', str(tmp_path),
+                          '--spec', str(tmp_path / 'spec.json'),
+                          '--census', str(tmp_path / 'census.json')]) == 0
+    printed = capsys.readouterr().out
+    assert f'derives {derived} GiB' in printed
+    assert str(PLAN_BYTES) in printed
+
+
+# ---------------------------------------------------------------------------
+# the row's own refusal
+# ---------------------------------------------------------------------------
+
+def test_the_row_refusal_detail_carries_every_term_of_its_predicate():
+    """The message the three lost rows did not have.
+
+    The same plan and the same cap, twice, with only the floor moving inside
+    the range the fleet measured: at the bottom of that range the row is
+    admitted with about 11 MB to spare, and at the top it is refused. That is
+    the coin flip #522 was filed on, and neither outcome was visible in the
+    old message.
+    """
+    from prismaquant.tessera_campaign import memory_admission_detail
+    admitted = memory_admission_detail(plan_bytes=108_630_000_000,
+                                       cap_bytes=102 * GIB,
+                                       baseline_bytes=880_000_000)
+    assert admitted == dict(plan_bytes=108_630_000_000, cap_bytes=102 * GIB,
+                            baseline_bytes=880_000_000,
+                            slack_bytes=102 * GIB - 880_000_000 - 108_630_000_000)
+    assert 0 < admitted['slack_bytes'] < 16 * 1024 ** 2
+
+    refused = memory_admission_detail(plan_bytes=108_630_000_000,
+                                      cap_bytes=102 * GIB,
+                                      baseline_bytes=1_150_000_000)
+    assert refused['slack_bytes'] < 0, 'the worst measured floor refuses'
+
+    # The capture-path predicate has taken no reading yet, so it reports no
+    # baseline rather than a measured zero.
+    unmeasured = memory_admission_detail(plan_bytes=10, cap_bytes=4)
+    assert 'baseline_bytes' not in unmeasured
+    assert unmeasured['slack_bytes'] == -6

--- a/tests/test_tessera_campaign_fanout.py
+++ b/tests/test_tessera_campaign_fanout.py
@@ -650,7 +650,7 @@ def test_a_row_too_wide_for_the_box_is_declined_and_the_rest_are_planned(
     assert [row["argv"][row["argv"].index("--units") + 1].split("/")[-1]
             for row in manifest] == ["row-0000.json", "row-0001.json",
                                      "row-0002.json"]
-    assert {row["demand"]["mem_gb"] for row in manifest} == {2}
+    assert {row["demand"]["mem_gb"] for row in manifest} == {5}
 
     plan = json.loads((workspace / "plan.json").read_text())
     # The plan is what an auditor reads, so it keeps the whole layout: every
@@ -659,12 +659,12 @@ def test_a_row_too_wide_for_the_box_is_declined_and_the_rest_are_planned(
         "row-0000", "row-0001", "row-0002", "row-0003"]
     assert [entry["admissible"] for entry in plan["rows"]] == [
         True, True, True, False]
-    assert plan["row_memory_gb"] == {"row-0000": 2, "row-0001": 2,
-                                     "row-0002": 2, "row-0003": 65}
+    assert plan["row_memory_gb"] == {"row-0000": 5, "row-0001": 5,
+                                     "row-0002": 5, "row-0003": 68}
     declined = plan["inadmissible_rows"]
     assert [record["row_id"] for record in declined] == ["row-0003"]
     # The demand is recorded as derived, never rewritten to fit the box.
-    assert declined[0]["mem_gb"] == 65
+    assert declined[0]["mem_gb"] == 68
     assert declined[0]["rows_per_box"] == 2
     assert declined[0]["box_memory_gb"] == 104
     assert declined[0]["members"] == ["wide"]
@@ -673,14 +673,14 @@ def test_a_row_too_wide_for_the_box_is_declined_and_the_rest_are_planned(
     out = capsys.readouterr().out
     assert "3 of 4 rows are admissible" in out
     assert "1 declined" in out
-    assert "row-0003" in out and "65" in out and "104" in out
+    assert "row-0003" in out and "68" in out and "104" in out
 
 
 def test_a_plan_whose_every_row_is_too_wide_refuses(tmp_path):
     import dispatch_tessera_campaign as dispatch
 
     spec, workspace = _partition_workspace(tmp_path, wide=False)
-    with pytest.raises(RuntimeError, match="65 GB"):
+    with pytest.raises(RuntimeError, match="68 GB"):
         dispatch.cmd_plan(_plan_args(spec, workspace))
     # Nothing to submit means nothing was written to submit.
     assert not (workspace / "manifest.json").exists()

--- a/tests/test_tessera_selected_source.py
+++ b/tests/test_tessera_selected_source.py
@@ -213,7 +213,9 @@ def test_streaming_planner_requires_capture_and_stamps_selected_phase_plan(monke
     monkeypatch.setattr(dispatch, '_streamed_resource_plan', resources)
     assert dispatch.main([*common, '--calibration-cache', '/capture']) == 0
     rows = json.loads((tmp_path/'manifest.json').read_text())
-    assert rows[0]['demand']['mem_gb'] == 3
+    # 3 GiB of plan, plus the process floor this fleet measured and the margin
+    # the row's own guard holds back from its cap (RobTand/prismaquant#522).
+    assert rows[0]['demand']['mem_gb'] == 7
     assert rows[0]['env']['MIMALLOC_PURGE_DELAY'] == '0'
     assert rows[0]['env']['PRISMAQUANT_RELEASE_SOURCE_PAGES'] == '1'
     assert '--calibration-cache-sha256' in rows[0]['argv']
@@ -351,7 +353,7 @@ _ROUNDING_LOSER_PLAN_BYTES = 20 * 1024 ** 3 + 173_741_824
 
 
 def _row_is_admitted(tmp_path, mem_gb, memory_bytes, floor_bytes, monkeypatch):
-    """The two ends a row's demand actually has to meet, joined.
+    """The ends a row's demand actually has to meet, joined.
 
     The cap is built the way PrismaBuild builds it -- ``pool.py:2850``
     constructs the resource scope with ``memory * 1024 ** 3``, so ``mem_gb``
@@ -366,6 +368,13 @@ def _row_is_admitted(tmp_path, mem_gb, memory_bytes, floor_bytes, monkeypatch):
     what makes this a regression on the mechanism: a change to how the guard
     measures its baseline, or to which of the two readings it sums, moves this
     test.  A hardcoded number would not have noticed.
+
+    Two verdicts, because the row faces two refusals.  ``admitted`` is the
+    row's own admission predicate.  ``clears_margin`` is whether the plan also
+    fits under the cap less the floor **and** the guard's physical margin,
+    which is where ``check`` refuses.  A demand can pass the first and fail the
+    second, and a demand derived without the margin regularly does
+    (RobTand/prismaquant#522).
     """
     from prismaquant import memory_management as memory
     root = tmp_path/'cgroup'
@@ -387,16 +396,19 @@ def _row_is_admitted(tmp_path, mem_gb, memory_bytes, floor_bytes, monkeypatch):
     guard.check('before_selected_capture_identity')
     assert guard.baseline_bytes() == floor_bytes, 'the guard did not read the floor under test'
     assert guard.cap_bytes == mem_gb * 1024 ** 3, 'the cap is not the demand PrismaBuild would set'
-    return not (memory_bytes > guard.cap_bytes - guard.baseline_bytes())
+    return dict(
+        admitted=not (memory_bytes > guard.cap_bytes - guard.baseline_bytes()),
+        clears_margin=(memory_bytes <= guard.cap_bytes - guard.baseline_bytes()
+                       - guard.margin_bytes))
 
 
-@pytest.mark.parametrize('reservation,demand_gb,admitted', [
-    (None, 21, False),
-    (800_000_000, 21, False),
-    (2147483648, 23, True),
+@pytest.mark.parametrize('reservation,demand_gb,admitted,clears_margin', [
+    (None, 24, True, True),
+    (0, 23, True, False),
+    (2147483648, 25, True, True),
 ])
 def test_row_demand_reserves_the_process_floor_it_will_be_admitted_against(
-        monkeypatch, tmp_path, reservation, demand_gb, admitted):
+        monkeypatch, tmp_path, reservation, demand_gb, admitted, clears_margin):
     """A row's demand has to cover the floor the row is judged against.
 
     The plan states **deltas** over whatever the process already holds; the cap
@@ -412,11 +424,15 @@ def test_row_demand_reserves_the_process_floor_it_will_be_admitted_against(
     accident no one owns and no receipt records.  Both inspected example rows
     lose it.
 
-    The middle arm is the one worth reading twice.  A declared 800,000,000
-    bytes is *smaller than the slack it replaces*, so it does not even move the
-    demand: the row still asks for 3 GiB and still refuses.  A reservation that
-    fits inside the rounding it was supposed to make unnecessary buys nothing,
-    and must not be able to report that it did.
+    The default reservation closed that (RobTand/prismaquant#522): a spec that
+    declares nothing now gets the worst floor this fleet has measured, plus the
+    margin the guard holds back from the cap, so the first arm admits.
+
+    The middle arm is the one worth reading twice.  A spec may still declare
+    zero, and then it has opted out: the demand covers the plan and the margin
+    but not the floor, the row's own admission predicate passes, and the
+    guard's margin check is what refuses.  That is what a demand short of one
+    term buys -- an admission followed by a refusal twenty seconds later.
     """
     import json
     from tools import dispatch_tessera_campaign as dispatch
@@ -451,9 +467,11 @@ def test_row_demand_reserves_the_process_floor_it_will_be_admitted_against(
                           '--calibration-cache', '/capture']) == 0
     row = json.loads((tmp_path/'manifest.json').read_text())[0]
     assert row['demand']['mem_gb'] == demand_gb
-    assert _row_is_admitted(tmp_path, row['demand']['mem_gb'],
-                            _ROUNDING_LOSER_PLAN_BYTES,
-                            GLM_MEASURED_PROCESS_FLOOR_BYTES, monkeypatch) is admitted
+    verdict = _row_is_admitted(tmp_path, row['demand']['mem_gb'],
+                               _ROUNDING_LOSER_PLAN_BYTES,
+                               GLM_MEASURED_PROCESS_FLOOR_BYTES, monkeypatch)
+    assert verdict['admitted'] is admitted
+    assert verdict['clears_margin'] is clears_margin
 
 
 @pytest.mark.parametrize('value', [-1, 1.5, '2147483648', True, None])
@@ -507,28 +525,38 @@ def test_the_resident_source_branch_charges_the_same_reservation(monkeypatch, tm
     """A process floor exists whether or not the row streams.
 
     The resident-source branch of ``_row_memory_gb`` is a different expression
-    with its own ``ceil`` and its own ``headroom_gb`` addend, so a key wired
+    with its own ``ceil`` and its own ``headroom_gb`` addend, so a term wired
     into the streaming branch alone would mean one thing on one path and
-    nothing on the other, under one name.
+    nothing on the other, under one name.  Both terms outside the plan -- the
+    process floor and the guard's margin -- are charged on both branches.
     """
     import math
     from tools import dispatch_tessera_campaign as dispatch
+    from prismaquant.memory_management import CaptureMemoryGuard
     gib = 1024 ** 3
+    margin = CaptureMemoryGuard.MARGIN_BYTES
     monkeypatch.setattr(dispatch, '_model_bytes', lambda model: 10 * gib)
     census = dict(unit_shapes={'layers.0.proj': [4, 8]})
     spec = dict(model='/source', campaign_argv=[], headroom_gb=3, max_act_rows=2)
     hessian, rows = 8 ** 2 * 4, 8 * 2 * 4
     body = 10 * gib + hessian + rows
 
-    plain = dispatch._row_memory_gb(spec, ['layers.0.proj'], census)
-    assert plain == math.ceil(body / gib) + 3
+    default = dispatch._row_memory_gb(spec, ['layers.0.proj'], census)
+    assert default == math.ceil(
+        (body + dispatch.DEFAULT_PROCESS_BASELINE_BYTES + margin) / gib) + 3
 
     reserved = dispatch._row_memory_gb(
         {**spec, 'process_baseline_bytes': 2147483648}, ['layers.0.proj'], census)
     # Charged inside the same ceil as the body, so the demand covers
-    # body + reservation rather than rounding each of them up separately.
-    assert reserved == math.ceil((body + 2147483648) / gib) + 3
-    assert reserved - plain == 2
+    # body + reservation + margin rather than rounding each of them up
+    # separately.
+    assert reserved == math.ceil((body + 2147483648 + margin) / gib) + 3
+
+    # A declared zero opts out of the floor and of nothing else: the margin is
+    # the guard's, not the spec's.
+    assert dispatch._row_memory_gb(
+        {**spec, 'process_baseline_bytes': 0}, ['layers.0.proj'],
+        census) == math.ceil((body + margin) / gib) + 3
 
     # Headroom is untouched by the reservation: they are separate terms and
     # only one of them is inside ``memory_bytes``.

--- a/tools/dispatch_tessera_campaign.py
+++ b/tools/dispatch_tessera_campaign.py
@@ -28,8 +28,16 @@ Four steps, and each one is separately re-runnable:
 ``plan``
     One ``--units`` selection file per row and one pbcampaign manifest.  Rows
     are portable (no host pin), not exclusive, GPU-demanding, and carry a
-    memory demand derived from the checkpoint's size and the selection's
-    shapes.
+    memory demand derived from the phase plan the row will check itself
+    against -- the plan's bytes, the process floor measured on this fleet, and
+    the margin the row's own guard holds back from its cap.
+
+``check``
+    The same derivation, run against a manifest that already exists, refusing
+    any row whose declared ``demand.mem_gb`` is below it or whose derived
+    demand is wider than a GPU box.  ``submit`` runs it first, so a row is
+    never queued for an admission that its own guard will decline
+    (RobTand/prismaquant#522).
 
 ``submit``
     ``pbcampaign`` over that manifest.  Re-running it **is** the resume: a
@@ -164,19 +172,68 @@ def load_spec(path: Path) -> dict:
     return spec
 
 
-def _process_baseline_bytes(spec: dict, *, where="spec") -> int:
-    """The per-row process floor this recipe reserves, in bytes.
+#: The process floor a row reserves when its spec declares none, in bytes.
+#:
+#: Measured, not invented.  Every completed row of the GLM-5.3
+#: ``extension-r1024-02`` campaign stamps the floor its own
+#: ``CaptureMemoryGuard`` read at its first check onto its ``cost.pkl``
+#: (``selected_source_preparation.memory_guard.baseline.bytes``).  Read on
+#: 2026-09-12 across rows 0058, 0061, 0062, 0063, 0066, 0074 and 0079, those
+#: readings span 0.88-1.15 GB, and this is the top of that range: a
+#: reservation is only worth the demand it moves if it covers the worst floor
+#: observed, not the average one.  The 1,062,359,040 bytes the
+#: ``_row_memory_gb`` docstring cites is an earlier reading, recorded on the
+#: RobTand/prismaquant#390 receipt rather than traced to one of these rows; it
+#: sits inside this range.
+#:
+#: Session note: ``pb_mem_gb_must_track_the_checked_phase_plan``, and
+#: RobTand/prismaquant#522, which records the three rows this default exists
+#: to stop losing.  It is a fleet number with a date on it, so a spec that
+#: knows its own box overrides it and says so in ``baseline_policy``.
+DEFAULT_PROCESS_BASELINE_BYTES = 1_150_000_000
 
-    Zero, the legacy default, reserves nothing and is what every spec written
-    before this key meant.  The value is the recipe's, not this tool's: no
-    universal torch-plus-CUDA constant is invented here, because a floor is a
-    property of the box and the runtime a row lands on and this planner never
-    enters either.
+
+def _process_baseline(spec: dict, *, where="spec") -> "tuple[int, str]":
+    """The per-row process floor this recipe reserves, and where it came from.
+
+    A spec that declares ``process_baseline_bytes`` owns the number, including
+    a declared zero, which reserves nothing.  A spec that declares nothing gets
+    ``DEFAULT_PROCESS_BASELINE_BYTES``, the worst floor measured on this fleet.
+    The two are reported under different ``baseline_policy`` values, so a
+    reader of a plan can tell a number an operator chose from a number this
+    tool supplied.
+
+    No universal torch-plus-CUDA constant is invented here: the default is a
+    reading taken on the boxes these rows run on, and it stays a reservation
+    rather than a measurement.  The row still measures its own floor at its
+    first ``CaptureMemoryGuard.check`` and stamps it on its receipt.
     """
-    from prismaquant.autoscale import validate_process_baseline_bytes
-    return validate_process_baseline_bytes(
-        spec.get("process_baseline_bytes", 0),
+    from prismaquant.autoscale import (BASELINE_POLICY_EXPLICIT_RESERVATION,
+                                       BASELINE_POLICY_MEASURED_DEFAULT_RESERVATION,
+                                       validate_process_baseline_bytes)
+    declared = "process_baseline_bytes" in spec
+    value = validate_process_baseline_bytes(
+        spec.get("process_baseline_bytes", DEFAULT_PROCESS_BASELINE_BYTES),
         where=f"{where}: process_baseline_bytes")
+    return value, (BASELINE_POLICY_EXPLICIT_RESERVATION if declared
+                   else BASELINE_POLICY_MEASURED_DEFAULT_RESERVATION)
+
+
+def _process_baseline_bytes(spec: dict, *, where="spec") -> int:
+    """The reservation alone, for callers that do not record its origin."""
+    return _process_baseline(spec, where=where)[0]
+
+
+def _guard_margin_bytes() -> int:
+    """The physical safety margin the row's own guard holds back from the cap.
+
+    Read from ``CaptureMemoryGuard`` rather than restated.  The guard refuses
+    at ``cap - margin``, so a demand that does not carry the margin buys an
+    admission the guard then declines, which is the failure this derivation
+    exists to stop.
+    """
+    from prismaquant.memory_management import CaptureMemoryGuard
+    return int(CaptureMemoryGuard.MARGIN_BYTES)
 
 
 def _model_bytes(model: str) -> int:
@@ -203,9 +260,13 @@ def _row_memory_gb(spec: dict, members: list[str], census: dict, *, selected_sou
     A phase plan states deltas, and the floor those deltas sit on --
     interpreter, torch, the CUDA runtime, the pages the row's process has
     touched -- is a property of the box the row lands on, which this planner
-    never enters. So it is still never derived here; it is *declared*, as the
-    spec's ``process_baseline_bytes``, defaulting to zero. Its own scope
-    travels with it: it is the recipe's number, not a universal maximum.
+    never enters. So it is still never derived here; it is *reserved*. A spec
+    that declares ``process_baseline_bytes`` owns the number, including a
+    declared zero; a spec that declares nothing gets
+    ``DEFAULT_PROCESS_BASELINE_BYTES``, the worst floor measured on this fleet.
+    ``baseline_policy`` records which of the two a plan used. Either way the
+    scope travels with the number: it is this fleet's or this recipe's
+    reservation, not a universal maximum.
 
     It is added to the demand and never to ``memory_bytes``, because the
     demand becomes a cgroup cap of exactly that many GiB
@@ -221,31 +282,67 @@ def _row_memory_gb(spec: dict, members: list[str], census: dict, *, selected_sou
     one thing on one path and nothing on the other.
 
     Rounding is not a reservation. ``ceil`` leaves at most one GiB of slack,
-    and the floor measured on this fleet is 1,062,359,040 bytes -- 0.9894 GiB,
+    and the floor on the #390 receipt is 1,062,359,040 bytes -- 0.9894 GiB,
     less than the most ``ceil`` can leave -- so before this key a row admitted
     according to where its ``memory_bytes`` landed modulo one GiB, which both
     inspected example rows lost. The row
     still measures its own floor at its first ``CaptureMemoryGuard.check`` and
     stamps it on its receipt (RobTand/prismaquant#390); that reading, not this
     declaration, remains the measured number.
+
+    **The guard's own margin is charged here too.** The row is refused not at
+    its cap but at ``cap - margin``: ``CaptureMemoryGuard.check`` compares its
+    absolute reading against ``cap_bytes - margin_bytes``
+    (``prismaquant/memory_management.py``). A demand that covers the plan and
+    the floor but not the margin therefore buys an admission the row's own
+    first check declines. The number is read from the guard, never restated,
+    so the two cannot drift apart.
+    """
+    return _row_memory_demand(spec, members, census,
+                              selected_source=selected_source)["mem_gb"]
+
+
+def _row_memory_demand(spec: dict, members: list[str], census: dict, *,
+                       selected_source=False) -> dict:
+    """The row's demand and every term it is made of.
+
+    ``_row_memory_gb`` is this, reduced to its GiB. The terms are kept because
+    a refusal has to name them: a row that dies on the admission predicate is
+    diagnosable from the plan, the floor and the margin, and before this they
+    were reachable only by unpickling a completed row's ``cost.pkl``
+    (RobTand/prismaquant#522).
     """
     gib = 1024 ** 3
-    baseline = _process_baseline_bytes(spec)
+    baseline, policy = _process_baseline(spec)
+    margin = _guard_margin_bytes()
     if "--streaming" in spec['campaign_argv']:
-        resource = _streamed_resource_plan(spec, census, members, selected_source=selected_source)
-        return int(math.ceil((resource['memory_bytes'] + baseline)/gib))
-    shapes = census.get("unit_shapes") or {}
-    hessian = sum(int(shapes.get(name, [0, 0])[1]) ** 2 * 4 for name in members)
-    rows = sum(int(shapes.get(name, [0, 0])[1]) * int(spec.get("max_act_rows", 512)) * 4
-               for name in members)
-    total = _model_bytes(spec["model"]) + hessian + rows
-    return (int(math.ceil((total + baseline) / gib))
-            + int(spec.get("headroom_gb", 24)))
+        resource = _streamed_resource_plan(spec, census, members,
+                                           selected_source=selected_source)
+        plan_bytes = int(resource['memory_bytes'])
+        headroom_gb = 0
+    else:
+        shapes = census.get("unit_shapes") or {}
+        hessian = sum(int(shapes.get(name, [0, 0])[1]) ** 2 * 4 for name in members)
+        rows = sum(int(shapes.get(name, [0, 0])[1]) * int(spec.get("max_act_rows", 512)) * 4
+                   for name in members)
+        plan_bytes = _model_bytes(spec["model"]) + hessian + rows
+        headroom_gb = int(spec.get("headroom_gb", 24))
+    demand_bytes = plan_bytes + baseline + margin
+    return {
+        "plan_bytes": int(plan_bytes),
+        "process_baseline_bytes": int(baseline),
+        "process_baseline_policy": policy,
+        "guard_margin_bytes": int(margin),
+        "demand_bytes": int(demand_bytes),
+        "headroom_gb": headroom_gb,
+        "mem_gb": int(math.ceil(demand_bytes / gib)) + headroom_gb,
+    }
 
 
 def _streamed_resource_plan(spec, census, members, *, selected_source=False):
     from prismaquant.autoscale import streamed_calibration_resources, selected_anchor_resources
     argv = spec['campaign_argv']
+    baseline_bytes, baseline_policy = _process_baseline(spec)
     def argument(name, default, convert=int):
         return convert(argv[argv.index(name)+1]) if name in argv else default
     shapes = census.get('unit_shapes') or {}
@@ -259,8 +356,9 @@ def _streamed_resource_plan(spec, census, members, *, selected_source=False):
                         argument('--streaming-cache-headroom-gb', 24., float)),
         # Recorded beside ``memory_bytes``, never summed into it: the plan
         # stays pure phase deltas and the reservation is charged once, in
-        # ``_row_memory_gb``, on the demand.
-        process_baseline_bytes=_process_baseline_bytes(spec))
+        # ``_row_memory_demand``, on the demand.
+        process_baseline_bytes=baseline_bytes,
+        process_baseline_policy=baseline_policy)
     if selected_source:
         return selected_anchor_resources(spec['model'], **options,
             anchor_batch_size=argument('--anchor-batch-size', 1),
@@ -277,6 +375,120 @@ def _streamed_resource_plan(spec, census, members, *, selected_source=False):
     return streamed_calibration_resources(spec['model'], **options,
         nsamples=argument('--nsamples', 8), seqlen=argument('--seqlen', 512),
         capture_policy=argument('--streaming-capture-policy', 'legacy', str))
+
+
+class DemandRefused(RuntimeError):
+    """A manifest row asks for less memory than the row it will run needs."""
+
+
+def _inner_campaign_argv(row: dict) -> list:
+    """The campaign argv a manifest row will actually run.
+
+    A row's command is ``python -u -m prismaquant.tessera_campaign <argv>``,
+    wrapped by the container launcher when the spec declares one, so the
+    campaign argv is whatever follows the LAST ``-m``. Reading it back from
+    the row, rather than rebuilding it from the spec, is the point: the
+    relaunch that lost three rows carried ``--publication-overlap-bytes`` in
+    the manifest while the spec that planned it did not
+    (RobTand/prismaquant#522).
+    """
+    argv = list(row.get("argv") or [])
+    if "-m" not in argv:
+        raise DemandRefused("row argv runs no python module, so its demand "
+                            "cannot be derived")
+    index = len(argv) - 1 - argv[::-1].index("-m")
+    return argv[index + 2:]
+
+
+def _row_label(inner_argv: list, index: int) -> str:
+    """The row id, taken from the selection file it names."""
+    if "--units" in inner_argv:
+        return Path(inner_argv[inner_argv.index("--units") + 1]).stem
+    return f"row-{index:04d}"
+
+
+def _units_members(inner_argv: list) -> list:
+    selection = json.loads(Path(inner_argv[inner_argv.index("--units") + 1]).read_text())
+    return [name for entry in selection["groups"]
+            for name in (entry.get("sampled") or entry["members"])]
+
+
+def verify_row_demand(spec: dict, census: dict, row: dict, *,
+                      box_memory_gb=None, label=None) -> dict:
+    """Recompute one row's demand from its own argv and refuse an under-declared one.
+
+    Two refusals, and neither is a warning:
+
+    * a declared ``demand.mem_gb`` below the derived one buys an admission the
+      row's own guard declines about twenty seconds later, which PrismaBuild
+      records as a failed row with no retry;
+    * a derived demand above the capacity the fleet's GPU boxes declare can
+      never be admitted at all, so it is refused here rather than queued.
+
+    ``box_memory_gb`` is a parameter and not a lookup: this function states
+    what the capacity has to be compared against, and the caller states what
+    the fleet declares.
+    """
+    inner = _inner_campaign_argv(row)
+    label = label or "row"
+    model = (inner[inner.index("--model") + 1] if "--model" in inner
+             else spec["model"])
+    row_spec = {**spec, "model": model, "campaign_argv": inner}
+    members = (_units_members(inner) if "--units" in inner
+               else sorted(census.get("counts") or {}))
+    demand = _row_memory_demand(row_spec, members, census,
+                                selected_source="--streaming" in inner)
+    gib = 1024 ** 3
+    declared_gb = int(row["demand"]["mem_gb"])
+    record = {"row": label, "declared_mem_gb": declared_gb,
+              "declared_bytes": declared_gb * gib, **demand}
+    terms = (f"plan {demand['plan_bytes']} B + process baseline "
+             f"{demand['process_baseline_bytes']} B "
+             f"({demand['process_baseline_policy']}) + guard margin "
+             f"{demand['guard_margin_bytes']} B = {demand['demand_bytes']} B")
+    if box_memory_gb is not None and demand["mem_gb"] > int(box_memory_gb):
+        raise DemandRefused(
+            f"{label}: derived demand {demand['mem_gb']} GiB is above the "
+            f"{int(box_memory_gb)} GiB a GPU box declares, so no admission "
+            f"can come: {terms}"
+            + (f" + {demand['headroom_gb']} GiB declared headroom"
+               if demand["headroom_gb"] else "")
+            + f"; declared demand.mem_gb {declared_gb} "
+            f"({declared_gb * gib} B). Reduce a plan term or run it on a "
+            "wider box; do not shrink the demand to fit.")
+    if declared_gb < demand["mem_gb"]:
+        raise DemandRefused(
+            f"{label}: declared demand.mem_gb {declared_gb} "
+            f"({declared_gb * gib} B) is below the {demand['mem_gb']} GiB its "
+            f"own argv derives: {terms}"
+            + (f" + {demand['headroom_gb']} GiB declared headroom"
+               if demand["headroom_gb"] else "")
+            + ". PrismaBuild would admit the row and its CaptureMemoryGuard "
+            "would then refuse it.")
+    return record
+
+
+def verify_manifest_demands(spec: dict, census: dict, rows: list, *,
+                            box_memory_gb=None) -> list:
+    """Every row in a manifest, refusing on the whole set rather than the first.
+
+    A campaign is re-queued as a set, so an operator needs every
+    under-declared row named at once, not one per run.
+    """
+    records, refusals = [], []
+    for index, row in enumerate(rows):
+        label = _row_label(_inner_campaign_argv(row), index)
+        try:
+            records.append(verify_row_demand(spec, census, row,
+                                             box_memory_gb=box_memory_gb,
+                                             label=label))
+        except DemandRefused as error:
+            refusals.append(str(error))
+    if refusals:
+        raise DemandRefused(
+            f"{len(refusals)} of {len(rows)} rows declare a memory demand "
+            "their own argv does not support:\n" + "\n".join(refusals))
+    return records
 
 
 def partition_rows_by_fit(row_memory_gb: "dict[str, int]", per_box: int,
@@ -858,6 +1070,11 @@ def cmd_plan(args) -> int:
     plan = {
         "schema": PLAN_SCHEMA,
         "model": spec["model"],
+        # The spec this plan was derived from, so ``check`` and ``submit`` can
+        # re-derive every row's demand without being told again. A plan
+        # written before this field exists is checked with an explicit
+        # ``--spec``.
+        "spec": str(args.spec),
         "census": str(workspace / "census.json"),
         "calibration_cache": calibration_cache,
         "manifest": str(manifest),
@@ -865,11 +1082,16 @@ def cmd_plan(args) -> int:
         "rows_per_box": per_box,
         "row_memory_gb": row_memory_gb,
         # The reservation those demands carry, stated once for the whole plan
-        # because it is a per-row constant. Zero means none was declared, and
-        # every row's phase plan records the same thing in its own
-        # ``baseline_policy``, so a reader cannot mistake an absent
-        # reservation for a covered one.
-        "process_baseline_bytes": _process_baseline_bytes(spec),
+        # because it is a per-row constant, with where it came from. Zero
+        # means the spec declared none, and every row's phase plan records the
+        # same thing in its own ``baseline_policy``, so a reader cannot
+        # mistake an absent reservation for a covered one.
+        "process_baseline_bytes": _process_baseline(spec)[0],
+        "process_baseline_policy": _process_baseline(spec)[1],
+        # The other term outside the phase deltas: the margin the row's own
+        # guard holds back from the cap. Recorded because a demand that does
+        # not carry it is admitted and then refused.
+        "guard_margin_bytes": _guard_margin_bytes(),
         # The rows the manifest does not hold, at the demand they were derived
         # at. A reader of the plan sees the whole layout; a reader of the
         # manifest sees only what was submitted.
@@ -904,11 +1126,63 @@ def cmd_plan(args) -> int:
     return 0
 
 
+def _checked_manifest(args, *, manifest: Path) -> list:
+    """Re-derive every row's demand from its own argv, or refuse to go on.
+
+    A manifest is an editable file and the plan that wrote it is not
+    authoritative over what it now says. So the check reads the rows as they
+    stand: a hand-edited argv, a hand-edited ``mem_gb``, or a plan term that
+    moved since are all the same question, asked of the bytes about to be
+    submitted.
+    """
+    workspace = Path(args.workspace)
+    plan_path = workspace / "plan.json"
+    plan = json.loads(plan_path.read_text()) if plan_path.is_file() else {}
+    spec_path = getattr(args, "spec", None) or plan.get("spec")
+    if not spec_path:
+        raise DemandRefused(
+            f"{manifest} cannot be checked: neither --spec nor a 'spec' field "
+            f"in {plan_path}. Pass the spec these rows were planned from.")
+    spec = load_spec(Path(spec_path))
+    census_path = getattr(args, "census", None) or plan.get("census") or (
+        workspace / "census.json")
+    census = json.loads(Path(census_path).read_text())
+    box_memory_gb = getattr(args, "box_memory_gb", None)
+    if box_memory_gb is None:
+        box_memory_gb = spec.get("box_memory_gb")
+    rows = json.loads(Path(manifest).read_text())
+    records = verify_manifest_demands(spec, census, rows,
+                                      box_memory_gb=box_memory_gb)
+    for record in records:
+        print(f"[dispatch] {record['row']} demands {record['declared_mem_gb']} "
+              f"GiB, derives {record['mem_gb']} GiB "
+              f"(plan {record['plan_bytes']} B, baseline "
+              f"{record['process_baseline_bytes']} B, margin "
+              f"{record['guard_margin_bytes']} B)")
+    return records
+
+
+def cmd_check(args) -> int:
+    """Recompute every manifest row's demand and refuse an under-declared one."""
+    manifest = Path(args.manifest) if getattr(args, "manifest", None) else (
+        Path(args.workspace) / "manifest.json")
+    records = _checked_manifest(args, manifest=manifest)
+    print(f"[dispatch] {len(records)} rows in {manifest} declare a demand "
+          "their own argv supports")
+    return 0
+
+
 def cmd_submit(args) -> int:
     workspace = Path(args.workspace)
+    manifest = workspace / "manifest.json"
+    # An under-declared row is admitted and then refused by its own guard
+    # about twenty seconds in, which PrismaBuild records as failed with no
+    # retry (RobTand/prismaquant#522). Nothing about that is cheaper to find
+    # out later, so the demands are re-derived before any row is submitted.
+    _checked_manifest(args, manifest=manifest)
     # Re-running the manifest IS the resume: a finished row is a cache hit and
     # a running row is re-attached, both by pbcampaign itself.
-    return _pbcampaign(workspace / "manifest.json", wait_s=args.wait_s,
+    return _pbcampaign(manifest, wait_s=args.wait_s,
                        receipts=workspace / "receipts.json")
 
 
@@ -1716,10 +1990,38 @@ def main(argv=None) -> int:
     plan.add_argument("--seed-wire-dir", default=None)
     plan.set_defaults(func=cmd_plan)
 
+    check = sub.add_parser(
+        "check", help="re-derive every manifest row's memory demand")
+    check.add_argument("--workspace", required=True)
+    check.add_argument("--manifest", default=None,
+                       help="the manifest to check; the workspace's "
+                            "manifest.json by default")
+    check.add_argument("--spec", default=None,
+                       help="the spec the rows were planned from; taken from "
+                            "the workspace's plan.json when it records one")
+    check.add_argument("--census", default=None,
+                       help="the census the rows were planned against; taken "
+                            "from plan.json or the workspace by default")
+    check.add_argument("--box-memory-gb", type=int, default=None,
+                       help="what a GPU box in the fleet declares, in GiB. A "
+                            "row deriving more than this can never be "
+                            "admitted and is refused. Defaults to the spec's "
+                            "'box_memory_gb'; unset on both, capacity is not "
+                            "checked.")
+    check.set_defaults(func=cmd_check)
+
     submit = sub.add_parser(
         "submit", help="submit the manifest; re-running it is the resume")
     submit.add_argument("--workspace", required=True)
     submit.add_argument("--wait-s", type=int, default=86400)
+    submit.add_argument("--spec", default=None,
+                       help="the spec the rows were planned from. Every row's "
+                            "demand is re-derived before submission, so a "
+                            "plan.json without a 'spec' field needs this.")
+    submit.add_argument("--census", default=None)
+    submit.add_argument("--box-memory-gb", type=int, default=None,
+                       help="what a GPU box in the fleet declares, in GiB; "
+                            "defaults to the spec's 'box_memory_gb'.")
     submit.set_defaults(func=cmd_submit)
 
     merge = sub.add_parser("merge", help="one cost.pkl and journal from the rows")


### PR DESCRIPTION
## What changed

A campaign row's PrismaBuild `demand.mem_gb` now carries every term of the
predicate the row checks against itself, and the dispatcher refuses a row whose
declared demand does not support its own argv.

Three rows of the GLM `extension-r1024-02` relaunch (0067, 0064, 0071) died
about twenty seconds after admission on 2026-09-12. The relaunch argv added
`--publication-overlap-bytes 2147483648`, the phase plan grew by 2 GiB to
108.6 GB, the manifest kept `demand.mem_gb: 102`, and each row's own predicate
(`selected_resources['memory_bytes'] > cap_bytes - baseline_bytes()`) refused
with 8-13 MB of slack. PrismaBuild records such a row as `failed` with
`max_attempts 1`; nothing re-queues it. The refusal printed no numbers, so the
cause was recovered by unpickling completed rows' `cost.pkl`.

### The three terms

`_row_memory_demand` returns `ceil((plan + baseline + margin) / GiB)` plus the
spec's declared headroom:

* **plan** — the phase plan's `memory_bytes`, as before.
* **process baseline** — `DEFAULT_PROCESS_BASELINE_BYTES = 1_150_000_000`
  replaces the previous default of zero. Seven completed rows (0058, 0061,
  0062, 0063, 0066, 0074, 0079) stamp the floor their own `CaptureMemoryGuard`
  measured at the first check; read on 2026-09-12 those readings span
  0.88-1.15 GB, and the constant is the top of that range. The origin is
  recorded in code beside the constant, with the rows, the date and the session
  note name. A spec still overrides it, including with a declared zero, and it
  is charged outside `memory_bytes` so the cap-versus-delta predicate does not
  net it to zero.
* **guard margin** — read from `CaptureMemoryGuard.MARGIN_BYTES`, not restated.
  The guard refuses at `cap - margin`, so a demand covering plan and floor but
  not the margin buys an admission the row's first check declines. Making the
  margin a class attribute is the whole of the change to
  `prismaquant/memory_management.py`.

`autoscale` gains a third `baseline_policy` value,
`measured-fleet-default-reservation-measured-in-row`, so a plan's reader can
tell a number an operator declared from a number this tool supplied. The
declared-versus-measured distinction stays honest rather than letting a fleet
default masquerade as a spec reservation.

### check and submit

`dispatch_tessera_campaign.py check` recomputes each manifest row's demand
**from the row's own argv** — the defect was an argv the planning spec never
had — and refuses a row whose explicit `demand.mem_gb` is below the derived
value, or whose derived value exceeds a GPU-box capacity. The capacity is a
parameter (`--box-memory-gb`, else `spec['box_memory_gb']`), so unit tests
never read `/mnt/shared`. Each refusal names plan, baseline, baseline policy,
margin, derived and declared bytes. `submit` runs the same check before
submitting anything.

Both cgroup-admission refusals in `tessera_campaign.py` now embed
`memory_admission_detail` (plan, cap, baseline, slack). The selected-anchor one
(`:5417`) also writes `selected-anchor-memory-refusal.json` beside the row's
cache, mirroring the existing `capture-memory-refusal.json`; there was no row
failure record at that site before. The capture-path sibling (`:4788`) was
trivially the same shape and got the same detail, minus the baseline term —
the guard has taken no reading at that point, so there is no baseline to state.

## The consequence, stated plainly

The relaunch rows derive 108.63 GB (plan) + 1.15 GB (floor) + 2 GiB (margin)
≈ 111.9 GB → **105 GiB**, above the **104 GiB** a Spark declares in
`pb-queue/workers/sparky.json`. Under the new rule those rows are **refused at
submit** instead of dying twenty seconds after admission. That is the intended
behaviour. The allowance is not shrunk to make them fit: a row that does not
fit the box is a row the fleet cannot run, and saying so before submission is
the point of this change.

## Operator notes

* `submit` refuses a workspace whose `plan.json` predates this change unless
  `--spec` is passed, because the check needs the spec to recompute demands.
  That includes the live GLM workspace. With `--spec`, that workspace's
  104-GiB manifest is itself refused, for the reason above. An operator
  resuming the campaign needs to know both halves.
* Over-capacity has two paths, deliberately left different: `plan` still
  *declines* a too-wide row into `inadmissible_rows` via
  `partition_rows_by_fit`, which is unchanged; `check` and `submit` *refuse*.
  Planning triages, submission gates.
* `census --submit` and `capture --submit` do not run the manifest check, but
  their demands come from the same `_row_memory_demand`, so they are consistent
  by construction. `prismaquant/tessera_materialization.py:137` calls
  `_row_memory_gb` and picks the new terms up the same way.
* `docs/ARCHITECTURE.md` is updated in this commit and its provenance block
  re-stamped, per principle 13: the default demand is a contract change. The
  two older paragraphs that stated the default is zero are marked superseded
  rather than left wrong.

## Tests

New `tests/test_campaign_demand_derivation.py` (14 tests) injects a fixed
resource plan — no model files, no NFS, no GPU. It covers the three-term
derivation; coupling to `CaptureMemoryGuard.MARGIN_BYTES` (mutating the class
attribute moves the demand); the spec override and each policy name including a
declared zero; the resident-source branch; an under-declared explicit `mem_gb`
refused with every number in the message; a passing row; the check reading the
row's own argv; an over-capacity refusal against a parameter capacity; the
relaunch row deriving 105 and being refused against 104; all offending rows
named at once; `submit` refusing before `_pbcampaign` and then succeeding;
`submit` refusing an unverifiable manifest; and the `memory_admission_detail`
shape.

Existing tests changed, each because the derivation they assert against now has
two more terms:

* `tests/test_tessera_campaign_fanout.py` — derived `mem_gb` 2 → 5 for the
  streaming rows and 65 → 68 for the resident one; the declined-row assertions
  and the `match="65 GB"` regex follow the same arithmetic. The fixture is
  unchanged; only the expected numbers moved.
* `tests/test_tessera_selected_source.py` — planner demand 3 → 7;
  `_row_is_admitted` now returns both verdicts (`admitted`, `clears_margin`)
  because admission and the margin are now separate questions. The parametrize
  arms become `(None, 24, True, True)`, `(0, 23, True, False)` and
  `(2147483648, 25, True, True)`: the declared-zero arm replaces the old
  800 MB arm, which no longer discriminates now that the 2 GiB margin dominates
  that fixture, and it is the arm that shows a row admitted by the cgroup yet
  failing its own margin check. The resident-branch test recomputes its
  formulas including `MARGIN_BYTES` and gains a declared-zero arm.

Both suites were re-read for `process_baseline_bytes`, `_row_memory_gb` and
`baseline_policy` before editing; no other test asserts on these.

## Receipts

Every shard ran through PrismaBuild at `38db5f6f` on `dl380g10` with
`pq-cpu312`; **6/6 shards, `detail.returncode: 0`**, 199 passed, 2 skipped.

| shard | files | summary | action key |
|---|---|---|---|
| 0 | demand_derivation, campaign_container, campaign_progress | `42 passed, 14 warnings in 8.38s` | `95a888e1dbf38d92…` |
| 1 | campaign_seed_workspace, docs_staleness | `12 passed, 14 warnings in 8.30s` | `cb1ee7bf459fa5ee…` |
| 2 | calibration_cache, stack_group_cli | `35 passed, 14 warnings in 367.06s` | `bbb929646f71be17…` |
| 3 | selected_source, architecture_doc | `35 passed, 1 skipped, 14 warnings in 9.08s` | `e55e05ee3759c093…` |
| 4 | capture_allocator_environment, stack_driver_integration | `13 passed, 1 skipped, 14 warnings in 9.08s` | `297476f221269b94…` |
| 5 | campaign_fanout, streamed_capture_admission | `62 passed, 14 warnings in 18.32s` | `cacbe91fe4d3adc4…` |

`tests/test_docs_staleness.py` (shard 1) and `tests/test_architecture_doc.py`
(shard 3) are the documentation gates and both pass.

Two skips, both environment-gated and pre-existing, certifying nothing about
this change: `test_native_bounded_encoder_memo_keeps_wire_and_price_bytes`
(`skipif not torch.cuda.is_available`, and these shards run on a CPU box) and
`test_campaign_main_consumes_persisted_draw_and_emits_packed_population`
(its fixture calls `importorskip("tessera.cached_unit")`).

Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmYxSxhmzbBcBoFTjbLi1G
