### PR TITLE
Sweep the prefill SLO into a frontier, one single solve per point

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,29 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-12 · `pq/530-amd-serving-profiles`. Stamps
+As of: 2026-09-13 · `pq/prefill-frontier-sweep`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-13, `pq/prefill-frontier-sweep`) for the **prefill-vs-
+accuracy frontier sweep** (#540, the sweep half of #237):
+`python -m prismaquant.prefill_frontier` drives the measured-runtime
+allocator over a grid of prefill p95-TTFT budgets and writes one
+`prismaquant.prefill_frontier.v1` document -- per point the objective, exact
+payload bytes, attained operator-sum prefill (and decode when priced), the
+assignment digest and file, feasibility or the solver's refusal reason;
+nondominance under `select_validated_frontier`'s envelope rule; and a
+**measured** saturation point (the attained prefill of the solve at the
+table's upper bound), verified against every looser point. Every point is
+the ordinary single solve: `allocator.main(argv, measured_runtime_sweep=...)`
+is the one new seam, prices the table once and hands the sweep a
+`MeasuredRuntimeSweep.solve(slo_ms, target_bits)` that runs the unchanged
+`_solve_for_target` / `solve_runtime_frontier` path; the DP is not
+re-implemented and the default path is byte-identical (§4.5). The grid is
+explicit, the solver's own breakpoints (`prefill_slo_breakpoints_ms`, now in
+every measured-runtime solve's diagnostics), or N linear points; no default.
+No real v2 table exists, so the curve is exercised on synthetic CPU tables
+only; what the producer side owes is stated, gate by gate, in
+`docs/design/joint_aura_runtime_allocation.md` §Frontier sweep. Gates:
+`tests/test_prefill_frontier.py`, `tests/test_allocator_measured_runtime_cli.py`.
 
 Re-stamped (2026-09-12, `pq/530-amd-serving-profiles`) for the two **AMD
 Tessera serving profiles** (#530): `serving_profile_specs/
@@ -7988,6 +8010,24 @@ role-split checkpoint is unloadable. Default off.
 
 Candidate legality, passthrough integrity, cost-source precedence and fused-sibling aggregation
 also live in `allocator_candidates.py`; the invariants they enforce are §6.4's.
+
+**Measured-runtime frontier sweep (2026-09-13, #540).** The opt-in measured-runtime path
+(`--measured-runtime-table` + `--measured-runtime-context` + `--slo-prefill-p95-ttft-ms`,
+`allocator_solver.solve_runtime_frontier`) answers one prefill budget per run.
+`prismaquant/prefill_frontier.py` sweeps that budget: `allocator.main(argv,
+measured_runtime_sweep=...)` loads, checks and prices the table once and hands the sweep a
+`MeasuredRuntimeSweep` whose `solve(slo_ms, target_bits)` is the unchanged single solve at
+that budget. The output, `prismaquant.prefill_frontier.v1`, carries the whole curve -- per
+point `slo_ms`, `predicted_dloss`, `payload_bytes`, `achieved_bits`, `attained_prefill_ms`
+(fixed work included), `attained_decode_ms`, `device_memory_bytes`, `assignment_sha256` and
+`assignment_path`, `refusal_reason`, `nondominated` -- plus `saturation` (measured at the
+table's upper bound and verified), `slo_axis` (table-derived bounds), `monotone_loss`, and
+provenance (table identity, context, cost digest, git commit, allocator argv). The grid is
+`--slo-ms`, `--slo-grid auto` (the solve's own `prefill_slo_breakpoints_ms`) or `--slo-grid N`;
+there is no default and no knee. An exact-search bound refusal inside a sweep is that point's
+`refusal_reason`; a single solve still exits. Loader refusals (stale cost digest, bad rows,
+context drift) surface unchanged. Synthetic CPU coverage only until a real v2 table exists
+(`docs/design/joint_aura_runtime_allocation.md` §Frontier sweep names what Tessera owes).
 
 ### 4.6 Selection
 

--- a/docs/design/joint_aura_runtime_allocation.md
+++ b/docs/design/joint_aura_runtime_allocation.md
@@ -151,6 +151,81 @@ auxiliary choices against the same measured resource contract. The sum of
 operator medians is a proposal estimate, not an end-to-end p95 TTFT or decode
 measurement. Existing serving and publication gates remain authoritative.
 
+## Frontier sweep
+
+`python -m prismaquant.prefill_frontier` (#540) turns the single-budget
+question above into the curve Rob asked for: one measured-runtime solve per
+prefill p95-TTFT budget, written as a `prismaquant.prefill_frontier.v1`
+document. The grid is explicit (`--slo-ms a,b,c`), the solver's own
+breakpoints (`--slo-grid auto`: the prefill values at which the lowest-loss
+proposal changes, from `prefill_slo_breakpoints_ms` in the solve
+diagnostics), or `N` linearly spaced budgets from the table's lower bound to
+the saturation point (`--slo-grid N`). Nothing is defaulted.
+
+Every point is the ordinary solve. `allocator.main(argv,
+measured_runtime_sweep=...)` loads, checks and prices the table exactly once,
+then hands the sweep a `MeasuredRuntimeSweep` whose `solve(slo_ms,
+target_bits)` runs the same `_solve_for_target` path, the same
+`solve_runtime_frontier` search and the same exact payload and serving checks
+one `--slo-prefill-p95-ttft-ms` run takes
+(`tests/test_prefill_frontier.py::test_sweep_point_equals_the_single_solve_at_that_slo`).
+The DP is not re-implemented, and the sweep's presence changes nothing on the
+default path (`test_default_allocator_path_is_untouched_by_the_hook`).
+
+The document records per point the SLO, `predicted_dloss`, exact payload
+bytes, the attained operator-sum prefill (fixed work included), decode when
+priced, device bytes, the assignment digest and the file it was written to,
+and either feasibility or the solver's refusal reason (including an
+exact-search bound refusal, which inside a sweep ends that point, not the
+sweep). It flags nondominance under `select_validated_frontier`'s
+lower-envelope rule on (attained prefill, `predicted_dloss`), with a noise
+floor that defaults to zero because the objective is deterministic. The
+saturation point is measured, not chosen: the attained prefill of the solve
+at the table's upper bound (fixed prefill plus every unit's slowest priced
+option), and the document checks that every point at or above it returned
+the same assignment. The whole curve is the answer; no knee is reported.
+
+**What the Tessera side must deliver for a real table.** The sweep consumes
+a `prismaquant.measured_runtime_prices.v2` table and nothing else; today none
+exists, and the consumer's own gates say exactly what is owed:
+
+- Native rows: one `native_receipt_bindings` entry per priced `(unit,
+  format)` -- `panel`, `receipt` and `memory_trace` artifacts -- admitted by
+  `runtime_provenance.admit_native_rows` (`runtime_provenance.py:622-697`)
+  through the same `consume_native_receipt` / `consume_moe_receipt`
+  consumers as #267. Each row needs **both** measured phases (`prefill` and
+  `decode`; a null decode refuses as "lacks a complete measured phase"), a
+  non-null per-phase `peak_scratch_bytes`, the panel's prefill `m` equal to
+  the context's `prompt_tokens`, batch size one, and the panel's runtime,
+  cost, source and calibration digests equal to the table's.
+- Fixed resources: `fixed_resources_receipt_path` must carry
+  `full_model_resources: {path, sha256}` naming a
+  `tessera.full_engine_resource_report.v1` report that
+  `full_engine_resource_report.consume_full_engine_resource_report`
+  recomputes from `observations` and `partition`
+  (`runtime_provenance.admit_fixed_resources`, `:418-453`). At report v1 the
+  owed observations (`OWED_OBSERVATIONS`: `kv_observations`,
+  `observer_qualification`, `owner_views`, `runtime_provenance_relation`,
+  `timing_captures`, `worker_startup_records`) are named and null, **and the
+  report has no timing partition at all**: a table declaring a nonzero fixed
+  `prefill_ms` or `decode_ms` is refused by name
+  (`_fixed_resource_refusals`, `:614-618`). A fixed `prefill_ms` of zero is
+  admissible only if the engine truly does no non-candidate prefill work,
+  which no capture has shown. Opening the prefill axis for real therefore
+  needs a report version that observes and partitions fixed timing, plus the
+  versioned native/full-engine transient charge boundary the same function
+  still refuses (`:609-610`); that is #420's producer half, tracked with
+  #237.
+- The context: a `prismaquant.measured_runtime_context.v2` with the
+  provenance-relation identity (`runtime_provenance_relation.md`), the same
+  `source_sha256` and `calibration_sha256` the joint AURA cost rows carry,
+  and an operator route per `(unit, format)`.
+
+Until that table exists the sweep is exercised only on synthetic CPU tables
+(`tests/test_prefill_frontier.py`, extending the fixture in
+`tests/test_allocator_measured_runtime_cli.py`); a curve it produces is a
+proposal under the sequential operator-sum model and certifies no p95.
+
 ## Validation and promotion plan
 
 The baseline is weight-only AURA over exactly the same production renders,

--- a/prismaquant/allocator.py
+++ b/prismaquant/allocator.py
@@ -90,7 +90,8 @@ import pickle
 import re
 import time as _time
 from collections import Counter, defaultdict
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from pathlib import Path
 
 from . import format_registry as fr
@@ -1667,7 +1668,48 @@ def clip_probe_fisher_outliers(stats: dict, meta: dict | None = None, *,
     return summary
 
 
-def main():
+@dataclass(frozen=True)
+class MeasuredRuntimeSweep:
+    """What ``main(measured_runtime_sweep=...)`` hands its caller.
+
+    ``solve(slo_ms, target_bits)`` runs one ordinary measured-runtime solve at
+    that prefill p95-TTFT budget -- the same ``_solve_for_target`` path, the
+    same exact payload and serving checks -- and returns a plain record:
+    ``feasible``, ``reason`` (when not), the expanded ``assignment``,
+    ``achieved_bits``, ``payload_bytes``, ``predicted_dloss``, the
+    ``serve_constraints`` verdict (whose ``predicted.operator_sum_prefill_ms``
+    is the attained prefill, fixed work included) and the solver
+    ``diagnostics`` (including ``prefill_slo_breakpoints_ms``). The two
+    prefill sums bound the SLO axis from the table alone: no assignment can
+    attain less than ``fixed_resources.prefill_ms + unit_min_prefill_sum_ms``,
+    and none needs more than the max sum.
+    """
+
+    solve: Callable[[float, float], dict]
+    table_identity: dict
+    runtime_context: dict
+    fixed_resources: dict
+    unit_min_prefill_sum_ms: float
+    unit_max_prefill_sum_ms: float
+    n_units: int
+    target_bits: float
+    slos: ServeSLOs
+    cost_path: str
+    probe_path: str
+
+
+def main(argv: list[str] | None = None, *, measured_runtime_sweep=None):
+    """Allocator CLI. ``argv`` defaults to ``sys.argv[1:]``.
+
+    ``measured_runtime_sweep`` is the one seam for a caller that needs several
+    single solves over one loaded allocator state instead of one: the prefill
+    frontier sweep (``prismaquant.prefill_frontier``). When it is given, the
+    measured-runtime inputs are loaded, checked and priced exactly as for a
+    single solve, then the callable receives a :class:`MeasuredRuntimeSweep`
+    and ``main`` returns without writing the layer config, Pareto CSV or
+    selection. ``None`` -- every existing caller -- is the unchanged
+    single-solve path.
+    """
     from .tessera_serving_scope import (
         add_serving_scope_arguments, serving_target_from_args,
         context_by_unit_from_stats, scope_provenance,
@@ -2128,17 +2170,24 @@ def main():
                     help="Operator-supplied peak scratch bytes for the "
                          "device memory constraint (not modelled by the "
                          "allocator).")
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
 
     if args.measured_runtime_context and not args.measured_runtime_table:
         ap.error("--measured-runtime-context requires --measured-runtime-table")
+    if measured_runtime_sweep is not None and not args.measured_runtime_table:
+        ap.error("a measured runtime sweep requires --measured-runtime-table")
     if args.measured_runtime_table:
         if args.serve_dispatch_table or args.serve_workload_mix:
             ap.error("--measured-runtime-table is mutually exclusive with "
                      "--serve-dispatch-table and --serve-workload-mix")
         if not args.measured_runtime_context:
             ap.error("--measured-runtime-table requires --measured-runtime-context")
-        if args.slo_prefill_p95_ttft_ms is None:
+        if measured_runtime_sweep is not None:
+            # The sweep owns the prefill budget: it sets one per grid point.
+            if args.slo_prefill_p95_ttft_ms is not None:
+                ap.error("--slo-prefill-p95-ttft-ms belongs to the prefill "
+                         "frontier sweep grid, not to its allocator arguments")
+        elif args.slo_prefill_p95_ttft_ms is None:
             ap.error("--measured-runtime-table requires --slo-prefill-p95-ttft-ms "
                      "as an operator-sum proposal budget")
         if args.slo_decode_p05_tps is not None:
@@ -3848,7 +3897,7 @@ def main():
         requested_target = float(target_bits)
         mutable_target_bits = requested_target
         if measured_runtime_table is not None:
-            from .allocator_solver import solve_runtime_frontier
+            from .allocator_solver import RuntimeFrontierLimitError, solve_runtime_frontier
             fixed = measured_runtime_table.fixed_resources
             fixed_device = (fixed.resident_bytes + fixed.activation_bytes
                             + fixed.peak_scratch_bytes + fixed.kv_bytes
@@ -3875,9 +3924,33 @@ def main():
                     max_prefill_ms=max_prefill, max_decode_ms=max_decode,
                     max_device_bytes=serve_slos.device_budget_bytes,
                     fixed_device_bytes=fixed_device, diagnostics=diag)
+            except RuntimeFrontierLimitError as exc:
+                # Inside a sweep one grid point over the exact-search bound is
+                # that point's recorded refusal, not the end of the sweep; a
+                # single solve keeps exiting, as before.
+                if measured_runtime_sweep is None:
+                    raise SystemExit(f"[alloc] ERROR: measured runtime search: {exc}") from None
+                diag["solver_seconds"] = _time.perf_counter() - start
+                diag["reason"] = f"exact_search_refused:{diag.get('refusal')}"
+                diag["refusal_detail"] = str(exc)
+                return None, float("nan"), float("inf"), float("inf")
             except (ValueError, RuntimeError) as exc:
                 raise SystemExit(f"[alloc] ERROR: measured runtime search: {exc}") from None
             diag["solver_seconds"] = _time.perf_counter() - start
+            # The prefill values at which the lowest-loss proposal changes as
+            # the prefill budget tightens: walk the loss-ordered frontier and
+            # keep each new running minimum of operator-sum prefill. These are
+            # the exact SLO breakpoints of this solve's proposal set (before
+            # the exact payload/serving checks below), which the frontier
+            # sweep uses as its derived grid. Fixed prefill work is added back
+            # so the values are on the SLO axis.
+            breakpoints = []
+            running_min = math.inf
+            for proposal in frontier:
+                if proposal.prefill_ms < running_min:
+                    running_min = proposal.prefill_ms
+                    breakpoints.append(proposal.prefill_ms + fixed.prefill_ms)
+            diag["prefill_slo_breakpoints_ms"] = breakpoints
             for proposal in frontier:
                 raw_expanded = {}
                 for unit, fmt in proposal.assignment.items():
@@ -4068,6 +4141,71 @@ def main():
         )
 
     pareto_seed_records: list[dict] = []
+
+    if measured_runtime_sweep is not None:
+        # Prefill frontier sweep (prismaquant.prefill_frontier): several
+        # single solves over this one loaded, checked and priced allocator
+        # state, each at its own prefill budget. Every solve goes through the
+        # same _solve_for_target path a single run takes; only the prefill
+        # SLO differs between calls. Nothing below this point runs: the sweep
+        # writes its own document and no layer config or Pareto CSV exists
+        # for "the" solve, because there is no single one.
+        from dataclasses import replace as _replace
+        fixed = measured_runtime_table.fixed_resources
+        unit_min_prefill = 0.0
+        unit_max_prefill = 0.0
+        for unit, options in sorted(candidates.items()):
+            prices = [measured_runtime_resources[(unit, option.fmt)].prefill_ms
+                      for option in options]
+            unit_min_prefill += min(prices)
+            unit_max_prefill += max(prices)
+
+        def _solve_at_prefill_slo(slo_ms: float, target_bits: float) -> dict:
+            nonlocal serve_slos
+            slo_ms = float(slo_ms)
+            if not math.isfinite(slo_ms) or slo_ms <= 0:
+                raise ValueError("prefill SLO must be positive and finite")
+            serve_slos = _replace(serve_slos, p95_ttft_ms=slo_ms)
+            # The memo is keyed by target only; a new budget is a new solve.
+            _solve_cache.clear()
+            _solve_diagnostics.clear()
+            assign, achieved, total, _mutable = _solve_for_target(float(target_bits))
+            diag = _solve_diagnostics.get(round(float(target_bits), 9), {})
+            record = {"slo_ms": slo_ms, "target_bits": float(target_bits),
+                      "feasible": assign is not None,
+                      "reason": None if assign is not None else diag.get("reason"),
+                      "diagnostics": diag}
+            if assign is None:
+                return record
+            expanded = _expand_assignment_for_seed_json(assign)
+            exact = _assignment_payload_totals(
+                {name: fmt for name, fmt in expanded.items()
+                 if name not in fixed_format_assignment}, require_all_stats=True)
+            verdict = _serve_feasibility(expanded)
+            record.update({
+                "assignment": dict(expanded),
+                "achieved_bits": float(achieved),
+                "payload_bytes": int(exact["bits_total"]) // 8,
+                "quantizable_params": int(exact["quantizable_params"]),
+                "predicted_dloss": float(total),
+                "serve_constraints": verdict.as_dict(),
+            })
+            return record
+
+        measured_runtime_sweep(MeasuredRuntimeSweep(
+            solve=_solve_at_prefill_slo,
+            table_identity=measured_runtime_table.identity(),
+            runtime_context=measured_runtime_table.context.as_dict(),
+            fixed_resources=fixed.as_dict(),
+            unit_min_prefill_sum_ms=float(unit_min_prefill),
+            unit_max_prefill_sum_ms=float(unit_max_prefill),
+            n_units=len(candidates),
+            target_bits=float(args.target_bits),
+            slos=serve_slos,
+            cost_path=str(args.costs),
+            probe_path=str(args.probe),
+        ))
+        return
 
     # Pareto sweep.
     targets = [float(x) for x in args.pareto_targets.split(",")]

--- a/prismaquant/prefill_frontier.py
+++ b/prismaquant/prefill_frontier.py
@@ -1,0 +1,420 @@
+"""Prefill-vs-accuracy frontier: one measured-runtime allocator solve per SLO.
+
+The allocator's measured-runtime path (``allocator.py`` with
+``--measured-runtime-table``) answers one question: the lowest predicted
+Δloss assignment that fits the byte budget *and* one declared prefill p95-TTFT
+budget. This module asks that question across a grid of prefill budgets and
+records the whole answer -- the curve, not a knee -- as a
+``prismaquant.prefill_frontier.v1`` document.
+
+Every grid point is an ordinary single solve. ``allocator.main`` loads, checks
+and prices the table exactly once (``MeasuredRuntimeSweep``), then this module
+calls its ``solve`` per point; each call runs the same ``_solve_for_target``
+path, the same ``solve_runtime_frontier`` search and the same exact payload
+and serving checks a lone ``--slo-prefill-p95-ttft-ms`` run takes. Nothing
+about the DP is re-implemented here, and a point in the document is what the
+single-solve CLI would have produced at that SLO.
+
+What the document says, and what it does not
+--------------------------------------------
+* ``points``: per SLO, feasibility (or the solver's refusal reason), the
+  objective (``predicted_dloss``), exact payload bytes, the attained
+  operator-sum prefill (fixed work included), decode when the table prices it,
+  the assignment digest and the file it was written to, and the dominance flag.
+* ``nondominated``: the lower envelope in (attained prefill, predicted Δloss),
+  the same rule ``select_validated_frontier`` applies to its measured (bpp, KL)
+  rows, with the same noise floor semantics. The predicted objective is
+  deterministic, so the floor defaults to exactly zero.
+* ``saturation``: the SLO beyond which relaxing the budget no longer changes
+  the assignment. It is *measured*, not chosen: the attained prefill of the
+  solve at the table's own upper bound (fixed work plus every unit's slowest
+  priced option). The document then checks that every grid point at or above
+  it returned the same assignment and says so.
+* ``slo_axis``: the lower bound the table implies (fixed work plus every
+  unit's fastest priced option) and that upper bound. Points below the lower
+  bound are recorded as infeasible; they are not pruned.
+
+The curve is a *proposal* under the table's sequential operator-sum model.
+Operator sums do not certify p95 TTFT (``measured_runtime_prices``); the
+served, fixed-teacher gates in ``docs/design/joint_aura_runtime_allocation.md``
+still decide what ships. No knee is reported: the measured operating-point
+frontier is log-linear with no interior optimum, so any single "best" point
+would be a heuristic, and CLAUDE.md demotes kneedle to a diagnostic.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from .layer_config import LAYER_CONFIG_META_KEY
+from .measured_runtime_prices import identity_sha256
+
+SCHEMA = "prismaquant.prefill_frontier.v1"
+ASSIGNMENT_SCHEMA = "prismaquant.prefill_frontier.assignment.v1"
+
+
+class PrefillFrontierError(ValueError):
+    """A sweep request this module refuses to run."""
+
+
+# --------------------------------------------------------------------------- #
+# Grid
+# --------------------------------------------------------------------------- #
+
+def parse_grid_spec(slo_ms: str | None, slo_grid: str | None) -> tuple[str, object]:
+    """Return ``("explicit", [ms...])``, ``("auto", None)`` or ``("linear", n)``."""
+    if (slo_ms is None) == (slo_grid is None):
+        raise PrefillFrontierError("pass exactly one of --slo-ms or --slo-grid")
+    if slo_ms is not None:
+        values = []
+        for token in slo_ms.split(","):
+            token = token.strip()
+            if not token:
+                continue
+            try:
+                value = float(token)
+            except ValueError:
+                raise PrefillFrontierError(f"--slo-ms: {token!r} is not a number") from None
+            if not math.isfinite(value) or value <= 0:
+                raise PrefillFrontierError(f"--slo-ms: {token!r} must be positive and finite")
+            values.append(value)
+        if not values:
+            raise PrefillFrontierError("--slo-ms is empty")
+        return "explicit", sorted(set(values))
+    if slo_grid.strip().lower() == "auto":
+        return "auto", None
+    try:
+        count = int(slo_grid)
+    except ValueError:
+        raise PrefillFrontierError("--slo-grid must be 'auto' or an integer >= 2") from None
+    if count < 2:
+        raise PrefillFrontierError("--slo-grid must be 'auto' or an integer >= 2")
+    return "linear", count
+
+
+def linear_grid(lower_ms: float, upper_ms: float, count: int) -> list[float]:
+    """``count`` SLOs from the table lower bound to saturation, ends included."""
+    if upper_ms < lower_ms:
+        raise PrefillFrontierError(
+            f"grid upper bound {upper_ms} is below lower bound {lower_ms}")
+    if upper_ms == lower_ms:
+        return [lower_ms]
+    step = (upper_ms - lower_ms) / (count - 1)
+    values = [lower_ms + step * i for i in range(count)]
+    values[-1] = upper_ms
+    return values
+
+
+# --------------------------------------------------------------------------- #
+# Document
+# --------------------------------------------------------------------------- #
+
+def _attained(record: dict, key: str):
+    predicted = record.get("serve_constraints", {}).get("predicted", {})
+    return predicted.get(key)
+
+
+def nondominated_flags(points: Sequence[dict], *, loss_noise_floor: float) -> list[bool]:
+    """The validated frontier's lower-envelope rule on (attained prefill, Δloss).
+
+    ``select_validated_frontier.measured_frontier`` is written for measured
+    (bpp, KL) rows: sort by the x axis, admit a point only when it lowers the
+    running best y by more than the noise floor. The rule is generic in its
+    two axes, so it is applied here under its own column names rather than
+    copied: ``bpp`` carries attained prefill, ``kl`` carries predicted Δloss.
+    Infeasible points are never on the envelope.
+    """
+    from .select_validated_frontier import measured_frontier
+
+    rows = []
+    for index, point in enumerate(points):
+        if not point["feasible"]:
+            continue
+        rows.append({"label": str(index), "path": point["assignment_path"],
+                     "bpp": point["attained_prefill_ms"],
+                     "kl": point["predicted_dloss"]})
+    envelope = measured_frontier(rows, kl_noise_floor=loss_noise_floor, tail_veto=None)
+    kept = {row["label"] for row in envelope}
+    return [str(index) in kept for index in range(len(points))]
+
+
+def build_frontier_document(points: Sequence[dict], *, saturation: dict | None,
+                            slo_axis: dict, loss_noise_floor: float,
+                            provenance: dict) -> dict:
+    """Assemble the v1 document from per-point records (pure; no solving)."""
+    points = [dict(point) for point in points]
+    flags = nondominated_flags(points, loss_noise_floor=loss_noise_floor)
+    for point, flag in zip(points, flags):
+        point["nondominated"] = flag
+    feasible = [point for point in points if point["feasible"]]
+    monotone_violations = []
+    previous = None
+    for point in feasible:
+        if previous is not None and point["predicted_dloss"] > previous["predicted_dloss"]:
+            monotone_violations.append({"slo_ms": point["slo_ms"],
+                                        "predicted_dloss": point["predicted_dloss"],
+                                        "previous_slo_ms": previous["slo_ms"],
+                                        "previous_predicted_dloss": previous["predicted_dloss"]})
+        previous = point
+    if saturation is not None:
+        above = [point for point in points if point["slo_ms"] >= saturation["slo_ms"]]
+        differing = [point["slo_ms"] for point in above
+                     if not point["feasible"]
+                     or point["assignment_sha256"] != saturation["assignment_sha256"]]
+        saturation = {**saturation, "points_at_or_above": len(above),
+                      "verified": bool(above) and not differing,
+                      "differing_slo_ms": differing}
+    return {
+        "schema": SCHEMA,
+        "status": "proposal_data",
+        "composition": "sequential_operator_sum",
+        "certifies_p95": False,
+        "certifies_end_to_end_slo": False,
+        "objective": "predicted_dloss",
+        "loss_noise_floor": float(loss_noise_floor),
+        "slo_axis": dict(slo_axis),
+        "saturation": saturation,
+        "n_points": len(points),
+        "n_feasible": len(feasible),
+        "n_nondominated": sum(flags),
+        "distinct_assignments": len({point["assignment_sha256"] for point in feasible}),
+        "monotone_loss": not monotone_violations,
+        "monotone_loss_violations": monotone_violations,
+        "points": points,
+        "provenance": dict(provenance),
+    }
+
+
+def _point_record(record: dict, assignments_dir: Path, *, provenance_stub: dict) -> dict:
+    """One grid point from the allocator's solve record; writes its assignment."""
+    diag = record.get("diagnostics", {})
+    point = {
+        "slo_ms": float(record["slo_ms"]),
+        "target_bits": float(record["target_bits"]),
+        "feasible": bool(record["feasible"]),
+        "refusal_reason": None if record["feasible"] else record.get("reason"),
+        "predicted_dloss": None,
+        "achieved_bits": None,
+        "payload_bytes": None,
+        "attained_prefill_ms": None,
+        "attained_decode_ms": None,
+        "device_memory_bytes": None,
+        "assignment_sha256": None,
+        "assignment_path": None,
+        "solver": {key: diag.get(key) for key in (
+            "frontier_size", "transitions", "solver_seconds", "refusal",
+            "refusal_detail", "prefill_slo_breakpoints_ms")},
+    }
+    if not record["feasible"]:
+        return point
+    assignment = dict(record["assignment"])
+    digest = identity_sha256(assignment)
+    path = assignments_dir / f"{digest}.json"
+    if not path.exists():
+        assignments_dir.mkdir(parents=True, exist_ok=True)
+        payload = {**assignment, LAYER_CONFIG_META_KEY: {
+            "schema": ASSIGNMENT_SCHEMA, "assignment_sha256": digest,
+            "research_only": True,
+            "note": ("prefill frontier sweep point; re-run the allocator at "
+                     "this SLO for a shippable layer config with full metadata"),
+            **provenance_stub}}
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    point.update({
+        "predicted_dloss": float(record["predicted_dloss"]),
+        "achieved_bits": float(record["achieved_bits"]),
+        "payload_bytes": int(record["payload_bytes"]),
+        "attained_prefill_ms": _attained(record, "operator_sum_prefill_ms"),
+        "attained_decode_ms": _attained(record, "operator_sum_decode_ms"),
+        "device_memory_bytes": _attained(record, "device_memory_bytes"),
+        "assignment_sha256": digest,
+        "assignment_path": str(path),
+        "serve_constraints": record["serve_constraints"],
+    })
+    if point["attained_prefill_ms"] is None:
+        raise PrefillFrontierError(
+            f"SLO {record['slo_ms']}: feasible solve carries no operator_sum_prefill_ms")
+    return point
+
+
+# --------------------------------------------------------------------------- #
+# Sweep
+# --------------------------------------------------------------------------- #
+
+def run_sweep(ctx, *, grid: tuple[str, object], assignments_dir: Path,
+              loss_noise_floor: float, allocator_argv: Sequence[str]) -> dict:
+    """Drive ``ctx.solve`` over the grid and return the v1 document."""
+    fixed_prefill = float(ctx.fixed_resources["prefill_ms"])
+    lower_bound = fixed_prefill + ctx.unit_min_prefill_sum_ms
+    upper_bound = fixed_prefill + ctx.unit_max_prefill_sum_ms
+    if not (upper_bound > 0 and math.isfinite(upper_bound)):
+        raise PrefillFrontierError(
+            "the table prices every option at zero prefill; there is no SLO axis")
+    provenance_stub = {"table_id": ctx.table_identity["table_id"],
+                       "table_sha256": ctx.table_identity["sha256"]}
+
+    # The unconstrained point: no assignment needs more than the table's own
+    # maximum, so this solve is what "no prefill SLO" would return, and its
+    # attained prefill is the saturation SLO.
+    top_record = ctx.solve(upper_bound, ctx.target_bits)
+    top = _point_record(top_record, assignments_dir, provenance_stub=provenance_stub)
+    saturation = None
+    if top["feasible"]:
+        saturation = {"slo_ms": float(top["attained_prefill_ms"]),
+                      "assignment_sha256": top["assignment_sha256"],
+                      "predicted_dloss": top["predicted_dloss"],
+                      "derived_from": "attained operator-sum prefill of the solve at slo_axis.upper_bound_ms"}
+
+    kind, spec = grid
+    if kind == "explicit":
+        requested = list(spec)
+    elif saturation is None:
+        requested = []
+    elif kind == "auto":
+        requested = list(top["solver"]["prefill_slo_breakpoints_ms"] or [])
+    else:
+        requested = linear_grid(lower_bound, saturation["slo_ms"], int(spec))
+    grid_ms = sorted({float(value) for value in requested}
+                     | ({saturation["slo_ms"]} if saturation else set()) | {upper_bound})
+    points = []
+    for slo_ms in grid_ms:
+        if slo_ms == upper_bound:
+            points.append(top)
+            continue
+        if saturation is None:
+            # Nothing tighter can be feasible when the loosest budget is not.
+            points.append({**_point_record({"slo_ms": slo_ms, "target_bits": ctx.target_bits,
+                                            "feasible": False, "reason": top["refusal_reason"]},
+                                           assignments_dir, provenance_stub=provenance_stub),
+                           "refusal_reason": f"unconstrained_point_infeasible:{top['refusal_reason']}"})
+            continue
+        record = ctx.solve(slo_ms, ctx.target_bits)
+        points.append(_point_record(record, assignments_dir, provenance_stub=provenance_stub))
+        point = points[-1]
+        print(f"[prefill-frontier] slo={slo_ms:.6g} ms: "
+              + (f"dloss={point['predicted_dloss']:.6g} prefill={point['attained_prefill_ms']:.6g} ms "
+                 f"bits={point['achieved_bits']:.4f} sha={point['assignment_sha256'][:12]}"
+                 if point["feasible"] else f"INFEASIBLE ({point['refusal_reason']})"),
+              flush=True)
+
+    from .aura_cost import _git_commit
+    cost_path = Path(ctx.cost_path)
+    with cost_path.open("rb") as stream:
+        cost_sha256 = hashlib.file_digest(stream, "sha256").hexdigest()
+    provenance = {
+        "git_commit": _git_commit(),
+        "table_identity": dict(ctx.table_identity),
+        "runtime_context": dict(ctx.runtime_context),
+        "fixed_resources": dict(ctx.fixed_resources),
+        "cost_path": str(cost_path), "cost_sha256": cost_sha256,
+        "probe_path": str(ctx.probe_path),
+        "target_bits": float(ctx.target_bits),
+        "serve_slos_other_axes": {key: value for key, value in ctx.slos.as_dict().items()
+                                  if key != "p95_ttft_ms"},
+        "grid": {"kind": kind, "spec": spec if kind != "auto" else "prefill_slo_breakpoints_ms"},
+        "allocator_argv": list(allocator_argv),
+        "assignments_dir": str(assignments_dir),
+        "n_units": int(ctx.n_units),
+    }
+    slo_axis = {"lower_bound_ms": lower_bound, "upper_bound_ms": upper_bound,
+                "fixed_prefill_ms": fixed_prefill,
+                "lower_bound_derivation": "fixed prefill + sum over units of the fastest priced option",
+                "upper_bound_derivation": "fixed prefill + sum over units of the slowest priced option"}
+    return build_frontier_document(points, saturation=saturation, slo_axis=slo_axis,
+                                   loss_noise_floor=loss_noise_floor, provenance=provenance)
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+def _split_argv(argv: Sequence[str]) -> tuple[list[str], list[str]]:
+    argv = list(argv)
+    if "--" not in argv:
+        return argv, []
+    cut = argv.index("--")
+    return argv[:cut], argv[cut + 1:]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        prog="python -m prismaquant.prefill_frontier",
+        description=("Sweep the prefill p95-TTFT SLO over a grid, solving each point "
+                     "through the allocator's measured-runtime path, and write the "
+                     "prismaquant.prefill_frontier.v1 curve. Allocator arguments follow "
+                     "'--' and must include --measured-runtime-table and "
+                     "--measured-runtime-context; the grid owns --slo-prefill-p95-ttft-ms."),
+        epilog=("Example: python -m prismaquant.prefill_frontier --output frontier.json "
+                "--slo-grid auto -- --probe probe.pkl --costs joint.pkl --formats F1,F2 "
+                "--target-bits 4.75 --measured-runtime-table runtime.json "
+                "--measured-runtime-context context.json --layer-config unused.json "
+                "--pareto-csv unused.csv"))
+    ap.add_argument("--output", required=True, help="Frontier JSON to write.")
+    ap.add_argument("--assignments-dir", default=None,
+                    help="Where each distinct assignment is written, one file per "
+                         "digest (default: <output>.assignments).")
+    ap.add_argument("--slo-ms", default=None,
+                    help="Explicit comma-separated prefill p95-TTFT SLOs in ms.")
+    ap.add_argument("--slo-grid", default=None,
+                    help="'auto': the exact SLO breakpoints of the unconstrained solve's "
+                         "proposal frontier; or an integer N >= 2: N linearly spaced SLOs "
+                         "from the table lower bound to the saturation point.")
+    ap.add_argument("--loss-noise-floor", type=float, default=0.0,
+                    help="Nondominance noise floor on predicted_dloss, as "
+                         "select_validated_frontier's --kl-noise-floor. The predicted "
+                         "objective is deterministic, so the default is exactly 0.")
+    return ap
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    own, allocator_argv = _split_argv(sys.argv[1:] if argv is None else argv)
+    ap = build_parser()
+    args = ap.parse_args(own)
+    try:
+        grid = parse_grid_spec(args.slo_ms, args.slo_grid)
+    except PrefillFrontierError as exc:
+        ap.error(str(exc))
+    if not allocator_argv:
+        ap.error("allocator arguments are required after '--'")
+    if not math.isfinite(args.loss_noise_floor) or args.loss_noise_floor < 0:
+        ap.error("--loss-noise-floor must be finite and nonnegative")
+    output = Path(args.output)
+    assignments_dir = (Path(args.assignments_dir) if args.assignments_dir
+                       else output.with_name(output.name + ".assignments"))
+
+    from . import allocator
+    document: dict | None = None
+
+    def sweep(ctx) -> None:
+        nonlocal document
+        document = run_sweep(ctx, grid=grid, assignments_dir=assignments_dir,
+                             loss_noise_floor=args.loss_noise_floor,
+                             allocator_argv=allocator_argv)
+
+    # Loader and identity refusals surface as the allocator's own SystemExit;
+    # they are not wrapped here.
+    allocator.main(list(allocator_argv), measured_runtime_sweep=sweep)
+    if document is None:
+        raise SystemExit("[prefill-frontier] the allocator returned without running the sweep")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(document, indent=2, sort_keys=True, allow_nan=False) + "\n")
+    saturation = document["saturation"]
+    print(f"[prefill-frontier] {document['n_feasible']}/{document['n_points']} feasible, "
+          f"{document['n_nondominated']} nondominated, "
+          f"{document['distinct_assignments']} distinct assignments -> {output}", flush=True)
+    if saturation is None:
+        print("[prefill-frontier] INFEASIBLE at the unconstrained point: "
+              f"{document['points'][-1]['refusal_reason']}", file=sys.stderr, flush=True)
+        return 2
+    print(f"[prefill-frontier] saturation at slo={saturation['slo_ms']:.6g} ms "
+          f"(verified={saturation['verified']}); lower bound "
+          f"{document['slo_axis']['lower_bound_ms']:.6g} ms", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_allocator_measured_runtime_cli.py
+++ b/tests/test_allocator_measured_runtime_cli.py
@@ -74,7 +74,22 @@ def test_measured_cli_refuses_ambiguous_configuration(monkeypatch, capsys, optio
     assert diagnostic in capsys.readouterr().err
 
 
-def _main_fixture(tmp_path, *, fixed_ms=0.0):
+#: Format -> (predicted_dloss, prefill_ms) for the default one-unit fixture:
+#: a same-byte pair where the slower rung has the lower loss.
+DEFAULT_MENU = {"FP8_E4M3": (1.0, 8.0), "FP8_E5M2": (2.0, 2.0)}
+
+
+def _main_fixture(tmp_path, *, fixed_ms=0.0, units=("model.layers.0.self_attn.o_proj",),
+                  menu=DEFAULT_MENU, target_bits="9"):
+    """Synthetic probe/cost/table/context files plus the allocator argv.
+
+    ``units`` are the Linears priced (each with the same ``menu``); ``menu``
+    maps a registry format to its per-unit (predicted_dloss, prefill_ms).
+    The defaults reproduce the original one-unit, two-format fixture exactly;
+    ``tests/test_prefill_frontier.py`` passes several units and three formats
+    to get a curve with more than one corner. Returns ``(name, argv)`` where
+    ``name`` is the first unit, as before.
+    """
     import torch
     from prismaquant.joint_aura import (
         activation_identity, arithmetic_identity, identity_sha256, make_joint_aura_entry,
@@ -83,8 +98,9 @@ def _main_fixture(tmp_path, *, fixed_ms=0.0):
     from prismaquant.cost_stage_checkpoint import canonical_json_sha256
     from prismaquant.measured_runtime_prices import SCHEMA, CONTEXT_SCHEMA
 
-    name = "model.layers.0.self_attn.o_proj"
-    formats = ["FP8_E4M3", "FP8_E5M2"]
+    units = list(units)
+    name = units[0]
+    formats = list(menu)
     shape = (64, 64)
     source_content = {"config": {"fixture": True}, "weight_map": {"fixture.weight": "fixture.weight"},
         "shards": [{"path": "/fixture/synthetic.safetensors", "size": 1, "sha256": "a" * 64}]}
@@ -93,29 +109,33 @@ def _main_fixture(tmp_path, *, fixed_ms=0.0):
         "content_sha256": canonical_json_sha256(source_content, where="synthetic CLI fixture"),
         **source_content}
     arithmetic = arithmetic_identity(torch.float32)
-    rows = {}
-    for fmt, loss in zip(formats, (1.0, 2.0)):
-        probe = {"schema": "prismaquant.joint_aura.probes.v2", "seed_base": 0,
-                 "n_probes": 3, "calibration_sha256": "c" * 64,
-                 "producer_source_sha256": "d" * 64, "source_model": source_model,
-                 "distribution": "rademacher", "normalization": "global_kl_fisher",
-                 "temperature": 1.0, "arithmetic": arithmetic}
-        operator = {"schema": "prismaquant.joint_aura.operator.v2", "qname": name,
-                    "format": fmt, "probe_identity_sha256": identity_sha256(probe),
-                    "source_weight": {"content_sha256": "a" * 64, "shape": list(shape),
-                                      "dtype": "torch.float32", "logical_bytes": 16384},
-                    "rendered_weight": {"content_sha256": "b" * 64, "shape": list(shape),
-                                        "dtype": "torch.float32", "logical_bytes": 16384},
-                    "activation": activation_identity(allocator.fr.get_format(fmt), {}, name),
-                    "arithmetic": arithmetic}
-        rows[fmt] = make_joint_aura_entry(operator_identity=operator, probe_identity=probe,
-            signed_components=[dict(weight=math.sqrt(2 * loss), activation=0.0,
-                                    mixed=0.0, total=math.sqrt(2 * loss)) for _ in range(3)])
+    rows_by_unit = {}
+    for unit in units:
+        rows = {}
+        for fmt, (loss, _milliseconds) in menu.items():
+            probe = {"schema": "prismaquant.joint_aura.probes.v2", "seed_base": 0,
+                     "n_probes": 3, "calibration_sha256": "c" * 64,
+                     "producer_source_sha256": "d" * 64, "source_model": source_model,
+                     "distribution": "rademacher", "normalization": "global_kl_fisher",
+                     "temperature": 1.0, "arithmetic": arithmetic}
+            operator = {"schema": "prismaquant.joint_aura.operator.v2", "qname": unit,
+                        "format": fmt, "probe_identity_sha256": identity_sha256(probe),
+                        "source_weight": {"content_sha256": "a" * 64, "shape": list(shape),
+                                          "dtype": "torch.float32", "logical_bytes": 16384},
+                        "rendered_weight": {"content_sha256": "b" * 64, "shape": list(shape),
+                                            "dtype": "torch.float32", "logical_bytes": 16384},
+                        "activation": activation_identity(allocator.fr.get_format(fmt), {}, unit),
+                        "arithmetic": arithmetic}
+            rows[fmt] = make_joint_aura_entry(operator_identity=operator, probe_identity=probe,
+                signed_components=[dict(weight=math.sqrt(2 * loss), activation=0.0,
+                                        mixed=0.0, total=math.sqrt(2 * loss)) for _ in range(3)])
+        rows_by_unit[unit] = rows
+    rows = rows_by_unit[name]
     probe_path, cost_path = tmp_path / "probe.pkl", tmp_path / "costs.pkl"
-    probe_path.write_bytes(pickle.dumps({"stats": {name: {
-        "h_trace": 1.0, "n_params": 4096, "in_features": 64, "out_features": 64}},
-        "meta": {"model": None}}))
-    cost_path.write_bytes(pickle.dumps({"costs": {name: rows},
+    probe_path.write_bytes(pickle.dumps({"stats": {unit: {
+        "h_trace": 1.0, "n_params": 4096, "in_features": 64, "out_features": 64}
+        for unit in units}, "meta": {"model": None}}))
+    cost_path.write_bytes(pickle.dumps({"costs": rows_by_unit,
         "meta": {"formats": formats}, "provenance": {"cost_mode": "aura",
             "joint_activation": True, "cost_currency": "joint_aura_predicted_dloss"}}))
     receipt = tmp_path / "synthetic-receipt.txt"
@@ -127,21 +147,22 @@ def _main_fixture(tmp_path, *, fixed_ms=0.0):
         "gpu_identity": "synthetic", "runtime_sha256": "a" * 64,
         "source_sha256": source_model["content_sha256"], "calibration_sha256": "c" * 64,
         "prompt_tokens": 16, "batch_size": 1, "tensor_parallel": 1, "graph_mode": "eager",
-        "operator_routes": {name: {fmt: f"synthetic-{fmt}" for fmt in formats}}}
+        "operator_routes": {unit: {fmt: f"synthetic-{fmt}" for fmt in formats} for unit in units}}
     table_rows = []
-    for fmt, milliseconds in zip(formats, (8.0, 2.0)):
-        from prismaquant.allocator_candidates import serialized_candidate_payload
-        serialized, _, _ = serialized_candidate_payload(
-            allocator.fr.get_format(fmt), shape, qname=name, cb_serialization_context=None)
-        table_rows.append({"unit": name, "format": fmt,
-            "binding": {"member_formats": {name: fmt},
-                "member_operator_identity_sha256": {name: rows[fmt]["joint_operator_identity_sha256"]},
-                "member_shapes": {name: list(shape)}, "operator_route": context["operator_routes"][name][fmt]},
-            "resources": vars(_resources(prefill_ms=milliseconds, decode_ms=None,
-                serialized_bytes=serialized, resident_bytes=16384)),
-            "prefill": {"method": "cuda_events", "samples_ms": [milliseconds] * 3,
-                "warmup_iterations": 3, "receipt_path": receipt.name, "receipt_sha256": receipt_sha},
-            "decode": None})
+    from prismaquant.allocator_candidates import serialized_candidate_payload
+    for unit in units:
+        for fmt, (_loss, milliseconds) in menu.items():
+            serialized, _, _ = serialized_candidate_payload(
+                allocator.fr.get_format(fmt), shape, qname=unit, cb_serialization_context=None)
+            table_rows.append({"unit": unit, "format": fmt,
+                "binding": {"member_formats": {unit: fmt},
+                    "member_operator_identity_sha256": {unit: rows_by_unit[unit][fmt]["joint_operator_identity_sha256"]},
+                    "member_shapes": {unit: list(shape)}, "operator_route": context["operator_routes"][unit][fmt]},
+                "resources": vars(_resources(prefill_ms=milliseconds, decode_ms=None,
+                    serialized_bytes=serialized, resident_bytes=16384)),
+                "prefill": {"method": "cuda_events", "samples_ms": [milliseconds] * 3,
+                    "warmup_iterations": 3, "receipt_path": receipt.name, "receipt_sha256": receipt_sha},
+                "decode": None})
     now = datetime.now(timezone.utc)
     table = {"schema": SCHEMA, "table_id": "synthetic-only", "status": "proposal_data",
         "composition": "sequential_operator_sum", "context": context,
@@ -155,8 +176,8 @@ def _main_fixture(tmp_path, *, fixed_ms=0.0):
     table_path.write_text(json.dumps(table))
     context_path.write_text(json.dumps(context))
     argv = ["allocator", "--probe", str(probe_path), "--costs", str(cost_path),
-        "--formats", ",".join(formats), "--allow-default-profile", "--target-bits", "9",
-        "--pareto-targets", "9", "--layer-config", str(tmp_path / "layer.json"),
+        "--formats", ",".join(formats), "--allow-default-profile", "--target-bits", target_bits,
+        "--pareto-targets", target_bits, "--layer-config", str(tmp_path / "layer.json"),
         "--pareto-csv", str(tmp_path / "pareto.csv"),
         "--pareto-output-dir", str(tmp_path / "seeds"),
         "--measured-runtime-table", str(table_path), "--measured-runtime-context", str(context_path),

--- a/tests/test_prefill_frontier.py
+++ b/tests/test_prefill_frontier.py
@@ -1,0 +1,272 @@
+"""Prefill-vs-accuracy frontier sweep on synthetic tables (CPU; not GPU evidence)."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from prismaquant import allocator, prefill_frontier
+from prismaquant.layer_config import load_assignment
+from prismaquant.measured_runtime_prices import identity_sha256
+from test_allocator_measured_runtime_cli import _main_fixture
+
+#: Three rungs per unit: the slow accurate one, a same-byte faster one with
+#: more loss, and a smaller, fastest, lossiest one.
+CURVE_MENU = {"FP8_E4M3": (1.0, 8.0), "FP8_E5M2": (2.0, 2.0), "NVFP4": (4.0, 1.0)}
+UNITS = tuple(f"model.layers.{i}.self_attn.o_proj" for i in range(3))
+
+POINT_KEYS = {"slo_ms", "target_bits", "feasible", "refusal_reason", "predicted_dloss",
+              "achieved_bits", "payload_bytes", "attained_prefill_ms", "attained_decode_ms",
+              "device_memory_bytes", "assignment_sha256", "assignment_path", "solver",
+              "nondominated"}
+DOCUMENT_KEYS = {"schema", "status", "composition", "certifies_p95", "certifies_end_to_end_slo",
+                 "objective", "loss_noise_floor", "slo_axis", "saturation", "n_points",
+                 "n_feasible", "n_nondominated", "distinct_assignments", "monotone_loss",
+                 "monotone_loss_violations", "points", "provenance"}
+
+
+def _curve_fixture(tmp_path, **overrides):
+    name, argv = _main_fixture(tmp_path, units=UNITS, menu=CURVE_MENU, **overrides)
+    cut = argv.index("--slo-prefill-p95-ttft-ms")
+    return name, argv[1:cut]          # drop the "allocator" prog name and the SLO
+
+
+def _without_wall_clock(doc):
+    doc = json.loads(json.dumps(doc))
+    for point in doc["points"]:
+        point["solver"].pop("solver_seconds", None)
+    return doc
+
+
+def _run(tmp_path, own, allocator_argv):
+    output = tmp_path / "frontier.json"
+    code = prefill_frontier.main([*own, "--output", str(output), "--", *allocator_argv])
+    return code, json.loads(output.read_text())
+
+
+def test_auto_grid_produces_the_whole_curve_and_a_verified_saturation(tmp_path):
+    _, allocator_argv = _curve_fixture(tmp_path)
+    code, doc = _run(tmp_path, ["--slo-grid", "auto"], allocator_argv)
+    assert code == 0
+    assert doc["schema"] == prefill_frontier.SCHEMA
+    assert DOCUMENT_KEYS <= set(doc)
+    assert doc["certifies_p95"] is False and doc["status"] == "proposal_data"
+    points = doc["points"]
+    assert len(points) >= 3
+    assert all(POINT_KEYS <= set(point) for point in points)
+    assert doc["n_feasible"] == len(points)
+    # The axis bounds come from the table alone: 3 units x fastest / slowest rung.
+    assert doc["slo_axis"]["lower_bound_ms"] == 3.0
+    assert doc["slo_axis"]["upper_bound_ms"] == 24.0
+    # Saturation is the attained prefill of the unconstrained solve (all FP8_E4M3).
+    saturation = doc["saturation"]
+    assert saturation["slo_ms"] == 24.0 and saturation["verified"] is True
+    assert saturation["predicted_dloss"] == pytest.approx(3.0)
+    assert saturation["differing_slo_ms"] == []
+    # Loss is nonincreasing as the budget relaxes; attained never exceeds the budget.
+    slos = [point["slo_ms"] for point in points]
+    assert slos == sorted(slos)
+    losses = [point["predicted_dloss"] for point in points]
+    assert losses == sorted(losses, reverse=True) and doc["monotone_loss"] is True
+    assert all(point["attained_prefill_ms"] <= point["slo_ms"] for point in points)
+    # The auto grid is the solver's own breakpoint set: every point sits on its
+    # own attained prefill, so every point is a corner and all are nondominated.
+    assert all(point["attained_prefill_ms"] == point["slo_ms"] for point in points)
+    assert all(point["nondominated"] for point in points)
+    assert doc["distinct_assignments"] == len(points) >= 3
+    # The tightest corner is every unit on the fastest rung.
+    fastest = load_assignment(points[0]["assignment_path"])
+    assert set(fastest.values()) == {"NVFP4"} and points[0]["slo_ms"] == 3.0
+    slowest = load_assignment(points[-1]["assignment_path"])
+    assert set(slowest.values()) == {"FP8_E4M3"}
+    for point in points:
+        assignment = json.loads(Path(point["assignment_path"]).read_text())
+        meta = assignment.pop("__prismaquant__")
+        assert meta["schema"] == prefill_frontier.ASSIGNMENT_SCHEMA
+        assert identity_sha256(assignment) == point["assignment_sha256"] == meta["assignment_sha256"]
+        assert Path(point["assignment_path"]).name == point["assignment_sha256"] + ".json"
+    provenance = doc["provenance"]
+    assert provenance["table_identity"]["table_id"] == "synthetic-only"
+    assert provenance["grid"] == {"kind": "auto", "spec": "prefill_slo_breakpoints_ms"}
+    assert provenance["cost_sha256"] == provenance["table_identity"]["cost_sha256"]
+    assert "p95_ttft_ms" not in provenance["serve_slos_other_axes"]
+
+
+def test_linear_grid_spans_lower_bound_to_saturation(tmp_path):
+    _, allocator_argv = _curve_fixture(tmp_path)
+    code, doc = _run(tmp_path, ["--slo-grid", "5"], allocator_argv)
+    assert code == 0
+    slos = [point["slo_ms"] for point in doc["points"]]
+    assert slos == pytest.approx([3.0, 8.25, 13.5, 18.75, 24.0])
+    assert doc["provenance"]["grid"] == {"kind": "linear", "spec": 5}
+    assert doc["monotone_loss"] is True and doc["saturation"]["verified"] is True
+    # Interior linear points attain less than their budget; a repeated
+    # assignment at a looser budget is dominated by its own first appearance.
+    corners = [point for point in doc["points"] if point["nondominated"]]
+    assert len(corners) == doc["distinct_assignments"]
+    losses = [point["predicted_dloss"] for point in corners]
+    assert losses == sorted(losses, reverse=True) and len(set(losses)) == len(losses)
+
+
+def test_explicit_grid_records_infeasible_points_and_keeps_going(tmp_path):
+    _, allocator_argv = _curve_fixture(tmp_path)
+    code, doc = _run(tmp_path, ["--slo-ms", "0.5,3,30"], allocator_argv)
+    assert code == 0
+    by_slo = {point["slo_ms"]: point for point in doc["points"]}
+    # Saturation (24) and the table upper bound (24) are always on the grid.
+    assert sorted(by_slo) == [0.5, 3.0, 24.0, 30.0]
+    assert by_slo[0.5]["feasible"] is False
+    assert by_slo[0.5]["refusal_reason"] == "no_runtime_frontier_assignment_passed_exact_checks"
+    assert by_slo[0.5]["assignment_sha256"] is None and by_slo[0.5]["nondominated"] is False
+    assert by_slo[3.0]["feasible"] and by_slo[3.0]["predicted_dloss"] == pytest.approx(12.0)
+    assert by_slo[30.0]["assignment_sha256"] == by_slo[24.0]["assignment_sha256"]
+    assert by_slo[30.0]["nondominated"] is False and by_slo[24.0]["nondominated"] is True
+    assert doc["n_feasible"] == 3 and doc["saturation"]["verified"] is True
+
+
+def test_sweep_point_equals_the_single_solve_at_that_slo(tmp_path, monkeypatch):
+    """A grid point is what one --slo-prefill-p95-ttft-ms run would ship."""
+    name, argv = _main_fixture(tmp_path, units=UNITS, menu=CURVE_MENU)
+    cut = argv.index("--slo-prefill-p95-ttft-ms")
+    code, doc = _run(tmp_path, ["--slo-ms", "12"], argv[1:cut])
+    assert code == 0
+    # The sweep never writes the single solve's outputs (it did not run one).
+    assert not (tmp_path / "pareto.csv").exists() and not (tmp_path / "layer.json").exists()
+    single = argv[:cut] + ["--slo-prefill-p95-ttft-ms", "12"]
+    monkeypatch.setattr(sys, "argv", single)
+    allocator.main()
+    single_assignment = load_assignment(tmp_path / "layer.json")
+    single_meta = json.loads((tmp_path / "layer.json").read_text())["__prismaquant__"]
+    point = next(point for point in doc["points"] if point["slo_ms"] == 12.0)
+    assert load_assignment(point["assignment_path"]) == single_assignment
+    assert point["attained_prefill_ms"] == single_meta["serve_constraints"]["predicted"]["operator_sum_prefill_ms"]
+    assert point["serve_constraints"]["predicted"] == single_meta["serve_constraints"]["predicted"]
+
+
+def test_default_allocator_path_is_untouched_by_the_hook(tmp_path, monkeypatch):
+    name, argv = _main_fixture(tmp_path)
+    monkeypatch.setattr(sys, "argv", argv)
+    allocator.main()
+    assert load_assignment(tmp_path / "layer.json")[name] == "FP8_E5M2"
+    # And main(argv) is the same call without touching sys.argv.
+    (tmp_path / "layer.json").unlink()
+    monkeypatch.setattr(sys, "argv", ["unrelated"])
+    allocator.main(argv[1:])
+    assert load_assignment(tmp_path / "layer.json")[name] == "FP8_E5M2"
+
+
+def test_invalid_table_rows_refuse_with_the_loader_message(tmp_path):
+    _, allocator_argv = _curve_fixture(tmp_path)
+    table_path = tmp_path / "runtime.json"
+    payload = json.loads(table_path.read_text())
+    payload["rows"][0]["resources"]["prefill_ms"] = 3.5   # no longer the sample median
+    table_path.write_text(json.dumps(payload))
+    with pytest.raises(SystemExit, match="resource times must equal medians"):
+        _run(tmp_path, ["--slo-grid", "auto"], allocator_argv)
+    assert not (tmp_path / "frontier.json").exists()
+
+
+def test_stale_cost_payload_refuses(tmp_path):
+    _, allocator_argv = _curve_fixture(tmp_path)
+    (tmp_path / "costs.pkl").write_bytes((tmp_path / "costs.pkl").read_bytes() + b"\n")
+    with pytest.raises(SystemExit, match="cost payload SHA-256 mismatch"):
+        _run(tmp_path, ["--slo-grid", "auto"], allocator_argv)
+
+
+def test_grid_owns_the_prefill_slo_flag(tmp_path, capsys):
+    _, allocator_argv = _curve_fixture(tmp_path)
+    with pytest.raises(SystemExit, match="2"):
+        _run(tmp_path, ["--slo-grid", "auto"],
+             allocator_argv + ["--slo-prefill-p95-ttft-ms", "5"])
+    assert "belongs to the prefill frontier sweep grid" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("own,message", [
+    ([], "exactly one of --slo-ms or --slo-grid"),
+    (["--slo-ms", "1", "--slo-grid", "auto"], "exactly one of"),
+    (["--slo-grid", "1"], "integer >= 2"),
+    (["--slo-ms", "0,4"], "positive and finite"),
+    (["--slo-grid", "auto", "--loss-noise-floor", "-1"], "nonnegative"),
+])
+def test_grid_arguments_refuse(tmp_path, capsys, own, message):
+    with pytest.raises(SystemExit, match="2"):
+        prefill_frontier.main([*own, "--output", str(tmp_path / "f.json"), "--", "--probe", "x"])
+    assert message in capsys.readouterr().err
+
+
+def test_sweep_without_a_table_refuses(tmp_path, capsys):
+    _, argv = _main_fixture(tmp_path)
+    cut = argv.index("--measured-runtime-table")
+    with pytest.raises(SystemExit, match="2"):
+        _run(tmp_path, ["--slo-grid", "auto"], argv[1:cut])
+    assert "requires --measured-runtime-table" in capsys.readouterr().err
+
+
+def test_ties_are_deterministic_and_lexical(tmp_path):
+    menu = {"FP8_E4M3": (1.0, 8.0), "FP8_E5M2": (1.0, 8.0)}   # same bytes, loss, prefill
+    _, argv = _main_fixture(tmp_path, units=UNITS[:2], menu=menu)
+    cut = argv.index("--slo-prefill-p95-ttft-ms")
+    first = _run(tmp_path, ["--slo-grid", "4"], argv[1:cut])[1]
+    second = _run(tmp_path, ["--slo-grid", "4"], argv[1:cut])[1]
+    assert _without_wall_clock(first) == _without_wall_clock(second)
+    for point in first["points"]:
+        if point["feasible"]:
+            assert set(load_assignment(point["assignment_path"]).values()) == {"FP8_E4M3"}
+    assert first["distinct_assignments"] == 1 and first["n_nondominated"] == 1
+
+
+def test_unconstrained_infeasibility_is_reported_not_hidden(tmp_path):
+    """A byte budget below every rung: no saturation point, exit 2, every point says why."""
+    _, argv = _main_fixture(tmp_path, units=UNITS, menu=CURVE_MENU, target_bits="1")
+    cut = argv.index("--slo-prefill-p95-ttft-ms")
+    output = tmp_path / "frontier.json"
+    code = prefill_frontier.main(["--slo-ms", "5,10", "--output", str(output), "--", *argv[1:cut]])
+    assert code == 2
+    doc = json.loads(output.read_text())
+    assert doc["saturation"] is None and doc["n_feasible"] == 0
+    reasons = {point["slo_ms"]: point["refusal_reason"] for point in doc["points"]}
+    assert reasons[24.0] == "no_runtime_frontier_assignment_passed_exact_checks"
+    assert reasons[5.0].startswith("unconstrained_point_infeasible:")
+
+
+def test_build_document_flags_dominance_saturation_and_monotonicity(tmp_path):
+    def point(slo, loss, prefill, sha, feasible=True):
+        return {"slo_ms": slo, "target_bits": 4.0, "feasible": feasible,
+                "refusal_reason": None if feasible else "x", "predicted_dloss": loss,
+                "achieved_bits": 4.0, "payload_bytes": 1, "attained_prefill_ms": prefill,
+                "attained_decode_ms": None, "device_memory_bytes": None,
+                "assignment_sha256": sha, "assignment_path": str(tmp_path / f"{sha}.json"),
+                "solver": {}}
+    points = [point(1.0, 9.0, 1.0, "a"), point(2.0, 9.0, 1.0, "a"),      # repeat: dominated
+              point(3.0, 5.0, 3.0, "b"), point(4.0, 6.0, 3.5, "c"),      # c: worse on both
+              point(6.0, 4.0, 5.0, "d"), point(0.5, 0.0, 0.0, None, False)]
+    doc = prefill_frontier.build_frontier_document(
+        points, saturation={"slo_ms": 5.0, "assignment_sha256": "d", "predicted_dloss": 4.0},
+        slo_axis={}, loss_noise_floor=0.0, provenance={})
+    flags = {p["slo_ms"]: p["nondominated"] for p in doc["points"]}
+    assert flags == {1.0: True, 2.0: False, 3.0: True, 4.0: False, 6.0: True, 0.5: False}
+    assert doc["monotone_loss"] is False
+    assert [v["slo_ms"] for v in doc["monotone_loss_violations"]] == [4.0]
+    assert doc["saturation"]["verified"] is True and doc["saturation"]["points_at_or_above"] == 1
+    # A noise floor wider than the b->d gain merges those corners, as the
+    # validated frontier's --kl-noise-floor does.
+    wide = prefill_frontier.build_frontier_document(
+        points, saturation={"slo_ms": 7.0, "assignment_sha256": "zzz", "predicted_dloss": 0},
+        slo_axis={}, loss_noise_floor=1.5, provenance={})
+    assert [p["slo_ms"] for p in wide["points"] if p["nondominated"]] == [1.0, 3.0]
+    # No grid point at or above the claimed saturation: nothing verifies it.
+    assert wide["saturation"]["verified"] is False and wide["saturation"]["differing_slo_ms"] == []
+    assert wide["saturation"]["points_at_or_above"] == 0
+
+
+def test_module_help_runs_from_a_clean_interpreter():
+    root = Path(__file__).resolve().parents[1]
+    env = {**os.environ, "PYTHONPATH": str(root)}
+    result = subprocess.run([sys.executable, "-m", "prismaquant.prefill_frontier", "--help"],
+                            cwd=root, env=env, capture_output=True, text=True, timeout=300)
+    assert result.returncode == 0, result.stderr
+    assert "--slo-grid" in result.stdout and "--measured-runtime-table" in result.stdout


### PR DESCRIPTION
Closes #540. The sweep half of #237.

## What changed

- **`prismaquant/prefill_frontier.py`** (new): `python -m prismaquant.prefill_frontier --output F.json (--slo-ms a,b,c | --slo-grid auto | --slo-grid N) -- <allocator args with --measured-runtime-table/--measured-runtime-context>`. One measured-runtime solve per prefill p95-TTFT budget, written as a `prismaquant.prefill_frontier.v1` document: per point `slo_ms`, `predicted_dloss`, `payload_bytes`, `achieved_bits`, `attained_prefill_ms` (fixed work included), `attained_decode_ms` when priced, `device_memory_bytes`, `assignment_sha256` + `assignment_path` (one loadable file per distinct assignment), `refusal_reason`, `nondominated` (the `select_validated_frontier` lower-envelope rule on (attained prefill, Δloss), noise floor defaults to 0 because the objective is deterministic); plus `saturation` (measured: the attained prefill of the solve at the table's upper bound, verified against every looser point), `slo_axis` (table-derived bounds), `monotone_loss`, and provenance (table identity, context, cost digest, git commit, allocator argv). No knee, no default grid. Exit 2 with the document written when the unconstrained point is infeasible.
- **`prismaquant/allocator.py`**: `main(argv=None, *, measured_runtime_sweep=None)`. With a sweep the allocator loads, checks and prices the table exactly as before, then hands the sweep a `MeasuredRuntimeSweep` whose `solve(slo_ms, target_bits)` runs the unchanged `_solve_for_target` / `solve_runtime_frontier` path and returns without writing layer config / Pareto CSV. Every measured-runtime solve now records `prefill_slo_breakpoints_ms` (the prefill values at which the lowest-loss proposal changes; the `auto` grid). Inside a sweep an exact-search bound refusal is that point's reason instead of an exit. **Default path byte-identical**; `--slo-prefill-p95-ttft-ms` is refused inside a sweep (the grid owns it).
- **Tests**: `tests/test_prefill_frontier.py` (14 new) on the `tests/test_allocator_measured_runtime_cli.py` fixture, generalized to several units and an explicit `(loss, prefill)` menu with defaults unchanged. Covers: full curve + verified saturation on an `auto` grid (7 corners at 3/4/5/6/12/18/24 ms, loss 12 → 3), linear grid, explicit grid with an infeasible point, **sweep point == single-solve CLI at that SLO**, default path untouched, loader refusals unwrapped (bad row medians, stale cost digest), grid-flag refusals, deterministic lexical ties, unconstrained infeasibility reported with exit 2, the pure document builder (dominance / saturation / monotonicity), and `--help` from a clean interpreter.
- **Docs, same commit**: `docs/ARCHITECTURE.md` (stamp + §4.5 paragraph), `docs/design/joint_aura_runtime_allocation.md` new "Frontier sweep" section stating, gate by gate and code-cited, what the Tessera side must deliver for a real table.

## Receipts (PrismaBuild, dl380g10, priority -10)

| run | tree | files | result | action key | done record |
|---|---|---|---|---|---|
| 1 | dirty pre-commit snapshot | `test_prefill_frontier.py`, `test_allocator_measured_runtime_cli.py`, `test_allocator_runtime_frontier.py` | 106 passed, 0 skipped, 17.47 s | `f992e9f94aca383fcd3a93e307aa8d94dc3acaeba6f43810ae19cd6c90acfdc9` | `/mnt/shared/prismabuild-fleet/pb-queue/done/f992e9f94aca383fcd3a93e307aa8d94dc3acaeba6f43810ae19cd6c90acfdc9.json` (detail.returncode 0) |
| 2 | commit `726fc2e5` | the three above + `test_architecture_doc.py`, `test_docs_staleness.py` | 125 passed, 0 skipped, 15.11 s | `75b0471fcce00cce516e0f8c8b882eb39114f9a5cd3b70101f6b250087c5d819` | `/mnt/shared/prismabuild-fleet/pb-queue/done/75b0471fcce00cce516e0f8c8b882eb39114f9a5cd3b70101f6b250087c5d819.json` (detail.returncode 0); CAS payload `/mnt/shared/prismabuild-fleet/cas/blobs/70/700123b672b5ab851f771418b0bb09253303321d7fd014b11aaf271ed7b7fd9c` |

| 3 | merge `3cd54cea` (origin/main `a8dd772d` merged; ARCHITECTURE.md stamp conflict resolved, both stamps kept) | the five above + `test_tessera_tp_audit.py` | 134 passed, 0 skipped, 18.83 s | `1dffed17b71a51075bd2081c7e6f5822f23ed6a0064d8fff432da633fd25cbe4` | `/mnt/shared/prismabuild-fleet/pb-queue/done/1dffed17b71a51075bd2081c7e6f5822f23ed6a0064d8fff432da633fd25cbe4.json` (detail.returncode 0) |

Interpreter `/home/rob/venvs/pq-cpu312/bin/python`; 1 shard, xdist workers, no GPU. Plus one local CPU smoke of the CLI on the synthetic three-unit fixture (`--slo-grid auto`, exit 0, 7/7 feasible, saturation verified at 24 ms) before submitting.

## Limitations

- **No real `prismaquant.measured_runtime_prices.v2` table exists**, so every curve here is synthetic. The design doc names what is owed: native rows with **both** measured phases and non-null scratch (`runtime_provenance.admit_native_rows`, #267), and a `tessera.full_engine_resource_report.v1` successor that partitions fixed timing — at v1 the report has no timing partition, so any nonzero fixed `prefill_ms`/`decode_ms` is refused by name (`runtime_provenance._fixed_resource_refusals`; #420's producer half).
- A sweep point is a proposal under the sequential operator-sum model; it certifies no p95 and no end-to-end SLO. The served, fixed-teacher gates still decide.
- Each grid point re-runs the exact search (no reuse across points), so a large menu at many points costs N solves; the `auto` grid is the minimal exact set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmYxSxhmzbBcBoFTjbLi1G
