### PR TITLE
Read the contract's loader_axes, refuse the cut it refuses (#536)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,48 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-12 · `pq/530-amd-serving-profiles`. Stamps
+As of: 2026-09-12 · `pq/536-loader-axes`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-12, `pq/536-loader-axes`) for the **loader-axis leg of
+tensor-parallel legality** (#536). The pinned contract's `tensor_parallel`
+unit rows publish two different facts and PrismaQuant read only one of them:
+`max_world_size` is the attestation bound, and `loader_axes` — per unit, per
+axis, `sharded` or `refused` — is what this build's LOADER does with a shard.
+Tessera validates that table equal to the `ROUTE_TP_AXES` its routes gate on
+at `create_weights`, so it is a status a gate may read (principle 14), and it
+refuses `TESSERA_E2M1_K2` on the `row` axis on **every** rank: a row shard
+begins mid-column and the span-2 decoders supply `state_{-1}` themselves.
+A column-parallel Linear splits vLLM's output features, which are this unit's
+rows, so every column-parallel K2 unit is unloadable at TP > 1 at any shape,
+and before this commit the allocator priced it as if it sharded.
+
+`tessera_runtime_contract` now parses the block into
+`TesseraContract.loader_axes` and refuses a malformed or missing axis
+vocabulary rather than reading absence as `sharded`; the statuses join
+`contract_answer`'s `families` projection, so the reviewed answer literal
+moved and that diff is the review. `tessera_menu.tessera_tp_axis_legal` is the
+third leg of `tessera_tp_legal`, asked before the geometry leg because it is
+the cheapest and the most informative, and asked independently of
+`require_attested_world`:
+"has this been measured" and "will this even load" are separate questions.
+It subtracts on a published status and never invents one — with no pinned
+contract, or a family the block does not list, it passes through and the
+closed world stays where it was, on `max_world_size`. Refusals read
+`tp_axis_refused:<family>:<unit>:<axis>`, and the allocator now passes the
+qname so `<unit>` names the Linear.
+
+`python -m prismaquant.tessera_tp_audit` is the read-only Step 5b check: it
+audits an existing `layer_config.json` at a world size with
+`require_attested_world=False` plus the loader-axis leg, asserts packed
+experts resolve to a `none` cut, emits per-unit JSON verdicts, and exits
+non-zero on any refusal. It never edits the assignment — the answer to a
+refusal is a re-run of the allocation with the offending rung excluded by
+that measured fact (principle 1). Two legs it does **not** audit, and the
+receipt says so in a field: shard geometry, because `layer_config.json` is a
+qname-to-format recipe carrying no shapes, and the attested world size, which
+is the other question. Gates:
+`tests/test_tessera_tp_loader_axes.py`, `tests/test_tessera_tp_audit.py`,
+plus `tests/test_docs_staleness.py` and `tests/test_architecture_doc.py`.
 
 Re-stamped (2026-09-12, `pq/530-amd-serving-profiles`) for the two **AMD
 Tessera serving profiles** (#530): `serving_profile_specs/
@@ -9032,13 +9073,26 @@ anchor** on all seven units, while `E4M3_K1_R1024` is an **interpolated**
 column of the rate surface on the five units that have one — so the attested
 menu's E4M3 leg rests on interpolation in the currency impeached above.
 
-**Tensor parallelism has two legs, and both bind.** The *attestation* leg is the
-contract's `tensor_parallel` block, whose semantics are `closed_world`: it lists
-both families at `max_world_size: 1`, so **no Tessera rung is attested at TP > 1
-at any shape**, and `tessera_tp_world_attested` refuses in the attested menu
-before geometry is consulted. The research menu passes that leg by construction
-(it prices unattested rungs deliberately and stamps every one). The *geometry*
-leg is below, and a refusal names which leg answered.
+**Tensor parallelism has three legs, and all three bind.** The *attestation*
+leg is the contract's `tensor_parallel` block, whose semantics are
+`closed_world`: it lists every family at `max_world_size: 1`, so **no Tessera
+rung is attested at TP > 1 at any shape**, and `tessera_tp_world_attested`
+refuses in the attested menu before geometry is consulted. The research menu
+passes that leg by construction (it prices unattested rungs deliberately and
+stamps every one). The *loader-axis* leg reads the second fact the same unit
+rows publish — `loader_axes`, `sharded` or `refused` per axis, validated by
+Tessera against the `ROUTE_TP_AXES` its routes gate on — and
+`tessera_menu.tessera_tp_axis_legal` asks it before the geometry leg, because
+a `refused` axis is refused on every rank: no world size and no shape makes it legal, so naming a
+granularity there would name the wrong obstacle. It does not depend on
+`require_attested_world`. Today it refuses `TESSERA_E2M1_K2` on `row`, which
+is the axis a **column**-parallel Linear cuts. The *geometry* leg is below,
+and a refusal names which leg answered:
+`tp{n}_unattested:…`, `tp_axis_refused:<family>:<unit>:<axis>`, or
+`tp{n}_{axis}_granularity: …`. `python -m prismaquant.tessera_tp_audit` asks
+the loader-axis leg of an assignment that already exists, at a world size, and
+exits non-zero on any refusal; it audits neither of the other two legs and its
+receipt says so.
 
 **Tensor parallelism is a per-unit legality input.** A Tessera rate is a schedule
 over the reduce dimension, so what a rank can encode is a function of *its* column

--- a/prismaquant/README.md
+++ b/prismaquant/README.md
@@ -20,6 +20,7 @@ declarative contract layer, not the executor.
 | Select | `validate_assignments_kl`, `select_validated_frontier` |
 | Export | `export_native_compressed` (compressed-tensors), `export_gguf` / `export_gguf_direct` (GGUF) |
 | Validate | `validation_harness`, `validate_native_export`, `validate_quantized_model` |
+| Audit | `tessera_tp_audit` (read-only: does the pinned runtime's loader cut each assigned Tessera unit at this world size?) |
 
 ## Library modules with no CLI (imported by the stages above)
 

--- a/prismaquant/allocator_candidates.py
+++ b/prismaquant/allocator_candidates.py
@@ -767,7 +767,7 @@ def _tensor_parallel_applicability(
     try:
         legal, reason = tessera_tp_legal(
             family, rung, (out_features, in_features),
-            tp_degree=world, parallel_kind=kind,
+            tp_degree=world, parallel_kind=kind, unit=qname,
             require_attested_world=(menu_mode() == MENU_ATTESTED),
         )
     except TesseraMenuError as exc:

--- a/prismaquant/name_projection.py
+++ b/prismaquant/name_projection.py
@@ -88,6 +88,7 @@ __all__ = [
     "NAMESPACES",
     "NameProjection",
     "NameProjectionError",
+    "is_packed_expert_qname",
     "packed_expert_alias",
     "PROJECTABLE_PAIRS",
     "ProjectedName",
@@ -189,6 +190,29 @@ def packed_expert_alias(qname: str, parent_for_projection=None) -> str | None:
     if not parent:
         return None
     return ".".join(parts[:-2] + [str(parent)])
+
+
+def is_packed_expert_qname(qname: str) -> bool:
+    """Does this name sit inside an expert stack, packed or per-expert?
+
+    ``...experts.<leaf>`` (the packed 3-D parent vLLM loads) and
+    ``...experts.{i}.<leaf>`` (the per-expert spelling a checkpoint may ship)
+    both answer True; ``...shared_experts.<leaf>`` answers False, because a
+    shared expert is an ordinary dense Linear that tensor parallelism cuts
+    like any other.
+
+    The same structural ``experts`` parse :func:`packed_expert_alias` uses,
+    exposed as a predicate for the callers that need the CLASS and not the
+    packed parent's name -- the ones applying "expert parallelism cuts the
+    stack and leaves each expert's 2-D unit whole", which is the rule
+    ``ServingProfile.check_shape`` and ``allocator_candidates`` already
+    resolve to a ``none`` tensor-parallel cut.
+    """
+    parts = strip_weight_leaf(str(qname)).split(".")
+    if len(parts) >= 2 and parts[-2] == "experts":
+        return True
+    return (len(parts) >= 3 and parts[-3] == "experts"
+            and parts[-2].isdigit())
 
 
 @dataclasses.dataclass(frozen=True)

--- a/prismaquant/tessera_menu.py
+++ b/prismaquant/tessera_menu.py
@@ -219,6 +219,19 @@ PARALLEL_ROW = "row"
 PARALLEL_NONE = "none"
 _PARALLEL_KINDS = frozenset({PARALLEL_COLUMN, PARALLEL_ROW, PARALLEL_NONE})
 
+#: The cut direction, in Tessera's axis vocabulary.  A column-parallel Linear
+#: splits vLLM's output features, and those are this unit's ROWS, so
+#: ``PARALLEL_COLUMN`` asks about ``"row"``.  The mapping is written once and
+#: read by both TP legs (``tessera.layout.can_shard`` and the contract's
+#: ``loader_axes``): inverting it answers plausibly in both directions and
+#: gates exactly the wrong half of a model.
+_CUT_AXIS = {PARALLEL_COLUMN: "row", PARALLEL_ROW: "column"}
+
+
+def tp_cut_axis(parallel_kind: str) -> "str | None":
+    """Which axis a cut of this kind shards, or ``None`` when it shards none."""
+    return _CUT_AXIS.get(str(parallel_kind))
+
 #: Nothing here enumerates grids or arities. The base set is
 #: ``tessera_formats._HARDWARE_BASES`` -- the grids that materialise into a
 #: stock format at load, which is the same table
@@ -377,6 +390,80 @@ def fused_module_licence():
     """
     contract = tessera_runtime_contract()
     return None if contract is None else contract.fused_module
+
+
+def tessera_loader_axes() -> "Mapping[str, Mapping[str, str]] | None":
+    """What the pinned contract says this build's loader does with each axis.
+
+    ``family -> axis -> status`` from ``tensor_parallel.units[].loader_axes``,
+    or ``None`` when no contract is pinned.  Routed through
+    :func:`tessera_runtime_contract` -- this module's declared one read -- so
+    the axis fact and the route admission cannot come from two different
+    Tessera builds inside one run.
+
+    ``None`` is the absence of a table, not a permissive default, and the leg
+    that reads it subtracts on a published status rather than inventing a
+    refusal from silence: see :func:`tessera_tp_axis_legal`.
+    """
+    contract = tessera_runtime_contract()
+    return None if contract is None else contract.loader_axes
+
+
+def tessera_tp_axis_legal(
+    family: "str | TesseraFamily",
+    *,
+    tp_degree: int = 1,
+    parallel_kind: str = PARALLEL_NONE,
+    unit: "str | None" = None,
+    loader_axes: "Mapping[str, Mapping[str, str]] | None" = None,
+) -> tuple[bool, str]:
+    """Will the pinned runtime's LOADER cut this family on this axis?
+
+    The third leg of TP legality, and the cheapest: it needs no shape and no
+    ``tessera.layout`` call, because it reads a status the contract publishes
+    per unit and per axis (``tensor_parallel.units[].loader_axes``, which
+    Tessera validates equal to the ``ROUTE_TP_AXES`` its routes gate on).
+
+    It is a different question from both of the others.
+    :func:`tessera_tp_world_attested` asks whether a served receipt covers
+    this world size -- the ATTESTATION -- and ``tessera.layout.can_shard``
+    asks whether the rung's own period divides the shard.  This one asks
+    whether the loader accepts the cut at all, and a ``refused`` axis is
+    refused on EVERY rank, so no world size and no shape makes it legal.
+    That is why it does not wait for ``require_attested_world``: the research
+    menu prices unattested rungs on purpose, and a cut the loader will not
+    load is not an unattested rung, it is an unloadable one.
+
+    Two absences are pass-throughs, both deliberate. With no pinned contract
+    there is no loader fact to read, and refusing here would turn the TP gate
+    into a second route gate that empties the research menu. With a contract
+    that does not list the family, the closed world lives on
+    ``max_world_size`` and the attestation leg reads it; this leg reports a
+    published status and nothing else. It adds a refusal; it never invents
+    one.
+
+    ``unit`` names the Linear the caller is asking about, so the refusal can
+    say which one; it falls back to the contract's unit key.
+    """
+    spec = get_tessera_family(family)
+    tp = int(tp_degree)
+    axis = tp_cut_axis(parallel_kind)
+    if tp <= 1 or axis is None:
+        return True, ""
+    table = tessera_loader_axes() if loader_axes is None else loader_axes
+    if not table:
+        return True, ""
+    published = table.get(spec.name)
+    if not published:
+        return True, ""
+    from .tessera_runtime_contract import TP_LOADER_AXIS_REFUSED
+
+    status = published.get(axis)
+    if status != TP_LOADER_AXIS_REFUSED:
+        return True, ""
+    return False, (
+        f"tp_axis_refused:{spec.name}:{unit or spec.name}:{axis}"
+    )
 
 
 def tessera_tp_world_attested(
@@ -1097,10 +1184,11 @@ def tessera_tp_legal(
     tp_degree: int = 1,
     parallel_kind: str = PARALLEL_NONE,
     require_attested_world: bool = False,
+    unit: "str | None" = None,
 ) -> tuple[bool, str]:
     """Is this rung legal on every rank at ``tp_degree``?  ``(legal, reason)``.
 
-    Three questions when the menu is the attested one, two when it is not.
+    Four questions when the menu is the attested one, three when it is not.
     ``require_attested_world`` adds the first: does the pinned runtime contract
     say it serves this family at this world size at all
     (:func:`tessera_tp_world_attested`)?  That is a *different* question from
@@ -1110,8 +1198,17 @@ def tessera_tp_legal(
     unattested rungs deliberately and stamps every one of them, so a second
     attestation refusal there would only hide the pricing.
 
-    Then two questions, both asked of Tessera:
+    Then three questions, all asked of Tessera:
 
+    * **Will the loader cut this family on this axis at all?**
+      :func:`tessera_tp_axis_legal`, reading the contract's published
+      ``loader_axes`` status.  It is asked before the geometry leg because
+      it is the cheapest and the most informative: a refused axis is refused
+      on every rank, so no shape and no world size makes it legal, and the
+      reason says so rather than naming a granularity that is not the
+      obstacle.  This leg
+      does NOT depend on ``require_attested_world`` -- "has this been
+      measured" and "will this even load" are separate questions.
     * **Can the whole unit be cut this way at all?**
       ``tessera.layout.can_shard(unit, tp, axis)`` -- and the axis mapping is
       Tessera's, not a local convention: a *column-parallel* Linear (q/k/v,
@@ -1137,6 +1234,10 @@ def tessera_tp_legal(
         attested, why = tessera_tp_world_attested(spec, tp)
         if not attested:
             return False, why
+    loads, why = tessera_tp_axis_legal(
+        spec, tp_degree=tp, parallel_kind=parallel_kind, unit=unit)
+    if not loads:
+        return False, why
     try:
         sharded = shard_shape(shape, tp, parallel_kind)
     except TesseraMenuError as exc:
@@ -1144,7 +1245,7 @@ def tessera_tp_legal(
     if tp > 1 and parallel_kind != PARALLEL_NONE:
         from tessera.layout import can_shard as _tessera_can_shard
 
-        axis = "row" if parallel_kind == PARALLEL_COLUMN else "column"
+        axis = tp_cut_axis(parallel_kind)
         try:
             geometry = _shard_geometry(
                 spec.name, int(body_rate_q256), int(shape[-2]), int(shape[-1]),

--- a/prismaquant/tessera_runtime_contract.py
+++ b/prismaquant/tessera_runtime_contract.py
@@ -319,13 +319,19 @@ TESSERA_DEV_PIN_ANSWER = {'schema': 'tessera.runtime-contract.v1',
                                               'grid_arities': [1]}}}],
  'families': {'TESSERA_BF16_K1': {'reader_rate_range_q256': [256, 4096],
                                   'attested_rungs_q256': [1792],
-                                  'max_world_size': 1},
+                                  'max_world_size': 1,
+                                  'loader_axes': {'column': 'sharded',
+                                                  'row': 'sharded'}},
               'TESSERA_E2M1_K2': {'reader_rate_range_q256': [896, 896],
                                   'attested_rungs_q256': [896],
-                                  'max_world_size': 1},
+                                  'max_world_size': 1,
+                                  'loader_axes': {'column': 'sharded',
+                                                  'row': 'refused'}},
               'TESSERA_E4M3_K1': {'reader_rate_range_q256': [256, 2048],
                                   'attested_rungs_q256': [1024],
-                                  'max_world_size': 1}},
+                                  'max_world_size': 1,
+                                  'loader_axes': {'column': 'sharded',
+                                                  'row': 'sharded'}}},
  'cells': [['tessera_bf16_k1_dense_sm121_batch',
             'sm_121',
             'TESSERA_BF16_K1',
@@ -948,6 +954,12 @@ class TesseraContract:
     native_extensions: tuple[TesseraNativeExtension, ...]
     #: ``family -> max tensor-parallel world size``, closed world.
     max_world_size: Mapping[str, int]
+    #: ``family -> axis -> status`` from the same unit rows: what this build's
+    #: LOADER does with a shard on each axis.  A different question from the
+    #: ceiling beside it -- ``max_world_size`` says what a served receipt
+    #: covers, this says whether the cut loads at all -- and a family the
+    #: block does not list publishes neither.
+    loader_axes: Mapping[str, Mapping[str, str]]
     #: What one vLLM-fused module's roles must share, and what is free.
     fused_module: FusedModuleLicence
     quant_method: str
@@ -1178,6 +1190,10 @@ def contract_answer(contract: "TesseraContract") -> dict:
                 "attested_rungs_q256": sorted(
                     int(r) for r in contract.attested_rungs.get(family, ())),
                 "max_world_size": int(contract.max_world_size.get(family, 0)),
+                "loader_axes": {
+                    str(axis): str(status) for axis, status in
+                    sorted(contract.loader_axes.get(family, {}).items())
+                },
             }
             for family, rng in sorted(contract.reader_rate_range.items())
         },
@@ -1576,8 +1592,77 @@ def _parse_fused_module(payload: Mapping[str, Any], path: str
     )
 
 
-def _parse_tensor_parallel_limits(payload: Mapping[str, Any], path: str) -> dict[str, int]:
-    """Read the closed-world TP ceiling for both pin paths."""
+#: The shard axes ``tensor_parallel.units[].loader_axes`` may name, in
+#: Tessera's own vocabulary (``tessera.serving.sharding.AXES``).  A unit that
+#: names another axis, or omits one of these, is refused rather than read with
+#: the axes this reader happens to know: the point of publishing a status per
+#: axis is that the answer is not derivable from the axis's name.
+TP_LOADER_AXES = ("column", "row")
+
+#: What a published axis status may say.  ``sharded`` is "this build's loader
+#: accepts a shard on this axis", ``refused`` is "it does not, on every rank".
+#: Neither is an attestation: ``max_world_size`` in the same unit row is the
+#: attestation, and the two are separate questions (a loader that would cut an
+#: axis it has never been measured cutting is still unattested).
+TP_LOADER_AXIS_SHARDED = "sharded"
+TP_LOADER_AXIS_REFUSED = "refused"
+TP_LOADER_AXIS_STATUSES = (TP_LOADER_AXIS_SHARDED, TP_LOADER_AXIS_REFUSED)
+
+
+def _parse_loader_axes(block: Any, where: str) -> dict[str, str]:
+    """Read one unit's per-axis loader statuses, or refuse the table.
+
+    There is no default here on purpose.  A missing block, an axis this
+    reader does not share, a status it does not know, and a ``status`` read
+    off the prose beside it are all the same failure: a claim about what
+    another runtime's loader does, read as something other than what was
+    published (principle 14).  Reading absence as ``sharded`` would price a
+    cut the loader refuses on every rank.
+    """
+    if not isinstance(block, Mapping):
+        raise TesseraContractError(
+            f"{where} publishes no usable 'loader_axes' mapping (got "
+            f"{type(block).__name__}). This reader will not assume an axis "
+            "shards because the table did not say it does not."
+        )
+    if set(block) != set(TP_LOADER_AXES):
+        raise TesseraContractError(
+            f"{where}.loader_axes names axes {sorted(block)}; this reader "
+            f"implements exactly {sorted(TP_LOADER_AXES)} and refuses a "
+            "vocabulary it does not share rather than reading the axes it "
+            "recognises and dropping the rest"
+        )
+    axes: dict[str, str] = {}
+    for axis in sorted(TP_LOADER_AXES):
+        entry = block[axis]
+        if not isinstance(entry, Mapping):
+            raise TesseraContractError(
+                f"{where}.loader_axes.{axis} must be an object carrying a "
+                f"'status', got {entry!r}"
+            )
+        status = str(_require(entry, "status", f"{where}.loader_axes.{axis}"))
+        if status not in TP_LOADER_AXIS_STATUSES:
+            raise TesseraContractError(
+                f"{where}.loader_axes.{axis}.status is {status!r}; this "
+                f"reader knows {sorted(TP_LOADER_AXIS_STATUSES)}. The "
+                "``reason`` beside it is prose and is never the value a gate "
+                "reads."
+            )
+        axes[axis] = status
+    return axes
+
+
+def _parse_tensor_parallel(
+    payload: Mapping[str, Any], path: str,
+) -> tuple[dict[str, int], dict[str, dict[str, str]]]:
+    """Read both facts the ``tensor_parallel`` unit rows publish.
+
+    ``max_world_size`` is the ATTESTATION bound -- the largest world size a
+    served receipt covers -- and ``loader_axes`` is what this build's loader
+    does with each shard axis.  They answer different questions and they are
+    read together here so a unit row cannot be half-read: a family with a
+    ceiling and no axis claim is a table this reader refuses.
+    """
     tp = _require(payload, "tensor_parallel", path)
     if str(tp.get("semantics")) != "closed_world":
         raise TesseraContractError(
@@ -1587,12 +1672,19 @@ def _parse_tensor_parallel_limits(payload: Mapping[str, Any], path: str) -> dict
             "will not read an open-world table under that assumption"
         )
     world: dict[str, int] = {}
+    axes: dict[str, dict[str, str]] = {}
     for i, unit in enumerate(tp.get("units", ())):
         where = f"{path}.tensor_parallel.units[{i}]"
-        world[str(_require(unit, "unit", where))] = int(
-            _require(unit, "max_world_size", where))
+        name = str(_require(unit, "unit", where))
+        world[name] = int(_require(unit, "max_world_size", where))
+        axes[name] = _parse_loader_axes(unit.get("loader_axes"), where)
 
-    return world
+    return world, axes
+
+
+def _parse_tensor_parallel_limits(payload: Mapping[str, Any], path: str) -> dict[str, int]:
+    """Read the closed-world TP ceiling for both pin paths."""
+    return _parse_tensor_parallel(payload, path)[0]
 
 
 @lru_cache(maxsize=8)
@@ -1601,11 +1693,31 @@ def published_tensor_parallel_limits(path: str, sha: str) -> Mapping[str, int]:
 
     This accessor reports ceilings only; it does not grant TP admission.
     """
+    return _published_tensor_parallel(path, sha)[0]
+
+
+@lru_cache(maxsize=8)
+def published_tensor_parallel_axes(
+    path: str, sha: str,
+) -> Mapping[str, Mapping[str, str]]:
+    """``family -> axis -> status``, read from a contract file on disk.
+
+    The same reader the parsed contract uses, for the two callers that hold a
+    contract path rather than a loaded contract: the packaged-table route
+    admission, and ``prismaquant.tessera_tp_audit``'s ``--contract``.  One
+    reader means the vocabulary refusal is identical on every path.
+    """
+    return _published_tensor_parallel(path, sha)[1]
+
+
+def _published_tensor_parallel(
+    path: str, sha: str,
+) -> tuple[Mapping[str, int], Mapping[str, Mapping[str, str]]]:
     raw = Path(path).read_bytes()
     if hashlib.sha256(raw).hexdigest() != sha:
         raise TesseraContractError(
             f"{path}: tensor-parallel metadata digest differs from attesting table")
-    return _parse_tensor_parallel_limits(json.loads(raw), path)
+    return _parse_tensor_parallel(json.loads(raw), path)
 
 
 def _parse(payload: Mapping[str, Any], *, commit: str, sha: str, path: str
@@ -1711,7 +1823,7 @@ def _parse(payload: Mapping[str, Any], *, commit: str, sha: str, path: str
             evidence=cell.evidence,
         ))
 
-    world = _parse_tensor_parallel_limits(payload, path)
+    world, loader_axes = _parse_tensor_parallel(payload, path)
 
     fused = _parse_fused_module(payload, path)
 
@@ -1723,6 +1835,7 @@ def _parse(payload: Mapping[str, Any], *, commit: str, sha: str, path: str
         cells=tuple(cells),
         native_extensions=extensions,
         max_world_size=world,
+        loader_axes=loader_axes,
         fused_module=fused,
         quant_method=str(method.get("canonical", "")),
         contract_version=int(payload.get("contract_version", 0)),

--- a/prismaquant/tessera_tp_audit.py
+++ b/prismaquant/tessera_tp_audit.py
@@ -1,0 +1,306 @@
+"""Audit an existing assignment at a tensor-parallel world size.  Read-only.
+
+    python -m prismaquant.tessera_tp_audit \\
+        --layer-config artifacts/layer_config.json \\
+        --target-profile glm_packed_research_sm121 --tp 2 \\
+        --out artifacts/tp2_audit.json
+
+The question this answers is narrow and worth stating exactly: **for every
+Tessera unit this assignment already names, will the pinned runtime's loader
+cut it on the axis the target profile says tensor parallelism cuts it on?**
+
+It is not an allocator and it never writes an assignment. A refusal here is a
+measured platform fact about the pinned runtime, and the answer to one is to
+re-run the allocation with the offending rung excluded by that fact -- never
+to edit the assignment by hand, which would put a choice the measurement did
+not make into the artifact.
+
+What it audits, and what it does not:
+
+* **Loader axis** -- audited. The contract publishes, per unit and per axis,
+  whether this build's loader accepts a shard (``tensor_parallel.units[]
+  .loader_axes``, which Tessera validates equal to the ``ROUTE_TP_AXES`` its
+  routes gate on). ``TESSERA_E2M1_K2`` refuses the ``row`` axis, which is the
+  axis a **column**-parallel Linear cuts, so every column-parallel K2 unit is
+  refused at ``--tp 2`` and above.
+* **Packed-expert cut kind** -- audited. Expert parallelism cuts the stack and
+  leaves each expert's 2-D unit whole, so a packed expert resolves to a
+  ``none`` cut whatever the profile's name rules say. The receipt records the
+  rule's answer beside the effective one so a disagreement is visible without
+  being a refusal.
+* **Shard geometry** -- NOT audited, and the receipt says so. The geometry leg
+  (``tessera.layout.can_shard`` on the half shape) needs each unit's shape and
+  ``layer_config.json`` carries no shapes: it is a qname-to-format recipe.
+  Auditing it means running the allocator's own legality gate, which reads the
+  model.
+* **Attested world size** -- NOT audited, by construction. The audit runs with
+  ``require_attested_world=False`` because it asks a geometry-side question
+  ("can the loader cut it"), not an attestation one ("has a served receipt
+  covered this world size"). ``max_world_size`` is recorded per family so the
+  reader can see what the contract does attest.
+
+Exit codes: ``0`` no refusals, ``1`` at least one refusal, ``2`` the audit
+could not be run (no contract, unknown profile, unreadable input).
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+#: Receipt schema. Bump when a consumer-visible field changes meaning.
+AUDIT_SCHEMA = "prismaquant.tessera_tp_audit.v1"
+
+EXIT_OK = 0
+EXIT_REFUSED = 1
+EXIT_CANNOT_RUN = 2
+
+
+class TesseraTpAuditError(Exception):
+    """The audit cannot be run, so it certifies nothing."""
+
+
+def _resolve_axes(contract_path: str | None) -> dict[str, Any]:
+    """The loader-axis table to audit against, and where it came from.
+
+    Two sources, one reader. ``--contract`` names a contract file directly --
+    what a worker container holds when the plugin is not importable -- and
+    otherwise the development pin's contract is read through
+    ``load_tessera_contract``. There is deliberately no third case: an audit
+    with no table would certify an assignment from silence.
+    """
+    from .tessera_runtime_contract import (
+        TesseraContractError, load_tessera_contract,
+        published_tensor_parallel_axes, published_tensor_parallel_limits,
+        TESSERA_DEV_PIN_ENV,
+    )
+
+    if contract_path:
+        path = Path(contract_path)
+        try:
+            raw = path.read_bytes()
+        except OSError as exc:
+            raise TesseraTpAuditError(f"--contract {contract_path}: {exc}") from exc
+        sha = hashlib.sha256(raw).hexdigest()
+        try:
+            axes = published_tensor_parallel_axes(str(path), sha)
+            world = published_tensor_parallel_limits(str(path), sha)
+        except TesseraContractError as exc:
+            raise TesseraTpAuditError(str(exc)) from exc
+        return {"source": "--contract", "path": str(path), "sha256": sha,
+                "commit": None, "loader_axes": dict(axes),
+                "max_world_size": dict(world)}
+
+    try:
+        contract = load_tessera_contract()
+    except TesseraContractError as exc:
+        raise TesseraTpAuditError(str(exc)) from exc
+    if contract is None:
+        raise TesseraTpAuditError(
+            "no Tessera runtime contract is pinned, so there is no loader-axis "
+            f"table to audit against. Set {TESSERA_DEV_PIN_ENV} to the reviewed "
+            "commit, or pass --contract with the contract file to read."
+        )
+    return {"source": "dev_pin", "path": contract.path,
+            "sha256": contract.sha256, "commit": contract.commit,
+            "loader_axes": dict(contract.loader_axes),
+            "max_world_size": dict(contract.max_world_size)}
+
+
+def audit_assignment(
+    *,
+    layer_config: str,
+    target_profile: str,
+    tp_degree: int,
+    contract_path: str | None = None,
+) -> dict[str, Any]:
+    """Build the audit receipt.  Reads only; returns the payload."""
+    from .layer_config import load_assignment
+    from .name_projection import is_packed_expert_qname
+    from .serving_profiles import load_serving_profile
+    from .tessera_formats import TesseraFormatError, parse_tessera_format_name
+    from .tessera_menu import (
+        PARALLEL_NONE, tessera_tp_axis_legal, tp_cut_axis,
+    )
+
+    tp = int(tp_degree)
+    if tp < 1:
+        raise TesseraTpAuditError(f"--tp must be >= 1, got {tp_degree}")
+
+    try:
+        assignment = load_assignment(layer_config)
+    except Exception as exc:
+        raise TesseraTpAuditError(
+            f"--layer-config {layer_config}: {exc}") from exc
+    try:
+        profile = load_serving_profile(target_profile)
+    except FileNotFoundError as exc:
+        raise TesseraTpAuditError(
+            f"--target-profile {target_profile!r} names no serving profile"
+        ) from exc
+
+    table = _resolve_axes(contract_path)
+    axes = table["loader_axes"]
+
+    units: list[dict[str, Any]] = []
+    refusals = 0
+    by_reason: dict[str, int] = {}
+    by_family: dict[str, int] = {}
+    non_tessera = 0
+    packed_units = 0
+
+    for qname in sorted(assignment):
+        fmt = str(assignment[qname])
+        try:
+            parsed = parse_tessera_format_name(fmt)
+        except TesseraFormatError as exc:
+            raise TesseraTpAuditError(f"{qname}: {exc}") from exc
+        if parsed is None:
+            non_tessera += 1
+            continue
+        family, body_rate_q256 = parsed
+        by_family[family.name] = by_family.get(family.name, 0) + 1
+
+        packed = is_packed_expert_qname(qname)
+        packed_units += int(packed)
+        rule_kind = profile.tensor_parallel.kind_for(qname)
+        cut_kind = PARALLEL_NONE if packed else rule_kind
+        cut_source = ("expert_parallel_construction" if packed
+                      else "serving_profile_rule")
+        axis = tp_cut_axis(cut_kind) if tp > 1 else None
+
+        verdict, reason = "pass", ""
+        if packed and cut_kind != PARALLEL_NONE:
+            # Unreachable while the rule above stands; kept because the
+            # assertion the issue asks for is the one worth keeping.
+            verdict = "refused"
+            reason = f"tp_packed_expert_cut:{family.name}:{qname}:{cut_kind}"
+        elif axis is not None:
+            if family.name not in axes:
+                verdict = "refused"
+                reason = f"tp_axis_unpublished:{family.name}:{qname}:{axis}"
+            else:
+                loads, why = tessera_tp_axis_legal(
+                    family, tp_degree=tp, parallel_kind=cut_kind,
+                    unit=qname, loader_axes=axes)
+                if not loads:
+                    verdict, reason = "refused", why
+        if verdict == "refused":
+            refusals += 1
+            key = reason.split(":", 1)[0]
+            by_reason[key] = by_reason.get(key, 0) + 1
+
+        units.append({
+            "unit": qname,
+            "format": fmt,
+            "family": family.name,
+            "body_rate_q256": int(body_rate_q256),
+            "packed_expert": packed,
+            "cut_kind": cut_kind,
+            "cut_kind_source": cut_source,
+            "profile_rule_kind": rule_kind,
+            "cut_axis": axis,
+            "axis_status": (axes.get(family.name, {}).get(axis)
+                            if axis is not None else None),
+            "max_world_size": table["max_world_size"].get(family.name),
+            "verdict": verdict,
+            "reason": reason,
+        })
+
+    return {
+        "schema": AUDIT_SCHEMA,
+        "layer_config": str(layer_config),
+        "target_profile": profile.id,
+        "profile_world_size": int(profile.tensor_parallel.world_size),
+        "tp_degree": tp,
+        "require_attested_world": False,
+        "contract": {k: table[k] for k in ("source", "path", "sha256", "commit")},
+        "loader_axes": {family: dict(sorted(status.items()))
+                        for family, status in sorted(axes.items())},
+        "legs": {
+            "loader_axis": "audited",
+            "packed_expert_cut_kind": "audited",
+            "shard_geometry": (
+                "not audited: layer_config.json is a qname-to-format recipe "
+                "and carries no shapes, and the geometry leg asks about the "
+                "shard a rank holds"),
+            "attested_world": (
+                "not audited: this audit asks whether the loader can cut the "
+                "unit, not whether a served receipt covers this world size; "
+                "each unit records the contract's max_world_size instead"),
+        },
+        "summary": {
+            "units_audited": len(units),
+            "non_tessera_units": non_tessera,
+            "packed_expert_units": packed_units,
+            "tessera_units_by_family": dict(sorted(by_family.items())),
+            "refusals": refusals,
+            "refusals_by_reason": dict(sorted(by_reason.items())),
+        },
+        "verdict": "refused" if refusals else "pass",
+        "units": units,
+    }
+
+
+def _write(receipt: dict[str, Any], out: str) -> None:
+    text = json.dumps(receipt, indent=2, sort_keys=False)
+    if out == "-":
+        sys.stdout.write(text + "\n")
+        return
+    path = Path(out)
+    if path.parent and not path.parent.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text + "\n", encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m prismaquant.tessera_tp_audit",
+        description=(
+            "Audit an existing layer_config assignment at a tensor-parallel "
+            "world size against the pinned runtime's loader-axis table. "
+            "Read-only: it never writes the assignment."),
+    )
+    parser.add_argument("--layer-config", required=True,
+                        help="the assignment to audit (read, never written)")
+    parser.add_argument("--target-profile", required=True,
+                        help="serving profile whose rules say how TP cuts "
+                             "each Linear")
+    parser.add_argument("--tp", required=True, type=int,
+                        help="world size to audit at")
+    parser.add_argument("--contract", default=None,
+                        help="contract file to read the loader-axis table "
+                             "from; the development pin's contract by default")
+    parser.add_argument("--out", required=True,
+                        help="receipt path, or - for stdout")
+    return parser
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        receipt = audit_assignment(
+            layer_config=args.layer_config,
+            target_profile=args.target_profile,
+            tp_degree=args.tp,
+            contract_path=args.contract,
+        )
+    except TesseraTpAuditError as exc:
+        print(f"tessera_tp_audit: {exc}", file=sys.stderr)
+        return EXIT_CANNOT_RUN
+    _write(receipt, args.out)
+    summary = receipt["summary"]
+    print(
+        f"tessera_tp_audit: tp={receipt['tp_degree']} "
+        f"{summary['units_audited']} Tessera unit(s), "
+        f"{summary['refusals']} refusal(s) -> {receipt['verdict']}",
+        file=sys.stderr,
+    )
+    return EXIT_REFUSED if summary["refusals"] else EXIT_OK
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/tests/fixtures/tessera_tp_audit_layer_config.json
+++ b/tests/fixtures/tessera_tp_audit_layer_config.json
@@ -1,0 +1,15 @@
+{
+  "__prismaquant__": {
+    "note": "Fixture for prismaquant.tessera_tp_audit. One column-parallel and one row-parallel Linear per family, a packed expert stack, a shared expert, and one non-Tessera unit -- the smallest assignment that exercises every branch of the loader-axis audit. Not produced by an allocator run.",
+    "target_profile": "tessera_research_sm121"
+  },
+  "model.layers.0.self_attn.q_proj": "TESSERA_E2M1_K2_R896",
+  "model.layers.0.self_attn.o_proj": "TESSERA_E2M1_K2_R896",
+  "model.layers.0.mlp.gate_up_proj": "TESSERA_E4M3_K1_R1024",
+  "model.layers.0.mlp.down_proj": "TESSERA_E4M3_K1_R1024",
+  "model.layers.1.mlp.experts.gate_up_proj": "TESSERA_E2M1_K2_R896",
+  "model.layers.1.mlp.experts.down_proj": "TESSERA_E2M1_K2_R896",
+  "model.layers.1.mlp.shared_experts.gate_up_proj": "TESSERA_BF16_K1_R1792",
+  "model.layers.1.mlp.shared_experts.down_proj": "TESSERA_BF16_K1_R1792",
+  "lm_head": "BF16"
+}

--- a/tests/test_tessera_menu.py
+++ b/tests/test_tessera_menu.py
@@ -737,9 +737,14 @@ def test_the_answer_excludes_every_field_a_gate_does_not_read(dev_pin):
                            "mixed_rung_receipt_note"):
         assert identity_field not in flat, (
             f"{identity_field} is identity or prose, not an answer")
+    # ``loader_axes`` is answer for the same reason ``max_world_size`` is:
+    # ``tessera_menu.tessera_tp_axis_legal`` subtracts a rung on a published
+    # ``refused`` status, so the statuses are values an admission decision is
+    # made of.  The publisher's per-axis reason is prose and stays out.
     for family in ("TESSERA_E2M1_K2", "TESSERA_E4M3_K1", "TESSERA_BF16_K1"):
         assert set(answer["families"][family]) == {
-            "reader_rate_range_q256", "attested_rungs_q256", "max_world_size"}
+            "reader_rate_range_q256", "attested_rungs_q256", "max_world_size",
+            "loader_axes"}
 
 
 def test_the_fused_module_answer_is_the_values_a_gate_reads(dev_pin):

--- a/tests/test_tessera_tp_audit.py
+++ b/tests/test_tessera_tp_audit.py
@@ -1,0 +1,175 @@
+"""``prismaquant.tessera_tp_audit``: audit an assignment, never edit it.
+
+The audit is the Step 5b check the GLM-5.3 TP2 export needs before Step 6:
+given an assignment the allocator already produced, does the pinned runtime's
+loader accept the cut the target profile says tensor parallelism makes on each
+Tessera unit? It refuses and reports; the answer to a refusal is a re-run of
+the allocation with the offending rung excluded by that measured fact, never a
+hand edit of the assignment.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from importlib.resources import as_file
+from pathlib import Path
+
+import pytest
+
+import prismaquant.tessera_runtime_contract as trc
+from prismaquant import tessera_tp_audit as audit
+
+FIXTURE = str(Path(__file__).parent / "fixtures"
+              / "tessera_tp_audit_layer_config.json")
+PROFILE = "tessera_research_sm121"
+
+#: The one column-parallel K2 Linear in the fixture: a column-parallel cut
+#: splits the output features, which are this unit's rows, and the contract
+#: refuses the K2 loader a row shard on every rank.
+REFUSED_UNIT = "model.layers.0.self_attn.q_proj"
+
+
+@pytest.fixture
+def contract_file(tmp_path):
+    """The installed contract, as a file the CLI can be pointed at."""
+    with as_file(trc.contract_path()) as path:
+        copy = tmp_path / "runtime_contract.json"
+        copy.write_bytes(Path(path).read_bytes())
+        return str(copy)
+
+
+def _run(tmp_path, contract_file, *, tp, out="receipt.json"):
+    target = str(tmp_path / out)
+    code = audit.main([
+        "--layer-config", FIXTURE, "--target-profile", PROFILE,
+        "--tp", str(tp), "--contract", contract_file, "--out", target,
+    ])
+    return code, json.loads(Path(target).read_text(encoding="utf-8"))
+
+
+def test_a_whole_unit_world_has_nothing_to_refuse(tmp_path, contract_file):
+    """At tp=1 no axis is cut, so every unit passes and the CLI exits 0."""
+    code, receipt = _run(tmp_path, contract_file, tp=1)
+    assert code == audit.EXIT_OK
+    assert receipt["verdict"] == "pass"
+    assert receipt["summary"]["refusals"] == 0
+    assert {unit["cut_axis"] for unit in receipt["units"]} == {None}
+
+
+def test_the_column_parallel_k2_linear_is_refused_at_tp2(tmp_path, contract_file):
+    """One refusal, named, and a non-zero exit."""
+    code, receipt = _run(tmp_path, contract_file, tp=2)
+    assert code == audit.EXIT_REFUSED
+    assert receipt["verdict"] == "refused"
+
+    refused = [unit for unit in receipt["units"] if unit["verdict"] == "refused"]
+    assert [unit["unit"] for unit in refused] == [REFUSED_UNIT]
+    assert refused[0]["reason"] == (
+        f"tp_axis_refused:TESSERA_E2M1_K2:{REFUSED_UNIT}:row")
+    assert refused[0]["cut_kind"] == "column"
+    assert refused[0]["axis_status"] == "refused"
+    assert receipt["summary"]["refusals_by_reason"] == {"tp_axis_refused": 1}
+
+
+def test_the_other_cut_direction_and_the_other_families_pass(tmp_path,
+                                                             contract_file):
+    """The refusal is per axis and per family, not per family alone."""
+    _, receipt = _run(tmp_path, contract_file, tp=2)
+    by_unit = {unit["unit"]: unit for unit in receipt["units"]}
+
+    row_parallel_k2 = by_unit["model.layers.0.self_attn.o_proj"]
+    assert row_parallel_k2["cut_axis"] == "column"
+    assert row_parallel_k2["axis_status"] == "sharded"
+    assert row_parallel_k2["verdict"] == "pass"
+
+    column_parallel_fp8 = by_unit["model.layers.0.mlp.gate_up_proj"]
+    assert column_parallel_fp8["cut_axis"] == "row"
+    assert column_parallel_fp8["verdict"] == "pass"
+
+
+def test_a_packed_expert_resolves_to_no_cut_at_all(tmp_path, contract_file):
+    """Expert parallelism cuts the stack; each expert's 2-D unit stays whole.
+
+    The fixture's packed experts carry the family whose row axis the loader
+    refuses, so a packed expert read as column-parallel would be refused
+    here. The receipt records the profile rule's answer beside the effective
+    one, because a disagreement is worth seeing and is not a refusal.
+    """
+    _, receipt = _run(tmp_path, contract_file, tp=2)
+    packed = [unit for unit in receipt["units"] if unit["packed_expert"]]
+    assert {unit["unit"] for unit in packed} == {
+        "model.layers.1.mlp.experts.gate_up_proj",
+        "model.layers.1.mlp.experts.down_proj",
+    }
+    for unit in packed:
+        assert unit["family"] == "TESSERA_E2M1_K2"
+        assert unit["cut_kind"] == "none"
+        assert unit["cut_kind_source"] == "expert_parallel_construction"
+        assert unit["cut_axis"] is None
+        assert unit["verdict"] == "pass"
+    rule_kinds = {unit["unit"]: unit["profile_rule_kind"] for unit in packed}
+    assert rule_kinds == {
+        "model.layers.1.mlp.experts.gate_up_proj": "column",
+        "model.layers.1.mlp.experts.down_proj": "row",
+    }
+
+    shared = next(unit for unit in receipt["units"]
+                  if unit["unit"].endswith("shared_experts.gate_up_proj"))
+    assert shared["packed_expert"] is False, (
+        "a shared expert is an ordinary dense Linear and TP cuts it"
+    )
+    assert shared["cut_kind"] == "column"
+
+
+def test_the_receipt_says_which_legs_it_did_not_audit(tmp_path, contract_file):
+    """A receipt that hid the unaudited legs would read as a clearance."""
+    _, receipt = _run(tmp_path, contract_file, tp=2)
+    assert receipt["schema"] == audit.AUDIT_SCHEMA
+    assert receipt["legs"]["loader_axis"] == "audited"
+    assert receipt["legs"]["shard_geometry"].startswith("not audited")
+    assert receipt["legs"]["attested_world"].startswith("not audited")
+    assert receipt["require_attested_world"] is False
+    assert receipt["contract"]["sha256"] == hashlib.sha256(
+        Path(contract_file).read_bytes()).hexdigest()
+    assert receipt["summary"]["non_tessera_units"] == 1, "lm_head is BF16"
+    assert receipt["units"][0]["max_world_size"] == 1, (
+        "what the contract does attest, recorded beside what it refuses"
+    )
+
+
+def test_the_audit_never_writes_the_assignment(tmp_path, contract_file):
+    before = hashlib.sha256(Path(FIXTURE).read_bytes()).hexdigest()
+    _run(tmp_path, contract_file, tp=2)
+    assert hashlib.sha256(Path(FIXTURE).read_bytes()).hexdigest() == before
+
+
+def test_the_receipt_can_be_written_to_stdout(tmp_path, contract_file, capsys):
+    """``--out -`` so a receipt survives a run on a machine you do not keep."""
+    code = audit.main([
+        "--layer-config", FIXTURE, "--target-profile", PROFILE,
+        "--tp", "2", "--contract", contract_file, "--out", "-",
+    ])
+    assert code == audit.EXIT_REFUSED
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)["verdict"] == "refused"
+    assert "1 refusal(s)" in captured.err
+
+
+def test_with_no_table_the_audit_refuses_to_run(tmp_path, monkeypatch):
+    """Certifying an assignment from silence is the failure to avoid."""
+    monkeypatch.delenv(trc.TESSERA_DEV_PIN_ENV, raising=False)
+    code = audit.main([
+        "--layer-config", FIXTURE, "--target-profile", PROFILE,
+        "--tp", "2", "--out", str(tmp_path / "receipt.json"),
+    ])
+    assert code == audit.EXIT_CANNOT_RUN
+
+
+def test_an_unknown_profile_is_a_refusal_to_run_not_a_pass(tmp_path,
+                                                           contract_file):
+    code = audit.main([
+        "--layer-config", FIXTURE, "--target-profile", "no_such_profile",
+        "--tp", "2", "--contract", contract_file,
+        "--out", str(tmp_path / "receipt.json"),
+    ])
+    assert code == audit.EXIT_CANNOT_RUN

--- a/tests/test_tessera_tp_loader_axes.py
+++ b/tests/test_tessera_tp_loader_axes.py
@@ -1,0 +1,328 @@
+"""The loader-axis leg of tensor-parallel legality (issue #536).
+
+Three legs decide whether a Tessera rung is servable at ``tp > 1`` and they
+answer different questions:
+
+* **attested world** -- ``tensor_parallel.units[].max_world_size``: has a
+  served receipt covered this world size? (``tessera_tp_world_attested``)
+* **shard geometry** -- ``tessera.layout.can_shard``: does the rung's own
+  period divide the shard a rank holds?
+* **loader axis** -- ``tensor_parallel.units[].loader_axes``: does this
+  build's loader accept a cut on this axis at all?
+
+The third is what this file pins. It is a published STATUS, not prose and not
+a bound: the pinned contract refuses ``TESSERA_E2M1_K2`` on the ``row`` axis
+because a row shard begins mid-column and the span-2 decoders supply
+``state_{-1}`` themselves, and it refuses it on every rank, so no world size
+makes it legal. A column-parallel Linear splits vLLM's output features, which
+are this unit's rows, so ``PARALLEL_COLUMN`` is the cut that asks about
+``row`` -- the same mapping the geometry leg uses, and inverting it would gate
+exactly the wrong half of a model.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import prismaquant.tessera_menu as tm
+import prismaquant.tessera_runtime_contract as trc
+
+E2M1 = "TESSERA_E2M1_K2"
+#: The contract's unit key for what Tessera's sharding table calls
+#: ``TESSERA_FP8``: both axes shard.
+FP8 = "TESSERA_E4M3_K1"
+BF16 = "TESSERA_BF16_K1"
+
+#: Divides cleanly by 2 on both axes, so nothing here refuses on geometry.
+SHAPE = (2048, 1024)
+
+_BOTH_SHARDED = {"row": "sharded", "column": "sharded"}
+#: What the pinned contract publishes for the K2 family.
+_COLUMN_CUT_REFUSED = {"row": "refused", "column": "sharded"}
+
+
+@pytest.fixture
+def dev_pin(monkeypatch):
+    """Turn on the Tessera development pin for one test.
+
+    Never autouse: with no pin the contract is ``None`` and the axis leg must
+    stay out of the way, which is its own test below.
+    """
+    monkeypatch.setenv(trc.TESSERA_DEV_PIN_ENV, trc.TESSERA_DEV_PIN_COMMIT)
+    return trc.TESSERA_DEV_PIN_COMMIT
+
+
+def _axis_contract(monkeypatch, axes):
+    """A stand-in contract that publishes ``axes`` and attests nothing.
+
+    It governs no family on purpose: the axis leg is a LOADER fact and must
+    answer without a route claim, so a table that attests nothing is the
+    honest witness for it.
+    """
+    contract = SimpleNamespace(
+        commit="synthetic",
+        requires_serving_context=False,
+        lane_schema="legacy",
+        max_world_size={},
+        reader_rate_range={},
+        attested_rungs={},
+        loader_axes=axes,
+        governs=lambda name: False,
+        native_cells=lambda name, rate, **_kw: (),
+    )
+    monkeypatch.setattr(tm, "tessera_runtime_contract", lambda: contract)
+    return contract
+
+
+def _rungs(family, *, tp_degree, parallel_kind):
+    return [
+        rung
+        for rung in tm.expand_tessera_menu(
+            SHAPE, mode=tm.MENU_RESEARCH,
+            tp_degree=tp_degree, parallel_kind=parallel_kind)
+        if rung.family == family
+    ]
+
+
+def _menu(family, *, tp_degree, parallel_kind):
+    return {rung.format_name for rung in
+            _rungs(family, tp_degree=tp_degree, parallel_kind=parallel_kind)}
+
+
+def _first_rung(family):
+    """A rung this family really carries on ``SHAPE``, from the menu itself.
+
+    Hard-coding one would make a geometry refusal read as an axis refusal.
+    """
+    rungs = _rungs(family, tp_degree=1, parallel_kind=tm.PARALLEL_NONE)
+    assert rungs, f"{family} carries no rung on {SHAPE}"
+    return rungs[0].body_rate_q256
+
+
+def _axes_payload(units):
+    return {"tensor_parallel": {"axis": "vllm_tensor_parallel_world_size",
+                                "semantics": "closed_world",
+                                "units": list(units)}}
+
+
+def _unit(name, axes, *, max_world_size=1):
+    unit = {"unit": name, "kind": "tessera_wire_family",
+            "max_world_size": max_world_size}
+    if axes is not None:
+        unit["loader_axes"] = {
+            axis: {"status": status, "reason": None}
+            for axis, status in axes.items()
+        }
+    return unit
+
+
+def _written(tmp_path, payload, name="runtime_contract.json"):
+    path = tmp_path / name
+    raw = json.dumps(payload, indent=1).encode("utf-8")
+    path.write_bytes(raw)
+    return str(path), hashlib.sha256(raw).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# The contract reader: a published vocabulary, or a refusal
+# ---------------------------------------------------------------------------
+
+def test_the_pinned_contract_round_trips_every_declared_loader_axis(dev_pin):
+    """The real table, read through the real loader, for all three families."""
+    contract = trc.load_tessera_contract()
+    assert contract is not None, "the dev pin must load"
+    assert contract.loader_axes == {
+        E2M1: {"column": "sharded", "row": "refused"},
+        FP8: {"column": "sharded", "row": "sharded"},
+        BF16: {"column": "sharded", "row": "sharded"},
+    }
+    assert set(contract.loader_axes) == set(contract.max_world_size), (
+        "both facts come off the same unit row; a family with a ceiling and "
+        "no axis claim would be half-read"
+    )
+
+
+def test_the_published_axes_accessor_reads_the_same_table(tmp_path):
+    """The file-reading path and the parsed-contract path are one reader."""
+    path, sha = _written(tmp_path, _axes_payload([
+        _unit(E2M1, _COLUMN_CUT_REFUSED), _unit(FP8, _BOTH_SHARDED)]))
+    assert trc.published_tensor_parallel_axes(path, sha) == {
+        E2M1: {"column": "sharded", "row": "refused"},
+        FP8: {"column": "sharded", "row": "sharded"},
+    }
+
+
+def test_a_unit_with_no_loader_axes_block_is_refused(tmp_path):
+    """Absence is not "both axes shard"; it is a table this reader cannot use."""
+    path, sha = _written(tmp_path, _axes_payload([_unit(FP8, None)]))
+    with pytest.raises(trc.TesseraContractError) as excinfo:
+        trc.published_tensor_parallel_axes(path, sha)
+    assert "loader_axes" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("axes", [
+    pytest.param({"row": "sharded"}, id="missing-an-axis"),
+    pytest.param({"row": "sharded", "column": "sharded", "diagonal": "sharded"},
+                 id="an-axis-this-reader-does-not-know"),
+])
+def test_an_axis_vocabulary_this_reader_does_not_share_is_refused(tmp_path, axes):
+    path, sha = _written(tmp_path, _axes_payload([_unit(FP8, axes)]))
+    with pytest.raises(trc.TesseraContractError):
+        trc.published_tensor_parallel_axes(path, sha)
+
+
+def test_a_status_this_reader_does_not_know_is_refused(tmp_path):
+    """``maybe`` is neither ``sharded`` nor ``refused``, so it is neither."""
+    path, sha = _written(tmp_path, _axes_payload([
+        _unit(FP8, {"row": "maybe", "column": "sharded"})]))
+    with pytest.raises(trc.TesseraContractError) as excinfo:
+        trc.published_tensor_parallel_axes(path, sha)
+    assert "maybe" in str(excinfo.value)
+
+
+def test_a_status_read_from_prose_is_refused(tmp_path):
+    """The status field is the value; the reason beside it is never read."""
+    payload = _axes_payload([_unit(FP8, _BOTH_SHARDED)])
+    unit = payload["tensor_parallel"]["units"][0]
+    unit["loader_axes"]["row"] = {"reason": "sharded"}
+    path, sha = _written(tmp_path, payload)
+    with pytest.raises(trc.TesseraContractError) as excinfo:
+        trc.published_tensor_parallel_axes(path, sha)
+    assert "status" in str(excinfo.value)
+
+
+def test_the_answer_carries_the_axis_statuses_and_not_their_prose(dev_pin):
+    """A value a gate reads is answer (principle 14); the reason is not.
+
+    Widening the projection is itself the re-review, so this asserts the
+    shape of what was widened: statuses only, per family, beside the ceiling
+    they are deliberately not a spelling of.
+    """
+    contract = trc.load_tessera_contract()
+    answer = trc.contract_answer(contract)
+    for family in (E2M1, FP8, BF16):
+        entry = answer["families"][family]
+        assert set(entry) == {
+            "reader_rate_range_q256", "attested_rungs_q256", "max_world_size",
+            "loader_axes",
+        }
+        assert set(entry["loader_axes"]) == {"row", "column"}
+        assert set(entry["loader_axes"].values()) <= {"sharded", "refused"}
+    assert answer["families"][E2M1]["loader_axes"]["row"] == "refused"
+    assert "state_{-1}" not in repr(answer), (
+        "the publisher's reason is prose and no gate reads it"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The legality leg
+# ---------------------------------------------------------------------------
+
+def test_a_refused_cut_axis_refuses_the_rung_at_tp2(monkeypatch):
+    """The regression: one family refused on the axis a column cut asks for."""
+    _axis_contract(monkeypatch, {E2M1: _COLUMN_CUT_REFUSED, FP8: _BOTH_SHARDED})
+    at_one = _rungs(E2M1, tp_degree=1, parallel_kind=tm.PARALLEL_COLUMN)
+    assert at_one, "the synthetic table must leave K2 rungs to remove"
+    body_rate_q256 = at_one[0].body_rate_q256
+
+    legal, reason = tm.tessera_tp_legal(
+        E2M1, body_rate_q256, SHAPE,
+        tp_degree=1, parallel_kind=tm.PARALLEL_COLUMN)
+    assert legal, reason
+
+    legal, reason = tm.tessera_tp_legal(
+        E2M1, body_rate_q256, SHAPE,
+        tp_degree=2, parallel_kind=tm.PARALLEL_COLUMN)
+    assert not legal
+    assert reason == f"tp_axis_refused:{E2M1}:{E2M1}:row", reason
+
+
+def test_the_axis_leg_does_not_wait_for_the_attestation_leg(monkeypatch):
+    """Two legs, and this one answers on its own.
+
+    ``require_attested_world`` turns the world-size question on. The loader
+    fact is a different question -- can the loader cut it at all -- and a
+    research menu that prices unattested rungs on purpose still must not
+    price a cut the loader refuses on every rank.
+    """
+    _axis_contract(monkeypatch, {E2M1: _COLUMN_CUT_REFUSED})
+    for require in (False, True):
+        legal, reason = tm.tessera_tp_legal(
+            E2M1, _first_rung(E2M1), SHAPE, tp_degree=2,
+            parallel_kind=tm.PARALLEL_COLUMN,
+            require_attested_world=require)
+        assert not legal
+        assert reason.startswith("tp_axis_refused:"), (require, reason)
+
+
+def test_the_refusal_names_the_linear_when_the_caller_knows_it(monkeypatch):
+    """``tp_axis_refused:<family>:<unit>:<axis>`` -- unit is the caller's."""
+    _axis_contract(monkeypatch, {E2M1: _COLUMN_CUT_REFUSED})
+    qname = "model.layers.0.self_attn.q_proj"
+    legal, reason = tm.tessera_tp_legal(
+        E2M1, _first_rung(E2M1), SHAPE, tp_degree=2,
+        parallel_kind=tm.PARALLEL_COLUMN, unit=qname)
+    assert not legal
+    assert reason == f"tp_axis_refused:{E2M1}:{qname}:row"
+
+
+def test_the_other_cut_direction_is_not_refused(monkeypatch):
+    """Only the refused axis is refused: a row-parallel cut asks about columns."""
+    _axis_contract(monkeypatch, {E2M1: _COLUMN_CUT_REFUSED})
+    _, reason = tm.tessera_tp_legal(
+        E2M1, _first_rung(E2M1), SHAPE, tp_degree=2,
+        parallel_kind=tm.PARALLEL_ROW)
+    assert "tp_axis_refused" not in reason
+
+
+def test_a_family_that_shards_both_axes_passes_at_both_degrees(monkeypatch):
+    """The control arm: same table, same shape, no refusal at either degree."""
+    _axis_contract(monkeypatch, {E2M1: _COLUMN_CUT_REFUSED, FP8: _BOTH_SHARDED})
+    at_one = _menu(FP8, tp_degree=1, parallel_kind=tm.PARALLEL_COLUMN)
+    at_two = _menu(FP8, tp_degree=2, parallel_kind=tm.PARALLEL_COLUMN)
+    assert at_one, "the control family must have rungs on this shape"
+    assert at_two == at_one, sorted(at_one ^ at_two)
+
+    assert _menu(E2M1, tp_degree=2, parallel_kind=tm.PARALLEL_COLUMN) == set(), (
+        "the refused family leaves the menu at the degree it is refused at"
+    )
+
+
+def test_a_whole_unit_is_never_refused_on_an_axis_it_does_not_cut(monkeypatch):
+    """``tp=1`` and ``PARALLEL_NONE`` shard nothing, so no axis is asked."""
+    _axis_contract(monkeypatch, {E2M1: _COLUMN_CUT_REFUSED})
+    rung = _first_rung(E2M1)
+    for tp, kind in ((1, tm.PARALLEL_COLUMN), (2, tm.PARALLEL_NONE)):
+        legal, reason = tm.tessera_tp_legal(
+            E2M1, rung, SHAPE, tp_degree=tp, parallel_kind=kind)
+        assert legal, (tp, kind, reason)
+
+
+def test_with_no_contract_pinned_the_axis_leg_adds_no_refusal(monkeypatch):
+    """This leg subtracts on a published fact; it never invents one.
+
+    With no pinned table there is no loader fact to read, and refusing here
+    would make the TP gate a second route gate that turns Tessera off on the
+    research menu -- whose whole purpose is to price what nothing attests.
+    """
+    monkeypatch.setattr(tm, "tessera_runtime_contract", lambda: None)
+    legal, reason = tm.tessera_tp_legal(
+        E2M1, _first_rung(E2M1), SHAPE, tp_degree=2,
+        parallel_kind=tm.PARALLEL_COLUMN)
+    assert legal, reason
+
+
+def test_a_family_the_table_does_not_list_gets_no_axis_verdict(monkeypatch):
+    """Silence about a family is silence, not a refusal.
+
+    The closed world lives on ``max_world_size`` and the attestation leg
+    reads it. This leg reports a published status and nothing else.
+    """
+    _axis_contract(monkeypatch, {FP8: _BOTH_SHARDED})
+    legal, reason = tm.tessera_tp_legal(
+        E2M1, _first_rung(E2M1), SHAPE, tp_degree=2,
+        parallel_kind=tm.PARALLEL_COLUMN)
+    assert legal, reason

--- a/tests/test_tessera_tp_loader_axes.py
+++ b/tests/test_tessera_tp_loader_axes.py
@@ -44,29 +44,23 @@ _BOTH_SHARDED = {"row": "sharded", "column": "sharded"}
 _COLUMN_CUT_REFUSED = {"row": "refused", "column": "sharded"}
 
 
-@pytest.fixture
-def dev_pin(monkeypatch):
-    """Turn on the Tessera development pin for one test.
-
-    Never autouse: with no pin the contract is ``None`` and the axis leg must
-    stay out of the way, which is its own test below.
-    """
-    monkeypatch.setenv(trc.TESSERA_DEV_PIN_ENV, trc.TESSERA_DEV_PIN_COMMIT)
-    return trc.TESSERA_DEV_PIN_COMMIT
-
-
-def _axis_contract(monkeypatch, axes):
+def _axis_contract(monkeypatch, axes, *, max_world_size=8):
     """A stand-in contract that publishes ``axes`` and attests nothing.
 
     It governs no family on purpose: the axis leg is a LOADER fact and must
     answer without a route claim, so a table that attests nothing is the
     honest witness for it.
+
+    ``max_world_size`` is deliberately generous. The attestation leg is a
+    different question and it must not be the leg that answers here: a table
+    that attested nothing would refuse first and hide whether the axis leg
+    works at all.
     """
     contract = SimpleNamespace(
         commit="synthetic",
         requires_serving_context=False,
         lane_schema="legacy",
-        max_world_size={},
+        max_world_size={family: max_world_size for family in axes},
         reader_rate_range={},
         attested_rungs={},
         loader_axes=axes,
@@ -130,19 +124,38 @@ def _written(tmp_path, payload, name="runtime_contract.json"):
 # The contract reader: a published vocabulary, or a refusal
 # ---------------------------------------------------------------------------
 
-def test_the_pinned_contract_round_trips_every_declared_loader_axis(dev_pin):
-    """The real table, read through the real loader, for all three families."""
-    contract = trc.load_tessera_contract()
-    assert contract is not None, "the dev pin must load"
-    assert contract.loader_axes == {
+def _installed_contract():
+    """The contract bytes the importable Tessera actually packages."""
+    from importlib.resources import as_file
+
+    with as_file(trc.contract_path()) as path:
+        raw = path.read_bytes()
+        return str(path), hashlib.sha256(raw).hexdigest(), json.loads(raw)
+
+
+def test_the_real_pinned_contract_round_trips_every_declared_loader_axis():
+    """The real table, read by the real reader, for all three families.
+
+    Read off the packaged file rather than through ``load_tessera_contract``
+    so this says what the TABLE publishes and not what the answer pin
+    accepts: the two are separate refusals and the answer pin has its own
+    test.
+    """
+    path, sha, payload = _installed_contract()
+    assert trc.published_tensor_parallel_axes(path, sha) == {
         E2M1: {"column": "sharded", "row": "refused"},
         FP8: {"column": "sharded", "row": "sharded"},
         BF16: {"column": "sharded", "row": "sharded"},
     }
-    assert set(contract.loader_axes) == set(contract.max_world_size), (
+    assert (set(trc.published_tensor_parallel_axes(path, sha))
+            == set(trc.published_tensor_parallel_limits(path, sha))), (
         "both facts come off the same unit row; a family with a ceiling and "
         "no axis claim would be half-read"
     )
+    for unit in payload["tensor_parallel"]["units"]:
+        assert "reason" in unit["loader_axes"]["row"], (
+            "the publisher's prose is there to be ignored, not absent"
+        )
 
 
 def test_the_published_axes_accessor_reads_the_same_table(tmp_path):
@@ -194,15 +207,15 @@ def test_a_status_read_from_prose_is_refused(tmp_path):
     assert "status" in str(excinfo.value)
 
 
-def test_the_answer_carries_the_axis_statuses_and_not_their_prose(dev_pin):
-    """A value a gate reads is answer (principle 14); the reason is not.
+def test_the_reviewed_answer_carries_the_axis_statuses():
+    """A value a gate reads is answer; widening the projection is the review.
 
-    Widening the projection is itself the re-review, so this asserts the
-    shape of what was widened: statuses only, per family, beside the ceiling
-    they are deliberately not a spelling of.
+    The literal is what refuses, so this asserts the shape of what was
+    widened: statuses only, per family, beside the ceiling they are
+    deliberately not a spelling of. The publisher's reason is prose and
+    stays out.
     """
-    contract = trc.load_tessera_contract()
-    answer = trc.contract_answer(contract)
+    answer = trc.TESSERA_DEV_PIN_ANSWER
     for family in (E2M1, FP8, BF16):
         entry = answer["families"][family]
         assert set(entry) == {
@@ -215,6 +228,22 @@ def test_the_answer_carries_the_axis_statuses_and_not_their_prose(dev_pin):
     assert "state_{-1}" not in repr(answer), (
         "the publisher's reason is prose and no gate reads it"
     )
+
+
+def test_the_projection_emits_what_the_reviewed_answer_declares():
+    """``contract_answer`` really reads the field the literal was widened for.
+
+    Against the installed contract, whichever pin it carries: every build
+    that publishes this block publishes the same statuses, and a literal that
+    named a field the projection never emitted would drift on every run.
+    """
+    path, sha, payload = _installed_contract()
+    contract = trc._parse(payload, commit="installed", sha=sha, path=path)
+    answer = trc.contract_answer(contract)
+    for family in (E2M1, FP8, BF16):
+        assert (answer["families"][family]["loader_axes"]
+                == dict(sorted(contract.loader_axes[family].items())))
+    assert answer["families"][E2M1]["loader_axes"]["row"] == "refused"
 
 
 # ---------------------------------------------------------------------------
@@ -246,9 +275,13 @@ def test_the_axis_leg_does_not_wait_for_the_attestation_leg(monkeypatch):
     ``require_attested_world`` turns the world-size question on. The loader
     fact is a different question -- can the loader cut it at all -- and a
     research menu that prices unattested rungs on purpose still must not
-    price a cut the loader refuses on every rank.
+    price a cut the loader refuses on every rank. The table here attests the
+    world size, so the attestation leg passes in both modes and the axis leg
+    is the one that answers.
     """
     _axis_contract(monkeypatch, {E2M1: _COLUMN_CUT_REFUSED})
+    attested, why = tm.tessera_tp_world_attested(E2M1, 2)
+    assert attested, why
     for require in (False, True):
         legal, reason = tm.tessera_tp_legal(
             E2M1, _first_rung(E2M1), SHAPE, tp_degree=2,


### PR DESCRIPTION
Closes #536

The pinned Tessera contract's `tensor_parallel` unit rows publish two
different facts and PrismaQuant read one of them.

- `max_world_size` is the **attestation** bound: the largest world size a
  served receipt covers. It is 1 for every family, and
  `tessera_tp_world_attested` already reads it.
- `loader_axes` is what this build's **loader** does with a shard on each
  axis, `sharded` or `refused`. Tessera validates it equal to the
  `ROUTE_TP_AXES` its routes gate on at `create_weights`, so it is a
  machine-readable status a gate may read (principle 14). Nothing on this
  side read it.

It refuses `TESSERA_E2M1_K2` on the `row` axis, on **every** rank: a row shard
begins mid-column, so it carries an `INITIAL_STATE` plane, and the span-2 TCQ
decoders that route packs for supply `state_{-1}` themselves. A
column-parallel Linear splits vLLM's output features, which are this unit's
rows, so every column-parallel K2 unit is unloadable at TP > 1 at any shape --
and the allocator priced it as if it sharded. The GLM-5.3 first export needs a
TP2 audit before Step 6, and this is the fact that audit turns on.

## What lands

**1. The contract reader.** `tensor_parallel.units[].loader_axes` parses into
`TesseraContract.loader_axes`, through one function that reads both facts off
the same unit row so a row cannot be half-read. A missing block, an axis this
reader does not share, a status it does not know, and a `status` read off the
prose beside it are all refusals -- reading absence as `sharded` would price a
cut the loader refuses. `published_tensor_parallel_axes(path, sha)` reads the
same table off a contract file for callers holding a path.

**2. The reviewed answer widened, deliberately.** A value a gate reads belongs
in `contract_answer`, so the statuses join the `families` projection and
`TESSERA_DEV_PIN_ANSWER` moved with them. That diff is the review. Statuses
only: the publisher's `reason` is prose and stays out.

**3. The third leg.** `tessera_menu.tessera_tp_axis_legal`, asked by
`tessera_tp_legal` before the geometry leg because a refused axis is refused
on every rank -- no world size and no shape makes it legal, so naming a
granularity there would name the wrong obstacle. It is independent of
`require_attested_world`: "has this been measured" and "will this even load"
are separate questions, and the research menu prices unattested rungs on
purpose but must not price an unloadable cut. It subtracts on a published
status and never invents one -- no pinned contract, or a family the block does
not list, passes through, and the closed world stays on `max_world_size`
where the attestation leg reads it. Refusals read
`tp_axis_refused:<family>:<unit>:<axis>`; the allocator passes the qname so
`<unit>` names the Linear.

**4. `python -m prismaquant.tessera_tp_audit`** -- read-only Step 5b:

```
python -m prismaquant.tessera_tp_audit \
    --layer-config artifacts/layer_config.json \
    --target-profile glm_packed_research_sm121 --tp 2 \
    [--contract <runtime_contract.json>] --out artifacts/tp2_audit.json
```

`require_attested_world=False` plus the loader-axis leg, packed experts
asserted to a `none` cut (expert parallelism cuts the stack and leaves each
expert's 2-D unit whole), per-unit JSON verdicts, exit 1 on any refusal, exit
2 when it cannot run. It never writes the assignment: the answer to a refusal
is a re-run of the allocation with the offending rung excluded by that
measured fact (principle 1), never a hand edit.

Two legs it does **not** audit, stated in a receipt field rather than left to
silence: shard geometry, because `layer_config.json` is a qname-to-format
recipe carrying no shapes and the geometry leg asks about the shard a rank
holds; and the attested world size, which is the other question -- each unit
records the contract's `max_world_size` instead.

## Evidence

Tests route through PrismaBuild `pbtest.py` at `--priority -10` on
`--tag x86` (pq-cpu312), never a GPU tag. Receipts on the issue.

Red first: `tests/test_tessera_tp_loader_axes.py` alone on the test-only
commit, `12 failed, 4 passed`, returncode 1. Green after the implementation
commit, with `tests/test_tessera_tp_audit.py` beside it.

`docs/ARCHITECTURE.md` is re-stamped in the same commit as the code, and
`prismaquant/README.md` gains the audit entry point.

## The receipt on the fixture, at `--tp 2`

One refusal, named:
`tp_axis_refused:TESSERA_E2M1_K2:model.layers.0.self_attn.q_proj:row`. The
row-parallel K2 Linear passes (its cut asks about `column`, which shards), the
E4M3 and BF16 units pass on both axes, and the packed experts pass because
they resolve to `none` -- which is the interesting case, since the fixture
gives them the family whose row axis is refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmYxSxhmzbBcBoFTjbLi1G
