### PR TITLE
Read the pinned Tessera contract in route_status_for, so `absent` means one thing

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,41 @@
 # PrismaQuant Architecture
 
-As of: 2026-09-12 · `pq/530-amd-serving-profiles`. Stamps
+As of: 2026-09-13 · `claude/537-route-status-reads-the-pin`. Stamps
 follow, newest first, each recording its own branch and date.
+
+Re-stamped (2026-09-13, `claude/537-route-status-reads-the-pin`) because
+**`ServingLaneSpec.route_status_for` now reads the pinned Tessera runtime
+contract by default** (#537). It resolved its eligibility table through
+`load_eligibility_table()` with no `contract_path`, and that loader has had no
+default table since the Gridbook lane retired (2026-09-02), so in production it
+answered `unattested` with source `serving_runtime_contract::absent` for every
+lane on every platform, sm_121 included. The gate still failed closed and no
+shipped verdict rested on that answer — the AMD and sm_121 facts are settled a
+second time through `tessera_render.tessera_attesting_cells` — but principle
+9's structured `route_status` carried the value "nobody handed me a table",
+which is not a fact about any runtime and so is not something principle 14 lets
+a producer field say.
+
+`serving_profiles._load_pinned_lane_tables` now resolves the tracked serving
+pin (`prismaquant/tessera_runtime/tessera_serving_runtime_pin.json`) and the
+`runtime_contract.json` the `tessera.serving` package it names actually
+packages, and hands the resolver BOTH the eligibility table and the published
+`formats` rows off that one file — without the second, `resolve_payload_rung`
+cannot name a family and every lane reports `:no_cell` for the wrong reason.
+**This changes a gate input on every lane.** `absent` is now reachable only
+when the pin file itself is missing, and says so
+(`serving_profiles.ROUTE_STATUS_SOURCE_NO_PIN`); each other miss carries its
+own token — `:runtime_not_importable` (the pin names a runtime this checkout
+cannot import), `:pin_unreadable`, `:contract_publishes_no_table`,
+`:installed_contract_not_pinned` (the installed contract's digest is not the
+pin's) — so an `unattested` verdict always names WHICH fact was absent. The
+resolver stays narrower than admission on purpose: it answers what the pinned
+table says about a lane's route, while `tessera_menu.route_admission` /
+`tessera_render.tessera_lane_admission` add the cell-evidence, lane-predicate
+and installed-release conjuncts that answer whether a rung may ship. Census in
+`tests/test_route_status_reads_the_pinned_contract.py`; the fixture that used
+to hand `tests/test_tessera_amd_serving_profiles.py` a contract is gone,
+because there is nothing left to hand.
 
 Re-stamped (2026-09-12, `pq/530-amd-serving-profiles`) for the two **AMD
 Tessera serving profiles** (#530): `serving_profile_specs/
@@ -23,13 +57,11 @@ for EVERY family on both targets, the backed one included, and export fails
 closed: `tessera_export_lane.require_assignment_scope` raises on any selected
 unit whose resolved route is not backed and device-qualified, and on this lane
 that refusal takes no override. `ServingLaneSpec.route_status_for` speaks
-the `:no_cell` vocabulary too, but only for a caller that hands it the pinned
-contract: with none supplied — every production call since the Gridbook
-retirement left no default table — it answers `unattested` with source
-`serving_runtime_contract::absent`, for every lane and every platform. Both are
-`unattested` and the gate fails closed on either; what the structured
-`route_status` on a serving-profile lane reads today is `absent`, not
-`no_cell`. §9's diagram and §9.4 are updated in this commit: the 2026-07-31
+the `:no_cell` vocabulary too, and since #537 (2026-09-13) it resolves the
+pinned contract itself, so on these targets it answers `unattested` with source
+`serving_runtime_contract:<v>:no_cell` — the runtime's own silence about the
+platform, not this side's silence about the runtime. Both are `unattested` and
+the gate fails closed on either. §9's diagram and §9.4 are updated in this commit: the 2026-07-31
 "Strix Halo CANCELED / UNSUPPORTED" node was a statement about a **Gridbook**
 prototype and about lost hardware access, and it had been standing in for a
 claim about Tessera on AMD that nobody measured. Gates:
@@ -14023,8 +14055,9 @@ which is this case) — while the refusal that actually stops bytes is
 takes no override on this lane. These two profiles declare no export lane at
 all, so the question never reaches it. The lane-level
 `ServingLaneSpec.route_status_for` reaches the same refusal by a shorter road:
-nothing hands it the pinned contract, so it answers `unattested` with source
-`serving_runtime_contract::absent` — see §9.4. A `gfx1201` receipt, when one exists, proves a code
+it resolves the pinned contract itself (#537) and no cell names either AMD
+platform, so it answers `unattested` with source
+`serving_runtime_contract:<v>:no_cell` — see §9.4. A `gfx1201` receipt, when one exists, proves a code
 path on gfx12 and never stands in for gfx1151 numerics or performance.
 
 **Admission is pinned to an exact commit and contract digest.** The pin names
@@ -14237,12 +14270,14 @@ one, because a cell is a device receipt and nobody here owns a Strix Halo. So
 no cell for every family — including the backed one — and export fails closed in
 `tessera_export_lane.require_assignment_scope`, which takes no override on this lane (and these
 two profiles declare no export lane to reach it with).
-`ServingLaneSpec.route_status_for` would say `:no_cell` if it were handed the pinned
-contract, and a test hands it one; in production nothing does, because
-`load_eligibility_table()` has had no default table since the Gridbook lane was retired
-(2026-09-02), so that resolver answers `unattested` with source `serving_runtime_contract::absent`
-for every lane on every platform, sm_121 included. Both refuse; only the first refuses because of
-something the contract says.
+`ServingLaneSpec.route_status_for` says `:no_cell` here too. Until #537 (2026-09-13) it did so
+only for a test that handed it a contract: in production it called `load_eligibility_table()` with
+no `contract_path`, which has had no default table since the Gridbook lane was retired
+(2026-09-02), so that resolver answered `unattested` with source `serving_runtime_contract::absent`
+for every lane on every platform, sm_121 included — a refusal about this side's own empty hands, not
+about the runtime. It now resolves the tracked serving pin and the contract that pin names, so both
+resolvers refuse because of something the contract says, and `absent` is reachable only when the pin
+file is missing.
 Backing is permission to PRICE; a cell is permission to ship. Promotion still requires the full
 served ladder, and a `gfx1201` receipt proves a code path on gfx12 and never stands in for
 gfx1151 numerics or performance.

--- a/prismaquant/serving_profiles.py
+++ b/prismaquant/serving_profiles.py
@@ -34,21 +34,116 @@ _LANE_STATUS_RANK = {
     "backed": 3,
 }
 
-_ELIGIBILITY_TABLE: Any = None
+#: Source token when no serving pin is on disk at all. This is the ONLY way
+#: ``route_status_for`` reaches ``absent``: on a normal checkout the pin is a
+#: tracked file, so "nobody handed me a table" is not a reachable answer.
+#: Every other refusal names what was read and why it did not attest.
+ROUTE_STATUS_SOURCE_NO_PIN = (
+    "serving_runtime_contract::absent(serving_runtime_pin_missing)"
+)
+
+_PINNED_LANE_TABLES: Any = None
 
 
-def _cached_eligibility_table(loader):
+def _load_pinned_lane_tables() -> tuple[Any, Any, str]:
+    """``(table, formats, refusal)`` from the PINNED Tessera serving runtime.
+
+    Principle 14's consumption half, for the lane resolver. Until #537 this
+    function did not exist and ``route_status_for`` called
+    ``load_eligibility_table()`` with no ``contract_path``. That loader has had
+    no default table since the Gridbook lane retired (2026-09-02), so the
+    answer in production was ``unattested`` with source
+    ``serving_runtime_contract::absent`` for every lane on every platform,
+    sm_121 included -- a structured ``route_status`` whose value meant "nobody
+    handed me a table", which is not a fact about any runtime.
+
+    What is read, in order, and what each miss is called:
+
+    * ``tessera_runtime/tessera_serving_runtime_pin.json``. Its absence is the
+      one ``absent`` (:data:`ROUTE_STATUS_SOURCE_NO_PIN`): with no pin there is
+      no runtime whose claims could be read. Its ``version`` labels the table,
+      so the source names the pinned RELEASE rather than whatever a contract
+      says about itself.
+    * The ``runtime_contract.json`` the importable ``tessera.serving`` packages
+      (``tessera_runtime_contract.contract_path`` -- the one resolver every
+      producer reader on this side shares). No importable runtime is
+      ``:runtime_not_importable``, not ``absent``: "the pin names a runtime
+      that is not installed here" and "no runtime is pinned" are different
+      facts and must not share a token.
+    * The pin's ``contract_sha256`` against the loaded contract's digest. A
+      different table is not the pinned table, and reading route status off it
+      would make the field attest a runtime nobody pinned
+      (``:installed_contract_not_pinned``).
+
+    Both loaders come off the SAME file. Handing over only the eligibility
+    table would leave ``resolve_payload_rung`` with no published formats, so
+    every Tessera name would resolve to a family the table does not carry and
+    the lane would report ``no_cell`` -- the right answer to the wrong
+    question.
+
+    This is deliberately NOT ``tessera_lane_admission``: that predicate adds
+    the cell-evidence, lane and installed-release conjuncts and answers "may
+    this rung ship". This answers the narrower question the field is for --
+    what the pinned runtime's own table says about this lane's route.
+    """
+    from .lane_eligibility import (
+        load_eligibility_table, load_published_formats,
+    )
+    from .tessera_serving_runtime_pin import (
+        TesseraServingRuntimePinError,
+        load_tessera_serving_runtime_pin,
+        tessera_serving_runtime_pin_path,
+    )
+
+    pin_path = tessera_serving_runtime_pin_path()
+    if not pin_path.exists():
+        return None, None, ROUTE_STATUS_SOURCE_NO_PIN
+    try:
+        pin = load_tessera_serving_runtime_pin()
+    except TesseraServingRuntimePinError:
+        # A malformed pin is a defect to fix, not an absence to report; it
+        # must not read as "no runtime is pinned".
+        return None, None, "serving_runtime_contract::pin_unreadable"
+    version = pin.version
+
+    from importlib.resources import as_file
+
+    try:
+        from .tessera_runtime_contract import contract_path
+        with as_file(contract_path()) as path:
+            table = load_eligibility_table(version, contract_path=path)
+            formats = load_published_formats(version, contract_path=path)
+    except Exception:  # ModuleNotFoundError, OSError, FileNotFoundError...
+        return None, None, (
+            f"serving_runtime_contract:{version}:runtime_not_importable")
+
+    if not table.present:
+        return None, None, (
+            f"serving_runtime_contract:{version}:contract_publishes_no_table")
+    if (pin.contract_sha256_is_resolved
+            and table.contract_sha256 != pin.contract_sha256):
+        return None, None, (
+            f"serving_runtime_contract:{version}:installed_contract_not_pinned")
+    return table, formats, ""
+
+
+def _cached_pinned_lane_tables():
     """One read of the pinned contract per process (it is immutable)."""
-    global _ELIGIBILITY_TABLE
-    if _ELIGIBILITY_TABLE is None:
-        _ELIGIBILITY_TABLE = loader()
-    return _ELIGIBILITY_TABLE
+    global _PINNED_LANE_TABLES
+    if _PINNED_LANE_TABLES is None:
+        _PINNED_LANE_TABLES = _load_pinned_lane_tables()
+    return _PINNED_LANE_TABLES
 
 
 def _reset_eligibility_table_cache() -> None:
-    """Test seam: the pinned contract is immutable, monkeypatched ones are not."""
-    global _ELIGIBILITY_TABLE
-    _ELIGIBILITY_TABLE = None
+    """Test seam: the pinned contract is immutable, a substituted one is not.
+
+    It clears the per-process memo only. It cannot substitute a verdict, and
+    since #537 there is nothing for a test to substitute a table THROUGH: the
+    resolver reads the pin and the packaged contract itself.
+    """
+    global _PINNED_LANE_TABLES
+    _PINNED_LANE_TABLES = None
 
 
 @dataclass(frozen=True)
@@ -576,7 +671,11 @@ class ServingLaneSpec:
 
         Resolved, never declared. The spec names which structural classes of
         the runtime's eligibility table this lane consults; the verdict comes
-        from the table the PINNED SERVING release packages.
+        from the table the PINNED SERVING release packages, read here through
+        :func:`_load_pinned_lane_tables` -- the tracked serving pin plus the
+        ``runtime_contract.json`` it names. ``absent`` is reachable only when
+        that pin file is missing (#537); every other miss carries its own
+        token, so an ``unattested`` verdict always says WHICH fact was absent.
 
         Under lane-eligibility v3 a cell is scoped to one platform, one payload
         family and an explicit rung list, so this lane-level answer is narrower
@@ -587,18 +686,13 @@ class ServingLaneSpec:
         """
         from .lane_eligibility import (
             ROUTE_STATUS_UNATTESTED,
-            load_eligibility_table,
             resolve_payload_rung,
         )
 
-        table = _cached_eligibility_table(load_eligibility_table)
+        table, formats, refusal = _cached_pinned_lane_tables()
+        if refusal:
+            return (ROUTE_STATUS_UNATTESTED, (), refusal)
         version = table.runtime_version
-        if not table.present:
-            return (
-                ROUTE_STATUS_UNATTESTED,
-                (),
-                f"serving_runtime_contract:{version}:absent",
-            )
         if not self.route_status_structures:
             # A lane that names no attestation has none. Fail-closed.
             return (
@@ -615,7 +709,10 @@ class ServingLaneSpec:
                 f"serving_runtime_contract:{version}:no_target_platform",
             )
         canonical = fr.canonical_format_name(fmt)
-        family, k, rate_q256 = resolve_payload_rung(canonical)
+        # The published formats come off the SAME pinned file as the table; a
+        # name resolved without them names a family no cell carries, and the
+        # lane would report ``no_cell`` for the wrong reason.
+        family, k, rate_q256 = resolve_payload_rung(canonical, formats)
         cells = [
             cell for cell in table.cells
             if cell.structure in self.route_status_structures

--- a/tests/test_route_status_reads_the_pinned_contract.py
+++ b/tests/test_route_status_reads_the_pinned_contract.py
@@ -1,0 +1,226 @@
+"""``ServingLaneSpec.route_status_for`` answers from the pin, not from absence.
+
+The defect this module pins (#537). ``route_status_for`` resolved its
+eligibility table through ``load_eligibility_table()`` with no
+``contract_path``. That loader has had no default table since the Gridbook
+lane retired on 2026-09-02, so on a normal checkout the resolver answered
+``unattested`` with source ``serving_runtime_contract::absent`` for every lane
+on every platform, sm_121 included. The gate still failed closed, but the
+structured ``route_status`` principle 9 requires ("never in prose a gate cannot
+read") carried the value "nobody handed me a table" -- which is not a fact
+about any runtime, and therefore not something principle 14 lets a producer
+field say.
+
+The fix reads the tracked serving pin
+(``prismaquant/tessera_runtime/tessera_serving_runtime_pin.json``) and the
+``runtime_contract.json`` the ``tessera.serving`` package it names actually
+packages. So ``absent`` now means one thing only: there is no pin on disk.
+
+Every expectation below is READ off that same pinned file rather than typed
+here, so a re-pin that moves a platform, a family or a rung moves this test
+with it instead of leaving a literal that fails for the wrong reason. Nothing
+here substitutes a table or a verdict: the one monkeypatch in the file points
+the pin RESOLVER at a path that does not exist, which is the driver's input,
+not its answer.
+"""
+from __future__ import annotations
+
+import json
+from importlib.resources import as_file
+
+import pytest
+
+from prismaquant import serving_profiles as sp
+from prismaquant.lane_eligibility import ROUTE_STATUS_UNATTESTED
+from prismaquant.tessera_runtime_contract import contract_path
+from prismaquant import tessera_serving_runtime_pin as pin_module
+
+NATIVE_STATUSES = ("backed", "backed_with_serve_flag")
+
+
+def _packaged() -> dict:
+    with as_file(contract_path()) as path:
+        return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _cells() -> list[dict]:
+    return list(_packaged()["lane_eligibility"]["cells"])
+
+
+def _pin_version() -> str:
+    return pin_module.load_tessera_serving_runtime_pin().version
+
+
+def _format_row(family: str) -> dict:
+    return next(r for r in _packaged()["formats"] if r["family"] == family)
+
+
+def _name_at(family: str, rung_q256: int) -> str:
+    """The family's name at one rate, spelled the contract's own way."""
+    return str(_format_row(family)["name_pattern"]).replace(
+        "{k}", str(int(rung_q256)))
+
+
+def _lane(structures: tuple[str, ...]) -> sp.ServingLaneSpec:
+    """A lane spec exactly as a serving profile would declare one.
+
+    Constructed rather than loaded because no live serving profile declares
+    ``serving_lanes`` today, so this class IS the production entry to the
+    resolver; ``ServingProfile.serving_lane_for`` only picks which instance to
+    ask. No live profile means no fixture to borrow, not a seam.
+    """
+    return sp.ServingLaneSpec(
+        id="tessera",
+        formats=tuple(str(row["family"]) for row in _packaged()["formats"]),
+        activation_contract="W16A16",
+        fallback_route="none",
+        route_status_structures=structures,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache():
+    """The resolver memoizes the pinned read; other modules may have filled it."""
+    sp._reset_eligibility_table_cache()
+    yield
+    sp._reset_eligibility_table_cache()
+
+
+# ---------------------------------------------------------------------------
+# The measured answer
+# ---------------------------------------------------------------------------
+def _cell_groups() -> dict[tuple[str, str, str, int], list[dict]]:
+    """Cells keyed the way the resolver filters them.
+
+    The lane answer is per (platform, family, structure, rung), and the pinned
+    contract ships several cells per key (one per regime, one per residency).
+    ``route_status_for`` ranks the covering cells and reports the best one, so
+    the census below is grouped the same way rather than asserted cell by cell.
+    """
+    groups: dict[tuple[str, str, str, int], list[dict]] = {}
+    for cell in _cells():
+        rungs = [int(r) for r in (cell.get("rungs_q256") or cell.get("rungs") or ())]
+        assert rungs, cell["id"]
+        for rung in rungs:
+            groups.setdefault(
+                (str(cell["platform"]), str(cell["family"]),
+                 str(cell["structure"]), rung), []).append(cell)
+    return groups
+
+
+def test_every_pinned_cell_resolves_to_its_own_measured_route():
+    """The regression: on the pre-#537 resolver every one of these was ``absent``.
+
+    One case per route the pinned contract ships, so the assertion is the
+    contract's census and not a hand-picked example. Each must come back with
+    a route status the contract itself carries and the id of one of the cells
+    that carry it.
+    """
+    groups = _cell_groups()
+    assert groups, "the pinned contract ships no eligibility cells"
+    for (platform, family, structure, rung), cells in sorted(groups.items()):
+        status, _flags, source = _lane((structure,)).route_status_for(
+            _name_at(family, rung), platform=platform)
+        statuses = {str(c["route_status"]) for c in cells}
+        assert status in statuses, (platform, family, rung, status, source)
+        assert source in {
+            f"serving_runtime_contract:{_pin_version()}:{c['id']}"
+            for c in cells}, source
+        assert "absent" not in source, source
+
+
+def test_the_sm121_control_lane_is_natively_backed():
+    """The issue's acceptance case, stated on its own so a regression is legible."""
+    sm121 = [k for k in _cell_groups() if k[0] == "sm_121"]
+    assert sm121, "the pinned contract ships no sm_121 cell"
+    for _platform, family, structure, rung in sorted(sm121):
+        status, _flags, source = _lane((structure,)).route_status_for(
+            _name_at(family, rung), platform="sm_121")
+        assert status in NATIVE_STATUSES, (family, rung, status, source)
+        assert "absent" not in source, source
+
+
+def test_the_published_formats_come_off_the_same_pinned_file():
+    """The second half of the same bug, which a table-only fix would leave.
+
+    ``resolve_payload_rung`` needs the pinned ``formats`` rows to turn a format
+    NAME into the runtime's family and rate. Called without them it hands back
+    the raw name, no cell matches it, and the lane reports ``no_cell`` -- which
+    reads as a platform fact and is not one. So ask for a rate the contract's
+    own reader range allows but no cell attests: the honest answer is
+    ``rung_not_listed`` (the family resolved, the rate is not in a cell), and
+    ``no_cell`` there would mean the formats table was never read.
+    """
+    for (platform, family, structure, _rung), cells in sorted(
+            _cell_groups().items()):
+        if platform != "sm_121":
+            continue
+        attested = {
+            int(r) for c in _cells() if c["family"] == family
+            for r in (c.get("rungs_q256") or c.get("rungs") or ())}
+        lo, hi = (int(v) for v in _format_row(family)["reader_rate_range_q256"])
+        spare = next((r for r in range(lo, hi + 1) if r not in attested), None)
+        if spare is None:  # a family the runtime reads at exactly one rate
+            continue
+        status, _flags, source = _lane((structure,)).route_status_for(
+            _name_at(family, spare), platform="sm_121")
+        assert status == ROUTE_STATUS_UNATTESTED, (family, spare, source)
+        assert source == (
+            f"serving_runtime_contract:{_pin_version()}:rung_not_listed"), source
+        return
+    pytest.fail("no pinned family reads a rate that no cell attests")
+
+
+# ---------------------------------------------------------------------------
+# `absent` means one thing
+# ---------------------------------------------------------------------------
+def test_absent_is_reachable_only_when_the_pin_file_is_missing(
+        monkeypatch, tmp_path):
+    """Point the pin RESOLVER at a path with no file; the verdict is untouched."""
+    monkeypatch.setattr(
+        pin_module, "tessera_serving_runtime_pin_path",
+        lambda: tmp_path / "no_such_tessera_serving_runtime_pin.json")
+    sp._reset_eligibility_table_cache()
+    cell = next(c for c in _cells() if c["platform"] == "sm_121")
+    rung = int((cell.get("rungs_q256") or cell.get("rungs"))[0])
+    status, flags, source = _lane((str(cell["structure"]),)).route_status_for(
+        _name_at(str(cell["family"]), rung), platform="sm_121")
+    assert status == ROUTE_STATUS_UNATTESTED
+    assert source == sp.ROUTE_STATUS_SOURCE_NO_PIN, source
+    assert "serving_runtime_pin_missing" in source
+    assert flags == ()
+
+
+def test_the_tracked_pin_exists_so_absent_is_not_the_production_answer():
+    """Stated once: the branch above is unreachable on a normal checkout."""
+    assert pin_module.tessera_serving_runtime_pin_path().exists()
+    _table, _formats, refusal = sp._load_pinned_lane_tables()
+    assert refusal == "", refusal
+
+
+def test_no_other_refusal_borrows_the_absent_token():
+    """Every miss says WHICH fact was absent; only a missing pin says ``absent``.
+
+    The four non-cell answers a live lane can reach, each asked for on purpose.
+    """
+    cell = next(c for c in _cells() if c["platform"] == "sm_121")
+    rung = int((cell.get("rungs_q256") or cell.get("rungs"))[0])
+    name = _name_at(str(cell["family"]), rung)
+    structure = str(cell["structure"])
+    sources = [
+        _lane(())  # a lane that names no attestation
+        .route_status_for(name, platform="sm_121")[2],
+        _lane((structure,))  # no target platform
+        .route_status_for(name, platform=None)[2],
+        _lane((structure,))  # a platform the contract ships no cell for
+        .route_status_for(name, platform="sm_90")[2],
+        _lane(("no_such_structure",))  # a structure class with no cell
+        .route_status_for(name, platform="sm_121")[2],
+    ]
+    assert sources == [
+        "lane_declares_no_route_status_source",
+        f"serving_runtime_contract:{_pin_version()}:no_target_platform",
+        f"serving_runtime_contract:{_pin_version()}:no_cell",
+        f"serving_runtime_contract:{_pin_version()}:no_cell",
+    ], sources
+    assert not any("absent" in s for s in sources), sources

--- a/tests/test_tessera_amd_serving_profiles.py
+++ b/tests/test_tessera_amd_serving_profiles.py
@@ -21,13 +21,14 @@ one, and export fails closed without an explicit override. Backing is
 permission to PRICE; a cell is permission to ship.
 
 That answer is asserted twice, through both resolvers, because neither alone
-says it: ``ServingLaneSpec.route_status_for`` speaks the ``no_cell`` vocabulary
-but reads no default table (absence, by design, since the Gridbook lane
-retired), so it is handed the pinned contract through the module's declared
-test seam -- and ``tessera_render.tessera_attesting_cells``, the predicate
-behind ``tessera_menu.route_admission`` and therefore the path production runs,
-resolves the pinned table itself and finds no cell. Each has its own sm_121
-control, so ``unattested`` here is never allowed to mean "nothing was read".
+says it: ``ServingLaneSpec.route_status_for``, which speaks the ``no_cell``
+vocabulary, and ``tessera_render.tessera_attesting_cells``, the predicate
+behind ``tessera_menu.route_admission`` and therefore the path production runs.
+Since #537 both resolve the pinned contract themselves -- the tracked serving
+pin plus the ``runtime_contract.json`` it names -- so no fixture hands either
+one a table, and ``:no_cell`` below is the answer the pinned runtime gives.
+Each has its own sm_121 control, so ``unattested`` here is never allowed to
+mean "nothing was read".
 """
 from __future__ import annotations
 
@@ -81,42 +82,19 @@ def _version() -> str:
 
 
 @pytest.fixture
-def pinned_table(monkeypatch):
-    """Hand ``route_status_for`` the pinned contract through its own seam.
+def pinned_table():
+    """Only a cache reset: since #537 the resolver reads the pin itself.
 
-    ``load_eligibility_table()`` with no ``contract_path`` is an honest
-    ABSENCE, by design since the Gridbook lane retired: there is no default
-    table any more (``lane_eligibility.py`` docstring), and every live caller
-    passes the pinned runtime's own file --
-    ``tessera_render._pinned_serving_table`` is the one that does it for
-    Tessera. ``ServingLaneSpec.route_status_for`` is the resolver that speaks
-    the ``serving_runtime_contract:<v>:no_cell`` vocabulary, and it reads the
-    table through a per-process cache with no argument, so asking it about a
-    real platform means supplying the real table first. That is what this
-    fixture does, through the module's declared test seam
-    (``_reset_eligibility_table_cache``). It substitutes the CONTRACT, never
-    the verdict: the table below is parsed from Tessera's own packaged
-    ``runtime_contract.json`` by the same parser the export gate uses.
+    Until then ``route_status_for`` called ``load_eligibility_table()`` with no
+    ``contract_path``, which has had no default table since the Gridbook lane
+    retired, so asking it about a real platform meant substituting the contract
+    first and the ``no_cell`` assertions below were evidence only with that
+    fixture in place. The resolver now resolves the tracked serving pin and the
+    packaged ``runtime_contract.json`` on its own, so all that is left to do is
+    drop a memo another module in this process may have filled.
     """
-    from prismaquant import lane_eligibility as lane
-
-    real_table = lane.load_eligibility_table
-    real_formats = lane.load_published_formats
-    with as_file(tr.tessera_serving_contract_path()) as path:
-        table = real_table(_version(), contract_path=path)
-        formats = real_formats(_version(), contract_path=path)
-    assert table.present, table.absent_reason
-    # Both loaders, from the same file. The rung vocabulary is the second half
-    # of the same absence: with no contract in hand `resolve_payload_rung`
-    # cannot name a family either, so it returns the raw format string, no cell
-    # matches it, and the resolver reports `no_cell` for sm_121 too -- the
-    # right answer to the wrong question. A test that patched only the table
-    # would read that as a platform fact. (`tessera_render` supplies the same
-    # pair from the same file for the live path.)
-    monkeypatch.setattr(lane, "load_eligibility_table", lambda *a, **k: table)
-    monkeypatch.setattr(lane, "load_published_formats", lambda *a, **k: formats)
     sp._reset_eligibility_table_cache()
-    yield table
+    yield
     sp._reset_eligibility_table_cache()
 
 
@@ -228,23 +206,21 @@ def test_the_same_lane_still_attests_the_sm121_cells(pinned_table):
     assert "no_cell" not in source, source
 
 
-def test_the_resolver_says_absent_when_nobody_supplies_a_contract():
-    """Why the fixture above exists, asserted rather than asserted-in-prose.
+def test_the_resolver_reads_the_pin_with_nothing_supplied(pinned_table):
+    """#537, from this file's side: no fixture supplies the table any more.
 
-    With no contract in hand this resolver answers ``unattested`` with source
-    ``...:absent`` for EVERY platform, sm_121 included. That is the designed
-    fail-closed default and it is also the reason the two tests above are not
-    evidence without the fixture: an ``unattested`` that means "nobody handed
-    me a table" must never be read as "the runtime has no cell here".
+    This used to assert the opposite -- that with no contract in hand the
+    resolver answered ``...:absent`` for EVERY platform, sm_121 included -- and
+    that was the reason the two tests above needed a fixture at all. It is now
+    the defect: an ``unattested`` meaning "nobody handed me a table" is not a
+    fact about a runtime, and principle 9's structured ``route_status`` must
+    not carry one. ``tests/test_route_status_reads_the_pinned_contract.py``
+    owns the full census; this keeps the AMD file honest about its own control.
     """
-    sp._reset_eligibility_table_cache()
-    try:
-        status, _flags, source = _tessera_lane().route_status_for(
-            _rung_name("TESSERA_BF16_K1"), platform="sm_121")
-    finally:
-        sp._reset_eligibility_table_cache()
-    assert status == ROUTE_STATUS_UNATTESTED
-    assert source.endswith(":absent"), source
+    status, _flags, source = _tessera_lane().route_status_for(
+        _rung_name("TESSERA_BF16_K1"), platform="sm_121")
+    assert status != ROUTE_STATUS_UNATTESTED, (status, source)
+    assert "absent" not in source, source
 
 
 @pytest.mark.parametrize("platform", sorted(set(AMD_PROFILES.values())))


### PR DESCRIPTION
Closes #537.

## The bug

`ServingLaneSpec.route_status_for` called `lane_eligibility.load_eligibility_table()`
with **no** `contract_path`, and separately `resolve_payload_rung(canonical)` with
**no** `published_formats`. Since the Gridbook lane retirement (2026-09-02) removed
the default table, the no-argument read returns `present=False`, so on a normal
checkout the production call path answered
`(unattested, (), "serving_runtime_contract::absent")` for **every** lane on
**every** platform — including the sm_121 control lane. A gate reading
`route_status` therefore read "no runtime ever said anything" where the pinned
runtime in fact publishes a measured cell. That is principle 14 inverted: the
default answer was an assertion of silence, not a derivation from the table.

Both halves were broken, so a table-only fix would have swapped `absent` for
`:no_cell` — the right refusal token for the wrong reason.

## The coordinator's chosen shape (option 1), stated as an assumption

> `route_status_for` reads the **PINNED** Tessera runtime contract by default —
> the pin at `prismaquant/tessera_runtime/tessera_serving_runtime_pin.json` and the
> packaged `runtime_contract.json` it names — and `absent` is reachable **only when
> the pin file is missing**, never as the default outcome on a normal checkout.

That is what this branch implements, and the tests assert exactly it.

## The change

`prismaquant/serving_profiles.py`:

* `_load_pinned_lane_tables()` does one read of the tracked pin and the packaged
  contract it names, and returns `(table, published_formats, refusal)`. Both the
  eligibility table and the published formats come off the **same** file, so a
  format name is never resolved against a family no cell carries.
* `_cached_pinned_lane_tables()` caches it per process (the contract is immutable);
  `_reset_eligibility_table_cache()` clears it.
* `route_status_for` consumes that pair. The refusal vocabulary is now distinct and
  machine-readable:
  * `serving_runtime_contract::absent(serving_runtime_pin_missing)` — **only** when
    the pin file does not exist,
  * `serving_runtime_contract::pin_unreadable`,
  * `serving_runtime_contract:<v>:runtime_not_importable`,
  * `serving_runtime_contract:<v>:contract_publishes_no_table`,
  * `serving_runtime_contract:<v>:installed_contract_not_pinned`,
  * and the per-cell / `:no_cell` / `:rung_not_listed` answers as before.

The digest gate (`installed_contract_not_pinned`) is deliberate: reading an
*unpinned* installed table and stamping `backed_with_serve_flag` off it would make
`route_status_for` disagree with `tessera_resolved_serving_lane`, which already
folds `_release_pin_satisfied()` into its verdict. Two resolvers, two answers, is
what #537 exists to end.

`tests/test_route_status_reads_the_pinned_contract.py` (new) is a census over the
pinned contract's own cells, not a fixture:

* every pinned cell resolves to its own measured route (grouped by
  `(platform, family, structure, rung)`, since the contract ships several cells per
  group and the resolver returns the best-ranked one),
* the sm_121 control lane is natively backed — the issue's acceptance case,
* the published formats come off the same pinned file (a rate inside the reader
  range that no cell attests gives `:rung_not_listed`, not `:no_cell`),
* `absent` is reachable **only** when the pin file is missing — the regression
  **mutates the driver** (`tessera_serving_runtime_pin_path` -> a nonexistent path),
  never the verdict and never a substituted table,
* the tracked pin exists, so `absent` is not the production answer,
* no other refusal borrows the `absent` token.

`tests/test_tessera_amd_serving_profiles.py`: the `pinned_table` fixture no longer
monkeypatches `load_eligibility_table` / `load_published_formats` — that seam is
redundant now that the production path reads the pin. It is a bare cache reset.
`test_the_resolver_says_absent_when_nobody_supplies_a_contract` is replaced by
`test_the_resolver_reads_the_pin_with_nothing_supplied`.

`docs/ARCHITECTURE.md` is updated in the same commit (principle 13): the
provenance block is re-stamped and the three stale
`serving_runtime_contract::absent` claims are corrected to the `:no_cell` answer
the resolver now gives, with the history preserved.

## Receipts

Regression demonstrated on the **pre-fix** code through PrismaBuild, on a worktree
holding origin/main + the new test file only:

* failed record
  `/mnt/shared/prismabuild-fleet/pb-queue/failed/3e40e660745a2b18ffe7633f57878cf5f153417634136def6589be37f8a2988e.json`
* `AssertionError: ('sm_121', 'TESSERA_BF16_K1', 1792, 'unattested', 'serving_runtime_contract::absent')`

Branch run (`--tag dl380g10`, `--priority -10`, `pq-cpu312`), 18 tessera/serving
test files + the new one, 4 shards:

* `f100896123cfa157cba65f1b836aaad148b0538f6753eb367961bfda39dda6ff` — 10 failed / 110 passed
* `0c565806c9a855cb2ed147ea3ec35e214032bd4094d2b737f71362f5a4fb3522` — 28 failed / 112 passed / 1 skipped
* `f0fd4b76fe861005f9df48c5163130f697b992ea867e91b6a251f21dce232dfd` — 4 failed / 72 passed
* `ac3214927cf82c6822e54cc78cc9b5a55b72d0c8bf37ffc527f7cd693b71a189` — 5 failed / 45 passed

Merged head `ffc25052` (origin/main merged in), same 18 files + the new module +
#536's two new test files, 4 shards:

* `6283d2ba9cbc…` — 9 failed / 115 passed / 1 skipped
* `fd118ff7b325…` — 18 failed / 50 passed
* shard 2 — 20 failed / 124 passed
* shard 3 — **76 passed, green** (includes #536's `test_tessera_tp_loader_axes.py`)

Total 47, per-file counts identical to the pre-merge branch.

origin/main baseline over the same files, same box — **38 failures**
(`lane_admission` 2, `platform_route` 3, `amd_serving_profiles` 8,
`lane_spec_platforms` 4, `serving_pin` 2, `menu_real_table` 2, `tessera_menu` 14,
`export_lane` 3):

* `55c3114f7ca8…` — 14 failed (lane_admission x2, amd x8, lane_spec_platforms x4)
* `4f370bc9a6fb…` — 4 failed (serving_pin x2, menu_real_table x2)
* `ea60621ca9e3…` — 20 failed (platform_route x3, menu x14, export_lane x3)
* `0f6c83a81dad…` — 17 failed (menu x14, export_lane x3), a second read of the same two files

**Failure-set delta = +9, and nothing else moves**: the new module x5 and
`test_tessera_amd_serving_profiles.py` x4. Every one of the nine reports
`serving_runtime_contract:0.1.0:installed_contract_not_pinned`. No pre-existing
test changes state in either direction.

## Limitation, and it is not this branch's

**dl380g10's `pq-cpu312` venv has Tessera at `ba582d47` (contract v22). The repo
pins `1c827abc` (contract v23) — the same commit for both
`TESSERA_DEV_PIN_COMMIT` and the serving pin, so there is no structural
pin-vs-pin drift; the venv is simply stale.**

Measured on the box: the installed `runtime_contract.json` hashes to
`a688f8de244f936ec3a63a782e20af7985733e7a6fb0b4b981b5fe4c44112212`; the serving
pin binds `bafe8a4e9eff8551b34bbd2d7be9c29bf2cfa7bd836724ac9a9ab2f4e0bb922a`.

Consequences, stated plainly:

* The same root cause already reds **main** on that box — `test_tessera_lane_admission.py`
  x2, `test_tessera_platform_route.py` x3 (`KeyError: 'executes'`, "the pinned
  contract declares no platform 'sm_121'"), `test_tessera_amd_serving_profiles.py`
  x8, `test_tessera_lane_spec_platforms.py` x4, `test_tessera_serving_pin.py` x2,
  `test_tessera_menu_real_table.py` x2.
* The new module's 5 tests and 4 of the AMD file's are red there for that same
  reason, every one of them reporting
  `serving_runtime_contract:0.1.0:installed_contract_not_pinned`.
* The tests are deliberately **unconditional** — the repo precedent is
  `test_the_tracked_pin_is_an_exact_commit_and_the_installed_contracts_digest`,
  which is also unconditional and also red on a stale box. A pin-state-conditional
  test would certify nothing.
* The fix is provisioning, not code: install Tessera `1c827abc` into
  `/home/rob/venvs/pq-cpu312` on dl380g10. That venv is shared with in-flight PB
  workers, so this branch does not touch it. GitHub CI installs the pin itself
  (`ci.yml` "Install pinned Tessera"), so CI is the authority for these tests until
  the fleet venv is re-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmYxSxhmzbBcBoFTjbLi1G
